### PR TITLE
Validate resource closeout windows

### DIFF
--- a/.changeset/resource-closeout-window-validation.md
+++ b/.changeset/resource-closeout-window-validation.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/operations": patch
+"@voyant-travel/operations-react": patch
+"@voyant-travel/i18n": patch
+"@voyant-travel/openapi": patch
+---
+
+Reject inverted, duplicate, and overlapping resource closeout windows and surface matching admin form validation.

--- a/packages/i18n/src/admin/resources.ts
+++ b/packages/i18n/src/admin/resources.ts
@@ -166,6 +166,7 @@ export const adminResourcesMessages = {
         closeout: {
           validationResourceRequired: "Resource is required",
           validationDateRequired: "Date is required",
+          validationWindowOrder: "Starts At must be before Ends At",
           editTitle: "Edit Closeout",
           newTitle: "New Closeout",
           resourceLabel: "Resource",
@@ -407,6 +408,7 @@ export const adminResourcesMessages = {
         closeout: {
           validationResourceRequired: "Resursa este obligatorie",
           validationDateRequired: "Data este obligatorie",
+          validationWindowOrder: "Ora de inceput trebuie sa fie inainte de ora de sfarsit",
           editTitle: "Editeaza closeout-ul",
           newTitle: "Closeout nou",
           resourceLabel: "Resursa",

--- a/packages/openapi/spec/admin/operations.json
+++ b/packages/openapi/spec/admin/operations.json
@@ -21121,6 +21121,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Resource closeout overlaps an existing closeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -21664,6 +21682,24 @@
           },
           "404": {
             "description": "Resource closeout or referenced resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource closeout overlaps an existing closeout",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx
+++ b/packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx
@@ -313,14 +313,25 @@ export function ResourceSlotAssignmentDialog({
 }
 
 const getCloseoutFormSchema = (messages: ReturnType<typeof useOperatorAdminMessages>) =>
-  z.object({
-    resourceId: z.string().min(1, messages.resources.dialogs.closeout.validationResourceRequired),
-    dateLocal: z.string().min(1, messages.resources.dialogs.closeout.validationDateRequired),
-    startsAt: z.string().optional(),
-    endsAt: z.string().optional(),
-    reason: z.string().optional(),
-    createdBy: z.string().optional(),
-  })
+  z
+    .object({
+      resourceId: z.string().min(1, messages.resources.dialogs.closeout.validationResourceRequired),
+      dateLocal: z.string().min(1, messages.resources.dialogs.closeout.validationDateRequired),
+      startsAt: z.string().optional(),
+      endsAt: z.string().optional(),
+      reason: z.string().optional(),
+      createdBy: z.string().optional(),
+    })
+    .superRefine((values, ctx) => {
+      if (!values.startsAt || !values.endsAt) return
+      if (new Date(values.startsAt).getTime() < new Date(values.endsAt).getTime()) return
+
+      ctx.addIssue({
+        code: "custom",
+        path: ["endsAt"],
+        message: messages.resources.dialogs.closeout.validationWindowOrder,
+      })
+    })
 
 export function ResourceCloseoutDialog({
   open,
@@ -442,7 +453,10 @@ export function ResourceCloseoutDialog({
                 <DateTimePicker
                   value={form.watch("startsAt") || null}
                   onChange={(value) =>
-                    form.setValue("startsAt", value ?? "", { shouldDirty: true })
+                    form.setValue("startsAt", value ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
                   }
                   className="w-full"
                 />
@@ -451,9 +465,17 @@ export function ResourceCloseoutDialog({
                 <Label>{dialogMessages.endsAtLabel}</Label>
                 <DateTimePicker
                   value={form.watch("endsAt") || null}
-                  onChange={(value) => form.setValue("endsAt", value ?? "", { shouldDirty: true })}
+                  onChange={(value) =>
+                    form.setValue("endsAt", value ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
                   className="w-full"
                 />
+                {form.formState.errors.endsAt ? (
+                  <p className="text-xs text-destructive">{form.formState.errors.endsAt.message}</p>
+                ) : null}
               </div>
               <div className="grid gap-2">
                 <Label>{dialogMessages.createdByLabel}</Label>

--- a/packages/operations/src/resources/routes.ts
+++ b/packages/operations/src/resources/routes.ts
@@ -1336,6 +1336,10 @@ const createCloseoutRoute = createRoute({
       description: "Referenced resource not found",
       content: { "application/json": { schema: errorResponseSchema } },
     },
+    409: {
+      description: "Resource closeout overlaps an existing closeout",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
   },
 })
 
@@ -1419,6 +1423,10 @@ const updateCloseoutRoute = createRoute({
       description: "Resource closeout or referenced resource not found",
       content: { "application/json": { schema: errorResponseSchema } },
     },
+    409: {
+      description: "Resource closeout overlaps an existing closeout",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
   },
 })
 
@@ -1447,7 +1455,7 @@ const closeoutRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook
       const row = await resourcesService.createCloseout(c.get("db"), c.req.valid("json"))
       return c.json({ data: row! }, 201)
     } catch (error) {
-      return handleResourcesNotFoundRouteError(c, error)
+      return handleResourcesRouteError(c, error)
     }
   })
   .openapi(batchUpdateCloseoutsRoute, async (c) => {
@@ -1488,7 +1496,7 @@ const closeoutRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook
         ? c.json({ data: row }, 200)
         : c.json({ error: "Resource closeout not found" }, 404)
     } catch (error) {
-      return handleResourcesNotFoundRouteError(c, error)
+      return handleResourcesRouteError(c, error)
     }
   })
   .openapi(deleteCloseoutRoute, async (c) => {

--- a/packages/operations/src/resources/service.ts
+++ b/packages/operations/src/resources/service.ts
@@ -100,6 +100,60 @@ function validateSlotAssignmentState(data: {
   }
 }
 
+type ResourceCloseoutWindow = {
+  id?: string
+  resourceId: string
+  dateLocal: string
+  startsAt: Date | null
+  endsAt: Date | null
+}
+
+function assertCloseoutWindowOrder(window: ResourceCloseoutWindow) {
+  if (window.startsAt && window.endsAt && window.startsAt.getTime() >= window.endsAt.getTime()) {
+    throw new ResourcesServiceError("Resource closeout startsAt must be before endsAt", 400)
+  }
+}
+
+function closeoutWindowsOverlap(left: ResourceCloseoutWindow, right: ResourceCloseoutWindow) {
+  const leftStartsAt = left.startsAt?.getTime() ?? Number.NEGATIVE_INFINITY
+  const leftEndsAt = left.endsAt?.getTime() ?? Number.POSITIVE_INFINITY
+  const rightStartsAt = right.startsAt?.getTime() ?? Number.NEGATIVE_INFINITY
+  const rightEndsAt = right.endsAt?.getTime() ?? Number.POSITIVE_INFINITY
+
+  return leftStartsAt < rightEndsAt && rightStartsAt < leftEndsAt
+}
+
+async function ensureCloseoutWindowAvailable(
+  db: PostgresJsDatabase,
+  window: ResourceCloseoutWindow,
+  excludeId?: string,
+) {
+  assertCloseoutWindowOrder(window)
+
+  const existing = await db
+    .select({
+      id: resourceCloseouts.id,
+      resourceId: resourceCloseouts.resourceId,
+      dateLocal: resourceCloseouts.dateLocal,
+      startsAt: resourceCloseouts.startsAt,
+      endsAt: resourceCloseouts.endsAt,
+    })
+    .from(resourceCloseouts)
+    .where(
+      and(
+        eq(resourceCloseouts.resourceId, window.resourceId),
+        eq(resourceCloseouts.dateLocal, window.dateLocal),
+      ),
+    )
+
+  const overlapping = existing.find(
+    (row) => row.id !== excludeId && closeoutWindowsOverlap(window, row),
+  )
+  if (overlapping) {
+    throw new ResourcesServiceError("Resource closeout overlaps an existing closeout", 409)
+  }
+}
+
 function isPostgresError(error: unknown, code: string, constraint?: string) {
   const candidate = error as {
     code?: unknown
@@ -496,12 +550,20 @@ export const resourcesService = {
 
   async createCloseout(db: PostgresJsDatabase, data: CreateResourceCloseoutInput) {
     await ensureResourceExists(db, data.resourceId)
+    const startsAt = toDateOrNull(data.startsAt)
+    const endsAt = toDateOrNull(data.endsAt)
+    await ensureCloseoutWindowAvailable(db, {
+      resourceId: data.resourceId,
+      dateLocal: data.dateLocal,
+      startsAt,
+      endsAt,
+    })
     const [row] = await db
       .insert(resourceCloseouts)
       .values({
         ...data,
-        startsAt: toDateOrNull(data.startsAt),
-        endsAt: toDateOrNull(data.endsAt),
+        startsAt,
+        endsAt,
       })
       .returning()
     return row
@@ -509,12 +571,28 @@ export const resourcesService = {
 
   async updateCloseout(db: PostgresJsDatabase, id: string, data: UpdateResourceCloseoutInput) {
     if (data.resourceId !== undefined) await ensureResourceExists(db, data.resourceId)
+    const current = await resourcesService.getCloseoutById(db, id)
+    if (!current) return null
+
+    const startsAt = data.startsAt === undefined ? current.startsAt : toDateOrNull(data.startsAt)
+    const endsAt = data.endsAt === undefined ? current.endsAt : toDateOrNull(data.endsAt)
+    await ensureCloseoutWindowAvailable(
+      db,
+      {
+        resourceId: data.resourceId ?? current.resourceId,
+        dateLocal: data.dateLocal ?? current.dateLocal,
+        startsAt,
+        endsAt,
+      },
+      id,
+    )
+
     const [row] = await db
       .update(resourceCloseouts)
       .set({
         ...data,
-        startsAt: data.startsAt === undefined ? undefined : toDateOrNull(data.startsAt),
-        endsAt: data.endsAt === undefined ? undefined : toDateOrNull(data.endsAt),
+        startsAt: data.startsAt === undefined ? undefined : startsAt,
+        endsAt: data.endsAt === undefined ? undefined : endsAt,
       })
       .where(eq(resourceCloseouts.id, id))
       .returning()

--- a/packages/operations/tests/resources/integration/assignments-and-closeouts.test.ts
+++ b/packages/operations/tests/resources/integration/assignments-and-closeouts.test.ts
@@ -230,6 +230,87 @@ describe.skipIf(!DB_AVAILABLE)("Slot assignment and closeout routes", () => {
       expect(closeout.dateLocal).toBe("2025-07-01")
     })
 
+    it("POST /closeouts → 400 for inverted time windows", async () => {
+      const resource = await ctx.seedResource()
+      const res = await ctx.request("/closeouts", {
+        method: "POST",
+        ...json({
+          resourceId: resource.id,
+          dateLocal: "2025-07-01",
+          startsAt: "2025-07-01T17:00:00.000Z",
+          endsAt: "2025-07-01T09:00:00.000Z",
+        }),
+      })
+
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toEqual({
+        error: "Resource closeout startsAt must be before endsAt",
+      })
+    })
+
+    it("POST /closeouts → 409 for duplicate time windows", async () => {
+      const resource = await ctx.seedResource()
+      const window = {
+        dateLocal: "2025-07-01",
+        startsAt: "2025-07-01T09:00:00.000Z",
+        endsAt: "2025-07-01T12:00:00.000Z",
+      }
+      await ctx.seedCloseout(resource.id, window)
+
+      const res = await ctx.request("/closeouts", {
+        method: "POST",
+        ...json({ resourceId: resource.id, ...window }),
+      })
+
+      expect(res.status).toBe(409)
+      await expect(res.json()).resolves.toEqual({
+        error: "Resource closeout overlaps an existing closeout",
+      })
+    })
+
+    it("POST /closeouts → 409 for overlapping time windows", async () => {
+      const resource = await ctx.seedResource()
+      await ctx.seedCloseout(resource.id, {
+        startsAt: "2025-07-01T09:00:00.000Z",
+        endsAt: "2025-07-01T12:00:00.000Z",
+      })
+
+      const res = await ctx.request("/closeouts", {
+        method: "POST",
+        ...json({
+          resourceId: resource.id,
+          dateLocal: "2025-07-01",
+          startsAt: "2025-07-01T11:00:00.000Z",
+          endsAt: "2025-07-01T13:00:00.000Z",
+        }),
+      })
+
+      expect(res.status).toBe(409)
+      await expect(res.json()).resolves.toEqual({
+        error: "Resource closeout overlaps an existing closeout",
+      })
+    })
+
+    it("POST /closeouts → 201 for adjacent time windows", async () => {
+      const resource = await ctx.seedResource()
+      await ctx.seedCloseout(resource.id, {
+        startsAt: "2025-07-01T09:00:00.000Z",
+        endsAt: "2025-07-01T12:00:00.000Z",
+      })
+
+      const res = await ctx.request("/closeouts", {
+        method: "POST",
+        ...json({
+          resourceId: resource.id,
+          dateLocal: "2025-07-01",
+          startsAt: "2025-07-01T12:00:00.000Z",
+          endsAt: "2025-07-01T14:00:00.000Z",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+    })
+
     it("POST /closeouts → 404 for missing resource", async () => {
       const res = await ctx.request("/closeouts", {
         method: "POST",
@@ -264,6 +345,46 @@ describe.skipIf(!DB_AVAILABLE)("Slot assignment and closeout routes", () => {
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.data.reason).toBe("Maintenance")
+    })
+
+    it("PATCH /closeouts/:id → 400 when merged time window is inverted", async () => {
+      const resource = await ctx.seedResource()
+      const closeout = await ctx.seedCloseout(resource.id, {
+        startsAt: "2025-07-01T09:00:00.000Z",
+        endsAt: "2025-07-01T12:00:00.000Z",
+      })
+
+      const res = await ctx.request(`/closeouts/${closeout.id}`, {
+        method: "PATCH",
+        ...json({ startsAt: "2025-07-01T13:00:00.000Z" }),
+      })
+
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toEqual({
+        error: "Resource closeout startsAt must be before endsAt",
+      })
+    })
+
+    it("PATCH /closeouts/:id → 409 when merged time window overlaps another closeout", async () => {
+      const resource = await ctx.seedResource()
+      await ctx.seedCloseout(resource.id, {
+        startsAt: "2025-07-01T09:00:00.000Z",
+        endsAt: "2025-07-01T12:00:00.000Z",
+      })
+      const closeout = await ctx.seedCloseout(resource.id, {
+        startsAt: "2025-07-01T13:00:00.000Z",
+        endsAt: "2025-07-01T14:00:00.000Z",
+      })
+
+      const res = await ctx.request(`/closeouts/${closeout.id}`, {
+        method: "PATCH",
+        ...json({ startsAt: "2025-07-01T11:00:00.000Z" }),
+      })
+
+      expect(res.status).toBe(409)
+      await expect(res.json()).resolves.toEqual({
+        error: "Resource closeout overlaps an existing closeout",
+      })
     })
 
     it("PATCH /closeouts/:id → 404 for missing", async () => {

--- a/starters/operator/openapi/admin/operations.json
+++ b/starters/operator/openapi/admin/operations.json
@@ -21121,6 +21121,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Resource closeout overlaps an existing closeout",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "tags": [
@@ -21664,6 +21682,24 @@
           },
           "404": {
             "description": "Resource closeout or referenced resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource closeout overlaps an existing closeout",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
Fixes #2571

## Summary
- reject inverted, duplicate, and overlapping resource closeout windows in the operations service
- surface matching admin closeout form validation
- update generated operations OpenAPI module specs

## Verification
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check packages/operations/src/resources/service.ts packages/operations/src/resources/routes.ts packages/operations/tests/resources/integration/assignments-and-closeouts.test.ts packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx packages/i18n/src/admin/resources.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/operations typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/operations-react typecheck
- pnpm --filter @voyant-travel/i18n typecheck
- pnpm --filter @voyant-travel/i18n check:parity
- pnpm --filter @voyant-travel/operations test -- --run packages/operations/tests/resources/integration/assignments-and-closeouts.test.ts

Note: DB-gated integration cases are skipped locally without TEST_DATABASE_URL; CI db-checks provide database coverage.