### PR TITLE
feat(openapi): tag operations with their module for Swagger/Scalar grouping

### DIFF
--- a/.changeset/openapi-operation-tags.md
+++ b/.changeset/openapi-operation-tags.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/hono": patch
+"@voyant-travel/openapi": patch
+---
+
+Tag every OpenAPI operation with its module for Swagger/Scalar grouping.
+
+`stampModuleMetadata` now also sets `tags: [module]` on each operation (unless
+the route already declares tags). Swagger UI, Scalar, and Redoc key their
+sidebar grouping off `tags` and ignore `x-*` extensions, so without this a
+whole-surface document (`framework-admin.json`) collapses under a single
+"default" group — the browsability pain in voyant#2733. With it, any deployment
+can point a viewer straight at a generated spec and get a module-grouped
+explorer with no extra work.

--- a/packages/hono/src/openapi.ts
+++ b/packages/hono/src/openapi.ts
@@ -383,17 +383,19 @@ export async function splitDocumentByModule(
 const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const
 
 /**
- * Stamp every operation with `x-voyant-module` and `x-voyant-surface`
- * extensions (voyant#2733 / voyant#2729), so the specs are self-describing:
- * tooling (a module-grouped docs UI, client generators) can read the owning
- * module and surface off each operation instead of re-deriving them from path
- * prefixes. The module is the authoritative owner from the manifest, so
- * `publicPath` overrides are labelled with their real owning module rather than
- * their mount prefix.
+ * Stamp every operation with its module metadata (voyant#2733 / voyant#2729):
+ *   - `tags: [module]` — so Swagger/Scalar group the sidebar by module (they
+ *     key grouping off `tags` and ignore `x-*`); left untouched when the route
+ *     already declares tags.
+ *   - `x-voyant-module` / `x-voyant-surface` — machine-readable owner + surface
+ *     for custom tooling (a docs UI, client generators) that shouldn't re-derive
+ *     them from path prefixes.
  *
- * Applied to the aggregate before it's split, so the per-module and surface
- * documents (all derived from it) inherit the stamps. Extensions are appended
- * to each operation, keeping key order deterministic for the drift gate.
+ * The module is the authoritative owner from the manifest, so `publicPath`
+ * overrides are labelled with their real owning module rather than their mount
+ * prefix. Applied to the aggregate before it's split, so the per-module and
+ * surface documents (all derived from it) inherit the stamps. Keys are appended,
+ * keeping order deterministic for the drift gate.
  */
 export function stampModuleMetadata(
   doc: OpenApiDocument,
@@ -411,8 +413,15 @@ export function stampModuleMetadata(
     for (const method of HTTP_METHODS) {
       const op = nextItem[method]
       if (op && typeof op === "object") {
+        const operation = op as Record<string, unknown>
+        // Group by module in Swagger/Scalar, which key their sidebar off `tags`
+        // (and ignore `x-*` extensions). Without this a whole-surface document
+        // collapses under one "default" group — the exact pain in voyant#2733.
+        // Never clobber a tag a route already declared.
+        const hasTags = Array.isArray(operation.tags) && operation.tags.length > 0
         nextItem[method] = {
-          ...(op as Record<string, unknown>),
+          ...operation,
+          ...(hasTags ? {} : { tags: [moduleName] }),
           "x-voyant-module": moduleName,
           ...(surface ? { "x-voyant-surface": surface } : {}),
         }

--- a/packages/hono/tests/unit/openapi-modules.test.ts
+++ b/packages/hono/tests/unit/openapi-modules.test.ts
@@ -163,15 +163,30 @@ describe("stampModuleMetadata", () => {
     const op = (path: string, method: string) =>
       (stamped.paths as Record<string, Record<string, Record<string, unknown>>>)[path][method]
 
-    // Segment-derived module + admin surface.
+    // Segment-derived module + admin surface + module tag (for Swagger grouping).
     expect(op("/v1/admin/bookings/list", "get")["x-voyant-module"]).toBe("bookings")
     expect(op("/v1/admin/bookings/list", "get")["x-voyant-surface"]).toBe("admin")
+    expect(op("/v1/admin/bookings/list", "get").tags).toEqual(["bookings"])
     // publicPath override → authoritative owner, not the `booking-engine` prefix.
     expect(op("/v1/public/booking-engine/hold", "post")["x-voyant-module"]).toBe("commerce")
     expect(op("/v1/public/booking-engine/hold", "post")["x-voyant-surface"]).toBe("storefront")
     // Non-surface route: module stamped, surface omitted.
     expect(op("/v1/webhooks/netopia", "post")["x-voyant-module"]).toBe("webhooks")
     expect(op("/v1/webhooks/netopia", "post")["x-voyant-surface"]).toBeUndefined()
+  })
+
+  it("does not clobber tags a route already declares", () => {
+    const tagged = {
+      openapi: "3.1.0",
+      info: INFO,
+      paths: { "/v1/admin/legal/contracts": { get: { tags: ["Legal"], responses: {} } } },
+    } as unknown as OpenApiDocument
+    const stamped = stampModuleMetadata(tagged, new Map())
+    const op = (stamped.paths as Record<string, Record<string, Record<string, unknown>>>)[
+      "/v1/admin/legal/contracts"
+    ].get
+    expect(op.tags).toEqual(["Legal"])
+    expect(op["x-voyant-module"]).toBe("legal")
   })
 
   it("does not mutate the input document", () => {

--- a/packages/openapi/spec/admin/accommodations.json
+++ b/packages/openapi/spec/admin/accommodations.json
@@ -368,6 +368,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -602,6 +605,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -767,6 +773,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -1062,6 +1071,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -1212,6 +1224,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -1398,6 +1413,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/action-ledger.json
+++ b/packages/openapi/spec/admin/action-ledger.json
@@ -906,6 +906,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -1668,6 +1671,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -2538,6 +2544,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -3141,6 +3150,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -3511,6 +3523,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -4159,6 +4174,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -4871,6 +4889,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -5506,6 +5527,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -5827,6 +5851,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -5963,6 +5990,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -6215,6 +6245,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/booking-requirements.json
+++ b/packages/openapi/spec/admin/booking-requirements.json
@@ -338,6 +338,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -535,6 +538,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -668,6 +674,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -889,6 +898,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -941,6 +953,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -1190,6 +1205,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -1435,6 +1453,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -1592,6 +1613,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -1861,6 +1885,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -1913,6 +1940,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2074,6 +2104,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2205,6 +2238,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2305,6 +2341,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2460,6 +2499,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2512,6 +2554,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2659,6 +2704,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2784,6 +2832,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2878,6 +2929,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3026,6 +3080,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3078,6 +3135,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -3237,6 +3297,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3366,6 +3429,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -3464,6 +3530,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3617,6 +3686,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3669,6 +3741,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -3821,6 +3896,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3936,6 +4014,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -4027,6 +4108,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4166,6 +4250,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4218,6 +4305,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -4395,6 +4485,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4542,6 +4635,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -4650,6 +4746,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4822,6 +4921,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4874,6 +4976,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -5097,6 +5202,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -5317,6 +5425,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -5464,6 +5575,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -5708,6 +5822,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -5760,6 +5877,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/bookings.json
+++ b/packages/openapi/spec/admin/bookings.json
@@ -240,6 +240,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -484,6 +487,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1000,6 +1006,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1088,6 +1097,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1171,6 +1183,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1323,6 +1338,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1422,6 +1440,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1491,6 +1512,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -2412,6 +2436,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -2493,6 +2520,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -2951,6 +2981,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -3383,6 +3416,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -3838,6 +3874,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -4293,6 +4332,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -4748,6 +4790,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -5203,6 +5248,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -5686,6 +5734,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -5846,6 +5897,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6035,6 +6089,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6165,6 +6222,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -6406,6 +6466,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6596,6 +6659,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6689,6 +6755,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -6922,6 +6991,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -7018,6 +7090,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -7307,6 +7382,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -7600,6 +7678,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -7847,6 +7928,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -7907,6 +7991,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -8161,6 +8248,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -8659,6 +8749,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9163,6 +9256,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -9241,6 +9337,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9322,6 +9421,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -9483,6 +9585,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9571,6 +9676,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9694,6 +9802,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -9909,6 +10020,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10135,6 +10249,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10272,6 +10389,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -10530,6 +10650,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10794,6 +10917,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10899,6 +11025,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11098,6 +11227,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11161,6 +11293,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11276,6 +11411,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11401,6 +11539,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11461,6 +11602,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11556,6 +11700,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11737,6 +11884,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11799,6 +11949,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11971,6 +12124,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12126,6 +12282,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12273,6 +12432,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12453,6 +12615,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12505,6 +12670,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12572,6 +12740,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12720,6 +12891,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12782,6 +12956,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12834,6 +13011,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -13427,6 +13607,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -14174,6 +14357,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -14928,6 +15114,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -15703,6 +15892,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -15755,6 +15947,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -16421,6 +16616,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -17342,6 +17540,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -18921,6 +19122,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/catalog.json
+++ b/packages/openapi/spec/admin/catalog.json
@@ -683,6 +683,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/distribution.json
+++ b/packages/openapi/spec/admin/distribution.json
@@ -345,6 +345,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -578,6 +581,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -856,6 +862,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -953,6 +962,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -1110,6 +1122,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -1367,6 +1382,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -1422,6 +1440,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -1544,6 +1565,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -1745,6 +1769,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -1954,6 +1981,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -2009,6 +2039,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -2138,6 +2171,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -2354,6 +2390,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -2579,6 +2618,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -2634,6 +2676,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -2843,6 +2888,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -3073,6 +3121,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -3348,6 +3399,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -3445,6 +3499,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -3611,6 +3668,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -3865,6 +3925,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -3920,6 +3983,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4104,6 +4170,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -4315,6 +4384,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4570,6 +4642,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4667,6 +4742,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4808,6 +4886,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -5042,6 +5123,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -5097,6 +5181,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -5291,6 +5378,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -5508,6 +5598,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -5766,6 +5859,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -5863,6 +5959,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -6014,6 +6113,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -6251,6 +6353,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -6306,6 +6411,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -6513,6 +6621,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -6743,6 +6854,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7000,6 +7114,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7097,6 +7214,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7267,6 +7387,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -7503,6 +7626,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -7558,6 +7684,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7715,6 +7844,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -7881,6 +8013,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8091,6 +8226,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8188,6 +8326,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8302,6 +8443,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -8491,6 +8635,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -8546,6 +8693,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8751,6 +8901,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -8955,6 +9108,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9204,6 +9360,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9301,6 +9460,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9439,6 +9601,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -9667,6 +9832,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -9722,6 +9890,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9909,6 +10080,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -10093,6 +10267,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10323,6 +10500,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10420,6 +10600,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10547,6 +10730,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -10756,6 +10942,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -10811,6 +11000,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10956,6 +11148,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -11111,6 +11306,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11312,6 +11510,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11409,6 +11610,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11521,6 +11725,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -11701,6 +11908,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -11756,6 +11966,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11956,6 +12169,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -12195,6 +12411,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -12351,6 +12570,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -12615,6 +12837,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -12670,6 +12895,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -12868,6 +13096,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13087,6 +13318,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -13233,6 +13467,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13477,6 +13714,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13532,6 +13772,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -13716,6 +13959,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13926,6 +14172,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -14067,6 +14316,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -14302,6 +14554,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -14357,6 +14612,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -14562,6 +14820,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -14768,6 +15029,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -14907,6 +15171,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15138,6 +15405,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15193,6 +15463,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -15396,6 +15669,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15611,6 +15887,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -15755,6 +16034,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15995,6 +16277,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16050,6 +16335,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -16246,6 +16534,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16452,6 +16743,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -16591,6 +16885,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16822,6 +17119,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16877,6 +17177,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -17067,6 +17370,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17262,6 +17568,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -17395,6 +17704,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17615,6 +17927,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17670,6 +17985,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -17834,6 +18152,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17996,6 +18317,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -18112,6 +18436,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -18299,6 +18626,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -18354,6 +18684,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -18542,6 +18875,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -18748,6 +19084,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -18885,6 +19224,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19115,6 +19457,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19170,6 +19515,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -19316,6 +19664,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19469,6 +19820,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -19581,6 +19935,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19759,6 +20116,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19814,6 +20174,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/external-refs.json
+++ b/packages/openapi/spec/admin/external-refs.json
@@ -352,6 +352,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -552,6 +555,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       }
@@ -681,6 +687,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -902,6 +911,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -957,6 +969,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       }
@@ -1181,6 +1196,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -1387,6 +1405,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/extras.json
+++ b/packages/openapi/spec/admin/extras.json
@@ -390,6 +390,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -676,6 +679,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -853,6 +859,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -1163,6 +1172,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -1215,6 +1227,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -1439,6 +1454,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -1693,6 +1711,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -1856,6 +1877,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -2134,6 +2158,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -2186,6 +2213,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -2440,6 +2470,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -2742,6 +2775,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -2926,6 +2962,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -3251,6 +3290,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -3303,6 +3345,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -3852,6 +3897,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -4128,6 +4176,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -4420,6 +4471,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -4677,6 +4731,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/finance.json
+++ b/packages/openapi/spec/admin/finance.json
@@ -647,6 +647,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -1530,6 +1533,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -1894,6 +1900,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -2801,6 +2810,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -3278,6 +3290,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -3695,6 +3710,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -4060,6 +4078,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -4425,6 +4446,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -4790,6 +4814,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -5116,6 +5143,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -5501,6 +5531,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -5725,6 +5758,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -6134,6 +6170,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -6186,6 +6225,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -6442,6 +6484,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -6975,6 +7020,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -7158,6 +7206,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -7715,6 +7766,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -7767,6 +7821,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -7949,6 +8006,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -8155,6 +8215,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8293,6 +8356,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -8523,6 +8589,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -8575,6 +8644,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8640,6 +8712,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8695,6 +8770,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8775,6 +8853,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9090,6 +9171,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9355,6 +9439,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9471,6 +9558,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9539,6 +9629,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9591,6 +9684,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9664,6 +9760,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -9758,6 +9857,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9882,6 +9984,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9959,6 +10064,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -10067,6 +10175,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10129,6 +10240,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10237,6 +10351,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -10477,6 +10594,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10687,6 +10807,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10932,6 +11055,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -10992,6 +11118,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -11772,6 +11901,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -11941,6 +12073,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -12258,6 +12393,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -13038,6 +13176,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -13362,6 +13503,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -13448,6 +13592,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -13564,6 +13711,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -13788,6 +13938,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -14017,6 +14170,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -14077,6 +14233,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -14219,6 +14378,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -14494,6 +14656,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -14774,6 +14939,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -14834,6 +15002,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -15172,6 +15343,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -15369,6 +15543,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -15671,6 +15848,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -15855,6 +16035,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -16154,6 +16337,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -16461,6 +16647,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -16792,6 +16981,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -17189,6 +17381,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -17649,6 +17844,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -18171,6 +18369,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -18462,6 +18663,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -18748,6 +18952,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -19208,6 +19415,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -19278,6 +19488,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -19587,6 +19800,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -20358,6 +20574,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -20454,6 +20673,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -20640,6 +20862,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -20831,6 +21056,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -20891,6 +21119,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -21043,6 +21274,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -21358,6 +21592,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -21470,6 +21707,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -21704,6 +21944,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -21942,6 +22185,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22025,6 +22271,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -22179,6 +22428,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22242,6 +22494,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -22356,6 +22611,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22537,6 +22795,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -22768,6 +23029,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22916,6 +23180,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -23178,6 +23445,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -23237,6 +23507,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -23335,6 +23608,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -23501,6 +23777,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -23690,6 +23969,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -23815,6 +24097,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24034,6 +24319,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24093,6 +24381,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -24264,6 +24555,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24454,6 +24748,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -24582,6 +24879,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24803,6 +25103,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24862,6 +25165,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25021,6 +25327,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25211,6 +25520,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25342,6 +25654,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25563,6 +25878,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25622,6 +25940,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25758,6 +26079,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25893,6 +26217,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25996,6 +26323,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26162,6 +26492,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26221,6 +26554,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -26381,6 +26717,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26556,6 +26895,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -26679,6 +27021,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26884,6 +27229,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26943,6 +27291,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -27072,6 +27423,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -27560,6 +27914,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -27652,6 +28009,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -27836,6 +28196,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28027,6 +28390,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -28087,6 +28453,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28144,6 +28513,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28250,6 +28622,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -28454,6 +28829,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28516,6 +28894,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28756,6 +29137,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -29027,6 +29411,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -29197,6 +29584,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -29443,6 +29833,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -29750,6 +30143,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -29927,6 +30323,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -30302,6 +30701,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -30677,6 +31079,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -31039,6 +31444,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -31761,6 +32169,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -32214,6 +32625,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -32789,6 +33203,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -32849,6 +33266,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -33409,6 +33829,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -33975,6 +34398,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34032,6 +34458,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34339,6 +34768,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -34652,6 +35084,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34744,6 +35179,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -34917,6 +35355,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34979,6 +35420,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35036,6 +35480,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35303,6 +35750,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35570,6 +36020,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35627,6 +36080,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35803,6 +36259,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/legal.json
+++ b/packages/openapi/spec/admin/legal.json
@@ -337,6 +337,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -529,6 +532,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -690,6 +696,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -817,6 +826,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1031,6 +1043,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1086,6 +1101,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1181,6 +1199,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1276,6 +1297,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1354,6 +1378,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1503,6 +1530,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1596,6 +1626,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1741,6 +1774,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1949,6 +1985,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -2088,6 +2127,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -2314,6 +2356,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -2369,6 +2414,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -2574,6 +2622,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -3070,6 +3121,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -3694,6 +3748,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -4020,6 +4077,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -4654,6 +4714,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -4727,6 +4790,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -5071,6 +5137,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -5433,6 +5502,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6141,6 +6213,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6485,6 +6560,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6829,6 +6907,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6924,6 +7005,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7033,6 +7117,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7142,6 +7229,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7251,6 +7341,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7433,6 +7526,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7577,6 +7673,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -7913,6 +8012,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8120,6 +8222,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8327,6 +8432,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8662,6 +8770,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -8717,6 +8828,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8924,6 +9038,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8981,6 +9098,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9086,6 +9206,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -9262,6 +9385,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9382,6 +9508,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -9555,6 +9684,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9693,6 +9825,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9813,6 +9948,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9951,6 +10089,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -10215,6 +10356,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -10477,6 +10621,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -10529,6 +10676,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -10746,6 +10896,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -10957,6 +11110,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -11194,6 +11350,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -11246,6 +11405,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -11519,6 +11681,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -11845,6 +12010,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -12276,6 +12444,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -12434,6 +12605,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -12594,6 +12768,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -12705,6 +12882,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -12887,6 +13067,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -12957,6 +13140,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -13079,6 +13265,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -13393,6 +13582,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -13793,6 +13985,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -13990,6 +14185,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -14414,6 +14612,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -14466,6 +14667,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/markets.json
+++ b/packages/openapi/spec/admin/markets.json
@@ -317,6 +317,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -520,6 +523,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -651,6 +657,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -876,6 +885,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -931,6 +943,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1067,6 +1082,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1209,6 +1227,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1348,6 +1369,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -1403,6 +1427,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1547,6 +1574,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1705,6 +1735,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1860,6 +1893,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -1915,6 +1951,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2070,6 +2109,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -2238,6 +2280,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2353,6 +2398,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -2545,6 +2593,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -2600,6 +2651,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2739,6 +2793,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2900,6 +2957,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3056,6 +3116,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3111,6 +3174,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3259,6 +3325,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3417,6 +3486,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3522,6 +3594,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3686,6 +3761,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3741,6 +3819,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3950,6 +4031,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4187,6 +4271,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -4332,6 +4419,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4575,6 +4665,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4630,6 +4723,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -4804,6 +4900,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4988,6 +5087,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -5106,6 +5208,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -5296,6 +5401,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -5351,6 +5459,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/notifications.json
+++ b/packages/openapi/spec/admin/notifications.json
@@ -340,6 +340,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -557,6 +560,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -699,6 +705,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -939,6 +948,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -976,6 +988,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -1128,6 +1143,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -1494,6 +1512,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -1739,6 +1760,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -2002,6 +2026,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -2213,6 +2240,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -2452,6 +2482,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -2966,6 +2999,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -3116,6 +3152,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -3377,6 +3416,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -3414,6 +3456,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -3570,6 +3615,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -3867,6 +3915,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4065,6 +4116,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4383,6 +4437,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -4428,6 +4485,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4552,6 +4612,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -4763,6 +4826,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4999,6 +5065,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -5052,6 +5121,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -5154,6 +5226,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -5355,6 +5430,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -5477,6 +5555,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -5929,6 +6010,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -6258,6 +6342,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -6322,6 +6409,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -6741,6 +6831,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -7160,6 +7253,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -7347,6 +7443,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -7807,6 +7906,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -8038,6 +8140,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -8472,6 +8577,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/operations.json
+++ b/packages/openapi/spec/admin/operations.json
@@ -251,6 +251,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -508,6 +511,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -697,6 +703,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -894,6 +903,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1134,6 +1146,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1231,6 +1246,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1363,6 +1381,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -1582,6 +1603,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -1637,6 +1661,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1808,6 +1835,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -1966,6 +1996,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2169,6 +2202,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2266,6 +2302,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2380,6 +2419,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -2562,6 +2604,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -2617,6 +2662,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2929,6 +2977,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -3277,6 +3328,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -3668,6 +3722,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -3765,6 +3822,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -3978,6 +4038,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -4348,6 +4411,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -4403,6 +4469,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -4497,6 +4566,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -4637,6 +4709,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -4761,6 +4836,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -4930,6 +5008,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5027,6 +5108,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5122,6 +5206,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -5270,6 +5357,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -5325,6 +5415,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5746,6 +5839,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5941,6 +6037,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6176,6 +6275,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -6259,6 +6361,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6425,6 +6530,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6582,6 +6690,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6737,6 +6848,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6897,6 +7011,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -7035,6 +7152,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7142,6 +7262,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7188,6 +7311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7234,6 +7360,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7452,6 +7581,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7572,6 +7704,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7790,6 +7925,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7939,6 +8077,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8190,6 +8331,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -8336,6 +8480,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8475,6 +8622,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8627,6 +8777,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -8763,6 +8916,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8944,6 +9100,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9041,6 +9200,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9144,6 +9306,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -9304,6 +9469,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -9359,6 +9527,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9480,6 +9651,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -9596,6 +9770,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9757,6 +9934,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9854,6 +10034,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9946,6 +10129,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -10086,6 +10272,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -10141,6 +10330,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -10353,6 +10545,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -10564,6 +10759,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -10821,6 +11019,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -10918,6 +11119,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11060,6 +11264,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -11296,6 +11503,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -11351,6 +11561,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11501,6 +11714,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -11637,6 +11853,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11817,6 +12036,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11914,6 +12136,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12016,6 +12241,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -12175,6 +12403,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -12230,6 +12461,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12387,6 +12621,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -12545,6 +12782,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12748,6 +12988,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12845,6 +13088,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12959,6 +13205,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -13141,6 +13390,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -13196,6 +13448,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -13382,6 +13637,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -13579,6 +13837,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -13822,6 +14083,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -13919,6 +14183,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14054,6 +14321,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -14276,6 +14546,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -14331,6 +14604,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14462,6 +14738,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -14585,6 +14864,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14753,6 +15035,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14850,6 +15135,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14946,6 +15234,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -15093,6 +15384,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -15148,6 +15442,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15332,6 +15629,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -15511,6 +15811,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15735,6 +16038,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15832,6 +16138,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15957,6 +16266,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -16160,6 +16472,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -16215,6 +16530,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16377,6 +16695,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -16530,6 +16851,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16728,6 +17052,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16825,6 +17152,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16936,6 +17266,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17113,6 +17446,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17168,6 +17504,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17271,6 +17610,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17391,6 +17733,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17448,6 +17793,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17601,6 +17949,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17766,6 +18117,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17958,6 +18312,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18055,6 +18412,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18163,6 +18523,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -18334,6 +18697,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -18389,6 +18755,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18542,6 +18911,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -18707,6 +19079,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18899,6 +19274,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18996,6 +19374,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -19104,6 +19485,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -19275,6 +19659,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -19330,6 +19717,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -19513,6 +19903,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -19708,6 +20101,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -19931,6 +20327,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20028,6 +20427,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20151,6 +20553,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -20353,6 +20758,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -20408,6 +20816,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20540,6 +20951,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -20697,6 +21111,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20881,6 +21298,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20978,6 +21398,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -21080,6 +21503,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21243,6 +21669,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21298,6 +21727,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -21447,6 +21879,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21590,6 +22025,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -21696,6 +22134,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21864,6 +22305,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21919,6 +22363,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -22139,6 +22586,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -22385,6 +22835,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -22543,6 +22996,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -22814,6 +23270,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -22869,6 +23328,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -23026,6 +23488,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -23186,6 +23651,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -23300,6 +23768,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -23485,6 +23956,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -23540,6 +24014,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -23813,6 +24290,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -24192,6 +24672,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -24421,6 +24904,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -24825,6 +25311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -24880,6 +25369,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -25153,6 +25645,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -25448,6 +25943,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -25632,6 +26130,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -25951,6 +26452,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26006,6 +26510,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -26164,6 +26671,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26335,6 +26845,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -26453,6 +26966,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26649,6 +27165,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26704,6 +27223,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -26892,6 +27414,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27082,6 +27607,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -27212,6 +27740,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27427,6 +27958,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27482,6 +28016,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -27648,6 +28185,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27839,6 +28379,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -27970,6 +28513,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28186,6 +28732,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28241,6 +28790,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -28372,6 +28924,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28504,6 +29059,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -28606,6 +29164,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28763,6 +29324,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28818,6 +29382,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -28992,6 +29559,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29166,6 +29736,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -29288,6 +29861,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29485,6 +30061,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29540,6 +30119,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -29711,6 +30293,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29891,6 +30476,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -30014,6 +30602,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -30218,6 +30809,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -30273,6 +30867,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -30443,6 +31040,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -30643,6 +31243,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -30778,6 +31381,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -31002,6 +31608,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -31057,6 +31666,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -31377,6 +31989,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -31738,6 +32353,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -31961,6 +32579,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -32346,6 +32967,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -32401,6 +33025,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -32516,6 +33143,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -32728,6 +33358,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -32948,6 +33581,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -33003,6 +33639,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -33169,6 +33808,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -33470,6 +34112,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -33783,6 +34428,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -33838,6 +34486,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34014,6 +34665,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34227,6 +34881,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34437,6 +35094,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -34492,6 +35152,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34648,6 +35311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34844,6 +35510,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35037,6 +35706,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -35092,6 +35764,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35260,6 +35935,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35472,6 +36150,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35684,6 +36365,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -35739,6 +36423,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35938,6 +36625,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -36172,6 +36862,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -36316,6 +37009,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -36557,6 +37253,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -36612,6 +37311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -36817,6 +37519,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37038,6 +37743,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -37184,6 +37892,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37430,6 +38141,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37485,6 +38199,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -37643,6 +38360,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37820,6 +38540,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -37934,6 +38657,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38117,6 +38843,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38172,6 +38901,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -38343,6 +39075,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38551,6 +39286,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -38732,6 +39470,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38949,6 +39690,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39098,6 +39842,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39336,6 +40083,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39556,6 +40306,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39712,6 +40465,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39982,6 +40738,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -40127,6 +40886,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -40307,6 +41069,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/operator-settings.json
+++ b/packages/openapi/spec/admin/operator-settings.json
@@ -273,6 +273,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -512,6 +515,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }
@@ -585,6 +591,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -692,6 +701,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }
@@ -752,6 +764,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -885,6 +900,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }
@@ -1042,6 +1060,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -1396,6 +1417,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/pricing.json
+++ b/packages/openapi/spec/admin/pricing.json
@@ -388,6 +388,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -633,6 +636,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -799,6 +805,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1063,6 +1072,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1115,6 +1127,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -1285,6 +1300,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1424,6 +1442,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -1537,6 +1558,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1698,6 +1722,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1750,6 +1777,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -1934,6 +1964,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2090,6 +2123,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -2211,6 +2247,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2389,6 +2428,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2441,6 +2483,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -2595,6 +2640,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2747,6 +2795,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -2866,6 +2917,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3040,6 +3094,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3092,6 +3149,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -3276,6 +3336,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3436,6 +3499,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -3557,6 +3623,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3738,6 +3807,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3790,6 +3862,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -3976,6 +4051,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -4185,6 +4263,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -4328,6 +4409,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -4558,6 +4642,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -4610,6 +4697,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -4872,6 +4962,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -5143,6 +5236,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -5323,6 +5419,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -5612,6 +5711,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -5664,6 +5766,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -5875,6 +5980,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6090,6 +6198,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -6242,6 +6353,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6477,6 +6591,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6529,6 +6646,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -6716,6 +6836,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6901,6 +7024,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -7037,6 +7163,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7243,6 +7372,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7295,6 +7427,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -7437,6 +7572,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7566,6 +7704,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -7673,6 +7814,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7824,6 +7968,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7876,6 +8023,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -8049,6 +8199,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8206,6 +8359,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -8328,6 +8484,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8505,6 +8664,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8557,6 +8719,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -8744,6 +8909,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8930,6 +9098,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -9066,6 +9237,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -9272,6 +9446,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -9324,6 +9501,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -9523,6 +9703,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -9714,6 +9897,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -9854,6 +10040,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10066,6 +10255,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10118,6 +10310,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -10293,6 +10488,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10438,6 +10636,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -10554,6 +10755,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10719,6 +10923,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10771,6 +10978,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/products.json
+++ b/packages/openapi/spec/admin/products.json
@@ -289,6 +289,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -400,6 +403,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -576,6 +582,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -628,6 +637,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -806,6 +818,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -964,6 +979,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1087,6 +1105,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1285,6 +1306,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1337,6 +1361,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1537,6 +1564,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1676,6 +1706,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1766,6 +1799,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1900,6 +1936,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1952,6 +1991,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2088,6 +2130,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2250,6 +2295,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2354,6 +2402,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -2514,6 +2565,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -2566,6 +2620,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2731,6 +2788,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2862,6 +2922,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2954,6 +3017,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3091,6 +3157,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3143,6 +3212,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3285,6 +3357,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3421,6 +3496,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3521,6 +3599,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3675,6 +3756,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3727,6 +3811,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3886,6 +3973,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3993,6 +4083,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4079,6 +4172,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -4207,6 +4303,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -4259,6 +4358,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4393,6 +4495,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4582,6 +4687,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4733,6 +4841,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -4993,6 +5104,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -5045,6 +5159,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -5310,6 +5427,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -5523,6 +5643,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -5728,6 +5851,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -5857,6 +5983,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -6087,6 +6216,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -6139,6 +6271,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6274,6 +6409,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6441,6 +6579,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6604,6 +6745,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -6656,6 +6800,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6791,6 +6938,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6958,6 +7108,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7121,6 +7274,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -7173,6 +7329,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7287,6 +7446,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7414,6 +7576,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7537,6 +7702,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -7589,6 +7757,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7708,6 +7879,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7826,6 +8000,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7888,6 +8065,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8045,6 +8225,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8168,6 +8351,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -8363,6 +8549,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -8415,6 +8604,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8618,6 +8810,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8813,6 +9008,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8971,6 +9169,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -9237,6 +9438,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -9289,6 +9493,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -9564,6 +9771,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -9734,6 +9944,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -9872,6 +10085,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10099,6 +10315,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10151,6 +10370,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10384,6 +10606,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10512,6 +10737,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10608,6 +10836,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10755,6 +10986,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10807,6 +11041,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10960,6 +11197,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11088,6 +11328,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11184,6 +11427,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -11331,6 +11577,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -11383,6 +11632,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11536,6 +11788,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11672,6 +11927,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -11808,6 +12066,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11909,6 +12170,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12069,6 +12333,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12121,6 +12388,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -12273,6 +12543,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12474,6 +12747,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -12583,6 +12859,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12808,6 +13087,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12860,6 +13142,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -12955,6 +13240,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13037,6 +13325,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -13111,6 +13402,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13218,6 +13512,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13270,6 +13567,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -13419,6 +13719,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13665,6 +13968,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13812,6 +14118,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -13997,6 +14306,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14131,6 +14443,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14288,6 +14603,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14445,6 +14763,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14594,6 +14915,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -14818,6 +15142,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -14965,6 +15292,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -15063,6 +15393,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -15282,6 +15615,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -15539,6 +15875,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -15766,6 +16105,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16031,6 +16373,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16102,6 +16447,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16232,6 +16580,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16361,6 +16712,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16413,6 +16767,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16534,6 +16891,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16626,6 +16986,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16788,6 +17151,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16872,6 +17238,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17026,6 +17395,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -17187,6 +17559,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17247,6 +17622,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -17373,6 +17751,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17610,6 +17991,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -17851,6 +18235,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17919,6 +18306,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18023,6 +18413,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18187,6 +18580,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18358,6 +18754,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18426,6 +18825,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18497,6 +18899,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18581,6 +18986,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18644,6 +19052,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18758,6 +19169,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18845,6 +19259,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18978,6 +19395,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19117,6 +19537,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19185,6 +19608,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19294,6 +19720,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19461,6 +19890,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19634,6 +20066,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19710,6 +20145,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19804,6 +20242,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19895,6 +20336,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19957,6 +20401,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20016,6 +20463,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -20104,6 +20554,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20166,6 +20619,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20232,6 +20688,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20337,6 +20796,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20842,6 +21304,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -21402,6 +21867,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -21700,6 +22168,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -22277,6 +22748,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -22329,6 +22803,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -22442,6 +22919,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/promotions.json
+++ b/packages/openapi/spec/admin/promotions.json
@@ -611,6 +611,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       },
@@ -1271,6 +1274,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       }
@@ -1622,6 +1628,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       },
@@ -2304,6 +2313,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       },
@@ -2382,6 +2394,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       }
@@ -2733,6 +2748,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/quotes.json
+++ b/packages/openapi/spec/admin/quotes.json
@@ -263,6 +263,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -380,6 +383,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -472,6 +478,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -614,6 +623,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -687,6 +699,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -809,6 +824,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -945,6 +963,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -1046,6 +1067,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -1206,6 +1230,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -1261,6 +1288,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -1549,6 +1579,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -1868,6 +1901,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2081,6 +2117,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -2423,6 +2462,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -2478,6 +2520,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2552,6 +2597,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -2672,6 +2720,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2729,6 +2780,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2845,6 +2899,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -3040,6 +3097,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3252,6 +3312,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -3307,6 +3370,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3410,6 +3476,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -3586,6 +3655,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3643,6 +3715,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3845,6 +3920,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4141,6 +4219,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4346,6 +4427,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4529,6 +4613,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4670,6 +4757,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4835,6 +4925,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -5125,6 +5218,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -5198,6 +5294,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -5556,6 +5655,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -5740,6 +5842,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -5905,6 +6010,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -6378,6 +6486,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -6562,6 +6673,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -6655,6 +6769,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -6846,6 +6963,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -7035,6 +7155,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -7108,6 +7231,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -439,6 +439,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -753,6 +756,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -946,6 +952,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -1285,6 +1294,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -1340,6 +1352,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -1570,6 +1585,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -1674,6 +1692,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -1869,6 +1890,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2025,6 +2049,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -2312,6 +2339,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2375,6 +2405,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -2489,6 +2522,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2605,6 +2641,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -2660,6 +2699,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2975,6 +3017,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -3408,6 +3453,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -3630,6 +3678,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -4087,6 +4138,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -4142,6 +4196,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -4401,6 +4458,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -4505,6 +4565,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -4700,6 +4763,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -4856,6 +4922,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5143,6 +5212,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5206,6 +5278,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5320,6 +5395,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5436,6 +5514,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5491,6 +5572,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5586,6 +5670,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5776,6 +5863,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5964,6 +6054,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6019,6 +6112,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6190,6 +6286,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6383,6 +6482,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6447,6 +6549,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6557,6 +6662,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6614,6 +6722,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6632,6 +6743,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6705,6 +6819,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6914,6 +7031,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6969,6 +7089,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -7272,6 +7395,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -7327,6 +7453,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -7500,6 +7629,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -7745,6 +7877,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -7885,6 +8020,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -8127,6 +8265,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -8182,6 +8323,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8322,6 +8466,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8469,6 +8616,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8602,6 +8752,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8859,6 +9012,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9113,6 +9269,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9222,6 +9381,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9415,6 +9577,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -9652,6 +9817,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9801,6 +9969,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -10045,6 +10216,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -10100,6 +10274,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -10353,6 +10530,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -10657,6 +10837,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -10834,6 +11017,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -11139,6 +11325,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -11194,6 +11383,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -11408,6 +11600,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -11570,6 +11765,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -11785,6 +11983,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -11980,6 +12181,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12115,6 +12319,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12334,6 +12541,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12389,6 +12599,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12466,6 +12679,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12592,6 +12808,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12649,6 +12868,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12712,6 +12934,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12810,6 +13035,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12867,6 +13095,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -13029,6 +13260,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -13232,6 +13466,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -13367,6 +13604,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -13567,6 +13807,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -13622,6 +13865,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -13799,6 +14045,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -14015,6 +14264,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -14072,6 +14324,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/sellability.json
+++ b/packages/openapi/spec/admin/sellability.json
@@ -282,6 +282,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -552,6 +555,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -785,6 +791,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -944,6 +953,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -1190,6 +1202,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -1442,6 +1457,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -1690,6 +1708,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -1850,6 +1871,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2123,6 +2147,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2175,6 +2202,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -2339,6 +2369,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2498,6 +2531,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -2611,6 +2647,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2795,6 +2834,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2847,6 +2889,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3009,6 +3054,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3177,6 +3225,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3295,6 +3346,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3488,6 +3542,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3540,6 +3597,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3700,6 +3760,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3864,6 +3927,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3981,6 +4047,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4169,6 +4238,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4221,6 +4293,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -4380,6 +4455,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4541,6 +4619,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -4654,6 +4735,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4839,6 +4923,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4891,6 +4978,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/storefront.json
+++ b/packages/openapi/spec/admin/storefront.json
@@ -769,6 +769,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "admin"
       },
@@ -1948,6 +1951,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/suppliers.json
+++ b/packages/openapi/spec/admin/suppliers.json
@@ -259,6 +259,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -471,6 +474,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -691,6 +697,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -743,6 +752,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -866,6 +878,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -1094,6 +1109,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -1331,6 +1349,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -1383,6 +1404,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -1549,6 +1573,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -1850,6 +1877,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2163,6 +2193,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -2215,6 +2248,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2332,6 +2368,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -2548,6 +2587,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2770,6 +2812,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -2830,6 +2875,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2951,6 +2999,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3177,6 +3228,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -3407,6 +3461,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3475,6 +3532,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -3538,6 +3598,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3652,6 +3715,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -3738,6 +3804,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3901,6 +3970,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4002,6 +4074,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -4188,6 +4263,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4381,6 +4459,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -4441,6 +4522,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4551,6 +4635,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4860,6 +4947,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -5244,6 +5334,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -5449,6 +5542,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -5857,6 +5953,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -5909,6 +6008,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/trips.json
+++ b/packages/openapi/spec/admin/trips.json
@@ -188,6 +188,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -797,6 +800,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -1313,6 +1319,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -1769,6 +1778,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -2093,6 +2105,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -2461,6 +2476,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -2601,6 +2619,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -2812,6 +2833,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -2968,6 +2992,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -3391,6 +3418,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -3755,6 +3785,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -4173,6 +4206,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -4509,6 +4545,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -4896,6 +4935,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -5142,6 +5184,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -5340,6 +5385,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -5710,6 +5758,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -6251,6 +6302,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -6621,6 +6675,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -7186,6 +7243,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -7749,6 +7809,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -8295,6 +8358,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -8843,6 +8909,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -9396,6 +9465,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/storefront/booking-requirements.json
+++ b/packages/openapi/spec/storefront/booking-requirements.json
@@ -360,6 +360,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/bookings.json
+++ b/packages/openapi/spec/storefront/bookings.json
@@ -1139,6 +1139,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -1788,6 +1791,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       },
@@ -2588,6 +2594,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -2689,6 +2698,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       },
@@ -2824,6 +2836,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -3707,6 +3722,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -4392,6 +4410,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -5077,6 +5098,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -5611,6 +5635,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -6148,6 +6175,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/catalog.json
+++ b/packages/openapi/spec/storefront/catalog.json
@@ -683,6 +683,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/customer-portal.json
+++ b/packages/openapi/spec/storefront/customer-portal.json
@@ -540,6 +540,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -1213,6 +1216,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -1322,6 +1328,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -1522,6 +1531,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -1656,6 +1668,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -1865,6 +1880,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -1920,6 +1938,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -3201,6 +3222,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -3450,6 +3474,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -3942,6 +3969,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -4241,6 +4271,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -4760,6 +4793,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -4833,6 +4869,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -4980,6 +5019,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -5701,6 +5743,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -5819,6 +5864,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -5947,6 +5995,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -6005,6 +6056,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -6067,6 +6121,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/finance.json
+++ b/packages/openapi/spec/storefront/finance.json
@@ -304,6 +304,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -502,6 +505,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -696,6 +702,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -902,6 +911,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -1079,6 +1091,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -1437,6 +1452,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -1945,6 +1963,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -2856,6 +2877,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -3767,6 +3791,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -4670,6 +4697,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -4766,6 +4796,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -4839,6 +4872,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/legal.json
+++ b/packages/openapi/spec/storefront/legal.json
@@ -305,6 +305,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -397,6 +400,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -489,6 +495,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -581,6 +590,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -673,6 +685,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -847,6 +862,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1057,6 +1075,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1246,6 +1267,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1584,6 +1608,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1898,6 +1925,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -2095,6 +2125,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/markets.json
+++ b/packages/openapi/spec/storefront/markets.json
@@ -249,6 +249,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/operator-settings.json
+++ b/packages/openapi/spec/storefront/operator-settings.json
@@ -224,6 +224,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "storefront"
       }
@@ -304,6 +307,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/pricing.json
+++ b/packages/openapi/spec/storefront/pricing.json
@@ -578,6 +578,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/products.json
+++ b/packages/openapi/spec/storefront/products.json
@@ -229,6 +229,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -344,6 +347,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -553,6 +559,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -1427,6 +1436,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -2110,6 +2122,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -2793,6 +2808,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -2915,6 +2933,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/storefront-verification.json
+++ b/packages/openapi/spec/storefront/storefront-verification.json
@@ -331,6 +331,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }
@@ -519,6 +522,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }
@@ -713,6 +719,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }
@@ -908,6 +917,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/storefront.json
+++ b/packages/openapi/spec/storefront/storefront.json
@@ -306,6 +306,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -483,6 +486,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -932,6 +938,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -1377,6 +1386,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -1670,6 +1682,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -1928,6 +1943,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -2553,6 +2571,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -2940,6 +2961,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -3382,6 +3406,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -3662,6 +3689,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -3804,6 +3834,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -4082,6 +4115,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }

--- a/packages/openapi/spec/storefront/trips.json
+++ b/packages/openapi/spec/storefront/trips.json
@@ -188,6 +188,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -797,6 +800,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -1313,6 +1319,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -1769,6 +1778,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -2093,6 +2105,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -2461,6 +2476,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -2601,6 +2619,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -2812,6 +2833,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -2968,6 +2992,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -3391,6 +3418,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -3755,6 +3785,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -4173,6 +4206,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -4509,6 +4545,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -4896,6 +4935,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -5142,6 +5184,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -5340,6 +5385,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -5710,6 +5758,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -6251,6 +6302,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -6621,6 +6675,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -7186,6 +7243,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -7749,6 +7809,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -8295,6 +8358,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -8843,6 +8909,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -9396,6 +9465,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/admin/accommodations.json
+++ b/starters/operator/openapi/admin/accommodations.json
@@ -368,6 +368,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -602,6 +605,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -767,6 +773,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -1062,6 +1071,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -1212,6 +1224,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }
@@ -1398,6 +1413,9 @@
             }
           }
         },
+        "tags": [
+          "accommodations"
+        ],
         "x-voyant-module": "accommodations",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/action-ledger.json
+++ b/starters/operator/openapi/admin/action-ledger.json
@@ -906,6 +906,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -1668,6 +1671,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -2538,6 +2544,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -3141,6 +3150,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -3511,6 +3523,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -4159,6 +4174,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -4871,6 +4889,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -5506,6 +5527,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -5827,6 +5851,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -5963,6 +5990,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }
@@ -6215,6 +6245,9 @@
             }
           }
         },
+        "tags": [
+          "action-ledger"
+        ],
         "x-voyant-module": "action-ledger",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/booking-requirements.json
+++ b/starters/operator/openapi/admin/booking-requirements.json
@@ -338,6 +338,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -535,6 +538,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -668,6 +674,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -889,6 +898,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -941,6 +953,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -1190,6 +1205,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -1435,6 +1453,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -1592,6 +1613,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -1861,6 +1885,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -1913,6 +1940,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2074,6 +2104,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2205,6 +2238,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2305,6 +2341,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2460,6 +2499,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2512,6 +2554,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2659,6 +2704,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -2784,6 +2832,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -2878,6 +2929,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3026,6 +3080,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3078,6 +3135,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -3237,6 +3297,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3366,6 +3429,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -3464,6 +3530,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3617,6 +3686,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3669,6 +3741,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -3821,6 +3896,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -3936,6 +4014,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -4027,6 +4108,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4166,6 +4250,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4218,6 +4305,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -4395,6 +4485,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4542,6 +4635,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -4650,6 +4746,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4822,6 +4921,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -4874,6 +4976,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -5097,6 +5202,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -5317,6 +5425,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }
@@ -5464,6 +5575,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -5708,6 +5822,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       },
@@ -5760,6 +5877,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/bookings.json
+++ b/starters/operator/openapi/admin/bookings.json
@@ -240,6 +240,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -484,6 +487,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1000,6 +1006,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1088,6 +1097,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1171,6 +1183,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1323,6 +1338,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1422,6 +1440,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -1491,6 +1512,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -2412,6 +2436,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -2493,6 +2520,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -2951,6 +2981,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -3383,6 +3416,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -3838,6 +3874,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -4293,6 +4332,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -4748,6 +4790,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -5203,6 +5248,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -5686,6 +5734,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -5846,6 +5897,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6035,6 +6089,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6165,6 +6222,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -6406,6 +6466,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6596,6 +6659,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -6689,6 +6755,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -6922,6 +6991,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -7018,6 +7090,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -7307,6 +7382,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -7600,6 +7678,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -7847,6 +7928,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -7907,6 +7991,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -8161,6 +8248,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -8659,6 +8749,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9163,6 +9256,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -9241,6 +9337,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9322,6 +9421,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -9483,6 +9585,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9571,6 +9676,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -9694,6 +9802,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -9909,6 +10020,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10135,6 +10249,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10272,6 +10389,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -10530,6 +10650,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10794,6 +10917,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -10899,6 +11025,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11098,6 +11227,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11161,6 +11293,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11276,6 +11411,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11401,6 +11539,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11461,6 +11602,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11556,6 +11700,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -11737,6 +11884,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11799,6 +11949,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -11971,6 +12124,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12126,6 +12282,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12273,6 +12432,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12453,6 +12615,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12505,6 +12670,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12572,6 +12740,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -12720,6 +12891,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12782,6 +12956,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -12834,6 +13011,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -13427,6 +13607,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -14174,6 +14357,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -14928,6 +15114,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -15703,6 +15892,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       },
@@ -15755,6 +15947,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -16421,6 +16616,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -17342,6 +17540,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -18921,6 +19122,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
@@ -19047,6 +19251,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/catalog-booking.json
+++ b/starters/operator/openapi/admin/catalog-booking.json
@@ -1559,6 +1559,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -1936,6 +1939,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -2236,6 +2242,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       },
@@ -2380,6 +2389,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       },
@@ -2399,6 +2411,9 @@
             "description": "Draft deleted (idempotent)"
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -2591,6 +2606,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -2726,6 +2744,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -2798,6 +2819,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -2877,6 +2901,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -3064,6 +3091,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -3199,6 +3229,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }
@@ -3286,6 +3319,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/catalog-content.json
+++ b/starters/operator/openapi/admin/catalog-content.json
@@ -640,6 +640,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-content"
+        ],
         "x-voyant-module": "catalog-content",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/catalog.json
+++ b/starters/operator/openapi/admin/catalog.json
@@ -683,6 +683,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }
@@ -744,6 +747,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }
@@ -823,6 +829,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }
@@ -907,6 +916,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }
@@ -956,6 +968,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }
@@ -1019,6 +1034,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }
@@ -1101,6 +1119,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/charters.json
+++ b/starters/operator/openapi/admin/charters.json
@@ -301,6 +301,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -629,6 +632,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -884,6 +890,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -969,6 +978,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -1057,6 +1069,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -1310,6 +1325,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -1563,6 +1581,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -1844,6 +1865,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -2182,6 +2206,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -2412,6 +2439,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -2569,6 +2599,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -2704,6 +2737,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -2773,6 +2809,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -2901,6 +2940,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -2970,6 +3012,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -3058,6 +3103,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -3302,6 +3350,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -3442,6 +3493,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -3710,6 +3764,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -4058,6 +4115,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }
@@ -4146,6 +4206,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       },
@@ -4397,6 +4460,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/contract-document.json
+++ b/starters/operator/openapi/admin/contract-document.json
@@ -253,6 +253,9 @@
             }
           }
         },
+        "tags": [
+          "contract-document"
+        ],
         "x-voyant-module": "contract-document",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/cruises.json
+++ b/starters/operator/openapi/admin/cruises.json
@@ -311,6 +311,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -827,6 +830,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -1125,6 +1131,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -1513,6 +1522,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -1905,6 +1917,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -2316,6 +2331,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -2548,6 +2566,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -2829,6 +2850,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -3173,6 +3197,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -3533,6 +3560,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -3571,6 +3601,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -3761,6 +3794,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -3799,6 +3835,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -4043,6 +4082,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -4297,6 +4339,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -4385,6 +4430,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -4681,6 +4729,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -4756,6 +4807,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -5048,6 +5102,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -5132,6 +5189,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -5596,6 +5656,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -5773,6 +5836,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -6104,6 +6170,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -6173,6 +6242,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -6476,6 +6548,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -6840,6 +6915,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -7228,6 +7306,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -7490,6 +7571,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -7824,6 +7908,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -8093,6 +8180,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -8470,6 +8560,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -8545,6 +8638,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -8688,6 +8784,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -8814,6 +8913,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -8889,6 +8991,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -9297,6 +9402,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -9665,6 +9773,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -9760,6 +9871,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -9914,6 +10028,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -10073,6 +10190,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -10363,6 +10483,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -10403,6 +10526,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -10464,6 +10590,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -10552,6 +10681,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -11111,6 +11243,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -11473,6 +11608,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -11837,6 +11975,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -11922,6 +12063,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -12189,6 +12333,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -12277,6 +12424,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -12622,6 +12772,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -12760,6 +12913,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       },
@@ -12949,6 +13105,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }
@@ -13154,6 +13313,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/distribution.json
+++ b/starters/operator/openapi/admin/distribution.json
@@ -345,6 +345,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -578,6 +581,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -856,6 +862,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -953,6 +962,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -1110,6 +1122,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -1367,6 +1382,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -1422,6 +1440,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -1544,6 +1565,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -1745,6 +1769,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -1954,6 +1981,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -2009,6 +2039,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -2138,6 +2171,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -2354,6 +2390,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -2579,6 +2618,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -2634,6 +2676,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -2843,6 +2888,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -3073,6 +3121,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -3348,6 +3399,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -3445,6 +3499,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -3611,6 +3668,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -3865,6 +3925,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -3920,6 +3983,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4104,6 +4170,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -4315,6 +4384,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4570,6 +4642,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4667,6 +4742,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -4808,6 +4886,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -5042,6 +5123,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -5097,6 +5181,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -5291,6 +5378,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -5508,6 +5598,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -5766,6 +5859,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -5863,6 +5959,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -6014,6 +6113,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -6251,6 +6353,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -6306,6 +6411,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -6513,6 +6621,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -6743,6 +6854,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7000,6 +7114,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7097,6 +7214,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7267,6 +7387,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -7503,6 +7626,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -7558,6 +7684,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -7715,6 +7844,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -7881,6 +8013,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8091,6 +8226,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8188,6 +8326,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8302,6 +8443,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -8491,6 +8635,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -8546,6 +8693,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -8751,6 +8901,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -8955,6 +9108,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9204,6 +9360,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9301,6 +9460,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9439,6 +9601,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -9667,6 +9832,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -9722,6 +9890,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -9909,6 +10080,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -10093,6 +10267,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10323,6 +10500,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10420,6 +10600,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10547,6 +10730,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -10756,6 +10942,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -10811,6 +11000,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -10956,6 +11148,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -11111,6 +11306,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11312,6 +11510,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11409,6 +11610,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11521,6 +11725,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -11701,6 +11908,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -11756,6 +11966,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -11956,6 +12169,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -12195,6 +12411,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -12351,6 +12570,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -12615,6 +12837,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -12670,6 +12895,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -12868,6 +13096,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13087,6 +13318,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -13233,6 +13467,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13477,6 +13714,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13532,6 +13772,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -13716,6 +13959,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -13926,6 +14172,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -14067,6 +14316,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -14302,6 +14554,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -14357,6 +14612,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -14562,6 +14820,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -14768,6 +15029,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -14907,6 +15171,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15138,6 +15405,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15193,6 +15463,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -15396,6 +15669,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15611,6 +15887,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -15755,6 +16034,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -15995,6 +16277,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16050,6 +16335,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -16246,6 +16534,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16452,6 +16743,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -16591,6 +16885,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16822,6 +17119,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -16877,6 +17177,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -17067,6 +17370,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17262,6 +17568,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -17395,6 +17704,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17615,6 +17927,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17670,6 +17985,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -17834,6 +18152,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -17996,6 +18317,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -18112,6 +18436,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -18299,6 +18626,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -18354,6 +18684,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -18542,6 +18875,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -18748,6 +19084,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -18885,6 +19224,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19115,6 +19457,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19170,6 +19515,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -19316,6 +19664,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19469,6 +19820,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }
@@ -19581,6 +19935,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19759,6 +20116,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       },
@@ -19814,6 +20174,9 @@
             }
           }
         },
+        "tags": [
+          "distribution"
+        ],
         "x-voyant-module": "distribution",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/external-refs.json
+++ b/starters/operator/openapi/admin/external-refs.json
@@ -352,6 +352,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -552,6 +555,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       }
@@ -681,6 +687,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -902,6 +911,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -957,6 +969,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       }
@@ -1181,6 +1196,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       },
@@ -1387,6 +1405,9 @@
             }
           }
         },
+        "tags": [
+          "external-refs"
+        ],
         "x-voyant-module": "external-refs",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/extras.json
+++ b/starters/operator/openapi/admin/extras.json
@@ -390,6 +390,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -676,6 +679,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -853,6 +859,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -1163,6 +1172,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -1215,6 +1227,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -1439,6 +1454,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -1693,6 +1711,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -1856,6 +1877,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -2134,6 +2158,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -2186,6 +2213,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -2440,6 +2470,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -2742,6 +2775,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -2926,6 +2962,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -3251,6 +3290,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       },
@@ -3303,6 +3345,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -3852,6 +3897,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -4128,6 +4176,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -4420,6 +4471,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }
@@ -4677,6 +4731,9 @@
             }
           }
         },
+        "tags": [
+          "extras"
+        ],
         "x-voyant-module": "extras",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/finance.json
+++ b/starters/operator/openapi/admin/finance.json
@@ -647,6 +647,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -1530,6 +1533,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -1894,6 +1900,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -2801,6 +2810,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -3278,6 +3290,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -3695,6 +3710,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -4060,6 +4078,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -4425,6 +4446,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -4790,6 +4814,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -5116,6 +5143,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -5501,6 +5531,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -5725,6 +5758,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -6134,6 +6170,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -6186,6 +6225,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -6442,6 +6484,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -6975,6 +7020,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -7158,6 +7206,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -7715,6 +7766,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -7767,6 +7821,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -7949,6 +8006,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -8155,6 +8215,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8293,6 +8356,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -8523,6 +8589,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -8575,6 +8644,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8640,6 +8712,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8695,6 +8770,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -8775,6 +8853,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9090,6 +9171,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9355,6 +9439,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9471,6 +9558,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9539,6 +9629,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9591,6 +9684,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9664,6 +9760,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -9758,6 +9857,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9882,6 +9984,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -9959,6 +10064,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -10067,6 +10175,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10129,6 +10240,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10237,6 +10351,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -10477,6 +10594,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10687,6 +10807,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -10932,6 +11055,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -10992,6 +11118,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -11772,6 +11901,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -11941,6 +12073,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -12258,6 +12393,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -13038,6 +13176,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -13362,6 +13503,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -13448,6 +13592,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -13564,6 +13711,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -13788,6 +13938,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -14017,6 +14170,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -14077,6 +14233,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -14219,6 +14378,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -14494,6 +14656,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -14774,6 +14939,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -14834,6 +15002,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -15172,6 +15343,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -15369,6 +15543,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -15671,6 +15848,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -15855,6 +16035,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -16154,6 +16337,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -16461,6 +16647,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -16792,6 +16981,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -17189,6 +17381,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -17649,6 +17844,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -18171,6 +18369,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -18462,6 +18663,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -18748,6 +18952,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -19208,6 +19415,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -19278,6 +19488,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -19587,6 +19800,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -20358,6 +20574,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -20454,6 +20673,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -20640,6 +20862,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -20831,6 +21056,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -20891,6 +21119,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -21043,6 +21274,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -21358,6 +21592,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -21470,6 +21707,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -21704,6 +21944,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -21942,6 +22185,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22025,6 +22271,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -22179,6 +22428,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22242,6 +22494,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -22356,6 +22611,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22537,6 +22795,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -22768,6 +23029,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -22916,6 +23180,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -23178,6 +23445,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -23237,6 +23507,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -23335,6 +23608,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -23501,6 +23777,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -23690,6 +23969,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -23815,6 +24097,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24034,6 +24319,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24093,6 +24381,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -24264,6 +24555,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24454,6 +24748,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -24582,6 +24879,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24803,6 +25103,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -24862,6 +25165,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25021,6 +25327,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25211,6 +25520,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25342,6 +25654,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25563,6 +25878,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25622,6 +25940,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25758,6 +26079,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -25893,6 +26217,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -25996,6 +26323,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26162,6 +26492,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26221,6 +26554,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -26381,6 +26717,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26556,6 +26895,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -26679,6 +27021,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26884,6 +27229,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -26943,6 +27291,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -27072,6 +27423,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -27560,6 +27914,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -27652,6 +28009,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -27836,6 +28196,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28027,6 +28390,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -28087,6 +28453,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28144,6 +28513,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28250,6 +28622,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -28454,6 +28829,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28516,6 +28894,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -28756,6 +29137,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -29027,6 +29411,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -29197,6 +29584,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -29443,6 +29833,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -29750,6 +30143,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -29927,6 +30323,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -30302,6 +30701,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -30677,6 +31079,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -31039,6 +31444,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -31761,6 +32169,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -32214,6 +32625,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -32789,6 +33203,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -32849,6 +33266,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -33409,6 +33829,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -33975,6 +34398,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34032,6 +34458,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34339,6 +34768,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -34652,6 +35084,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34744,6 +35179,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       },
@@ -34917,6 +35355,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -34979,6 +35420,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35036,6 +35480,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35303,6 +35750,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35570,6 +36020,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35627,6 +36080,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }
@@ -35803,6 +36259,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/legal.json
+++ b/starters/operator/openapi/admin/legal.json
@@ -337,6 +337,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -529,6 +532,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -690,6 +696,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -817,6 +826,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1031,6 +1043,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1086,6 +1101,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1181,6 +1199,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1276,6 +1297,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1354,6 +1378,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1503,6 +1530,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1596,6 +1626,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -1741,6 +1774,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -1949,6 +1985,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -2088,6 +2127,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -2314,6 +2356,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -2369,6 +2414,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -2574,6 +2622,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -3070,6 +3121,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -3694,6 +3748,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -4020,6 +4077,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -4654,6 +4714,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -4727,6 +4790,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -5071,6 +5137,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -5433,6 +5502,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6141,6 +6213,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6485,6 +6560,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6829,6 +6907,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -6924,6 +7005,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7033,6 +7117,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7142,6 +7229,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7251,6 +7341,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7433,6 +7526,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -7577,6 +7673,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -7913,6 +8012,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8120,6 +8222,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8327,6 +8432,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8662,6 +8770,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -8717,6 +8828,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8924,6 +9038,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -8981,6 +9098,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9086,6 +9206,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -9262,6 +9385,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9382,6 +9508,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -9555,6 +9684,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9693,6 +9825,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9813,6 +9948,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -9951,6 +10089,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -10215,6 +10356,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -10477,6 +10621,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -10529,6 +10676,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -10746,6 +10896,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -10957,6 +11110,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -11194,6 +11350,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -11246,6 +11405,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -11519,6 +11681,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -11845,6 +12010,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -12276,6 +12444,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -12434,6 +12605,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -12594,6 +12768,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -12705,6 +12882,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -12887,6 +13067,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -12957,6 +13140,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -13079,6 +13265,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -13393,6 +13582,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -13793,6 +13985,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }
@@ -13990,6 +14185,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -14414,6 +14612,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       },
@@ -14466,6 +14667,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/markets.json
+++ b/starters/operator/openapi/admin/markets.json
@@ -317,6 +317,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -520,6 +523,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -651,6 +657,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -876,6 +885,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -931,6 +943,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1067,6 +1082,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1209,6 +1227,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1348,6 +1369,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -1403,6 +1427,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1547,6 +1574,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1705,6 +1735,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -1860,6 +1893,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -1915,6 +1951,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2070,6 +2109,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -2238,6 +2280,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2353,6 +2398,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -2545,6 +2593,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -2600,6 +2651,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2739,6 +2793,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -2900,6 +2957,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3056,6 +3116,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3111,6 +3174,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3259,6 +3325,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3417,6 +3486,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3522,6 +3594,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3686,6 +3761,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -3741,6 +3819,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -3950,6 +4031,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4187,6 +4271,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -4332,6 +4419,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4575,6 +4665,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4630,6 +4723,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -4804,6 +4900,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -4988,6 +5087,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }
@@ -5106,6 +5208,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -5296,6 +5401,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       },
@@ -5351,6 +5459,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/media.json
+++ b/starters/operator/openapi/admin/media.json
@@ -353,6 +353,9 @@
             }
           }
         },
+        "tags": [
+          "media"
+        ],
         "x-voyant-module": "media",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/mice.json
+++ b/starters/operator/openapi/admin/mice.json
@@ -375,6 +375,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -628,6 +631,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -772,6 +778,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -954,6 +963,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -1265,6 +1277,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -1452,6 +1467,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -1676,6 +1694,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -1891,6 +1912,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -2117,6 +2141,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -2172,6 +2199,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -2354,6 +2384,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -2547,6 +2580,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -2758,6 +2794,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -2941,6 +2980,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -3155,6 +3197,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -3360,6 +3405,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -3509,6 +3557,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -3690,6 +3741,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -3859,6 +3913,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -4043,6 +4100,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -4231,6 +4291,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -4382,6 +4445,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -4555,6 +4621,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -4732,6 +4801,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -4919,6 +4991,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -5174,6 +5249,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -5410,6 +5488,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -5585,6 +5666,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -5750,6 +5834,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -5903,6 +5990,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }
@@ -6137,6 +6227,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       },
@@ -6315,6 +6408,9 @@
             }
           }
         },
+        "tags": [
+          "mice"
+        ],
         "x-voyant-module": "mice",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/notifications.json
+++ b/starters/operator/openapi/admin/notifications.json
@@ -340,6 +340,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -557,6 +560,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -699,6 +705,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -939,6 +948,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -976,6 +988,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -1128,6 +1143,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -1494,6 +1512,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -1739,6 +1760,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -2002,6 +2026,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -2213,6 +2240,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -2452,6 +2482,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -2966,6 +2999,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -3116,6 +3152,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -3377,6 +3416,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -3414,6 +3456,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -3570,6 +3615,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -3867,6 +3915,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4065,6 +4116,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4383,6 +4437,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -4428,6 +4485,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4552,6 +4612,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -4763,6 +4826,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -4999,6 +5065,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -5052,6 +5121,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -5154,6 +5226,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       },
@@ -5355,6 +5430,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -5477,6 +5555,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -5929,6 +6010,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -6258,6 +6342,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -6322,6 +6409,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -6741,6 +6831,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -7160,6 +7253,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -7347,6 +7443,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -7807,6 +7906,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -8038,6 +8140,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }
@@ -8472,6 +8577,9 @@
             }
           }
         },
+        "tags": [
+          "notifications"
+        ],
         "x-voyant-module": "notifications",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/operations.json
+++ b/starters/operator/openapi/admin/operations.json
@@ -251,6 +251,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -508,6 +511,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -697,6 +703,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -894,6 +903,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1134,6 +1146,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1231,6 +1246,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1363,6 +1381,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -1582,6 +1603,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -1637,6 +1661,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -1808,6 +1835,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -1966,6 +1996,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2169,6 +2202,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2266,6 +2302,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2380,6 +2419,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -2562,6 +2604,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -2617,6 +2662,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -2929,6 +2977,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -3277,6 +3328,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -3668,6 +3722,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -3765,6 +3822,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -3978,6 +4038,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -4348,6 +4411,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -4403,6 +4469,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -4497,6 +4566,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -4637,6 +4709,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -4761,6 +4836,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -4930,6 +5008,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5027,6 +5108,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5122,6 +5206,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -5270,6 +5357,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -5325,6 +5415,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5746,6 +5839,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -5941,6 +6037,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6176,6 +6275,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -6259,6 +6361,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6425,6 +6530,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6582,6 +6690,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6737,6 +6848,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -6897,6 +7011,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -7035,6 +7152,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7142,6 +7262,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7188,6 +7311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7234,6 +7360,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7452,6 +7581,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7572,6 +7704,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7790,6 +7925,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -7939,6 +8077,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8190,6 +8331,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -8336,6 +8480,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8475,6 +8622,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8627,6 +8777,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -8763,6 +8916,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -8944,6 +9100,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9041,6 +9200,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9144,6 +9306,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -9304,6 +9469,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -9359,6 +9527,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9480,6 +9651,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -9596,6 +9770,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9757,6 +9934,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9854,6 +10034,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -9946,6 +10129,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -10086,6 +10272,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -10141,6 +10330,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -10353,6 +10545,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -10564,6 +10759,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -10821,6 +11019,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -10918,6 +11119,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11060,6 +11264,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -11296,6 +11503,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -11351,6 +11561,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11501,6 +11714,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -11637,6 +11853,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11817,6 +12036,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -11914,6 +12136,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12016,6 +12241,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -12175,6 +12403,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -12230,6 +12461,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12387,6 +12621,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -12545,6 +12782,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12748,6 +12988,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12845,6 +13088,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -12959,6 +13205,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -13141,6 +13390,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -13196,6 +13448,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -13382,6 +13637,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -13579,6 +13837,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -13822,6 +14083,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -13919,6 +14183,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14054,6 +14321,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -14276,6 +14546,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -14331,6 +14604,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14462,6 +14738,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -14585,6 +14864,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14753,6 +15035,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14850,6 +15135,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -14946,6 +15234,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -15093,6 +15384,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -15148,6 +15442,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15332,6 +15629,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -15511,6 +15811,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15735,6 +16038,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15832,6 +16138,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -15957,6 +16266,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -16160,6 +16472,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -16215,6 +16530,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16377,6 +16695,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -16530,6 +16851,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16728,6 +17052,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16825,6 +17152,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -16936,6 +17266,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17113,6 +17446,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17168,6 +17504,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17271,6 +17610,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17391,6 +17733,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17448,6 +17793,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17601,6 +17949,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -17766,6 +18117,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -17958,6 +18312,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18055,6 +18412,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18163,6 +18523,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -18334,6 +18697,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -18389,6 +18755,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18542,6 +18911,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -18707,6 +19079,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18899,6 +19274,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -18996,6 +19374,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -19104,6 +19485,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -19275,6 +19659,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -19330,6 +19717,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -19513,6 +19903,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -19708,6 +20101,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -19931,6 +20327,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20028,6 +20427,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20151,6 +20553,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -20353,6 +20758,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -20408,6 +20816,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20540,6 +20951,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -20697,6 +21111,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20881,6 +21298,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -20978,6 +21398,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -21080,6 +21503,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21243,6 +21669,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21298,6 +21727,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -21447,6 +21879,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21590,6 +22025,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -21696,6 +22134,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21864,6 +22305,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -21919,6 +22363,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -22139,6 +22586,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -22385,6 +22835,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -22543,6 +22996,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -22814,6 +23270,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -22869,6 +23328,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -23026,6 +23488,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -23186,6 +23651,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -23300,6 +23768,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -23485,6 +23956,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -23540,6 +24014,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -23813,6 +24290,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -24192,6 +24672,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -24421,6 +24904,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -24825,6 +25311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -24880,6 +25369,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -25153,6 +25645,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -25448,6 +25943,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -25632,6 +26130,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -25951,6 +26452,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26006,6 +26510,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -26164,6 +26671,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26335,6 +26845,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -26453,6 +26966,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26649,6 +27165,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -26704,6 +27223,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -26892,6 +27414,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27082,6 +27607,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -27212,6 +27740,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27427,6 +27958,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27482,6 +28016,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -27648,6 +28185,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -27839,6 +28379,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -27970,6 +28513,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28186,6 +28732,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28241,6 +28790,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -28372,6 +28924,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28504,6 +29059,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -28606,6 +29164,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28763,6 +29324,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -28818,6 +29382,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -28992,6 +29559,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29166,6 +29736,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -29288,6 +29861,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29485,6 +30061,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29540,6 +30119,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -29711,6 +30293,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -29891,6 +30476,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -30014,6 +30602,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -30218,6 +30809,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -30273,6 +30867,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -30443,6 +31040,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -30643,6 +31243,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -30778,6 +31381,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -31002,6 +31608,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -31057,6 +31666,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -31377,6 +31989,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -31738,6 +32353,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -31961,6 +32579,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -32346,6 +32967,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -32401,6 +33025,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -32516,6 +33143,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -32728,6 +33358,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -32948,6 +33581,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -33003,6 +33639,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -33169,6 +33808,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -33470,6 +34112,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -33783,6 +34428,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -33838,6 +34486,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34014,6 +34665,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34227,6 +34881,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34437,6 +35094,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -34492,6 +35152,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34648,6 +35311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -34844,6 +35510,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35037,6 +35706,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -35092,6 +35764,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35260,6 +35935,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35472,6 +36150,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35684,6 +36365,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -35739,6 +36423,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -35938,6 +36625,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -36172,6 +36862,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -36316,6 +37009,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -36557,6 +37253,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -36612,6 +37311,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -36817,6 +37519,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37038,6 +37743,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -37184,6 +37892,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37430,6 +38141,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37485,6 +38199,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -37643,6 +38360,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -37820,6 +38540,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -37934,6 +38657,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38117,6 +38843,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38172,6 +38901,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -38343,6 +39075,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38551,6 +39286,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -38732,6 +39470,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       },
@@ -38949,6 +39690,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39098,6 +39842,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39336,6 +40083,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39556,6 +40306,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39712,6 +40465,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -39982,6 +40738,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -40127,6 +40886,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }
@@ -40307,6 +41069,9 @@
             }
           }
         },
+        "tags": [
+          "operations"
+        ],
         "x-voyant-module": "operations",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/operator-settings.json
+++ b/starters/operator/openapi/admin/operator-settings.json
@@ -273,6 +273,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -512,6 +515,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }
@@ -585,6 +591,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -692,6 +701,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }
@@ -752,6 +764,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -885,6 +900,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }
@@ -1042,6 +1060,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       },
@@ -1396,6 +1417,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/pricing.json
+++ b/starters/operator/openapi/admin/pricing.json
@@ -388,6 +388,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -633,6 +636,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -799,6 +805,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1063,6 +1072,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1115,6 +1127,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -1285,6 +1300,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1424,6 +1442,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -1537,6 +1558,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1698,6 +1722,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -1750,6 +1777,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -1934,6 +1964,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2090,6 +2123,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -2211,6 +2247,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2389,6 +2428,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2441,6 +2483,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -2595,6 +2640,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -2747,6 +2795,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -2866,6 +2917,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3040,6 +3094,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3092,6 +3149,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -3276,6 +3336,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3436,6 +3499,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -3557,6 +3623,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3738,6 +3807,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -3790,6 +3862,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -3976,6 +4051,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -4185,6 +4263,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -4328,6 +4409,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -4558,6 +4642,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -4610,6 +4697,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -4872,6 +4962,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -5143,6 +5236,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -5323,6 +5419,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -5612,6 +5711,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -5664,6 +5766,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -5875,6 +5980,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6090,6 +6198,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -6242,6 +6353,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6477,6 +6591,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6529,6 +6646,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -6716,6 +6836,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -6901,6 +7024,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -7037,6 +7163,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7243,6 +7372,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7295,6 +7427,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -7437,6 +7572,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7566,6 +7704,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -7673,6 +7814,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7824,6 +7968,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -7876,6 +8023,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -8049,6 +8199,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8206,6 +8359,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -8328,6 +8484,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8505,6 +8664,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8557,6 +8719,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -8744,6 +8909,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -8930,6 +9098,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -9066,6 +9237,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -9272,6 +9446,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -9324,6 +9501,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -9523,6 +9703,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -9714,6 +9897,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -9854,6 +10040,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10066,6 +10255,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10118,6 +10310,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -10293,6 +10488,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10438,6 +10636,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }
@@ -10554,6 +10755,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10719,6 +10923,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       },
@@ -10771,6 +10978,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/products.json
+++ b/starters/operator/openapi/admin/products.json
@@ -289,6 +289,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -400,6 +403,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -576,6 +582,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -628,6 +637,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -806,6 +818,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -964,6 +979,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1087,6 +1105,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1285,6 +1306,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1337,6 +1361,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1537,6 +1564,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1676,6 +1706,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -1766,6 +1799,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1900,6 +1936,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -1952,6 +1991,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2088,6 +2130,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2250,6 +2295,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2354,6 +2402,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -2514,6 +2565,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -2566,6 +2620,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2731,6 +2788,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2862,6 +2922,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -2954,6 +3017,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3091,6 +3157,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3143,6 +3212,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3285,6 +3357,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3421,6 +3496,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3521,6 +3599,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3675,6 +3756,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -3727,6 +3811,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3886,6 +3973,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -3993,6 +4083,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4079,6 +4172,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -4207,6 +4303,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -4259,6 +4358,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4393,6 +4495,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4582,6 +4687,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -4733,6 +4841,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -4993,6 +5104,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -5045,6 +5159,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -5310,6 +5427,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -5523,6 +5643,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -5728,6 +5851,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -5857,6 +5983,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -6087,6 +6216,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -6139,6 +6271,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6274,6 +6409,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6441,6 +6579,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6604,6 +6745,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -6656,6 +6800,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6791,6 +6938,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -6958,6 +7108,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7121,6 +7274,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -7173,6 +7329,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7287,6 +7446,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7414,6 +7576,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7537,6 +7702,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -7589,6 +7757,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7708,6 +7879,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7826,6 +8000,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -7888,6 +8065,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8045,6 +8225,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8168,6 +8351,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -8363,6 +8549,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -8415,6 +8604,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8618,6 +8810,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8813,6 +9008,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -8971,6 +9169,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -9237,6 +9438,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -9289,6 +9493,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -9564,6 +9771,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -9734,6 +9944,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -9872,6 +10085,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10099,6 +10315,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10151,6 +10370,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10384,6 +10606,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10512,6 +10737,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10608,6 +10836,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10755,6 +10986,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -10807,6 +11041,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -10960,6 +11197,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11088,6 +11328,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11184,6 +11427,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -11331,6 +11577,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -11383,6 +11632,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11536,6 +11788,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11672,6 +11927,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -11808,6 +12066,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -11909,6 +12170,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12069,6 +12333,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12121,6 +12388,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -12273,6 +12543,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12474,6 +12747,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -12583,6 +12859,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12808,6 +13087,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -12860,6 +13142,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -12955,6 +13240,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13037,6 +13325,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -13111,6 +13402,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13218,6 +13512,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13270,6 +13567,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -13419,6 +13719,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13665,6 +13968,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -13812,6 +14118,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -13997,6 +14306,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14131,6 +14443,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14288,6 +14603,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14445,6 +14763,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -14594,6 +14915,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -14818,6 +15142,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -14965,6 +15292,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -15063,6 +15393,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -15282,6 +15615,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -15539,6 +15875,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -15766,6 +16105,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16031,6 +16373,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16102,6 +16447,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16232,6 +16580,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16361,6 +16712,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16413,6 +16767,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16534,6 +16891,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16626,6 +16986,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -16788,6 +17151,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -16872,6 +17238,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17026,6 +17395,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -17187,6 +17559,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17247,6 +17622,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -17373,6 +17751,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17610,6 +17991,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -17851,6 +18235,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -17919,6 +18306,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18023,6 +18413,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18187,6 +18580,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18358,6 +18754,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18426,6 +18825,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18497,6 +18899,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18581,6 +18986,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18644,6 +19052,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18758,6 +19169,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -18845,6 +19259,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -18978,6 +19395,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19117,6 +19537,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19185,6 +19608,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19294,6 +19720,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19461,6 +19890,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19634,6 +20066,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19710,6 +20145,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19804,6 +20242,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -19895,6 +20336,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -19957,6 +20401,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20016,6 +20463,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -20104,6 +20554,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20166,6 +20619,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20232,6 +20688,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20337,6 +20796,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -20842,6 +21304,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -21402,6 +21867,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -21700,6 +22168,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -22277,6 +22748,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       },
@@ -22329,6 +22803,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }
@@ -22442,6 +22919,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/promotions.json
+++ b/starters/operator/openapi/admin/promotions.json
@@ -611,6 +611,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       },
@@ -1271,6 +1274,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       }
@@ -1622,6 +1628,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       },
@@ -2304,6 +2313,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       },
@@ -2382,6 +2394,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       }
@@ -2733,6 +2748,9 @@
             }
           }
         },
+        "tags": [
+          "promotions"
+        ],
         "x-voyant-module": "promotions",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/quotes.json
+++ b/starters/operator/openapi/admin/quotes.json
@@ -263,6 +263,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -380,6 +383,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -472,6 +478,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -614,6 +623,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -687,6 +699,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -809,6 +824,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -945,6 +963,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -1046,6 +1067,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -1206,6 +1230,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -1261,6 +1288,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -1549,6 +1579,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -1868,6 +1901,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2081,6 +2117,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -2423,6 +2462,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -2478,6 +2520,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2552,6 +2597,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -2672,6 +2720,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2729,6 +2780,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -2845,6 +2899,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -3040,6 +3097,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3252,6 +3312,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -3307,6 +3370,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3410,6 +3476,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -3586,6 +3655,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3643,6 +3715,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -3845,6 +3920,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4141,6 +4219,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4346,6 +4427,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4529,6 +4613,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4670,6 +4757,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -4835,6 +4925,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -5125,6 +5218,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -5198,6 +5294,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -5556,6 +5655,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -5740,6 +5842,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -5905,6 +6010,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -6378,6 +6486,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -6562,6 +6673,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -6655,6 +6769,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -6846,6 +6963,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }
@@ -7035,6 +7155,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       },
@@ -7108,6 +7231,9 @@
             }
           }
         },
+        "tags": [
+          "quotes"
+        ],
         "x-voyant-module": "quotes",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -439,6 +439,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -753,6 +756,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -946,6 +952,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -1285,6 +1294,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -1340,6 +1352,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -1570,6 +1585,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -1674,6 +1692,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -1869,6 +1890,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2025,6 +2049,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -2312,6 +2339,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2375,6 +2405,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -2489,6 +2522,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2605,6 +2641,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -2660,6 +2699,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -2975,6 +3017,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -3408,6 +3453,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -3630,6 +3678,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -4087,6 +4138,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -4142,6 +4196,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -4401,6 +4458,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -4505,6 +4565,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -4700,6 +4763,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -4856,6 +4922,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5143,6 +5212,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5206,6 +5278,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5320,6 +5395,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5436,6 +5514,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5491,6 +5572,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5586,6 +5670,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -5776,6 +5863,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -5964,6 +6054,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6019,6 +6112,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6190,6 +6286,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6383,6 +6482,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6447,6 +6549,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6557,6 +6662,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6614,6 +6722,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6632,6 +6743,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6705,6 +6819,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -6914,6 +7031,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -6969,6 +7089,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -7272,6 +7395,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -7327,6 +7453,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -7500,6 +7629,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -7745,6 +7877,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -7885,6 +8020,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -8127,6 +8265,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -8182,6 +8323,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8322,6 +8466,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8469,6 +8616,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8602,6 +8752,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -8859,6 +9012,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9113,6 +9269,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9222,6 +9381,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9415,6 +9577,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -9652,6 +9817,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -9801,6 +9969,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -10045,6 +10216,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -10100,6 +10274,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -10353,6 +10530,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -10657,6 +10837,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -10834,6 +11017,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -11139,6 +11325,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -11194,6 +11383,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -11408,6 +11600,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -11570,6 +11765,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -11785,6 +11983,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -11980,6 +12181,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12115,6 +12319,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12334,6 +12541,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12389,6 +12599,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12466,6 +12679,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12592,6 +12808,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12649,6 +12868,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12712,6 +12934,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -12810,6 +13035,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -12867,6 +13095,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -13029,6 +13260,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -13232,6 +13466,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -13367,6 +13604,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -13567,6 +13807,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       },
@@ -13622,6 +13865,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -13799,6 +14045,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -14015,6 +14264,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }
@@ -14072,6 +14324,9 @@
             }
           }
         },
+        "tags": [
+          "relationships"
+        ],
         "x-voyant-module": "relationships",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/sellability.json
+++ b/starters/operator/openapi/admin/sellability.json
@@ -282,6 +282,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -552,6 +555,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -785,6 +791,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -944,6 +953,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -1190,6 +1202,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -1442,6 +1457,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -1690,6 +1708,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -1850,6 +1871,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2123,6 +2147,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2175,6 +2202,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -2339,6 +2369,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2498,6 +2531,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -2611,6 +2647,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2795,6 +2834,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -2847,6 +2889,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3009,6 +3054,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3177,6 +3225,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3295,6 +3346,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3488,6 +3542,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3540,6 +3597,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3700,6 +3760,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -3864,6 +3927,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -3981,6 +4047,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4169,6 +4238,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4221,6 +4293,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -4380,6 +4455,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4541,6 +4619,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }
@@ -4654,6 +4735,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4839,6 +4923,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       },
@@ -4891,6 +4978,9 @@
             }
           }
         },
+        "tags": [
+          "sellability"
+        ],
         "x-voyant-module": "sellability",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/storefront.json
+++ b/starters/operator/openapi/admin/storefront.json
@@ -769,6 +769,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "admin"
       },
@@ -1948,6 +1951,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/suppliers.json
+++ b/starters/operator/openapi/admin/suppliers.json
@@ -259,6 +259,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -471,6 +474,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -691,6 +697,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -743,6 +752,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -866,6 +878,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -1094,6 +1109,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -1331,6 +1349,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -1383,6 +1404,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -1549,6 +1573,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -1850,6 +1877,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2163,6 +2193,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -2215,6 +2248,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2332,6 +2368,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -2548,6 +2587,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2770,6 +2812,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -2830,6 +2875,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -2951,6 +2999,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3177,6 +3228,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -3407,6 +3461,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3475,6 +3532,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -3538,6 +3598,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3652,6 +3715,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -3738,6 +3804,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -3901,6 +3970,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4002,6 +4074,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -4188,6 +4263,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4381,6 +4459,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -4441,6 +4522,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4551,6 +4635,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -4860,6 +4947,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -5244,6 +5334,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }
@@ -5449,6 +5542,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -5857,6 +5953,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       },
@@ -5909,6 +6008,9 @@
             }
           }
         },
+        "tags": [
+          "suppliers"
+        ],
         "x-voyant-module": "suppliers",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/trips.json
+++ b/starters/operator/openapi/admin/trips.json
@@ -188,6 +188,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -797,6 +800,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -1313,6 +1319,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -1769,6 +1778,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -2093,6 +2105,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -2461,6 +2476,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -2601,6 +2619,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -2812,6 +2833,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -2968,6 +2992,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -3391,6 +3418,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -3755,6 +3785,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -4173,6 +4206,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -4509,6 +4545,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -4896,6 +4935,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -5142,6 +5184,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       },
@@ -5340,6 +5385,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -5710,6 +5758,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -6251,6 +6302,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -6621,6 +6675,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -7186,6 +7243,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -7749,6 +7809,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -8295,6 +8358,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -8843,6 +8909,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }
@@ -9396,6 +9465,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/workflow-runs.json
+++ b/starters/operator/openapi/admin/workflow-runs.json
@@ -350,6 +350,9 @@
             }
           }
         },
+        "tags": [
+          "workflow-runs"
+        ],
         "x-voyant-module": "workflow-runs",
         "x-voyant-surface": "admin"
       }
@@ -647,6 +650,9 @@
             }
           }
         },
+        "tags": [
+          "workflow-runs"
+        ],
         "x-voyant-module": "workflow-runs",
         "x-voyant-surface": "admin"
       }
@@ -809,6 +815,9 @@
             }
           }
         },
+        "tags": [
+          "workflow-runs"
+        ],
         "x-voyant-module": "workflow-runs",
         "x-voyant-surface": "admin"
       }
@@ -956,6 +965,9 @@
             }
           }
         },
+        "tags": [
+          "workflow-runs"
+        ],
         "x-voyant-module": "workflow-runs",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/workflows.json
+++ b/starters/operator/openapi/admin/workflows.json
@@ -291,6 +291,9 @@
             }
           }
         },
+        "tags": [
+          "workflows"
+        ],
         "x-voyant-module": "workflows",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/storefront/booking-requirements.json
+++ b/starters/operator/openapi/storefront/booking-requirements.json
@@ -360,6 +360,9 @@
             }
           }
         },
+        "tags": [
+          "booking-requirements"
+        ],
         "x-voyant-module": "booking-requirements",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/bookings.json
+++ b/starters/operator/openapi/storefront/bookings.json
@@ -1139,6 +1139,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -1788,6 +1791,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       },
@@ -2588,6 +2594,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -2689,6 +2698,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       },
@@ -2824,6 +2836,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -3707,6 +3722,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -4392,6 +4410,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -5077,6 +5098,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -5611,6 +5635,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -6148,6 +6175,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }
@@ -6269,6 +6299,9 @@
             }
           }
         },
+        "tags": [
+          "bookings"
+        ],
         "x-voyant-module": "bookings",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/catalog-booking.json
+++ b/starters/operator/openapi/storefront/catalog-booking.json
@@ -1559,6 +1559,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       }
@@ -1936,6 +1939,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       }
@@ -2236,6 +2242,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       },
@@ -2380,6 +2389,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       },
@@ -2399,6 +2411,9 @@
             "description": "Draft deleted (idempotent)"
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       }
@@ -2591,6 +2606,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       }
@@ -2726,6 +2744,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       }
@@ -2861,6 +2882,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-booking"
+        ],
         "x-voyant-module": "catalog-booking",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/catalog-content.json
+++ b/starters/operator/openapi/storefront/catalog-content.json
@@ -640,6 +640,9 @@
             }
           }
         },
+        "tags": [
+          "catalog-content"
+        ],
         "x-voyant-module": "catalog-content",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/catalog.json
+++ b/starters/operator/openapi/storefront/catalog.json
@@ -683,6 +683,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "storefront"
       }
@@ -1038,6 +1041,9 @@
             }
           }
         },
+        "tags": [
+          "catalog"
+        ],
         "x-voyant-module": "catalog",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/charters.json
+++ b/starters/operator/openapi/storefront/charters.json
@@ -274,6 +274,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }
@@ -555,6 +558,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }
@@ -836,6 +842,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }
@@ -996,6 +1005,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }
@@ -1145,6 +1157,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }
@@ -1233,6 +1248,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }
@@ -1302,6 +1320,9 @@
             }
           }
         },
+        "tags": [
+          "charters"
+        ],
         "x-voyant-module": "charters",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/cruises.json
+++ b/starters/operator/openapi/storefront/cruises.json
@@ -587,6 +587,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "storefront"
       }
@@ -700,6 +703,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "storefront"
       }
@@ -1011,6 +1017,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "storefront"
       }
@@ -1099,6 +1108,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "storefront"
       }
@@ -1458,6 +1470,9 @@
             }
           }
         },
+        "tags": [
+          "cruises"
+        ],
         "x-voyant-module": "cruises",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/customer-portal.json
+++ b/starters/operator/openapi/storefront/customer-portal.json
@@ -540,6 +540,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -1213,6 +1216,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -1322,6 +1328,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -1522,6 +1531,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -1656,6 +1668,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -1865,6 +1880,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -1920,6 +1938,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -3201,6 +3222,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -3450,6 +3474,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -3942,6 +3969,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -4241,6 +4271,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -4760,6 +4793,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       },
@@ -4833,6 +4869,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -4980,6 +5019,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -5701,6 +5743,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -5819,6 +5864,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -5947,6 +5995,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -6005,6 +6056,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }
@@ -6067,6 +6121,9 @@
             }
           }
         },
+        "tags": [
+          "customer-portal"
+        ],
         "x-voyant-module": "customer-portal",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/finance.json
+++ b/starters/operator/openapi/storefront/finance.json
@@ -304,6 +304,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -502,6 +505,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -696,6 +702,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -902,6 +911,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -1079,6 +1091,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -1437,6 +1452,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -1945,6 +1963,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -2856,6 +2877,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -3767,6 +3791,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -4670,6 +4697,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -4766,6 +4796,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }
@@ -4839,6 +4872,9 @@
             }
           }
         },
+        "tags": [
+          "finance"
+        ],
         "x-voyant-module": "finance",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/legal.json
+++ b/starters/operator/openapi/storefront/legal.json
@@ -305,6 +305,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -397,6 +400,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -489,6 +495,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -581,6 +590,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -673,6 +685,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -847,6 +862,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1057,6 +1075,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1246,6 +1267,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1584,6 +1608,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -1898,6 +1925,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }
@@ -2095,6 +2125,9 @@
             }
           }
         },
+        "tags": [
+          "legal"
+        ],
         "x-voyant-module": "legal",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/markets.json
+++ b/starters/operator/openapi/storefront/markets.json
@@ -249,6 +249,9 @@
             }
           }
         },
+        "tags": [
+          "markets"
+        ],
         "x-voyant-module": "markets",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/operator-settings.json
+++ b/starters/operator/openapi/storefront/operator-settings.json
@@ -224,6 +224,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "storefront"
       }
@@ -304,6 +307,9 @@
             }
           }
         },
+        "tags": [
+          "operator-settings"
+        ],
         "x-voyant-module": "operator-settings",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/payment-link.json
+++ b/starters/operator/openapi/storefront/payment-link.json
@@ -206,6 +206,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }
@@ -289,6 +292,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }
@@ -369,6 +375,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }
@@ -470,6 +479,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }
@@ -642,6 +654,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }
@@ -835,6 +850,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }
@@ -1056,6 +1074,9 @@
             }
           }
         },
+        "tags": [
+          "payment-link"
+        ],
         "x-voyant-module": "payment-link",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/pricing.json
+++ b/starters/operator/openapi/storefront/pricing.json
@@ -578,6 +578,9 @@
             }
           }
         },
+        "tags": [
+          "pricing"
+        ],
         "x-voyant-module": "pricing",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/products.json
+++ b/starters/operator/openapi/storefront/products.json
@@ -229,6 +229,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -344,6 +347,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -553,6 +559,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -1427,6 +1436,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -2110,6 +2122,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -2793,6 +2808,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }
@@ -2915,6 +2933,9 @@
             }
           }
         },
+        "tags": [
+          "products"
+        ],
         "x-voyant-module": "products",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/storefront-verification.json
+++ b/starters/operator/openapi/storefront/storefront-verification.json
@@ -331,6 +331,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }
@@ -519,6 +522,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }
@@ -713,6 +719,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }
@@ -908,6 +917,9 @@
             }
           }
         },
+        "tags": [
+          "storefront-verification"
+        ],
         "x-voyant-module": "storefront-verification",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/storefront.json
+++ b/starters/operator/openapi/storefront/storefront.json
@@ -306,6 +306,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -483,6 +486,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -932,6 +938,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -1377,6 +1386,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -1670,6 +1682,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -1928,6 +1943,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -2553,6 +2571,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -2940,6 +2961,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -3382,6 +3406,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -3662,6 +3689,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -3804,6 +3834,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }
@@ -4082,6 +4115,9 @@
             }
           }
         },
+        "tags": [
+          "storefront"
+        ],
         "x-voyant-module": "storefront",
         "x-voyant-surface": "storefront"
       }

--- a/starters/operator/openapi/storefront/trips.json
+++ b/starters/operator/openapi/storefront/trips.json
@@ -188,6 +188,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -797,6 +800,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -1313,6 +1319,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -1769,6 +1778,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -2093,6 +2105,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -2461,6 +2476,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -2601,6 +2619,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -2812,6 +2833,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -2968,6 +2992,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -3391,6 +3418,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -3755,6 +3785,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -4173,6 +4206,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -4509,6 +4545,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -4896,6 +4935,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -5142,6 +5184,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       },
@@ -5340,6 +5385,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -5710,6 +5758,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -6251,6 +6302,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -6621,6 +6675,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -7186,6 +7243,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -7749,6 +7809,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -8295,6 +8358,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -8843,6 +8909,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }
@@ -9396,6 +9465,9 @@
             }
           }
         },
+        "tags": [
+          "trips"
+        ],
         "x-voyant-module": "trips",
         "x-voyant-surface": "storefront"
       }


### PR DESCRIPTION
Follow-up to #2769. The cheap, high-leverage half of "make the specs Swagger-ready".

## What

`stampModuleMetadata` now also sets `tags: [module]` on each operation (unless the route already declares tags).

## Why

Swagger UI, Scalar, and Redoc build their sidebar grouping from **`tags`** — and they **ignore** `x-*` extensions. So the `x-voyant-module`/`x-voyant-surface` metadata from #2769 is great for custom tooling but does nothing for an off-the-shelf viewer. Without `tags`, pointing Swagger at a whole-surface document (`framework-admin.json`, ~700 operations) collapses everything under a single "default" group — exactly the browsability complaint in #2733.

With `tags`, **any deployment can point a viewer straight at a generated spec and get a module-grouped explorer with zero extra work** — no custom UI required. This is what makes "is it enough to do a Swagger?" a yes for the grouped experience.

The tag is the authoritative owning module (same source as the `x-voyant-module` stamp), so `publicPath` routes group under their real module (e.g. `/v1/public/payment-policy/resolve` → `bookings`). Existing route-declared tags are never clobbered.

## Testing

- `pnpm --filter @voyant-travel/hono test` — 260 pass (added: tag assertion + "doesn't clobber existing tags").
- `pnpm --filter @voyant-travel/openapi test` + `pnpm --filter operator test` — drift gates green (43 / 57), all specs regenerated.
- `pnpm release:plan` — clean.

## Still open (own PRs)

- A shipped **Scalar/Swagger docs route** in the operator starter (a demo explorer with a per-module selector) — the visible UI. This PR makes the specs it would render group correctly.
- `operationId`, `summary`, `securitySchemes` for #2729.