### PR TITLE
feat(openapi): stamp x-voyant-module and x-voyant-surface on every operation

### DIFF
--- a/.changeset/openapi-module-metadata.md
+++ b/.changeset/openapi-module-metadata.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/hono": minor
+"@voyant-travel/openapi": minor
+---
+
+Stamp `x-voyant-module` and `x-voyant-surface` on every OpenAPI operation.
+
+Follow-up to the per-module spec split (voyant#2733) and a step toward
+voyant#2729. Each operation in the generated specs (aggregate + per-module) now
+carries `x-voyant-module` and `x-voyant-surface` extensions, so the specs are
+self-describing — a module-grouped docs UI or a client generator can read the
+owning module and surface off each operation instead of re-deriving them from
+path prefixes. The module is the authoritative owner from the mount manifest, so
+`publicPath` routes are labelled with their real owning module (e.g.
+`/v1/public/payment-policy/resolve` → `x-voyant-module: bookings`) rather than
+their mount prefix.
+
+`@voyant-travel/hono/openapi` exposes the underlying pieces:
+`buildModulePathOwnership` (path → module map), `partitionByModule`
+(synchronous split from a precomputed map), and `stampModuleMetadata`.
+`splitDocumentByModule` is retained as a convenience wrapper.

--- a/packages/hono/src/openapi.ts
+++ b/packages/hono/src/openapi.ts
@@ -280,50 +280,72 @@ export async function generateModuleOpenApiDocuments(
   return result
 }
 
-/** Second path segment after the surface prefix — `/v1/admin/<seg>/...`. */
-function moduleSegment(path: string): string {
-  return path.split("/")[3] ?? "misc"
+/**
+ * The module a path belongs to, given the authoritative owner map: the manifest
+ * owner if known (which is what keeps `publicPath` overrides correct), else the
+ * path's own module segment — `<seg>` in `/v1/admin/<seg>/...`,
+ * `/v1/public/<seg>/...`, or `/v1/<seg>/...` (webhooks/legacy).
+ */
+function moduleNameForPath(path: string, owner: ReadonlyMap<string, string>): string {
+  const known = owner.get(path)
+  if (known) return known
+  const parts = path.split("/").filter(Boolean) // ["v1","admin","bookings",...]
+  const seg = parts[1] === "admin" || parts[1] === "public" ? parts[2] : parts[1]
+  return seg ?? "misc"
+}
+
+/** The API surface a path is served on, or `null` for non-surface routes. */
+function surfaceForPath(path: string): ApiSurface | null {
+  if (path.startsWith("/v1/admin/")) return "admin"
+  if (path.startsWith("/v1/public/")) return "storefront"
+  return null
+}
+
+/**
+ * Build the authoritative path → module ownership map from the mount manifest.
+ *
+ * Generates each module's isolated doc (see `generateModuleOpenApiDocuments`)
+ * only to learn which real absolute paths it owns — so `publicPath` overrides
+ * (whose prefix isn't the module name, e.g. `/v1/public/booking-engine`) map to
+ * the right module. Routes the manifest doesn't record (`additionalRoutes`,
+ * directly-mounted routes) are absent here and fall back to their path segment.
+ *
+ * Build-time only.
+ */
+export async function buildModulePathOwnership(
+  mounts: readonly ModuleMount[],
+  options: GenerateOpenApiOptions,
+): Promise<Map<string, string>> {
+  const moduleDocs = await generateModuleOpenApiDocuments(mounts, options)
+  const owner = new Map<string, string>()
+  for (const [moduleName, doc] of moduleDocs) {
+    for (const path of Object.keys(doc.paths ?? {})) owner.set(path, moduleName)
+  }
+  return owner
 }
 
 /**
  * Partition a composed document into one document per module, covering EVERY
  * admin/storefront path (voyant#2733).
  *
- * `generateModuleOpenApiDocuments` alone only sees routes recorded in the module
- * mount manifest — it misses `additionalRoutes` and any route mounted directly
- * on the composed app (e.g. the operator's workflow-runs admin surface, the
- * `_meta/capabilities` route). Those were present in the old committed aggregate
- * and must not silently vanish from the committed per-module specs.
- *
- * This uses the manifest as the *authoritative* owner for the routes it knows
- * about — which is what makes `publicPath` overrides (whose prefix isn't the
- * module name, e.g. `/v1/public/booking-engine`) land under the right module —
- * and falls back to the path's own second segment for anything the manifest
- * doesn't claim. The result therefore partitions the full surface exactly: every
- * `/v1/admin/*` and `/v1/public/*` path lands in exactly one module document.
- * Non-surface routes (`/v1/<name>` webhooks, legacy `/v1/*`) live only in the
- * aggregate, as before.
+ * Uses the ownership map as the authoritative module owner, falling back to the
+ * path's own segment for anything the manifest doesn't claim (e.g.
+ * `additionalRoutes` mounts like the operator's workflow-runs admin surface).
+ * The full surface is therefore partitioned exactly: every `/v1/admin/*` and
+ * `/v1/public/*` path lands in exactly one module document. Non-surface routes
+ * (`/v1/<name>` webhooks, legacy `/v1/*`) live only in the aggregate, as before.
  *
  * Each per-module document carries the aggregate's shared `components` verbatim
  * (there is ~one), so it stays a valid, self-contained OpenAPI document.
- *
- * Build-time only.
  */
-export async function splitDocumentByModule(
+export function partitionByModule(
   full: OpenApiDocument,
-  mounts: readonly ModuleMount[],
-  options: GenerateOpenApiOptions,
-): Promise<Map<string, OpenApiDocument>> {
-  const moduleDocs = await generateModuleOpenApiDocuments(mounts, options)
-  const owner = new Map<string, string>()
-  for (const [moduleName, doc] of moduleDocs) {
-    for (const path of Object.keys(doc.paths ?? {})) owner.set(path, moduleName)
-  }
-
+  owner: ReadonlyMap<string, string>,
+): Map<string, OpenApiDocument> {
   const buckets = new Map<string, Record<string, unknown>>()
   for (const [path, item] of Object.entries(full.paths ?? {})) {
     if (!path.startsWith("/v1/admin/") && !path.startsWith("/v1/public/")) continue
-    const moduleName = owner.get(path) ?? moduleSegment(path)
+    const moduleName = moduleNameForPath(path, owner)
     let bucket = buckets.get(moduleName)
     if (!bucket) {
       bucket = {}
@@ -341,4 +363,62 @@ export async function splitDocumentByModule(
     } as OpenApiDocument)
   }
   return result
+}
+
+/**
+ * Convenience: build the ownership map and partition in one call. Prefer the
+ * two-step `buildModulePathOwnership` + `partitionByModule` when you also want
+ * to `stampModuleMetadata` the aggregate from the same map (so it's built once).
+ *
+ * Build-time only.
+ */
+export async function splitDocumentByModule(
+  full: OpenApiDocument,
+  mounts: readonly ModuleMount[],
+  options: GenerateOpenApiOptions,
+): Promise<Map<string, OpenApiDocument>> {
+  return partitionByModule(full, await buildModulePathOwnership(mounts, options))
+}
+
+const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const
+
+/**
+ * Stamp every operation with `x-voyant-module` and `x-voyant-surface`
+ * extensions (voyant#2733 / voyant#2729), so the specs are self-describing:
+ * tooling (a module-grouped docs UI, client generators) can read the owning
+ * module and surface off each operation instead of re-deriving them from path
+ * prefixes. The module is the authoritative owner from the manifest, so
+ * `publicPath` overrides are labelled with their real owning module rather than
+ * their mount prefix.
+ *
+ * Applied to the aggregate before it's split, so the per-module and surface
+ * documents (all derived from it) inherit the stamps. Extensions are appended
+ * to each operation, keeping key order deterministic for the drift gate.
+ */
+export function stampModuleMetadata(
+  doc: OpenApiDocument,
+  owner: ReadonlyMap<string, string>,
+): OpenApiDocument {
+  const paths: Record<string, unknown> = {}
+  for (const [path, item] of Object.entries(doc.paths ?? {})) {
+    if (!item || typeof item !== "object") {
+      paths[path] = item
+      continue
+    }
+    const moduleName = moduleNameForPath(path, owner)
+    const surface = surfaceForPath(path)
+    const nextItem: Record<string, unknown> = { ...(item as Record<string, unknown>) }
+    for (const method of HTTP_METHODS) {
+      const op = nextItem[method]
+      if (op && typeof op === "object") {
+        nextItem[method] = {
+          ...(op as Record<string, unknown>),
+          "x-voyant-module": moduleName,
+          ...(surface ? { "x-voyant-surface": surface } : {}),
+        }
+      }
+    }
+    paths[path] = nextItem
+  }
+  return { ...doc, paths } as OpenApiDocument
 }

--- a/packages/hono/tests/unit/openapi-modules.test.ts
+++ b/packages/hono/tests/unit/openapi-modules.test.ts
@@ -6,6 +6,7 @@ import {
   type ModuleMount,
   type OpenApiDocument,
   splitDocumentByModule,
+  stampModuleMetadata,
 } from "../../src/openapi.js"
 
 const INFO = { title: "Test", version: "0.0.0" } as const
@@ -142,5 +143,40 @@ describe("splitDocumentByModule", () => {
       "/v1/admin/workflow-runs/{id}",
       "/v1/public/booking-engine/hold",
     ])
+  })
+})
+
+describe("stampModuleMetadata", () => {
+  const owner = new Map<string, string>([["/v1/public/booking-engine/hold", "commerce"]])
+  const doc = {
+    openapi: "3.1.0",
+    info: INFO,
+    paths: {
+      "/v1/admin/bookings/list": { get: { responses: {} } },
+      "/v1/public/booking-engine/hold": { post: { responses: {} } },
+      "/v1/webhooks/netopia": { post: { responses: {} } },
+    },
+  } as unknown as OpenApiDocument
+
+  it("stamps x-voyant-module (authoritative owner) and x-voyant-surface per operation", () => {
+    const stamped = stampModuleMetadata(doc, owner)
+    const op = (path: string, method: string) =>
+      (stamped.paths as Record<string, Record<string, Record<string, unknown>>>)[path][method]
+
+    // Segment-derived module + admin surface.
+    expect(op("/v1/admin/bookings/list", "get")["x-voyant-module"]).toBe("bookings")
+    expect(op("/v1/admin/bookings/list", "get")["x-voyant-surface"]).toBe("admin")
+    // publicPath override → authoritative owner, not the `booking-engine` prefix.
+    expect(op("/v1/public/booking-engine/hold", "post")["x-voyant-module"]).toBe("commerce")
+    expect(op("/v1/public/booking-engine/hold", "post")["x-voyant-surface"]).toBe("storefront")
+    // Non-surface route: module stamped, surface omitted.
+    expect(op("/v1/webhooks/netopia", "post")["x-voyant-module"]).toBe("webhooks")
+    expect(op("/v1/webhooks/netopia", "post")["x-voyant-surface"]).toBeUndefined()
+  })
+
+  it("does not mutate the input document", () => {
+    const before = JSON.stringify(doc)
+    stampModuleMetadata(doc, owner)
+    expect(JSON.stringify(doc)).toBe(before)
   })
 })

--- a/packages/openapi/spec/admin/accommodations.json
+++ b/packages/openapi/spec/admin/accommodations.json
@@ -367,7 +367,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}": {
@@ -599,7 +601,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/nights": {
@@ -762,7 +766,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/pickups": {
@@ -1055,7 +1061,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/pickups/reverse": {
@@ -1203,7 +1211,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/release": {
@@ -1387,7 +1397,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/action-ledger.json
+++ b/packages/openapi/spec/admin/action-ledger.json
@@ -905,7 +905,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/entries": {
@@ -1665,7 +1667,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/entries/{id}/reversals": {
@@ -2533,7 +2537,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/entries/{id}": {
@@ -3134,7 +3140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals": {
@@ -3502,7 +3510,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals/request": {
@@ -4148,7 +4158,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals/{id}": {
@@ -4858,7 +4870,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals/{id}/decide": {
@@ -5491,7 +5505,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/delegations": {
@@ -5810,7 +5826,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/delegations/{id}": {
@@ -5944,7 +5962,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/relay-outbox": {
@@ -6194,7 +6214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/booking-requirements.json
+++ b/packages/openapi/spec/admin/booking-requirements.json
@@ -337,7 +337,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -532,7 +534,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/contact-requirements/{id}": {
@@ -663,7 +667,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -882,7 +888,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -932,7 +940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/questions": {
@@ -1179,7 +1189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1422,7 +1434,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/questions/{id}": {
@@ -1577,7 +1591,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1844,7 +1860,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1894,7 +1912,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-questions": {
@@ -2053,7 +2073,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2182,7 +2204,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-questions/{id}": {
@@ -2280,7 +2304,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2433,7 +2459,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2483,7 +2511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/question-options": {
@@ -2628,7 +2658,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2751,7 +2783,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/question-options/{id}": {
@@ -2843,7 +2877,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2989,7 +3025,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3039,7 +3077,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/unit-triggers": {
@@ -3196,7 +3236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3323,7 +3365,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/unit-triggers/{id}": {
@@ -3419,7 +3463,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3570,7 +3616,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3620,7 +3668,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-triggers": {
@@ -3770,7 +3820,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3883,7 +3935,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-triggers/{id}": {
@@ -3972,7 +4026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4109,7 +4165,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4159,7 +4217,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/extra-triggers": {
@@ -4334,7 +4394,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4479,7 +4541,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/extra-triggers/{id}": {
@@ -4585,7 +4649,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4755,7 +4821,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4805,7 +4873,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/answers": {
@@ -5026,7 +5096,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5244,7 +5316,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/answers/{id}": {
@@ -5389,7 +5463,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5631,7 +5707,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5681,7 +5759,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/bookings.json
+++ b/packages/openapi/spec/admin/bookings.json
@@ -239,7 +239,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/aggregates": {
@@ -481,7 +483,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/overview": {
@@ -995,7 +999,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/sharing-groups": {
@@ -1081,7 +1087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/sharing-groups/{groupId}/travelers": {
@@ -1162,7 +1170,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/allocations": {
@@ -1312,7 +1322,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/activity": {
@@ -1409,7 +1421,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/group": {
@@ -1476,7 +1490,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/reserve": {
@@ -2395,7 +2411,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/expire-stale": {
@@ -2474,7 +2492,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/confirm": {
@@ -2930,7 +2950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/extend-hold": {
@@ -3360,7 +3382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/expire": {
@@ -3813,7 +3837,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/cancel": {
@@ -4266,7 +4292,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/start": {
@@ -4719,7 +4747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/complete": {
@@ -5172,7 +5202,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/override-status": {
@@ -5653,7 +5685,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/action-ledger": {
@@ -5811,7 +5845,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/action-approvals/{approvalId}/decide": {
@@ -5998,7 +6034,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers": {
@@ -6126,7 +6164,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -6365,7 +6405,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}/reveal": {
@@ -6553,7 +6595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}/travel-details": {
@@ -6644,7 +6688,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6875,7 +6921,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6969,7 +7017,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/with-travel-details": {
@@ -7256,7 +7306,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}/with-travel-details": {
@@ -7547,7 +7599,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}": {
@@ -7792,7 +7846,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7850,7 +7906,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items": {
@@ -8102,7 +8160,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -8598,7 +8658,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items/{itemId}": {
@@ -9100,7 +9162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9176,7 +9240,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items/{itemId}/travelers": {
@@ -9255,7 +9321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9414,7 +9482,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items/{itemId}/travelers/{linkId}": {
@@ -9500,7 +9570,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/supplier-statuses": {
@@ -9621,7 +9693,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9834,7 +9908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/supplier-statuses/{statusId}": {
@@ -10058,7 +10134,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/fulfillments": {
@@ -10193,7 +10271,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -10449,7 +10529,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/fulfillments/{fulfillmentId}": {
@@ -10711,7 +10793,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/redemptions": {
@@ -10814,7 +10898,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -11011,7 +11097,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/notes": {
@@ -11072,7 +11160,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -11185,7 +11275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/notes/{noteId}": {
@@ -11308,7 +11400,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11366,7 +11460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/documents": {
@@ -11459,7 +11555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -11638,7 +11736,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/documents/{documentId}": {
@@ -11698,7 +11798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups": {
@@ -11868,7 +11970,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12021,7 +12125,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}": {
@@ -12166,7 +12272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12344,7 +12452,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12394,7 +12504,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}/members": {
@@ -12459,7 +12571,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12605,7 +12719,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}/members/{bookingId}": {
@@ -12665,7 +12781,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}/travelers": {
@@ -12715,7 +12833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings": {
@@ -13306,7 +13426,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -14051,7 +14173,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}": {
@@ -14803,7 +14927,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -15576,7 +15702,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -15626,7 +15754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/from-product": {
@@ -16290,7 +16420,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/create": {
@@ -17209,7 +17341,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/dual-create": {
@@ -18786,7 +18920,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/catalog.json
+++ b/packages/openapi/spec/admin/catalog.json
@@ -682,7 +682,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/distribution.json
+++ b/packages/openapi/spec/admin/distribution.json
@@ -344,7 +344,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -575,7 +577,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/batch-update": {
@@ -851,7 +855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/batch-delete": {
@@ -946,7 +952,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/{id}": {
@@ -1101,7 +1109,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1356,7 +1366,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1409,7 +1421,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/{id}/contact-points": {
@@ -1529,7 +1543,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1728,7 +1744,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channel-contact-points/{contactPointId}": {
@@ -1935,7 +1953,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1988,7 +2008,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/{id}/contacts": {
@@ -2115,7 +2137,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2329,7 +2353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channel-contacts/{contactId}": {
@@ -2552,7 +2578,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2605,7 +2633,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts": {
@@ -2812,7 +2842,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3040,7 +3072,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts/batch-update": {
@@ -3313,7 +3347,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts/batch-delete": {
@@ -3408,7 +3444,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts/{id}": {
@@ -3572,7 +3610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3824,7 +3864,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3877,7 +3919,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules": {
@@ -4059,7 +4103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4268,7 +4314,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules/batch-update": {
@@ -4521,7 +4569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules/batch-delete": {
@@ -4616,7 +4666,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules/{id}": {
@@ -4755,7 +4807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4987,7 +5041,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5040,7 +5096,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings": {
@@ -5232,7 +5290,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5447,7 +5507,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings/batch-update": {
@@ -5703,7 +5765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings/batch-delete": {
@@ -5798,7 +5862,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings/{id}": {
@@ -5947,7 +6013,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6182,7 +6250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6235,7 +6305,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links": {
@@ -6440,7 +6512,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6668,7 +6742,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links/batch-update": {
@@ -6923,7 +6999,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links/batch-delete": {
@@ -7018,7 +7096,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links/{id}": {
@@ -7186,7 +7266,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7420,7 +7502,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7473,7 +7557,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events": {
@@ -7628,7 +7714,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -7792,7 +7880,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events/batch-update": {
@@ -8000,7 +8090,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events/batch-delete": {
@@ -8095,7 +8187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events/{id}": {
@@ -8207,7 +8301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8394,7 +8490,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8447,7 +8545,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments": {
@@ -8650,7 +8750,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8852,7 +8954,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments/batch-update": {
@@ -9099,7 +9203,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments/batch-delete": {
@@ -9194,7 +9300,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments/{id}": {
@@ -9330,7 +9438,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9556,7 +9666,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9609,7 +9721,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets": {
@@ -9794,7 +9908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9976,7 +10092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets/batch-update": {
@@ -10204,7 +10322,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets/batch-delete": {
@@ -10299,7 +10419,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets/{id}": {
@@ -10424,7 +10546,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -10631,7 +10755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10684,7 +10810,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules": {
@@ -10827,7 +10955,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10980,7 +11110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules/batch-update": {
@@ -11179,7 +11311,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules/batch-delete": {
@@ -11274,7 +11408,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules/{id}": {
@@ -11384,7 +11520,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11562,7 +11700,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11615,7 +11755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-runs": {
@@ -11813,7 +11955,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12050,7 +12194,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-runs/{id}": {
@@ -12204,7 +12350,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12466,7 +12614,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12519,7 +12669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-items": {
@@ -12715,7 +12867,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12932,7 +13086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-items/{id}": {
@@ -13076,7 +13232,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13318,7 +13476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13371,7 +13531,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-runs": {
@@ -13553,7 +13715,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13761,7 +13925,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-runs/{id}": {
@@ -13900,7 +14066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14133,7 +14301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14186,7 +14356,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-items": {
@@ -14389,7 +14561,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -14593,7 +14767,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-items/{id}": {
@@ -14730,7 +14906,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14959,7 +15137,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -15012,7 +15192,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-executions": {
@@ -15213,7 +15395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -15426,7 +15610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-executions/{id}": {
@@ -15568,7 +15754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -15806,7 +15994,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -15859,7 +16049,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-policies": {
@@ -16053,7 +16245,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -16257,7 +16451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-policies/{id}": {
@@ -16394,7 +16590,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -16623,7 +16821,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16676,7 +16876,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-policies": {
@@ -16864,7 +17066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17057,7 +17261,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-policies/{id}": {
@@ -17188,7 +17394,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -17406,7 +17614,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -17459,7 +17669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/release-schedules": {
@@ -17621,7 +17833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17781,7 +17995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/release-schedules/{id}": {
@@ -17895,7 +18111,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -18080,7 +18298,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18133,7 +18353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/remittance-exceptions": {
@@ -18319,7 +18541,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -18523,7 +18747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/remittance-exceptions/{id}": {
@@ -18658,7 +18884,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -18886,7 +19114,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18939,7 +19169,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-approvals": {
@@ -19083,7 +19315,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -19234,7 +19468,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-approvals/{id}": {
@@ -19344,7 +19580,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -19520,7 +19758,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19573,7 +19813,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/external-refs.json
+++ b/packages/openapi/spec/admin/external-refs.json
@@ -351,7 +351,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -549,7 +551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/external-refs/refs/{id}": {
@@ -676,7 +680,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -895,7 +901,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -948,7 +956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/external-refs/entities/{entityType}/{entityId}/refs": {
@@ -1170,7 +1180,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1374,7 +1386,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/extras.json
+++ b/packages/openapi/spec/admin/extras.json
@@ -389,7 +389,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -673,7 +675,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/product-extras/{id}": {
@@ -848,7 +852,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1156,7 +1162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1206,7 +1214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/option-extra-configs": {
@@ -1428,7 +1438,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1680,7 +1692,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/option-extra-configs/{id}": {
@@ -1841,7 +1855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2117,7 +2133,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2167,7 +2185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/booking-extras": {
@@ -2419,7 +2439,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2719,7 +2741,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/booking-extras/{id}": {
@@ -2901,7 +2925,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3224,7 +3250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3274,7 +3302,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}": {
@@ -3821,7 +3851,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}/selections": {
@@ -4095,7 +4127,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}/selections/bulk": {
@@ -4385,7 +4419,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}/collections/bulk": {
@@ -4640,7 +4676,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/finance.json
+++ b/packages/openapi/spec/admin/finance.json
@@ -646,7 +646,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1527,7 +1529,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}": {
@@ -1889,7 +1893,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2794,7 +2800,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/requires-redirect": {
@@ -3269,7 +3277,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/complete": {
@@ -3684,7 +3694,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/fail": {
@@ -4047,7 +4059,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/cancel": {
@@ -4410,7 +4424,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/expire": {
@@ -4773,7 +4789,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-instruments": {
@@ -5097,7 +5115,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5480,7 +5500,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-instruments/{id}": {
@@ -5702,7 +5724,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6109,7 +6133,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6159,7 +6185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-authorizations": {
@@ -6413,7 +6441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6944,7 +6974,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-authorizations/{id}": {
@@ -7125,7 +7157,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7680,7 +7714,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7730,7 +7766,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-captures": {
@@ -7910,7 +7948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8114,7 +8154,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-captures/{id}": {
@@ -8250,7 +8292,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8478,7 +8522,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8528,7 +8574,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/revenue": {
@@ -8591,7 +8639,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/aging": {
@@ -8644,7 +8694,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability": {
@@ -8722,7 +8774,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/departures": {
@@ -9035,7 +9089,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/products": {
@@ -9298,7 +9354,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/travelers": {
@@ -9412,7 +9470,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/departures/export": {
@@ -9478,7 +9538,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/products/export": {
@@ -9528,7 +9590,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/cost-categories": {
@@ -9599,7 +9663,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9691,7 +9757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/cost-categories/{id}": {
@@ -9813,7 +9881,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/accountant-shares": {
@@ -9888,7 +9958,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9994,7 +10066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/accountant-shares/{id}/revoke": {
@@ -10054,7 +10128,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules": {
@@ -10160,7 +10236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -10398,7 +10476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules/default-plan": {
@@ -10606,7 +10686,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}": {
@@ -10849,7 +10931,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10907,7 +10991,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session": {
@@ -11685,7 +11771,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/guarantees": {
@@ -11852,7 +11940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12167,7 +12257,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session": {
@@ -12945,7 +13037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}": {
@@ -13267,7 +13361,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13351,7 +13447,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/tax-lines": {
@@ -13465,7 +13563,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -13687,7 +13787,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/tax-lines/{taxLineId}": {
@@ -13914,7 +14016,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13972,7 +14076,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/commissions": {
@@ -14112,7 +14218,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -14385,7 +14493,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/commissions/{commissionId}": {
@@ -14663,7 +14773,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14721,7 +14833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payments": {
@@ -15057,7 +15171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payments/{id}": {
@@ -15252,7 +15368,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "description": "Update a customer payment. Recomputes the invoice's paid/balance/status from the remaining completed payments. Supplier payments (`spay_*` id) must be updated via `/supplier-payments/{id}` and return 400 here.",
@@ -15552,7 +15670,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "description": "Remove a customer payment, recomputing invoice totals the same way PATCH does. Supplier payments (`spay_*` id) must be deleted via `/supplier-payments/{id}` and return 400 here.",
@@ -15734,7 +15854,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-payments": {
@@ -16031,7 +16153,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -16336,7 +16460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-payments/{id}": {
@@ -16665,7 +16791,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices": {
@@ -17060,7 +17188,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17518,7 +17648,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/from-booking": {
@@ -18038,7 +18170,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/convert-to-invoice": {
@@ -18327,7 +18461,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}": {
@@ -18611,7 +18747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -19069,7 +19207,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19137,7 +19277,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/void": {
@@ -19444,7 +19586,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/payment-session": {
@@ -20213,7 +20357,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/line-items": {
@@ -20307,7 +20453,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -20491,7 +20639,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/line-items/{lineId}": {
@@ -20680,7 +20830,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -20738,7 +20890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/payments": {
@@ -20888,7 +21042,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -21201,7 +21357,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/credit-notes": {
@@ -21311,7 +21469,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -21543,7 +21703,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}": {
@@ -21779,7 +21941,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}/line-items": {
@@ -21860,7 +22024,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -22012,7 +22178,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/notes": {
@@ -22073,7 +22241,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -22185,7 +22355,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-number-series": {
@@ -22364,7 +22536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -22593,7 +22767,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-number-series/{id}": {
@@ -22739,7 +22915,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -22999,7 +23177,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -23056,7 +23236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-number-series/{id}/allocate": {
@@ -23152,7 +23334,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-templates": {
@@ -23316,7 +23500,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -23503,7 +23689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-templates/{id}": {
@@ -23626,7 +23814,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -23843,7 +24033,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -23900,7 +24092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-regimes": {
@@ -24069,7 +24263,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -24257,7 +24453,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-regimes/{id}": {
@@ -24383,7 +24581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -24602,7 +24802,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -24659,7 +24861,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-classes": {
@@ -24816,7 +25020,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25004,7 +25210,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-classes/{id}": {
@@ -25133,7 +25341,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -25352,7 +25562,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -25409,7 +25621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-profiles": {
@@ -25543,7 +25757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25676,7 +25892,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-profiles/{id}": {
@@ -25777,7 +25995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -25941,7 +26161,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -25998,7 +26220,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-rules": {
@@ -26156,7 +26380,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -26329,7 +26555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-rules/{id}": {
@@ -26450,7 +26678,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -26653,7 +26883,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -26710,7 +26942,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/renditions": {
@@ -26837,7 +27071,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/render": {
@@ -27323,7 +27559,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/attachments": {
@@ -27413,7 +27651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -27595,7 +27835,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/attachments/{attachmentId}": {
@@ -27784,7 +28026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -27842,7 +28086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-attachments/{id}/download": {
@@ -27897,7 +28143,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/external-refs": {
@@ -28001,7 +28249,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -28203,7 +28453,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/external-refs/{refId}": {
@@ -28263,7 +28515,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/vouchers": {
@@ -28501,7 +28755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -28770,7 +29026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/vouchers/{id}": {
@@ -28938,7 +29196,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -29182,7 +29442,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/vouchers/{id}/redeem": {
@@ -29487,7 +29749,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payments": {
@@ -29662,7 +29926,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/action-ledger": {
@@ -30035,7 +30301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/action-ledger": {
@@ -30408,7 +30676,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices": {
@@ -30768,7 +31038,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -31488,7 +31760,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}": {
@@ -31939,7 +32213,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -32512,7 +32788,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -32570,7 +32848,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/lines": {
@@ -33128,7 +33408,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/allocations": {
@@ -33692,7 +33974,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/document/download": {
@@ -33747,7 +34031,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/payments": {
@@ -34052,7 +34338,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -34363,7 +34651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/attachments": {
@@ -34453,7 +34743,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -34624,7 +34916,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/attachments/{attachmentId}": {
@@ -34684,7 +34978,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoice-attachments/{id}/download": {
@@ -34739,7 +35035,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/generate-document": {
@@ -35004,7 +35302,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/regenerate-document": {
@@ -35269,7 +35569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-renditions/{id}/download": {
@@ -35324,7 +35626,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/poll-settlement": {
@@ -35498,7 +35802,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/identity.json
+++ b/packages/openapi/spec/admin/identity.json
@@ -349,7 +349,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -547,7 +549,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/contact-points/{id}": {
@@ -679,7 +683,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "tags": [
@@ -899,7 +905,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "tags": [
@@ -956,7 +964,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/addresses": {
@@ -1210,7 +1220,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -1499,7 +1511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/addresses/{id}": {
@@ -1682,7 +1696,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "tags": [
@@ -1995,7 +2011,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "tags": [
@@ -2052,7 +2070,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/named-contacts": {
@@ -2265,7 +2285,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -2479,7 +2501,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/named-contacts/{id}": {
@@ -2619,7 +2643,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "tags": [
@@ -2856,7 +2882,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "tags": [
@@ -2913,7 +2941,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/contact-points": {
@@ -3038,7 +3068,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -3242,7 +3274,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/addresses": {
@@ -3418,7 +3452,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -3711,7 +3747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/named-contacts": {
@@ -3844,7 +3882,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -4064,7 +4104,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/legal.json
+++ b/packages/openapi/spec/admin/legal.json
@@ -336,7 +336,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -526,7 +528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/default": {
@@ -685,7 +689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}": {
@@ -810,7 +816,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1022,7 +1030,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1075,7 +1085,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}/preview": {
@@ -1168,7 +1180,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}/render-preview": {
@@ -1261,7 +1275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}/versions": {
@@ -1337,7 +1353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1484,7 +1502,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/template-versions/{id}": {
@@ -1575,7 +1595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/number-series": {
@@ -1718,7 +1740,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1924,7 +1948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/number-series/{id}": {
@@ -2061,7 +2087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2285,7 +2313,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2338,7 +2368,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/bookings/{bookingId}/generate-document": {
@@ -2541,7 +2573,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts": {
@@ -3035,7 +3069,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3657,7 +3693,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}": {
@@ -3981,7 +4019,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4613,7 +4653,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4684,7 +4726,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/issue": {
@@ -5026,7 +5070,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/send": {
@@ -5386,7 +5432,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/sign": {
@@ -6092,7 +6140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/execute": {
@@ -6434,7 +6484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/void": {
@@ -6776,7 +6828,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/render": {
@@ -6869,7 +6923,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/generate-document": {
@@ -6976,7 +7032,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/regenerate-document": {
@@ -7083,7 +7141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/regenerate-pdf": {
@@ -7190,7 +7250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/signatures": {
@@ -7370,7 +7432,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/attachments": {
@@ -7512,7 +7576,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -7846,7 +7912,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/attachments/upload": {
@@ -8051,7 +8119,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/attach-document": {
@@ -8256,7 +8326,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/attachments/{attachmentId}": {
@@ -8589,7 +8661,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8642,7 +8716,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/attachments/{attachmentId}/upload": {
@@ -8847,7 +8923,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/attachments/{attachmentId}/download": {
@@ -8902,7 +8980,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/{id}/versions": {
@@ -9005,7 +9085,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9179,7 +9261,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}": {
@@ -9297,7 +9381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9468,7 +9554,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}/publish": {
@@ -9604,7 +9692,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}/retire": {
@@ -9722,7 +9812,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}/rules": {
@@ -9858,7 +9950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -10120,7 +10214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/rules/{ruleId}": {
@@ -10380,7 +10476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10430,7 +10528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/assignments": {
@@ -10645,7 +10745,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10854,7 +10956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/assignments/{id}": {
@@ -11089,7 +11193,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11139,7 +11245,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/acceptances": {
@@ -11410,7 +11518,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11734,7 +11844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/resolve": {
@@ -12163,7 +12275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies": {
@@ -12319,7 +12433,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12477,7 +12593,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/{id}": {
@@ -12586,7 +12704,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12766,7 +12886,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12834,7 +12956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/{id}/evaluate": {
@@ -12954,7 +13078,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/terms": {
@@ -13266,7 +13392,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13664,7 +13792,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/terms/{id}": {
@@ -13859,7 +13989,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14281,7 +14413,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14331,7 +14465,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/markets.json
+++ b/packages/openapi/spec/admin/markets.json
@@ -316,7 +316,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -517,7 +519,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/markets/{id}": {
@@ -646,7 +650,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -869,7 +875,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -922,7 +930,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-locales": {
@@ -1056,7 +1066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/markets/{id}/locales": {
@@ -1196,7 +1208,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-locales/{id}": {
@@ -1333,7 +1347,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1386,7 +1402,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-currencies": {
@@ -1528,7 +1546,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/markets/{id}/currencies": {
@@ -1684,7 +1704,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-currencies/{id}": {
@@ -1837,7 +1859,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1890,7 +1914,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/fx-rate-sets": {
@@ -2043,7 +2069,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2209,7 +2237,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/fx-rate-sets/{id}": {
@@ -2322,7 +2352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2512,7 +2544,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2565,7 +2599,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/exchange-rates": {
@@ -2702,7 +2738,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/fx-rate-sets/{id}/exchange-rates": {
@@ -2861,7 +2899,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/exchange-rates/{id}": {
@@ -3015,7 +3055,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3068,7 +3110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/price-catalogs": {
@@ -3214,7 +3258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3370,7 +3416,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/price-catalogs/{id}": {
@@ -3473,7 +3521,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3635,7 +3685,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3688,7 +3740,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/product-rules": {
@@ -3895,7 +3949,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4130,7 +4186,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/product-rules/{id}": {
@@ -4273,7 +4331,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4514,7 +4574,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4567,7 +4629,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/channel-rules": {
@@ -4739,7 +4803,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4921,7 +4987,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/channel-rules/{id}": {
@@ -5037,7 +5105,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5225,7 +5295,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5278,7 +5350,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/notifications.json
+++ b/packages/openapi/spec/admin/notifications.json
@@ -339,7 +339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -554,7 +556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/templates/{id}": {
@@ -694,7 +698,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -932,7 +938,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -967,7 +975,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/preview": {
@@ -1117,7 +1127,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/deliveries": {
@@ -1481,7 +1493,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/deliveries/{id}": {
@@ -1724,7 +1738,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/deliveries/{id}/resend": {
@@ -1985,7 +2001,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules": {
@@ -2194,7 +2212,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2431,7 +2451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/compose": {
@@ -2943,7 +2965,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}": {
@@ -3091,7 +3115,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3350,7 +3376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3385,7 +3413,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages": {
@@ -3539,7 +3569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3834,7 +3866,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/reorder": {
@@ -4030,7 +4064,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/{stageId}": {
@@ -4346,7 +4382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4389,7 +4427,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels": {
@@ -4511,7 +4551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -4720,7 +4762,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels/{channelId}": {
@@ -4954,7 +4998,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5005,7 +5051,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/notification-settings": {
@@ -5105,7 +5153,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -5304,7 +5354,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminders/preview": {
@@ -5424,7 +5476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-runs": {
@@ -5874,7 +5928,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-runs/{id}": {
@@ -6201,7 +6257,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminders/run-due": {
@@ -6263,7 +6321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/payment-sessions/{id}/send": {
@@ -6680,7 +6740,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/invoices/{id}/send": {
@@ -7097,7 +7159,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/bookings/{id}/document-bundle": {
@@ -7282,7 +7346,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/bookings/{id}/confirm-and-dispatch": {
@@ -7740,7 +7806,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/bookings/{id}/send-documents": {
@@ -7969,7 +8037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/send": {
@@ -8401,7 +8471,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/operations.json
+++ b/packages/openapi/spec/admin/operations.json
@@ -250,7 +250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/overview": {
@@ -505,7 +507,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules": {
@@ -692,7 +696,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -887,7 +893,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules/batch-update": {
@@ -1125,7 +1133,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules/batch-delete": {
@@ -1220,7 +1230,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules/{id}": {
@@ -1350,7 +1362,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1567,7 +1581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1620,7 +1636,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times": {
@@ -1789,7 +1807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1945,7 +1965,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times/batch-update": {
@@ -2146,7 +2168,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times/batch-delete": {
@@ -2241,7 +2265,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times/{id}": {
@@ -2353,7 +2379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2533,7 +2561,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2586,7 +2616,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots": {
@@ -2896,7 +2928,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3242,7 +3276,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/batch-update": {
@@ -3631,7 +3667,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/batch-delete": {
@@ -3726,7 +3764,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}": {
@@ -3937,7 +3977,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4305,7 +4347,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4358,7 +4402,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/unit-availability": {
@@ -4450,7 +4496,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts": {
@@ -4588,7 +4636,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4710,7 +4760,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts/batch-update": {
@@ -4877,7 +4929,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts/batch-delete": {
@@ -4972,7 +5026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts/{id}": {
@@ -5065,7 +5121,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5211,7 +5269,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5264,7 +5324,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation": {
@@ -5683,7 +5745,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/resources": {
@@ -5876,7 +5940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}": {
@@ -6109,7 +6175,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6190,7 +6258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}": {
@@ -6354,7 +6424,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}/sharing-group": {
@@ -6509,7 +6581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/pair": {
@@ -6662,7 +6736,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/{groupId}/label": {
@@ -6820,7 +6896,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6956,7 +7034,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/audit-log": {
@@ -7061,7 +7141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/export-passengers": {
@@ -7105,7 +7187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/export-rooming-list": {
@@ -7149,7 +7233,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/auto-materialize": {
@@ -7365,7 +7451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/materialize-templates": {
@@ -7483,7 +7571,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/auto-allocate": {
@@ -7699,7 +7789,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/products/{productId}/allocation/resource-templates": {
@@ -7846,7 +7938,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/products/{productId}/options/{optionId}/allocation/resource-templates/{kind}": {
@@ -8095,7 +8189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8239,7 +8335,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/products/{id}/allocation/materialize-open-slots": {
@@ -8376,7 +8474,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points": {
@@ -8526,7 +8626,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8660,7 +8762,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points/batch-update": {
@@ -8839,7 +8943,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points/batch-delete": {
@@ -8934,7 +9040,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points/{id}": {
@@ -9035,7 +9143,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9193,7 +9303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9246,7 +9358,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups": {
@@ -9365,7 +9479,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9479,7 +9595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups/batch-update": {
@@ -9638,7 +9756,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups/batch-delete": {
@@ -9733,7 +9853,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups/{id}": {
@@ -9823,7 +9945,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9961,7 +10085,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10014,7 +10140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs": {
@@ -10224,7 +10352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10433,7 +10563,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs/batch-update": {
@@ -10688,7 +10820,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs/batch-delete": {
@@ -10783,7 +10917,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs/{id}": {
@@ -10923,7 +11059,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11157,7 +11295,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11210,7 +11350,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups": {
@@ -11358,7 +11500,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11492,7 +11636,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups/batch-update": {
@@ -11670,7 +11816,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups/batch-delete": {
@@ -11765,7 +11913,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups/{id}": {
@@ -11865,7 +12015,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12022,7 +12174,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12075,7 +12229,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations": {
@@ -12230,7 +12386,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12386,7 +12544,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations/batch-update": {
@@ -12587,7 +12747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations/batch-delete": {
@@ -12682,7 +12844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations/{id}": {
@@ -12794,7 +12958,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12974,7 +13140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13027,7 +13195,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times": {
@@ -13211,7 +13381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13406,7 +13578,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times/batch-update": {
@@ -13647,7 +13821,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times/batch-delete": {
@@ -13742,7 +13918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times/{id}": {
@@ -13875,7 +14053,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14095,7 +14275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14148,7 +14330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas": {
@@ -14277,7 +14461,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -14398,7 +14584,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas/batch-update": {
@@ -14564,7 +14752,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas/batch-delete": {
@@ -14659,7 +14849,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas/{id}": {
@@ -14753,7 +14945,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14898,7 +15092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14951,7 +15147,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources": {
@@ -15133,7 +15331,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -15310,7 +15510,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources/batch-update": {
@@ -15532,7 +15734,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources/batch-delete": {
@@ -15627,7 +15831,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources/{id}": {
@@ -15750,7 +15956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -15951,7 +16159,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16004,7 +16214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools": {
@@ -16164,7 +16376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -16315,7 +16529,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools/batch-update": {
@@ -16511,7 +16727,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools/batch-delete": {
@@ -16606,7 +16824,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools/{id}": {
@@ -16715,7 +16935,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -16890,7 +17112,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16943,7 +17167,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pool-members": {
@@ -17044,7 +17270,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17162,7 +17390,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pool-members/{id}": {
@@ -17217,7 +17447,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements": {
@@ -17368,7 +17600,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17531,7 +17765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements/batch-update": {
@@ -17721,7 +17957,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements/batch-delete": {
@@ -17816,7 +18054,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements/{id}": {
@@ -17922,7 +18162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -18091,7 +18333,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18144,7 +18388,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations": {
@@ -18295,7 +18541,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -18458,7 +18706,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations/batch-update": {
@@ -18648,7 +18898,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations/batch-delete": {
@@ -18743,7 +18995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations/{id}": {
@@ -18849,7 +19103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -19018,7 +19274,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19071,7 +19329,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments": {
@@ -19252,7 +19512,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -19445,7 +19707,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments/batch-update": {
@@ -19666,7 +19930,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments/batch-delete": {
@@ -19761,7 +20027,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments/{id}": {
@@ -19882,7 +20150,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -20082,7 +20352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -20135,7 +20407,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts": {
@@ -20265,7 +20539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -20420,7 +20696,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts/batch-update": {
@@ -20602,7 +20880,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts/batch-delete": {
@@ -20697,7 +20977,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts/{id}": {
@@ -20797,7 +21079,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -20958,7 +21242,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -21011,7 +21297,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/operators": {
@@ -21158,7 +21446,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -21299,7 +21589,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/operators/{id}": {
@@ -21403,7 +21695,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -21569,7 +21863,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -21622,7 +21918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/vehicles": {
@@ -21840,7 +22138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -22084,7 +22384,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/vehicles/{id}": {
@@ -22240,7 +22542,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -22509,7 +22813,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -22562,7 +22868,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/drivers": {
@@ -22717,7 +23025,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -22875,7 +23185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/drivers/{id}": {
@@ -22987,7 +23299,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -23170,7 +23484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -23223,7 +23539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/transfer-preferences": {
@@ -23494,7 +23812,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -23871,7 +24191,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/transfer-preferences/{id}": {
@@ -24098,7 +24420,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -24500,7 +24824,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -24553,7 +24879,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatches": {
@@ -24824,7 +25152,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25117,7 +25447,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatches/{id}": {
@@ -25299,7 +25631,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -25616,7 +25950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -25669,7 +26005,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/execution-events": {
@@ -25825,7 +26163,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25994,7 +26334,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/execution-events/{id}": {
@@ -26110,7 +26452,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -26304,7 +26648,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -26357,7 +26703,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-assignments": {
@@ -26543,7 +26891,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -26731,7 +27081,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-assignments/{id}": {
@@ -26859,7 +27211,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -27072,7 +27426,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -27125,7 +27481,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-legs": {
@@ -27289,7 +27647,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -27478,7 +27838,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-legs/{id}": {
@@ -27607,7 +27969,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -27821,7 +28185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -27874,7 +28240,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-passengers": {
@@ -28003,7 +28371,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -28133,7 +28503,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-passengers/{id}": {
@@ -28233,7 +28605,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -28388,7 +28762,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -28441,7 +28817,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/driver-shifts": {
@@ -28613,7 +28991,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -28785,7 +29165,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/driver-shifts/{id}": {
@@ -28905,7 +29287,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -29100,7 +29484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -29153,7 +29539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/service-incidents": {
@@ -29322,7 +29710,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -29500,7 +29890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/service-incidents/{id}": {
@@ -29621,7 +30013,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -29823,7 +30217,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -29876,7 +30272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-checkpoints": {
@@ -30044,7 +30442,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -30242,7 +30642,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-checkpoints/{id}": {
@@ -30375,7 +30777,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -30597,7 +31001,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -30650,7 +31056,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities": {
@@ -30968,7 +31376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -31327,7 +31737,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}": {
@@ -31548,7 +31960,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -31931,7 +32345,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -31984,7 +32400,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/contact-points": {
@@ -32097,7 +32515,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -32307,7 +32727,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/contact-points/{id}": {
@@ -32525,7 +32947,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -32578,7 +33002,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/addresses": {
@@ -32742,7 +33168,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -33041,7 +33469,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/addresses/{id}": {
@@ -33352,7 +33782,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -33405,7 +33837,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-contacts": {
@@ -33579,7 +34013,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/contacts": {
@@ -33790,7 +34226,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-contacts/{id}": {
@@ -33998,7 +34436,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -34051,7 +34491,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-features": {
@@ -34205,7 +34647,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/features": {
@@ -34399,7 +34843,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-features/{id}": {
@@ -34590,7 +35036,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -34643,7 +35091,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-operation-schedules": {
@@ -34809,7 +35259,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/operation-schedules": {
@@ -35019,7 +35471,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-operation-schedules/{id}": {
@@ -35229,7 +35683,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -35282,7 +35738,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/properties": {
@@ -35479,7 +35937,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -35711,7 +36171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/properties/{id}": {
@@ -35853,7 +36315,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -36092,7 +36556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -36145,7 +36611,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-groups": {
@@ -36348,7 +36816,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -36567,7 +37037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-groups/{id}": {
@@ -36711,7 +37183,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -36955,7 +37429,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -37008,7 +37484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-group-members": {
@@ -37164,7 +37642,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -37339,7 +37819,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-group-members/{id}": {
@@ -37451,7 +37933,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -37632,7 +38116,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -37685,7 +38171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/function-spaces": {
@@ -37854,7 +38342,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -38060,7 +38550,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/function-spaces/{id}": {
@@ -38239,7 +38731,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -38454,7 +38948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/function-spaces/{id}/capacities": {
@@ -38601,7 +39097,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks": {
@@ -38837,7 +39335,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}": {
@@ -39055,7 +39555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/slots": {
@@ -39209,7 +39711,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/pickups": {
@@ -39477,7 +39981,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/pickups/reverse": {
@@ -39620,7 +40126,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/release": {
@@ -39798,7 +40306,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/operator-settings.json
+++ b/packages/openapi/spec/admin/operator-settings.json
@@ -272,7 +272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -509,7 +511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/settings/operator-payment-instructions": {
@@ -580,7 +584,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -685,7 +691,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/settings/operator-payment-defaults": {
@@ -743,7 +751,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -874,7 +884,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/settings/operator": {
@@ -1029,7 +1041,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -1381,7 +1395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/pricing.json
+++ b/packages/openapi/spec/admin/pricing.json
@@ -387,7 +387,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -630,7 +632,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pricing-categories/{id}": {
@@ -794,7 +798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1056,7 +1062,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1106,7 +1114,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pricing-category-dependencies": {
@@ -1274,7 +1284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1411,7 +1423,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pricing-category-dependencies/{id}": {
@@ -1522,7 +1536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1681,7 +1697,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1731,7 +1749,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policies": {
@@ -1913,7 +1933,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2067,7 +2089,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policies/{id}": {
@@ -2186,7 +2210,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2362,7 +2388,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2412,7 +2440,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policy-rules": {
@@ -2564,7 +2594,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2714,7 +2746,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policy-rules/{id}": {
@@ -2831,7 +2865,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3003,7 +3039,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3053,7 +3091,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-catalogs": {
@@ -3235,7 +3275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3393,7 +3435,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-catalogs/{id}": {
@@ -3512,7 +3556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3691,7 +3737,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3741,7 +3789,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-schedules": {
@@ -3925,7 +3975,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4132,7 +4184,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-schedules/{id}": {
@@ -4273,7 +4327,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4501,7 +4557,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4551,7 +4609,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-price-rules": {
@@ -4811,7 +4871,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5080,7 +5142,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-price-rules/{id}": {
@@ -5258,7 +5322,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5545,7 +5611,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5595,7 +5663,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-price-rules": {
@@ -5804,7 +5874,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6017,7 +6089,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-price-rules/{id}": {
@@ -6167,7 +6241,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6400,7 +6476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6450,7 +6528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-start-time-rules": {
@@ -6635,7 +6715,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6818,7 +6900,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-start-time-rules/{id}": {
@@ -6952,7 +7036,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7156,7 +7242,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7206,7 +7294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-tiers": {
@@ -7346,7 +7436,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -7473,7 +7565,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-tiers/{id}": {
@@ -7578,7 +7672,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7727,7 +7823,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7777,7 +7875,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pickup-price-rules": {
@@ -7948,7 +8048,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8103,7 +8205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pickup-price-rules/{id}": {
@@ -8223,7 +8327,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8398,7 +8504,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8448,7 +8556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/dropoff-price-rules": {
@@ -8633,7 +8743,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8817,7 +8929,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/dropoff-price-rules/{id}": {
@@ -8951,7 +9065,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9155,7 +9271,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9205,7 +9323,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/extra-price-rules": {
@@ -9402,7 +9522,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9591,7 +9713,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/extra-price-rules/{id}": {
@@ -9729,7 +9853,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9939,7 +10065,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9989,7 +10117,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/departure-price-overrides": {
@@ -10162,7 +10292,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10305,7 +10437,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/departure-price-overrides/{id}": {
@@ -10419,7 +10553,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -10582,7 +10718,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10632,7 +10770,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/products.json
+++ b/packages/openapi/spec/admin/products.json
@@ -288,7 +288,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/activation-settings/{id}": {
@@ -397,7 +399,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -571,7 +575,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -621,7 +627,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/activation-settings": {
@@ -797,7 +805,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/ticket-settings": {
@@ -953,7 +963,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/ticket-settings/{id}": {
@@ -1074,7 +1086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1270,7 +1284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1320,7 +1336,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/ticket-settings": {
@@ -1518,7 +1536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/visibility-settings": {
@@ -1655,7 +1675,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/visibility-settings/{id}": {
@@ -1743,7 +1765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1875,7 +1899,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1925,7 +1951,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/visibility-settings": {
@@ -2059,7 +2087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/capabilities": {
@@ -2219,7 +2249,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/capabilities/{id}": {
@@ -2321,7 +2353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2479,7 +2513,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2529,7 +2565,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/capabilities": {
@@ -2692,7 +2730,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/delivery-formats": {
@@ -2821,7 +2861,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/delivery-formats/{id}": {
@@ -2911,7 +2953,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3046,7 +3090,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3096,7 +3142,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/delivery-formats": {
@@ -3236,7 +3284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/features": {
@@ -3370,7 +3420,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/features/{id}": {
@@ -3468,7 +3520,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3620,7 +3674,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3670,7 +3726,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/features": {
@@ -3827,7 +3885,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/faqs": {
@@ -3932,7 +3992,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/faqs/{id}": {
@@ -4016,7 +4078,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4142,7 +4206,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4192,7 +4258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/faqs": {
@@ -4324,7 +4392,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/locations": {
@@ -4511,7 +4581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/locations/{id}": {
@@ -4660,7 +4732,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4918,7 +4992,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4968,7 +5044,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/locations": {
@@ -5231,7 +5309,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destinations": {
@@ -5442,7 +5522,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5645,7 +5727,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destinations/{id}": {
@@ -5772,7 +5856,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6000,7 +6086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6050,7 +6138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destination-translations": {
@@ -6183,7 +6273,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destinations/{id}/translations": {
@@ -6348,7 +6440,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destination-translations/{id}": {
@@ -6509,7 +6603,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6559,7 +6655,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-category-translations": {
@@ -6692,7 +6790,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-categories/{id}/translations": {
@@ -6857,7 +6957,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-category-translations/{id}": {
@@ -7018,7 +7120,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7068,7 +7172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tag-translations": {
@@ -7180,7 +7286,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tags/{id}/translations": {
@@ -7305,7 +7413,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tag-translations/{id}": {
@@ -7426,7 +7536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7476,7 +7588,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destination-links": {
@@ -7593,7 +7707,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/destinations": {
@@ -7709,7 +7825,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/destinations/{destinationId}": {
@@ -7769,7 +7887,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options": {
@@ -7924,7 +8044,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options/{optionId}": {
@@ -8045,7 +8167,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8238,7 +8362,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8288,7 +8414,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/options": {
@@ -8489,7 +8617,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/units": {
@@ -8682,7 +8812,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/units/{unitId}": {
@@ -8838,7 +8970,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9102,7 +9236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9152,7 +9288,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options/{optionId}/units": {
@@ -9425,7 +9563,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/translations": {
@@ -9593,7 +9733,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/translations/{translationId}": {
@@ -9729,7 +9871,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9954,7 +10098,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10004,7 +10150,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/translations": {
@@ -10235,7 +10383,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/option-translations": {
@@ -10361,7 +10511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/option-translations/{translationId}": {
@@ -10455,7 +10607,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -10600,7 +10754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10650,7 +10806,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options/{optionId}/translations": {
@@ -10801,7 +10959,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/unit-translations": {
@@ -10927,7 +11087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/unit-translations/{translationId}": {
@@ -11021,7 +11183,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11166,7 +11330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11216,7 +11382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/units/{unitId}/translations": {
@@ -11367,7 +11535,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-types": {
@@ -11501,7 +11671,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11635,7 +11807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-types/{typeId}": {
@@ -11734,7 +11908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11892,7 +12068,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11942,7 +12120,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-categories": {
@@ -12092,7 +12272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12291,7 +12473,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-categories/{categoryId}": {
@@ -12398,7 +12582,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12621,7 +12807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12671,7 +12859,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tags": {
@@ -12764,7 +12954,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12844,7 +13036,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tags/{tagId}": {
@@ -12916,7 +13110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13021,7 +13217,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13071,7 +13269,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/media/{mediaId}": {
@@ -13218,7 +13418,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13462,7 +13664,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13607,7 +13811,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/media/{mediaId}/set-cover": {
@@ -13790,7 +13996,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure/versions": {
@@ -13922,7 +14130,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure/versions/{brochureId}/set-current": {
@@ -14077,7 +14287,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure/versions/{brochureId}": {
@@ -14232,7 +14444,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure": {
@@ -14379,7 +14593,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -14601,7 +14817,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14746,7 +14964,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/media/reorder": {
@@ -14842,7 +15062,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/media": {
@@ -15059,7 +15281,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -15314,7 +15538,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/media": {
@@ -15539,7 +15765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -15802,7 +16030,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries": {
@@ -15871,7 +16101,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -15999,7 +16231,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/itineraries/{itineraryId}": {
@@ -16126,7 +16360,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16176,7 +16412,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/itineraries/{itineraryId}/duplicate": {
@@ -16295,7 +16533,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries/{itineraryId}/days": {
@@ -16385,7 +16625,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -16545,7 +16787,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days": {
@@ -16627,7 +16871,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -16779,7 +17025,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}": {
@@ -16938,7 +17186,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16996,7 +17246,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services": {
@@ -17120,7 +17372,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -17355,7 +17609,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services/{serviceId}": {
@@ -17594,7 +17850,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -17660,7 +17918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/translations": {
@@ -17762,7 +18022,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -17924,7 +18186,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/translations/{translationId}": {
@@ -18093,7 +18357,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18159,7 +18425,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/versions": {
@@ -18228,7 +18496,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -18310,7 +18580,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/notes": {
@@ -18371,7 +18643,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -18483,7 +18757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries/{itineraryId}/translations": {
@@ -18568,7 +18844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -18699,7 +18977,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries/{itineraryId}/translations/{translationId}": {
@@ -18836,7 +19116,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18902,7 +19184,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations": {
@@ -19009,7 +19293,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -19174,7 +19460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations/{translationId}": {
@@ -19345,7 +19633,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19419,7 +19709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/categories": {
@@ -19511,7 +19803,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -19600,7 +19894,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/categories/{categoryId}": {
@@ -19660,7 +19956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/tags": {
@@ -19717,7 +20015,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -19803,7 +20103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/tags/{tagId}": {
@@ -19863,7 +20165,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/recalculate": {
@@ -19927,7 +20231,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/aggregates": {
@@ -20030,7 +20336,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products": {
@@ -20533,7 +20841,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -21091,7 +21401,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}": {
@@ -21387,7 +21699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -21962,7 +22276,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -22012,7 +22328,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/action-ledger": {
@@ -22123,7 +22441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/promotions.json
+++ b/packages/openapi/spec/admin/promotions.json
@@ -610,7 +610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1268,7 +1270,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/promotions/{id}": {
@@ -1617,7 +1621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2297,7 +2303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2373,7 +2381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/promotions/{id}/archive": {
@@ -2722,7 +2732,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/quotes.json
+++ b/packages/openapi/spec/admin/quotes.json
@@ -262,7 +262,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -377,7 +379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/pipelines/{id}": {
@@ -467,7 +471,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -607,7 +613,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -678,7 +686,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/stages": {
@@ -798,7 +808,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -932,7 +944,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/stages/{id}": {
@@ -1031,7 +1045,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1189,7 +1205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1242,7 +1260,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes": {
@@ -1528,7 +1548,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1845,7 +1867,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}": {
@@ -2056,7 +2080,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2396,7 +2422,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2449,7 +2477,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/participants": {
@@ -2521,7 +2551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2639,7 +2671,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-participants/{id}": {
@@ -2694,7 +2728,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/products": {
@@ -2808,7 +2844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3001,7 +3039,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-products/{id}": {
@@ -3211,7 +3251,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3264,7 +3306,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/media": {
@@ -3365,7 +3409,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3539,7 +3585,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-media/{id}": {
@@ -3594,7 +3642,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions": {
@@ -3794,7 +3844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/versions": {
@@ -4088,7 +4140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/validity": {
@@ -4291,7 +4345,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/versions/snapshot": {
@@ -4472,7 +4528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/expire": {
@@ -4611,7 +4669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}": {
@@ -4774,7 +4834,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5062,7 +5124,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5133,7 +5197,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/trip-snapshot": {
@@ -5489,7 +5555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/send": {
@@ -5671,7 +5739,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/view": {
@@ -5834,7 +5904,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/accept": {
@@ -6305,7 +6377,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/decline": {
@@ -6487,7 +6561,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/lines": {
@@ -6578,7 +6654,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -6767,7 +6845,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-version-lines/{id}": {
@@ -6954,7 +7034,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7025,7 +7107,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -438,7 +438,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -750,7 +752,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}": {
@@ -941,7 +945,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1278,7 +1284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1331,7 +1339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/merge": {
@@ -1559,7 +1569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/contact-methods": {
@@ -1661,7 +1673,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1854,7 +1868,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/addresses": {
@@ -2008,7 +2024,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2293,7 +2311,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/notes": {
@@ -2354,7 +2374,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2466,7 +2488,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organization-notes/{id}": {
@@ -2580,7 +2604,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2633,7 +2659,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people": {
@@ -2946,7 +2974,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3377,7 +3407,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}": {
@@ -3597,7 +3629,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4052,7 +4086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4105,7 +4141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/merge": {
@@ -4362,7 +4400,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/contact-methods": {
@@ -4464,7 +4504,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -4657,7 +4699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/addresses": {
@@ -4811,7 +4855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -5096,7 +5142,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/notes": {
@@ -5157,7 +5205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -5269,7 +5319,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-notes/{id}": {
@@ -5383,7 +5435,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5436,7 +5490,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/payment-methods": {
@@ -5529,7 +5585,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -5717,7 +5775,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-payment-methods/{id}": {
@@ -5903,7 +5963,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5956,7 +6018,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/communications": {
@@ -6125,7 +6189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -6316,7 +6382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/segments": {
@@ -6378,7 +6446,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6486,7 +6556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/segments/{segmentId}": {
@@ -6541,7 +6613,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/export": {
@@ -6557,7 +6631,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/import": {
@@ -6628,7 +6704,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/contact-methods/{id}": {
@@ -6835,7 +6913,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6888,7 +6968,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/addresses/{id}": {
@@ -7189,7 +7271,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7242,7 +7326,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/documents": {
@@ -7413,7 +7499,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -7656,7 +7744,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}": {
@@ -7794,7 +7884,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8034,7 +8126,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8087,7 +8181,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}/set-primary": {
@@ -8225,7 +8321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/travel-snapshot": {
@@ -8370,7 +8468,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/profile-pii": {
@@ -8501,7 +8601,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/documents/from-plaintext": {
@@ -8756,7 +8858,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}/from-plaintext": {
@@ -9008,7 +9112,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}/reveal": {
@@ -9115,7 +9221,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/relationships": {
@@ -9306,7 +9414,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9541,7 +9651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-relationships/{id}": {
@@ -9688,7 +9800,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9930,7 +10044,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9983,7 +10099,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/customer-signals": {
@@ -10234,7 +10352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10536,7 +10656,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/customer-signals/{id}": {
@@ -10711,7 +10833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11014,7 +11138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11067,7 +11193,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/customer-signals/{id}/resolve": {
@@ -11279,7 +11407,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/signals": {
@@ -11439,7 +11569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities": {
@@ -11652,7 +11784,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11845,7 +11979,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities/{id}": {
@@ -11978,7 +12114,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12195,7 +12333,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12248,7 +12388,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities/{id}/links": {
@@ -12323,7 +12465,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12447,7 +12591,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activity-links/{id}": {
@@ -12502,7 +12648,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities/{id}/participants": {
@@ -12563,7 +12711,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12659,7 +12809,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activity-participants/{id}": {
@@ -12714,7 +12866,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-fields": {
@@ -12874,7 +13028,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13075,7 +13231,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-fields/{id}": {
@@ -13208,7 +13366,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13406,7 +13566,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13459,7 +13621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-field-values": {
@@ -13634,7 +13798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-fields/{id}/value": {
@@ -13848,7 +14014,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-field-values/{id}": {
@@ -13903,7 +14071,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/sellability.json
+++ b/packages/openapi/spec/admin/sellability.json
@@ -281,7 +281,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/resolve-and-persist": {
@@ -549,7 +551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/snapshots": {
@@ -780,7 +784,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/snapshots/{id}": {
@@ -937,7 +943,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/snapshot-items": {
@@ -1181,7 +1189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policies": {
@@ -1431,7 +1441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1677,7 +1689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policies/{id}": {
@@ -1835,7 +1849,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2106,7 +2122,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2156,7 +2174,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policy-results": {
@@ -2318,7 +2338,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2475,7 +2497,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policy-results/{id}": {
@@ -2586,7 +2610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2768,7 +2794,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2818,7 +2846,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-refresh-runs": {
@@ -2978,7 +3008,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3144,7 +3176,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-refresh-runs/{id}": {
@@ -3260,7 +3294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3451,7 +3487,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3501,7 +3539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-expiration-events": {
@@ -3659,7 +3699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3821,7 +3863,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-expiration-events/{id}": {
@@ -3936,7 +3980,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4122,7 +4168,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4172,7 +4220,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/explanations": {
@@ -4329,7 +4379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4488,7 +4540,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/explanations/{id}": {
@@ -4599,7 +4653,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4782,7 +4838,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4832,7 +4890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/storefront.json
+++ b/packages/openapi/spec/admin/storefront.json
@@ -768,7 +768,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -1945,7 +1947,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/suppliers.json
+++ b/packages/openapi/spec/admin/suppliers.json
@@ -258,7 +258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -468,7 +470,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/contact-points/{contactPointId}": {
@@ -686,7 +690,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -736,7 +742,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/contacts": {
@@ -857,7 +865,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1083,7 +1093,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/contacts/{contactId}": {
@@ -1318,7 +1330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1368,7 +1382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/addresses": {
@@ -1532,7 +1548,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1831,7 +1849,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/addresses/{addressId}": {
@@ -2142,7 +2162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2192,7 +2214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services": {
@@ -2307,7 +2331,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2521,7 +2547,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services/{serviceId}": {
@@ -2741,7 +2769,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2799,7 +2829,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services/{serviceId}/rates": {
@@ -2918,7 +2950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3142,7 +3176,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services/{serviceId}/rates/{rateId}": {
@@ -3370,7 +3406,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3436,7 +3474,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/notes": {
@@ -3497,7 +3537,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3609,7 +3651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/availability": {
@@ -3693,7 +3737,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3854,7 +3900,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/contracts": {
@@ -3953,7 +4001,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -4137,7 +4187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/contracts/{contractId}": {
@@ -4328,7 +4380,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4386,7 +4440,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/aggregates": {
@@ -4494,7 +4550,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers": {
@@ -4801,7 +4859,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5183,7 +5243,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}": {
@@ -5386,7 +5448,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5792,7 +5856,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5842,7 +5908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/admin/trips.json
+++ b/packages/openapi/spec/admin/trips.json
@@ -187,7 +187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips": {
@@ -794,7 +796,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1308,7 +1312,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}": {
@@ -1762,7 +1768,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2084,7 +2092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/reshop": {
@@ -2450,7 +2460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/snapshots": {
@@ -2588,7 +2600,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2797,7 +2811,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/snapshots/{snapshotId}": {
@@ -2951,7 +2967,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/components": {
@@ -3372,7 +3390,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/components/reorder": {
@@ -3734,7 +3754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/components/{componentId}": {
@@ -4150,7 +4172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4484,7 +4508,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/components/{componentId}/refs": {
@@ -4869,7 +4895,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/requirements": {
@@ -5113,7 +5141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "get": {
         "parameters": [
@@ -5309,7 +5339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/requirements/{requirementId}/candidates": {
@@ -5677,7 +5709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/requirements/{requirementId}/select": {
@@ -6216,7 +6250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/requirements/{requirementId}/reshop": {
@@ -6584,7 +6620,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/price": {
@@ -7147,7 +7185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/reserve": {
@@ -7708,7 +7748,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/checkout": {
@@ -8252,7 +8294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/cancellation-preview": {
@@ -8798,7 +8842,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/cancel-components": {
@@ -9349,7 +9395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/packages/openapi/spec/storefront/booking-requirements.json
+++ b/packages/openapi/spec/storefront/booking-requirements.json
@@ -359,7 +359,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/bookings.json
+++ b/packages/openapi/spec/storefront/bookings.json
@@ -1138,7 +1138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}": {
@@ -1785,7 +1787,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       },
       "patch": {
         "parameters": [
@@ -2583,7 +2587,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/state": {
@@ -2682,7 +2688,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       },
       "put": {
         "parameters": [
@@ -2815,7 +2823,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/reprice": {
@@ -3696,7 +3706,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/confirm": {
@@ -4379,7 +4391,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/expire": {
@@ -5062,7 +5076,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/overview": {
@@ -5594,7 +5610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/guest-lookup": {
@@ -6129,7 +6147,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/catalog.json
+++ b/packages/openapi/spec/storefront/catalog.json
@@ -682,7 +682,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/customer-portal.json
+++ b/packages/openapi/spec/storefront/customer-portal.json
@@ -539,7 +539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "patch": {
         "requestBody": {
@@ -1210,7 +1212,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/me/documents": {
@@ -1317,7 +1321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "requestBody": {
@@ -1515,7 +1521,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/me/documents/{id}/set-primary": {
@@ -1647,7 +1655,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/me/documents/{id}": {
@@ -1854,7 +1864,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -1907,7 +1919,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bootstrap": {
@@ -3186,7 +3200,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/companions": {
@@ -3433,7 +3449,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "requestBody": {
@@ -3923,7 +3941,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/companions/import-booking-travelers": {
@@ -4220,7 +4240,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/companions/{companionId}": {
@@ -4737,7 +4759,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -4808,7 +4832,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings": {
@@ -4953,7 +4979,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings/{bookingId}": {
@@ -5672,7 +5700,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings/{bookingId}/documents": {
@@ -5788,7 +5818,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings/{bookingId}/billing-contact": {
@@ -5914,7 +5946,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/contact-exists": {
@@ -5970,7 +6004,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/contact-exists/phone": {
@@ -6030,7 +6066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/finance.json
+++ b/packages/openapi/spec/storefront/finance.json
@@ -303,7 +303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/documents/by-reference": {
@@ -499,7 +501,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/documents": {
@@ -691,7 +695,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/documents/by-reference": {
@@ -895,7 +901,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/payments": {
@@ -1070,7 +1078,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/payment-options": {
@@ -1426,7 +1436,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/payment-sessions/{sessionId}": {
@@ -1932,7 +1944,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session": {
@@ -2841,7 +2855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session": {
@@ -3750,7 +3766,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/invoices/{invoiceId}/payment-session": {
@@ -4651,7 +4669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/accountant/{token}/summary": {
@@ -4745,7 +4765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/accountant/{token}/invoices": {
@@ -4816,7 +4838,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/legal.json
+++ b/packages/openapi/spec/storefront/legal.json
@@ -304,7 +304,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/{id}/preview": {
@@ -394,7 +396,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/{id}/render-preview": {
@@ -484,7 +488,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/by-slug/{slug}/preview": {
@@ -574,7 +580,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/by-slug/{slug}/render-preview": {
@@ -664,7 +672,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/{id}": {
@@ -836,7 +846,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/{id}/sign": {
@@ -1044,7 +1056,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/policies/{slug}": {
@@ -1231,7 +1245,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/policies/{id}/accept": {
@@ -1567,7 +1583,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/terms": {
@@ -1879,7 +1897,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/terms/{id}": {
@@ -2074,7 +2094,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/markets.json
+++ b/packages/openapi/spec/storefront/markets.json
@@ -248,7 +248,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/operator-settings.json
+++ b/packages/openapi/spec/storefront/operator-settings.json
@@ -223,7 +223,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/settings/operator": {
@@ -301,7 +303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/pricing.json
+++ b/packages/openapi/spec/storefront/pricing.json
@@ -577,7 +577,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/products.json
+++ b/packages/openapi/spec/storefront/products.json
@@ -228,7 +228,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/categories": {
@@ -341,7 +343,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/destinations": {
@@ -548,7 +552,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products": {
@@ -1420,7 +1426,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/slug/{slug}": {
@@ -2101,7 +2109,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{id}": {
@@ -2782,7 +2792,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{id}/brochure": {
@@ -2902,7 +2914,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/storefront-verification.json
+++ b/packages/openapi/spec/storefront/storefront-verification.json
@@ -330,7 +330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/storefront-verification/sms/start": {
@@ -516,7 +518,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/storefront-verification/email/confirm": {
@@ -708,7 +712,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/storefront-verification/sms/confirm": {
@@ -901,7 +907,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/storefront.json
+++ b/packages/openapi/spec/storefront/storefront.json
@@ -305,7 +305,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/offers/{slug}": {
@@ -480,7 +482,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/offers/{slug}/apply": {
@@ -927,7 +931,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/offers/redeem": {
@@ -1370,7 +1376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/leads": {
@@ -1661,7 +1669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/newsletter/subscribe": {
@@ -1917,7 +1927,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/settings": {
@@ -2540,7 +2552,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/departures/{departureId}": {
@@ -2925,7 +2939,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/departures": {
@@ -3365,7 +3381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/availability": {
@@ -3643,7 +3661,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/departures/{departureId}/itinerary": {
@@ -3783,7 +3803,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/extensions": {
@@ -4059,7 +4081,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/spec/storefront/trips.json
+++ b/packages/openapi/spec/storefront/trips.json
@@ -187,7 +187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips": {
@@ -794,7 +796,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "requestBody": {
@@ -1308,7 +1312,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}": {
@@ -1762,7 +1768,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "patch": {
         "parameters": [
@@ -2084,7 +2092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/reshop": {
@@ -2450,7 +2460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/snapshots": {
@@ -2588,7 +2600,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "parameters": [
@@ -2797,7 +2811,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/snapshots/{snapshotId}": {
@@ -2951,7 +2967,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/components": {
@@ -3372,7 +3390,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/components/reorder": {
@@ -3734,7 +3754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/components/{componentId}": {
@@ -4150,7 +4172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -4484,7 +4508,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/components/{componentId}/refs": {
@@ -4869,7 +4895,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/requirements": {
@@ -5113,7 +5141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "get": {
         "parameters": [
@@ -5309,7 +5339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/requirements/{requirementId}/candidates": {
@@ -5677,7 +5709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/requirements/{requirementId}/select": {
@@ -6216,7 +6250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/requirements/{requirementId}/reshop": {
@@ -6584,7 +6620,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/price": {
@@ -7147,7 +7185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/reserve": {
@@ -7708,7 +7748,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/checkout": {
@@ -8252,7 +8294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/cancellation-preview": {
@@ -8798,7 +8842,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/cancel-components": {
@@ -9349,7 +9395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -1,11 +1,13 @@
 import { createVoyantApp } from "@voyant-travel/framework"
 import {
+  buildModulePathOwnership,
   type GenerateOpenApiOptions,
   generateOpenApiDocument,
   mergeLazyOpenApiPaths,
   type OpenApiDocument,
+  partitionByModule,
   selectSurface,
-  splitDocumentByModule,
+  stampModuleMetadata,
 } from "@voyant-travel/hono/openapi"
 
 /**
@@ -64,14 +66,18 @@ export async function buildFrameworkOpenApiDocuments(): Promise<FrameworkOpenApi
   // Lazy families mount as runtime wildcard stubs, so their `.openapi()` routes
   // never reach the composed registry — replay their loaders and merge, matching
   // the operator generator and the per-module docs (which load lazily too).
-  const full = await mergeLazyOpenApiPaths(eager, app.lazyMounts ?? [], OPENAPI_OPTIONS)
-  // Partition the FULL surface so nothing is dropped — `additionalRoutes` and
-  // directly-mounted routes (`_meta/capabilities`) aren't in the manifest.
-  const modules = await splitDocumentByModule(full, app.moduleMounts ?? [], OPENAPI_OPTIONS)
+  const merged = await mergeLazyOpenApiPaths(eager, app.lazyMounts ?? [], OPENAPI_OPTIONS)
+  // Build the authoritative path→module map once, then stamp the aggregate so
+  // every derived doc (surfaces + per-module) inherits `x-voyant-module` /
+  // `x-voyant-surface`. Partitioning covers the FULL surface, so nothing is
+  // dropped — `additionalRoutes` / directly-mounted routes aren't in the
+  // manifest and fall back to their path segment.
+  const owner = await buildModulePathOwnership(app.moduleMounts ?? [], OPENAPI_OPTIONS)
+  const full = stampModuleMetadata(merged, owner)
   return {
     full,
     admin: selectSurface(full, "admin"),
     storefront: selectSurface(full, "storefront"),
-    modules,
+    modules: partitionByModule(full, owner),
   }
 }

--- a/starters/operator/openapi/admin/accommodations.json
+++ b/starters/operator/openapi/admin/accommodations.json
@@ -367,7 +367,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}": {
@@ -599,7 +601,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/nights": {
@@ -762,7 +766,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/pickups": {
@@ -1055,7 +1061,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/pickups/reverse": {
@@ -1203,7 +1211,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/accommodations/room-blocks/{id}/release": {
@@ -1387,7 +1397,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "accommodations",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/action-ledger.json
+++ b/starters/operator/openapi/admin/action-ledger.json
@@ -905,7 +905,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/entries": {
@@ -1665,7 +1667,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/entries/{id}/reversals": {
@@ -2533,7 +2537,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/entries/{id}": {
@@ -3134,7 +3140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals": {
@@ -3502,7 +3510,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals/request": {
@@ -4148,7 +4158,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals/{id}": {
@@ -4858,7 +4870,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/approvals/{id}/decide": {
@@ -5491,7 +5505,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/delegations": {
@@ -5810,7 +5826,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/delegations/{id}": {
@@ -5944,7 +5962,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/action-ledger/relay-outbox": {
@@ -6194,7 +6214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "action-ledger",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/booking-requirements.json
+++ b/starters/operator/openapi/admin/booking-requirements.json
@@ -337,7 +337,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -532,7 +534,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/contact-requirements/{id}": {
@@ -663,7 +667,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -882,7 +888,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -932,7 +940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/questions": {
@@ -1179,7 +1189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1422,7 +1434,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/questions/{id}": {
@@ -1577,7 +1591,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1844,7 +1860,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1894,7 +1912,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-questions": {
@@ -2053,7 +2073,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2182,7 +2204,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-questions/{id}": {
@@ -2280,7 +2304,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2433,7 +2459,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2483,7 +2511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/question-options": {
@@ -2628,7 +2658,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2751,7 +2783,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/question-options/{id}": {
@@ -2843,7 +2877,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2989,7 +3025,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3039,7 +3077,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/unit-triggers": {
@@ -3196,7 +3236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3323,7 +3365,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/unit-triggers/{id}": {
@@ -3419,7 +3463,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3570,7 +3616,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3620,7 +3668,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-triggers": {
@@ -3770,7 +3820,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3883,7 +3935,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/option-triggers/{id}": {
@@ -3972,7 +4026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4109,7 +4165,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4159,7 +4217,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/extra-triggers": {
@@ -4334,7 +4394,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4479,7 +4541,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/extra-triggers/{id}": {
@@ -4585,7 +4649,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4755,7 +4821,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4805,7 +4873,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/answers": {
@@ -5026,7 +5096,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5244,7 +5316,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/booking-requirements/answers/{id}": {
@@ -5389,7 +5463,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5631,7 +5707,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5681,7 +5759,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/bookings.json
+++ b/starters/operator/openapi/admin/bookings.json
@@ -239,7 +239,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/aggregates": {
@@ -481,7 +483,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/overview": {
@@ -995,7 +999,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/sharing-groups": {
@@ -1081,7 +1087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/sharing-groups/{groupId}/travelers": {
@@ -1162,7 +1170,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/allocations": {
@@ -1312,7 +1322,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/activity": {
@@ -1409,7 +1421,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/group": {
@@ -1476,7 +1490,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/reserve": {
@@ -2395,7 +2411,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/expire-stale": {
@@ -2474,7 +2492,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/confirm": {
@@ -2930,7 +2950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/extend-hold": {
@@ -3360,7 +3382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/expire": {
@@ -3813,7 +3837,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/cancel": {
@@ -4266,7 +4292,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/start": {
@@ -4719,7 +4747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/complete": {
@@ -5172,7 +5202,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/override-status": {
@@ -5653,7 +5685,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/action-ledger": {
@@ -5811,7 +5845,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/action-approvals/{approvalId}/decide": {
@@ -5998,7 +6034,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers": {
@@ -6126,7 +6164,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -6365,7 +6405,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}/reveal": {
@@ -6553,7 +6595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}/travel-details": {
@@ -6644,7 +6688,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6875,7 +6921,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6969,7 +7017,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/with-travel-details": {
@@ -7256,7 +7306,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}/with-travel-details": {
@@ -7547,7 +7599,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/travelers/{travelerId}": {
@@ -7792,7 +7846,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7850,7 +7906,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items": {
@@ -8102,7 +8160,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -8598,7 +8658,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items/{itemId}": {
@@ -9100,7 +9162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9176,7 +9240,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items/{itemId}/travelers": {
@@ -9255,7 +9321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9414,7 +9482,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/items/{itemId}/travelers/{linkId}": {
@@ -9500,7 +9570,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/supplier-statuses": {
@@ -9621,7 +9693,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9834,7 +9908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/supplier-statuses/{statusId}": {
@@ -10058,7 +10134,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/fulfillments": {
@@ -10193,7 +10271,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -10449,7 +10529,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/fulfillments/{fulfillmentId}": {
@@ -10711,7 +10793,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/redemptions": {
@@ -10814,7 +10898,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -11011,7 +11097,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/notes": {
@@ -11072,7 +11160,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -11185,7 +11275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/notes/{noteId}": {
@@ -11308,7 +11400,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11366,7 +11460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/documents": {
@@ -11459,7 +11555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -11638,7 +11736,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/documents/{documentId}": {
@@ -11698,7 +11798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups": {
@@ -11868,7 +11970,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12021,7 +12125,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}": {
@@ -12166,7 +12272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12344,7 +12452,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12394,7 +12504,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}/members": {
@@ -12459,7 +12571,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12605,7 +12719,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}/members/{bookingId}": {
@@ -12665,7 +12781,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/groups/{id}/travelers": {
@@ -12715,7 +12833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings": {
@@ -13306,7 +13426,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -14051,7 +14173,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}": {
@@ -14803,7 +14927,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -15576,7 +15702,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -15626,7 +15754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/from-product": {
@@ -16290,7 +16420,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/create": {
@@ -17209,7 +17341,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/dual-create": {
@@ -18786,7 +18920,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{bookingId}/payment-schedule/regenerate": {
@@ -18910,7 +19046,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/catalog-booking.json
+++ b/starters/operator/openapi/admin/catalog-booking.json
@@ -1558,7 +1558,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/book": {
@@ -1933,7 +1935,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/drafts/{id}": {
@@ -2231,7 +2235,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       },
       "get": {
         "parameters": [
@@ -2373,7 +2379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2390,7 +2398,9 @@
           "204": {
             "description": "Draft deleted (idempotent)"
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/holds/place": {
@@ -2580,7 +2590,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/holds/release": {
@@ -2713,7 +2725,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/orders": {
@@ -2783,7 +2797,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/orders/{id}": {
@@ -2860,7 +2876,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/orders/{id}/cancel": {
@@ -3045,7 +3063,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/slots": {
@@ -3178,7 +3198,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/bookings/{id}/catalog-snapshot": {
@@ -3263,7 +3285,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/catalog-content.json
+++ b/starters/operator/openapi/admin/catalog-content.json
@@ -639,7 +639,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-content",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/catalog.json
+++ b/starters/operator/openapi/admin/catalog.json
@@ -682,7 +682,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/package-offers": {
@@ -741,7 +743,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/package-detail": {
@@ -818,7 +822,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/package-search": {
@@ -900,7 +906,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/departure-airports": {
@@ -947,7 +955,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/cruise-price": {
@@ -1008,7 +1018,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/catalog/cruise-sailing-pricing": {
@@ -1088,7 +1100,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/charters.json
+++ b/starters/operator/openapi/admin/charters.json
@@ -300,7 +300,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -626,7 +628,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/products/{key}/aggregates/recompute": {
@@ -879,7 +883,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/products/{key}/voyages": {
@@ -962,7 +968,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/products/{key}": {
@@ -1048,7 +1056,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -1299,7 +1309,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1550,7 +1562,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages": {
@@ -1829,7 +1843,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2165,7 +2181,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}/suites/bulk": {
@@ -2393,7 +2411,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}/schedule/bulk": {
@@ -2548,7 +2568,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}/quote/per-suite": {
@@ -2681,7 +2703,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}/bookings/per-suite": {
@@ -2748,7 +2772,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}/quote/whole-yacht": {
@@ -2874,7 +2900,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}/bookings/whole-yacht": {
@@ -2941,7 +2969,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/voyages/{key}": {
@@ -3027,7 +3057,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -3269,7 +3301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/bookings/{bookingId}/myba": {
@@ -3407,7 +3441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/yachts": {
@@ -3673,7 +3709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4019,7 +4057,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/charters/yachts/{key}": {
@@ -4105,7 +4145,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -4354,7 +4396,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/contract-document.json
+++ b/starters/operator/openapi/admin/contract-document.json
@@ -252,7 +252,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "contract-document",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/cruises.json
+++ b/starters/operator/openapi/admin/cruises.json
@@ -310,7 +310,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -824,7 +826,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/voyage-groups": {
@@ -1120,7 +1124,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1506,7 +1512,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/voyage-groups/{id}": {
@@ -1896,7 +1904,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -2305,7 +2315,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2535,7 +2547,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/voyage-groups/{id}/segments": {
@@ -2814,7 +2828,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3156,7 +3172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/voyage-group-segments/{segmentId}": {
@@ -3514,7 +3532,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3550,7 +3570,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/enrichment/{programId}": {
@@ -3738,7 +3760,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3774,7 +3798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings": {
@@ -4016,7 +4042,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4268,7 +4296,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}": {
@@ -4354,7 +4384,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -4648,7 +4680,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/itinerary": {
@@ -4721,7 +4755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/days/bulk": {
@@ -5011,7 +5047,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/pricing": {
@@ -5093,7 +5131,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/pricing/bulk": {
@@ -5555,7 +5595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/quote": {
@@ -5730,7 +5772,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/bookings": {
@@ -6059,7 +6103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/sailings/{key}/party-bookings": {
@@ -6126,7 +6172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/prices": {
@@ -6427,7 +6475,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6789,7 +6839,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/prices/{priceId}": {
@@ -7175,7 +7227,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/ships": {
@@ -7435,7 +7489,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -7767,7 +7823,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/ships/{key}": {
@@ -8034,7 +8092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -8409,7 +8469,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/ships/{key}/decks": {
@@ -8482,7 +8544,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -8623,7 +8687,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/decks/{deckId}": {
@@ -8747,7 +8813,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/ships/{key}/categories": {
@@ -8820,7 +8888,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/ships/{key}/categories/bulk": {
@@ -9226,7 +9296,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/categories/{categoryId}": {
@@ -9592,7 +9664,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/categories/{categoryId}/cabins": {
@@ -9685,7 +9759,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/categories/{categoryId}/cabins/bulk": {
@@ -9837,7 +9913,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/cabins/{cabinId}": {
@@ -9994,7 +10072,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/search-index/bulk": {
@@ -10282,7 +10362,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/search-index/{crsiId}": {
@@ -10320,7 +10402,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/search-index/rebuild": {
@@ -10379,7 +10463,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}": {
@@ -10465,7 +10551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -11022,7 +11110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11382,7 +11472,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/aggregates/recompute": {
@@ -11744,7 +11836,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/sailings": {
@@ -11827,7 +11921,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/days/bulk": {
@@ -12092,7 +12188,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/refresh": {
@@ -12178,7 +12276,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/detach": {
@@ -12521,7 +12621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/enrichment": {
@@ -12657,7 +12759,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12844,7 +12948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/cruises/{key}/enrichment/bulk": {
@@ -13047,7 +13153,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/distribution.json
+++ b/starters/operator/openapi/admin/distribution.json
@@ -344,7 +344,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -575,7 +577,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/batch-update": {
@@ -851,7 +855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/batch-delete": {
@@ -946,7 +952,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/{id}": {
@@ -1101,7 +1109,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1356,7 +1366,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1409,7 +1421,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/{id}/contact-points": {
@@ -1529,7 +1543,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1728,7 +1744,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channel-contact-points/{contactPointId}": {
@@ -1935,7 +1953,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1988,7 +2008,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channels/{id}/contacts": {
@@ -2115,7 +2137,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2329,7 +2353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/channel-contacts/{contactId}": {
@@ -2552,7 +2578,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2605,7 +2633,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts": {
@@ -2812,7 +2842,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3040,7 +3072,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts/batch-update": {
@@ -3313,7 +3347,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts/batch-delete": {
@@ -3408,7 +3444,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/contracts/{id}": {
@@ -3572,7 +3610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3824,7 +3864,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3877,7 +3919,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules": {
@@ -4059,7 +4103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4268,7 +4314,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules/batch-update": {
@@ -4521,7 +4569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules/batch-delete": {
@@ -4616,7 +4666,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/commission-rules/{id}": {
@@ -4755,7 +4807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4987,7 +5041,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5040,7 +5096,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings": {
@@ -5232,7 +5290,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5447,7 +5507,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings/batch-update": {
@@ -5703,7 +5765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings/batch-delete": {
@@ -5798,7 +5862,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/product-mappings/{id}": {
@@ -5947,7 +6013,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6182,7 +6250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6235,7 +6305,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links": {
@@ -6440,7 +6512,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6668,7 +6742,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links/batch-update": {
@@ -6923,7 +6999,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links/batch-delete": {
@@ -7018,7 +7096,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/booking-links/{id}": {
@@ -7186,7 +7266,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7420,7 +7502,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7473,7 +7557,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events": {
@@ -7628,7 +7714,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -7792,7 +7880,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events/batch-update": {
@@ -8000,7 +8090,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events/batch-delete": {
@@ -8095,7 +8187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/webhook-events/{id}": {
@@ -8207,7 +8301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8394,7 +8490,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8447,7 +8545,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments": {
@@ -8650,7 +8750,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8852,7 +8954,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments/batch-update": {
@@ -9099,7 +9203,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments/batch-delete": {
@@ -9194,7 +9300,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotments/{id}": {
@@ -9330,7 +9438,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9556,7 +9666,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9609,7 +9721,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets": {
@@ -9794,7 +9908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9976,7 +10092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets/batch-update": {
@@ -10204,7 +10322,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets/batch-delete": {
@@ -10299,7 +10419,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-allotment-targets/{id}": {
@@ -10424,7 +10546,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -10631,7 +10755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10684,7 +10810,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules": {
@@ -10827,7 +10955,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10980,7 +11110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules/batch-update": {
@@ -11179,7 +11311,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules/batch-delete": {
@@ -11274,7 +11408,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-rules/{id}": {
@@ -11384,7 +11520,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11562,7 +11700,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11615,7 +11755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-runs": {
@@ -11813,7 +11955,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12050,7 +12194,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-runs/{id}": {
@@ -12204,7 +12350,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12466,7 +12614,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12519,7 +12669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-items": {
@@ -12715,7 +12867,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12932,7 +13086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-items/{id}": {
@@ -13076,7 +13232,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13318,7 +13476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13371,7 +13531,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-runs": {
@@ -13553,7 +13715,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13761,7 +13925,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-runs/{id}": {
@@ -13900,7 +14066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14133,7 +14301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14186,7 +14356,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-items": {
@@ -14389,7 +14561,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -14593,7 +14767,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-items/{id}": {
@@ -14730,7 +14906,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14959,7 +15137,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -15012,7 +15192,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-executions": {
@@ -15213,7 +15395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -15426,7 +15610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/inventory-release-executions/{id}": {
@@ -15568,7 +15754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -15806,7 +15994,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -15859,7 +16049,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-policies": {
@@ -16053,7 +16245,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -16257,7 +16451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-policies/{id}": {
@@ -16394,7 +16590,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -16623,7 +16821,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16676,7 +16876,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-policies": {
@@ -16864,7 +17066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17057,7 +17261,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/reconciliation-policies/{id}": {
@@ -17188,7 +17394,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -17406,7 +17614,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -17459,7 +17669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/release-schedules": {
@@ -17621,7 +17833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17781,7 +17995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/release-schedules/{id}": {
@@ -17895,7 +18111,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -18080,7 +18298,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18133,7 +18353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/remittance-exceptions": {
@@ -18319,7 +18541,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -18523,7 +18747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/remittance-exceptions/{id}": {
@@ -18658,7 +18884,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -18886,7 +19114,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18939,7 +19169,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-approvals": {
@@ -19083,7 +19315,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -19234,7 +19468,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/distribution/settlement-approvals/{id}": {
@@ -19344,7 +19580,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -19520,7 +19758,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19573,7 +19813,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "distribution",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/external-refs.json
+++ b/starters/operator/openapi/admin/external-refs.json
@@ -351,7 +351,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -549,7 +551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/external-refs/refs/{id}": {
@@ -676,7 +680,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -895,7 +901,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -948,7 +956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/external-refs/entities/{entityType}/{entityId}/refs": {
@@ -1170,7 +1180,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1374,7 +1386,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "external-refs",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/extras.json
+++ b/starters/operator/openapi/admin/extras.json
@@ -389,7 +389,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -673,7 +675,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/product-extras/{id}": {
@@ -848,7 +852,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1156,7 +1162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1206,7 +1214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/option-extra-configs": {
@@ -1428,7 +1438,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1680,7 +1692,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/option-extra-configs/{id}": {
@@ -1841,7 +1855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2117,7 +2133,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2167,7 +2185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/booking-extras": {
@@ -2419,7 +2439,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2719,7 +2741,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/booking-extras/{id}": {
@@ -2901,7 +2925,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3224,7 +3250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3274,7 +3302,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}": {
@@ -3821,7 +3851,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}/selections": {
@@ -4095,7 +4127,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}/selections/bulk": {
@@ -4385,7 +4419,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/extras/slot-manifests/{slotId}/collections/bulk": {
@@ -4640,7 +4676,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "extras",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/finance.json
+++ b/starters/operator/openapi/admin/finance.json
@@ -646,7 +646,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1527,7 +1529,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}": {
@@ -1889,7 +1893,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2794,7 +2800,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/requires-redirect": {
@@ -3269,7 +3277,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/complete": {
@@ -3684,7 +3694,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/fail": {
@@ -4047,7 +4059,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/cancel": {
@@ -4410,7 +4424,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/expire": {
@@ -4773,7 +4789,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-instruments": {
@@ -5097,7 +5115,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5480,7 +5500,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-instruments/{id}": {
@@ -5702,7 +5724,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6109,7 +6133,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6159,7 +6185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-authorizations": {
@@ -6413,7 +6441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6944,7 +6974,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-authorizations/{id}": {
@@ -7125,7 +7157,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7680,7 +7714,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7730,7 +7766,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-captures": {
@@ -7910,7 +7948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8114,7 +8154,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-captures/{id}": {
@@ -8250,7 +8292,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8478,7 +8522,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8528,7 +8574,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/revenue": {
@@ -8591,7 +8639,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/aging": {
@@ -8644,7 +8694,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability": {
@@ -8722,7 +8774,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/departures": {
@@ -9035,7 +9089,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/products": {
@@ -9298,7 +9354,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/travelers": {
@@ -9412,7 +9470,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/departures/export": {
@@ -9478,7 +9538,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/reports/profitability/products/export": {
@@ -9528,7 +9590,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/cost-categories": {
@@ -9599,7 +9663,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9691,7 +9757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/cost-categories/{id}": {
@@ -9813,7 +9881,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/accountant-shares": {
@@ -9888,7 +9958,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9994,7 +10066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/accountant-shares/{id}/revoke": {
@@ -10054,7 +10128,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules": {
@@ -10160,7 +10236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -10398,7 +10476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules/default-plan": {
@@ -10606,7 +10686,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}": {
@@ -10849,7 +10931,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10907,7 +10991,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session": {
@@ -11685,7 +11771,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/guarantees": {
@@ -11852,7 +11940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12167,7 +12257,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session": {
@@ -12945,7 +13037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}": {
@@ -13267,7 +13361,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13351,7 +13447,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/tax-lines": {
@@ -13465,7 +13563,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -13687,7 +13787,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/tax-lines/{taxLineId}": {
@@ -13914,7 +14016,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13972,7 +14076,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/commissions": {
@@ -14112,7 +14218,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -14385,7 +14493,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/booking-items/{bookingItemId}/commissions/{commissionId}": {
@@ -14663,7 +14773,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14721,7 +14833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payments": {
@@ -15057,7 +15171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payments/{id}": {
@@ -15252,7 +15368,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "description": "Update a customer payment. Recomputes the invoice's paid/balance/status from the remaining completed payments. Supplier payments (`spay_*` id) must be updated via `/supplier-payments/{id}` and return 400 here.",
@@ -15552,7 +15670,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "description": "Remove a customer payment, recomputing invoice totals the same way PATCH does. Supplier payments (`spay_*` id) must be deleted via `/supplier-payments/{id}` and return 400 here.",
@@ -15734,7 +15854,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-payments": {
@@ -16031,7 +16153,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -16336,7 +16460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-payments/{id}": {
@@ -16665,7 +16791,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices": {
@@ -17060,7 +17188,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17518,7 +17648,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/from-booking": {
@@ -18038,7 +18170,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/convert-to-invoice": {
@@ -18327,7 +18461,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}": {
@@ -18611,7 +18747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -19069,7 +19207,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19137,7 +19277,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/void": {
@@ -19444,7 +19586,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/payment-session": {
@@ -20213,7 +20357,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/line-items": {
@@ -20307,7 +20453,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -20491,7 +20639,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/line-items/{lineId}": {
@@ -20680,7 +20830,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -20738,7 +20890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/payments": {
@@ -20888,7 +21042,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -21201,7 +21357,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/credit-notes": {
@@ -21311,7 +21469,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -21543,7 +21703,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}": {
@@ -21779,7 +21941,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}/line-items": {
@@ -21860,7 +22024,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -22012,7 +22178,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/notes": {
@@ -22073,7 +22241,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -22185,7 +22355,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-number-series": {
@@ -22364,7 +22536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -22593,7 +22767,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-number-series/{id}": {
@@ -22739,7 +22915,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -22999,7 +23177,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -23056,7 +23236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-number-series/{id}/allocate": {
@@ -23152,7 +23334,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-templates": {
@@ -23316,7 +23500,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -23503,7 +23689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-templates/{id}": {
@@ -23626,7 +23814,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -23843,7 +24033,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -23900,7 +24092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-regimes": {
@@ -24069,7 +24263,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -24257,7 +24453,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-regimes/{id}": {
@@ -24383,7 +24581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -24602,7 +24802,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -24659,7 +24861,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-classes": {
@@ -24816,7 +25020,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25004,7 +25210,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-classes/{id}": {
@@ -25133,7 +25341,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -25352,7 +25562,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -25409,7 +25621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-profiles": {
@@ -25543,7 +25757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25676,7 +25892,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-profiles/{id}": {
@@ -25777,7 +25995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -25941,7 +26161,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -25998,7 +26220,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-rules": {
@@ -26156,7 +26380,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -26329,7 +26555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/tax-policy-rules/{id}": {
@@ -26450,7 +26678,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -26653,7 +26883,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -26710,7 +26942,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/renditions": {
@@ -26837,7 +27071,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/render": {
@@ -27323,7 +27559,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/attachments": {
@@ -27413,7 +27651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -27595,7 +27835,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/attachments/{attachmentId}": {
@@ -27784,7 +28026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -27842,7 +28086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-attachments/{id}/download": {
@@ -27897,7 +28143,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/external-refs": {
@@ -28001,7 +28249,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -28203,7 +28453,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/external-refs/{refId}": {
@@ -28263,7 +28515,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/vouchers": {
@@ -28501,7 +28755,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -28770,7 +29026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/vouchers/{id}": {
@@ -28938,7 +29196,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -29182,7 +29442,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/vouchers/{id}/redeem": {
@@ -29487,7 +29749,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/bookings/{bookingId}/payments": {
@@ -29662,7 +29926,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/action-ledger": {
@@ -30035,7 +30301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/payment-sessions/{id}/action-ledger": {
@@ -30408,7 +30676,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices": {
@@ -30768,7 +31038,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -31488,7 +31760,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}": {
@@ -31939,7 +32213,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -32512,7 +32788,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -32570,7 +32848,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/lines": {
@@ -33128,7 +33408,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/allocations": {
@@ -33692,7 +33974,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/document/download": {
@@ -33747,7 +34031,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/payments": {
@@ -34052,7 +34338,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -34363,7 +34651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/attachments": {
@@ -34453,7 +34743,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -34624,7 +34916,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoices/{id}/attachments/{attachmentId}": {
@@ -34684,7 +34978,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/supplier-invoice-attachments/{id}/download": {
@@ -34739,7 +35035,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/generate-document": {
@@ -35004,7 +35302,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/regenerate-document": {
@@ -35269,7 +35569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoice-renditions/{id}/download": {
@@ -35324,7 +35626,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/finance/invoices/{id}/poll-settlement": {
@@ -35498,7 +35802,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/identity.json
+++ b/starters/operator/openapi/admin/identity.json
@@ -349,7 +349,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -547,7 +549,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/contact-points/{id}": {
@@ -679,7 +683,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "tags": [
@@ -899,7 +905,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "tags": [
@@ -956,7 +964,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/addresses": {
@@ -1210,7 +1220,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -1499,7 +1511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/addresses/{id}": {
@@ -1682,7 +1696,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "tags": [
@@ -1995,7 +2011,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "tags": [
@@ -2052,7 +2070,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/named-contacts": {
@@ -2265,7 +2285,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -2479,7 +2501,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/named-contacts/{id}": {
@@ -2619,7 +2643,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "tags": [
@@ -2856,7 +2882,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "tags": [
@@ -2913,7 +2941,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/contact-points": {
@@ -3038,7 +3068,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -3242,7 +3274,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/addresses": {
@@ -3418,7 +3452,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -3711,7 +3747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/named-contacts": {
@@ -3844,7 +3882,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "tags": [
@@ -4064,7 +4104,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "identity",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/legal.json
+++ b/starters/operator/openapi/admin/legal.json
@@ -336,7 +336,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -526,7 +528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/default": {
@@ -685,7 +689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}": {
@@ -810,7 +816,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1022,7 +1030,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1075,7 +1085,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}/preview": {
@@ -1168,7 +1180,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}/render-preview": {
@@ -1261,7 +1275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/templates/{id}/versions": {
@@ -1337,7 +1353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1484,7 +1502,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/template-versions/{id}": {
@@ -1575,7 +1595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/number-series": {
@@ -1718,7 +1740,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1924,7 +1948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/number-series/{id}": {
@@ -2061,7 +2087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2285,7 +2313,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2338,7 +2368,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/bookings/{bookingId}/generate-document": {
@@ -2541,7 +2573,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts": {
@@ -3035,7 +3069,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3657,7 +3693,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}": {
@@ -3981,7 +4019,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4613,7 +4653,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4684,7 +4726,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/issue": {
@@ -5026,7 +5070,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/send": {
@@ -5386,7 +5432,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/sign": {
@@ -6092,7 +6140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/execute": {
@@ -6434,7 +6484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/void": {
@@ -6776,7 +6828,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/render": {
@@ -6869,7 +6923,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/generate-document": {
@@ -6976,7 +7032,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/regenerate-document": {
@@ -7083,7 +7141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/regenerate-pdf": {
@@ -7190,7 +7250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/signatures": {
@@ -7370,7 +7432,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/attachments": {
@@ -7512,7 +7576,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -7846,7 +7912,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/attachments/upload": {
@@ -8051,7 +8119,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/{id}/attach-document": {
@@ -8256,7 +8326,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/attachments/{attachmentId}": {
@@ -8589,7 +8661,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8642,7 +8716,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/attachments/{attachmentId}/upload": {
@@ -8847,7 +8923,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/contracts/attachments/{attachmentId}/download": {
@@ -8902,7 +8980,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/{id}/versions": {
@@ -9005,7 +9085,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9179,7 +9261,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}": {
@@ -9297,7 +9381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9468,7 +9554,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}/publish": {
@@ -9604,7 +9692,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}/retire": {
@@ -9722,7 +9812,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/versions/{versionId}/rules": {
@@ -9858,7 +9950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -10120,7 +10214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/rules/{ruleId}": {
@@ -10380,7 +10476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10430,7 +10528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/assignments": {
@@ -10645,7 +10745,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10854,7 +10956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/assignments/{id}": {
@@ -11089,7 +11193,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11139,7 +11245,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/acceptances": {
@@ -11410,7 +11518,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11734,7 +11844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/resolve": {
@@ -12163,7 +12275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies": {
@@ -12319,7 +12433,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12477,7 +12593,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/{id}": {
@@ -12586,7 +12704,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12766,7 +12886,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12834,7 +12956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/policies/{id}/evaluate": {
@@ -12954,7 +13078,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/terms": {
@@ -13266,7 +13392,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13664,7 +13792,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/legal/terms/{id}": {
@@ -13859,7 +13989,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14281,7 +14413,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14331,7 +14465,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/markets.json
+++ b/starters/operator/openapi/admin/markets.json
@@ -316,7 +316,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -517,7 +519,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/markets/{id}": {
@@ -646,7 +650,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -869,7 +875,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -922,7 +930,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-locales": {
@@ -1056,7 +1066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/markets/{id}/locales": {
@@ -1196,7 +1208,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-locales/{id}": {
@@ -1333,7 +1347,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1386,7 +1402,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-currencies": {
@@ -1528,7 +1546,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/markets/{id}/currencies": {
@@ -1684,7 +1704,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/market-currencies/{id}": {
@@ -1837,7 +1859,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1890,7 +1914,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/fx-rate-sets": {
@@ -2043,7 +2069,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2209,7 +2237,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/fx-rate-sets/{id}": {
@@ -2322,7 +2352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2512,7 +2544,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2565,7 +2599,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/exchange-rates": {
@@ -2702,7 +2738,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/fx-rate-sets/{id}/exchange-rates": {
@@ -2861,7 +2899,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/exchange-rates/{id}": {
@@ -3015,7 +3055,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3068,7 +3110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/price-catalogs": {
@@ -3214,7 +3258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3370,7 +3416,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/price-catalogs/{id}": {
@@ -3473,7 +3521,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3635,7 +3685,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3688,7 +3740,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/product-rules": {
@@ -3895,7 +3949,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4130,7 +4186,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/product-rules/{id}": {
@@ -4273,7 +4331,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4514,7 +4574,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4567,7 +4629,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/channel-rules": {
@@ -4739,7 +4803,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4921,7 +4987,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/markets/channel-rules/{id}": {
@@ -5037,7 +5105,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5225,7 +5295,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5278,7 +5350,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/media.json
+++ b/starters/operator/openapi/admin/media.json
@@ -352,7 +352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "media",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/mice.json
+++ b/starters/operator/openapi/admin/mice.json
@@ -374,7 +374,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -625,7 +627,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/programs/{id}/cost-sheet": {
@@ -767,7 +771,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/programs/{id}": {
@@ -947,7 +953,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1256,7 +1264,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/sessions": {
@@ -1441,7 +1451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1663,7 +1675,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/sessions/{id}": {
@@ -1876,7 +1890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2100,7 +2116,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2153,7 +2171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/sessions/{id}/inclusions": {
@@ -2333,7 +2353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/delegates": {
@@ -2524,7 +2546,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2733,7 +2757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/delegates/{id}": {
@@ -2914,7 +2940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3126,7 +3154,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/delegates/{id}/enrollments": {
@@ -3329,7 +3359,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rooming-assignments": {
@@ -3476,7 +3508,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3655,7 +3689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rooming-assignments/{id}": {
@@ -3822,7 +3858,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4004,7 +4042,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rooming-assignments/{id}/delegates": {
@@ -4190,7 +4230,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rfps": {
@@ -4339,7 +4381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4510,7 +4554,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rfps/{id}/invitations": {
@@ -4685,7 +4731,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rfps/{id}/bids": {
@@ -4870,7 +4918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rfps/{id}/award": {
@@ -5123,7 +5173,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/rfps/{id}": {
@@ -5357,7 +5409,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5530,7 +5584,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/bids/{id}/lines": {
@@ -5693,7 +5749,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/bids/{id}/evaluations": {
@@ -5844,7 +5902,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/mice/bids/{id}": {
@@ -6076,7 +6136,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6252,7 +6314,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "mice",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/notifications.json
+++ b/starters/operator/openapi/admin/notifications.json
@@ -339,7 +339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -554,7 +556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/templates/{id}": {
@@ -694,7 +698,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -932,7 +938,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -967,7 +975,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/preview": {
@@ -1117,7 +1127,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/deliveries": {
@@ -1481,7 +1493,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/deliveries/{id}": {
@@ -1724,7 +1738,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/deliveries/{id}/resend": {
@@ -1985,7 +2001,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules": {
@@ -2194,7 +2212,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2431,7 +2451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/compose": {
@@ -2943,7 +2965,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}": {
@@ -3091,7 +3115,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3350,7 +3376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3385,7 +3413,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages": {
@@ -3539,7 +3569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3834,7 +3866,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/reorder": {
@@ -4030,7 +4064,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/{stageId}": {
@@ -4346,7 +4382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4389,7 +4427,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels": {
@@ -4511,7 +4551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -4720,7 +4762,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels/{channelId}": {
@@ -4954,7 +4998,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5005,7 +5051,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/notification-settings": {
@@ -5105,7 +5153,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -5304,7 +5354,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminders/preview": {
@@ -5424,7 +5476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-runs": {
@@ -5874,7 +5928,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminder-runs/{id}": {
@@ -6201,7 +6257,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/reminders/run-due": {
@@ -6263,7 +6321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/payment-sessions/{id}/send": {
@@ -6680,7 +6740,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/invoices/{id}/send": {
@@ -7097,7 +7159,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/bookings/{id}/document-bundle": {
@@ -7282,7 +7346,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/bookings/{id}/confirm-and-dispatch": {
@@ -7740,7 +7806,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/bookings/{id}/send-documents": {
@@ -7969,7 +8037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/notifications/send": {
@@ -8401,7 +8471,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "notifications",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/operations.json
+++ b/starters/operator/openapi/admin/operations.json
@@ -250,7 +250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/overview": {
@@ -505,7 +507,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules": {
@@ -692,7 +696,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -887,7 +893,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules/batch-update": {
@@ -1125,7 +1133,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules/batch-delete": {
@@ -1220,7 +1230,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/rules/{id}": {
@@ -1350,7 +1362,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1567,7 +1581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1620,7 +1636,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times": {
@@ -1789,7 +1807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1945,7 +1965,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times/batch-update": {
@@ -2146,7 +2168,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times/batch-delete": {
@@ -2241,7 +2265,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/start-times/{id}": {
@@ -2353,7 +2379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2533,7 +2561,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2586,7 +2616,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots": {
@@ -2896,7 +2928,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3242,7 +3276,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/batch-update": {
@@ -3631,7 +3667,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/batch-delete": {
@@ -3726,7 +3764,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}": {
@@ -3937,7 +3977,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4305,7 +4347,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4358,7 +4402,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/unit-availability": {
@@ -4450,7 +4496,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts": {
@@ -4588,7 +4636,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4710,7 +4760,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts/batch-update": {
@@ -4877,7 +4929,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts/batch-delete": {
@@ -4972,7 +5026,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/closeouts/{id}": {
@@ -5065,7 +5121,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5211,7 +5269,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5264,7 +5324,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation": {
@@ -5683,7 +5745,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/resources": {
@@ -5876,7 +5940,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}": {
@@ -6109,7 +6175,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6190,7 +6258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}": {
@@ -6354,7 +6424,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}/sharing-group": {
@@ -6509,7 +6581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/pair": {
@@ -6662,7 +6736,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/{groupId}/label": {
@@ -6820,7 +6896,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6956,7 +7034,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/audit-log": {
@@ -7061,7 +7141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/export-passengers": {
@@ -7105,7 +7187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/export-rooming-list": {
@@ -7149,7 +7233,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/auto-materialize": {
@@ -7365,7 +7451,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/materialize-templates": {
@@ -7483,7 +7571,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slots/{id}/allocation/auto-allocate": {
@@ -7699,7 +7789,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/products/{productId}/allocation/resource-templates": {
@@ -7846,7 +7938,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/products/{productId}/options/{optionId}/allocation/resource-templates/{kind}": {
@@ -8095,7 +8189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8239,7 +8335,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/products/{id}/allocation/materialize-open-slots": {
@@ -8376,7 +8474,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points": {
@@ -8526,7 +8626,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8660,7 +8762,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points/batch-update": {
@@ -8839,7 +8943,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points/batch-delete": {
@@ -8934,7 +9040,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-points/{id}": {
@@ -9035,7 +9143,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9193,7 +9303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9246,7 +9358,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups": {
@@ -9365,7 +9479,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9479,7 +9595,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups/batch-update": {
@@ -9638,7 +9756,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups/batch-delete": {
@@ -9733,7 +9853,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/slot-pickups/{id}": {
@@ -9823,7 +9945,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9961,7 +10085,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10014,7 +10140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs": {
@@ -10224,7 +10352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10433,7 +10563,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs/batch-update": {
@@ -10688,7 +10820,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs/batch-delete": {
@@ -10783,7 +10917,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/meeting-configs/{id}": {
@@ -10923,7 +11059,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11157,7 +11295,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11210,7 +11350,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups": {
@@ -11358,7 +11500,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11492,7 +11636,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups/batch-update": {
@@ -11670,7 +11816,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups/batch-delete": {
@@ -11765,7 +11913,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-groups/{id}": {
@@ -11865,7 +12015,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12022,7 +12174,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12075,7 +12229,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations": {
@@ -12230,7 +12386,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12386,7 +12544,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations/batch-update": {
@@ -12587,7 +12747,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations/batch-delete": {
@@ -12682,7 +12844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/pickup-locations/{id}": {
@@ -12794,7 +12958,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12974,7 +13140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13027,7 +13195,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times": {
@@ -13211,7 +13381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13406,7 +13578,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times/batch-update": {
@@ -13647,7 +13821,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times/batch-delete": {
@@ -13742,7 +13918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/location-pickup-times/{id}": {
@@ -13875,7 +14053,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14095,7 +14275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14148,7 +14330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas": {
@@ -14277,7 +14461,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -14398,7 +14584,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas/batch-update": {
@@ -14564,7 +14752,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas/batch-delete": {
@@ -14659,7 +14849,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/availability/custom-pickup-areas/{id}": {
@@ -14753,7 +14945,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -14898,7 +15092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14951,7 +15147,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources": {
@@ -15133,7 +15331,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -15310,7 +15510,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources/batch-update": {
@@ -15532,7 +15734,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources/batch-delete": {
@@ -15627,7 +15831,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/resources/{id}": {
@@ -15750,7 +15956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -15951,7 +16159,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16004,7 +16214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools": {
@@ -16164,7 +16376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -16315,7 +16529,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools/batch-update": {
@@ -16511,7 +16727,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools/batch-delete": {
@@ -16606,7 +16824,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pools/{id}": {
@@ -16715,7 +16935,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -16890,7 +17112,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16943,7 +17167,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pool-members": {
@@ -17044,7 +17270,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17162,7 +17390,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/pool-members/{id}": {
@@ -17217,7 +17447,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements": {
@@ -17368,7 +17600,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -17531,7 +17765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements/batch-update": {
@@ -17721,7 +17957,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements/batch-delete": {
@@ -17816,7 +18054,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/requirements/{id}": {
@@ -17922,7 +18162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -18091,7 +18333,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18144,7 +18388,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations": {
@@ -18295,7 +18541,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -18458,7 +18706,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations/batch-update": {
@@ -18648,7 +18898,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations/batch-delete": {
@@ -18743,7 +18995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/allocations/{id}": {
@@ -18849,7 +19103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -19018,7 +19274,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19071,7 +19329,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments": {
@@ -19252,7 +19512,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -19445,7 +19707,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments/batch-update": {
@@ -19666,7 +19930,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments/batch-delete": {
@@ -19761,7 +20027,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/slot-assignments/{id}": {
@@ -19882,7 +20150,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -20082,7 +20352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -20135,7 +20407,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts": {
@@ -20265,7 +20539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -20420,7 +20696,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts/batch-update": {
@@ -20602,7 +20880,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts/batch-delete": {
@@ -20697,7 +20977,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/closeouts/{id}": {
@@ -20797,7 +21079,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -20958,7 +21242,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -21011,7 +21297,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/operators": {
@@ -21158,7 +21446,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -21299,7 +21589,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/operators/{id}": {
@@ -21403,7 +21695,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -21569,7 +21863,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -21622,7 +21918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/vehicles": {
@@ -21840,7 +22138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -22084,7 +22384,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/vehicles/{id}": {
@@ -22240,7 +22542,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -22509,7 +22813,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -22562,7 +22868,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/drivers": {
@@ -22717,7 +23025,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -22875,7 +23185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/drivers/{id}": {
@@ -22987,7 +23299,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -23170,7 +23484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -23223,7 +23539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/transfer-preferences": {
@@ -23494,7 +23812,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -23871,7 +24191,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/transfer-preferences/{id}": {
@@ -24098,7 +24420,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -24500,7 +24824,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -24553,7 +24879,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatches": {
@@ -24824,7 +25152,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25117,7 +25447,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatches/{id}": {
@@ -25299,7 +25631,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -25616,7 +25950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -25669,7 +26005,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/execution-events": {
@@ -25825,7 +26163,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -25994,7 +26334,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/execution-events/{id}": {
@@ -26110,7 +26452,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -26304,7 +26648,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -26357,7 +26703,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-assignments": {
@@ -26543,7 +26891,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -26731,7 +27081,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-assignments/{id}": {
@@ -26859,7 +27211,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -27072,7 +27426,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -27125,7 +27481,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-legs": {
@@ -27289,7 +27647,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -27478,7 +27838,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-legs/{id}": {
@@ -27607,7 +27969,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -27821,7 +28185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -27874,7 +28240,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-passengers": {
@@ -28003,7 +28371,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -28133,7 +28503,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-passengers/{id}": {
@@ -28233,7 +28605,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -28388,7 +28762,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -28441,7 +28817,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/driver-shifts": {
@@ -28613,7 +28991,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -28785,7 +29165,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/driver-shifts/{id}": {
@@ -28905,7 +29287,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -29100,7 +29484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -29153,7 +29539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/service-incidents": {
@@ -29322,7 +29710,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -29500,7 +29890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/service-incidents/{id}": {
@@ -29621,7 +30013,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -29823,7 +30217,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -29876,7 +30272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-checkpoints": {
@@ -30044,7 +30442,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -30242,7 +30642,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/dispatch-checkpoints/{id}": {
@@ -30375,7 +30777,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -30597,7 +31001,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -30650,7 +31056,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities": {
@@ -30968,7 +31376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -31327,7 +31737,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}": {
@@ -31548,7 +31960,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -31931,7 +32345,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -31984,7 +32400,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/contact-points": {
@@ -32097,7 +32515,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -32307,7 +32727,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/contact-points/{id}": {
@@ -32525,7 +32947,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -32578,7 +33002,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/addresses": {
@@ -32742,7 +33168,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -33041,7 +33469,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/addresses/{id}": {
@@ -33352,7 +33782,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -33405,7 +33837,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-contacts": {
@@ -33579,7 +34013,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/contacts": {
@@ -33790,7 +34226,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-contacts/{id}": {
@@ -33998,7 +34436,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -34051,7 +34491,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-features": {
@@ -34205,7 +34647,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/features": {
@@ -34399,7 +34843,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-features/{id}": {
@@ -34590,7 +35036,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -34643,7 +35091,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-operation-schedules": {
@@ -34809,7 +35259,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facilities/{id}/operation-schedules": {
@@ -35019,7 +35471,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/facility-operation-schedules/{id}": {
@@ -35229,7 +35683,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -35282,7 +35738,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/properties": {
@@ -35479,7 +35937,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -35711,7 +36171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/properties/{id}": {
@@ -35853,7 +36315,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -36092,7 +36556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -36145,7 +36611,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-groups": {
@@ -36348,7 +36816,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -36567,7 +37037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-groups/{id}": {
@@ -36711,7 +37183,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -36955,7 +37429,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -37008,7 +37484,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-group-members": {
@@ -37164,7 +37642,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -37339,7 +37819,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/property-group-members/{id}": {
@@ -37451,7 +37933,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -37632,7 +38116,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -37685,7 +38171,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/function-spaces": {
@@ -37854,7 +38342,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -38060,7 +38550,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/function-spaces/{id}": {
@@ -38239,7 +38731,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -38454,7 +38948,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/function-spaces/{id}/capacities": {
@@ -38601,7 +39097,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks": {
@@ -38837,7 +39335,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}": {
@@ -39055,7 +39555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/slots": {
@@ -39209,7 +39711,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/pickups": {
@@ -39477,7 +39981,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/pickups/reverse": {
@@ -39620,7 +40126,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/operations/space-blocks/{id}/release": {
@@ -39798,7 +40306,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operations",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/operator-settings.json
+++ b/starters/operator/openapi/admin/operator-settings.json
@@ -272,7 +272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -509,7 +511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/settings/operator-payment-instructions": {
@@ -580,7 +584,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -685,7 +691,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/settings/operator-payment-defaults": {
@@ -743,7 +751,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -874,7 +884,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/settings/operator": {
@@ -1029,7 +1041,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -1381,7 +1395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/pricing.json
+++ b/starters/operator/openapi/admin/pricing.json
@@ -387,7 +387,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -630,7 +632,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pricing-categories/{id}": {
@@ -794,7 +798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1056,7 +1062,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1106,7 +1114,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pricing-category-dependencies": {
@@ -1274,7 +1284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1411,7 +1423,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pricing-category-dependencies/{id}": {
@@ -1522,7 +1536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1681,7 +1697,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1731,7 +1749,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policies": {
@@ -1913,7 +1933,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2067,7 +2089,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policies/{id}": {
@@ -2186,7 +2210,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2362,7 +2388,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2412,7 +2440,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policy-rules": {
@@ -2564,7 +2594,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2714,7 +2746,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/cancellation-policy-rules/{id}": {
@@ -2831,7 +2865,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3003,7 +3039,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3053,7 +3091,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-catalogs": {
@@ -3235,7 +3275,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3393,7 +3435,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-catalogs/{id}": {
@@ -3512,7 +3556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3691,7 +3737,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3741,7 +3789,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-schedules": {
@@ -3925,7 +3975,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4132,7 +4184,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/price-schedules/{id}": {
@@ -4273,7 +4327,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4501,7 +4557,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4551,7 +4609,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-price-rules": {
@@ -4811,7 +4871,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5080,7 +5142,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-price-rules/{id}": {
@@ -5258,7 +5322,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5545,7 +5611,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5595,7 +5663,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-price-rules": {
@@ -5804,7 +5874,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6017,7 +6089,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-price-rules/{id}": {
@@ -6167,7 +6241,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6400,7 +6476,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6450,7 +6528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-start-time-rules": {
@@ -6635,7 +6715,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6818,7 +6900,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-start-time-rules/{id}": {
@@ -6952,7 +7036,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7156,7 +7242,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7206,7 +7294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-tiers": {
@@ -7346,7 +7436,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -7473,7 +7565,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/option-unit-tiers/{id}": {
@@ -7578,7 +7672,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -7727,7 +7823,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7777,7 +7875,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pickup-price-rules": {
@@ -7948,7 +8048,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8103,7 +8205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/pickup-price-rules/{id}": {
@@ -8223,7 +8327,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8398,7 +8504,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8448,7 +8556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/dropoff-price-rules": {
@@ -8633,7 +8743,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -8817,7 +8929,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/dropoff-price-rules/{id}": {
@@ -8951,7 +9065,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9155,7 +9271,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9205,7 +9323,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/extra-price-rules": {
@@ -9402,7 +9522,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -9591,7 +9713,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/extra-price-rules/{id}": {
@@ -9729,7 +9853,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9939,7 +10065,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9989,7 +10117,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/departure-price-overrides": {
@@ -10162,7 +10292,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10305,7 +10437,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/pricing/departure-price-overrides/{id}": {
@@ -10419,7 +10553,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -10582,7 +10718,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10632,7 +10770,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/products.json
+++ b/starters/operator/openapi/admin/products.json
@@ -288,7 +288,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/activation-settings/{id}": {
@@ -397,7 +399,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -571,7 +575,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -621,7 +627,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/activation-settings": {
@@ -797,7 +805,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/ticket-settings": {
@@ -953,7 +963,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/ticket-settings/{id}": {
@@ -1074,7 +1086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1270,7 +1284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1320,7 +1336,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/ticket-settings": {
@@ -1518,7 +1536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/visibility-settings": {
@@ -1655,7 +1675,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/visibility-settings/{id}": {
@@ -1743,7 +1765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1875,7 +1899,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1925,7 +1951,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/visibility-settings": {
@@ -2059,7 +2087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/capabilities": {
@@ -2219,7 +2249,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/capabilities/{id}": {
@@ -2321,7 +2353,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2479,7 +2513,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2529,7 +2565,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/capabilities": {
@@ -2692,7 +2730,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/delivery-formats": {
@@ -2821,7 +2861,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/delivery-formats/{id}": {
@@ -2911,7 +2953,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3046,7 +3090,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3096,7 +3142,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/delivery-formats": {
@@ -3236,7 +3284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/features": {
@@ -3370,7 +3420,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/features/{id}": {
@@ -3468,7 +3520,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3620,7 +3674,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3670,7 +3726,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/features": {
@@ -3827,7 +3885,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/faqs": {
@@ -3932,7 +3992,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/faqs/{id}": {
@@ -4016,7 +4078,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4142,7 +4206,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4192,7 +4258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/faqs": {
@@ -4324,7 +4392,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/locations": {
@@ -4511,7 +4581,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/locations/{id}": {
@@ -4660,7 +4732,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4918,7 +4992,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4968,7 +5044,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/locations": {
@@ -5231,7 +5309,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destinations": {
@@ -5442,7 +5522,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5645,7 +5727,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destinations/{id}": {
@@ -5772,7 +5856,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -6000,7 +6086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6050,7 +6138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destination-translations": {
@@ -6183,7 +6273,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destinations/{id}/translations": {
@@ -6348,7 +6440,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destination-translations/{id}": {
@@ -6509,7 +6603,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6559,7 +6655,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-category-translations": {
@@ -6692,7 +6790,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-categories/{id}/translations": {
@@ -6857,7 +6957,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-category-translations/{id}": {
@@ -7018,7 +7120,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7068,7 +7172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tag-translations": {
@@ -7180,7 +7286,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tags/{id}/translations": {
@@ -7305,7 +7413,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tag-translations/{id}": {
@@ -7426,7 +7536,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7476,7 +7588,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/destination-links": {
@@ -7593,7 +7707,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/destinations": {
@@ -7709,7 +7825,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/destinations/{destinationId}": {
@@ -7769,7 +7887,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options": {
@@ -7924,7 +8044,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options/{optionId}": {
@@ -8045,7 +8167,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8238,7 +8362,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8288,7 +8414,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/options": {
@@ -8489,7 +8617,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/units": {
@@ -8682,7 +8812,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/units/{unitId}": {
@@ -8838,7 +8970,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9102,7 +9236,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9152,7 +9288,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options/{optionId}/units": {
@@ -9425,7 +9563,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/translations": {
@@ -9593,7 +9733,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/translations/{translationId}": {
@@ -9729,7 +9871,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9954,7 +10098,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10004,7 +10150,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/translations": {
@@ -10235,7 +10383,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/option-translations": {
@@ -10361,7 +10511,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/option-translations/{translationId}": {
@@ -10455,7 +10607,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -10600,7 +10754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -10650,7 +10806,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/options/{optionId}/translations": {
@@ -10801,7 +10959,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/unit-translations": {
@@ -10927,7 +11087,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/unit-translations/{translationId}": {
@@ -11021,7 +11183,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11166,7 +11330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11216,7 +11382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/units/{unitId}/translations": {
@@ -11367,7 +11535,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-types": {
@@ -11501,7 +11671,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11635,7 +11807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-types/{typeId}": {
@@ -11734,7 +11908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11892,7 +12068,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11942,7 +12120,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-categories": {
@@ -12092,7 +12272,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12291,7 +12473,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-categories/{categoryId}": {
@@ -12398,7 +12582,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12621,7 +12807,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12671,7 +12859,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tags": {
@@ -12764,7 +12954,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -12844,7 +13036,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/product-tags/{tagId}": {
@@ -12916,7 +13110,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13021,7 +13217,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13071,7 +13269,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/media/{mediaId}": {
@@ -13218,7 +13418,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13462,7 +13664,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13607,7 +13811,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/media/{mediaId}/set-cover": {
@@ -13790,7 +13996,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure/versions": {
@@ -13922,7 +14130,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure/versions/{brochureId}/set-current": {
@@ -14077,7 +14287,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure/versions/{brochureId}": {
@@ -14232,7 +14444,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/brochure": {
@@ -14379,7 +14593,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "put": {
         "parameters": [
@@ -14601,7 +14817,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -14746,7 +14964,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/media/reorder": {
@@ -14842,7 +15062,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/media": {
@@ -15059,7 +15281,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -15314,7 +15538,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/media": {
@@ -15539,7 +15765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -15802,7 +16030,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries": {
@@ -15871,7 +16101,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -15999,7 +16231,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/itineraries/{itineraryId}": {
@@ -16126,7 +16360,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16176,7 +16412,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/itineraries/{itineraryId}/duplicate": {
@@ -16295,7 +16533,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries/{itineraryId}/days": {
@@ -16385,7 +16625,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -16545,7 +16787,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days": {
@@ -16627,7 +16871,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -16779,7 +17025,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}": {
@@ -16938,7 +17186,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -16996,7 +17246,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services": {
@@ -17120,7 +17372,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -17355,7 +17609,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services/{serviceId}": {
@@ -17594,7 +17850,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -17660,7 +17918,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/translations": {
@@ -17762,7 +18022,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -17924,7 +18186,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/translations/{translationId}": {
@@ -18093,7 +18357,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18159,7 +18425,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/versions": {
@@ -18228,7 +18496,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -18310,7 +18580,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/notes": {
@@ -18371,7 +18643,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -18483,7 +18757,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries/{itineraryId}/translations": {
@@ -18568,7 +18844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -18699,7 +18977,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/itineraries/{itineraryId}/translations/{translationId}": {
@@ -18836,7 +19116,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -18902,7 +19184,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations": {
@@ -19009,7 +19293,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -19174,7 +19460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations/{translationId}": {
@@ -19345,7 +19633,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -19419,7 +19709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/categories": {
@@ -19511,7 +19803,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -19600,7 +19894,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/categories/{categoryId}": {
@@ -19660,7 +19956,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/tags": {
@@ -19717,7 +20015,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -19803,7 +20103,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/tags/{tagId}": {
@@ -19863,7 +20165,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/recalculate": {
@@ -19927,7 +20231,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/aggregates": {
@@ -20030,7 +20336,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products": {
@@ -20533,7 +20841,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -21091,7 +21401,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}": {
@@ -21387,7 +21699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -21962,7 +22276,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -22012,7 +22328,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/products/{id}/action-ledger": {
@@ -22123,7 +22441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/promotions.json
+++ b/starters/operator/openapi/admin/promotions.json
@@ -610,7 +610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1268,7 +1270,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/promotions/{id}": {
@@ -1617,7 +1621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2297,7 +2303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2373,7 +2381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/promotions/{id}/archive": {
@@ -2722,7 +2732,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "promotions",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/quotes.json
+++ b/starters/operator/openapi/admin/quotes.json
@@ -262,7 +262,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -377,7 +379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/pipelines/{id}": {
@@ -467,7 +471,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -607,7 +613,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -678,7 +686,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/stages": {
@@ -798,7 +808,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -932,7 +944,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/stages/{id}": {
@@ -1031,7 +1045,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1189,7 +1205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1242,7 +1260,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes": {
@@ -1528,7 +1548,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1845,7 +1867,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}": {
@@ -2056,7 +2080,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2396,7 +2422,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2449,7 +2477,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/participants": {
@@ -2521,7 +2551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2639,7 +2671,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-participants/{id}": {
@@ -2694,7 +2728,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/products": {
@@ -2808,7 +2844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3001,7 +3039,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-products/{id}": {
@@ -3211,7 +3251,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3264,7 +3306,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/media": {
@@ -3365,7 +3409,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3539,7 +3585,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-media/{id}": {
@@ -3594,7 +3642,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions": {
@@ -3794,7 +3844,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/versions": {
@@ -4088,7 +4140,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/validity": {
@@ -4291,7 +4345,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quotes/{id}/versions/snapshot": {
@@ -4472,7 +4528,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/expire": {
@@ -4611,7 +4669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}": {
@@ -4774,7 +4834,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5062,7 +5124,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5133,7 +5197,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/trip-snapshot": {
@@ -5489,7 +5555,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/send": {
@@ -5671,7 +5739,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/view": {
@@ -5834,7 +5904,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/accept": {
@@ -6305,7 +6377,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/decline": {
@@ -6487,7 +6561,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-versions/{id}/lines": {
@@ -6578,7 +6654,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -6767,7 +6845,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/quotes/quote-version-lines/{id}": {
@@ -6954,7 +7034,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7025,7 +7107,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "quotes",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -438,7 +438,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -750,7 +752,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}": {
@@ -941,7 +945,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -1278,7 +1284,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1331,7 +1339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/merge": {
@@ -1559,7 +1569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/contact-methods": {
@@ -1661,7 +1673,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1854,7 +1868,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/addresses": {
@@ -2008,7 +2024,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2293,7 +2311,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organizations/{id}/notes": {
@@ -2354,7 +2374,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2466,7 +2488,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/organization-notes/{id}": {
@@ -2580,7 +2604,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2633,7 +2659,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people": {
@@ -2946,7 +2974,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3377,7 +3407,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}": {
@@ -3597,7 +3629,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4052,7 +4086,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4105,7 +4141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/merge": {
@@ -4362,7 +4400,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/contact-methods": {
@@ -4464,7 +4504,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -4657,7 +4699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/addresses": {
@@ -4811,7 +4855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -5096,7 +5142,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/notes": {
@@ -5157,7 +5205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -5269,7 +5319,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-notes/{id}": {
@@ -5383,7 +5435,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5436,7 +5490,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/payment-methods": {
@@ -5529,7 +5585,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -5717,7 +5775,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-payment-methods/{id}": {
@@ -5903,7 +5963,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5956,7 +6018,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/communications": {
@@ -6125,7 +6189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -6316,7 +6382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/segments": {
@@ -6378,7 +6446,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -6486,7 +6556,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/segments/{segmentId}": {
@@ -6541,7 +6613,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/export": {
@@ -6557,7 +6631,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/import": {
@@ -6628,7 +6704,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/contact-methods/{id}": {
@@ -6835,7 +6913,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -6888,7 +6968,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/addresses/{id}": {
@@ -7189,7 +7271,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -7242,7 +7326,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/documents": {
@@ -7413,7 +7499,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -7656,7 +7744,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}": {
@@ -7794,7 +7884,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -8034,7 +8126,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -8087,7 +8181,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}/set-primary": {
@@ -8225,7 +8321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/travel-snapshot": {
@@ -8370,7 +8468,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/profile-pii": {
@@ -8501,7 +8601,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/documents/from-plaintext": {
@@ -8756,7 +8858,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}/from-plaintext": {
@@ -9008,7 +9112,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-documents/{id}/reveal": {
@@ -9115,7 +9221,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/relationships": {
@@ -9306,7 +9414,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -9541,7 +9651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/person-relationships/{id}": {
@@ -9688,7 +9800,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -9930,7 +10044,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -9983,7 +10099,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/customer-signals": {
@@ -10234,7 +10352,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -10536,7 +10656,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/customer-signals/{id}": {
@@ -10711,7 +10833,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -11014,7 +11138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -11067,7 +11193,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/customer-signals/{id}/resolve": {
@@ -11279,7 +11407,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/people/{id}/signals": {
@@ -11439,7 +11569,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities": {
@@ -11652,7 +11784,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -11845,7 +11979,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities/{id}": {
@@ -11978,7 +12114,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -12195,7 +12333,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -12248,7 +12388,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities/{id}/links": {
@@ -12323,7 +12465,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12447,7 +12591,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activity-links/{id}": {
@@ -12502,7 +12648,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activities/{id}/participants": {
@@ -12563,7 +12711,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -12659,7 +12809,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/activity-participants/{id}": {
@@ -12714,7 +12866,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-fields": {
@@ -12874,7 +13028,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -13075,7 +13231,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-fields/{id}": {
@@ -13208,7 +13366,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -13406,7 +13566,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -13459,7 +13621,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-field-values": {
@@ -13634,7 +13798,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-fields/{id}/value": {
@@ -13848,7 +14014,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/relationships/custom-field-values/{id}": {
@@ -13903,7 +14071,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "relationships",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/sellability.json
+++ b/starters/operator/openapi/admin/sellability.json
@@ -281,7 +281,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/resolve-and-persist": {
@@ -549,7 +551,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/snapshots": {
@@ -780,7 +784,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/snapshots/{id}": {
@@ -937,7 +943,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/snapshot-items": {
@@ -1181,7 +1189,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policies": {
@@ -1431,7 +1441,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1677,7 +1689,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policies/{id}": {
@@ -1835,7 +1849,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2106,7 +2122,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2156,7 +2174,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policy-results": {
@@ -2318,7 +2338,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -2475,7 +2497,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/policy-results/{id}": {
@@ -2586,7 +2610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2768,7 +2794,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2818,7 +2846,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-refresh-runs": {
@@ -2978,7 +3008,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3144,7 +3176,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-refresh-runs/{id}": {
@@ -3260,7 +3294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -3451,7 +3487,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3501,7 +3539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-expiration-events": {
@@ -3659,7 +3699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -3821,7 +3863,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/offer-expiration-events/{id}": {
@@ -3936,7 +3980,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4122,7 +4168,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4172,7 +4220,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/explanations": {
@@ -4329,7 +4379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -4488,7 +4540,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/sellability/explanations/{id}": {
@@ -4599,7 +4653,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -4782,7 +4838,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4832,7 +4890,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "sellability",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/storefront.json
+++ b/starters/operator/openapi/admin/storefront.json
@@ -768,7 +768,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "requestBody": {
@@ -1945,7 +1947,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/suppliers.json
+++ b/starters/operator/openapi/admin/suppliers.json
@@ -258,7 +258,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -468,7 +470,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/contact-points/{contactPointId}": {
@@ -686,7 +690,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -736,7 +742,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/contacts": {
@@ -857,7 +865,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1083,7 +1093,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/contacts/{contactId}": {
@@ -1318,7 +1330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -1368,7 +1382,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/addresses": {
@@ -1532,7 +1548,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -1831,7 +1849,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/addresses/{addressId}": {
@@ -2142,7 +2162,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2192,7 +2214,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services": {
@@ -2307,7 +2331,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2521,7 +2547,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services/{serviceId}": {
@@ -2741,7 +2769,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -2799,7 +2829,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services/{serviceId}/rates": {
@@ -2918,7 +2950,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3142,7 +3176,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/services/{serviceId}/rates/{rateId}": {
@@ -3370,7 +3406,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -3436,7 +3474,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/notes": {
@@ -3497,7 +3537,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3609,7 +3651,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/availability": {
@@ -3693,7 +3737,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -3854,7 +3900,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/contracts": {
@@ -3953,7 +4001,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -4137,7 +4187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}/contracts/{contractId}": {
@@ -4328,7 +4380,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4386,7 +4440,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/aggregates": {
@@ -4494,7 +4550,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers": {
@@ -4801,7 +4859,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -5183,7 +5243,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/suppliers/{id}": {
@@ -5386,7 +5448,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -5792,7 +5856,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -5842,7 +5908,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "suppliers",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/trips.json
+++ b/starters/operator/openapi/admin/trips.json
@@ -187,7 +187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips": {
@@ -794,7 +796,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "requestBody": {
@@ -1308,7 +1312,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}": {
@@ -1762,7 +1768,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "patch": {
         "parameters": [
@@ -2084,7 +2092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/reshop": {
@@ -2450,7 +2460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/snapshots": {
@@ -2588,7 +2600,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "post": {
         "parameters": [
@@ -2797,7 +2811,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/snapshots/{snapshotId}": {
@@ -2951,7 +2967,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/components": {
@@ -3372,7 +3390,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/components/reorder": {
@@ -3734,7 +3754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/components/{componentId}": {
@@ -4150,7 +4172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "delete": {
         "parameters": [
@@ -4484,7 +4508,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/components/{componentId}/refs": {
@@ -4869,7 +4895,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/requirements": {
@@ -5113,7 +5141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       },
       "get": {
         "parameters": [
@@ -5309,7 +5339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/requirements/{requirementId}/candidates": {
@@ -5677,7 +5709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/requirements/{requirementId}/select": {
@@ -6216,7 +6250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/requirements/{requirementId}/reshop": {
@@ -6584,7 +6620,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/price": {
@@ -7147,7 +7185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/reserve": {
@@ -7708,7 +7748,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/checkout": {
@@ -8252,7 +8294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/cancellation-preview": {
@@ -8798,7 +8842,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/trips/{envelopeId}/cancel-components": {
@@ -9349,7 +9395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/workflow-runs.json
+++ b/starters/operator/openapi/admin/workflow-runs.json
@@ -349,7 +349,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "workflow-runs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/workflow-runs/{id}": {
@@ -644,7 +646,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "workflow-runs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/workflow-runs/{id}/rerun": {
@@ -804,7 +808,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "workflow-runs",
+        "x-voyant-surface": "admin"
       }
     },
     "/v1/admin/workflow-runs/{id}/resume": {
@@ -949,7 +955,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "workflow-runs",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/admin/workflows.json
+++ b/starters/operator/openapi/admin/workflows.json
@@ -290,7 +290,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "workflows",
+        "x-voyant-surface": "admin"
       }
     }
   },

--- a/starters/operator/openapi/storefront/booking-requirements.json
+++ b/starters/operator/openapi/storefront/booking-requirements.json
@@ -359,7 +359,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "booking-requirements",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/bookings.json
+++ b/starters/operator/openapi/storefront/bookings.json
@@ -1138,7 +1138,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}": {
@@ -1785,7 +1787,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       },
       "patch": {
         "parameters": [
@@ -2583,7 +2587,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/state": {
@@ -2682,7 +2688,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       },
       "put": {
         "parameters": [
@@ -2815,7 +2823,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/reprice": {
@@ -3696,7 +3706,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/confirm": {
@@ -4379,7 +4391,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/sessions/{sessionId}/expire": {
@@ -5062,7 +5076,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/overview": {
@@ -5594,7 +5610,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/guest-lookup": {
@@ -6129,7 +6147,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/payment-policy/resolve": {
@@ -6248,7 +6268,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/catalog-booking.json
+++ b/starters/operator/openapi/storefront/catalog-booking.json
@@ -1558,7 +1558,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/catalog/book": {
@@ -1933,7 +1935,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/catalog/drafts/{id}": {
@@ -2231,7 +2235,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       },
       "get": {
         "parameters": [
@@ -2373,7 +2379,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -2390,7 +2398,9 @@
           "204": {
             "description": "Draft deleted (idempotent)"
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/catalog/holds/place": {
@@ -2580,7 +2590,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/catalog/holds/release": {
@@ -2713,7 +2725,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/catalog/slots": {
@@ -2846,7 +2860,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/catalog-content.json
+++ b/starters/operator/openapi/storefront/catalog-content.json
@@ -639,7 +639,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog-content",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/catalog.json
+++ b/starters/operator/openapi/storefront/catalog.json
@@ -682,7 +682,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/catalog/checkout/start": {
@@ -1035,7 +1037,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "catalog",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/charters.json
+++ b/starters/operator/openapi/storefront/charters.json
@@ -273,7 +273,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/charters/voyages": {
@@ -552,7 +554,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/charters/voyages/{key}": {
@@ -831,7 +835,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/charters/voyages/{key}/quote/per-suite": {
@@ -989,7 +995,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/charters/voyages/{key}/quote/whole-yacht": {
@@ -1136,7 +1144,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/charters/yachts/{key}": {
@@ -1222,7 +1232,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/charters/products/{key}": {
@@ -1289,7 +1301,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "charters",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/cruises.json
+++ b/starters/operator/openapi/storefront/cruises.json
@@ -586,7 +586,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/cruises/sailings/{key}": {
@@ -697,7 +699,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/cruises/sailings/{key}/quote": {
@@ -1006,7 +1010,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/cruises/ships/{key}": {
@@ -1092,7 +1098,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/cruises/{slug}": {
@@ -1449,7 +1457,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "cruises",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/customer-portal.json
+++ b/starters/operator/openapi/storefront/customer-portal.json
@@ -539,7 +539,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "patch": {
         "requestBody": {
@@ -1210,7 +1212,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/me/documents": {
@@ -1317,7 +1321,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "requestBody": {
@@ -1515,7 +1521,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/me/documents/{id}/set-primary": {
@@ -1647,7 +1655,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/me/documents/{id}": {
@@ -1854,7 +1864,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -1907,7 +1919,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bootstrap": {
@@ -3186,7 +3200,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/companions": {
@@ -3433,7 +3449,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "requestBody": {
@@ -3923,7 +3941,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/companions/import-booking-travelers": {
@@ -4220,7 +4240,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/companions/{companionId}": {
@@ -4737,7 +4759,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -4808,7 +4832,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings": {
@@ -4953,7 +4979,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings/{bookingId}": {
@@ -5672,7 +5700,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings/{bookingId}/documents": {
@@ -5788,7 +5818,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/bookings/{bookingId}/billing-contact": {
@@ -5914,7 +5946,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/contact-exists": {
@@ -5970,7 +6004,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/customer-portal/contact-exists/phone": {
@@ -6030,7 +6066,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "customer-portal",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/finance.json
+++ b/starters/operator/openapi/storefront/finance.json
@@ -303,7 +303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/documents/by-reference": {
@@ -499,7 +501,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/documents": {
@@ -691,7 +695,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/documents/by-reference": {
@@ -895,7 +901,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/payments": {
@@ -1070,7 +1078,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/payment-options": {
@@ -1426,7 +1436,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/payment-sessions/{sessionId}": {
@@ -1932,7 +1944,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session": {
@@ -2841,7 +2855,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session": {
@@ -3750,7 +3766,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/invoices/{invoiceId}/payment-session": {
@@ -4651,7 +4669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/accountant/{token}/summary": {
@@ -4745,7 +4765,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/finance/accountant/{token}/invoices": {
@@ -4816,7 +4838,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "finance",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/legal.json
+++ b/starters/operator/openapi/storefront/legal.json
@@ -304,7 +304,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/{id}/preview": {
@@ -394,7 +396,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/{id}/render-preview": {
@@ -484,7 +488,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/by-slug/{slug}/preview": {
@@ -574,7 +580,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/templates/by-slug/{slug}/render-preview": {
@@ -664,7 +672,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/{id}": {
@@ -836,7 +846,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/contracts/{id}/sign": {
@@ -1044,7 +1056,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/policies/{slug}": {
@@ -1231,7 +1245,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/policies/{id}/accept": {
@@ -1567,7 +1583,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/terms": {
@@ -1879,7 +1897,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/legal/terms/{id}": {
@@ -2074,7 +2094,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "legal",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/markets.json
+++ b/starters/operator/openapi/storefront/markets.json
@@ -248,7 +248,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "markets",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/operator-settings.json
+++ b/starters/operator/openapi/storefront/operator-settings.json
@@ -223,7 +223,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/settings/operator": {
@@ -301,7 +303,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "operator-settings",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/payment-link.json
+++ b/starters/operator/openapi/storefront/payment-link.json
@@ -205,7 +205,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/payment-link/{sessionId}/retry": {
@@ -286,7 +288,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/payment-link/resolve": {
@@ -364,7 +368,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/payment-link/{sessionId}/start-card": {
@@ -463,7 +469,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/payment-link/{sessionId}/trip-summary": {
@@ -633,7 +641,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/payment-link/{sessionId}/booking-summary": {
@@ -824,7 +834,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/bookings/{bookingId}/checkout-status": {
@@ -1043,7 +1055,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "payment-link",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/pricing.json
+++ b/starters/operator/openapi/storefront/pricing.json
@@ -577,7 +577,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "pricing",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/products.json
+++ b/starters/operator/openapi/storefront/products.json
@@ -228,7 +228,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/categories": {
@@ -341,7 +343,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/destinations": {
@@ -548,7 +552,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products": {
@@ -1420,7 +1426,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/slug/{slug}": {
@@ -2101,7 +2109,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{id}": {
@@ -2782,7 +2792,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{id}/brochure": {
@@ -2902,7 +2914,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "products",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/storefront-verification.json
+++ b/starters/operator/openapi/storefront/storefront-verification.json
@@ -330,7 +330,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/storefront-verification/sms/start": {
@@ -516,7 +518,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/storefront-verification/email/confirm": {
@@ -708,7 +712,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/storefront-verification/sms/confirm": {
@@ -901,7 +907,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront-verification",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/storefront.json
+++ b/starters/operator/openapi/storefront/storefront.json
@@ -305,7 +305,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/offers/{slug}": {
@@ -480,7 +482,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/offers/{slug}/apply": {
@@ -927,7 +931,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/offers/redeem": {
@@ -1370,7 +1376,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/leads": {
@@ -1661,7 +1669,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/newsletter/subscribe": {
@@ -1917,7 +1927,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/settings": {
@@ -2540,7 +2552,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/departures/{departureId}": {
@@ -2925,7 +2939,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/departures": {
@@ -3365,7 +3381,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/availability": {
@@ -3643,7 +3661,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/departures/{departureId}/itinerary": {
@@ -3783,7 +3803,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/products/{productId}/extensions": {
@@ -4059,7 +4081,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "storefront",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/openapi/storefront/trips.json
+++ b/starters/operator/openapi/storefront/trips.json
@@ -187,7 +187,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips": {
@@ -794,7 +796,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "requestBody": {
@@ -1308,7 +1312,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}": {
@@ -1762,7 +1768,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "patch": {
         "parameters": [
@@ -2084,7 +2092,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/reshop": {
@@ -2450,7 +2460,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/snapshots": {
@@ -2588,7 +2600,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "post": {
         "parameters": [
@@ -2797,7 +2811,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/snapshots/{snapshotId}": {
@@ -2951,7 +2967,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/components": {
@@ -3372,7 +3390,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/components/reorder": {
@@ -3734,7 +3754,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/components/{componentId}": {
@@ -4150,7 +4172,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "delete": {
         "parameters": [
@@ -4484,7 +4508,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/components/{componentId}/refs": {
@@ -4869,7 +4895,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/requirements": {
@@ -5113,7 +5141,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       },
       "get": {
         "parameters": [
@@ -5309,7 +5339,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/requirements/{requirementId}/candidates": {
@@ -5677,7 +5709,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/requirements/{requirementId}/select": {
@@ -6216,7 +6250,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/requirements/{requirementId}/reshop": {
@@ -6584,7 +6620,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/price": {
@@ -7147,7 +7185,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/reserve": {
@@ -7708,7 +7748,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/checkout": {
@@ -8252,7 +8294,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/cancellation-preview": {
@@ -8798,7 +8842,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     },
     "/v1/public/trips/{envelopeId}/cancel-components": {
@@ -9349,7 +9395,9 @@
               }
             }
           }
-        }
+        },
+        "x-voyant-module": "trips",
+        "x-voyant-surface": "storefront"
       }
     }
   },

--- a/starters/operator/src/api/openapi.ts
+++ b/starters/operator/src/api/openapi.ts
@@ -1,9 +1,11 @@
 import {
+  buildModulePathOwnership,
   generateOpenApiDocument,
   mergeLazyOpenApiPaths,
   type OpenApiDocument,
+  partitionByModule,
   selectSurface,
-  splitDocumentByModule,
+  stampModuleMetadata,
 } from "@voyant-travel/hono/openapi"
 import { app } from "./app.js"
 
@@ -45,14 +47,17 @@ export async function buildOperatorOpenApiDocuments(): Promise<OperatorOpenApiDo
   // Lazy route families mount as wildcard dispatch stubs at runtime, so their
   // `.openapi()` operations never reach the composed registry — replay their
   // loaders at build time and merge any documented routes (voyant#2114).
-  const full = await mergeLazyOpenApiPaths(eager, app.lazyMounts ?? [], options)
-  // Partition the FULL surface so `additionalRoutes` (e.g. the workflow-runs
-  // admin surface) and directly-mounted routes aren't dropped from the specs.
-  const modules = await splitDocumentByModule(full, app.moduleMounts ?? [], options)
+  const merged = await mergeLazyOpenApiPaths(eager, app.lazyMounts ?? [], options)
+  // Build the path→module map once, stamp the aggregate with `x-voyant-module` /
+  // `x-voyant-surface` (derived docs inherit it), then partition the FULL surface
+  // so `additionalRoutes` (e.g. the workflow-runs admin surface) and
+  // directly-mounted routes aren't dropped.
+  const owner = await buildModulePathOwnership(app.moduleMounts ?? [], options)
+  const full = stampModuleMetadata(merged, owner)
   return {
     full,
     admin: selectSurface(full, "admin"),
     storefront: selectSurface(full, "storefront"),
-    modules,
+    modules: partitionByModule(full, owner),
   }
 }


### PR DESCRIPTION
Follow-up to #2766 (per-module OpenAPI split, closing #2733) and a step toward #2729's "missing metadata" ask.

## What

Every operation in the generated specs — aggregate **and** per-module — now carries two extensions:

- `x-voyant-module` — the owning module
- `x-voyant-surface` — `admin` or `storefront`

This makes the specs self-describing: a module-grouped docs UI, a client generator, or any tooling can read the owning module/surface straight off each operation instead of re-deriving it from path prefixes.

## Why it's more than a path heuristic

The module is the **authoritative owner from the mount manifest** (`app.moduleMounts`), so `publicPath` routes — whose URL segment isn't the module name — are labelled with their real owner. Verified in the operator specs:

| path | segment | `x-voyant-module` |
|---|---|---|
| `/v1/public/payment-policy/resolve` | `payment-policy` | **`bookings`** |
| `/v1/public/catalog/quote` | `catalog` | **`catalog-booking`** |
| `/v1/public/operator-profile` | `operator-profile` | **`operator-settings`** |

A path-prefix split could never get these right.

## Implementation

Refactored the generator helpers in `@voyant-travel/hono/openapi` so the ownership map is built once and reused:

- `buildModulePathOwnership(mounts, options)` → `Map<path, module>` (the authoritative owner).
- `partitionByModule(full, owner)` → synchronous per-module split from a precomputed map.
- `stampModuleMetadata(doc, owner)` → appends the extensions to every operation (pure; deterministic key order for the drift gate).
- `splitDocumentByModule` retained as a convenience wrapper.

Both generators now: build the owner map → `stampModuleMetadata(full)` → derive surfaces (`selectSurface`) and per-module docs (`partitionByModule`) from the stamped aggregate, so everything inherits the stamps from one pass.

The committed per-module specs are regenerated (every operation gains the two keys — large but mechanical diff).

## Testing

- `pnpm --filter @voyant-travel/hono {typecheck,test}` — 259 pass (new `stampModuleMetadata` unit tests, incl. the publicPath-override attribution and no-mutation guarantees).
- `pnpm --filter @voyant-travel/openapi test` + `pnpm --filter operator test` — drift gates green (43 / 186).
- `pnpm release:plan` — clean.

## Not in this PR

The **Swagger/Scalar docs UI** (the other #2733 follow-up) is deliberately separate: it needs a viewer choice and a home, and can't naively serve live specs from the Worker without pulling the doc generator back into the runtime bundle. This metadata is the enabling step — a docs UI can group by `x-voyant-module` / `x-voyant-surface`. `x-voyant-auth` and stable `tags` remain open for #2729.