### PR TITLE
Fix operations resource patch defaults

### DIFF
--- a/.changeset/tidy-operations-patches.md
+++ b/.changeset/tidy-operations-patches.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operations": patch
+---
+
+Prevent operations resource PATCH payloads from applying create defaults to omitted fields.

--- a/packages/operations/src/resources/validation.ts
+++ b/packages/operations/src/resources/validation.ts
@@ -26,11 +26,13 @@ export const resourceCoreSchema = z.object({
   name: z.string().min(1),
   code: z.string().nullable().optional(),
   capacity: z.number().int().min(0).nullable().optional(),
-  active: z.boolean().default(true),
+  active: z.boolean(),
   notes: z.string().nullable().optional(),
 })
 
-export const insertResourceSchema = resourceCoreSchema
+export const insertResourceSchema = resourceCoreSchema.extend({
+  active: resourceCoreSchema.shape.active.default(true),
+})
 export const updateResourceSchema = resourceCoreSchema.partial()
 export const resourceListQuerySchema = paginationSchema.extend({
   supplierId: z.string().optional(),
@@ -44,11 +46,13 @@ export const resourcePoolCoreSchema = z.object({
   kind: resourceKindSchema,
   name: z.string().min(1),
   sharedCapacity: z.number().int().min(0).nullable().optional(),
-  active: z.boolean().default(true),
+  active: z.boolean(),
   notes: z.string().nullable().optional(),
 })
 
-export const insertResourcePoolSchema = resourcePoolCoreSchema
+export const insertResourcePoolSchema = resourcePoolCoreSchema.extend({
+  active: resourcePoolCoreSchema.shape.active.default(true),
+})
 export const updateResourcePoolSchema = resourcePoolCoreSchema.partial()
 export const resourcePoolListQuerySchema = paginationSchema.extend({
   productId: z.string().optional(),
@@ -71,12 +75,16 @@ export const resourceRequirementCoreSchema = z.object({
   productId: z.string(),
   availabilityRuleId: z.string().nullable().optional(),
   startTimeId: z.string().nullable().optional(),
-  quantityRequired: z.number().int().min(1).default(1),
-  allocationMode: resourceAllocationModeSchema.default("shared"),
-  priority: z.number().int().default(0),
+  quantityRequired: z.number().int().min(1),
+  allocationMode: resourceAllocationModeSchema,
+  priority: z.number().int(),
 })
 
-export const insertResourceRequirementSchema = resourceRequirementCoreSchema
+export const insertResourceRequirementSchema = resourceRequirementCoreSchema.extend({
+  quantityRequired: resourceRequirementCoreSchema.shape.quantityRequired.default(1),
+  allocationMode: resourceRequirementCoreSchema.shape.allocationMode.default("shared"),
+  priority: resourceRequirementCoreSchema.shape.priority.default(0),
+})
 export const updateResourceRequirementSchema = resourceRequirementCoreSchema.partial()
 export const resourceRequirementListQuerySchema = paginationSchema.extend({
   poolId: z.string().optional(),
@@ -94,7 +102,7 @@ export const resourceSlotAssignmentCoreSchema = z.object({
   poolId: z.string().nullable().optional(),
   resourceId: z.string().nullable().optional(),
   bookingId: z.string().nullable().optional(),
-  status: resourceAssignmentStatusSchema.default("reserved"),
+  status: resourceAssignmentStatusSchema,
   assignedAt: isoDateTimeSchema.optional(),
   assignedBy: z.string().nullable().optional(),
   releasedAt: isoDateTimeSchema.nullable().optional(),
@@ -140,9 +148,11 @@ function validateSlotAssignmentLifecycle(
   }
 }
 
-export const insertResourceSlotAssignmentSchema = resourceSlotAssignmentCoreSchema.superRefine(
-  validateSlotAssignmentLifecycle,
-)
+export const insertResourceSlotAssignmentSchema = resourceSlotAssignmentCoreSchema
+  .extend({
+    status: resourceSlotAssignmentCoreSchema.shape.status.default("reserved"),
+  })
+  .superRefine(validateSlotAssignmentLifecycle)
 export const updateResourceSlotAssignmentSchema = resourceSlotAssignmentCoreSchema.partial()
 export const resourceSlotAssignmentListQuerySchema = paginationSchema.extend({
   slotId: z.string().optional(),

--- a/packages/operations/tests/resources/unit/validation-patch-defaults.test.ts
+++ b/packages/operations/tests/resources/unit/validation-patch-defaults.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  insertResourceAllocationSchema,
+  insertResourcePoolSchema,
+  insertResourceSchema,
+  insertResourceSlotAssignmentSchema,
+  updateResourceAllocationSchema,
+  updateResourcePoolSchema,
+  updateResourceSchema,
+  updateResourceSlotAssignmentSchema,
+} from "../../../src/resources/validation.js"
+
+describe("resources PATCH validation", () => {
+  it("does not apply resource create defaults to partial updates", () => {
+    expect(updateResourceSchema.parse({ name: "Updated guide" })).toEqual({
+      name: "Updated guide",
+    })
+    expect(updateResourcePoolSchema.parse({ name: "Updated pool" })).toEqual({
+      name: "Updated pool",
+    })
+  })
+
+  it("does not apply allocation create defaults to partial updates", () => {
+    expect(updateResourceAllocationSchema.parse({ priority: 3 })).toEqual({ priority: 3 })
+  })
+
+  it("does not apply assignment create defaults to partial updates", () => {
+    expect(updateResourceSlotAssignmentSchema.parse({ notes: "Confirmed" })).toEqual({
+      notes: "Confirmed",
+    })
+  })
+
+  it("keeps create defaults for resource, pool, allocation, and assignment payloads", () => {
+    expect(
+      insertResourceSchema.parse({
+        kind: "guide",
+        name: "Guide",
+      }),
+    ).toMatchObject({ active: true })
+    expect(
+      insertResourcePoolSchema.parse({
+        kind: "guide",
+        name: "Guides",
+      }),
+    ).toMatchObject({ active: true })
+    expect(
+      insertResourceAllocationSchema.parse({
+        poolId: "repl_123",
+        productId: "prod_123",
+      }),
+    ).toMatchObject({
+      allocationMode: "shared",
+      priority: 0,
+      quantityRequired: 1,
+    })
+    expect(
+      insertResourceSlotAssignmentSchema.parse({
+        slotId: "slot_123",
+        resourceId: "res_123",
+      }),
+    ).toMatchObject({ status: "reserved" })
+  })
+})


### PR DESCRIPTION
Fixes #2569

## Summary
- keep create defaults on operations resource insert schemas
- ensure PATCH schemas do not apply defaults for resources, pools, allocations, or assignments
- add focused validation regression tests, preserving assignment lifecycle validation

## Verification
- pnpm --filter @voyant-travel/operations exec vitest run tests/resources/unit/validation-patch-defaults.test.ts tests/resources/unit/slot-assignment-validation.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/operations typecheck
- pnpm exec biome check packages/operations/src/resources/validation.ts packages/operations/tests/resources/unit/validation-patch-defaults.test.ts