### PR TITLE
Preserve organization fields on patch

### DIFF
--- a/.changeset/organizations-patch-preserves-omitted-fields.md
+++ b/.changeset/organizations-patch-preserves-omitted-fields.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/relationships": patch
+"@voyant-travel/relationships-contracts": patch
+---
+
+Keep organization PATCH requests partial by avoiding create defaults on update
+payloads, so omitted fields such as status and tags remain unchanged.

--- a/packages/openapi/spec/admin/operations.json
+++ b/packages/openapi/spec/admin/operations.json
@@ -15879,8 +15879,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -16331,8 +16330,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -16907,8 +16905,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -17319,8 +17316,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -18164,20 +18160,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -18567,20 +18560,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -19126,20 +19116,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -19529,20 +19516,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -20161,8 +20145,7 @@
                           "released",
                           "cancelled",
                           "completed"
-                        ],
-                        "default": "reserved"
+                        ]
                       },
                       "assignedAt": {
                         "type": "string",
@@ -20614,8 +20597,7 @@
                       "released",
                       "cancelled",
                       "completed"
-                    ],
-                    "default": "reserved"
+                    ]
                   },
                   "assignedAt": {
                     "type": "string",

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -1062,8 +1062,7 @@
                       "active",
                       "inactive",
                       "archived"
-                    ],
-                    "default": "active"
+                    ]
                   },
                   "source": {
                     "type": [
@@ -1081,8 +1080,7 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "default": []
+                    }
                   },
                   "customFields": {
                     "type": "object",

--- a/packages/relationships-contracts/src/validation/accounts.ts
+++ b/packages/relationships-contracts/src/validation/accounts.ts
@@ -36,7 +36,12 @@ export const organizationCoreSchema = z.object({
 })
 
 export const insertOrganizationSchema = organizationCoreSchema
-export const updateOrganizationSchema = organizationCoreSchema.partial()
+export const updateOrganizationSchema = organizationCoreSchema
+  .extend({
+    status: recordStatusSchema.optional(),
+    tags: z.array(z.string()).optional(),
+  })
+  .partial()
 export const mergeOrganizationSchema = z.object({
   mergeId: z.string().min(1),
 })

--- a/packages/relationships/src/service/accounts-organizations.ts
+++ b/packages/relationships/src/service/accounts-organizations.ts
@@ -75,9 +75,12 @@ export const organizationAccountsService = {
   },
 
   async updateOrganization(db: PostgresJsDatabase, id: string, data: UpdateOrganizationInput) {
+    const updates = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value !== undefined),
+    )
     const [row] = await db
       .update(organizations)
-      .set({ ...data, updatedAt: new Date() })
+      .set({ ...updates, updatedAt: new Date() })
       .where(eq(organizations.id, id))
       .returning()
     return row ?? null

--- a/packages/relationships/tests/integration/accounts-organizations.suite.ts
+++ b/packages/relationships/tests/integration/accounts-organizations.suite.ts
@@ -124,6 +124,33 @@ describe.skipIf(!DB_AVAILABLE)("Organization account routes", () => {
       expect(body.data.name).toBe("New Name")
     })
 
+    it("patches only fields explicitly sent by the caller", async () => {
+      const createRes = await getApp().request("/organizations", {
+        method: "POST",
+        ...json({
+          name: "Partial Update Org",
+          legalName: "Partial Update Org SRL",
+          status: "inactive",
+          tags: ["preferred", "agency"],
+        }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/organizations/${created.id}`, {
+        method: "PATCH",
+        ...json({ name: "Renamed Partial Update Org" }),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        name: "Renamed Partial Update Org",
+        legalName: "Partial Update Org SRL",
+        status: "inactive",
+        tags: ["preferred", "agency"],
+      })
+    })
+
     it("merges duplicate organizations and repoints people and booking references", async () => {
       const { createTestDb } = await import("@voyant-travel/db/test-utils")
       const db = createTestDb()

--- a/packages/relationships/tests/unit/validation-accounts.test.ts
+++ b/packages/relationships/tests/unit/validation-accounts.test.ts
@@ -50,8 +50,13 @@ describe("Organization schemas", () => {
   it("allows partial updates with only provided fields", () => {
     const result = updateOrganizationSchema.parse({ name: "New Name" })
     expect(result.name).toBe("New Name")
-    expect(result.status).toBe("active")
+    expect(result.status).toBeUndefined()
+    expect(result.tags).toBeUndefined()
     expect(result.legalName).toBeUndefined()
+  })
+
+  it("does not apply create defaults to empty updates", () => {
+    expect(updateOrganizationSchema.parse({})).toEqual({})
   })
 
   it("accepts relation enum", () => {

--- a/starters/operator/openapi/admin/operations.json
+++ b/starters/operator/openapi/admin/operations.json
@@ -15879,8 +15879,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -16331,8 +16330,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -16907,8 +16905,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -17319,8 +17316,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -18164,20 +18160,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -18567,20 +18560,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -19126,20 +19116,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -19529,20 +19516,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -20161,8 +20145,7 @@
                           "released",
                           "cancelled",
                           "completed"
-                        ],
-                        "default": "reserved"
+                        ]
                       },
                       "assignedAt": {
                         "type": "string",
@@ -20614,8 +20597,7 @@
                       "released",
                       "cancelled",
                       "completed"
-                    ],
-                    "default": "reserved"
+                    ]
                   },
                   "assignedAt": {
                     "type": "string",

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -1062,8 +1062,7 @@
                       "active",
                       "inactive",
                       "archived"
-                    ],
-                    "default": "active"
+                    ]
                   },
                   "source": {
                     "type": [
@@ -1081,8 +1080,7 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "default": []
+                    }
                   },
                   "customFields": {
                     "type": "object",


### PR DESCRIPTION
Fixes #2566

## Summary
- keep organization PATCH schemas free of create defaults for status and tags
- filter undefined organization update fields before persistence
- add validation and route regression coverage for partial/empty updates preserving omitted fields

## Verification
- pnpm --filter @voyant-travel/relationships exec vitest run tests/unit/validation-accounts.test.ts tests/unit/accounts-custom-fields.test.ts
- pnpm --filter @voyant-travel/relationships exec vitest run tests/unit/validation-accounts.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/relationships typecheck
- pnpm exec biome check .changeset/organizations-patch-preserves-omitted-fields.md packages/relationships-contracts/src/validation/accounts.ts packages/relationships/src/service/accounts-organizations.ts packages/relationships/tests/integration/accounts-organizations.suite.ts packages/relationships/tests/unit/validation-accounts.test.ts
- git diff --check

Note: DB-gated integration tests are skipped locally unless TEST_DATABASE_URL is configured.