### PR TITLE
feat(openapi): add servers, operationId, and summary to generated specs (#2729)

### DIFF
--- a/.changeset/openapi-servers-operationid-summary.md
+++ b/.changeset/openapi-servers-operationid-summary.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/hono": patch
+"@voyant-travel/openapi": patch
+---
+
+Add `servers`, `operationId`, and `summary` to generated OpenAPI specs (#2729).
+
+Completes the metadata Redocly/Swagger tooling expects:
+
+- **`servers`** — a relative `[{ url: "/" }]` entry so "try it out" targets the
+  origin the deployment serves the contract from (overridable per deployment).
+- **`operationId`** — a stable camelCase id derived from method + path
+  (`GET /v1/admin/bookings/{id}` → `getAdminBookingsById`), unique per document,
+  so generated clients get readable, deterministic method names.
+- **`summary`** — the method + path signature on every operation, so viewers
+  and linters have a title for each.
+
+All three are stamped by `stampModuleMetadata` and are non-destructive — a value
+a route already declares (e.g. a hand-authored `summary`) is never overwritten.

--- a/packages/hono/src/openapi.ts
+++ b/packages/hono/src/openapi.ts
@@ -382,14 +382,55 @@ export async function splitDocumentByModule(
 
 const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch", "trace"] as const
 
+/** PascalCase a path segment, splitting on non-alphanumerics (kebab, etc.). */
+function pascalCase(segment: string): string {
+  return segment
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join("")
+}
+
 /**
- * Stamp every operation with its module metadata (voyant#2733 / voyant#2729):
+ * Stable camelCase operationId derived from method + path (voyant#2729) — gives
+ * client generators readable, deterministic method names instead of guessing.
+ * Path params render as `ByX`, the `v1` prefix is dropped:
+ * `GET /v1/admin/bookings/{id}` → `getAdminBookingsById`. Method + path is unique
+ * per OpenAPI, so the derived id is too (a numeric suffix guards edge cases).
+ */
+function deriveOperationId(method: string, path: string): string {
+  const parts = path
+    .split("/")
+    .filter(Boolean)
+    .filter((segment) => segment !== "v1")
+    .map((segment) => {
+      const param = /^\{(.+)\}$/.exec(segment)
+      return param?.[1] ? `By${pascalCase(param[1])}` : pascalCase(segment)
+    })
+  return `${method}${parts.join("")}`
+}
+
+/**
+ * A readable, always-correct operation summary (voyant#2729): the method + path
+ * signature. Deliberately mechanical rather than guessed prose — a hand-authored
+ * per-route `summary` overrides it (forward-only).
+ */
+function deriveSummary(method: string, path: string): string {
+  return `${method.toUpperCase()} ${path}`
+}
+
+/**
+ * Stamp every operation with the metadata standard OpenAPI tooling expects
+ * (voyant#2733 / voyant#2729). All fields are non-destructive — a value a route
+ * already declares is never overwritten:
+ *   - `operationId` — stable camelCase id from method + path, for readable
+ *     generated client method names.
+ *   - `summary` — the method + path signature, so viewers/linters have a title
+ *     for every operation.
  *   - `tags: [module]` — so Swagger/Scalar group the sidebar by module (they
- *     key grouping off `tags` and ignore `x-*`); left untouched when the route
- *     already declares tags.
+ *     key grouping off `tags` and ignore `x-*`).
  *   - `x-voyant-module` / `x-voyant-surface` — machine-readable owner + surface
- *     for custom tooling (a docs UI, client generators) that shouldn't re-derive
- *     them from path prefixes.
+ *     for custom tooling that shouldn't re-derive them from path prefixes.
  *
  * The module is the authoritative owner from the manifest, so `publicPath`
  * overrides are labelled with their real owning module rather than their mount
@@ -402,6 +443,9 @@ export function stampModuleMetadata(
   owner: ReadonlyMap<string, string>,
 ): OpenApiDocument {
   const paths: Record<string, unknown> = {}
+  // operationId must be unique across the document; track what we've assigned
+  // (including route-declared ids) so a derived id never collides.
+  const usedOperationIds = new Set<string>()
   for (const [path, item] of Object.entries(doc.paths ?? {})) {
     if (!item || typeof item !== "object") {
       paths[path] = item
@@ -412,19 +456,34 @@ export function stampModuleMetadata(
     const nextItem: Record<string, unknown> = { ...(item as Record<string, unknown>) }
     for (const method of HTTP_METHODS) {
       const op = nextItem[method]
-      if (op && typeof op === "object") {
-        const operation = op as Record<string, unknown>
-        // Group by module in Swagger/Scalar, which key their sidebar off `tags`
-        // (and ignore `x-*` extensions). Without this a whole-surface document
-        // collapses under one "default" group — the exact pain in voyant#2733.
-        // Never clobber a tag a route already declared.
-        const hasTags = Array.isArray(operation.tags) && operation.tags.length > 0
-        nextItem[method] = {
-          ...operation,
-          ...(hasTags ? {} : { tags: [moduleName] }),
-          "x-voyant-module": moduleName,
-          ...(surface ? { "x-voyant-surface": surface } : {}),
+      if (!op || typeof op !== "object") continue
+      const operation = op as Record<string, unknown>
+
+      const declaredId =
+        typeof operation.operationId === "string" && operation.operationId.length > 0
+          ? operation.operationId
+          : null
+      let operationId = declaredId ?? deriveOperationId(method, path)
+      if (!declaredId) {
+        let suffix = 2
+        while (usedOperationIds.has(operationId)) {
+          operationId = `${deriveOperationId(method, path)}_${suffix++}`
         }
+      }
+      usedOperationIds.add(operationId)
+
+      const hasSummary = typeof operation.summary === "string" && operation.summary.length > 0
+      // Swagger/Scalar group by `tags` (and ignore `x-*`) — without one a
+      // whole-surface document collapses under a single "default" group (#2733).
+      const hasTags = Array.isArray(operation.tags) && operation.tags.length > 0
+
+      nextItem[method] = {
+        ...operation,
+        operationId,
+        ...(hasSummary ? {} : { summary: deriveSummary(method, path) }),
+        ...(hasTags ? {} : { tags: [moduleName] }),
+        "x-voyant-module": moduleName,
+        ...(surface ? { "x-voyant-surface": surface } : {}),
       }
     }
     paths[path] = nextItem

--- a/packages/hono/tests/unit/openapi-modules.test.ts
+++ b/packages/hono/tests/unit/openapi-modules.test.ts
@@ -167,6 +167,9 @@ describe("stampModuleMetadata", () => {
     expect(op("/v1/admin/bookings/list", "get")["x-voyant-module"]).toBe("bookings")
     expect(op("/v1/admin/bookings/list", "get")["x-voyant-surface"]).toBe("admin")
     expect(op("/v1/admin/bookings/list", "get").tags).toEqual(["bookings"])
+    // Derived operationId (camelCase, `v1` dropped) + method+path summary.
+    expect(op("/v1/admin/bookings/list", "get").operationId).toBe("getAdminBookingsList")
+    expect(op("/v1/admin/bookings/list", "get").summary).toBe("GET /v1/admin/bookings/list")
     // publicPath override → authoritative owner, not the `booking-engine` prefix.
     expect(op("/v1/public/booking-engine/hold", "post")["x-voyant-module"]).toBe("commerce")
     expect(op("/v1/public/booking-engine/hold", "post")["x-voyant-surface"]).toBe("storefront")
@@ -175,17 +178,28 @@ describe("stampModuleMetadata", () => {
     expect(op("/v1/webhooks/netopia", "post")["x-voyant-surface"]).toBeUndefined()
   })
 
-  it("does not clobber tags a route already declares", () => {
+  it("does not clobber tags / operationId / summary a route already declares", () => {
     const tagged = {
       openapi: "3.1.0",
       info: INFO,
-      paths: { "/v1/admin/legal/contracts": { get: { tags: ["Legal"], responses: {} } } },
+      paths: {
+        "/v1/admin/legal/contracts": {
+          get: {
+            tags: ["Legal"],
+            operationId: "listContracts",
+            summary: "List all contracts",
+            responses: {},
+          },
+        },
+      },
     } as unknown as OpenApiDocument
     const stamped = stampModuleMetadata(tagged, new Map())
     const op = (stamped.paths as Record<string, Record<string, Record<string, unknown>>>)[
       "/v1/admin/legal/contracts"
     ].get
     expect(op.tags).toEqual(["Legal"])
+    expect(op.operationId).toBe("listContracts")
+    expect(op.summary).toBe("List all contracts")
     expect(op["x-voyant-module"]).toBe("legal")
   })
 

--- a/packages/openapi/spec/admin/accommodations.json
+++ b/packages/openapi/spec/admin/accommodations.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -368,6 +374,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocks",
+        "summary": "POST /v1/admin/accommodations/room-blocks",
         "tags": [
           "accommodations"
         ],
@@ -605,6 +613,8 @@
             }
           }
         },
+        "operationId": "getAdminAccommodationsRoomBlocksById",
+        "summary": "GET /v1/admin/accommodations/room-blocks/{id}",
         "tags": [
           "accommodations"
         ],
@@ -773,6 +783,8 @@
             }
           }
         },
+        "operationId": "putAdminAccommodationsRoomBlocksByIdNights",
+        "summary": "PUT /v1/admin/accommodations/room-blocks/{id}/nights",
         "tags": [
           "accommodations"
         ],
@@ -1071,6 +1083,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocksByIdPickups",
+        "summary": "POST /v1/admin/accommodations/room-blocks/{id}/pickups",
         "tags": [
           "accommodations"
         ],
@@ -1224,6 +1238,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocksByIdPickupsReverse",
+        "summary": "POST /v1/admin/accommodations/room-blocks/{id}/pickups/reverse",
         "tags": [
           "accommodations"
         ],
@@ -1413,6 +1429,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocksByIdRelease",
+        "summary": "POST /v1/admin/accommodations/room-blocks/{id}/release",
         "tags": [
           "accommodations"
         ],

--- a/packages/openapi/spec/admin/action-ledger.json
+++ b/packages/openapi/spec/admin/action-ledger.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -906,6 +912,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedger",
+        "summary": "GET /v1/admin/action-ledger",
         "tags": [
           "action-ledger"
         ],
@@ -1671,6 +1679,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerEntries",
+        "summary": "GET /v1/admin/action-ledger/entries",
         "tags": [
           "action-ledger"
         ],
@@ -2544,6 +2554,8 @@
             }
           }
         },
+        "operationId": "postAdminActionLedgerEntriesByIdReversals",
+        "summary": "POST /v1/admin/action-ledger/entries/{id}/reversals",
         "tags": [
           "action-ledger"
         ],
@@ -3150,6 +3162,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerEntriesById",
+        "summary": "GET /v1/admin/action-ledger/entries/{id}",
         "tags": [
           "action-ledger"
         ],
@@ -3523,6 +3537,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerApprovals",
+        "summary": "GET /v1/admin/action-ledger/approvals",
         "tags": [
           "action-ledger"
         ],
@@ -4174,6 +4190,8 @@
             }
           }
         },
+        "operationId": "postAdminActionLedgerApprovalsRequest",
+        "summary": "POST /v1/admin/action-ledger/approvals/request",
         "tags": [
           "action-ledger"
         ],
@@ -4889,6 +4907,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerApprovalsById",
+        "summary": "GET /v1/admin/action-ledger/approvals/{id}",
         "tags": [
           "action-ledger"
         ],
@@ -5527,6 +5547,8 @@
             }
           }
         },
+        "operationId": "postAdminActionLedgerApprovalsByIdDecide",
+        "summary": "POST /v1/admin/action-ledger/approvals/{id}/decide",
         "tags": [
           "action-ledger"
         ],
@@ -5851,6 +5873,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerDelegations",
+        "summary": "GET /v1/admin/action-ledger/delegations",
         "tags": [
           "action-ledger"
         ],
@@ -5990,6 +6014,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerDelegationsById",
+        "summary": "GET /v1/admin/action-ledger/delegations/{id}",
         "tags": [
           "action-ledger"
         ],
@@ -6245,6 +6271,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerRelayOutbox",
+        "summary": "GET /v1/admin/action-ledger/relay-outbox",
         "tags": [
           "action-ledger"
         ],

--- a/packages/openapi/spec/admin/booking-requirements.json
+++ b/packages/openapi/spec/admin/booking-requirements.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -338,6 +344,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsContactRequirements",
+        "summary": "GET /v1/admin/booking-requirements/contact-requirements",
         "tags": [
           "booking-requirements"
         ],
@@ -538,6 +546,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsContactRequirements",
+        "summary": "POST /v1/admin/booking-requirements/contact-requirements",
         "tags": [
           "booking-requirements"
         ],
@@ -674,6 +684,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsContactRequirementsById",
+        "summary": "GET /v1/admin/booking-requirements/contact-requirements/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -898,6 +910,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsContactRequirementsById",
+        "summary": "PATCH /v1/admin/booking-requirements/contact-requirements/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -953,6 +967,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsContactRequirementsById",
+        "summary": "DELETE /v1/admin/booking-requirements/contact-requirements/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -1205,6 +1221,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestions",
+        "summary": "GET /v1/admin/booking-requirements/questions",
         "tags": [
           "booking-requirements"
         ],
@@ -1453,6 +1471,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsQuestions",
+        "summary": "POST /v1/admin/booking-requirements/questions",
         "tags": [
           "booking-requirements"
         ],
@@ -1613,6 +1633,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestionsById",
+        "summary": "GET /v1/admin/booking-requirements/questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -1885,6 +1907,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsQuestionsById",
+        "summary": "PATCH /v1/admin/booking-requirements/questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -1940,6 +1964,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsQuestionsById",
+        "summary": "DELETE /v1/admin/booking-requirements/questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2104,6 +2130,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionQuestions",
+        "summary": "GET /v1/admin/booking-requirements/option-questions",
         "tags": [
           "booking-requirements"
         ],
@@ -2238,6 +2266,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsOptionQuestions",
+        "summary": "POST /v1/admin/booking-requirements/option-questions",
         "tags": [
           "booking-requirements"
         ],
@@ -2341,6 +2371,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionQuestionsById",
+        "summary": "GET /v1/admin/booking-requirements/option-questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2499,6 +2531,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsOptionQuestionsById",
+        "summary": "PATCH /v1/admin/booking-requirements/option-questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2554,6 +2588,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsOptionQuestionsById",
+        "summary": "DELETE /v1/admin/booking-requirements/option-questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2704,6 +2740,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestionOptions",
+        "summary": "GET /v1/admin/booking-requirements/question-options",
         "tags": [
           "booking-requirements"
         ],
@@ -2832,6 +2870,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsQuestionOptions",
+        "summary": "POST /v1/admin/booking-requirements/question-options",
         "tags": [
           "booking-requirements"
         ],
@@ -2929,6 +2969,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestionOptionsById",
+        "summary": "GET /v1/admin/booking-requirements/question-options/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3080,6 +3122,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsQuestionOptionsById",
+        "summary": "PATCH /v1/admin/booking-requirements/question-options/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3135,6 +3179,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsQuestionOptionsById",
+        "summary": "DELETE /v1/admin/booking-requirements/question-options/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3297,6 +3343,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsUnitTriggers",
+        "summary": "GET /v1/admin/booking-requirements/unit-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -3429,6 +3477,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsUnitTriggers",
+        "summary": "POST /v1/admin/booking-requirements/unit-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -3530,6 +3580,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsUnitTriggersById",
+        "summary": "GET /v1/admin/booking-requirements/unit-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3686,6 +3738,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsUnitTriggersById",
+        "summary": "PATCH /v1/admin/booking-requirements/unit-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3741,6 +3795,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsUnitTriggersById",
+        "summary": "DELETE /v1/admin/booking-requirements/unit-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3896,6 +3952,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionTriggers",
+        "summary": "GET /v1/admin/booking-requirements/option-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4014,6 +4072,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsOptionTriggers",
+        "summary": "POST /v1/admin/booking-requirements/option-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4108,6 +4168,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionTriggersById",
+        "summary": "GET /v1/admin/booking-requirements/option-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4250,6 +4312,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsOptionTriggersById",
+        "summary": "PATCH /v1/admin/booking-requirements/option-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4305,6 +4369,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsOptionTriggersById",
+        "summary": "DELETE /v1/admin/booking-requirements/option-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4485,6 +4551,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsExtraTriggers",
+        "summary": "GET /v1/admin/booking-requirements/extra-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4635,6 +4703,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsExtraTriggers",
+        "summary": "POST /v1/admin/booking-requirements/extra-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4746,6 +4816,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsExtraTriggersById",
+        "summary": "GET /v1/admin/booking-requirements/extra-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4921,6 +4993,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsExtraTriggersById",
+        "summary": "PATCH /v1/admin/booking-requirements/extra-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4976,6 +5050,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsExtraTriggersById",
+        "summary": "DELETE /v1/admin/booking-requirements/extra-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -5202,6 +5278,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsAnswers",
+        "summary": "GET /v1/admin/booking-requirements/answers",
         "tags": [
           "booking-requirements"
         ],
@@ -5425,6 +5503,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsAnswers",
+        "summary": "POST /v1/admin/booking-requirements/answers",
         "tags": [
           "booking-requirements"
         ],
@@ -5575,6 +5655,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsAnswersById",
+        "summary": "GET /v1/admin/booking-requirements/answers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -5822,6 +5904,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsAnswersById",
+        "summary": "PATCH /v1/admin/booking-requirements/answers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -5877,6 +5961,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsAnswersById",
+        "summary": "DELETE /v1/admin/booking-requirements/answers/{id}",
         "tags": [
           "booking-requirements"
         ],

--- a/packages/openapi/spec/admin/bookings.json
+++ b/packages/openapi/spec/admin/bookings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -240,6 +246,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsPricingPreview",
+        "summary": "POST /v1/admin/bookings/pricing-preview",
         "tags": [
           "bookings"
         ],
@@ -487,6 +495,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsAggregates",
+        "summary": "GET /v1/admin/bookings/aggregates",
         "tags": [
           "bookings"
         ],
@@ -1006,6 +1016,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsOverview",
+        "summary": "GET /v1/admin/bookings/overview",
         "tags": [
           "bookings"
         ],
@@ -1097,6 +1109,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsSharingGroups",
+        "summary": "GET /v1/admin/bookings/sharing-groups",
         "tags": [
           "bookings"
         ],
@@ -1183,6 +1197,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsSharingGroupsByGroupIdTravelers",
+        "summary": "GET /v1/admin/bookings/sharing-groups/{groupId}/travelers",
         "tags": [
           "bookings"
         ],
@@ -1338,6 +1354,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdAllocations",
+        "summary": "GET /v1/admin/bookings/{id}/allocations",
         "tags": [
           "bookings"
         ],
@@ -1440,6 +1458,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdActivity",
+        "summary": "GET /v1/admin/bookings/{id}/activity",
         "tags": [
           "bookings"
         ],
@@ -1512,6 +1532,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdGroup",
+        "summary": "GET /v1/admin/bookings/{id}/group",
         "tags": [
           "bookings"
         ],
@@ -2436,6 +2458,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsReserve",
+        "summary": "POST /v1/admin/bookings/reserve",
         "tags": [
           "bookings"
         ],
@@ -2520,6 +2544,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsExpireStale",
+        "summary": "POST /v1/admin/bookings/expire-stale",
         "tags": [
           "bookings"
         ],
@@ -2981,6 +3007,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdConfirm",
+        "summary": "POST /v1/admin/bookings/{id}/confirm",
         "tags": [
           "bookings"
         ],
@@ -3416,6 +3444,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdExtendHold",
+        "summary": "POST /v1/admin/bookings/{id}/extend-hold",
         "tags": [
           "bookings"
         ],
@@ -3874,6 +3904,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdExpire",
+        "summary": "POST /v1/admin/bookings/{id}/expire",
         "tags": [
           "bookings"
         ],
@@ -4332,6 +4364,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdCancel",
+        "summary": "POST /v1/admin/bookings/{id}/cancel",
         "tags": [
           "bookings"
         ],
@@ -4790,6 +4824,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdStart",
+        "summary": "POST /v1/admin/bookings/{id}/start",
         "tags": [
           "bookings"
         ],
@@ -5248,6 +5284,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdComplete",
+        "summary": "POST /v1/admin/bookings/{id}/complete",
         "tags": [
           "bookings"
         ],
@@ -5734,6 +5772,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdOverrideStatus",
+        "summary": "POST /v1/admin/bookings/{id}/override-status",
         "tags": [
           "bookings"
         ],
@@ -5897,6 +5937,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdActionLedger",
+        "summary": "GET /v1/admin/bookings/{id}/action-ledger",
         "tags": [
           "bookings"
         ],
@@ -6089,6 +6131,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdActionApprovalsByApprovalIdDecide",
+        "summary": "POST /v1/admin/bookings/{id}/action-approvals/{approvalId}/decide",
         "tags": [
           "bookings"
         ],
@@ -6222,6 +6266,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdTravelers",
+        "summary": "GET /v1/admin/bookings/{id}/travelers",
         "tags": [
           "bookings"
         ],
@@ -6466,6 +6512,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdTravelers",
+        "summary": "POST /v1/admin/bookings/{id}/travelers",
         "tags": [
           "bookings"
         ],
@@ -6659,6 +6707,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdTravelersByTravelerIdReveal",
+        "summary": "GET /v1/admin/bookings/{id}/travelers/{travelerId}/reveal",
         "tags": [
           "bookings"
         ],
@@ -6755,6 +6805,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdTravelersByTravelerIdTravelDetails",
+        "summary": "GET /v1/admin/bookings/{id}/travelers/{travelerId}/travel-details",
         "tags": [
           "bookings"
         ],
@@ -6991,6 +7043,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdTravelersByTravelerIdTravelDetails",
+        "summary": "PATCH /v1/admin/bookings/{id}/travelers/{travelerId}/travel-details",
         "tags": [
           "bookings"
         ],
@@ -7090,6 +7144,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdTravelersByTravelerIdTravelDetails",
+        "summary": "DELETE /v1/admin/bookings/{id}/travelers/{travelerId}/travel-details",
         "tags": [
           "bookings"
         ],
@@ -7382,6 +7438,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdTravelersWithTravelDetails",
+        "summary": "POST /v1/admin/bookings/{id}/travelers/with-travel-details",
         "tags": [
           "bookings"
         ],
@@ -7678,6 +7736,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdTravelersByTravelerIdWithTravelDetails",
+        "summary": "PATCH /v1/admin/bookings/{id}/travelers/{travelerId}/with-travel-details",
         "tags": [
           "bookings"
         ],
@@ -7928,6 +7988,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdTravelersByTravelerId",
+        "summary": "PATCH /v1/admin/bookings/{id}/travelers/{travelerId}",
         "tags": [
           "bookings"
         ],
@@ -7991,6 +8053,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdTravelersByTravelerId",
+        "summary": "DELETE /v1/admin/bookings/{id}/travelers/{travelerId}",
         "tags": [
           "bookings"
         ],
@@ -8248,6 +8312,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdItems",
+        "summary": "GET /v1/admin/bookings/{id}/items",
         "tags": [
           "bookings"
         ],
@@ -8749,6 +8815,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdItems",
+        "summary": "POST /v1/admin/bookings/{id}/items",
         "tags": [
           "bookings"
         ],
@@ -9256,6 +9324,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdItemsByItemId",
+        "summary": "PATCH /v1/admin/bookings/{id}/items/{itemId}",
         "tags": [
           "bookings"
         ],
@@ -9337,6 +9407,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdItemsByItemId",
+        "summary": "DELETE /v1/admin/bookings/{id}/items/{itemId}",
         "tags": [
           "bookings"
         ],
@@ -9421,6 +9493,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdItemsByItemIdTravelers",
+        "summary": "GET /v1/admin/bookings/{id}/items/{itemId}/travelers",
         "tags": [
           "bookings"
         ],
@@ -9585,6 +9659,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdItemsByItemIdTravelers",
+        "summary": "POST /v1/admin/bookings/{id}/items/{itemId}/travelers",
         "tags": [
           "bookings"
         ],
@@ -9676,6 +9752,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdItemsByItemIdTravelersByLinkId",
+        "summary": "DELETE /v1/admin/bookings/{id}/items/{itemId}/travelers/{linkId}",
         "tags": [
           "bookings"
         ],
@@ -9802,6 +9880,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdSupplierStatuses",
+        "summary": "GET /v1/admin/bookings/{id}/supplier-statuses",
         "tags": [
           "bookings"
         ],
@@ -10020,6 +10100,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdSupplierStatuses",
+        "summary": "POST /v1/admin/bookings/{id}/supplier-statuses",
         "tags": [
           "bookings"
         ],
@@ -10249,6 +10331,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdSupplierStatusesByStatusId",
+        "summary": "PATCH /v1/admin/bookings/{id}/supplier-statuses/{statusId}",
         "tags": [
           "bookings"
         ],
@@ -10389,6 +10473,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdFulfillments",
+        "summary": "GET /v1/admin/bookings/{id}/fulfillments",
         "tags": [
           "bookings"
         ],
@@ -10650,6 +10736,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdFulfillments",
+        "summary": "POST /v1/admin/bookings/{id}/fulfillments",
         "tags": [
           "bookings"
         ],
@@ -10917,6 +11005,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdFulfillmentsByFulfillmentId",
+        "summary": "PATCH /v1/admin/bookings/{id}/fulfillments/{fulfillmentId}",
         "tags": [
           "bookings"
         ],
@@ -11025,6 +11115,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdRedemptions",
+        "summary": "GET /v1/admin/bookings/{id}/redemptions",
         "tags": [
           "bookings"
         ],
@@ -11227,6 +11319,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdRedemptions",
+        "summary": "POST /v1/admin/bookings/{id}/redemptions",
         "tags": [
           "bookings"
         ],
@@ -11293,6 +11387,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdNotes",
+        "summary": "GET /v1/admin/bookings/{id}/notes",
         "tags": [
           "bookings"
         ],
@@ -11411,6 +11507,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdNotes",
+        "summary": "POST /v1/admin/bookings/{id}/notes",
         "tags": [
           "bookings"
         ],
@@ -11539,6 +11637,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdNotesByNoteId",
+        "summary": "PATCH /v1/admin/bookings/{id}/notes/{noteId}",
         "tags": [
           "bookings"
         ],
@@ -11602,6 +11702,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdNotesByNoteId",
+        "summary": "DELETE /v1/admin/bookings/{id}/notes/{noteId}",
         "tags": [
           "bookings"
         ],
@@ -11700,6 +11802,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdDocuments",
+        "summary": "GET /v1/admin/bookings/{id}/documents",
         "tags": [
           "bookings"
         ],
@@ -11884,6 +11988,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdDocuments",
+        "summary": "POST /v1/admin/bookings/{id}/documents",
         "tags": [
           "bookings"
         ],
@@ -11949,6 +12055,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdDocumentsByDocumentId",
+        "summary": "DELETE /v1/admin/bookings/{id}/documents/{documentId}",
         "tags": [
           "bookings"
         ],
@@ -12124,6 +12232,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroups",
+        "summary": "GET /v1/admin/bookings/groups",
         "tags": [
           "bookings"
         ],
@@ -12282,6 +12392,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsGroups",
+        "summary": "POST /v1/admin/bookings/groups",
         "tags": [
           "bookings"
         ],
@@ -12432,6 +12544,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroupsById",
+        "summary": "GET /v1/admin/bookings/groups/{id}",
         "tags": [
           "bookings"
         ],
@@ -12615,6 +12729,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsGroupsById",
+        "summary": "PATCH /v1/admin/bookings/groups/{id}",
         "tags": [
           "bookings"
         ],
@@ -12670,6 +12786,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsGroupsById",
+        "summary": "DELETE /v1/admin/bookings/groups/{id}",
         "tags": [
           "bookings"
         ],
@@ -12740,6 +12858,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroupsByIdMembers",
+        "summary": "GET /v1/admin/bookings/groups/{id}/members",
         "tags": [
           "bookings"
         ],
@@ -12891,6 +13011,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsGroupsByIdMembers",
+        "summary": "POST /v1/admin/bookings/groups/{id}/members",
         "tags": [
           "bookings"
         ],
@@ -12956,6 +13078,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsGroupsByIdMembersByBookingId",
+        "summary": "DELETE /v1/admin/bookings/groups/{id}/members/{bookingId}",
         "tags": [
           "bookings"
         ],
@@ -13011,6 +13135,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroupsByIdTravelers",
+        "summary": "GET /v1/admin/bookings/groups/{id}/travelers",
         "tags": [
           "bookings"
         ],
@@ -13607,6 +13733,8 @@
             }
           }
         },
+        "operationId": "getAdminBookings",
+        "summary": "GET /v1/admin/bookings",
         "tags": [
           "bookings"
         ],
@@ -14357,6 +14485,8 @@
             }
           }
         },
+        "operationId": "postAdminBookings",
+        "summary": "POST /v1/admin/bookings",
         "tags": [
           "bookings"
         ],
@@ -15114,6 +15244,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsById",
+        "summary": "GET /v1/admin/bookings/{id}",
         "tags": [
           "bookings"
         ],
@@ -15892,6 +16024,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsById",
+        "summary": "PATCH /v1/admin/bookings/{id}",
         "tags": [
           "bookings"
         ],
@@ -15947,6 +16081,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsById",
+        "summary": "DELETE /v1/admin/bookings/{id}",
         "tags": [
           "bookings"
         ],
@@ -16616,6 +16752,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsFromProduct",
+        "summary": "POST /v1/admin/bookings/from-product",
         "tags": [
           "bookings"
         ],
@@ -17540,6 +17678,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsCreate",
+        "summary": "POST /v1/admin/bookings/create",
         "tags": [
           "bookings"
         ],
@@ -19122,6 +19262,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsDualCreate",
+        "summary": "POST /v1/admin/bookings/dual-create",
         "tags": [
           "bookings"
         ],

--- a/packages/openapi/spec/admin/catalog.json
+++ b/packages/openapi/spec/admin/catalog.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -683,6 +689,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogSearch",
+        "summary": "POST /v1/admin/catalog/search",
         "tags": [
           "catalog"
         ],

--- a/packages/openapi/spec/admin/distribution.json
+++ b/packages/openapi/spec/admin/distribution.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -345,6 +351,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannels",
+        "summary": "GET /v1/admin/distribution/channels",
         "tags": [
           "distribution"
         ],
@@ -581,6 +589,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannels",
+        "summary": "POST /v1/admin/distribution/channels",
         "tags": [
           "distribution"
         ],
@@ -862,6 +872,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/channels/batch-update",
         "tags": [
           "distribution"
         ],
@@ -962,6 +974,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsBatchDelete",
+        "summary": "POST /v1/admin/distribution/channels/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -1122,6 +1136,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannelsById",
+        "summary": "GET /v1/admin/distribution/channels/{id}",
         "tags": [
           "distribution"
         ],
@@ -1382,6 +1398,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionChannelsById",
+        "summary": "PATCH /v1/admin/distribution/channels/{id}",
         "tags": [
           "distribution"
         ],
@@ -1440,6 +1458,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionChannelsById",
+        "summary": "DELETE /v1/admin/distribution/channels/{id}",
         "tags": [
           "distribution"
         ],
@@ -1565,6 +1585,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannelsByIdContactPoints",
+        "summary": "GET /v1/admin/distribution/channels/{id}/contact-points",
         "tags": [
           "distribution"
         ],
@@ -1769,6 +1791,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsByIdContactPoints",
+        "summary": "POST /v1/admin/distribution/channels/{id}/contact-points",
         "tags": [
           "distribution"
         ],
@@ -1981,6 +2005,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionChannelContactPointsByContactPointId",
+        "summary": "PATCH /v1/admin/distribution/channel-contact-points/{contactPointId}",
         "tags": [
           "distribution"
         ],
@@ -2039,6 +2065,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionChannelContactPointsByContactPointId",
+        "summary": "DELETE /v1/admin/distribution/channel-contact-points/{contactPointId}",
         "tags": [
           "distribution"
         ],
@@ -2171,6 +2199,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannelsByIdContacts",
+        "summary": "GET /v1/admin/distribution/channels/{id}/contacts",
         "tags": [
           "distribution"
         ],
@@ -2390,6 +2420,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsByIdContacts",
+        "summary": "POST /v1/admin/distribution/channels/{id}/contacts",
         "tags": [
           "distribution"
         ],
@@ -2618,6 +2650,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionChannelContactsByContactId",
+        "summary": "PATCH /v1/admin/distribution/channel-contacts/{contactId}",
         "tags": [
           "distribution"
         ],
@@ -2676,6 +2710,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionChannelContactsByContactId",
+        "summary": "DELETE /v1/admin/distribution/channel-contacts/{contactId}",
         "tags": [
           "distribution"
         ],
@@ -2888,6 +2924,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionContracts",
+        "summary": "GET /v1/admin/distribution/contracts",
         "tags": [
           "distribution"
         ],
@@ -3121,6 +3159,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionContracts",
+        "summary": "POST /v1/admin/distribution/contracts",
         "tags": [
           "distribution"
         ],
@@ -3399,6 +3439,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionContractsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/contracts/batch-update",
         "tags": [
           "distribution"
         ],
@@ -3499,6 +3541,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionContractsBatchDelete",
+        "summary": "POST /v1/admin/distribution/contracts/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -3668,6 +3712,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionContractsById",
+        "summary": "GET /v1/admin/distribution/contracts/{id}",
         "tags": [
           "distribution"
         ],
@@ -3925,6 +3971,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionContractsById",
+        "summary": "PATCH /v1/admin/distribution/contracts/{id}",
         "tags": [
           "distribution"
         ],
@@ -3983,6 +4031,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionContractsById",
+        "summary": "DELETE /v1/admin/distribution/contracts/{id}",
         "tags": [
           "distribution"
         ],
@@ -4170,6 +4220,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionCommissionRules",
+        "summary": "GET /v1/admin/distribution/commission-rules",
         "tags": [
           "distribution"
         ],
@@ -4384,6 +4436,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionCommissionRules",
+        "summary": "POST /v1/admin/distribution/commission-rules",
         "tags": [
           "distribution"
         ],
@@ -4642,6 +4696,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionCommissionRulesBatchUpdate",
+        "summary": "POST /v1/admin/distribution/commission-rules/batch-update",
         "tags": [
           "distribution"
         ],
@@ -4742,6 +4798,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionCommissionRulesBatchDelete",
+        "summary": "POST /v1/admin/distribution/commission-rules/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -4886,6 +4944,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionCommissionRulesById",
+        "summary": "GET /v1/admin/distribution/commission-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -5123,6 +5183,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionCommissionRulesById",
+        "summary": "PATCH /v1/admin/distribution/commission-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -5181,6 +5243,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionCommissionRulesById",
+        "summary": "DELETE /v1/admin/distribution/commission-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -5378,6 +5442,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionProductMappings",
+        "summary": "GET /v1/admin/distribution/product-mappings",
         "tags": [
           "distribution"
         ],
@@ -5598,6 +5664,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionProductMappings",
+        "summary": "POST /v1/admin/distribution/product-mappings",
         "tags": [
           "distribution"
         ],
@@ -5859,6 +5927,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionProductMappingsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/product-mappings/batch-update",
         "tags": [
           "distribution"
         ],
@@ -5959,6 +6029,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionProductMappingsBatchDelete",
+        "summary": "POST /v1/admin/distribution/product-mappings/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -6113,6 +6185,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionProductMappingsById",
+        "summary": "GET /v1/admin/distribution/product-mappings/{id}",
         "tags": [
           "distribution"
         ],
@@ -6353,6 +6427,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionProductMappingsById",
+        "summary": "PATCH /v1/admin/distribution/product-mappings/{id}",
         "tags": [
           "distribution"
         ],
@@ -6411,6 +6487,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionProductMappingsById",
+        "summary": "DELETE /v1/admin/distribution/product-mappings/{id}",
         "tags": [
           "distribution"
         ],
@@ -6621,6 +6699,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionBookingLinks",
+        "summary": "GET /v1/admin/distribution/booking-links",
         "tags": [
           "distribution"
         ],
@@ -6854,6 +6934,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionBookingLinks",
+        "summary": "POST /v1/admin/distribution/booking-links",
         "tags": [
           "distribution"
         ],
@@ -7114,6 +7196,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionBookingLinksBatchUpdate",
+        "summary": "POST /v1/admin/distribution/booking-links/batch-update",
         "tags": [
           "distribution"
         ],
@@ -7214,6 +7298,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionBookingLinksBatchDelete",
+        "summary": "POST /v1/admin/distribution/booking-links/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -7387,6 +7473,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionBookingLinksById",
+        "summary": "GET /v1/admin/distribution/booking-links/{id}",
         "tags": [
           "distribution"
         ],
@@ -7626,6 +7714,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionBookingLinksById",
+        "summary": "PATCH /v1/admin/distribution/booking-links/{id}",
         "tags": [
           "distribution"
         ],
@@ -7684,6 +7774,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionBookingLinksById",
+        "summary": "DELETE /v1/admin/distribution/booking-links/{id}",
         "tags": [
           "distribution"
         ],
@@ -7844,6 +7936,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionWebhookEvents",
+        "summary": "GET /v1/admin/distribution/webhook-events",
         "tags": [
           "distribution"
         ],
@@ -8013,6 +8107,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionWebhookEvents",
+        "summary": "POST /v1/admin/distribution/webhook-events",
         "tags": [
           "distribution"
         ],
@@ -8226,6 +8322,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionWebhookEventsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/webhook-events/batch-update",
         "tags": [
           "distribution"
         ],
@@ -8326,6 +8424,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionWebhookEventsBatchDelete",
+        "summary": "POST /v1/admin/distribution/webhook-events/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -8443,6 +8543,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionWebhookEventsById",
+        "summary": "GET /v1/admin/distribution/webhook-events/{id}",
         "tags": [
           "distribution"
         ],
@@ -8635,6 +8737,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionWebhookEventsById",
+        "summary": "PATCH /v1/admin/distribution/webhook-events/{id}",
         "tags": [
           "distribution"
         ],
@@ -8693,6 +8797,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionWebhookEventsById",
+        "summary": "DELETE /v1/admin/distribution/webhook-events/{id}",
         "tags": [
           "distribution"
         ],
@@ -8901,6 +9007,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotments",
+        "summary": "GET /v1/admin/distribution/inventory-allotments",
         "tags": [
           "distribution"
         ],
@@ -9108,6 +9216,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotments",
+        "summary": "POST /v1/admin/distribution/inventory-allotments",
         "tags": [
           "distribution"
         ],
@@ -9360,6 +9470,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/inventory-allotments/batch-update",
         "tags": [
           "distribution"
         ],
@@ -9460,6 +9572,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentsBatchDelete",
+        "summary": "POST /v1/admin/distribution/inventory-allotments/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -9601,6 +9715,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotmentsById",
+        "summary": "GET /v1/admin/distribution/inventory-allotments/{id}",
         "tags": [
           "distribution"
         ],
@@ -9832,6 +9948,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryAllotmentsById",
+        "summary": "PATCH /v1/admin/distribution/inventory-allotments/{id}",
         "tags": [
           "distribution"
         ],
@@ -9890,6 +10008,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryAllotmentsById",
+        "summary": "DELETE /v1/admin/distribution/inventory-allotments/{id}",
         "tags": [
           "distribution"
         ],
@@ -10080,6 +10200,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotmentTargets",
+        "summary": "GET /v1/admin/distribution/inventory-allotment-targets",
         "tags": [
           "distribution"
         ],
@@ -10267,6 +10389,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentTargets",
+        "summary": "POST /v1/admin/distribution/inventory-allotment-targets",
         "tags": [
           "distribution"
         ],
@@ -10500,6 +10624,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentTargetsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/inventory-allotment-targets/batch-update",
         "tags": [
           "distribution"
         ],
@@ -10600,6 +10726,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentTargetsBatchDelete",
+        "summary": "POST /v1/admin/distribution/inventory-allotment-targets/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -10730,6 +10858,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotmentTargetsById",
+        "summary": "GET /v1/admin/distribution/inventory-allotment-targets/{id}",
         "tags": [
           "distribution"
         ],
@@ -10942,6 +11072,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryAllotmentTargetsById",
+        "summary": "PATCH /v1/admin/distribution/inventory-allotment-targets/{id}",
         "tags": [
           "distribution"
         ],
@@ -11000,6 +11132,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryAllotmentTargetsById",
+        "summary": "DELETE /v1/admin/distribution/inventory-allotment-targets/{id}",
         "tags": [
           "distribution"
         ],
@@ -11148,6 +11282,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseRules",
+        "summary": "GET /v1/admin/distribution/inventory-release-rules",
         "tags": [
           "distribution"
         ],
@@ -11306,6 +11442,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseRules",
+        "summary": "POST /v1/admin/distribution/inventory-release-rules",
         "tags": [
           "distribution"
         ],
@@ -11510,6 +11648,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseRulesBatchUpdate",
+        "summary": "POST /v1/admin/distribution/inventory-release-rules/batch-update",
         "tags": [
           "distribution"
         ],
@@ -11610,6 +11750,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseRulesBatchDelete",
+        "summary": "POST /v1/admin/distribution/inventory-release-rules/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -11725,6 +11867,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseRulesById",
+        "summary": "GET /v1/admin/distribution/inventory-release-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -11908,6 +12052,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryReleaseRulesById",
+        "summary": "PATCH /v1/admin/distribution/inventory-release-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -11966,6 +12112,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryReleaseRulesById",
+        "summary": "DELETE /v1/admin/distribution/inventory-release-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -12169,6 +12317,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementRuns",
+        "summary": "GET /v1/admin/distribution/settlement-runs",
         "tags": [
           "distribution"
         ],
@@ -12411,6 +12561,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementRuns",
+        "summary": "POST /v1/admin/distribution/settlement-runs",
         "tags": [
           "distribution"
         ],
@@ -12570,6 +12722,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementRunsById",
+        "summary": "GET /v1/admin/distribution/settlement-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -12837,6 +12991,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementRunsById",
+        "summary": "PATCH /v1/admin/distribution/settlement-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -12895,6 +13051,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementRunsById",
+        "summary": "DELETE /v1/admin/distribution/settlement-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -13096,6 +13254,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementItems",
+        "summary": "GET /v1/admin/distribution/settlement-items",
         "tags": [
           "distribution"
         ],
@@ -13318,6 +13478,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementItems",
+        "summary": "POST /v1/admin/distribution/settlement-items",
         "tags": [
           "distribution"
         ],
@@ -13467,6 +13629,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementItemsById",
+        "summary": "GET /v1/admin/distribution/settlement-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -13714,6 +13878,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementItemsById",
+        "summary": "PATCH /v1/admin/distribution/settlement-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -13772,6 +13938,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementItemsById",
+        "summary": "DELETE /v1/admin/distribution/settlement-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -13959,6 +14127,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationRuns",
+        "summary": "GET /v1/admin/distribution/reconciliation-runs",
         "tags": [
           "distribution"
         ],
@@ -14172,6 +14342,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReconciliationRuns",
+        "summary": "POST /v1/admin/distribution/reconciliation-runs",
         "tags": [
           "distribution"
         ],
@@ -14316,6 +14488,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationRunsById",
+        "summary": "GET /v1/admin/distribution/reconciliation-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -14554,6 +14728,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReconciliationRunsById",
+        "summary": "PATCH /v1/admin/distribution/reconciliation-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -14612,6 +14788,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReconciliationRunsById",
+        "summary": "DELETE /v1/admin/distribution/reconciliation-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -14820,6 +14998,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationItems",
+        "summary": "GET /v1/admin/distribution/reconciliation-items",
         "tags": [
           "distribution"
         ],
@@ -15029,6 +15209,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReconciliationItems",
+        "summary": "POST /v1/admin/distribution/reconciliation-items",
         "tags": [
           "distribution"
         ],
@@ -15171,6 +15353,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationItemsById",
+        "summary": "GET /v1/admin/distribution/reconciliation-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -15405,6 +15589,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReconciliationItemsById",
+        "summary": "PATCH /v1/admin/distribution/reconciliation-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -15463,6 +15649,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReconciliationItemsById",
+        "summary": "DELETE /v1/admin/distribution/reconciliation-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -15669,6 +15857,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseExecutions",
+        "summary": "GET /v1/admin/distribution/inventory-release-executions",
         "tags": [
           "distribution"
         ],
@@ -15887,6 +16077,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseExecutions",
+        "summary": "POST /v1/admin/distribution/inventory-release-executions",
         "tags": [
           "distribution"
         ],
@@ -16034,6 +16226,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseExecutionsById",
+        "summary": "GET /v1/admin/distribution/inventory-release-executions/{id}",
         "tags": [
           "distribution"
         ],
@@ -16277,6 +16471,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryReleaseExecutionsById",
+        "summary": "PATCH /v1/admin/distribution/inventory-release-executions/{id}",
         "tags": [
           "distribution"
         ],
@@ -16335,6 +16531,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryReleaseExecutionsById",
+        "summary": "DELETE /v1/admin/distribution/inventory-release-executions/{id}",
         "tags": [
           "distribution"
         ],
@@ -16534,6 +16732,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementPolicies",
+        "summary": "GET /v1/admin/distribution/settlement-policies",
         "tags": [
           "distribution"
         ],
@@ -16743,6 +16943,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementPolicies",
+        "summary": "POST /v1/admin/distribution/settlement-policies",
         "tags": [
           "distribution"
         ],
@@ -16885,6 +17087,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementPoliciesById",
+        "summary": "GET /v1/admin/distribution/settlement-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17119,6 +17323,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementPoliciesById",
+        "summary": "PATCH /v1/admin/distribution/settlement-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17177,6 +17383,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementPoliciesById",
+        "summary": "DELETE /v1/admin/distribution/settlement-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17370,6 +17578,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationPolicies",
+        "summary": "GET /v1/admin/distribution/reconciliation-policies",
         "tags": [
           "distribution"
         ],
@@ -17568,6 +17778,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReconciliationPolicies",
+        "summary": "POST /v1/admin/distribution/reconciliation-policies",
         "tags": [
           "distribution"
         ],
@@ -17704,6 +17916,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationPoliciesById",
+        "summary": "GET /v1/admin/distribution/reconciliation-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17927,6 +18141,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReconciliationPoliciesById",
+        "summary": "PATCH /v1/admin/distribution/reconciliation-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17985,6 +18201,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReconciliationPoliciesById",
+        "summary": "DELETE /v1/admin/distribution/reconciliation-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -18152,6 +18370,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReleaseSchedules",
+        "summary": "GET /v1/admin/distribution/release-schedules",
         "tags": [
           "distribution"
         ],
@@ -18317,6 +18537,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReleaseSchedules",
+        "summary": "POST /v1/admin/distribution/release-schedules",
         "tags": [
           "distribution"
         ],
@@ -18436,6 +18658,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReleaseSchedulesById",
+        "summary": "GET /v1/admin/distribution/release-schedules/{id}",
         "tags": [
           "distribution"
         ],
@@ -18626,6 +18850,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReleaseSchedulesById",
+        "summary": "PATCH /v1/admin/distribution/release-schedules/{id}",
         "tags": [
           "distribution"
         ],
@@ -18684,6 +18910,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReleaseSchedulesById",
+        "summary": "DELETE /v1/admin/distribution/release-schedules/{id}",
         "tags": [
           "distribution"
         ],
@@ -18875,6 +19103,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionRemittanceExceptions",
+        "summary": "GET /v1/admin/distribution/remittance-exceptions",
         "tags": [
           "distribution"
         ],
@@ -19084,6 +19314,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionRemittanceExceptions",
+        "summary": "POST /v1/admin/distribution/remittance-exceptions",
         "tags": [
           "distribution"
         ],
@@ -19224,6 +19456,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionRemittanceExceptionsById",
+        "summary": "GET /v1/admin/distribution/remittance-exceptions/{id}",
         "tags": [
           "distribution"
         ],
@@ -19457,6 +19691,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionRemittanceExceptionsById",
+        "summary": "PATCH /v1/admin/distribution/remittance-exceptions/{id}",
         "tags": [
           "distribution"
         ],
@@ -19515,6 +19751,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionRemittanceExceptionsById",
+        "summary": "DELETE /v1/admin/distribution/remittance-exceptions/{id}",
         "tags": [
           "distribution"
         ],
@@ -19664,6 +19902,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementApprovals",
+        "summary": "GET /v1/admin/distribution/settlement-approvals",
         "tags": [
           "distribution"
         ],
@@ -19820,6 +20060,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementApprovals",
+        "summary": "POST /v1/admin/distribution/settlement-approvals",
         "tags": [
           "distribution"
         ],
@@ -19935,6 +20177,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementApprovalsById",
+        "summary": "GET /v1/admin/distribution/settlement-approvals/{id}",
         "tags": [
           "distribution"
         ],
@@ -20116,6 +20360,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementApprovalsById",
+        "summary": "PATCH /v1/admin/distribution/settlement-approvals/{id}",
         "tags": [
           "distribution"
         ],
@@ -20174,6 +20420,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementApprovalsById",
+        "summary": "DELETE /v1/admin/distribution/settlement-approvals/{id}",
         "tags": [
           "distribution"
         ],

--- a/packages/openapi/spec/admin/external-refs.json
+++ b/packages/openapi/spec/admin/external-refs.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -352,6 +358,8 @@
             }
           }
         },
+        "operationId": "getAdminExternalRefsRefs",
+        "summary": "GET /v1/admin/external-refs/refs",
         "tags": [
           "external-refs"
         ],
@@ -555,6 +563,8 @@
             }
           }
         },
+        "operationId": "postAdminExternalRefsRefs",
+        "summary": "POST /v1/admin/external-refs/refs",
         "tags": [
           "external-refs"
         ],
@@ -687,6 +697,8 @@
             }
           }
         },
+        "operationId": "getAdminExternalRefsRefsById",
+        "summary": "GET /v1/admin/external-refs/refs/{id}",
         "tags": [
           "external-refs"
         ],
@@ -911,6 +923,8 @@
             }
           }
         },
+        "operationId": "patchAdminExternalRefsRefsById",
+        "summary": "PATCH /v1/admin/external-refs/refs/{id}",
         "tags": [
           "external-refs"
         ],
@@ -969,6 +983,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExternalRefsRefsById",
+        "summary": "DELETE /v1/admin/external-refs/refs/{id}",
         "tags": [
           "external-refs"
         ],
@@ -1196,6 +1212,8 @@
             }
           }
         },
+        "operationId": "getAdminExternalRefsEntitiesByEntityTypeByEntityIdRefs",
+        "summary": "GET /v1/admin/external-refs/entities/{entityType}/{entityId}/refs",
         "tags": [
           "external-refs"
         ],
@@ -1405,6 +1423,8 @@
             }
           }
         },
+        "operationId": "postAdminExternalRefsEntitiesByEntityTypeByEntityIdRefs",
+        "summary": "POST /v1/admin/external-refs/entities/{entityType}/{entityId}/refs",
         "tags": [
           "external-refs"
         ],

--- a/packages/openapi/spec/admin/extras.json
+++ b/packages/openapi/spec/admin/extras.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -390,6 +396,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasProductExtras",
+        "summary": "GET /v1/admin/extras/product-extras",
         "tags": [
           "extras"
         ],
@@ -679,6 +687,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasProductExtras",
+        "summary": "POST /v1/admin/extras/product-extras",
         "tags": [
           "extras"
         ],
@@ -859,6 +869,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasProductExtrasById",
+        "summary": "GET /v1/admin/extras/product-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -1172,6 +1184,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasProductExtrasById",
+        "summary": "PATCH /v1/admin/extras/product-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -1227,6 +1241,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExtrasProductExtrasById",
+        "summary": "DELETE /v1/admin/extras/product-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -1454,6 +1470,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasOptionExtraConfigs",
+        "summary": "GET /v1/admin/extras/option-extra-configs",
         "tags": [
           "extras"
         ],
@@ -1711,6 +1729,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasOptionExtraConfigs",
+        "summary": "POST /v1/admin/extras/option-extra-configs",
         "tags": [
           "extras"
         ],
@@ -1877,6 +1897,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasOptionExtraConfigsById",
+        "summary": "GET /v1/admin/extras/option-extra-configs/{id}",
         "tags": [
           "extras"
         ],
@@ -2158,6 +2180,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasOptionExtraConfigsById",
+        "summary": "PATCH /v1/admin/extras/option-extra-configs/{id}",
         "tags": [
           "extras"
         ],
@@ -2213,6 +2237,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExtrasOptionExtraConfigsById",
+        "summary": "DELETE /v1/admin/extras/option-extra-configs/{id}",
         "tags": [
           "extras"
         ],
@@ -2470,6 +2496,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasBookingExtras",
+        "summary": "GET /v1/admin/extras/booking-extras",
         "tags": [
           "extras"
         ],
@@ -2775,6 +2803,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasBookingExtras",
+        "summary": "POST /v1/admin/extras/booking-extras",
         "tags": [
           "extras"
         ],
@@ -2962,6 +2992,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasBookingExtrasById",
+        "summary": "GET /v1/admin/extras/booking-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -3290,6 +3322,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasBookingExtrasById",
+        "summary": "PATCH /v1/admin/extras/booking-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -3345,6 +3379,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExtrasBookingExtrasById",
+        "summary": "DELETE /v1/admin/extras/booking-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -3897,6 +3933,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasSlotManifestsBySlotId",
+        "summary": "GET /v1/admin/extras/slot-manifests/{slotId}",
         "tags": [
           "extras"
         ],
@@ -4176,6 +4214,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasSlotManifestsBySlotIdSelections",
+        "summary": "PATCH /v1/admin/extras/slot-manifests/{slotId}/selections",
         "tags": [
           "extras"
         ],
@@ -4471,6 +4511,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasSlotManifestsBySlotIdSelectionsBulk",
+        "summary": "POST /v1/admin/extras/slot-manifests/{slotId}/selections/bulk",
         "tags": [
           "extras"
         ],
@@ -4731,6 +4773,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasSlotManifestsBySlotIdCollectionsBulk",
+        "summary": "POST /v1/admin/extras/slot-manifests/{slotId}/collections/bulk",
         "tags": [
           "extras"
         ],

--- a/packages/openapi/spec/admin/finance.json
+++ b/packages/openapi/spec/admin/finance.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -647,6 +653,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentSessions",
+        "summary": "GET /v1/admin/finance/payment-sessions",
         "tags": [
           "finance"
         ],
@@ -1533,6 +1541,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessions",
+        "summary": "POST /v1/admin/finance/payment-sessions",
         "tags": [
           "finance"
         ],
@@ -1900,6 +1910,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentSessionsById",
+        "summary": "GET /v1/admin/finance/payment-sessions/{id}",
         "tags": [
           "finance"
         ],
@@ -2810,6 +2822,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentSessionsById",
+        "summary": "PATCH /v1/admin/finance/payment-sessions/{id}",
         "tags": [
           "finance"
         ],
@@ -3290,6 +3304,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdRequiresRedirect",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/requires-redirect",
         "tags": [
           "finance"
         ],
@@ -3710,6 +3726,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdComplete",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/complete",
         "tags": [
           "finance"
         ],
@@ -4078,6 +4096,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdFail",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/fail",
         "tags": [
           "finance"
         ],
@@ -4446,6 +4466,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdCancel",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/cancel",
         "tags": [
           "finance"
         ],
@@ -4814,6 +4836,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdExpire",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/expire",
         "tags": [
           "finance"
         ],
@@ -5143,6 +5167,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentInstruments",
+        "summary": "GET /v1/admin/finance/payment-instruments",
         "tags": [
           "finance"
         ],
@@ -5531,6 +5557,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentInstruments",
+        "summary": "POST /v1/admin/finance/payment-instruments",
         "tags": [
           "finance"
         ],
@@ -5758,6 +5786,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentInstrumentsById",
+        "summary": "GET /v1/admin/finance/payment-instruments/{id}",
         "tags": [
           "finance"
         ],
@@ -6170,6 +6200,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentInstrumentsById",
+        "summary": "PATCH /v1/admin/finance/payment-instruments/{id}",
         "tags": [
           "finance"
         ],
@@ -6225,6 +6257,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentInstrumentsById",
+        "summary": "DELETE /v1/admin/finance/payment-instruments/{id}",
         "tags": [
           "finance"
         ],
@@ -6484,6 +6518,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentAuthorizations",
+        "summary": "GET /v1/admin/finance/payment-authorizations",
         "tags": [
           "finance"
         ],
@@ -7020,6 +7056,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentAuthorizations",
+        "summary": "POST /v1/admin/finance/payment-authorizations",
         "tags": [
           "finance"
         ],
@@ -7206,6 +7244,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentAuthorizationsById",
+        "summary": "GET /v1/admin/finance/payment-authorizations/{id}",
         "tags": [
           "finance"
         ],
@@ -7766,6 +7806,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentAuthorizationsById",
+        "summary": "PATCH /v1/admin/finance/payment-authorizations/{id}",
         "tags": [
           "finance"
         ],
@@ -7821,6 +7863,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentAuthorizationsById",
+        "summary": "DELETE /v1/admin/finance/payment-authorizations/{id}",
         "tags": [
           "finance"
         ],
@@ -8006,6 +8050,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentCaptures",
+        "summary": "GET /v1/admin/finance/payment-captures",
         "tags": [
           "finance"
         ],
@@ -8215,6 +8261,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentCaptures",
+        "summary": "POST /v1/admin/finance/payment-captures",
         "tags": [
           "finance"
         ],
@@ -8356,6 +8404,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentCapturesById",
+        "summary": "GET /v1/admin/finance/payment-captures/{id}",
         "tags": [
           "finance"
         ],
@@ -8589,6 +8639,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentCapturesById",
+        "summary": "PATCH /v1/admin/finance/payment-captures/{id}",
         "tags": [
           "finance"
         ],
@@ -8644,6 +8696,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentCapturesById",
+        "summary": "DELETE /v1/admin/finance/payment-captures/{id}",
         "tags": [
           "finance"
         ],
@@ -8712,6 +8766,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsRevenue",
+        "summary": "GET /v1/admin/finance/reports/revenue",
         "tags": [
           "finance"
         ],
@@ -8770,6 +8826,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsAging",
+        "summary": "GET /v1/admin/finance/reports/aging",
         "tags": [
           "finance"
         ],
@@ -8853,6 +8911,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitability",
+        "summary": "GET /v1/admin/finance/reports/profitability",
         "tags": [
           "finance"
         ],
@@ -9171,6 +9231,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityDepartures",
+        "summary": "GET /v1/admin/finance/reports/profitability/departures",
         "tags": [
           "finance"
         ],
@@ -9439,6 +9501,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityProducts",
+        "summary": "GET /v1/admin/finance/reports/profitability/products",
         "tags": [
           "finance"
         ],
@@ -9558,6 +9622,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityTravelers",
+        "summary": "GET /v1/admin/finance/reports/profitability/travelers",
         "tags": [
           "finance"
         ],
@@ -9629,6 +9695,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityDeparturesExport",
+        "summary": "GET /v1/admin/finance/reports/profitability/departures/export",
         "tags": [
           "finance"
         ],
@@ -9684,6 +9752,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityProductsExport",
+        "summary": "GET /v1/admin/finance/reports/profitability/products/export",
         "tags": [
           "finance"
         ],
@@ -9760,6 +9830,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceCostCategories",
+        "summary": "GET /v1/admin/finance/cost-categories",
         "tags": [
           "finance"
         ],
@@ -9857,6 +9929,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceCostCategories",
+        "summary": "POST /v1/admin/finance/cost-categories",
         "tags": [
           "finance"
         ],
@@ -9984,6 +10058,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceCostCategoriesById",
+        "summary": "PATCH /v1/admin/finance/cost-categories/{id}",
         "tags": [
           "finance"
         ],
@@ -10064,6 +10140,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceAccountantShares",
+        "summary": "GET /v1/admin/finance/accountant-shares",
         "tags": [
           "finance"
         ],
@@ -10175,6 +10253,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceAccountantShares",
+        "summary": "POST /v1/admin/finance/accountant-shares",
         "tags": [
           "finance"
         ],
@@ -10240,6 +10320,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceAccountantSharesByIdRevoke",
+        "summary": "POST /v1/admin/finance/accountant-shares/{id}/revoke",
         "tags": [
           "finance"
         ],
@@ -10351,6 +10433,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingsByBookingIdPaymentSchedules",
+        "summary": "GET /v1/admin/finance/bookings/{bookingId}/payment-schedules",
         "tags": [
           "finance"
         ],
@@ -10594,6 +10678,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdPaymentSchedules",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/payment-schedules",
         "tags": [
           "finance"
         ],
@@ -10807,6 +10893,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdPaymentSchedulesDefaultPlan",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/payment-schedules/default-plan",
         "tags": [
           "finance"
         ],
@@ -11055,6 +11143,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingsByBookingIdPaymentSchedulesByScheduleId",
+        "summary": "PATCH /v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}",
         "tags": [
           "finance"
         ],
@@ -11118,6 +11208,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingsByBookingIdPaymentSchedulesByScheduleId",
+        "summary": "DELETE /v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}",
         "tags": [
           "finance"
         ],
@@ -11901,6 +11993,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdPaymentSchedulesByScheduleIdPaymentSession",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -12073,6 +12167,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingsByBookingIdGuarantees",
+        "summary": "GET /v1/admin/finance/bookings/{bookingId}/guarantees",
         "tags": [
           "finance"
         ],
@@ -12393,6 +12489,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdGuarantees",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/guarantees",
         "tags": [
           "finance"
         ],
@@ -13176,6 +13274,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdGuaranteesByGuaranteeIdPaymentSession",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -13503,6 +13603,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingsByBookingIdGuaranteesByGuaranteeId",
+        "summary": "PATCH /v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}",
         "tags": [
           "finance"
         ],
@@ -13592,6 +13694,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingsByBookingIdGuaranteesByGuaranteeId",
+        "summary": "DELETE /v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}",
         "tags": [
           "finance"
         ],
@@ -13711,6 +13815,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingItemsByBookingItemIdTaxLines",
+        "summary": "GET /v1/admin/finance/booking-items/{bookingItemId}/tax-lines",
         "tags": [
           "finance"
         ],
@@ -13938,6 +14044,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingItemsByBookingItemIdTaxLines",
+        "summary": "POST /v1/admin/finance/booking-items/{bookingItemId}/tax-lines",
         "tags": [
           "finance"
         ],
@@ -14170,6 +14278,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingItemsByBookingItemIdTaxLinesByTaxLineId",
+        "summary": "PATCH /v1/admin/finance/booking-items/{bookingItemId}/tax-lines/{taxLineId}",
         "tags": [
           "finance"
         ],
@@ -14233,6 +14343,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingItemsByBookingItemIdTaxLinesByTaxLineId",
+        "summary": "DELETE /v1/admin/finance/booking-items/{bookingItemId}/tax-lines/{taxLineId}",
         "tags": [
           "finance"
         ],
@@ -14378,6 +14490,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingItemsByBookingItemIdCommissions",
+        "summary": "GET /v1/admin/finance/booking-items/{bookingItemId}/commissions",
         "tags": [
           "finance"
         ],
@@ -14656,6 +14770,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingItemsByBookingItemIdCommissions",
+        "summary": "POST /v1/admin/finance/booking-items/{bookingItemId}/commissions",
         "tags": [
           "finance"
         ],
@@ -14939,6 +15055,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingItemsByBookingItemIdCommissionsByCommissionId",
+        "summary": "PATCH /v1/admin/finance/booking-items/{bookingItemId}/commissions/{commissionId}",
         "tags": [
           "finance"
         ],
@@ -15002,6 +15120,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingItemsByBookingItemIdCommissionsByCommissionId",
+        "summary": "DELETE /v1/admin/finance/booking-items/{bookingItemId}/commissions/{commissionId}",
         "tags": [
           "finance"
         ],
@@ -15343,6 +15463,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePayments",
+        "summary": "GET /v1/admin/finance/payments",
         "tags": [
           "finance"
         ],
@@ -15543,6 +15665,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentsById",
+        "summary": "GET /v1/admin/finance/payments/{id}",
         "tags": [
           "finance"
         ],
@@ -15848,6 +15972,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentsById",
+        "summary": "PATCH /v1/admin/finance/payments/{id}",
         "tags": [
           "finance"
         ],
@@ -16035,6 +16161,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentsById",
+        "summary": "DELETE /v1/admin/finance/payments/{id}",
         "tags": [
           "finance"
         ],
@@ -16337,6 +16465,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierPayments",
+        "summary": "GET /v1/admin/finance/supplier-payments",
         "tags": [
           "finance"
         ],
@@ -16647,6 +16777,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierPayments",
+        "summary": "POST /v1/admin/finance/supplier-payments",
         "tags": [
           "finance"
         ],
@@ -16981,6 +17113,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceSupplierPaymentsById",
+        "summary": "PATCH /v1/admin/finance/supplier-payments/{id}",
         "tags": [
           "finance"
         ],
@@ -17381,6 +17515,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoices",
+        "summary": "GET /v1/admin/finance/invoices",
         "tags": [
           "finance"
         ],
@@ -17844,6 +17980,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoices",
+        "summary": "POST /v1/admin/finance/invoices",
         "tags": [
           "finance"
         ],
@@ -18369,6 +18507,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesFromBooking",
+        "summary": "POST /v1/admin/finance/invoices/from-booking",
         "tags": [
           "finance"
         ],
@@ -18663,6 +18803,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdConvertToInvoice",
+        "summary": "POST /v1/admin/finance/invoices/{id}/convert-to-invoice",
         "tags": [
           "finance"
         ],
@@ -18952,6 +19094,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesById",
+        "summary": "GET /v1/admin/finance/invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -19415,6 +19559,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesById",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -19488,6 +19634,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesById",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -19800,6 +19948,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdVoid",
+        "summary": "POST /v1/admin/finance/invoices/{id}/void",
         "tags": [
           "finance"
         ],
@@ -20574,6 +20724,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdPaymentSession",
+        "summary": "POST /v1/admin/finance/invoices/{id}/payment-session",
         "tags": [
           "finance"
         ],
@@ -20673,6 +20825,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdLineItems",
+        "summary": "GET /v1/admin/finance/invoices/{id}/line-items",
         "tags": [
           "finance"
         ],
@@ -20862,6 +21016,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdLineItems",
+        "summary": "POST /v1/admin/finance/invoices/{id}/line-items",
         "tags": [
           "finance"
         ],
@@ -21056,6 +21212,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesByIdLineItemsByLineId",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}/line-items/{lineId}",
         "tags": [
           "finance"
         ],
@@ -21119,6 +21277,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesByIdLineItemsByLineId",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}/line-items/{lineId}",
         "tags": [
           "finance"
         ],
@@ -21274,6 +21434,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdPayments",
+        "summary": "GET /v1/admin/finance/invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -21592,6 +21754,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdPayments",
+        "summary": "POST /v1/admin/finance/invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -21707,6 +21871,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdCreditNotes",
+        "summary": "GET /v1/admin/finance/invoices/{id}/credit-notes",
         "tags": [
           "finance"
         ],
@@ -21944,6 +22110,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdCreditNotes",
+        "summary": "POST /v1/admin/finance/invoices/{id}/credit-notes",
         "tags": [
           "finance"
         ],
@@ -22185,6 +22353,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesByIdCreditNotesByCreditNoteId",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}",
         "tags": [
           "finance"
         ],
@@ -22271,6 +22441,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdCreditNotesByCreditNoteIdLineItems",
+        "summary": "GET /v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}/line-items",
         "tags": [
           "finance"
         ],
@@ -22428,6 +22600,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdCreditNotesByCreditNoteIdLineItems",
+        "summary": "POST /v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}/line-items",
         "tags": [
           "finance"
         ],
@@ -22494,6 +22668,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdNotes",
+        "summary": "GET /v1/admin/finance/invoices/{id}/notes",
         "tags": [
           "finance"
         ],
@@ -22611,6 +22787,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdNotes",
+        "summary": "POST /v1/admin/finance/invoices/{id}/notes",
         "tags": [
           "finance"
         ],
@@ -22795,6 +22973,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceNumberSeries",
+        "summary": "GET /v1/admin/finance/invoice-number-series",
         "tags": [
           "finance"
         ],
@@ -23029,6 +23209,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoiceNumberSeries",
+        "summary": "POST /v1/admin/finance/invoice-number-series",
         "tags": [
           "finance"
         ],
@@ -23180,6 +23362,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceNumberSeriesById",
+        "summary": "GET /v1/admin/finance/invoice-number-series/{id}",
         "tags": [
           "finance"
         ],
@@ -23445,6 +23629,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoiceNumberSeriesById",
+        "summary": "PATCH /v1/admin/finance/invoice-number-series/{id}",
         "tags": [
           "finance"
         ],
@@ -23507,6 +23693,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoiceNumberSeriesById",
+        "summary": "DELETE /v1/admin/finance/invoice-number-series/{id}",
         "tags": [
           "finance"
         ],
@@ -23608,6 +23796,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoiceNumberSeriesByIdAllocate",
+        "summary": "POST /v1/admin/finance/invoice-number-series/{id}/allocate",
         "tags": [
           "finance"
         ],
@@ -23777,6 +23967,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceTemplates",
+        "summary": "GET /v1/admin/finance/invoice-templates",
         "tags": [
           "finance"
         ],
@@ -23969,6 +24161,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoiceTemplates",
+        "summary": "POST /v1/admin/finance/invoice-templates",
         "tags": [
           "finance"
         ],
@@ -24097,6 +24291,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceTemplatesById",
+        "summary": "GET /v1/admin/finance/invoice-templates/{id}",
         "tags": [
           "finance"
         ],
@@ -24319,6 +24515,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoiceTemplatesById",
+        "summary": "PATCH /v1/admin/finance/invoice-templates/{id}",
         "tags": [
           "finance"
         ],
@@ -24381,6 +24579,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoiceTemplatesById",
+        "summary": "DELETE /v1/admin/finance/invoice-templates/{id}",
         "tags": [
           "finance"
         ],
@@ -24555,6 +24755,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxRegimes",
+        "summary": "GET /v1/admin/finance/tax-regimes",
         "tags": [
           "finance"
         ],
@@ -24748,6 +24950,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxRegimes",
+        "summary": "POST /v1/admin/finance/tax-regimes",
         "tags": [
           "finance"
         ],
@@ -24879,6 +25083,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxRegimesById",
+        "summary": "GET /v1/admin/finance/tax-regimes/{id}",
         "tags": [
           "finance"
         ],
@@ -25103,6 +25309,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxRegimesById",
+        "summary": "PATCH /v1/admin/finance/tax-regimes/{id}",
         "tags": [
           "finance"
         ],
@@ -25165,6 +25373,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxRegimesById",
+        "summary": "DELETE /v1/admin/finance/tax-regimes/{id}",
         "tags": [
           "finance"
         ],
@@ -25327,6 +25537,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxClasses",
+        "summary": "GET /v1/admin/finance/tax-classes",
         "tags": [
           "finance"
         ],
@@ -25520,6 +25732,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxClasses",
+        "summary": "POST /v1/admin/finance/tax-classes",
         "tags": [
           "finance"
         ],
@@ -25654,6 +25868,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxClassesById",
+        "summary": "GET /v1/admin/finance/tax-classes/{id}",
         "tags": [
           "finance"
         ],
@@ -25878,6 +26094,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxClassesById",
+        "summary": "PATCH /v1/admin/finance/tax-classes/{id}",
         "tags": [
           "finance"
         ],
@@ -25940,6 +26158,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxClassesById",
+        "summary": "DELETE /v1/admin/finance/tax-classes/{id}",
         "tags": [
           "finance"
         ],
@@ -26079,6 +26299,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyProfiles",
+        "summary": "GET /v1/admin/finance/tax-policy-profiles",
         "tags": [
           "finance"
         ],
@@ -26217,6 +26439,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxPolicyProfiles",
+        "summary": "POST /v1/admin/finance/tax-policy-profiles",
         "tags": [
           "finance"
         ],
@@ -26323,6 +26547,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyProfilesById",
+        "summary": "GET /v1/admin/finance/tax-policy-profiles/{id}",
         "tags": [
           "finance"
         ],
@@ -26492,6 +26718,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxPolicyProfilesById",
+        "summary": "PATCH /v1/admin/finance/tax-policy-profiles/{id}",
         "tags": [
           "finance"
         ],
@@ -26554,6 +26782,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxPolicyProfilesById",
+        "summary": "DELETE /v1/admin/finance/tax-policy-profiles/{id}",
         "tags": [
           "finance"
         ],
@@ -26717,6 +26947,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyRules",
+        "summary": "GET /v1/admin/finance/tax-policy-rules",
         "tags": [
           "finance"
         ],
@@ -26895,6 +27127,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxPolicyRules",
+        "summary": "POST /v1/admin/finance/tax-policy-rules",
         "tags": [
           "finance"
         ],
@@ -27021,6 +27255,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyRulesById",
+        "summary": "GET /v1/admin/finance/tax-policy-rules/{id}",
         "tags": [
           "finance"
         ],
@@ -27229,6 +27465,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxPolicyRulesById",
+        "summary": "PATCH /v1/admin/finance/tax-policy-rules/{id}",
         "tags": [
           "finance"
         ],
@@ -27291,6 +27529,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxPolicyRulesById",
+        "summary": "DELETE /v1/admin/finance/tax-policy-rules/{id}",
         "tags": [
           "finance"
         ],
@@ -27423,6 +27663,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdRenditions",
+        "summary": "GET /v1/admin/finance/invoices/{id}/renditions",
         "tags": [
           "finance"
         ],
@@ -27914,6 +28156,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdRender",
+        "summary": "POST /v1/admin/finance/invoices/{id}/render",
         "tags": [
           "finance"
         ],
@@ -28009,6 +28253,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdAttachments",
+        "summary": "GET /v1/admin/finance/invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -28196,6 +28442,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdAttachments",
+        "summary": "POST /v1/admin/finance/invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -28390,6 +28638,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesByIdAttachmentsByAttachmentId",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}/attachments/{attachmentId}",
         "tags": [
           "finance"
         ],
@@ -28453,6 +28703,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesByIdAttachmentsByAttachmentId",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}/attachments/{attachmentId}",
         "tags": [
           "finance"
         ],
@@ -28513,6 +28765,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceAttachmentsByIdDownload",
+        "summary": "GET /v1/admin/finance/invoice-attachments/{id}/download",
         "tags": [
           "finance"
         ],
@@ -28622,6 +28876,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdExternalRefs",
+        "summary": "GET /v1/admin/finance/invoices/{id}/external-refs",
         "tags": [
           "finance"
         ],
@@ -28829,6 +29085,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdExternalRefs",
+        "summary": "POST /v1/admin/finance/invoices/{id}/external-refs",
         "tags": [
           "finance"
         ],
@@ -28894,6 +29152,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesByIdExternalRefsByRefId",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}/external-refs/{refId}",
         "tags": [
           "finance"
         ],
@@ -29137,6 +29397,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceVouchers",
+        "summary": "GET /v1/admin/finance/vouchers",
         "tags": [
           "finance"
         ],
@@ -29411,6 +29673,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceVouchers",
+        "summary": "POST /v1/admin/finance/vouchers",
         "tags": [
           "finance"
         ],
@@ -29584,6 +29848,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceVouchersById",
+        "summary": "GET /v1/admin/finance/vouchers/{id}",
         "tags": [
           "finance"
         ],
@@ -29833,6 +30099,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceVouchersById",
+        "summary": "PATCH /v1/admin/finance/vouchers/{id}",
         "tags": [
           "finance"
         ],
@@ -30143,6 +30411,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceVouchersByIdRedeem",
+        "summary": "POST /v1/admin/finance/vouchers/{id}/redeem",
         "tags": [
           "finance"
         ],
@@ -30323,6 +30593,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingsByBookingIdPayments",
+        "summary": "GET /v1/admin/finance/bookings/{bookingId}/payments",
         "tags": [
           "finance"
         ],
@@ -30701,6 +30973,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdActionLedger",
+        "summary": "GET /v1/admin/finance/invoices/{id}/action-ledger",
         "tags": [
           "finance"
         ],
@@ -31079,6 +31353,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentSessionsByIdActionLedger",
+        "summary": "GET /v1/admin/finance/payment-sessions/{id}/action-ledger",
         "tags": [
           "finance"
         ],
@@ -31444,6 +31720,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoices",
+        "summary": "GET /v1/admin/finance/supplier-invoices",
         "tags": [
           "finance"
         ],
@@ -32169,6 +32447,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierInvoices",
+        "summary": "POST /v1/admin/finance/supplier-invoices",
         "tags": [
           "finance"
         ],
@@ -32625,6 +32905,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesById",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -33203,6 +33485,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceSupplierInvoicesById",
+        "summary": "PATCH /v1/admin/finance/supplier-invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -33266,6 +33550,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceSupplierInvoicesById",
+        "summary": "DELETE /v1/admin/finance/supplier-invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -33829,6 +34115,8 @@
             }
           }
         },
+        "operationId": "putAdminFinanceSupplierInvoicesByIdLines",
+        "summary": "PUT /v1/admin/finance/supplier-invoices/{id}/lines",
         "tags": [
           "finance"
         ],
@@ -34398,6 +34686,8 @@
             }
           }
         },
+        "operationId": "putAdminFinanceSupplierInvoicesByIdAllocations",
+        "summary": "PUT /v1/admin/finance/supplier-invoices/{id}/allocations",
         "tags": [
           "finance"
         ],
@@ -34458,6 +34748,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesByIdDocumentDownload",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}/document/download",
         "tags": [
           "finance"
         ],
@@ -34768,6 +35060,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesByIdPayments",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -35084,6 +35378,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierInvoicesByIdPayments",
+        "summary": "POST /v1/admin/finance/supplier-invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -35179,6 +35475,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesByIdAttachments",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -35355,6 +35653,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierInvoicesByIdAttachments",
+        "summary": "POST /v1/admin/finance/supplier-invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -35420,6 +35720,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceSupplierInvoicesByIdAttachmentsByAttachmentId",
+        "summary": "DELETE /v1/admin/finance/supplier-invoices/{id}/attachments/{attachmentId}",
         "tags": [
           "finance"
         ],
@@ -35480,6 +35782,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoiceAttachmentsByIdDownload",
+        "summary": "GET /v1/admin/finance/supplier-invoice-attachments/{id}/download",
         "tags": [
           "finance"
         ],
@@ -35750,6 +36054,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdGenerateDocument",
+        "summary": "POST /v1/admin/finance/invoices/{id}/generate-document",
         "tags": [
           "finance"
         ],
@@ -36020,6 +36326,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdRegenerateDocument",
+        "summary": "POST /v1/admin/finance/invoices/{id}/regenerate-document",
         "tags": [
           "finance"
         ],
@@ -36080,6 +36388,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceRenditionsByIdDownload",
+        "summary": "GET /v1/admin/finance/invoice-renditions/{id}/download",
         "tags": [
           "finance"
         ],
@@ -36259,6 +36569,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdPollSettlement",
+        "summary": "POST /v1/admin/finance/invoices/{id}/poll-settlement",
         "tags": [
           "finance"
         ],

--- a/packages/openapi/spec/admin/identity.json
+++ b/packages/openapi/spec/admin/identity.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -350,6 +356,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -550,6 +557,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -684,6 +692,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -906,6 +915,7 @@
             }
           }
         },
+        "operationId": "patchAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -965,6 +975,7 @@
             }
           }
         },
+        "operationId": "deleteAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -1221,6 +1232,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -1512,6 +1524,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -1697,6 +1710,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityAddressesById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2012,6 +2026,7 @@
             }
           }
         },
+        "operationId": "patchAdminIdentityAddressesById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2071,6 +2086,7 @@
             }
           }
         },
+        "operationId": "deleteAdminIdentityAddressesById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -2286,6 +2302,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2502,6 +2519,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -2644,6 +2662,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2883,6 +2902,7 @@
             }
           }
         },
+        "operationId": "patchAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2942,6 +2962,7 @@
             }
           }
         },
+        "operationId": "deleteAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -3069,6 +3090,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -3275,6 +3297,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -3453,6 +3476,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -3748,6 +3772,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -3883,6 +3908,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -4105,6 +4131,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }

--- a/packages/openapi/spec/admin/legal.json
+++ b/packages/openapi/spec/admin/legal.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -337,6 +343,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplates",
+        "summary": "GET /v1/admin/legal/contracts/templates",
         "tags": [
           "legal"
         ],
@@ -532,6 +540,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplates",
+        "summary": "POST /v1/admin/legal/contracts/templates",
         "tags": [
           "legal"
         ],
@@ -696,6 +706,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplatesDefault",
+        "summary": "GET /v1/admin/legal/contracts/templates/default",
         "tags": [
           "legal"
         ],
@@ -826,6 +838,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplatesById",
+        "summary": "GET /v1/admin/legal/contracts/templates/{id}",
         "tags": [
           "legal"
         ],
@@ -1043,6 +1057,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsTemplatesById",
+        "summary": "PATCH /v1/admin/legal/contracts/templates/{id}",
         "tags": [
           "legal"
         ],
@@ -1101,6 +1117,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsTemplatesById",
+        "summary": "DELETE /v1/admin/legal/contracts/templates/{id}",
         "tags": [
           "legal"
         ],
@@ -1199,6 +1217,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplatesByIdPreview",
+        "summary": "POST /v1/admin/legal/contracts/templates/{id}/preview",
         "tags": [
           "legal"
         ],
@@ -1297,6 +1317,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplatesByIdRenderPreview",
+        "summary": "POST /v1/admin/legal/contracts/templates/{id}/render-preview",
         "tags": [
           "legal"
         ],
@@ -1378,6 +1400,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplatesByIdVersions",
+        "summary": "GET /v1/admin/legal/contracts/templates/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -1530,6 +1554,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplatesByIdVersions",
+        "summary": "POST /v1/admin/legal/contracts/templates/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -1626,6 +1652,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplateVersionsById",
+        "summary": "GET /v1/admin/legal/contracts/template-versions/{id}",
         "tags": [
           "legal"
         ],
@@ -1774,6 +1802,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsNumberSeries",
+        "summary": "GET /v1/admin/legal/contracts/number-series",
         "tags": [
           "legal"
         ],
@@ -1985,6 +2015,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsNumberSeries",
+        "summary": "POST /v1/admin/legal/contracts/number-series",
         "tags": [
           "legal"
         ],
@@ -2127,6 +2159,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsNumberSeriesById",
+        "summary": "GET /v1/admin/legal/contracts/number-series/{id}",
         "tags": [
           "legal"
         ],
@@ -2356,6 +2390,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsNumberSeriesById",
+        "summary": "PATCH /v1/admin/legal/contracts/number-series/{id}",
         "tags": [
           "legal"
         ],
@@ -2414,6 +2450,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsNumberSeriesById",
+        "summary": "DELETE /v1/admin/legal/contracts/number-series/{id}",
         "tags": [
           "legal"
         ],
@@ -2622,6 +2660,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsBookingsByBookingIdGenerateDocument",
+        "summary": "POST /v1/admin/legal/contracts/bookings/{bookingId}/generate-document",
         "tags": [
           "legal"
         ],
@@ -3121,6 +3161,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContracts",
+        "summary": "GET /v1/admin/legal/contracts",
         "tags": [
           "legal"
         ],
@@ -3748,6 +3790,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContracts",
+        "summary": "POST /v1/admin/legal/contracts",
         "tags": [
           "legal"
         ],
@@ -4077,6 +4121,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsById",
+        "summary": "GET /v1/admin/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -4714,6 +4760,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsById",
+        "summary": "PATCH /v1/admin/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -4790,6 +4838,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsById",
+        "summary": "DELETE /v1/admin/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -5137,6 +5187,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdIssue",
+        "summary": "POST /v1/admin/legal/contracts/{id}/issue",
         "tags": [
           "legal"
         ],
@@ -5502,6 +5554,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdSend",
+        "summary": "POST /v1/admin/legal/contracts/{id}/send",
         "tags": [
           "legal"
         ],
@@ -6213,6 +6267,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdSign",
+        "summary": "POST /v1/admin/legal/contracts/{id}/sign",
         "tags": [
           "legal"
         ],
@@ -6560,6 +6616,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdExecute",
+        "summary": "POST /v1/admin/legal/contracts/{id}/execute",
         "tags": [
           "legal"
         ],
@@ -6907,6 +6965,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdVoid",
+        "summary": "POST /v1/admin/legal/contracts/{id}/void",
         "tags": [
           "legal"
         ],
@@ -7005,6 +7065,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdRender",
+        "summary": "POST /v1/admin/legal/contracts/{id}/render",
         "tags": [
           "legal"
         ],
@@ -7117,6 +7179,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdGenerateDocument",
+        "summary": "POST /v1/admin/legal/contracts/{id}/generate-document",
         "tags": [
           "legal"
         ],
@@ -7229,6 +7293,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdRegenerateDocument",
+        "summary": "POST /v1/admin/legal/contracts/{id}/regenerate-document",
         "tags": [
           "legal"
         ],
@@ -7341,6 +7407,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdRegeneratePdf",
+        "summary": "POST /v1/admin/legal/contracts/{id}/regenerate-pdf",
         "tags": [
           "legal"
         ],
@@ -7526,6 +7594,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsByIdSignatures",
+        "summary": "GET /v1/admin/legal/contracts/{id}/signatures",
         "tags": [
           "legal"
         ],
@@ -7673,6 +7743,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsByIdAttachments",
+        "summary": "GET /v1/admin/legal/contracts/{id}/attachments",
         "tags": [
           "legal"
         ],
@@ -8012,6 +8084,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdAttachments",
+        "summary": "POST /v1/admin/legal/contracts/{id}/attachments",
         "tags": [
           "legal"
         ],
@@ -8222,6 +8296,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdAttachmentsUpload",
+        "summary": "POST /v1/admin/legal/contracts/{id}/attachments/upload",
         "tags": [
           "legal"
         ],
@@ -8432,6 +8508,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdAttachDocument",
+        "summary": "POST /v1/admin/legal/contracts/{id}/attach-document",
         "tags": [
           "legal"
         ],
@@ -8770,6 +8848,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsAttachmentsByAttachmentId",
+        "summary": "PATCH /v1/admin/legal/contracts/attachments/{attachmentId}",
         "tags": [
           "legal"
         ],
@@ -8828,6 +8908,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsAttachmentsByAttachmentId",
+        "summary": "DELETE /v1/admin/legal/contracts/attachments/{attachmentId}",
         "tags": [
           "legal"
         ],
@@ -9038,6 +9120,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsAttachmentsByAttachmentIdUpload",
+        "summary": "PATCH /v1/admin/legal/contracts/attachments/{attachmentId}/upload",
         "tags": [
           "legal"
         ],
@@ -9098,6 +9182,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsAttachmentsByAttachmentIdDownload",
+        "summary": "GET /v1/admin/legal/contracts/attachments/{attachmentId}/download",
         "tags": [
           "legal"
         ],
@@ -9206,6 +9292,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesByIdVersions",
+        "summary": "GET /v1/admin/legal/policies/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -9385,6 +9473,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesByIdVersions",
+        "summary": "POST /v1/admin/legal/policies/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -9508,6 +9598,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesVersionsByVersionId",
+        "summary": "GET /v1/admin/legal/policies/versions/{versionId}",
         "tags": [
           "legal"
         ],
@@ -9684,6 +9776,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesVersionsByVersionId",
+        "summary": "PATCH /v1/admin/legal/policies/versions/{versionId}",
         "tags": [
           "legal"
         ],
@@ -9825,6 +9919,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesVersionsByVersionIdPublish",
+        "summary": "POST /v1/admin/legal/policies/versions/{versionId}/publish",
         "tags": [
           "legal"
         ],
@@ -9948,6 +10044,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesVersionsByVersionIdRetire",
+        "summary": "POST /v1/admin/legal/policies/versions/{versionId}/retire",
         "tags": [
           "legal"
         ],
@@ -10089,6 +10187,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesVersionsByVersionIdRules",
+        "summary": "GET /v1/admin/legal/policies/versions/{versionId}/rules",
         "tags": [
           "legal"
         ],
@@ -10356,6 +10456,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesVersionsByVersionIdRules",
+        "summary": "POST /v1/admin/legal/policies/versions/{versionId}/rules",
         "tags": [
           "legal"
         ],
@@ -10621,6 +10723,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesRulesByRuleId",
+        "summary": "PATCH /v1/admin/legal/policies/rules/{ruleId}",
         "tags": [
           "legal"
         ],
@@ -10676,6 +10780,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalPoliciesRulesByRuleId",
+        "summary": "DELETE /v1/admin/legal/policies/rules/{ruleId}",
         "tags": [
           "legal"
         ],
@@ -10896,6 +11002,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesAssignments",
+        "summary": "GET /v1/admin/legal/policies/assignments",
         "tags": [
           "legal"
         ],
@@ -11110,6 +11218,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesAssignments",
+        "summary": "POST /v1/admin/legal/policies/assignments",
         "tags": [
           "legal"
         ],
@@ -11350,6 +11460,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesAssignmentsById",
+        "summary": "PATCH /v1/admin/legal/policies/assignments/{id}",
         "tags": [
           "legal"
         ],
@@ -11405,6 +11517,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalPoliciesAssignmentsById",
+        "summary": "DELETE /v1/admin/legal/policies/assignments/{id}",
         "tags": [
           "legal"
         ],
@@ -11681,6 +11795,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesAcceptances",
+        "summary": "GET /v1/admin/legal/policies/acceptances",
         "tags": [
           "legal"
         ],
@@ -12010,6 +12126,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesAcceptances",
+        "summary": "POST /v1/admin/legal/policies/acceptances",
         "tags": [
           "legal"
         ],
@@ -12444,6 +12562,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesResolve",
+        "summary": "GET /v1/admin/legal/policies/resolve",
         "tags": [
           "legal"
         ],
@@ -12605,6 +12725,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPolicies",
+        "summary": "GET /v1/admin/legal/policies",
         "tags": [
           "legal"
         ],
@@ -12768,6 +12890,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPolicies",
+        "summary": "POST /v1/admin/legal/policies",
         "tags": [
           "legal"
         ],
@@ -12882,6 +13006,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesById",
+        "summary": "GET /v1/admin/legal/policies/{id}",
         "tags": [
           "legal"
         ],
@@ -13067,6 +13193,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesById",
+        "summary": "PATCH /v1/admin/legal/policies/{id}",
         "tags": [
           "legal"
         ],
@@ -13140,6 +13268,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalPoliciesById",
+        "summary": "DELETE /v1/admin/legal/policies/{id}",
         "tags": [
           "legal"
         ],
@@ -13265,6 +13395,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesByIdEvaluate",
+        "summary": "POST /v1/admin/legal/policies/{id}/evaluate",
         "tags": [
           "legal"
         ],
@@ -13582,6 +13714,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalTerms",
+        "summary": "GET /v1/admin/legal/terms",
         "tags": [
           "legal"
         ],
@@ -13985,6 +14119,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalTerms",
+        "summary": "POST /v1/admin/legal/terms",
         "tags": [
           "legal"
         ],
@@ -14185,6 +14321,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalTermsById",
+        "summary": "GET /v1/admin/legal/terms/{id}",
         "tags": [
           "legal"
         ],
@@ -14612,6 +14750,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalTermsById",
+        "summary": "PATCH /v1/admin/legal/terms/{id}",
         "tags": [
           "legal"
         ],
@@ -14667,6 +14807,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalTermsById",
+        "summary": "DELETE /v1/admin/legal/terms/{id}",
         "tags": [
           "legal"
         ],

--- a/packages/openapi/spec/admin/markets.json
+++ b/packages/openapi/spec/admin/markets.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -317,6 +323,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarkets",
+        "summary": "GET /v1/admin/markets/markets",
         "tags": [
           "markets"
         ],
@@ -523,6 +531,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsMarkets",
+        "summary": "POST /v1/admin/markets/markets",
         "tags": [
           "markets"
         ],
@@ -657,6 +667,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarketsById",
+        "summary": "GET /v1/admin/markets/markets/{id}",
         "tags": [
           "markets"
         ],
@@ -885,6 +897,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsMarketsById",
+        "summary": "PATCH /v1/admin/markets/markets/{id}",
         "tags": [
           "markets"
         ],
@@ -943,6 +957,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsMarketsById",
+        "summary": "DELETE /v1/admin/markets/markets/{id}",
         "tags": [
           "markets"
         ],
@@ -1082,6 +1098,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarketLocales",
+        "summary": "GET /v1/admin/markets/market-locales",
         "tags": [
           "markets"
         ],
@@ -1227,6 +1245,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsMarketsByIdLocales",
+        "summary": "POST /v1/admin/markets/markets/{id}/locales",
         "tags": [
           "markets"
         ],
@@ -1369,6 +1389,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsMarketLocalesById",
+        "summary": "PATCH /v1/admin/markets/market-locales/{id}",
         "tags": [
           "markets"
         ],
@@ -1427,6 +1449,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsMarketLocalesById",
+        "summary": "DELETE /v1/admin/markets/market-locales/{id}",
         "tags": [
           "markets"
         ],
@@ -1574,6 +1598,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarketCurrencies",
+        "summary": "GET /v1/admin/markets/market-currencies",
         "tags": [
           "markets"
         ],
@@ -1735,6 +1761,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsMarketsByIdCurrencies",
+        "summary": "POST /v1/admin/markets/markets/{id}/currencies",
         "tags": [
           "markets"
         ],
@@ -1893,6 +1921,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsMarketCurrenciesById",
+        "summary": "PATCH /v1/admin/markets/market-currencies/{id}",
         "tags": [
           "markets"
         ],
@@ -1951,6 +1981,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsMarketCurrenciesById",
+        "summary": "DELETE /v1/admin/markets/market-currencies/{id}",
         "tags": [
           "markets"
         ],
@@ -2109,6 +2141,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsFxRateSets",
+        "summary": "GET /v1/admin/markets/fx-rate-sets",
         "tags": [
           "markets"
         ],
@@ -2280,6 +2314,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsFxRateSets",
+        "summary": "POST /v1/admin/markets/fx-rate-sets",
         "tags": [
           "markets"
         ],
@@ -2398,6 +2434,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsFxRateSetsById",
+        "summary": "GET /v1/admin/markets/fx-rate-sets/{id}",
         "tags": [
           "markets"
         ],
@@ -2593,6 +2631,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsFxRateSetsById",
+        "summary": "PATCH /v1/admin/markets/fx-rate-sets/{id}",
         "tags": [
           "markets"
         ],
@@ -2651,6 +2691,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsFxRateSetsById",
+        "summary": "DELETE /v1/admin/markets/fx-rate-sets/{id}",
         "tags": [
           "markets"
         ],
@@ -2793,6 +2835,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsExchangeRates",
+        "summary": "GET /v1/admin/markets/exchange-rates",
         "tags": [
           "markets"
         ],
@@ -2957,6 +3001,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsFxRateSetsByIdExchangeRates",
+        "summary": "POST /v1/admin/markets/fx-rate-sets/{id}/exchange-rates",
         "tags": [
           "markets"
         ],
@@ -3116,6 +3162,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsExchangeRatesById",
+        "summary": "PATCH /v1/admin/markets/exchange-rates/{id}",
         "tags": [
           "markets"
         ],
@@ -3174,6 +3222,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsExchangeRatesById",
+        "summary": "DELETE /v1/admin/markets/exchange-rates/{id}",
         "tags": [
           "markets"
         ],
@@ -3325,6 +3375,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsPriceCatalogs",
+        "summary": "GET /v1/admin/markets/price-catalogs",
         "tags": [
           "markets"
         ],
@@ -3486,6 +3538,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsPriceCatalogs",
+        "summary": "POST /v1/admin/markets/price-catalogs",
         "tags": [
           "markets"
         ],
@@ -3594,6 +3648,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsPriceCatalogsById",
+        "summary": "GET /v1/admin/markets/price-catalogs/{id}",
         "tags": [
           "markets"
         ],
@@ -3761,6 +3817,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsPriceCatalogsById",
+        "summary": "PATCH /v1/admin/markets/price-catalogs/{id}",
         "tags": [
           "markets"
         ],
@@ -3819,6 +3877,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsPriceCatalogsById",
+        "summary": "DELETE /v1/admin/markets/price-catalogs/{id}",
         "tags": [
           "markets"
         ],
@@ -4031,6 +4091,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsProductRules",
+        "summary": "GET /v1/admin/markets/product-rules",
         "tags": [
           "markets"
         ],
@@ -4271,6 +4333,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsProductRules",
+        "summary": "POST /v1/admin/markets/product-rules",
         "tags": [
           "markets"
         ],
@@ -4419,6 +4483,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsProductRulesById",
+        "summary": "GET /v1/admin/markets/product-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -4665,6 +4731,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsProductRulesById",
+        "summary": "PATCH /v1/admin/markets/product-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -4723,6 +4791,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsProductRulesById",
+        "summary": "DELETE /v1/admin/markets/product-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -4900,6 +4970,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsChannelRules",
+        "summary": "GET /v1/admin/markets/channel-rules",
         "tags": [
           "markets"
         ],
@@ -5087,6 +5159,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsChannelRules",
+        "summary": "POST /v1/admin/markets/channel-rules",
         "tags": [
           "markets"
         ],
@@ -5208,6 +5282,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsChannelRulesById",
+        "summary": "GET /v1/admin/markets/channel-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -5401,6 +5477,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsChannelRulesById",
+        "summary": "PATCH /v1/admin/markets/channel-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -5459,6 +5537,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsChannelRulesById",
+        "summary": "DELETE /v1/admin/markets/channel-rules/{id}",
         "tags": [
           "markets"
         ],

--- a/packages/openapi/spec/admin/notifications.json
+++ b/packages/openapi/spec/admin/notifications.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -340,6 +346,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsTemplates",
+        "summary": "GET /v1/admin/notifications/templates",
         "tags": [
           "notifications"
         ],
@@ -560,6 +568,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsTemplates",
+        "summary": "POST /v1/admin/notifications/templates",
         "tags": [
           "notifications"
         ],
@@ -705,6 +715,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsTemplatesById",
+        "summary": "GET /v1/admin/notifications/templates/{id}",
         "tags": [
           "notifications"
         ],
@@ -948,6 +960,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsTemplatesById",
+        "summary": "PATCH /v1/admin/notifications/templates/{id}",
         "tags": [
           "notifications"
         ],
@@ -988,6 +1002,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsTemplatesById",
+        "summary": "DELETE /v1/admin/notifications/templates/{id}",
         "tags": [
           "notifications"
         ],
@@ -1143,6 +1159,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsPreview",
+        "summary": "POST /v1/admin/notifications/preview",
         "tags": [
           "notifications"
         ],
@@ -1512,6 +1530,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsDeliveries",
+        "summary": "GET /v1/admin/notifications/deliveries",
         "tags": [
           "notifications"
         ],
@@ -1760,6 +1780,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsDeliveriesById",
+        "summary": "GET /v1/admin/notifications/deliveries/{id}",
         "tags": [
           "notifications"
         ],
@@ -2026,6 +2048,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsDeliveriesByIdResend",
+        "summary": "POST /v1/admin/notifications/deliveries/{id}/resend",
         "tags": [
           "notifications"
         ],
@@ -2240,6 +2264,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRules",
+        "summary": "GET /v1/admin/notifications/reminder-rules",
         "tags": [
           "notifications"
         ],
@@ -2482,6 +2508,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRules",
+        "summary": "POST /v1/admin/notifications/reminder-rules",
         "tags": [
           "notifications"
         ],
@@ -2999,6 +3027,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesCompose",
+        "summary": "POST /v1/admin/notifications/reminder-rules/compose",
         "tags": [
           "notifications"
         ],
@@ -3152,6 +3182,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRulesById",
+        "summary": "GET /v1/admin/notifications/reminder-rules/{id}",
         "tags": [
           "notifications"
         ],
@@ -3416,6 +3448,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsReminderRulesById",
+        "summary": "PATCH /v1/admin/notifications/reminder-rules/{id}",
         "tags": [
           "notifications"
         ],
@@ -3456,6 +3490,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsReminderRulesById",
+        "summary": "DELETE /v1/admin/notifications/reminder-rules/{id}",
         "tags": [
           "notifications"
         ],
@@ -3615,6 +3651,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRulesByIdStages",
+        "summary": "GET /v1/admin/notifications/reminder-rules/{id}/stages",
         "tags": [
           "notifications"
         ],
@@ -3915,6 +3953,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesByIdStages",
+        "summary": "POST /v1/admin/notifications/reminder-rules/{id}/stages",
         "tags": [
           "notifications"
         ],
@@ -4116,6 +4156,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesByIdStagesReorder",
+        "summary": "POST /v1/admin/notifications/reminder-rules/{id}/stages/reorder",
         "tags": [
           "notifications"
         ],
@@ -4437,6 +4479,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsReminderRulesByIdStagesByStageId",
+        "summary": "PATCH /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}",
         "tags": [
           "notifications"
         ],
@@ -4485,6 +4529,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsReminderRulesByIdStagesByStageId",
+        "summary": "DELETE /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}",
         "tags": [
           "notifications"
         ],
@@ -4612,6 +4658,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRulesByIdStagesByStageIdChannels",
+        "summary": "GET /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels",
         "tags": [
           "notifications"
         ],
@@ -4826,6 +4874,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesByIdStagesByStageIdChannels",
+        "summary": "POST /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels",
         "tags": [
           "notifications"
         ],
@@ -5065,6 +5115,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsReminderRulesByIdStagesByStageIdChannelsByChannelId",
+        "summary": "PATCH /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels/{channelId}",
         "tags": [
           "notifications"
         ],
@@ -5121,6 +5173,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsReminderRulesByIdStagesByStageIdChannelsByChannelId",
+        "summary": "DELETE /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels/{channelId}",
         "tags": [
           "notifications"
         ],
@@ -5226,6 +5280,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsNotificationSettings",
+        "summary": "GET /v1/admin/notifications/notification-settings",
         "tags": [
           "notifications"
         ],
@@ -5430,6 +5486,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsNotificationSettings",
+        "summary": "PATCH /v1/admin/notifications/notification-settings",
         "tags": [
           "notifications"
         ],
@@ -5555,6 +5613,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsRemindersPreview",
+        "summary": "GET /v1/admin/notifications/reminders/preview",
         "tags": [
           "notifications"
         ],
@@ -6010,6 +6070,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRuns",
+        "summary": "GET /v1/admin/notifications/reminder-runs",
         "tags": [
           "notifications"
         ],
@@ -6342,6 +6404,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRunsById",
+        "summary": "GET /v1/admin/notifications/reminder-runs/{id}",
         "tags": [
           "notifications"
         ],
@@ -6409,6 +6473,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsRemindersRunDue",
+        "summary": "POST /v1/admin/notifications/reminders/run-due",
         "tags": [
           "notifications"
         ],
@@ -6831,6 +6897,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsPaymentSessionsByIdSend",
+        "summary": "POST /v1/admin/notifications/payment-sessions/{id}/send",
         "tags": [
           "notifications"
         ],
@@ -7253,6 +7321,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsInvoicesByIdSend",
+        "summary": "POST /v1/admin/notifications/invoices/{id}/send",
         "tags": [
           "notifications"
         ],
@@ -7443,6 +7513,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsBookingsByIdDocumentBundle",
+        "summary": "GET /v1/admin/notifications/bookings/{id}/document-bundle",
         "tags": [
           "notifications"
         ],
@@ -7906,6 +7978,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsBookingsByIdConfirmAndDispatch",
+        "summary": "POST /v1/admin/notifications/bookings/{id}/confirm-and-dispatch",
         "tags": [
           "notifications"
         ],
@@ -8140,6 +8214,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsBookingsByIdSendDocuments",
+        "summary": "POST /v1/admin/notifications/bookings/{id}/send-documents",
         "tags": [
           "notifications"
         ],
@@ -8577,6 +8653,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsSend",
+        "summary": "POST /v1/admin/notifications/send",
         "tags": [
           "notifications"
         ],

--- a/packages/openapi/spec/admin/operations.json
+++ b/packages/openapi/spec/admin/operations.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -251,6 +257,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityAggregates",
+        "summary": "GET /v1/admin/operations/availability/aggregates",
         "tags": [
           "operations"
         ],
@@ -511,6 +519,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityOverview",
+        "summary": "GET /v1/admin/operations/availability/overview",
         "tags": [
           "operations"
         ],
@@ -703,6 +713,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityRules",
+        "summary": "GET /v1/admin/operations/availability/rules",
         "tags": [
           "operations"
         ],
@@ -903,6 +915,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityRules",
+        "summary": "POST /v1/admin/operations/availability/rules",
         "tags": [
           "operations"
         ],
@@ -1146,6 +1160,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityRulesBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/rules/batch-update",
         "tags": [
           "operations"
         ],
@@ -1246,6 +1262,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityRulesBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/rules/batch-delete",
         "tags": [
           "operations"
         ],
@@ -1381,6 +1399,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityRulesById",
+        "summary": "GET /v1/admin/operations/availability/rules/{id}",
         "tags": [
           "operations"
         ],
@@ -1603,6 +1623,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityRulesById",
+        "summary": "PATCH /v1/admin/operations/availability/rules/{id}",
         "tags": [
           "operations"
         ],
@@ -1661,6 +1683,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityRulesById",
+        "summary": "DELETE /v1/admin/operations/availability/rules/{id}",
         "tags": [
           "operations"
         ],
@@ -1835,6 +1859,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityStartTimes",
+        "summary": "GET /v1/admin/operations/availability/start-times",
         "tags": [
           "operations"
         ],
@@ -1996,6 +2022,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityStartTimes",
+        "summary": "POST /v1/admin/operations/availability/start-times",
         "tags": [
           "operations"
         ],
@@ -2202,6 +2230,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityStartTimesBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/start-times/batch-update",
         "tags": [
           "operations"
         ],
@@ -2302,6 +2332,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityStartTimesBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/start-times/batch-delete",
         "tags": [
           "operations"
         ],
@@ -2419,6 +2451,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityStartTimesById",
+        "summary": "GET /v1/admin/operations/availability/start-times/{id}",
         "tags": [
           "operations"
         ],
@@ -2604,6 +2638,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityStartTimesById",
+        "summary": "PATCH /v1/admin/operations/availability/start-times/{id}",
         "tags": [
           "operations"
         ],
@@ -2662,6 +2698,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityStartTimesById",
+        "summary": "DELETE /v1/admin/operations/availability/start-times/{id}",
         "tags": [
           "operations"
         ],
@@ -2977,6 +3015,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlots",
+        "summary": "GET /v1/admin/operations/availability/slots",
         "tags": [
           "operations"
         ],
@@ -3328,6 +3368,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlots",
+        "summary": "POST /v1/admin/operations/availability/slots",
         "tags": [
           "operations"
         ],
@@ -3722,6 +3764,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/slots/batch-update",
         "tags": [
           "operations"
         ],
@@ -3822,6 +3866,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/slots/batch-delete",
         "tags": [
           "operations"
         ],
@@ -4038,6 +4084,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsById",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}",
         "tags": [
           "operations"
         ],
@@ -4411,6 +4459,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsById",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}",
         "tags": [
           "operations"
         ],
@@ -4469,6 +4519,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsById",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}",
         "tags": [
           "operations"
         ],
@@ -4566,6 +4618,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdUnitAvailability",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/unit-availability",
         "tags": [
           "operations"
         ],
@@ -4709,6 +4763,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCloseouts",
+        "summary": "GET /v1/admin/operations/availability/closeouts",
         "tags": [
           "operations"
         ],
@@ -4836,6 +4892,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCloseouts",
+        "summary": "POST /v1/admin/operations/availability/closeouts",
         "tags": [
           "operations"
         ],
@@ -5008,6 +5066,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCloseoutsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/closeouts/batch-update",
         "tags": [
           "operations"
         ],
@@ -5108,6 +5168,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCloseoutsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/closeouts/batch-delete",
         "tags": [
           "operations"
         ],
@@ -5206,6 +5268,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCloseoutsById",
+        "summary": "GET /v1/admin/operations/availability/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -5357,6 +5421,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityCloseoutsById",
+        "summary": "PATCH /v1/admin/operations/availability/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -5415,6 +5481,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityCloseoutsById",
+        "summary": "DELETE /v1/admin/operations/availability/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -5839,6 +5907,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocation",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation",
         "tags": [
           "operations"
         ],
@@ -6037,6 +6107,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationResources",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/resources",
         "tags": [
           "operations"
         ],
@@ -6275,6 +6347,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationResourcesByResourceId",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}",
         "tags": [
           "operations"
         ],
@@ -6361,6 +6435,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsByIdAllocationResourcesByResourceId",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}",
         "tags": [
           "operations"
         ],
@@ -6530,6 +6606,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationTravelersByTravelerId",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}",
         "tags": [
           "operations"
         ],
@@ -6690,6 +6768,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationTravelersByTravelerIdSharingGroup",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}/sharing-group",
         "tags": [
           "operations"
         ],
@@ -6848,6 +6928,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationSharingGroupsPair",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/pair",
         "tags": [
           "operations"
         ],
@@ -7011,6 +7093,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsAvailabilitySlotsByIdAllocationSharingGroupsByGroupIdLabel",
+        "summary": "PUT /v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/{groupId}/label",
         "tags": [
           "operations"
         ],
@@ -7152,6 +7236,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsByIdAllocationSharingGroupsByGroupIdLabel",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/{groupId}/label",
         "tags": [
           "operations"
         ],
@@ -7262,6 +7348,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocationAuditLog",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation/audit-log",
         "tags": [
           "operations"
         ],
@@ -7311,6 +7399,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocationExportPassengers",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation/export-passengers",
         "tags": [
           "operations"
         ],
@@ -7360,6 +7450,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocationExportRoomingList",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation/export-rooming-list",
         "tags": [
           "operations"
         ],
@@ -7581,6 +7673,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationAutoMaterialize",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/auto-materialize",
         "tags": [
           "operations"
         ],
@@ -7704,6 +7798,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationMaterializeTemplates",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/materialize-templates",
         "tags": [
           "operations"
         ],
@@ -7925,6 +8021,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationAutoAllocate",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/auto-allocate",
         "tags": [
           "operations"
         ],
@@ -8077,6 +8175,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityProductsByProductIdAllocationResourceTemplates",
+        "summary": "GET /v1/admin/operations/availability/products/{productId}/allocation/resource-templates",
         "tags": [
           "operations"
         ],
@@ -8331,6 +8431,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsAvailabilityProductsByProductIdOptionsByOptionIdAllocationResourceTemplatesByKind",
+        "summary": "PUT /v1/admin/operations/availability/products/{productId}/options/{optionId}/allocation/resource-templates/{kind}",
         "tags": [
           "operations"
         ],
@@ -8480,6 +8582,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityProductsByProductIdOptionsByOptionIdAllocationResourceTemplatesByKind",
+        "summary": "DELETE /v1/admin/operations/availability/products/{productId}/options/{optionId}/allocation/resource-templates/{kind}",
         "tags": [
           "operations"
         ],
@@ -8622,6 +8726,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityProductsByIdAllocationMaterializeOpenSlots",
+        "summary": "POST /v1/admin/operations/availability/products/{id}/allocation/materialize-open-slots",
         "tags": [
           "operations"
         ],
@@ -8777,6 +8883,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupPoints",
+        "summary": "GET /v1/admin/operations/availability/pickup-points",
         "tags": [
           "operations"
         ],
@@ -8916,6 +9024,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupPoints",
+        "summary": "POST /v1/admin/operations/availability/pickup-points",
         "tags": [
           "operations"
         ],
@@ -9100,6 +9210,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupPointsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/pickup-points/batch-update",
         "tags": [
           "operations"
         ],
@@ -9200,6 +9312,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupPointsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/pickup-points/batch-delete",
         "tags": [
           "operations"
         ],
@@ -9306,6 +9420,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupPointsById",
+        "summary": "GET /v1/admin/operations/availability/pickup-points/{id}",
         "tags": [
           "operations"
         ],
@@ -9469,6 +9585,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityPickupPointsById",
+        "summary": "PATCH /v1/admin/operations/availability/pickup-points/{id}",
         "tags": [
           "operations"
         ],
@@ -9527,6 +9645,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityPickupPointsById",
+        "summary": "DELETE /v1/admin/operations/availability/pickup-points/{id}",
         "tags": [
           "operations"
         ],
@@ -9651,6 +9771,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotPickups",
+        "summary": "GET /v1/admin/operations/availability/slot-pickups",
         "tags": [
           "operations"
         ],
@@ -9770,6 +9892,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotPickups",
+        "summary": "POST /v1/admin/operations/availability/slot-pickups",
         "tags": [
           "operations"
         ],
@@ -9934,6 +10058,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotPickupsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/slot-pickups/batch-update",
         "tags": [
           "operations"
         ],
@@ -10034,6 +10160,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotPickupsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/slot-pickups/batch-delete",
         "tags": [
           "operations"
         ],
@@ -10129,6 +10257,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotPickupsById",
+        "summary": "GET /v1/admin/operations/availability/slot-pickups/{id}",
         "tags": [
           "operations"
         ],
@@ -10272,6 +10402,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotPickupsById",
+        "summary": "PATCH /v1/admin/operations/availability/slot-pickups/{id}",
         "tags": [
           "operations"
         ],
@@ -10330,6 +10462,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotPickupsById",
+        "summary": "DELETE /v1/admin/operations/availability/slot-pickups/{id}",
         "tags": [
           "operations"
         ],
@@ -10545,6 +10679,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityMeetingConfigs",
+        "summary": "GET /v1/admin/operations/availability/meeting-configs",
         "tags": [
           "operations"
         ],
@@ -10759,6 +10895,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityMeetingConfigs",
+        "summary": "POST /v1/admin/operations/availability/meeting-configs",
         "tags": [
           "operations"
         ],
@@ -11019,6 +11157,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityMeetingConfigsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/meeting-configs/batch-update",
         "tags": [
           "operations"
         ],
@@ -11119,6 +11259,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityMeetingConfigsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/meeting-configs/batch-delete",
         "tags": [
           "operations"
         ],
@@ -11264,6 +11406,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityMeetingConfigsById",
+        "summary": "GET /v1/admin/operations/availability/meeting-configs/{id}",
         "tags": [
           "operations"
         ],
@@ -11503,6 +11647,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityMeetingConfigsById",
+        "summary": "PATCH /v1/admin/operations/availability/meeting-configs/{id}",
         "tags": [
           "operations"
         ],
@@ -11561,6 +11707,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityMeetingConfigsById",
+        "summary": "DELETE /v1/admin/operations/availability/meeting-configs/{id}",
         "tags": [
           "operations"
         ],
@@ -11714,6 +11862,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupGroups",
+        "summary": "GET /v1/admin/operations/availability/pickup-groups",
         "tags": [
           "operations"
         ],
@@ -11853,6 +12003,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupGroups",
+        "summary": "POST /v1/admin/operations/availability/pickup-groups",
         "tags": [
           "operations"
         ],
@@ -12036,6 +12188,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupGroupsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/pickup-groups/batch-update",
         "tags": [
           "operations"
         ],
@@ -12136,6 +12290,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupGroupsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/pickup-groups/batch-delete",
         "tags": [
           "operations"
         ],
@@ -12241,6 +12397,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupGroupsById",
+        "summary": "GET /v1/admin/operations/availability/pickup-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -12403,6 +12561,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityPickupGroupsById",
+        "summary": "PATCH /v1/admin/operations/availability/pickup-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -12461,6 +12621,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityPickupGroupsById",
+        "summary": "DELETE /v1/admin/operations/availability/pickup-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -12621,6 +12783,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupLocations",
+        "summary": "GET /v1/admin/operations/availability/pickup-locations",
         "tags": [
           "operations"
         ],
@@ -12782,6 +12946,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupLocations",
+        "summary": "POST /v1/admin/operations/availability/pickup-locations",
         "tags": [
           "operations"
         ],
@@ -12988,6 +13154,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupLocationsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/pickup-locations/batch-update",
         "tags": [
           "operations"
         ],
@@ -13088,6 +13256,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupLocationsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/pickup-locations/batch-delete",
         "tags": [
           "operations"
         ],
@@ -13205,6 +13375,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupLocationsById",
+        "summary": "GET /v1/admin/operations/availability/pickup-locations/{id}",
         "tags": [
           "operations"
         ],
@@ -13390,6 +13562,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityPickupLocationsById",
+        "summary": "PATCH /v1/admin/operations/availability/pickup-locations/{id}",
         "tags": [
           "operations"
         ],
@@ -13448,6 +13622,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityPickupLocationsById",
+        "summary": "DELETE /v1/admin/operations/availability/pickup-locations/{id}",
         "tags": [
           "operations"
         ],
@@ -13637,6 +13813,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityLocationPickupTimes",
+        "summary": "GET /v1/admin/operations/availability/location-pickup-times",
         "tags": [
           "operations"
         ],
@@ -13837,6 +14015,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityLocationPickupTimes",
+        "summary": "POST /v1/admin/operations/availability/location-pickup-times",
         "tags": [
           "operations"
         ],
@@ -14083,6 +14263,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityLocationPickupTimesBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/location-pickup-times/batch-update",
         "tags": [
           "operations"
         ],
@@ -14183,6 +14365,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityLocationPickupTimesBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/location-pickup-times/batch-delete",
         "tags": [
           "operations"
         ],
@@ -14321,6 +14505,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityLocationPickupTimesById",
+        "summary": "GET /v1/admin/operations/availability/location-pickup-times/{id}",
         "tags": [
           "operations"
         ],
@@ -14546,6 +14732,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityLocationPickupTimesById",
+        "summary": "PATCH /v1/admin/operations/availability/location-pickup-times/{id}",
         "tags": [
           "operations"
         ],
@@ -14604,6 +14792,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityLocationPickupTimesById",
+        "summary": "DELETE /v1/admin/operations/availability/location-pickup-times/{id}",
         "tags": [
           "operations"
         ],
@@ -14738,6 +14928,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCustomPickupAreas",
+        "summary": "GET /v1/admin/operations/availability/custom-pickup-areas",
         "tags": [
           "operations"
         ],
@@ -14864,6 +15056,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCustomPickupAreas",
+        "summary": "POST /v1/admin/operations/availability/custom-pickup-areas",
         "tags": [
           "operations"
         ],
@@ -15035,6 +15229,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCustomPickupAreasBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/custom-pickup-areas/batch-update",
         "tags": [
           "operations"
         ],
@@ -15135,6 +15331,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCustomPickupAreasBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/custom-pickup-areas/batch-delete",
         "tags": [
           "operations"
         ],
@@ -15234,6 +15432,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCustomPickupAreasById",
+        "summary": "GET /v1/admin/operations/availability/custom-pickup-areas/{id}",
         "tags": [
           "operations"
         ],
@@ -15384,6 +15584,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityCustomPickupAreasById",
+        "summary": "PATCH /v1/admin/operations/availability/custom-pickup-areas/{id}",
         "tags": [
           "operations"
         ],
@@ -15442,6 +15644,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityCustomPickupAreasById",
+        "summary": "DELETE /v1/admin/operations/availability/custom-pickup-areas/{id}",
         "tags": [
           "operations"
         ],
@@ -15629,6 +15833,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsResources",
+        "summary": "GET /v1/admin/operations/resources",
         "tags": [
           "operations"
         ],
@@ -15811,6 +16017,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsResources",
+        "summary": "POST /v1/admin/operations/resources",
         "tags": [
           "operations"
         ],
@@ -15879,8 +16087,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -16038,6 +16245,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsResourcesBatchUpdate",
+        "summary": "POST /v1/admin/operations/resources/batch-update",
         "tags": [
           "operations"
         ],
@@ -16138,6 +16347,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsResourcesBatchDelete",
+        "summary": "POST /v1/admin/operations/resources/batch-delete",
         "tags": [
           "operations"
         ],
@@ -16266,6 +16477,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsResourcesById",
+        "summary": "GET /v1/admin/operations/resources/{id}",
         "tags": [
           "operations"
         ],
@@ -16331,8 +16544,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -16472,6 +16684,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsResourcesById",
+        "summary": "PATCH /v1/admin/operations/resources/{id}",
         "tags": [
           "operations"
         ],
@@ -16530,6 +16744,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsResourcesById",
+        "summary": "DELETE /v1/admin/operations/resources/{id}",
         "tags": [
           "operations"
         ],
@@ -16695,6 +16911,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPools",
+        "summary": "GET /v1/admin/operations/pools",
         "tags": [
           "operations"
         ],
@@ -16851,6 +17069,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPools",
+        "summary": "POST /v1/admin/operations/pools",
         "tags": [
           "operations"
         ],
@@ -16907,8 +17127,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -17052,6 +17271,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPoolsBatchUpdate",
+        "summary": "POST /v1/admin/operations/pools/batch-update",
         "tags": [
           "operations"
         ],
@@ -17152,6 +17373,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPoolsBatchDelete",
+        "summary": "POST /v1/admin/operations/pools/batch-delete",
         "tags": [
           "operations"
         ],
@@ -17266,6 +17489,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPoolsById",
+        "summary": "GET /v1/admin/operations/pools/{id}",
         "tags": [
           "operations"
         ],
@@ -17319,8 +17544,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -17446,6 +17670,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPoolsById",
+        "summary": "PATCH /v1/admin/operations/pools/{id}",
         "tags": [
           "operations"
         ],
@@ -17504,6 +17730,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPoolsById",
+        "summary": "DELETE /v1/admin/operations/pools/{id}",
         "tags": [
           "operations"
         ],
@@ -17610,6 +17838,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPoolMembers",
+        "summary": "GET /v1/admin/operations/pool-members",
         "tags": [
           "operations"
         ],
@@ -17733,6 +17963,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPoolMembers",
+        "summary": "POST /v1/admin/operations/pool-members",
         "tags": [
           "operations"
         ],
@@ -17793,6 +18025,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPoolMembersById",
+        "summary": "DELETE /v1/admin/operations/pool-members/{id}",
         "tags": [
           "operations"
         ],
@@ -17949,6 +18183,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsRequirements",
+        "summary": "GET /v1/admin/operations/requirements",
         "tags": [
           "operations"
         ],
@@ -18117,6 +18353,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsRequirements",
+        "summary": "POST /v1/admin/operations/requirements",
         "tags": [
           "operations"
         ],
@@ -18164,20 +18402,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -18312,6 +18547,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsRequirementsBatchUpdate",
+        "summary": "POST /v1/admin/operations/requirements/batch-update",
         "tags": [
           "operations"
         ],
@@ -18412,6 +18649,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsRequirementsBatchDelete",
+        "summary": "POST /v1/admin/operations/requirements/batch-delete",
         "tags": [
           "operations"
         ],
@@ -18523,6 +18762,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsRequirementsById",
+        "summary": "GET /v1/admin/operations/requirements/{id}",
         "tags": [
           "operations"
         ],
@@ -18567,20 +18808,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -18697,6 +18935,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsRequirementsById",
+        "summary": "PATCH /v1/admin/operations/requirements/{id}",
         "tags": [
           "operations"
         ],
@@ -18755,6 +18995,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsRequirementsById",
+        "summary": "DELETE /v1/admin/operations/requirements/{id}",
         "tags": [
           "operations"
         ],
@@ -18911,6 +19153,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAllocations",
+        "summary": "GET /v1/admin/operations/allocations",
         "tags": [
           "operations"
         ],
@@ -19079,6 +19323,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAllocations",
+        "summary": "POST /v1/admin/operations/allocations",
         "tags": [
           "operations"
         ],
@@ -19126,20 +19372,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -19274,6 +19517,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAllocationsBatchUpdate",
+        "summary": "POST /v1/admin/operations/allocations/batch-update",
         "tags": [
           "operations"
         ],
@@ -19374,6 +19619,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAllocationsBatchDelete",
+        "summary": "POST /v1/admin/operations/allocations/batch-delete",
         "tags": [
           "operations"
         ],
@@ -19485,6 +19732,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAllocationsById",
+        "summary": "GET /v1/admin/operations/allocations/{id}",
         "tags": [
           "operations"
         ],
@@ -19529,20 +19778,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -19659,6 +19905,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAllocationsById",
+        "summary": "PATCH /v1/admin/operations/allocations/{id}",
         "tags": [
           "operations"
         ],
@@ -19717,6 +19965,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAllocationsById",
+        "summary": "DELETE /v1/admin/operations/allocations/{id}",
         "tags": [
           "operations"
         ],
@@ -19903,6 +20153,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsSlotAssignments",
+        "summary": "GET /v1/admin/operations/slot-assignments",
         "tags": [
           "operations"
         ],
@@ -20105,6 +20357,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSlotAssignments",
+        "summary": "POST /v1/admin/operations/slot-assignments",
         "tags": [
           "operations"
         ],
@@ -20161,8 +20415,7 @@
                           "released",
                           "cancelled",
                           "completed"
-                        ],
-                        "default": "reserved"
+                        ]
                       },
                       "assignedAt": {
                         "type": "string",
@@ -20335,6 +20588,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSlotAssignmentsBatchUpdate",
+        "summary": "POST /v1/admin/operations/slot-assignments/batch-update",
         "tags": [
           "operations"
         ],
@@ -20435,6 +20690,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSlotAssignmentsBatchDelete",
+        "summary": "POST /v1/admin/operations/slot-assignments/batch-delete",
         "tags": [
           "operations"
         ],
@@ -20561,6 +20818,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsSlotAssignmentsById",
+        "summary": "GET /v1/admin/operations/slot-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -20614,8 +20873,7 @@
                       "released",
                       "cancelled",
                       "completed"
-                    ],
-                    "default": "reserved"
+                    ]
                   },
                   "assignedAt": {
                     "type": "string",
@@ -20770,6 +21028,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsSlotAssignmentsById",
+        "summary": "PATCH /v1/admin/operations/slot-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -20828,6 +21088,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsSlotAssignmentsById",
+        "summary": "DELETE /v1/admin/operations/slot-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -20963,6 +21225,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsCloseouts",
+        "summary": "GET /v1/admin/operations/closeouts",
         "tags": [
           "operations"
         ],
@@ -21141,6 +21405,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsCloseouts",
+        "summary": "POST /v1/admin/operations/closeouts",
         "tags": [
           "operations"
         ],
@@ -21328,6 +21594,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsCloseoutsBatchUpdate",
+        "summary": "POST /v1/admin/operations/closeouts/batch-update",
         "tags": [
           "operations"
         ],
@@ -21428,6 +21696,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsCloseoutsBatchDelete",
+        "summary": "POST /v1/admin/operations/closeouts/batch-delete",
         "tags": [
           "operations"
         ],
@@ -21533,6 +21803,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsCloseoutsById",
+        "summary": "GET /v1/admin/operations/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -21717,6 +21989,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsCloseoutsById",
+        "summary": "PATCH /v1/admin/operations/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -21775,6 +22049,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsCloseoutsById",
+        "summary": "DELETE /v1/admin/operations/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -21927,6 +22203,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsOperators",
+        "summary": "GET /v1/admin/operations/operators",
         "tags": [
           "operations"
         ],
@@ -22073,6 +22351,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsOperators",
+        "summary": "POST /v1/admin/operations/operators",
         "tags": [
           "operations"
         ],
@@ -22182,6 +22462,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsOperatorsById",
+        "summary": "GET /v1/admin/operations/operators/{id}",
         "tags": [
           "operations"
         ],
@@ -22353,6 +22635,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsOperatorsById",
+        "summary": "PATCH /v1/admin/operations/operators/{id}",
         "tags": [
           "operations"
         ],
@@ -22411,6 +22695,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsOperatorsById",
+        "summary": "DELETE /v1/admin/operations/operators/{id}",
         "tags": [
           "operations"
         ],
@@ -22634,6 +22920,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsVehicles",
+        "summary": "GET /v1/admin/operations/vehicles",
         "tags": [
           "operations"
         ],
@@ -22883,6 +23171,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsVehicles",
+        "summary": "POST /v1/admin/operations/vehicles",
         "tags": [
           "operations"
         ],
@@ -23044,6 +23334,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsVehiclesById",
+        "summary": "GET /v1/admin/operations/vehicles/{id}",
         "tags": [
           "operations"
         ],
@@ -23318,6 +23610,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsVehiclesById",
+        "summary": "PATCH /v1/admin/operations/vehicles/{id}",
         "tags": [
           "operations"
         ],
@@ -23376,6 +23670,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsVehiclesById",
+        "summary": "DELETE /v1/admin/operations/vehicles/{id}",
         "tags": [
           "operations"
         ],
@@ -23536,6 +23832,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDrivers",
+        "summary": "GET /v1/admin/operations/drivers",
         "tags": [
           "operations"
         ],
@@ -23699,6 +23997,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDrivers",
+        "summary": "POST /v1/admin/operations/drivers",
         "tags": [
           "operations"
         ],
@@ -23816,6 +24116,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDriversById",
+        "summary": "GET /v1/admin/operations/drivers/{id}",
         "tags": [
           "operations"
         ],
@@ -24004,6 +24306,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDriversById",
+        "summary": "PATCH /v1/admin/operations/drivers/{id}",
         "tags": [
           "operations"
         ],
@@ -24062,6 +24366,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDriversById",
+        "summary": "DELETE /v1/admin/operations/drivers/{id}",
         "tags": [
           "operations"
         ],
@@ -24338,6 +24644,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsTransferPreferences",
+        "summary": "GET /v1/admin/operations/transfer-preferences",
         "tags": [
           "operations"
         ],
@@ -24720,6 +25028,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsTransferPreferences",
+        "summary": "POST /v1/admin/operations/transfer-preferences",
         "tags": [
           "operations"
         ],
@@ -24952,6 +25262,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsTransferPreferencesById",
+        "summary": "GET /v1/admin/operations/transfer-preferences/{id}",
         "tags": [
           "operations"
         ],
@@ -25359,6 +25671,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsTransferPreferencesById",
+        "summary": "PATCH /v1/admin/operations/transfer-preferences/{id}",
         "tags": [
           "operations"
         ],
@@ -25417,6 +25731,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsTransferPreferencesById",
+        "summary": "DELETE /v1/admin/operations/transfer-preferences/{id}",
         "tags": [
           "operations"
         ],
@@ -25693,6 +26009,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatches",
+        "summary": "GET /v1/admin/operations/dispatches",
         "tags": [
           "operations"
         ],
@@ -25991,6 +26309,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatches",
+        "summary": "POST /v1/admin/operations/dispatches",
         "tags": [
           "operations"
         ],
@@ -26178,6 +26498,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchesById",
+        "summary": "GET /v1/admin/operations/dispatches/{id}",
         "tags": [
           "operations"
         ],
@@ -26500,6 +26822,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchesById",
+        "summary": "PATCH /v1/admin/operations/dispatches/{id}",
         "tags": [
           "operations"
         ],
@@ -26558,6 +26882,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchesById",
+        "summary": "DELETE /v1/admin/operations/dispatches/{id}",
         "tags": [
           "operations"
         ],
@@ -26719,6 +27045,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsExecutionEvents",
+        "summary": "GET /v1/admin/operations/execution-events",
         "tags": [
           "operations"
         ],
@@ -26893,6 +27221,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsExecutionEvents",
+        "summary": "POST /v1/admin/operations/execution-events",
         "tags": [
           "operations"
         ],
@@ -27014,6 +27344,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsExecutionEventsById",
+        "summary": "GET /v1/admin/operations/execution-events/{id}",
         "tags": [
           "operations"
         ],
@@ -27213,6 +27545,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsExecutionEventsById",
+        "summary": "PATCH /v1/admin/operations/execution-events/{id}",
         "tags": [
           "operations"
         ],
@@ -27271,6 +27605,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsExecutionEventsById",
+        "summary": "DELETE /v1/admin/operations/execution-events/{id}",
         "tags": [
           "operations"
         ],
@@ -27462,6 +27798,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchAssignments",
+        "summary": "GET /v1/admin/operations/dispatch-assignments",
         "tags": [
           "operations"
         ],
@@ -27655,6 +27993,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchAssignments",
+        "summary": "POST /v1/admin/operations/dispatch-assignments",
         "tags": [
           "operations"
         ],
@@ -27788,6 +28128,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchAssignmentsById",
+        "summary": "GET /v1/admin/operations/dispatch-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -28006,6 +28348,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchAssignmentsById",
+        "summary": "PATCH /v1/admin/operations/dispatch-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -28064,6 +28408,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchAssignmentsById",
+        "summary": "DELETE /v1/admin/operations/dispatch-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -28233,6 +28579,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchLegs",
+        "summary": "GET /v1/admin/operations/dispatch-legs",
         "tags": [
           "operations"
         ],
@@ -28427,6 +28775,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchLegs",
+        "summary": "POST /v1/admin/operations/dispatch-legs",
         "tags": [
           "operations"
         ],
@@ -28561,6 +28911,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchLegsById",
+        "summary": "GET /v1/admin/operations/dispatch-legs/{id}",
         "tags": [
           "operations"
         ],
@@ -28780,6 +29132,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchLegsById",
+        "summary": "PATCH /v1/admin/operations/dispatch-legs/{id}",
         "tags": [
           "operations"
         ],
@@ -28838,6 +29192,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchLegsById",
+        "summary": "DELETE /v1/admin/operations/dispatch-legs/{id}",
         "tags": [
           "operations"
         ],
@@ -28972,6 +29328,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchPassengers",
+        "summary": "GET /v1/admin/operations/dispatch-passengers",
         "tags": [
           "operations"
         ],
@@ -29107,6 +29465,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchPassengers",
+        "summary": "POST /v1/admin/operations/dispatch-passengers",
         "tags": [
           "operations"
         ],
@@ -29212,6 +29572,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchPassengersById",
+        "summary": "GET /v1/admin/operations/dispatch-passengers/{id}",
         "tags": [
           "operations"
         ],
@@ -29372,6 +29734,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchPassengersById",
+        "summary": "PATCH /v1/admin/operations/dispatch-passengers/{id}",
         "tags": [
           "operations"
         ],
@@ -29430,6 +29794,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchPassengersById",
+        "summary": "DELETE /v1/admin/operations/dispatch-passengers/{id}",
         "tags": [
           "operations"
         ],
@@ -29607,6 +29973,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDriverShifts",
+        "summary": "GET /v1/admin/operations/driver-shifts",
         "tags": [
           "operations"
         ],
@@ -29784,6 +30152,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDriverShifts",
+        "summary": "POST /v1/admin/operations/driver-shifts",
         "tags": [
           "operations"
         ],
@@ -29909,6 +30279,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDriverShiftsById",
+        "summary": "GET /v1/admin/operations/driver-shifts/{id}",
         "tags": [
           "operations"
         ],
@@ -30109,6 +30481,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDriverShiftsById",
+        "summary": "PATCH /v1/admin/operations/driver-shifts/{id}",
         "tags": [
           "operations"
         ],
@@ -30167,6 +30541,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDriverShiftsById",
+        "summary": "DELETE /v1/admin/operations/driver-shifts/{id}",
         "tags": [
           "operations"
         ],
@@ -30341,6 +30717,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsServiceIncidents",
+        "summary": "GET /v1/admin/operations/service-incidents",
         "tags": [
           "operations"
         ],
@@ -30524,6 +30902,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsServiceIncidents",
+        "summary": "POST /v1/admin/operations/service-incidents",
         "tags": [
           "operations"
         ],
@@ -30650,6 +31030,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsServiceIncidentsById",
+        "summary": "GET /v1/admin/operations/service-incidents/{id}",
         "tags": [
           "operations"
         ],
@@ -30857,6 +31239,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsServiceIncidentsById",
+        "summary": "PATCH /v1/admin/operations/service-incidents/{id}",
         "tags": [
           "operations"
         ],
@@ -30915,6 +31299,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsServiceIncidentsById",
+        "summary": "DELETE /v1/admin/operations/service-incidents/{id}",
         "tags": [
           "operations"
         ],
@@ -31088,6 +31474,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchCheckpoints",
+        "summary": "GET /v1/admin/operations/dispatch-checkpoints",
         "tags": [
           "operations"
         ],
@@ -31291,6 +31679,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchCheckpoints",
+        "summary": "POST /v1/admin/operations/dispatch-checkpoints",
         "tags": [
           "operations"
         ],
@@ -31429,6 +31819,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchCheckpointsById",
+        "summary": "GET /v1/admin/operations/dispatch-checkpoints/{id}",
         "tags": [
           "operations"
         ],
@@ -31656,6 +32048,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchCheckpointsById",
+        "summary": "PATCH /v1/admin/operations/dispatch-checkpoints/{id}",
         "tags": [
           "operations"
         ],
@@ -31714,6 +32108,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchCheckpointsById",
+        "summary": "DELETE /v1/admin/operations/dispatch-checkpoints/{id}",
         "tags": [
           "operations"
         ],
@@ -32037,6 +32433,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilities",
+        "summary": "GET /v1/admin/operations/facilities",
         "tags": [
           "operations"
         ],
@@ -32401,6 +32799,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilities",
+        "summary": "POST /v1/admin/operations/facilities",
         "tags": [
           "operations"
         ],
@@ -32627,6 +33027,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilitiesById",
+        "summary": "GET /v1/admin/operations/facilities/{id}",
         "tags": [
           "operations"
         ],
@@ -33015,6 +33417,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilitiesById",
+        "summary": "PATCH /v1/admin/operations/facilities/{id}",
         "tags": [
           "operations"
         ],
@@ -33073,6 +33477,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilitiesById",
+        "summary": "DELETE /v1/admin/operations/facilities/{id}",
         "tags": [
           "operations"
         ],
@@ -33191,6 +33597,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilitiesByIdContactPoints",
+        "summary": "GET /v1/admin/operations/facilities/{id}/contact-points",
         "tags": [
           "operations"
         ],
@@ -33406,6 +33814,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdContactPoints",
+        "summary": "POST /v1/admin/operations/facilities/{id}/contact-points",
         "tags": [
           "operations"
         ],
@@ -33629,6 +34039,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsContactPointsById",
+        "summary": "PATCH /v1/admin/operations/contact-points/{id}",
         "tags": [
           "operations"
         ],
@@ -33687,6 +34099,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsContactPointsById",
+        "summary": "DELETE /v1/admin/operations/contact-points/{id}",
         "tags": [
           "operations"
         ],
@@ -33856,6 +34270,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilitiesByIdAddresses",
+        "summary": "GET /v1/admin/operations/facilities/{id}/addresses",
         "tags": [
           "operations"
         ],
@@ -34160,6 +34576,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdAddresses",
+        "summary": "POST /v1/admin/operations/facilities/{id}/addresses",
         "tags": [
           "operations"
         ],
@@ -34476,6 +34894,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAddressesById",
+        "summary": "PATCH /v1/admin/operations/addresses/{id}",
         "tags": [
           "operations"
         ],
@@ -34534,6 +34954,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAddressesById",
+        "summary": "DELETE /v1/admin/operations/addresses/{id}",
         "tags": [
           "operations"
         ],
@@ -34713,6 +35135,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilityContacts",
+        "summary": "GET /v1/admin/operations/facility-contacts",
         "tags": [
           "operations"
         ],
@@ -34929,6 +35353,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdContacts",
+        "summary": "POST /v1/admin/operations/facilities/{id}/contacts",
         "tags": [
           "operations"
         ],
@@ -35142,6 +35568,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilityContactsById",
+        "summary": "PATCH /v1/admin/operations/facility-contacts/{id}",
         "tags": [
           "operations"
         ],
@@ -35200,6 +35628,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilityContactsById",
+        "summary": "DELETE /v1/admin/operations/facility-contacts/{id}",
         "tags": [
           "operations"
         ],
@@ -35359,6 +35789,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilityFeatures",
+        "summary": "GET /v1/admin/operations/facility-features",
         "tags": [
           "operations"
         ],
@@ -35558,6 +35990,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdFeatures",
+        "summary": "POST /v1/admin/operations/facilities/{id}/features",
         "tags": [
           "operations"
         ],
@@ -35754,6 +36188,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilityFeaturesById",
+        "summary": "PATCH /v1/admin/operations/facility-features/{id}",
         "tags": [
           "operations"
         ],
@@ -35812,6 +36248,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilityFeaturesById",
+        "summary": "DELETE /v1/admin/operations/facility-features/{id}",
         "tags": [
           "operations"
         ],
@@ -35983,6 +36421,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilityOperationSchedules",
+        "summary": "GET /v1/admin/operations/facility-operation-schedules",
         "tags": [
           "operations"
         ],
@@ -36198,6 +36638,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdOperationSchedules",
+        "summary": "POST /v1/admin/operations/facilities/{id}/operation-schedules",
         "tags": [
           "operations"
         ],
@@ -36413,6 +36855,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilityOperationSchedulesById",
+        "summary": "PATCH /v1/admin/operations/facility-operation-schedules/{id}",
         "tags": [
           "operations"
         ],
@@ -36471,6 +36915,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilityOperationSchedulesById",
+        "summary": "DELETE /v1/admin/operations/facility-operation-schedules/{id}",
         "tags": [
           "operations"
         ],
@@ -36673,6 +37119,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsProperties",
+        "summary": "GET /v1/admin/operations/properties",
         "tags": [
           "operations"
         ],
@@ -36910,6 +37358,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsProperties",
+        "summary": "POST /v1/admin/operations/properties",
         "tags": [
           "operations"
         ],
@@ -37057,6 +37507,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertiesById",
+        "summary": "GET /v1/admin/operations/properties/{id}",
         "tags": [
           "operations"
         ],
@@ -37301,6 +37753,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPropertiesById",
+        "summary": "PATCH /v1/admin/operations/properties/{id}",
         "tags": [
           "operations"
         ],
@@ -37359,6 +37813,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPropertiesById",
+        "summary": "DELETE /v1/admin/operations/properties/{id}",
         "tags": [
           "operations"
         ],
@@ -37567,6 +38023,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroups",
+        "summary": "GET /v1/admin/operations/property-groups",
         "tags": [
           "operations"
         ],
@@ -37791,6 +38249,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPropertyGroups",
+        "summary": "POST /v1/admin/operations/property-groups",
         "tags": [
           "operations"
         ],
@@ -37940,6 +38400,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroupsById",
+        "summary": "GET /v1/admin/operations/property-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -38189,6 +38651,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPropertyGroupsById",
+        "summary": "PATCH /v1/admin/operations/property-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -38247,6 +38711,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPropertyGroupsById",
+        "summary": "DELETE /v1/admin/operations/property-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -38408,6 +38874,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroupMembers",
+        "summary": "GET /v1/admin/operations/property-group-members",
         "tags": [
           "operations"
         ],
@@ -38588,6 +39056,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPropertyGroupMembers",
+        "summary": "POST /v1/admin/operations/property-group-members",
         "tags": [
           "operations"
         ],
@@ -38705,6 +39175,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroupMembersById",
+        "summary": "GET /v1/admin/operations/property-group-members/{id}",
         "tags": [
           "operations"
         ],
@@ -38891,6 +39363,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPropertyGroupMembersById",
+        "summary": "PATCH /v1/admin/operations/property-group-members/{id}",
         "tags": [
           "operations"
         ],
@@ -38949,6 +39423,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPropertyGroupMembersById",
+        "summary": "DELETE /v1/admin/operations/property-group-members/{id}",
         "tags": [
           "operations"
         ],
@@ -39123,6 +39599,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFunctionSpaces",
+        "summary": "GET /v1/admin/operations/function-spaces",
         "tags": [
           "operations"
         ],
@@ -39334,6 +39812,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFunctionSpaces",
+        "summary": "POST /v1/admin/operations/function-spaces",
         "tags": [
           "operations"
         ],
@@ -39518,6 +39998,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFunctionSpacesById",
+        "summary": "GET /v1/admin/operations/function-spaces/{id}",
         "tags": [
           "operations"
         ],
@@ -39738,6 +40220,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFunctionSpacesById",
+        "summary": "PATCH /v1/admin/operations/function-spaces/{id}",
         "tags": [
           "operations"
         ],
@@ -39890,6 +40374,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsFunctionSpacesByIdCapacities",
+        "summary": "PUT /v1/admin/operations/function-spaces/{id}/capacities",
         "tags": [
           "operations"
         ],
@@ -40131,6 +40617,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocks",
+        "summary": "POST /v1/admin/operations/space-blocks",
         "tags": [
           "operations"
         ],
@@ -40354,6 +40842,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsSpaceBlocksById",
+        "summary": "GET /v1/admin/operations/space-blocks/{id}",
         "tags": [
           "operations"
         ],
@@ -40513,6 +41003,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsSpaceBlocksByIdSlots",
+        "summary": "PUT /v1/admin/operations/space-blocks/{id}/slots",
         "tags": [
           "operations"
         ],
@@ -40786,6 +41278,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocksByIdPickups",
+        "summary": "POST /v1/admin/operations/space-blocks/{id}/pickups",
         "tags": [
           "operations"
         ],
@@ -40934,6 +41428,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocksByIdPickupsReverse",
+        "summary": "POST /v1/admin/operations/space-blocks/{id}/pickups/reverse",
         "tags": [
           "operations"
         ],
@@ -41117,6 +41613,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocksByIdRelease",
+        "summary": "POST /v1/admin/operations/space-blocks/{id}/release",
         "tags": [
           "operations"
         ],

--- a/packages/openapi/spec/admin/operator-settings.json
+++ b/packages/openapi/spec/admin/operator-settings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -273,6 +279,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperatorProfile",
+        "summary": "GET /v1/admin/settings/operator-profile",
         "tags": [
           "operator-settings"
         ],
@@ -515,6 +523,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperatorProfile",
+        "summary": "PATCH /v1/admin/settings/operator-profile",
         "tags": [
           "operator-settings"
         ],
@@ -591,6 +601,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperatorPaymentInstructions",
+        "summary": "GET /v1/admin/settings/operator-payment-instructions",
         "tags": [
           "operator-settings"
         ],
@@ -701,6 +713,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperatorPaymentInstructions",
+        "summary": "PATCH /v1/admin/settings/operator-payment-instructions",
         "tags": [
           "operator-settings"
         ],
@@ -764,6 +778,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperatorPaymentDefaults",
+        "summary": "GET /v1/admin/settings/operator-payment-defaults",
         "tags": [
           "operator-settings"
         ],
@@ -900,6 +916,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperatorPaymentDefaults",
+        "summary": "PATCH /v1/admin/settings/operator-payment-defaults",
         "tags": [
           "operator-settings"
         ],
@@ -1060,6 +1078,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperator",
+        "summary": "GET /v1/admin/settings/operator",
         "tags": [
           "operator-settings"
         ],
@@ -1417,6 +1437,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperator",
+        "summary": "PATCH /v1/admin/settings/operator",
         "tags": [
           "operator-settings"
         ],

--- a/packages/openapi/spec/admin/pricing.json
+++ b/packages/openapi/spec/admin/pricing.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -388,6 +394,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategories",
+        "summary": "GET /v1/admin/pricing/pricing-categories",
         "tags": [
           "pricing"
         ],
@@ -636,6 +644,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPricingCategories",
+        "summary": "POST /v1/admin/pricing/pricing-categories",
         "tags": [
           "pricing"
         ],
@@ -805,6 +815,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategoriesById",
+        "summary": "GET /v1/admin/pricing/pricing-categories/{id}",
         "tags": [
           "pricing"
         ],
@@ -1072,6 +1084,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPricingCategoriesById",
+        "summary": "PATCH /v1/admin/pricing/pricing-categories/{id}",
         "tags": [
           "pricing"
         ],
@@ -1127,6 +1141,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPricingCategoriesById",
+        "summary": "DELETE /v1/admin/pricing/pricing-categories/{id}",
         "tags": [
           "pricing"
         ],
@@ -1300,6 +1316,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategoryDependencies",
+        "summary": "GET /v1/admin/pricing/pricing-category-dependencies",
         "tags": [
           "pricing"
         ],
@@ -1442,6 +1460,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPricingCategoryDependencies",
+        "summary": "POST /v1/admin/pricing/pricing-category-dependencies",
         "tags": [
           "pricing"
         ],
@@ -1558,6 +1578,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategoryDependenciesById",
+        "summary": "GET /v1/admin/pricing/pricing-category-dependencies/{id}",
         "tags": [
           "pricing"
         ],
@@ -1722,6 +1744,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPricingCategoryDependenciesById",
+        "summary": "PATCH /v1/admin/pricing/pricing-category-dependencies/{id}",
         "tags": [
           "pricing"
         ],
@@ -1777,6 +1801,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPricingCategoryDependenciesById",
+        "summary": "DELETE /v1/admin/pricing/pricing-category-dependencies/{id}",
         "tags": [
           "pricing"
         ],
@@ -1964,6 +1990,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPolicies",
+        "summary": "GET /v1/admin/pricing/cancellation-policies",
         "tags": [
           "pricing"
         ],
@@ -2123,6 +2151,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingCancellationPolicies",
+        "summary": "POST /v1/admin/pricing/cancellation-policies",
         "tags": [
           "pricing"
         ],
@@ -2247,6 +2277,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPoliciesById",
+        "summary": "GET /v1/admin/pricing/cancellation-policies/{id}",
         "tags": [
           "pricing"
         ],
@@ -2428,6 +2460,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingCancellationPoliciesById",
+        "summary": "PATCH /v1/admin/pricing/cancellation-policies/{id}",
         "tags": [
           "pricing"
         ],
@@ -2483,6 +2517,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingCancellationPoliciesById",
+        "summary": "DELETE /v1/admin/pricing/cancellation-policies/{id}",
         "tags": [
           "pricing"
         ],
@@ -2640,6 +2676,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPolicyRules",
+        "summary": "GET /v1/admin/pricing/cancellation-policy-rules",
         "tags": [
           "pricing"
         ],
@@ -2795,6 +2833,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingCancellationPolicyRules",
+        "summary": "POST /v1/admin/pricing/cancellation-policy-rules",
         "tags": [
           "pricing"
         ],
@@ -2917,6 +2957,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPolicyRulesById",
+        "summary": "GET /v1/admin/pricing/cancellation-policy-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -3094,6 +3136,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingCancellationPolicyRulesById",
+        "summary": "PATCH /v1/admin/pricing/cancellation-policy-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -3149,6 +3193,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingCancellationPolicyRulesById",
+        "summary": "DELETE /v1/admin/pricing/cancellation-policy-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -3336,6 +3382,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceCatalogs",
+        "summary": "GET /v1/admin/pricing/price-catalogs",
         "tags": [
           "pricing"
         ],
@@ -3499,6 +3547,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPriceCatalogs",
+        "summary": "POST /v1/admin/pricing/price-catalogs",
         "tags": [
           "pricing"
         ],
@@ -3623,6 +3673,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceCatalogsById",
+        "summary": "GET /v1/admin/pricing/price-catalogs/{id}",
         "tags": [
           "pricing"
         ],
@@ -3807,6 +3859,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPriceCatalogsById",
+        "summary": "PATCH /v1/admin/pricing/price-catalogs/{id}",
         "tags": [
           "pricing"
         ],
@@ -3862,6 +3916,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPriceCatalogsById",
+        "summary": "DELETE /v1/admin/pricing/price-catalogs/{id}",
         "tags": [
           "pricing"
         ],
@@ -4051,6 +4107,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceSchedules",
+        "summary": "GET /v1/admin/pricing/price-schedules",
         "tags": [
           "pricing"
         ],
@@ -4263,6 +4321,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPriceSchedules",
+        "summary": "POST /v1/admin/pricing/price-schedules",
         "tags": [
           "pricing"
         ],
@@ -4409,6 +4469,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceSchedulesById",
+        "summary": "GET /v1/admin/pricing/price-schedules/{id}",
         "tags": [
           "pricing"
         ],
@@ -4642,6 +4704,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPriceSchedulesById",
+        "summary": "PATCH /v1/admin/pricing/price-schedules/{id}",
         "tags": [
           "pricing"
         ],
@@ -4697,6 +4761,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPriceSchedulesById",
+        "summary": "DELETE /v1/admin/pricing/price-schedules/{id}",
         "tags": [
           "pricing"
         ],
@@ -4962,6 +5028,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionPriceRules",
+        "summary": "GET /v1/admin/pricing/option-price-rules",
         "tags": [
           "pricing"
         ],
@@ -5236,6 +5304,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionPriceRules",
+        "summary": "POST /v1/admin/pricing/option-price-rules",
         "tags": [
           "pricing"
         ],
@@ -5419,6 +5489,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionPriceRulesById",
+        "summary": "GET /v1/admin/pricing/option-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -5711,6 +5783,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/option-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -5766,6 +5840,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/option-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -5980,6 +6056,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitPriceRules",
+        "summary": "GET /v1/admin/pricing/option-unit-price-rules",
         "tags": [
           "pricing"
         ],
@@ -6198,6 +6276,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionUnitPriceRules",
+        "summary": "POST /v1/admin/pricing/option-unit-price-rules",
         "tags": [
           "pricing"
         ],
@@ -6353,6 +6433,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitPriceRulesById",
+        "summary": "GET /v1/admin/pricing/option-unit-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -6591,6 +6673,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionUnitPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/option-unit-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -6646,6 +6730,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionUnitPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/option-unit-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -6836,6 +6922,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionStartTimeRules",
+        "summary": "GET /v1/admin/pricing/option-start-time-rules",
         "tags": [
           "pricing"
         ],
@@ -7024,6 +7112,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionStartTimeRules",
+        "summary": "POST /v1/admin/pricing/option-start-time-rules",
         "tags": [
           "pricing"
         ],
@@ -7163,6 +7253,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionStartTimeRulesById",
+        "summary": "GET /v1/admin/pricing/option-start-time-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -7372,6 +7464,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionStartTimeRulesById",
+        "summary": "PATCH /v1/admin/pricing/option-start-time-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -7427,6 +7521,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionStartTimeRulesById",
+        "summary": "DELETE /v1/admin/pricing/option-start-time-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -7572,6 +7668,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitTiers",
+        "summary": "GET /v1/admin/pricing/option-unit-tiers",
         "tags": [
           "pricing"
         ],
@@ -7704,6 +7802,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionUnitTiers",
+        "summary": "POST /v1/admin/pricing/option-unit-tiers",
         "tags": [
           "pricing"
         ],
@@ -7814,6 +7914,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitTiersById",
+        "summary": "GET /v1/admin/pricing/option-unit-tiers/{id}",
         "tags": [
           "pricing"
         ],
@@ -7968,6 +8070,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionUnitTiersById",
+        "summary": "PATCH /v1/admin/pricing/option-unit-tiers/{id}",
         "tags": [
           "pricing"
         ],
@@ -8023,6 +8127,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionUnitTiersById",
+        "summary": "DELETE /v1/admin/pricing/option-unit-tiers/{id}",
         "tags": [
           "pricing"
         ],
@@ -8199,6 +8305,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPickupPriceRules",
+        "summary": "GET /v1/admin/pricing/pickup-price-rules",
         "tags": [
           "pricing"
         ],
@@ -8359,6 +8467,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPickupPriceRules",
+        "summary": "POST /v1/admin/pricing/pickup-price-rules",
         "tags": [
           "pricing"
         ],
@@ -8484,6 +8594,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPickupPriceRulesById",
+        "summary": "GET /v1/admin/pricing/pickup-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -8664,6 +8776,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPickupPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/pickup-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -8719,6 +8833,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPickupPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/pickup-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -8909,6 +9025,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDropoffPriceRules",
+        "summary": "GET /v1/admin/pricing/dropoff-price-rules",
         "tags": [
           "pricing"
         ],
@@ -9098,6 +9216,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingDropoffPriceRules",
+        "summary": "POST /v1/admin/pricing/dropoff-price-rules",
         "tags": [
           "pricing"
         ],
@@ -9237,6 +9357,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDropoffPriceRulesById",
+        "summary": "GET /v1/admin/pricing/dropoff-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -9446,6 +9568,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingDropoffPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/dropoff-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -9501,6 +9625,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingDropoffPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/dropoff-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -9703,6 +9829,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingExtraPriceRules",
+        "summary": "GET /v1/admin/pricing/extra-price-rules",
         "tags": [
           "pricing"
         ],
@@ -9897,6 +10025,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingExtraPriceRules",
+        "summary": "POST /v1/admin/pricing/extra-price-rules",
         "tags": [
           "pricing"
         ],
@@ -10040,6 +10170,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingExtraPriceRulesById",
+        "summary": "GET /v1/admin/pricing/extra-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -10255,6 +10387,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingExtraPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/extra-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -10310,6 +10444,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingExtraPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/extra-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -10488,6 +10624,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDeparturePriceOverrides",
+        "summary": "GET /v1/admin/pricing/departure-price-overrides",
         "tags": [
           "pricing"
         ],
@@ -10636,6 +10774,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingDeparturePriceOverrides",
+        "summary": "POST /v1/admin/pricing/departure-price-overrides",
         "tags": [
           "pricing"
         ],
@@ -10755,6 +10895,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDeparturePriceOverridesById",
+        "summary": "GET /v1/admin/pricing/departure-price-overrides/{id}",
         "tags": [
           "pricing"
         ],
@@ -10923,6 +11065,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingDeparturePriceOverridesById",
+        "summary": "PATCH /v1/admin/pricing/departure-price-overrides/{id}",
         "tags": [
           "pricing"
         ],
@@ -10978,6 +11122,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingDeparturePriceOverridesById",
+        "summary": "DELETE /v1/admin/pricing/departure-price-overrides/{id}",
         "tags": [
           "pricing"
         ],

--- a/packages/openapi/spec/admin/products.json
+++ b/packages/openapi/spec/admin/products.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -289,6 +295,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsActivationSettings",
+        "summary": "GET /v1/admin/products/activation-settings",
         "tags": [
           "products"
         ],
@@ -403,6 +411,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsActivationSettingsById",
+        "summary": "GET /v1/admin/products/activation-settings/{id}",
         "tags": [
           "products"
         ],
@@ -582,6 +592,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsActivationSettingsById",
+        "summary": "PATCH /v1/admin/products/activation-settings/{id}",
         "tags": [
           "products"
         ],
@@ -637,6 +649,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsActivationSettingsById",
+        "summary": "DELETE /v1/admin/products/activation-settings/{id}",
         "tags": [
           "products"
         ],
@@ -818,6 +832,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdActivationSettings",
+        "summary": "POST /v1/admin/products/{id}/activation-settings",
         "tags": [
           "products"
         ],
@@ -979,6 +995,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTicketSettings",
+        "summary": "GET /v1/admin/products/ticket-settings",
         "tags": [
           "products"
         ],
@@ -1105,6 +1123,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTicketSettingsById",
+        "summary": "GET /v1/admin/products/ticket-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1306,6 +1326,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsTicketSettingsById",
+        "summary": "PATCH /v1/admin/products/ticket-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1361,6 +1383,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsTicketSettingsById",
+        "summary": "DELETE /v1/admin/products/ticket-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1564,6 +1588,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdTicketSettings",
+        "summary": "POST /v1/admin/products/{id}/ticket-settings",
         "tags": [
           "products"
         ],
@@ -1706,6 +1732,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsVisibilitySettings",
+        "summary": "GET /v1/admin/products/visibility-settings",
         "tags": [
           "products"
         ],
@@ -1799,6 +1827,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsVisibilitySettingsById",
+        "summary": "GET /v1/admin/products/visibility-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1936,6 +1966,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsVisibilitySettingsById",
+        "summary": "PATCH /v1/admin/products/visibility-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1991,6 +2023,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsVisibilitySettingsById",
+        "summary": "DELETE /v1/admin/products/visibility-settings/{id}",
         "tags": [
           "products"
         ],
@@ -2130,6 +2164,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdVisibilitySettings",
+        "summary": "POST /v1/admin/products/{id}/visibility-settings",
         "tags": [
           "products"
         ],
@@ -2295,6 +2331,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsCapabilities",
+        "summary": "GET /v1/admin/products/capabilities",
         "tags": [
           "products"
         ],
@@ -2402,6 +2440,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsCapabilitiesById",
+        "summary": "GET /v1/admin/products/capabilities/{id}",
         "tags": [
           "products"
         ],
@@ -2565,6 +2605,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsCapabilitiesById",
+        "summary": "PATCH /v1/admin/products/capabilities/{id}",
         "tags": [
           "products"
         ],
@@ -2620,6 +2662,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsCapabilitiesById",
+        "summary": "DELETE /v1/admin/products/capabilities/{id}",
         "tags": [
           "products"
         ],
@@ -2788,6 +2832,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdCapabilities",
+        "summary": "POST /v1/admin/products/{id}/capabilities",
         "tags": [
           "products"
         ],
@@ -2922,6 +2968,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDeliveryFormats",
+        "summary": "GET /v1/admin/products/delivery-formats",
         "tags": [
           "products"
         ],
@@ -3017,6 +3065,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDeliveryFormatsById",
+        "summary": "GET /v1/admin/products/delivery-formats/{id}",
         "tags": [
           "products"
         ],
@@ -3157,6 +3207,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsDeliveryFormatsById",
+        "summary": "PATCH /v1/admin/products/delivery-formats/{id}",
         "tags": [
           "products"
         ],
@@ -3212,6 +3264,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsDeliveryFormatsById",
+        "summary": "DELETE /v1/admin/products/delivery-formats/{id}",
         "tags": [
           "products"
         ],
@@ -3357,6 +3411,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDeliveryFormats",
+        "summary": "POST /v1/admin/products/{id}/delivery-formats",
         "tags": [
           "products"
         ],
@@ -3496,6 +3552,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFeatures",
+        "summary": "GET /v1/admin/products/features",
         "tags": [
           "products"
         ],
@@ -3599,6 +3657,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFeaturesById",
+        "summary": "GET /v1/admin/products/features/{id}",
         "tags": [
           "products"
         ],
@@ -3756,6 +3816,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsFeaturesById",
+        "summary": "PATCH /v1/admin/products/features/{id}",
         "tags": [
           "products"
         ],
@@ -3811,6 +3873,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsFeaturesById",
+        "summary": "DELETE /v1/admin/products/features/{id}",
         "tags": [
           "products"
         ],
@@ -3973,6 +4037,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdFeatures",
+        "summary": "POST /v1/admin/products/{id}/features",
         "tags": [
           "products"
         ],
@@ -4083,6 +4149,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFaqs",
+        "summary": "GET /v1/admin/products/faqs",
         "tags": [
           "products"
         ],
@@ -4172,6 +4240,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFaqsById",
+        "summary": "GET /v1/admin/products/faqs/{id}",
         "tags": [
           "products"
         ],
@@ -4303,6 +4373,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsFaqsById",
+        "summary": "PATCH /v1/admin/products/faqs/{id}",
         "tags": [
           "products"
         ],
@@ -4358,6 +4430,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsFaqsById",
+        "summary": "DELETE /v1/admin/products/faqs/{id}",
         "tags": [
           "products"
         ],
@@ -4495,6 +4569,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdFaqs",
+        "summary": "POST /v1/admin/products/{id}/faqs",
         "tags": [
           "products"
         ],
@@ -4687,6 +4763,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsLocations",
+        "summary": "GET /v1/admin/products/locations",
         "tags": [
           "products"
         ],
@@ -4841,6 +4919,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsLocationsById",
+        "summary": "GET /v1/admin/products/locations/{id}",
         "tags": [
           "products"
         ],
@@ -5104,6 +5184,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsLocationsById",
+        "summary": "PATCH /v1/admin/products/locations/{id}",
         "tags": [
           "products"
         ],
@@ -5159,6 +5241,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsLocationsById",
+        "summary": "DELETE /v1/admin/products/locations/{id}",
         "tags": [
           "products"
         ],
@@ -5427,6 +5511,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdLocations",
+        "summary": "POST /v1/admin/products/{id}/locations",
         "tags": [
           "products"
         ],
@@ -5643,6 +5729,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinations",
+        "summary": "GET /v1/admin/products/destinations",
         "tags": [
           "products"
         ],
@@ -5851,6 +5939,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsDestinations",
+        "summary": "POST /v1/admin/products/destinations",
         "tags": [
           "products"
         ],
@@ -5983,6 +6073,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinationsById",
+        "summary": "GET /v1/admin/products/destinations/{id}",
         "tags": [
           "products"
         ],
@@ -6216,6 +6308,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsDestinationsById",
+        "summary": "PATCH /v1/admin/products/destinations/{id}",
         "tags": [
           "products"
         ],
@@ -6271,6 +6365,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsDestinationsById",
+        "summary": "DELETE /v1/admin/products/destinations/{id}",
         "tags": [
           "products"
         ],
@@ -6409,6 +6505,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinationTranslations",
+        "summary": "GET /v1/admin/products/destination-translations",
         "tags": [
           "products"
         ],
@@ -6579,6 +6677,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsDestinationsByIdTranslations",
+        "summary": "POST /v1/admin/products/destinations/{id}/translations",
         "tags": [
           "products"
         ],
@@ -6745,6 +6845,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsDestinationTranslationsById",
+        "summary": "PATCH /v1/admin/products/destination-translations/{id}",
         "tags": [
           "products"
         ],
@@ -6800,6 +6902,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsDestinationTranslationsById",
+        "summary": "DELETE /v1/admin/products/destination-translations/{id}",
         "tags": [
           "products"
         ],
@@ -6938,6 +7042,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductCategoryTranslations",
+        "summary": "GET /v1/admin/products/product-category-translations",
         "tags": [
           "products"
         ],
@@ -7108,6 +7214,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductCategoriesByIdTranslations",
+        "summary": "POST /v1/admin/products/product-categories/{id}/translations",
         "tags": [
           "products"
         ],
@@ -7274,6 +7382,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductCategoryTranslationsById",
+        "summary": "PATCH /v1/admin/products/product-category-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7329,6 +7439,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductCategoryTranslationsById",
+        "summary": "DELETE /v1/admin/products/product-category-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7446,6 +7558,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTagTranslations",
+        "summary": "GET /v1/admin/products/product-tag-translations",
         "tags": [
           "products"
         ],
@@ -7576,6 +7690,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductTagsByIdTranslations",
+        "summary": "POST /v1/admin/products/product-tags/{id}/translations",
         "tags": [
           "products"
         ],
@@ -7702,6 +7818,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductTagTranslationsById",
+        "summary": "PATCH /v1/admin/products/product-tag-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7757,6 +7875,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductTagTranslationsById",
+        "summary": "DELETE /v1/admin/products/product-tag-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7879,6 +7999,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinationLinks",
+        "summary": "GET /v1/admin/products/destination-links",
         "tags": [
           "products"
         ],
@@ -8000,6 +8122,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDestinations",
+        "summary": "POST /v1/admin/products/{id}/destinations",
         "tags": [
           "products"
         ],
@@ -8065,6 +8189,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDestinationsByDestinationId",
+        "summary": "DELETE /v1/admin/products/{id}/destinations/{destinationId}",
         "tags": [
           "products"
         ],
@@ -8225,6 +8351,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptions",
+        "summary": "GET /v1/admin/products/options",
         "tags": [
           "products"
         ],
@@ -8351,6 +8479,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptionsByOptionId",
+        "summary": "GET /v1/admin/products/options/{optionId}",
         "tags": [
           "products"
         ],
@@ -8549,6 +8679,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsOptionsByOptionId",
+        "summary": "PATCH /v1/admin/products/options/{optionId}",
         "tags": [
           "products"
         ],
@@ -8604,6 +8736,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsOptionsByOptionId",
+        "summary": "DELETE /v1/admin/products/options/{optionId}",
         "tags": [
           "products"
         ],
@@ -8810,6 +8944,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdOptions",
+        "summary": "POST /v1/admin/products/{id}/options",
         "tags": [
           "products"
         ],
@@ -9008,6 +9144,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnits",
+        "summary": "GET /v1/admin/products/units",
         "tags": [
           "products"
         ],
@@ -9169,6 +9307,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnitsByUnitId",
+        "summary": "GET /v1/admin/products/units/{unitId}",
         "tags": [
           "products"
         ],
@@ -9438,6 +9578,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsUnitsByUnitId",
+        "summary": "PATCH /v1/admin/products/units/{unitId}",
         "tags": [
           "products"
         ],
@@ -9493,6 +9635,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsUnitsByUnitId",
+        "summary": "DELETE /v1/admin/products/units/{unitId}",
         "tags": [
           "products"
         ],
@@ -9771,6 +9915,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsOptionsByOptionIdUnits",
+        "summary": "POST /v1/admin/products/options/{optionId}/units",
         "tags": [
           "products"
         ],
@@ -9944,6 +10090,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTranslations",
+        "summary": "GET /v1/admin/products/translations",
         "tags": [
           "products"
         ],
@@ -10085,6 +10233,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTranslationsByTranslationId",
+        "summary": "GET /v1/admin/products/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10315,6 +10465,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10370,6 +10522,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10606,6 +10760,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/translations",
         "tags": [
           "products"
         ],
@@ -10737,6 +10893,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptionTranslations",
+        "summary": "GET /v1/admin/products/option-translations",
         "tags": [
           "products"
         ],
@@ -10836,6 +10994,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptionTranslationsByTranslationId",
+        "summary": "GET /v1/admin/products/option-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10986,6 +11146,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsOptionTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/option-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11041,6 +11203,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsOptionTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/option-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11197,6 +11361,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsOptionsByOptionIdTranslations",
+        "summary": "POST /v1/admin/products/options/{optionId}/translations",
         "tags": [
           "products"
         ],
@@ -11328,6 +11494,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnitTranslations",
+        "summary": "GET /v1/admin/products/unit-translations",
         "tags": [
           "products"
         ],
@@ -11427,6 +11595,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnitTranslationsByTranslationId",
+        "summary": "GET /v1/admin/products/unit-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11577,6 +11747,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsUnitTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/unit-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11632,6 +11804,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsUnitTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/unit-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11788,6 +11962,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsUnitsByUnitIdTranslations",
+        "summary": "POST /v1/admin/products/units/{unitId}/translations",
         "tags": [
           "products"
         ],
@@ -11927,6 +12103,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTypes",
+        "summary": "GET /v1/admin/products/product-types",
         "tags": [
           "products"
         ],
@@ -12066,6 +12244,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductTypes",
+        "summary": "POST /v1/admin/products/product-types",
         "tags": [
           "products"
         ],
@@ -12170,6 +12350,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTypesByTypeId",
+        "summary": "GET /v1/admin/products/product-types/{typeId}",
         "tags": [
           "products"
         ],
@@ -12333,6 +12515,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductTypesByTypeId",
+        "summary": "PATCH /v1/admin/products/product-types/{typeId}",
         "tags": [
           "products"
         ],
@@ -12388,6 +12572,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductTypesByTypeId",
+        "summary": "DELETE /v1/admin/products/product-types/{typeId}",
         "tags": [
           "products"
         ],
@@ -12543,6 +12729,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductCategories",
+        "summary": "GET /v1/admin/products/product-categories",
         "tags": [
           "products"
         ],
@@ -12747,6 +12935,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductCategories",
+        "summary": "POST /v1/admin/products/product-categories",
         "tags": [
           "products"
         ],
@@ -12859,6 +13049,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductCategoriesByCategoryId",
+        "summary": "GET /v1/admin/products/product-categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -13087,6 +13279,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductCategoriesByCategoryId",
+        "summary": "PATCH /v1/admin/products/product-categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -13142,6 +13336,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductCategoriesByCategoryId",
+        "summary": "DELETE /v1/admin/products/product-categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -13240,6 +13436,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTags",
+        "summary": "GET /v1/admin/products/product-tags",
         "tags": [
           "products"
         ],
@@ -13325,6 +13523,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductTags",
+        "summary": "POST /v1/admin/products/product-tags",
         "tags": [
           "products"
         ],
@@ -13402,6 +13602,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTagsByTagId",
+        "summary": "GET /v1/admin/products/product-tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -13512,6 +13714,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductTagsByTagId",
+        "summary": "PATCH /v1/admin/products/product-tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -13567,6 +13771,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductTagsByTagId",
+        "summary": "DELETE /v1/admin/products/product-tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -13719,6 +13925,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsMediaByMediaId",
+        "summary": "GET /v1/admin/products/media/{mediaId}",
         "tags": [
           "products"
         ],
@@ -13968,6 +14176,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsMediaByMediaId",
+        "summary": "PATCH /v1/admin/products/media/{mediaId}",
         "tags": [
           "products"
         ],
@@ -14118,6 +14328,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsMediaByMediaId",
+        "summary": "DELETE /v1/admin/products/media/{mediaId}",
         "tags": [
           "products"
         ],
@@ -14306,6 +14518,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsMediaByMediaIdSetCover",
+        "summary": "PATCH /v1/admin/products/media/{mediaId}/set-cover",
         "tags": [
           "products"
         ],
@@ -14443,6 +14657,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdBrochureVersions",
+        "summary": "GET /v1/admin/products/{id}/brochure/versions",
         "tags": [
           "products"
         ],
@@ -14603,6 +14819,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdBrochureVersionsByBrochureIdSetCurrent",
+        "summary": "POST /v1/admin/products/{id}/brochure/versions/{brochureId}/set-current",
         "tags": [
           "products"
         ],
@@ -14763,6 +14981,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdBrochureVersionsByBrochureId",
+        "summary": "DELETE /v1/admin/products/{id}/brochure/versions/{brochureId}",
         "tags": [
           "products"
         ],
@@ -14915,6 +15135,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdBrochure",
+        "summary": "GET /v1/admin/products/{id}/brochure",
         "tags": [
           "products"
         ],
@@ -15142,6 +15364,8 @@
             }
           }
         },
+        "operationId": "putAdminProductsByIdBrochure",
+        "summary": "PUT /v1/admin/products/{id}/brochure",
         "tags": [
           "products"
         ],
@@ -15292,6 +15516,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdBrochure",
+        "summary": "DELETE /v1/admin/products/{id}/brochure",
         "tags": [
           "products"
         ],
@@ -15393,6 +15619,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdMediaReorder",
+        "summary": "POST /v1/admin/products/{id}/media/reorder",
         "tags": [
           "products"
         ],
@@ -15615,6 +15843,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdMedia",
+        "summary": "GET /v1/admin/products/{id}/media",
         "tags": [
           "products"
         ],
@@ -15875,6 +16105,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdMedia",
+        "summary": "POST /v1/admin/products/{id}/media",
         "tags": [
           "products"
         ],
@@ -16105,6 +16337,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdMedia",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/media",
         "tags": [
           "products"
         ],
@@ -16373,6 +16607,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdMedia",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/media",
         "tags": [
           "products"
         ],
@@ -16447,6 +16683,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdItineraries",
+        "summary": "GET /v1/admin/products/{id}/itineraries",
         "tags": [
           "products"
         ],
@@ -16580,6 +16818,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdItineraries",
+        "summary": "POST /v1/admin/products/{id}/itineraries",
         "tags": [
           "products"
         ],
@@ -16712,6 +16952,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsItinerariesByItineraryId",
+        "summary": "PATCH /v1/admin/products/itineraries/{itineraryId}",
         "tags": [
           "products"
         ],
@@ -16767,6 +17009,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsItinerariesByItineraryId",
+        "summary": "DELETE /v1/admin/products/itineraries/{itineraryId}",
         "tags": [
           "products"
         ],
@@ -16891,6 +17135,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsItinerariesByItineraryIdDuplicate",
+        "summary": "POST /v1/admin/products/itineraries/{itineraryId}/duplicate",
         "tags": [
           "products"
         ],
@@ -16986,6 +17232,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdItinerariesByItineraryIdDays",
+        "summary": "GET /v1/admin/products/{id}/itineraries/{itineraryId}/days",
         "tags": [
           "products"
         ],
@@ -17151,6 +17399,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdItinerariesByItineraryIdDays",
+        "summary": "POST /v1/admin/products/{id}/itineraries/{itineraryId}/days",
         "tags": [
           "products"
         ],
@@ -17238,6 +17488,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDays",
+        "summary": "GET /v1/admin/products/{id}/days",
         "tags": [
           "products"
         ],
@@ -17395,6 +17647,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDays",
+        "summary": "POST /v1/admin/products/{id}/days",
         "tags": [
           "products"
         ],
@@ -17559,6 +17813,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}",
         "tags": [
           "products"
         ],
@@ -17622,6 +17878,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}",
         "tags": [
           "products"
         ],
@@ -17751,6 +18009,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdServices",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/services",
         "tags": [
           "products"
         ],
@@ -17991,6 +18251,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdServices",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/services",
         "tags": [
           "products"
         ],
@@ -18235,6 +18497,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayIdServicesByServiceId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}/services/{serviceId}",
         "tags": [
           "products"
         ],
@@ -18306,6 +18570,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayIdServicesByServiceId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}/services/{serviceId}",
         "tags": [
           "products"
         ],
@@ -18413,6 +18679,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdTranslations",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/translations",
         "tags": [
           "products"
         ],
@@ -18580,6 +18848,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/translations",
         "tags": [
           "products"
         ],
@@ -18754,6 +19024,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayIdTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -18825,6 +19097,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayIdTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -18899,6 +19173,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdVersions",
+        "summary": "GET /v1/admin/products/{id}/versions",
         "tags": [
           "products"
         ],
@@ -18986,6 +19262,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdVersions",
+        "summary": "POST /v1/admin/products/{id}/versions",
         "tags": [
           "products"
         ],
@@ -19052,6 +19330,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdNotes",
+        "summary": "GET /v1/admin/products/{id}/notes",
         "tags": [
           "products"
         ],
@@ -19169,6 +19449,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdNotes",
+        "summary": "POST /v1/admin/products/{id}/notes",
         "tags": [
           "products"
         ],
@@ -19259,6 +19541,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdItinerariesByItineraryIdTranslations",
+        "summary": "GET /v1/admin/products/{id}/itineraries/{itineraryId}/translations",
         "tags": [
           "products"
         ],
@@ -19395,6 +19679,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdItinerariesByItineraryIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/itineraries/{itineraryId}/translations",
         "tags": [
           "products"
         ],
@@ -19537,6 +19823,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdItinerariesByItineraryIdTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/{id}/itineraries/{itineraryId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -19608,6 +19896,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdItinerariesByItineraryIdTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/{id}/itineraries/{itineraryId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -19720,6 +20010,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdServicesByServiceIdTranslations",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations",
         "tags": [
           "products"
         ],
@@ -19890,6 +20182,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdServicesByServiceIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations",
         "tags": [
           "products"
         ],
@@ -20066,6 +20360,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayIdServicesByServiceIdTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -20145,6 +20441,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayIdServicesByServiceIdTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -20242,6 +20540,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdCategories",
+        "summary": "GET /v1/admin/products/{id}/categories",
         "tags": [
           "products"
         ],
@@ -20336,6 +20636,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdCategories",
+        "summary": "POST /v1/admin/products/{id}/categories",
         "tags": [
           "products"
         ],
@@ -20401,6 +20703,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdCategoriesByCategoryId",
+        "summary": "DELETE /v1/admin/products/{id}/categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -20463,6 +20767,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdTags",
+        "summary": "GET /v1/admin/products/{id}/tags",
         "tags": [
           "products"
         ],
@@ -20554,6 +20860,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdTags",
+        "summary": "POST /v1/admin/products/{id}/tags",
         "tags": [
           "products"
         ],
@@ -20619,6 +20927,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdTagsByTagId",
+        "summary": "DELETE /v1/admin/products/{id}/tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -20688,6 +20998,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdRecalculate",
+        "summary": "POST /v1/admin/products/{id}/recalculate",
         "tags": [
           "products"
         ],
@@ -20796,6 +21108,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsAggregates",
+        "summary": "GET /v1/admin/products/aggregates",
         "tags": [
           "products"
         ],
@@ -21304,6 +21618,8 @@
             }
           }
         },
+        "operationId": "getAdminProducts",
+        "summary": "GET /v1/admin/products",
         "tags": [
           "products"
         ],
@@ -21867,6 +22183,8 @@
             }
           }
         },
+        "operationId": "postAdminProducts",
+        "summary": "POST /v1/admin/products",
         "tags": [
           "products"
         ],
@@ -22168,6 +22486,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsById",
+        "summary": "GET /v1/admin/products/{id}",
         "tags": [
           "products"
         ],
@@ -22748,6 +23068,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsById",
+        "summary": "PATCH /v1/admin/products/{id}",
         "tags": [
           "products"
         ],
@@ -22803,6 +23125,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsById",
+        "summary": "DELETE /v1/admin/products/{id}",
         "tags": [
           "products"
         ],
@@ -22919,6 +23243,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdActionLedger",
+        "summary": "GET /v1/admin/products/{id}/action-ledger",
         "tags": [
           "products"
         ],

--- a/packages/openapi/spec/admin/promotions.json
+++ b/packages/openapi/spec/admin/promotions.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -611,6 +617,8 @@
             }
           }
         },
+        "operationId": "getAdminPromotions",
+        "summary": "GET /v1/admin/promotions",
         "tags": [
           "promotions"
         ],
@@ -1274,6 +1282,8 @@
             }
           }
         },
+        "operationId": "postAdminPromotions",
+        "summary": "POST /v1/admin/promotions",
         "tags": [
           "promotions"
         ],
@@ -1628,6 +1638,8 @@
             }
           }
         },
+        "operationId": "getAdminPromotionsById",
+        "summary": "GET /v1/admin/promotions/{id}",
         "tags": [
           "promotions"
         ],
@@ -2313,6 +2325,8 @@
             }
           }
         },
+        "operationId": "patchAdminPromotionsById",
+        "summary": "PATCH /v1/admin/promotions/{id}",
         "tags": [
           "promotions"
         ],
@@ -2394,6 +2408,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPromotionsById",
+        "summary": "DELETE /v1/admin/promotions/{id}",
         "tags": [
           "promotions"
         ],
@@ -2748,6 +2764,8 @@
             }
           }
         },
+        "operationId": "postAdminPromotionsByIdArchive",
+        "summary": "POST /v1/admin/promotions/{id}/archive",
         "tags": [
           "promotions"
         ],

--- a/packages/openapi/spec/admin/quotes.json
+++ b/packages/openapi/spec/admin/quotes.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -263,6 +269,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesPipelines",
+        "summary": "GET /v1/admin/quotes/pipelines",
         "tags": [
           "quotes"
         ],
@@ -383,6 +391,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesPipelines",
+        "summary": "POST /v1/admin/quotes/pipelines",
         "tags": [
           "quotes"
         ],
@@ -478,6 +488,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesPipelinesById",
+        "summary": "GET /v1/admin/quotes/pipelines/{id}",
         "tags": [
           "quotes"
         ],
@@ -623,6 +635,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesPipelinesById",
+        "summary": "PATCH /v1/admin/quotes/pipelines/{id}",
         "tags": [
           "quotes"
         ],
@@ -699,6 +713,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesPipelinesById",
+        "summary": "DELETE /v1/admin/quotes/pipelines/{id}",
         "tags": [
           "quotes"
         ],
@@ -824,6 +840,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesStages",
+        "summary": "GET /v1/admin/quotes/stages",
         "tags": [
           "quotes"
         ],
@@ -963,6 +981,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesStages",
+        "summary": "POST /v1/admin/quotes/stages",
         "tags": [
           "quotes"
         ],
@@ -1067,6 +1087,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesStagesById",
+        "summary": "GET /v1/admin/quotes/stages/{id}",
         "tags": [
           "quotes"
         ],
@@ -1230,6 +1252,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesStagesById",
+        "summary": "PATCH /v1/admin/quotes/stages/{id}",
         "tags": [
           "quotes"
         ],
@@ -1288,6 +1312,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesStagesById",
+        "summary": "DELETE /v1/admin/quotes/stages/{id}",
         "tags": [
           "quotes"
         ],
@@ -1579,6 +1605,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotes",
+        "summary": "GET /v1/admin/quotes/quotes",
         "tags": [
           "quotes"
         ],
@@ -1901,6 +1929,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotes",
+        "summary": "POST /v1/admin/quotes/quotes",
         "tags": [
           "quotes"
         ],
@@ -2117,6 +2147,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesById",
+        "summary": "GET /v1/admin/quotes/quotes/{id}",
         "tags": [
           "quotes"
         ],
@@ -2462,6 +2494,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuotesById",
+        "summary": "PATCH /v1/admin/quotes/quotes/{id}",
         "tags": [
           "quotes"
         ],
@@ -2520,6 +2554,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuotesById",
+        "summary": "DELETE /v1/admin/quotes/quotes/{id}",
         "tags": [
           "quotes"
         ],
@@ -2597,6 +2633,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesByIdParticipants",
+        "summary": "GET /v1/admin/quotes/quotes/{id}/participants",
         "tags": [
           "quotes"
         ],
@@ -2720,6 +2758,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdParticipants",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/participants",
         "tags": [
           "quotes"
         ],
@@ -2780,6 +2820,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteParticipantsById",
+        "summary": "DELETE /v1/admin/quotes/quote-participants/{id}",
         "tags": [
           "quotes"
         ],
@@ -2899,6 +2941,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesByIdProducts",
+        "summary": "GET /v1/admin/quotes/quotes/{id}/products",
         "tags": [
           "quotes"
         ],
@@ -3097,6 +3141,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdProducts",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/products",
         "tags": [
           "quotes"
         ],
@@ -3312,6 +3358,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteProductsById",
+        "summary": "PATCH /v1/admin/quotes/quote-products/{id}",
         "tags": [
           "quotes"
         ],
@@ -3370,6 +3418,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteProductsById",
+        "summary": "DELETE /v1/admin/quotes/quote-products/{id}",
         "tags": [
           "quotes"
         ],
@@ -3476,6 +3526,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesByIdMedia",
+        "summary": "GET /v1/admin/quotes/quotes/{id}/media",
         "tags": [
           "quotes"
         ],
@@ -3655,6 +3707,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdMedia",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/media",
         "tags": [
           "quotes"
         ],
@@ -3715,6 +3769,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteMediaById",
+        "summary": "DELETE /v1/admin/quotes/quote-media/{id}",
         "tags": [
           "quotes"
         ],
@@ -3920,6 +3976,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuoteVersions",
+        "summary": "GET /v1/admin/quotes/quote-versions",
         "tags": [
           "quotes"
         ],
@@ -4219,6 +4277,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdVersions",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/versions",
         "tags": [
           "quotes"
         ],
@@ -4427,6 +4487,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteVersionsByIdValidity",
+        "summary": "PATCH /v1/admin/quotes/quote-versions/{id}/validity",
         "tags": [
           "quotes"
         ],
@@ -4613,6 +4675,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdVersionsSnapshot",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/versions/snapshot",
         "tags": [
           "quotes"
         ],
@@ -4757,6 +4821,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsExpire",
+        "summary": "POST /v1/admin/quotes/quote-versions/expire",
         "tags": [
           "quotes"
         ],
@@ -4925,6 +4991,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuoteVersionsById",
+        "summary": "GET /v1/admin/quotes/quote-versions/{id}",
         "tags": [
           "quotes"
         ],
@@ -5218,6 +5286,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteVersionsById",
+        "summary": "PATCH /v1/admin/quotes/quote-versions/{id}",
         "tags": [
           "quotes"
         ],
@@ -5294,6 +5364,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteVersionsById",
+        "summary": "DELETE /v1/admin/quotes/quote-versions/{id}",
         "tags": [
           "quotes"
         ],
@@ -5655,6 +5727,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdTripSnapshot",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/trip-snapshot",
         "tags": [
           "quotes"
         ],
@@ -5842,6 +5916,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdSend",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/send",
         "tags": [
           "quotes"
         ],
@@ -6010,6 +6086,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdView",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/view",
         "tags": [
           "quotes"
         ],
@@ -6486,6 +6564,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdAccept",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/accept",
         "tags": [
           "quotes"
         ],
@@ -6673,6 +6753,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdDecline",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/decline",
         "tags": [
           "quotes"
         ],
@@ -6769,6 +6851,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuoteVersionsByIdLines",
+        "summary": "GET /v1/admin/quotes/quote-versions/{id}/lines",
         "tags": [
           "quotes"
         ],
@@ -6963,6 +7047,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdLines",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/lines",
         "tags": [
           "quotes"
         ],
@@ -7155,6 +7241,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteVersionLinesById",
+        "summary": "PATCH /v1/admin/quotes/quote-version-lines/{id}",
         "tags": [
           "quotes"
         ],
@@ -7231,6 +7319,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteVersionLinesById",
+        "summary": "DELETE /v1/admin/quotes/quote-version-lines/{id}",
         "tags": [
           "quotes"
         ],

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -439,6 +445,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizations",
+        "summary": "GET /v1/admin/relationships/organizations",
         "tags": [
           "relationships"
         ],
@@ -756,6 +764,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizations",
+        "summary": "POST /v1/admin/relationships/organizations",
         "tags": [
           "relationships"
         ],
@@ -952,6 +962,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsById",
+        "summary": "GET /v1/admin/relationships/organizations/{id}",
         "tags": [
           "relationships"
         ],
@@ -1294,6 +1306,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsOrganizationsById",
+        "summary": "PATCH /v1/admin/relationships/organizations/{id}",
         "tags": [
           "relationships"
         ],
@@ -1352,6 +1366,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsOrganizationsById",
+        "summary": "DELETE /v1/admin/relationships/organizations/{id}",
         "tags": [
           "relationships"
         ],
@@ -1585,6 +1601,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdMerge",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/merge",
         "tags": [
           "relationships"
         ],
@@ -1692,6 +1710,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsByIdContactMethods",
+        "summary": "GET /v1/admin/relationships/organizations/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -1890,6 +1910,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdContactMethods",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -2049,6 +2071,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsByIdAddresses",
+        "summary": "GET /v1/admin/relationships/organizations/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -2339,6 +2363,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdAddresses",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -2405,6 +2431,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsByIdNotes",
+        "summary": "GET /v1/admin/relationships/organizations/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -2522,6 +2550,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdNotes",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -2641,6 +2671,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsOrganizationNotesById",
+        "summary": "PATCH /v1/admin/relationships/organization-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -2699,6 +2731,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsOrganizationNotesById",
+        "summary": "DELETE /v1/admin/relationships/organization-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -3017,6 +3051,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeople",
+        "summary": "GET /v1/admin/relationships/people",
         "tags": [
           "relationships"
         ],
@@ -3453,6 +3489,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeople",
+        "summary": "POST /v1/admin/relationships/people",
         "tags": [
           "relationships"
         ],
@@ -3678,6 +3716,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleById",
+        "summary": "GET /v1/admin/relationships/people/{id}",
         "tags": [
           "relationships"
         ],
@@ -4138,6 +4178,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPeopleById",
+        "summary": "PATCH /v1/admin/relationships/people/{id}",
         "tags": [
           "relationships"
         ],
@@ -4196,6 +4238,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPeopleById",
+        "summary": "DELETE /v1/admin/relationships/people/{id}",
         "tags": [
           "relationships"
         ],
@@ -4458,6 +4502,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdMerge",
+        "summary": "POST /v1/admin/relationships/people/{id}/merge",
         "tags": [
           "relationships"
         ],
@@ -4565,6 +4611,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdContactMethods",
+        "summary": "GET /v1/admin/relationships/people/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -4763,6 +4811,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdContactMethods",
+        "summary": "POST /v1/admin/relationships/people/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -4922,6 +4972,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdAddresses",
+        "summary": "GET /v1/admin/relationships/people/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -5212,6 +5264,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdAddresses",
+        "summary": "POST /v1/admin/relationships/people/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -5278,6 +5332,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdNotes",
+        "summary": "GET /v1/admin/relationships/people/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -5395,6 +5451,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdNotes",
+        "summary": "POST /v1/admin/relationships/people/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -5514,6 +5572,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonNotesById",
+        "summary": "PATCH /v1/admin/relationships/person-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -5572,6 +5632,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonNotesById",
+        "summary": "DELETE /v1/admin/relationships/person-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -5670,6 +5732,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdPaymentMethods",
+        "summary": "GET /v1/admin/relationships/people/{id}/payment-methods",
         "tags": [
           "relationships"
         ],
@@ -5863,6 +5927,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdPaymentMethods",
+        "summary": "POST /v1/admin/relationships/people/{id}/payment-methods",
         "tags": [
           "relationships"
         ],
@@ -6054,6 +6120,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonPaymentMethodsById",
+        "summary": "PATCH /v1/admin/relationships/person-payment-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -6112,6 +6180,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonPaymentMethodsById",
+        "summary": "DELETE /v1/admin/relationships/person-payment-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -6286,6 +6356,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdCommunications",
+        "summary": "GET /v1/admin/relationships/people/{id}/communications",
         "tags": [
           "relationships"
         ],
@@ -6482,6 +6554,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdCommunications",
+        "summary": "POST /v1/admin/relationships/people/{id}/communications",
         "tags": [
           "relationships"
         ],
@@ -6549,6 +6623,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsSegments",
+        "summary": "GET /v1/admin/relationships/segments",
         "tags": [
           "relationships"
         ],
@@ -6662,6 +6738,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsSegments",
+        "summary": "POST /v1/admin/relationships/segments",
         "tags": [
           "relationships"
         ],
@@ -6722,6 +6800,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsSegmentsBySegmentId",
+        "summary": "DELETE /v1/admin/relationships/segments/{segmentId}",
         "tags": [
           "relationships"
         ],
@@ -6743,6 +6823,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleExport",
+        "summary": "POST /v1/admin/relationships/people/export",
         "tags": [
           "relationships"
         ],
@@ -6819,6 +6901,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleImport",
+        "summary": "POST /v1/admin/relationships/people/import",
         "tags": [
           "relationships"
         ],
@@ -7031,6 +7115,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsContactMethodsById",
+        "summary": "PATCH /v1/admin/relationships/contact-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -7089,6 +7175,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsContactMethodsById",
+        "summary": "DELETE /v1/admin/relationships/contact-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -7395,6 +7483,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsAddressesById",
+        "summary": "PATCH /v1/admin/relationships/addresses/{id}",
         "tags": [
           "relationships"
         ],
@@ -7453,6 +7543,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsAddressesById",
+        "summary": "DELETE /v1/admin/relationships/addresses/{id}",
         "tags": [
           "relationships"
         ],
@@ -7629,6 +7721,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdDocuments",
+        "summary": "GET /v1/admin/relationships/people/{id}/documents",
         "tags": [
           "relationships"
         ],
@@ -7877,6 +7971,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdDocuments",
+        "summary": "POST /v1/admin/relationships/people/{id}/documents",
         "tags": [
           "relationships"
         ],
@@ -8020,6 +8116,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPersonDocumentsById",
+        "summary": "GET /v1/admin/relationships/person-documents/{id}",
         "tags": [
           "relationships"
         ],
@@ -8265,6 +8363,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonDocumentsById",
+        "summary": "PATCH /v1/admin/relationships/person-documents/{id}",
         "tags": [
           "relationships"
         ],
@@ -8323,6 +8423,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonDocumentsById",
+        "summary": "DELETE /v1/admin/relationships/person-documents/{id}",
         "tags": [
           "relationships"
         ],
@@ -8466,6 +8568,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPersonDocumentsByIdSetPrimary",
+        "summary": "POST /v1/admin/relationships/person-documents/{id}/set-primary",
         "tags": [
           "relationships"
         ],
@@ -8616,6 +8720,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdTravelSnapshot",
+        "summary": "GET /v1/admin/relationships/people/{id}/travel-snapshot",
         "tags": [
           "relationships"
         ],
@@ -8752,6 +8858,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPeopleByIdProfilePii",
+        "summary": "PATCH /v1/admin/relationships/people/{id}/profile-pii",
         "tags": [
           "relationships"
         ],
@@ -9012,6 +9120,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdDocumentsFromPlaintext",
+        "summary": "POST /v1/admin/relationships/people/{id}/documents/from-plaintext",
         "tags": [
           "relationships"
         ],
@@ -9269,6 +9379,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonDocumentsByIdFromPlaintext",
+        "summary": "PATCH /v1/admin/relationships/person-documents/{id}/from-plaintext",
         "tags": [
           "relationships"
         ],
@@ -9381,6 +9493,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPersonDocumentsByIdReveal",
+        "summary": "GET /v1/admin/relationships/person-documents/{id}/reveal",
         "tags": [
           "relationships"
         ],
@@ -9577,6 +9691,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdRelationships",
+        "summary": "GET /v1/admin/relationships/people/{id}/relationships",
         "tags": [
           "relationships"
         ],
@@ -9817,6 +9933,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdRelationships",
+        "summary": "POST /v1/admin/relationships/people/{id}/relationships",
         "tags": [
           "relationships"
         ],
@@ -9969,6 +10087,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPersonRelationshipsById",
+        "summary": "GET /v1/admin/relationships/person-relationships/{id}",
         "tags": [
           "relationships"
         ],
@@ -10216,6 +10336,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonRelationshipsById",
+        "summary": "PATCH /v1/admin/relationships/person-relationships/{id}",
         "tags": [
           "relationships"
         ],
@@ -10274,6 +10396,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonRelationshipsById",
+        "summary": "DELETE /v1/admin/relationships/person-relationships/{id}",
         "tags": [
           "relationships"
         ],
@@ -10530,6 +10654,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomerSignals",
+        "summary": "GET /v1/admin/relationships/customer-signals",
         "tags": [
           "relationships"
         ],
@@ -10837,6 +10963,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsCustomerSignals",
+        "summary": "POST /v1/admin/relationships/customer-signals",
         "tags": [
           "relationships"
         ],
@@ -11017,6 +11145,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomerSignalsById",
+        "summary": "GET /v1/admin/relationships/customer-signals/{id}",
         "tags": [
           "relationships"
         ],
@@ -11325,6 +11455,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsCustomerSignalsById",
+        "summary": "PATCH /v1/admin/relationships/customer-signals/{id}",
         "tags": [
           "relationships"
         ],
@@ -11383,6 +11515,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsCustomerSignalsById",
+        "summary": "DELETE /v1/admin/relationships/customer-signals/{id}",
         "tags": [
           "relationships"
         ],
@@ -11600,6 +11734,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsCustomerSignalsByIdResolve",
+        "summary": "POST /v1/admin/relationships/customer-signals/{id}/resolve",
         "tags": [
           "relationships"
         ],
@@ -11765,6 +11901,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdSignals",
+        "summary": "GET /v1/admin/relationships/people/{id}/signals",
         "tags": [
           "relationships"
         ],
@@ -11983,6 +12121,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivities",
+        "summary": "GET /v1/admin/relationships/activities",
         "tags": [
           "relationships"
         ],
@@ -12181,6 +12321,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsActivities",
+        "summary": "POST /v1/admin/relationships/activities",
         "tags": [
           "relationships"
         ],
@@ -12319,6 +12461,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivitiesById",
+        "summary": "GET /v1/admin/relationships/activities/{id}",
         "tags": [
           "relationships"
         ],
@@ -12541,6 +12685,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsActivitiesById",
+        "summary": "PATCH /v1/admin/relationships/activities/{id}",
         "tags": [
           "relationships"
         ],
@@ -12599,6 +12745,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsActivitiesById",
+        "summary": "DELETE /v1/admin/relationships/activities/{id}",
         "tags": [
           "relationships"
         ],
@@ -12679,6 +12827,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivitiesByIdLinks",
+        "summary": "GET /v1/admin/relationships/activities/{id}/links",
         "tags": [
           "relationships"
         ],
@@ -12808,6 +12958,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsActivitiesByIdLinks",
+        "summary": "POST /v1/admin/relationships/activities/{id}/links",
         "tags": [
           "relationships"
         ],
@@ -12868,6 +13020,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsActivityLinksById",
+        "summary": "DELETE /v1/admin/relationships/activity-links/{id}",
         "tags": [
           "relationships"
         ],
@@ -12934,6 +13088,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivitiesByIdParticipants",
+        "summary": "GET /v1/admin/relationships/activities/{id}/participants",
         "tags": [
           "relationships"
         ],
@@ -13035,6 +13191,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsActivitiesByIdParticipants",
+        "summary": "POST /v1/admin/relationships/activities/{id}/participants",
         "tags": [
           "relationships"
         ],
@@ -13095,6 +13253,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsActivityParticipantsById",
+        "summary": "DELETE /v1/admin/relationships/activity-participants/{id}",
         "tags": [
           "relationships"
         ],
@@ -13260,6 +13420,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomFields",
+        "summary": "GET /v1/admin/relationships/custom-fields",
         "tags": [
           "relationships"
         ],
@@ -13466,6 +13628,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsCustomFields",
+        "summary": "POST /v1/admin/relationships/custom-fields",
         "tags": [
           "relationships"
         ],
@@ -13604,6 +13768,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomFieldsById",
+        "summary": "GET /v1/admin/relationships/custom-fields/{id}",
         "tags": [
           "relationships"
         ],
@@ -13807,6 +13973,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsCustomFieldsById",
+        "summary": "PATCH /v1/admin/relationships/custom-fields/{id}",
         "tags": [
           "relationships"
         ],
@@ -13865,6 +14033,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsCustomFieldsById",
+        "summary": "DELETE /v1/admin/relationships/custom-fields/{id}",
         "tags": [
           "relationships"
         ],
@@ -14045,6 +14215,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomFieldValues",
+        "summary": "GET /v1/admin/relationships/custom-field-values",
         "tags": [
           "relationships"
         ],
@@ -14264,6 +14436,8 @@
             }
           }
         },
+        "operationId": "putAdminRelationshipsCustomFieldsByIdValue",
+        "summary": "PUT /v1/admin/relationships/custom-fields/{id}/value",
         "tags": [
           "relationships"
         ],
@@ -14324,6 +14498,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsCustomFieldValuesById",
+        "summary": "DELETE /v1/admin/relationships/custom-field-values/{id}",
         "tags": [
           "relationships"
         ],

--- a/packages/openapi/spec/admin/sellability.json
+++ b/packages/openapi/spec/admin/sellability.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -282,6 +288,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityResolve",
+        "summary": "POST /v1/admin/sellability/resolve",
         "tags": [
           "sellability"
         ],
@@ -555,6 +563,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityResolveAndPersist",
+        "summary": "POST /v1/admin/sellability/resolve-and-persist",
         "tags": [
           "sellability"
         ],
@@ -791,6 +801,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilitySnapshots",
+        "summary": "GET /v1/admin/sellability/snapshots",
         "tags": [
           "sellability"
         ],
@@ -953,6 +965,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilitySnapshotsById",
+        "summary": "GET /v1/admin/sellability/snapshots/{id}",
         "tags": [
           "sellability"
         ],
@@ -1202,6 +1216,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilitySnapshotItems",
+        "summary": "GET /v1/admin/sellability/snapshot-items",
         "tags": [
           "sellability"
         ],
@@ -1457,6 +1473,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPolicies",
+        "summary": "GET /v1/admin/sellability/policies",
         "tags": [
           "sellability"
         ],
@@ -1708,6 +1726,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityPolicies",
+        "summary": "POST /v1/admin/sellability/policies",
         "tags": [
           "sellability"
         ],
@@ -1871,6 +1891,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPoliciesById",
+        "summary": "GET /v1/admin/sellability/policies/{id}",
         "tags": [
           "sellability"
         ],
@@ -2147,6 +2169,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityPoliciesById",
+        "summary": "PATCH /v1/admin/sellability/policies/{id}",
         "tags": [
           "sellability"
         ],
@@ -2202,6 +2226,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityPoliciesById",
+        "summary": "DELETE /v1/admin/sellability/policies/{id}",
         "tags": [
           "sellability"
         ],
@@ -2369,6 +2395,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPolicyResults",
+        "summary": "GET /v1/admin/sellability/policy-results",
         "tags": [
           "sellability"
         ],
@@ -2531,6 +2559,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityPolicyResults",
+        "summary": "POST /v1/admin/sellability/policy-results",
         "tags": [
           "sellability"
         ],
@@ -2647,6 +2677,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPolicyResultsById",
+        "summary": "GET /v1/admin/sellability/policy-results/{id}",
         "tags": [
           "sellability"
         ],
@@ -2834,6 +2866,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityPolicyResultsById",
+        "summary": "PATCH /v1/admin/sellability/policy-results/{id}",
         "tags": [
           "sellability"
         ],
@@ -2889,6 +2923,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityPolicyResultsById",
+        "summary": "DELETE /v1/admin/sellability/policy-results/{id}",
         "tags": [
           "sellability"
         ],
@@ -3054,6 +3090,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferRefreshRuns",
+        "summary": "GET /v1/admin/sellability/offer-refresh-runs",
         "tags": [
           "sellability"
         ],
@@ -3225,6 +3263,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityOfferRefreshRuns",
+        "summary": "POST /v1/admin/sellability/offer-refresh-runs",
         "tags": [
           "sellability"
         ],
@@ -3346,6 +3386,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferRefreshRunsById",
+        "summary": "GET /v1/admin/sellability/offer-refresh-runs/{id}",
         "tags": [
           "sellability"
         ],
@@ -3542,6 +3584,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityOfferRefreshRunsById",
+        "summary": "PATCH /v1/admin/sellability/offer-refresh-runs/{id}",
         "tags": [
           "sellability"
         ],
@@ -3597,6 +3641,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityOfferRefreshRunsById",
+        "summary": "DELETE /v1/admin/sellability/offer-refresh-runs/{id}",
         "tags": [
           "sellability"
         ],
@@ -3760,6 +3806,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferExpirationEvents",
+        "summary": "GET /v1/admin/sellability/offer-expiration-events",
         "tags": [
           "sellability"
         ],
@@ -3927,6 +3975,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityOfferExpirationEvents",
+        "summary": "POST /v1/admin/sellability/offer-expiration-events",
         "tags": [
           "sellability"
         ],
@@ -4047,6 +4097,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferExpirationEventsById",
+        "summary": "GET /v1/admin/sellability/offer-expiration-events/{id}",
         "tags": [
           "sellability"
         ],
@@ -4238,6 +4290,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityOfferExpirationEventsById",
+        "summary": "PATCH /v1/admin/sellability/offer-expiration-events/{id}",
         "tags": [
           "sellability"
         ],
@@ -4293,6 +4347,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityOfferExpirationEventsById",
+        "summary": "DELETE /v1/admin/sellability/offer-expiration-events/{id}",
         "tags": [
           "sellability"
         ],
@@ -4455,6 +4511,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityExplanations",
+        "summary": "GET /v1/admin/sellability/explanations",
         "tags": [
           "sellability"
         ],
@@ -4619,6 +4677,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityExplanations",
+        "summary": "POST /v1/admin/sellability/explanations",
         "tags": [
           "sellability"
         ],
@@ -4735,6 +4795,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityExplanationsById",
+        "summary": "GET /v1/admin/sellability/explanations/{id}",
         "tags": [
           "sellability"
         ],
@@ -4923,6 +4985,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityExplanationsById",
+        "summary": "PATCH /v1/admin/sellability/explanations/{id}",
         "tags": [
           "sellability"
         ],
@@ -4978,6 +5042,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityExplanationsById",
+        "summary": "DELETE /v1/admin/sellability/explanations/{id}",
         "tags": [
           "sellability"
         ],

--- a/packages/openapi/spec/admin/storefront.json
+++ b/packages/openapi/spec/admin/storefront.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -769,6 +775,8 @@
             }
           }
         },
+        "operationId": "getAdminStorefrontSettings",
+        "summary": "GET /v1/admin/storefront/settings",
         "tags": [
           "storefront"
         ],
@@ -1951,6 +1959,8 @@
             }
           }
         },
+        "operationId": "patchAdminStorefrontSettings",
+        "summary": "PATCH /v1/admin/storefront/settings",
         "tags": [
           "storefront"
         ],

--- a/packages/openapi/spec/admin/suppliers.json
+++ b/packages/openapi/spec/admin/suppliers.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -259,6 +265,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdContactPoints",
+        "summary": "GET /v1/admin/suppliers/{id}/contact-points",
         "tags": [
           "suppliers"
         ],
@@ -474,6 +482,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdContactPoints",
+        "summary": "POST /v1/admin/suppliers/{id}/contact-points",
         "tags": [
           "suppliers"
         ],
@@ -697,6 +707,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersContactPointsByContactPointId",
+        "summary": "PATCH /v1/admin/suppliers/contact-points/{contactPointId}",
         "tags": [
           "suppliers"
         ],
@@ -752,6 +764,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersContactPointsByContactPointId",
+        "summary": "DELETE /v1/admin/suppliers/contact-points/{contactPointId}",
         "tags": [
           "suppliers"
         ],
@@ -878,6 +892,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdContacts",
+        "summary": "GET /v1/admin/suppliers/{id}/contacts",
         "tags": [
           "suppliers"
         ],
@@ -1109,6 +1125,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdContacts",
+        "summary": "POST /v1/admin/suppliers/{id}/contacts",
         "tags": [
           "suppliers"
         ],
@@ -1349,6 +1367,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersContactsByContactId",
+        "summary": "PATCH /v1/admin/suppliers/contacts/{contactId}",
         "tags": [
           "suppliers"
         ],
@@ -1404,6 +1424,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersContactsByContactId",
+        "summary": "DELETE /v1/admin/suppliers/contacts/{contactId}",
         "tags": [
           "suppliers"
         ],
@@ -1573,6 +1595,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdAddresses",
+        "summary": "GET /v1/admin/suppliers/{id}/addresses",
         "tags": [
           "suppliers"
         ],
@@ -1877,6 +1901,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdAddresses",
+        "summary": "POST /v1/admin/suppliers/{id}/addresses",
         "tags": [
           "suppliers"
         ],
@@ -2193,6 +2219,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersAddressesByAddressId",
+        "summary": "PATCH /v1/admin/suppliers/addresses/{addressId}",
         "tags": [
           "suppliers"
         ],
@@ -2248,6 +2276,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersAddressesByAddressId",
+        "summary": "DELETE /v1/admin/suppliers/addresses/{addressId}",
         "tags": [
           "suppliers"
         ],
@@ -2368,6 +2398,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdServices",
+        "summary": "GET /v1/admin/suppliers/{id}/services",
         "tags": [
           "suppliers"
         ],
@@ -2587,6 +2619,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdServices",
+        "summary": "POST /v1/admin/suppliers/{id}/services",
         "tags": [
           "suppliers"
         ],
@@ -2812,6 +2846,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersByIdServicesByServiceId",
+        "summary": "PATCH /v1/admin/suppliers/{id}/services/{serviceId}",
         "tags": [
           "suppliers"
         ],
@@ -2875,6 +2911,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersByIdServicesByServiceId",
+        "summary": "DELETE /v1/admin/suppliers/{id}/services/{serviceId}",
         "tags": [
           "suppliers"
         ],
@@ -2999,6 +3037,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdServicesByServiceIdRates",
+        "summary": "GET /v1/admin/suppliers/{id}/services/{serviceId}/rates",
         "tags": [
           "suppliers"
         ],
@@ -3228,6 +3268,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdServicesByServiceIdRates",
+        "summary": "POST /v1/admin/suppliers/{id}/services/{serviceId}/rates",
         "tags": [
           "suppliers"
         ],
@@ -3461,6 +3503,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersByIdServicesByServiceIdRatesByRateId",
+        "summary": "PATCH /v1/admin/suppliers/{id}/services/{serviceId}/rates/{rateId}",
         "tags": [
           "suppliers"
         ],
@@ -3532,6 +3576,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersByIdServicesByServiceIdRatesByRateId",
+        "summary": "DELETE /v1/admin/suppliers/{id}/services/{serviceId}/rates/{rateId}",
         "tags": [
           "suppliers"
         ],
@@ -3598,6 +3644,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdNotes",
+        "summary": "GET /v1/admin/suppliers/{id}/notes",
         "tags": [
           "suppliers"
         ],
@@ -3715,6 +3763,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdNotes",
+        "summary": "POST /v1/admin/suppliers/{id}/notes",
         "tags": [
           "suppliers"
         ],
@@ -3804,6 +3854,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdAvailability",
+        "summary": "GET /v1/admin/suppliers/{id}/availability",
         "tags": [
           "suppliers"
         ],
@@ -3970,6 +4022,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdAvailability",
+        "summary": "POST /v1/admin/suppliers/{id}/availability",
         "tags": [
           "suppliers"
         ],
@@ -4074,6 +4128,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdContracts",
+        "summary": "GET /v1/admin/suppliers/{id}/contracts",
         "tags": [
           "suppliers"
         ],
@@ -4263,6 +4319,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdContracts",
+        "summary": "POST /v1/admin/suppliers/{id}/contracts",
         "tags": [
           "suppliers"
         ],
@@ -4459,6 +4517,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersByIdContractsByContractId",
+        "summary": "PATCH /v1/admin/suppliers/{id}/contracts/{contractId}",
         "tags": [
           "suppliers"
         ],
@@ -4522,6 +4582,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersByIdContractsByContractId",
+        "summary": "DELETE /v1/admin/suppliers/{id}/contracts/{contractId}",
         "tags": [
           "suppliers"
         ],
@@ -4635,6 +4697,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersAggregates",
+        "summary": "GET /v1/admin/suppliers/aggregates",
         "tags": [
           "suppliers"
         ],
@@ -4947,6 +5011,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliers",
+        "summary": "GET /v1/admin/suppliers",
         "tags": [
           "suppliers"
         ],
@@ -5334,6 +5400,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliers",
+        "summary": "POST /v1/admin/suppliers",
         "tags": [
           "suppliers"
         ],
@@ -5542,6 +5610,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersById",
+        "summary": "GET /v1/admin/suppliers/{id}",
         "tags": [
           "suppliers"
         ],
@@ -5953,6 +6023,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersById",
+        "summary": "PATCH /v1/admin/suppliers/{id}",
         "tags": [
           "suppliers"
         ],
@@ -6008,6 +6080,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersById",
+        "summary": "DELETE /v1/admin/suppliers/{id}",
         "tags": [
           "suppliers"
         ],

--- a/packages/openapi/spec/admin/trips.json
+++ b/packages/openapi/spec/admin/trips.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -188,6 +194,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsHealth",
+        "summary": "GET /v1/admin/trips/health",
         "tags": [
           "trips"
         ],
@@ -800,6 +808,8 @@
             }
           }
         },
+        "operationId": "getAdminTrips",
+        "summary": "GET /v1/admin/trips",
         "tags": [
           "trips"
         ],
@@ -1319,6 +1329,8 @@
             }
           }
         },
+        "operationId": "postAdminTrips",
+        "summary": "POST /v1/admin/trips",
         "tags": [
           "trips"
         ],
@@ -1778,6 +1790,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsByEnvelopeId",
+        "summary": "GET /v1/admin/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2105,6 +2119,8 @@
             }
           }
         },
+        "operationId": "patchAdminTripsByEnvelopeId",
+        "summary": "PATCH /v1/admin/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2476,6 +2492,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdReshop",
+        "summary": "POST /v1/admin/trips/{envelopeId}/reshop",
         "tags": [
           "trips"
         ],
@@ -2619,6 +2637,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsByEnvelopeIdSnapshots",
+        "summary": "GET /v1/admin/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2833,6 +2853,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdSnapshots",
+        "summary": "POST /v1/admin/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2992,6 +3014,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsSnapshotsBySnapshotId",
+        "summary": "GET /v1/admin/trips/snapshots/{snapshotId}",
         "tags": [
           "trips"
         ],
@@ -3418,6 +3442,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdComponents",
+        "summary": "POST /v1/admin/trips/{envelopeId}/components",
         "tags": [
           "trips"
         ],
@@ -3785,6 +3811,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdComponentsReorder",
+        "summary": "POST /v1/admin/trips/{envelopeId}/components/reorder",
         "tags": [
           "trips"
         ],
@@ -4206,6 +4234,8 @@
             }
           }
         },
+        "operationId": "patchAdminTripsComponentsByComponentId",
+        "summary": "PATCH /v1/admin/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4545,6 +4575,8 @@
             }
           }
         },
+        "operationId": "deleteAdminTripsComponentsByComponentId",
+        "summary": "DELETE /v1/admin/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4935,6 +4967,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsComponentsByComponentIdRefs",
+        "summary": "POST /v1/admin/trips/components/{componentId}/refs",
         "tags": [
           "trips"
         ],
@@ -5184,6 +5218,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdRequirements",
+        "summary": "POST /v1/admin/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5385,6 +5421,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsByEnvelopeIdRequirements",
+        "summary": "GET /v1/admin/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5758,6 +5796,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsRequirementsByRequirementIdCandidates",
+        "summary": "POST /v1/admin/trips/requirements/{requirementId}/candidates",
         "tags": [
           "trips"
         ],
@@ -6302,6 +6342,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsRequirementsByRequirementIdSelect",
+        "summary": "POST /v1/admin/trips/requirements/{requirementId}/select",
         "tags": [
           "trips"
         ],
@@ -6675,6 +6717,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsRequirementsByRequirementIdReshop",
+        "summary": "POST /v1/admin/trips/requirements/{requirementId}/reshop",
         "tags": [
           "trips"
         ],
@@ -7243,6 +7287,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdPrice",
+        "summary": "POST /v1/admin/trips/{envelopeId}/price",
         "tags": [
           "trips"
         ],
@@ -7809,6 +7855,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdReserve",
+        "summary": "POST /v1/admin/trips/{envelopeId}/reserve",
         "tags": [
           "trips"
         ],
@@ -8358,6 +8406,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdCheckout",
+        "summary": "POST /v1/admin/trips/{envelopeId}/checkout",
         "tags": [
           "trips"
         ],
@@ -8909,6 +8959,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdCancellationPreview",
+        "summary": "POST /v1/admin/trips/{envelopeId}/cancellation-preview",
         "tags": [
           "trips"
         ],
@@ -9465,6 +9517,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdCancelComponents",
+        "summary": "POST /v1/admin/trips/{envelopeId}/cancel-components",
         "tags": [
           "trips"
         ],

--- a/packages/openapi/spec/storefront/booking-requirements.json
+++ b/packages/openapi/spec/storefront/booking-requirements.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -360,6 +366,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingRequirementsProductsByProductIdTransportRequirements",
+        "summary": "GET /v1/public/booking-requirements/products/{productId}/transport-requirements",
         "tags": [
           "booking-requirements"
         ],

--- a/packages/openapi/spec/storefront/bookings.json
+++ b/packages/openapi/spec/storefront/bookings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -1139,6 +1145,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessions",
+        "summary": "POST /v1/public/bookings/sessions",
         "tags": [
           "bookings"
         ],
@@ -1791,6 +1799,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsSessionsBySessionId",
+        "summary": "GET /v1/public/bookings/sessions/{sessionId}",
         "tags": [
           "bookings"
         ],
@@ -2594,6 +2604,8 @@
             }
           }
         },
+        "operationId": "patchPublicBookingsSessionsBySessionId",
+        "summary": "PATCH /v1/public/bookings/sessions/{sessionId}",
         "tags": [
           "bookings"
         ],
@@ -2698,6 +2710,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsSessionsBySessionIdState",
+        "summary": "GET /v1/public/bookings/sessions/{sessionId}/state",
         "tags": [
           "bookings"
         ],
@@ -2836,6 +2850,8 @@
             }
           }
         },
+        "operationId": "putPublicBookingsSessionsBySessionIdState",
+        "summary": "PUT /v1/public/bookings/sessions/{sessionId}/state",
         "tags": [
           "bookings"
         ],
@@ -3722,6 +3738,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessionsBySessionIdReprice",
+        "summary": "POST /v1/public/bookings/sessions/{sessionId}/reprice",
         "tags": [
           "bookings"
         ],
@@ -4410,6 +4428,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessionsBySessionIdConfirm",
+        "summary": "POST /v1/public/bookings/sessions/{sessionId}/confirm",
         "tags": [
           "bookings"
         ],
@@ -5098,6 +5118,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessionsBySessionIdExpire",
+        "summary": "POST /v1/public/bookings/sessions/{sessionId}/expire",
         "tags": [
           "bookings"
         ],
@@ -5635,6 +5657,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsOverview",
+        "summary": "GET /v1/public/bookings/overview",
         "tags": [
           "bookings"
         ],
@@ -6175,6 +6199,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsGuestLookup",
+        "summary": "POST /v1/public/bookings/guest-lookup",
         "tags": [
           "bookings"
         ],

--- a/packages/openapi/spec/storefront/catalog.json
+++ b/packages/openapi/spec/storefront/catalog.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -683,6 +689,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogSearch",
+        "summary": "POST /v1/public/catalog/search",
         "tags": [
           "catalog"
         ],

--- a/packages/openapi/spec/storefront/customer-portal.json
+++ b/packages/openapi/spec/storefront/customer-portal.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -540,6 +546,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalMe",
+        "summary": "GET /v1/public/customer-portal/me",
         "tags": [
           "customer-portal"
         ],
@@ -1216,6 +1224,8 @@
             }
           }
         },
+        "operationId": "patchPublicCustomerPortalMe",
+        "summary": "PATCH /v1/public/customer-portal/me",
         "tags": [
           "customer-portal"
         ],
@@ -1328,6 +1338,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalMeDocuments",
+        "summary": "GET /v1/public/customer-portal/me/documents",
         "tags": [
           "customer-portal"
         ],
@@ -1531,6 +1543,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalMeDocuments",
+        "summary": "POST /v1/public/customer-portal/me/documents",
         "tags": [
           "customer-portal"
         ],
@@ -1668,6 +1682,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalMeDocumentsByIdSetPrimary",
+        "summary": "POST /v1/public/customer-portal/me/documents/{id}/set-primary",
         "tags": [
           "customer-portal"
         ],
@@ -1880,6 +1896,8 @@
             }
           }
         },
+        "operationId": "patchPublicCustomerPortalMeDocumentsById",
+        "summary": "PATCH /v1/public/customer-portal/me/documents/{id}",
         "tags": [
           "customer-portal"
         ],
@@ -1938,6 +1956,8 @@
             }
           }
         },
+        "operationId": "deletePublicCustomerPortalMeDocumentsById",
+        "summary": "DELETE /v1/public/customer-portal/me/documents/{id}",
         "tags": [
           "customer-portal"
         ],
@@ -3222,6 +3242,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalBootstrap",
+        "summary": "POST /v1/public/customer-portal/bootstrap",
         "tags": [
           "customer-portal"
         ],
@@ -3474,6 +3496,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalCompanions",
+        "summary": "GET /v1/public/customer-portal/companions",
         "tags": [
           "customer-portal"
         ],
@@ -3969,6 +3993,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalCompanions",
+        "summary": "POST /v1/public/customer-portal/companions",
         "tags": [
           "customer-portal"
         ],
@@ -4271,6 +4297,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalCompanionsImportBookingTravelers",
+        "summary": "POST /v1/public/customer-portal/companions/import-booking-travelers",
         "tags": [
           "customer-portal"
         ],
@@ -4793,6 +4821,8 @@
             }
           }
         },
+        "operationId": "patchPublicCustomerPortalCompanionsByCompanionId",
+        "summary": "PATCH /v1/public/customer-portal/companions/{companionId}",
         "tags": [
           "customer-portal"
         ],
@@ -4869,6 +4899,8 @@
             }
           }
         },
+        "operationId": "deletePublicCustomerPortalCompanionsByCompanionId",
+        "summary": "DELETE /v1/public/customer-portal/companions/{companionId}",
         "tags": [
           "customer-portal"
         ],
@@ -5019,6 +5051,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookings",
+        "summary": "GET /v1/public/customer-portal/bookings",
         "tags": [
           "customer-portal"
         ],
@@ -5743,6 +5777,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookingsByBookingId",
+        "summary": "GET /v1/public/customer-portal/bookings/{bookingId}",
         "tags": [
           "customer-portal"
         ],
@@ -5864,6 +5900,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookingsByBookingIdDocuments",
+        "summary": "GET /v1/public/customer-portal/bookings/{bookingId}/documents",
         "tags": [
           "customer-portal"
         ],
@@ -5995,6 +6033,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookingsByBookingIdBillingContact",
+        "summary": "GET /v1/public/customer-portal/bookings/{bookingId}/billing-contact",
         "tags": [
           "customer-portal"
         ],
@@ -6056,6 +6096,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalContactExists",
+        "summary": "GET /v1/public/customer-portal/contact-exists",
         "tags": [
           "customer-portal"
         ],
@@ -6121,6 +6163,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalContactExistsPhone",
+        "summary": "GET /v1/public/customer-portal/contact-exists/phone",
         "tags": [
           "customer-portal"
         ],

--- a/packages/openapi/spec/storefront/finance.json
+++ b/packages/openapi/spec/storefront/finance.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -304,6 +310,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceVouchersValidate",
+        "summary": "POST /v1/public/finance/vouchers/validate",
         "tags": [
           "finance"
         ],
@@ -505,6 +513,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceDocumentsByReference",
+        "summary": "GET /v1/public/finance/documents/by-reference",
         "tags": [
           "finance"
         ],
@@ -702,6 +712,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdDocuments",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/documents",
         "tags": [
           "finance"
         ],
@@ -911,6 +923,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdDocumentsByReference",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/documents/by-reference",
         "tags": [
           "finance"
         ],
@@ -1091,6 +1105,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdPayments",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/payments",
         "tags": [
           "finance"
         ],
@@ -1452,6 +1468,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdPaymentOptions",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/payment-options",
         "tags": [
           "finance"
         ],
@@ -1963,6 +1981,8 @@
             }
           }
         },
+        "operationId": "getPublicFinancePaymentSessionsBySessionId",
+        "summary": "GET /v1/public/finance/payment-sessions/{sessionId}",
         "tags": [
           "finance"
         ],
@@ -2877,6 +2897,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceBookingsByBookingIdPaymentSchedulesByScheduleIdPaymentSession",
+        "summary": "POST /v1/public/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -3791,6 +3813,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceBookingsByBookingIdGuaranteesByGuaranteeIdPaymentSession",
+        "summary": "POST /v1/public/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -4697,6 +4721,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceInvoicesByInvoiceIdPaymentSession",
+        "summary": "POST /v1/public/finance/invoices/{invoiceId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -4796,6 +4822,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceAccountantByTokenSummary",
+        "summary": "GET /v1/public/finance/accountant/{token}/summary",
         "tags": [
           "finance"
         ],
@@ -4872,6 +4900,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceAccountantByTokenInvoices",
+        "summary": "GET /v1/public/finance/accountant/{token}/invoices",
         "tags": [
           "finance"
         ],

--- a/packages/openapi/spec/storefront/legal.json
+++ b/packages/openapi/spec/storefront/legal.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -305,6 +311,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalContractsTemplatesDefault",
+        "summary": "GET /v1/public/legal/contracts/templates/default",
         "tags": [
           "legal"
         ],
@@ -400,6 +408,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesByIdPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/{id}/preview",
         "tags": [
           "legal"
         ],
@@ -495,6 +505,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesByIdRenderPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/{id}/render-preview",
         "tags": [
           "legal"
         ],
@@ -590,6 +602,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesBySlugBySlugPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/by-slug/{slug}/preview",
         "tags": [
           "legal"
         ],
@@ -685,6 +699,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesBySlugBySlugRenderPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/by-slug/{slug}/render-preview",
         "tags": [
           "legal"
         ],
@@ -862,6 +878,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalContractsById",
+        "summary": "GET /v1/public/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -1075,6 +1093,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsByIdSign",
+        "summary": "POST /v1/public/legal/contracts/{id}/sign",
         "tags": [
           "legal"
         ],
@@ -1267,6 +1287,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalPoliciesBySlug",
+        "summary": "GET /v1/public/legal/policies/{slug}",
         "tags": [
           "legal"
         ],
@@ -1608,6 +1630,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalPoliciesByIdAccept",
+        "summary": "POST /v1/public/legal/policies/{id}/accept",
         "tags": [
           "legal"
         ],
@@ -1925,6 +1949,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalTerms",
+        "summary": "GET /v1/public/legal/terms",
         "tags": [
           "legal"
         ],
@@ -2125,6 +2151,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalTermsById",
+        "summary": "GET /v1/public/legal/terms/{id}",
         "tags": [
           "legal"
         ],

--- a/packages/openapi/spec/storefront/markets.json
+++ b/packages/openapi/spec/storefront/markets.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -249,6 +255,8 @@
             }
           }
         },
+        "operationId": "getPublicMarkets",
+        "summary": "GET /v1/public/markets",
         "tags": [
           "markets"
         ],

--- a/packages/openapi/spec/storefront/operator-settings.json
+++ b/packages/openapi/spec/storefront/operator-settings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -224,6 +230,8 @@
             }
           }
         },
+        "operationId": "getPublicOperatorProfile",
+        "summary": "GET /v1/public/operator-profile",
         "tags": [
           "operator-settings"
         ],
@@ -307,6 +315,8 @@
             }
           }
         },
+        "operationId": "getPublicSettingsOperator",
+        "summary": "GET /v1/public/settings/operator",
         "tags": [
           "operator-settings"
         ],

--- a/packages/openapi/spec/storefront/pricing.json
+++ b/packages/openapi/spec/storefront/pricing.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -578,6 +584,8 @@
             }
           }
         },
+        "operationId": "getPublicPricingProductsByProductIdPricing",
+        "summary": "GET /v1/public/pricing/products/{productId}/pricing",
         "tags": [
           "pricing"
         ],

--- a/packages/openapi/spec/storefront/products.json
+++ b/packages/openapi/spec/storefront/products.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -229,6 +235,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsTags",
+        "summary": "GET /v1/public/products/tags",
         "tags": [
           "products"
         ],
@@ -347,6 +355,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsCategories",
+        "summary": "GET /v1/public/products/categories",
         "tags": [
           "products"
         ],
@@ -559,6 +569,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsDestinations",
+        "summary": "GET /v1/public/products/destinations",
         "tags": [
           "products"
         ],
@@ -1436,6 +1448,8 @@
             }
           }
         },
+        "operationId": "getPublicProducts",
+        "summary": "GET /v1/public/products",
         "tags": [
           "products"
         ],
@@ -2122,6 +2136,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsSlugBySlug",
+        "summary": "GET /v1/public/products/slug/{slug}",
         "tags": [
           "products"
         ],
@@ -2808,6 +2824,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsById",
+        "summary": "GET /v1/public/products/{id}",
         "tags": [
           "products"
         ],
@@ -2933,6 +2951,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByIdBrochure",
+        "summary": "GET /v1/public/products/{id}/brochure",
         "tags": [
           "products"
         ],

--- a/packages/openapi/spec/storefront/storefront-verification.json
+++ b/packages/openapi/spec/storefront/storefront-verification.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -331,6 +337,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationEmailStart",
+        "summary": "POST /v1/public/storefront-verification/email/start",
         "tags": [
           "storefront-verification"
         ],
@@ -522,6 +530,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationSmsStart",
+        "summary": "POST /v1/public/storefront-verification/sms/start",
         "tags": [
           "storefront-verification"
         ],
@@ -719,6 +729,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationEmailConfirm",
+        "summary": "POST /v1/public/storefront-verification/email/confirm",
         "tags": [
           "storefront-verification"
         ],
@@ -917,6 +929,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationSmsConfirm",
+        "summary": "POST /v1/public/storefront-verification/sms/confirm",
         "tags": [
           "storefront-verification"
         ],

--- a/packages/openapi/spec/storefront/storefront.json
+++ b/packages/openapi/spec/storefront/storefront.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -306,6 +312,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdOffers",
+        "summary": "GET /v1/public/products/{productId}/offers",
         "tags": [
           "storefront"
         ],
@@ -486,6 +494,8 @@
             }
           }
         },
+        "operationId": "getPublicOffersBySlug",
+        "summary": "GET /v1/public/offers/{slug}",
         "tags": [
           "storefront"
         ],
@@ -938,6 +948,8 @@
             }
           }
         },
+        "operationId": "postPublicOffersBySlugApply",
+        "summary": "POST /v1/public/offers/{slug}/apply",
         "tags": [
           "storefront"
         ],
@@ -1386,6 +1398,8 @@
             }
           }
         },
+        "operationId": "postPublicOffersRedeem",
+        "summary": "POST /v1/public/offers/redeem",
         "tags": [
           "storefront"
         ],
@@ -1682,6 +1696,8 @@
             }
           }
         },
+        "operationId": "postPublicLeads",
+        "summary": "POST /v1/public/leads",
         "tags": [
           "storefront"
         ],
@@ -1943,6 +1959,8 @@
             }
           }
         },
+        "operationId": "postPublicNewsletterSubscribe",
+        "summary": "POST /v1/public/newsletter/subscribe",
         "tags": [
           "storefront"
         ],
@@ -2571,6 +2589,8 @@
             }
           }
         },
+        "operationId": "getPublicSettings",
+        "summary": "GET /v1/public/settings",
         "tags": [
           "storefront"
         ],
@@ -2961,6 +2981,8 @@
             }
           }
         },
+        "operationId": "getPublicDeparturesByDepartureId",
+        "summary": "GET /v1/public/departures/{departureId}",
         "tags": [
           "storefront"
         ],
@@ -3406,6 +3428,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdDepartures",
+        "summary": "GET /v1/public/products/{productId}/departures",
         "tags": [
           "storefront"
         ],
@@ -3689,6 +3713,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdAvailability",
+        "summary": "GET /v1/public/products/{productId}/availability",
         "tags": [
           "storefront"
         ],
@@ -3834,6 +3860,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdDeparturesByDepartureIdItinerary",
+        "summary": "GET /v1/public/products/{productId}/departures/{departureId}/itinerary",
         "tags": [
           "storefront"
         ],
@@ -4115,6 +4143,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdExtensions",
+        "summary": "GET /v1/public/products/{productId}/extensions",
         "tags": [
           "storefront"
         ],

--- a/packages/openapi/spec/storefront/trips.json
+++ b/packages/openapi/spec/storefront/trips.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the Voyant framework's standard module composition. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -188,6 +194,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsHealth",
+        "summary": "GET /v1/public/trips/health",
         "tags": [
           "trips"
         ],
@@ -800,6 +808,8 @@
             }
           }
         },
+        "operationId": "getPublicTrips",
+        "summary": "GET /v1/public/trips",
         "tags": [
           "trips"
         ],
@@ -1319,6 +1329,8 @@
             }
           }
         },
+        "operationId": "postPublicTrips",
+        "summary": "POST /v1/public/trips",
         "tags": [
           "trips"
         ],
@@ -1778,6 +1790,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsByEnvelopeId",
+        "summary": "GET /v1/public/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2105,6 +2119,8 @@
             }
           }
         },
+        "operationId": "patchPublicTripsByEnvelopeId",
+        "summary": "PATCH /v1/public/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2476,6 +2492,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdReshop",
+        "summary": "POST /v1/public/trips/{envelopeId}/reshop",
         "tags": [
           "trips"
         ],
@@ -2619,6 +2637,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsByEnvelopeIdSnapshots",
+        "summary": "GET /v1/public/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2833,6 +2853,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdSnapshots",
+        "summary": "POST /v1/public/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2992,6 +3014,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsSnapshotsBySnapshotId",
+        "summary": "GET /v1/public/trips/snapshots/{snapshotId}",
         "tags": [
           "trips"
         ],
@@ -3418,6 +3442,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdComponents",
+        "summary": "POST /v1/public/trips/{envelopeId}/components",
         "tags": [
           "trips"
         ],
@@ -3785,6 +3811,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdComponentsReorder",
+        "summary": "POST /v1/public/trips/{envelopeId}/components/reorder",
         "tags": [
           "trips"
         ],
@@ -4206,6 +4234,8 @@
             }
           }
         },
+        "operationId": "patchPublicTripsComponentsByComponentId",
+        "summary": "PATCH /v1/public/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4545,6 +4575,8 @@
             }
           }
         },
+        "operationId": "deletePublicTripsComponentsByComponentId",
+        "summary": "DELETE /v1/public/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4935,6 +4967,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsComponentsByComponentIdRefs",
+        "summary": "POST /v1/public/trips/components/{componentId}/refs",
         "tags": [
           "trips"
         ],
@@ -5184,6 +5218,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdRequirements",
+        "summary": "POST /v1/public/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5385,6 +5421,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsByEnvelopeIdRequirements",
+        "summary": "GET /v1/public/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5758,6 +5796,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsRequirementsByRequirementIdCandidates",
+        "summary": "POST /v1/public/trips/requirements/{requirementId}/candidates",
         "tags": [
           "trips"
         ],
@@ -6302,6 +6342,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsRequirementsByRequirementIdSelect",
+        "summary": "POST /v1/public/trips/requirements/{requirementId}/select",
         "tags": [
           "trips"
         ],
@@ -6675,6 +6717,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsRequirementsByRequirementIdReshop",
+        "summary": "POST /v1/public/trips/requirements/{requirementId}/reshop",
         "tags": [
           "trips"
         ],
@@ -7243,6 +7287,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdPrice",
+        "summary": "POST /v1/public/trips/{envelopeId}/price",
         "tags": [
           "trips"
         ],
@@ -7809,6 +7855,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdReserve",
+        "summary": "POST /v1/public/trips/{envelopeId}/reserve",
         "tags": [
           "trips"
         ],
@@ -8358,6 +8406,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdCheckout",
+        "summary": "POST /v1/public/trips/{envelopeId}/checkout",
         "tags": [
           "trips"
         ],
@@ -8909,6 +8959,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdCancellationPreview",
+        "summary": "POST /v1/public/trips/{envelopeId}/cancellation-preview",
         "tags": [
           "trips"
         ],
@@ -9465,6 +9517,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdCancelComponents",
+        "summary": "POST /v1/public/trips/{envelopeId}/cancel-components",
         "tags": [
           "trips"
         ],

--- a/packages/openapi/src/generate.ts
+++ b/packages/openapi/src/generate.ts
@@ -58,6 +58,10 @@ const OPENAPI_OPTIONS: GenerateOpenApiOptions = {
     description:
       "Generated from the Voyant framework's standard module composition. Do not edit by hand.",
   },
+  // Relative server so Swagger/Scalar "try it out" targets whatever origin the
+  // deployment serves this contract from (voyant#2729). A deployment can
+  // override with a concrete host.
+  servers: [{ url: "/", description: "This deployment (same origin)" }],
 }
 
 export async function buildFrameworkOpenApiDocuments(): Promise<FrameworkOpenApiDocuments> {

--- a/starters/operator/openapi/admin/accommodations.json
+++ b/starters/operator/openapi/admin/accommodations.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -368,6 +374,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocks",
+        "summary": "POST /v1/admin/accommodations/room-blocks",
         "tags": [
           "accommodations"
         ],
@@ -605,6 +613,8 @@
             }
           }
         },
+        "operationId": "getAdminAccommodationsRoomBlocksById",
+        "summary": "GET /v1/admin/accommodations/room-blocks/{id}",
         "tags": [
           "accommodations"
         ],
@@ -773,6 +783,8 @@
             }
           }
         },
+        "operationId": "putAdminAccommodationsRoomBlocksByIdNights",
+        "summary": "PUT /v1/admin/accommodations/room-blocks/{id}/nights",
         "tags": [
           "accommodations"
         ],
@@ -1071,6 +1083,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocksByIdPickups",
+        "summary": "POST /v1/admin/accommodations/room-blocks/{id}/pickups",
         "tags": [
           "accommodations"
         ],
@@ -1224,6 +1238,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocksByIdPickupsReverse",
+        "summary": "POST /v1/admin/accommodations/room-blocks/{id}/pickups/reverse",
         "tags": [
           "accommodations"
         ],
@@ -1413,6 +1429,8 @@
             }
           }
         },
+        "operationId": "postAdminAccommodationsRoomBlocksByIdRelease",
+        "summary": "POST /v1/admin/accommodations/room-blocks/{id}/release",
         "tags": [
           "accommodations"
         ],

--- a/starters/operator/openapi/admin/action-ledger.json
+++ b/starters/operator/openapi/admin/action-ledger.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -906,6 +912,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedger",
+        "summary": "GET /v1/admin/action-ledger",
         "tags": [
           "action-ledger"
         ],
@@ -1671,6 +1679,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerEntries",
+        "summary": "GET /v1/admin/action-ledger/entries",
         "tags": [
           "action-ledger"
         ],
@@ -2544,6 +2554,8 @@
             }
           }
         },
+        "operationId": "postAdminActionLedgerEntriesByIdReversals",
+        "summary": "POST /v1/admin/action-ledger/entries/{id}/reversals",
         "tags": [
           "action-ledger"
         ],
@@ -3150,6 +3162,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerEntriesById",
+        "summary": "GET /v1/admin/action-ledger/entries/{id}",
         "tags": [
           "action-ledger"
         ],
@@ -3523,6 +3537,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerApprovals",
+        "summary": "GET /v1/admin/action-ledger/approvals",
         "tags": [
           "action-ledger"
         ],
@@ -4174,6 +4190,8 @@
             }
           }
         },
+        "operationId": "postAdminActionLedgerApprovalsRequest",
+        "summary": "POST /v1/admin/action-ledger/approvals/request",
         "tags": [
           "action-ledger"
         ],
@@ -4889,6 +4907,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerApprovalsById",
+        "summary": "GET /v1/admin/action-ledger/approvals/{id}",
         "tags": [
           "action-ledger"
         ],
@@ -5527,6 +5547,8 @@
             }
           }
         },
+        "operationId": "postAdminActionLedgerApprovalsByIdDecide",
+        "summary": "POST /v1/admin/action-ledger/approvals/{id}/decide",
         "tags": [
           "action-ledger"
         ],
@@ -5851,6 +5873,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerDelegations",
+        "summary": "GET /v1/admin/action-ledger/delegations",
         "tags": [
           "action-ledger"
         ],
@@ -5990,6 +6014,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerDelegationsById",
+        "summary": "GET /v1/admin/action-ledger/delegations/{id}",
         "tags": [
           "action-ledger"
         ],
@@ -6245,6 +6271,8 @@
             }
           }
         },
+        "operationId": "getAdminActionLedgerRelayOutbox",
+        "summary": "GET /v1/admin/action-ledger/relay-outbox",
         "tags": [
           "action-ledger"
         ],

--- a/starters/operator/openapi/admin/booking-requirements.json
+++ b/starters/operator/openapi/admin/booking-requirements.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -338,6 +344,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsContactRequirements",
+        "summary": "GET /v1/admin/booking-requirements/contact-requirements",
         "tags": [
           "booking-requirements"
         ],
@@ -538,6 +546,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsContactRequirements",
+        "summary": "POST /v1/admin/booking-requirements/contact-requirements",
         "tags": [
           "booking-requirements"
         ],
@@ -674,6 +684,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsContactRequirementsById",
+        "summary": "GET /v1/admin/booking-requirements/contact-requirements/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -898,6 +910,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsContactRequirementsById",
+        "summary": "PATCH /v1/admin/booking-requirements/contact-requirements/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -953,6 +967,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsContactRequirementsById",
+        "summary": "DELETE /v1/admin/booking-requirements/contact-requirements/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -1205,6 +1221,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestions",
+        "summary": "GET /v1/admin/booking-requirements/questions",
         "tags": [
           "booking-requirements"
         ],
@@ -1453,6 +1471,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsQuestions",
+        "summary": "POST /v1/admin/booking-requirements/questions",
         "tags": [
           "booking-requirements"
         ],
@@ -1613,6 +1633,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestionsById",
+        "summary": "GET /v1/admin/booking-requirements/questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -1885,6 +1907,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsQuestionsById",
+        "summary": "PATCH /v1/admin/booking-requirements/questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -1940,6 +1964,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsQuestionsById",
+        "summary": "DELETE /v1/admin/booking-requirements/questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2104,6 +2130,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionQuestions",
+        "summary": "GET /v1/admin/booking-requirements/option-questions",
         "tags": [
           "booking-requirements"
         ],
@@ -2238,6 +2266,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsOptionQuestions",
+        "summary": "POST /v1/admin/booking-requirements/option-questions",
         "tags": [
           "booking-requirements"
         ],
@@ -2341,6 +2371,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionQuestionsById",
+        "summary": "GET /v1/admin/booking-requirements/option-questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2499,6 +2531,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsOptionQuestionsById",
+        "summary": "PATCH /v1/admin/booking-requirements/option-questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2554,6 +2588,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsOptionQuestionsById",
+        "summary": "DELETE /v1/admin/booking-requirements/option-questions/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -2704,6 +2740,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestionOptions",
+        "summary": "GET /v1/admin/booking-requirements/question-options",
         "tags": [
           "booking-requirements"
         ],
@@ -2832,6 +2870,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsQuestionOptions",
+        "summary": "POST /v1/admin/booking-requirements/question-options",
         "tags": [
           "booking-requirements"
         ],
@@ -2929,6 +2969,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsQuestionOptionsById",
+        "summary": "GET /v1/admin/booking-requirements/question-options/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3080,6 +3122,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsQuestionOptionsById",
+        "summary": "PATCH /v1/admin/booking-requirements/question-options/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3135,6 +3179,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsQuestionOptionsById",
+        "summary": "DELETE /v1/admin/booking-requirements/question-options/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3297,6 +3343,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsUnitTriggers",
+        "summary": "GET /v1/admin/booking-requirements/unit-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -3429,6 +3477,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsUnitTriggers",
+        "summary": "POST /v1/admin/booking-requirements/unit-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -3530,6 +3580,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsUnitTriggersById",
+        "summary": "GET /v1/admin/booking-requirements/unit-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3686,6 +3738,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsUnitTriggersById",
+        "summary": "PATCH /v1/admin/booking-requirements/unit-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3741,6 +3795,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsUnitTriggersById",
+        "summary": "DELETE /v1/admin/booking-requirements/unit-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -3896,6 +3952,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionTriggers",
+        "summary": "GET /v1/admin/booking-requirements/option-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4014,6 +4072,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsOptionTriggers",
+        "summary": "POST /v1/admin/booking-requirements/option-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4108,6 +4168,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsOptionTriggersById",
+        "summary": "GET /v1/admin/booking-requirements/option-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4250,6 +4312,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsOptionTriggersById",
+        "summary": "PATCH /v1/admin/booking-requirements/option-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4305,6 +4369,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsOptionTriggersById",
+        "summary": "DELETE /v1/admin/booking-requirements/option-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4485,6 +4551,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsExtraTriggers",
+        "summary": "GET /v1/admin/booking-requirements/extra-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4635,6 +4703,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsExtraTriggers",
+        "summary": "POST /v1/admin/booking-requirements/extra-triggers",
         "tags": [
           "booking-requirements"
         ],
@@ -4746,6 +4816,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsExtraTriggersById",
+        "summary": "GET /v1/admin/booking-requirements/extra-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4921,6 +4993,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsExtraTriggersById",
+        "summary": "PATCH /v1/admin/booking-requirements/extra-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -4976,6 +5050,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsExtraTriggersById",
+        "summary": "DELETE /v1/admin/booking-requirements/extra-triggers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -5202,6 +5278,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsAnswers",
+        "summary": "GET /v1/admin/booking-requirements/answers",
         "tags": [
           "booking-requirements"
         ],
@@ -5425,6 +5503,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingRequirementsAnswers",
+        "summary": "POST /v1/admin/booking-requirements/answers",
         "tags": [
           "booking-requirements"
         ],
@@ -5575,6 +5655,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingRequirementsAnswersById",
+        "summary": "GET /v1/admin/booking-requirements/answers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -5822,6 +5904,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingRequirementsAnswersById",
+        "summary": "PATCH /v1/admin/booking-requirements/answers/{id}",
         "tags": [
           "booking-requirements"
         ],
@@ -5877,6 +5961,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingRequirementsAnswersById",
+        "summary": "DELETE /v1/admin/booking-requirements/answers/{id}",
         "tags": [
           "booking-requirements"
         ],

--- a/starters/operator/openapi/admin/bookings.json
+++ b/starters/operator/openapi/admin/bookings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -240,6 +246,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsPricingPreview",
+        "summary": "POST /v1/admin/bookings/pricing-preview",
         "tags": [
           "bookings"
         ],
@@ -487,6 +495,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsAggregates",
+        "summary": "GET /v1/admin/bookings/aggregates",
         "tags": [
           "bookings"
         ],
@@ -1006,6 +1016,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsOverview",
+        "summary": "GET /v1/admin/bookings/overview",
         "tags": [
           "bookings"
         ],
@@ -1097,6 +1109,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsSharingGroups",
+        "summary": "GET /v1/admin/bookings/sharing-groups",
         "tags": [
           "bookings"
         ],
@@ -1183,6 +1197,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsSharingGroupsByGroupIdTravelers",
+        "summary": "GET /v1/admin/bookings/sharing-groups/{groupId}/travelers",
         "tags": [
           "bookings"
         ],
@@ -1338,6 +1354,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdAllocations",
+        "summary": "GET /v1/admin/bookings/{id}/allocations",
         "tags": [
           "bookings"
         ],
@@ -1440,6 +1458,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdActivity",
+        "summary": "GET /v1/admin/bookings/{id}/activity",
         "tags": [
           "bookings"
         ],
@@ -1512,6 +1532,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdGroup",
+        "summary": "GET /v1/admin/bookings/{id}/group",
         "tags": [
           "bookings"
         ],
@@ -2436,6 +2458,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsReserve",
+        "summary": "POST /v1/admin/bookings/reserve",
         "tags": [
           "bookings"
         ],
@@ -2520,6 +2544,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsExpireStale",
+        "summary": "POST /v1/admin/bookings/expire-stale",
         "tags": [
           "bookings"
         ],
@@ -2981,6 +3007,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdConfirm",
+        "summary": "POST /v1/admin/bookings/{id}/confirm",
         "tags": [
           "bookings"
         ],
@@ -3416,6 +3444,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdExtendHold",
+        "summary": "POST /v1/admin/bookings/{id}/extend-hold",
         "tags": [
           "bookings"
         ],
@@ -3874,6 +3904,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdExpire",
+        "summary": "POST /v1/admin/bookings/{id}/expire",
         "tags": [
           "bookings"
         ],
@@ -4332,6 +4364,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdCancel",
+        "summary": "POST /v1/admin/bookings/{id}/cancel",
         "tags": [
           "bookings"
         ],
@@ -4790,6 +4824,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdStart",
+        "summary": "POST /v1/admin/bookings/{id}/start",
         "tags": [
           "bookings"
         ],
@@ -5248,6 +5284,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdComplete",
+        "summary": "POST /v1/admin/bookings/{id}/complete",
         "tags": [
           "bookings"
         ],
@@ -5734,6 +5772,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdOverrideStatus",
+        "summary": "POST /v1/admin/bookings/{id}/override-status",
         "tags": [
           "bookings"
         ],
@@ -5897,6 +5937,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdActionLedger",
+        "summary": "GET /v1/admin/bookings/{id}/action-ledger",
         "tags": [
           "bookings"
         ],
@@ -6089,6 +6131,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdActionApprovalsByApprovalIdDecide",
+        "summary": "POST /v1/admin/bookings/{id}/action-approvals/{approvalId}/decide",
         "tags": [
           "bookings"
         ],
@@ -6222,6 +6266,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdTravelers",
+        "summary": "GET /v1/admin/bookings/{id}/travelers",
         "tags": [
           "bookings"
         ],
@@ -6466,6 +6512,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdTravelers",
+        "summary": "POST /v1/admin/bookings/{id}/travelers",
         "tags": [
           "bookings"
         ],
@@ -6659,6 +6707,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdTravelersByTravelerIdReveal",
+        "summary": "GET /v1/admin/bookings/{id}/travelers/{travelerId}/reveal",
         "tags": [
           "bookings"
         ],
@@ -6755,6 +6805,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdTravelersByTravelerIdTravelDetails",
+        "summary": "GET /v1/admin/bookings/{id}/travelers/{travelerId}/travel-details",
         "tags": [
           "bookings"
         ],
@@ -6991,6 +7043,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdTravelersByTravelerIdTravelDetails",
+        "summary": "PATCH /v1/admin/bookings/{id}/travelers/{travelerId}/travel-details",
         "tags": [
           "bookings"
         ],
@@ -7090,6 +7144,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdTravelersByTravelerIdTravelDetails",
+        "summary": "DELETE /v1/admin/bookings/{id}/travelers/{travelerId}/travel-details",
         "tags": [
           "bookings"
         ],
@@ -7382,6 +7438,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdTravelersWithTravelDetails",
+        "summary": "POST /v1/admin/bookings/{id}/travelers/with-travel-details",
         "tags": [
           "bookings"
         ],
@@ -7678,6 +7736,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdTravelersByTravelerIdWithTravelDetails",
+        "summary": "PATCH /v1/admin/bookings/{id}/travelers/{travelerId}/with-travel-details",
         "tags": [
           "bookings"
         ],
@@ -7928,6 +7988,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdTravelersByTravelerId",
+        "summary": "PATCH /v1/admin/bookings/{id}/travelers/{travelerId}",
         "tags": [
           "bookings"
         ],
@@ -7991,6 +8053,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdTravelersByTravelerId",
+        "summary": "DELETE /v1/admin/bookings/{id}/travelers/{travelerId}",
         "tags": [
           "bookings"
         ],
@@ -8248,6 +8312,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdItems",
+        "summary": "GET /v1/admin/bookings/{id}/items",
         "tags": [
           "bookings"
         ],
@@ -8749,6 +8815,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdItems",
+        "summary": "POST /v1/admin/bookings/{id}/items",
         "tags": [
           "bookings"
         ],
@@ -9256,6 +9324,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdItemsByItemId",
+        "summary": "PATCH /v1/admin/bookings/{id}/items/{itemId}",
         "tags": [
           "bookings"
         ],
@@ -9337,6 +9407,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdItemsByItemId",
+        "summary": "DELETE /v1/admin/bookings/{id}/items/{itemId}",
         "tags": [
           "bookings"
         ],
@@ -9421,6 +9493,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdItemsByItemIdTravelers",
+        "summary": "GET /v1/admin/bookings/{id}/items/{itemId}/travelers",
         "tags": [
           "bookings"
         ],
@@ -9585,6 +9659,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdItemsByItemIdTravelers",
+        "summary": "POST /v1/admin/bookings/{id}/items/{itemId}/travelers",
         "tags": [
           "bookings"
         ],
@@ -9676,6 +9752,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdItemsByItemIdTravelersByLinkId",
+        "summary": "DELETE /v1/admin/bookings/{id}/items/{itemId}/travelers/{linkId}",
         "tags": [
           "bookings"
         ],
@@ -9802,6 +9880,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdSupplierStatuses",
+        "summary": "GET /v1/admin/bookings/{id}/supplier-statuses",
         "tags": [
           "bookings"
         ],
@@ -10020,6 +10100,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdSupplierStatuses",
+        "summary": "POST /v1/admin/bookings/{id}/supplier-statuses",
         "tags": [
           "bookings"
         ],
@@ -10249,6 +10331,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdSupplierStatusesByStatusId",
+        "summary": "PATCH /v1/admin/bookings/{id}/supplier-statuses/{statusId}",
         "tags": [
           "bookings"
         ],
@@ -10389,6 +10473,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdFulfillments",
+        "summary": "GET /v1/admin/bookings/{id}/fulfillments",
         "tags": [
           "bookings"
         ],
@@ -10650,6 +10736,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdFulfillments",
+        "summary": "POST /v1/admin/bookings/{id}/fulfillments",
         "tags": [
           "bookings"
         ],
@@ -10917,6 +11005,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdFulfillmentsByFulfillmentId",
+        "summary": "PATCH /v1/admin/bookings/{id}/fulfillments/{fulfillmentId}",
         "tags": [
           "bookings"
         ],
@@ -11025,6 +11115,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdRedemptions",
+        "summary": "GET /v1/admin/bookings/{id}/redemptions",
         "tags": [
           "bookings"
         ],
@@ -11227,6 +11319,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdRedemptions",
+        "summary": "POST /v1/admin/bookings/{id}/redemptions",
         "tags": [
           "bookings"
         ],
@@ -11293,6 +11387,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdNotes",
+        "summary": "GET /v1/admin/bookings/{id}/notes",
         "tags": [
           "bookings"
         ],
@@ -11411,6 +11507,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdNotes",
+        "summary": "POST /v1/admin/bookings/{id}/notes",
         "tags": [
           "bookings"
         ],
@@ -11539,6 +11637,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsByIdNotesByNoteId",
+        "summary": "PATCH /v1/admin/bookings/{id}/notes/{noteId}",
         "tags": [
           "bookings"
         ],
@@ -11602,6 +11702,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdNotesByNoteId",
+        "summary": "DELETE /v1/admin/bookings/{id}/notes/{noteId}",
         "tags": [
           "bookings"
         ],
@@ -11700,6 +11802,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdDocuments",
+        "summary": "GET /v1/admin/bookings/{id}/documents",
         "tags": [
           "bookings"
         ],
@@ -11884,6 +11988,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByIdDocuments",
+        "summary": "POST /v1/admin/bookings/{id}/documents",
         "tags": [
           "bookings"
         ],
@@ -11949,6 +12055,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsByIdDocumentsByDocumentId",
+        "summary": "DELETE /v1/admin/bookings/{id}/documents/{documentId}",
         "tags": [
           "bookings"
         ],
@@ -12124,6 +12232,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroups",
+        "summary": "GET /v1/admin/bookings/groups",
         "tags": [
           "bookings"
         ],
@@ -12282,6 +12392,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsGroups",
+        "summary": "POST /v1/admin/bookings/groups",
         "tags": [
           "bookings"
         ],
@@ -12432,6 +12544,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroupsById",
+        "summary": "GET /v1/admin/bookings/groups/{id}",
         "tags": [
           "bookings"
         ],
@@ -12615,6 +12729,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsGroupsById",
+        "summary": "PATCH /v1/admin/bookings/groups/{id}",
         "tags": [
           "bookings"
         ],
@@ -12670,6 +12786,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsGroupsById",
+        "summary": "DELETE /v1/admin/bookings/groups/{id}",
         "tags": [
           "bookings"
         ],
@@ -12740,6 +12858,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroupsByIdMembers",
+        "summary": "GET /v1/admin/bookings/groups/{id}/members",
         "tags": [
           "bookings"
         ],
@@ -12891,6 +13011,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsGroupsByIdMembers",
+        "summary": "POST /v1/admin/bookings/groups/{id}/members",
         "tags": [
           "bookings"
         ],
@@ -12956,6 +13078,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsGroupsByIdMembersByBookingId",
+        "summary": "DELETE /v1/admin/bookings/groups/{id}/members/{bookingId}",
         "tags": [
           "bookings"
         ],
@@ -13011,6 +13135,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsGroupsByIdTravelers",
+        "summary": "GET /v1/admin/bookings/groups/{id}/travelers",
         "tags": [
           "bookings"
         ],
@@ -13607,6 +13733,8 @@
             }
           }
         },
+        "operationId": "getAdminBookings",
+        "summary": "GET /v1/admin/bookings",
         "tags": [
           "bookings"
         ],
@@ -14357,6 +14485,8 @@
             }
           }
         },
+        "operationId": "postAdminBookings",
+        "summary": "POST /v1/admin/bookings",
         "tags": [
           "bookings"
         ],
@@ -15114,6 +15244,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsById",
+        "summary": "GET /v1/admin/bookings/{id}",
         "tags": [
           "bookings"
         ],
@@ -15892,6 +16024,8 @@
             }
           }
         },
+        "operationId": "patchAdminBookingsById",
+        "summary": "PATCH /v1/admin/bookings/{id}",
         "tags": [
           "bookings"
         ],
@@ -15947,6 +16081,8 @@
             }
           }
         },
+        "operationId": "deleteAdminBookingsById",
+        "summary": "DELETE /v1/admin/bookings/{id}",
         "tags": [
           "bookings"
         ],
@@ -16616,6 +16752,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsFromProduct",
+        "summary": "POST /v1/admin/bookings/from-product",
         "tags": [
           "bookings"
         ],
@@ -17540,6 +17678,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsCreate",
+        "summary": "POST /v1/admin/bookings/create",
         "tags": [
           "bookings"
         ],
@@ -19122,6 +19262,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsDualCreate",
+        "summary": "POST /v1/admin/bookings/dual-create",
         "tags": [
           "bookings"
         ],
@@ -19251,6 +19393,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByBookingIdPaymentScheduleRegenerate",
+        "summary": "POST /v1/admin/bookings/{bookingId}/payment-schedule/regenerate",
         "tags": [
           "bookings"
         ],

--- a/starters/operator/openapi/admin/catalog-booking.json
+++ b/starters/operator/openapi/admin/catalog-booking.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -1559,6 +1565,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogQuote",
+        "summary": "POST /v1/admin/catalog/quote",
         "tags": [
           "catalog-booking"
         ],
@@ -1939,6 +1947,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogBook",
+        "summary": "POST /v1/admin/catalog/book",
         "tags": [
           "catalog-booking"
         ],
@@ -2242,6 +2252,8 @@
             }
           }
         },
+        "operationId": "putAdminCatalogDraftsById",
+        "summary": "PUT /v1/admin/catalog/drafts/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -2389,6 +2401,8 @@
             }
           }
         },
+        "operationId": "getAdminCatalogDraftsById",
+        "summary": "GET /v1/admin/catalog/drafts/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -2411,6 +2425,8 @@
             "description": "Draft deleted (idempotent)"
           }
         },
+        "operationId": "deleteAdminCatalogDraftsById",
+        "summary": "DELETE /v1/admin/catalog/drafts/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -2606,6 +2622,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogHoldsPlace",
+        "summary": "POST /v1/admin/catalog/holds/place",
         "tags": [
           "catalog-booking"
         ],
@@ -2744,6 +2762,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogHoldsRelease",
+        "summary": "POST /v1/admin/catalog/holds/release",
         "tags": [
           "catalog-booking"
         ],
@@ -2819,6 +2839,8 @@
             }
           }
         },
+        "operationId": "getAdminCatalogOrders",
+        "summary": "GET /v1/admin/catalog/orders",
         "tags": [
           "catalog-booking"
         ],
@@ -2901,6 +2923,8 @@
             }
           }
         },
+        "operationId": "getAdminCatalogOrdersById",
+        "summary": "GET /v1/admin/catalog/orders/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -3091,6 +3115,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogOrdersByIdCancel",
+        "summary": "POST /v1/admin/catalog/orders/{id}/cancel",
         "tags": [
           "catalog-booking"
         ],
@@ -3229,6 +3255,8 @@
             }
           }
         },
+        "operationId": "getAdminCatalogSlots",
+        "summary": "GET /v1/admin/catalog/slots",
         "tags": [
           "catalog-booking"
         ],
@@ -3319,6 +3347,8 @@
             }
           }
         },
+        "operationId": "getAdminBookingsByIdCatalogSnapshot",
+        "summary": "GET /v1/admin/bookings/{id}/catalog-snapshot",
         "tags": [
           "catalog-booking"
         ],

--- a/starters/operator/openapi/admin/catalog-content.json
+++ b/starters/operator/openapi/admin/catalog-content.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -640,6 +646,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdContent",
+        "summary": "GET /v1/admin/products/{id}/content",
         "tags": [
           "catalog-content"
         ],

--- a/starters/operator/openapi/admin/catalog.json
+++ b/starters/operator/openapi/admin/catalog.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -683,6 +689,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogSearch",
+        "summary": "POST /v1/admin/catalog/search",
         "tags": [
           "catalog"
         ],
@@ -747,6 +755,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogPackageOffers",
+        "summary": "POST /v1/admin/catalog/package-offers",
         "tags": [
           "catalog"
         ],
@@ -829,6 +839,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogPackageDetail",
+        "summary": "POST /v1/admin/catalog/package-detail",
         "tags": [
           "catalog"
         ],
@@ -916,6 +928,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogPackageSearch",
+        "summary": "POST /v1/admin/catalog/package-search",
         "tags": [
           "catalog"
         ],
@@ -968,6 +982,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogDepartureAirports",
+        "summary": "POST /v1/admin/catalog/departure-airports",
         "tags": [
           "catalog"
         ],
@@ -1034,6 +1050,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogCruisePrice",
+        "summary": "POST /v1/admin/catalog/cruise-price",
         "tags": [
           "catalog"
         ],
@@ -1119,6 +1137,8 @@
             }
           }
         },
+        "operationId": "postAdminCatalogCruiseSailingPricing",
+        "summary": "POST /v1/admin/catalog/cruise-sailing-pricing",
         "tags": [
           "catalog"
         ],

--- a/starters/operator/openapi/admin/charters.json
+++ b/starters/operator/openapi/admin/charters.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -301,6 +307,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersProducts",
+        "summary": "GET /v1/admin/charters/products",
         "tags": [
           "charters"
         ],
@@ -632,6 +640,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersProducts",
+        "summary": "POST /v1/admin/charters/products",
         "tags": [
           "charters"
         ],
@@ -890,6 +900,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersProductsByKeyAggregatesRecompute",
+        "summary": "POST /v1/admin/charters/products/{key}/aggregates/recompute",
         "tags": [
           "charters"
         ],
@@ -978,6 +990,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersProductsByKeyVoyages",
+        "summary": "GET /v1/admin/charters/products/{key}/voyages",
         "tags": [
           "charters"
         ],
@@ -1069,6 +1083,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersProductsByKey",
+        "summary": "GET /v1/admin/charters/products/{key}",
         "tags": [
           "charters"
         ],
@@ -1325,6 +1341,8 @@
             }
           }
         },
+        "operationId": "putAdminChartersProductsByKey",
+        "summary": "PUT /v1/admin/charters/products/{key}",
         "tags": [
           "charters"
         ],
@@ -1581,6 +1599,8 @@
             }
           }
         },
+        "operationId": "deleteAdminChartersProductsByKey",
+        "summary": "DELETE /v1/admin/charters/products/{key}",
         "tags": [
           "charters"
         ],
@@ -1865,6 +1885,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersVoyages",
+        "summary": "GET /v1/admin/charters/voyages",
         "tags": [
           "charters"
         ],
@@ -2206,6 +2228,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersVoyages",
+        "summary": "POST /v1/admin/charters/voyages",
         "tags": [
           "charters"
         ],
@@ -2439,6 +2463,8 @@
             }
           }
         },
+        "operationId": "putAdminChartersVoyagesByKeySuitesBulk",
+        "summary": "PUT /v1/admin/charters/voyages/{key}/suites/bulk",
         "tags": [
           "charters"
         ],
@@ -2599,6 +2625,8 @@
             }
           }
         },
+        "operationId": "putAdminChartersVoyagesByKeyScheduleBulk",
+        "summary": "PUT /v1/admin/charters/voyages/{key}/schedule/bulk",
         "tags": [
           "charters"
         ],
@@ -2737,6 +2765,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersVoyagesByKeyQuotePerSuite",
+        "summary": "POST /v1/admin/charters/voyages/{key}/quote/per-suite",
         "tags": [
           "charters"
         ],
@@ -2809,6 +2839,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersVoyagesByKeyBookingsPerSuite",
+        "summary": "POST /v1/admin/charters/voyages/{key}/bookings/per-suite",
         "tags": [
           "charters"
         ],
@@ -2940,6 +2972,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersVoyagesByKeyQuoteWholeYacht",
+        "summary": "POST /v1/admin/charters/voyages/{key}/quote/whole-yacht",
         "tags": [
           "charters"
         ],
@@ -3012,6 +3046,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersVoyagesByKeyBookingsWholeYacht",
+        "summary": "POST /v1/admin/charters/voyages/{key}/bookings/whole-yacht",
         "tags": [
           "charters"
         ],
@@ -3103,6 +3139,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersVoyagesByKey",
+        "summary": "GET /v1/admin/charters/voyages/{key}",
         "tags": [
           "charters"
         ],
@@ -3350,6 +3388,8 @@
             }
           }
         },
+        "operationId": "putAdminChartersVoyagesByKey",
+        "summary": "PUT /v1/admin/charters/voyages/{key}",
         "tags": [
           "charters"
         ],
@@ -3493,6 +3533,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersBookingsByBookingIdMyba",
+        "summary": "POST /v1/admin/charters/bookings/{bookingId}/myba",
         "tags": [
           "charters"
         ],
@@ -3764,6 +3806,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersYachts",
+        "summary": "GET /v1/admin/charters/yachts",
         "tags": [
           "charters"
         ],
@@ -4115,6 +4159,8 @@
             }
           }
         },
+        "operationId": "postAdminChartersYachts",
+        "summary": "POST /v1/admin/charters/yachts",
         "tags": [
           "charters"
         ],
@@ -4206,6 +4252,8 @@
             }
           }
         },
+        "operationId": "getAdminChartersYachtsByKey",
+        "summary": "GET /v1/admin/charters/yachts/{key}",
         "tags": [
           "charters"
         ],
@@ -4460,6 +4508,8 @@
             }
           }
         },
+        "operationId": "putAdminChartersYachtsByKey",
+        "summary": "PUT /v1/admin/charters/yachts/{key}",
         "tags": [
           "charters"
         ],

--- a/starters/operator/openapi/admin/contract-document.json
+++ b/starters/operator/openapi/admin/contract-document.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -253,6 +259,8 @@
             }
           }
         },
+        "operationId": "postAdminBookingsByBookingIdGenerateContract",
+        "summary": "POST /v1/admin/bookings/{bookingId}/generate-contract",
         "tags": [
           "contract-document"
         ],

--- a/starters/operator/openapi/admin/cruises.json
+++ b/starters/operator/openapi/admin/cruises.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -311,6 +317,8 @@
             }
           }
         },
+        "operationId": "getAdminCruises",
+        "summary": "GET /v1/admin/cruises",
         "tags": [
           "cruises"
         ],
@@ -830,6 +838,8 @@
             }
           }
         },
+        "operationId": "postAdminCruises",
+        "summary": "POST /v1/admin/cruises",
         "tags": [
           "cruises"
         ],
@@ -1131,6 +1141,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesVoyageGroups",
+        "summary": "GET /v1/admin/cruises/voyage-groups",
         "tags": [
           "cruises"
         ],
@@ -1522,6 +1534,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesVoyageGroups",
+        "summary": "POST /v1/admin/cruises/voyage-groups",
         "tags": [
           "cruises"
         ],
@@ -1917,6 +1931,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesVoyageGroupsById",
+        "summary": "GET /v1/admin/cruises/voyage-groups/{id}",
         "tags": [
           "cruises"
         ],
@@ -2331,6 +2347,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesVoyageGroupsById",
+        "summary": "PUT /v1/admin/cruises/voyage-groups/{id}",
         "tags": [
           "cruises"
         ],
@@ -2566,6 +2584,8 @@
             }
           }
         },
+        "operationId": "deleteAdminCruisesVoyageGroupsById",
+        "summary": "DELETE /v1/admin/cruises/voyage-groups/{id}",
         "tags": [
           "cruises"
         ],
@@ -2850,6 +2870,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesVoyageGroupsByIdSegments",
+        "summary": "GET /v1/admin/cruises/voyage-groups/{id}/segments",
         "tags": [
           "cruises"
         ],
@@ -3197,6 +3219,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesVoyageGroupsByIdSegments",
+        "summary": "POST /v1/admin/cruises/voyage-groups/{id}/segments",
         "tags": [
           "cruises"
         ],
@@ -3560,6 +3584,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesVoyageGroupSegmentsBySegmentId",
+        "summary": "PUT /v1/admin/cruises/voyage-group-segments/{segmentId}",
         "tags": [
           "cruises"
         ],
@@ -3601,6 +3627,8 @@
             }
           }
         },
+        "operationId": "deleteAdminCruisesVoyageGroupSegmentsBySegmentId",
+        "summary": "DELETE /v1/admin/cruises/voyage-group-segments/{segmentId}",
         "tags": [
           "cruises"
         ],
@@ -3794,6 +3822,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesEnrichmentByProgramId",
+        "summary": "PUT /v1/admin/cruises/enrichment/{programId}",
         "tags": [
           "cruises"
         ],
@@ -3835,6 +3865,8 @@
             }
           }
         },
+        "operationId": "deleteAdminCruisesEnrichmentByProgramId",
+        "summary": "DELETE /v1/admin/cruises/enrichment/{programId}",
         "tags": [
           "cruises"
         ],
@@ -4082,6 +4114,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesSailings",
+        "summary": "GET /v1/admin/cruises/sailings",
         "tags": [
           "cruises"
         ],
@@ -4339,6 +4373,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesSailings",
+        "summary": "POST /v1/admin/cruises/sailings",
         "tags": [
           "cruises"
         ],
@@ -4430,6 +4466,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesSailingsByKey",
+        "summary": "GET /v1/admin/cruises/sailings/{key}",
         "tags": [
           "cruises"
         ],
@@ -4729,6 +4767,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesSailingsByKey",
+        "summary": "PUT /v1/admin/cruises/sailings/{key}",
         "tags": [
           "cruises"
         ],
@@ -4807,6 +4847,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesSailingsByKeyItinerary",
+        "summary": "GET /v1/admin/cruises/sailings/{key}/itinerary",
         "tags": [
           "cruises"
         ],
@@ -5102,6 +5144,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesSailingsByKeyDaysBulk",
+        "summary": "PUT /v1/admin/cruises/sailings/{key}/days/bulk",
         "tags": [
           "cruises"
         ],
@@ -5189,6 +5233,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesSailingsByKeyPricing",
+        "summary": "GET /v1/admin/cruises/sailings/{key}/pricing",
         "tags": [
           "cruises"
         ],
@@ -5656,6 +5702,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesSailingsByKeyPricingBulk",
+        "summary": "PUT /v1/admin/cruises/sailings/{key}/pricing/bulk",
         "tags": [
           "cruises"
         ],
@@ -5836,6 +5884,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesSailingsByKeyQuote",
+        "summary": "POST /v1/admin/cruises/sailings/{key}/quote",
         "tags": [
           "cruises"
         ],
@@ -6170,6 +6220,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesSailingsByKeyBookings",
+        "summary": "POST /v1/admin/cruises/sailings/{key}/bookings",
         "tags": [
           "cruises"
         ],
@@ -6242,6 +6294,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesSailingsByKeyPartyBookings",
+        "summary": "POST /v1/admin/cruises/sailings/{key}/party-bookings",
         "tags": [
           "cruises"
         ],
@@ -6548,6 +6602,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesPrices",
+        "summary": "GET /v1/admin/cruises/prices",
         "tags": [
           "cruises"
         ],
@@ -6915,6 +6971,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesPrices",
+        "summary": "POST /v1/admin/cruises/prices",
         "tags": [
           "cruises"
         ],
@@ -7306,6 +7364,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesPricesByPriceId",
+        "summary": "PUT /v1/admin/cruises/prices/{priceId}",
         "tags": [
           "cruises"
         ],
@@ -7571,6 +7631,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesShips",
+        "summary": "GET /v1/admin/cruises/ships",
         "tags": [
           "cruises"
         ],
@@ -7908,6 +7970,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesShips",
+        "summary": "POST /v1/admin/cruises/ships",
         "tags": [
           "cruises"
         ],
@@ -8180,6 +8244,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesShipsByKey",
+        "summary": "GET /v1/admin/cruises/ships/{key}",
         "tags": [
           "cruises"
         ],
@@ -8560,6 +8626,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesShipsByKey",
+        "summary": "PUT /v1/admin/cruises/ships/{key}",
         "tags": [
           "cruises"
         ],
@@ -8638,6 +8706,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesShipsByKeyDecks",
+        "summary": "GET /v1/admin/cruises/ships/{key}/decks",
         "tags": [
           "cruises"
         ],
@@ -8784,6 +8854,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesShipsByKeyDecks",
+        "summary": "POST /v1/admin/cruises/ships/{key}/decks",
         "tags": [
           "cruises"
         ],
@@ -8913,6 +8985,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesDecksByDeckId",
+        "summary": "PUT /v1/admin/cruises/decks/{deckId}",
         "tags": [
           "cruises"
         ],
@@ -8991,6 +9065,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesShipsByKeyCategories",
+        "summary": "GET /v1/admin/cruises/ships/{key}/categories",
         "tags": [
           "cruises"
         ],
@@ -9402,6 +9478,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesShipsByKeyCategoriesBulk",
+        "summary": "PUT /v1/admin/cruises/ships/{key}/categories/bulk",
         "tags": [
           "cruises"
         ],
@@ -9773,6 +9851,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesCategoriesByCategoryId",
+        "summary": "PUT /v1/admin/cruises/categories/{categoryId}",
         "tags": [
           "cruises"
         ],
@@ -9871,6 +9951,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesCategoriesByCategoryIdCabins",
+        "summary": "GET /v1/admin/cruises/categories/{categoryId}/cabins",
         "tags": [
           "cruises"
         ],
@@ -10028,6 +10110,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesCategoriesByCategoryIdCabinsBulk",
+        "summary": "PUT /v1/admin/cruises/categories/{categoryId}/cabins/bulk",
         "tags": [
           "cruises"
         ],
@@ -10190,6 +10274,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesCabinsByCabinId",
+        "summary": "PUT /v1/admin/cruises/cabins/{cabinId}",
         "tags": [
           "cruises"
         ],
@@ -10483,6 +10569,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesSearchIndexBulk",
+        "summary": "PUT /v1/admin/cruises/search-index/bulk",
         "tags": [
           "cruises"
         ],
@@ -10526,6 +10614,8 @@
             }
           }
         },
+        "operationId": "deleteAdminCruisesSearchIndexByCrsiId",
+        "summary": "DELETE /v1/admin/cruises/search-index/{crsiId}",
         "tags": [
           "cruises"
         ],
@@ -10590,6 +10680,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesSearchIndexRebuild",
+        "summary": "POST /v1/admin/cruises/search-index/rebuild",
         "tags": [
           "cruises"
         ],
@@ -10681,6 +10773,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesByKey",
+        "summary": "GET /v1/admin/cruises/{key}",
         "tags": [
           "cruises"
         ],
@@ -11243,6 +11337,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesByKey",
+        "summary": "PUT /v1/admin/cruises/{key}",
         "tags": [
           "cruises"
         ],
@@ -11608,6 +11704,8 @@
             }
           }
         },
+        "operationId": "deleteAdminCruisesByKey",
+        "summary": "DELETE /v1/admin/cruises/{key}",
         "tags": [
           "cruises"
         ],
@@ -11975,6 +12073,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesByKeyAggregatesRecompute",
+        "summary": "POST /v1/admin/cruises/{key}/aggregates/recompute",
         "tags": [
           "cruises"
         ],
@@ -12063,6 +12163,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesByKeySailings",
+        "summary": "GET /v1/admin/cruises/{key}/sailings",
         "tags": [
           "cruises"
         ],
@@ -12333,6 +12435,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesByKeyDaysBulk",
+        "summary": "PUT /v1/admin/cruises/{key}/days/bulk",
         "tags": [
           "cruises"
         ],
@@ -12424,6 +12528,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesByKeyRefresh",
+        "summary": "POST /v1/admin/cruises/{key}/refresh",
         "tags": [
           "cruises"
         ],
@@ -12772,6 +12878,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesByKeyDetach",
+        "summary": "POST /v1/admin/cruises/{key}/detach",
         "tags": [
           "cruises"
         ],
@@ -12913,6 +13021,8 @@
             }
           }
         },
+        "operationId": "getAdminCruisesByKeyEnrichment",
+        "summary": "GET /v1/admin/cruises/{key}/enrichment",
         "tags": [
           "cruises"
         ],
@@ -13105,6 +13215,8 @@
             }
           }
         },
+        "operationId": "postAdminCruisesByKeyEnrichment",
+        "summary": "POST /v1/admin/cruises/{key}/enrichment",
         "tags": [
           "cruises"
         ],
@@ -13313,6 +13425,8 @@
             }
           }
         },
+        "operationId": "putAdminCruisesByKeyEnrichmentBulk",
+        "summary": "PUT /v1/admin/cruises/{key}/enrichment/bulk",
         "tags": [
           "cruises"
         ],

--- a/starters/operator/openapi/admin/distribution.json
+++ b/starters/operator/openapi/admin/distribution.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -345,6 +351,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannels",
+        "summary": "GET /v1/admin/distribution/channels",
         "tags": [
           "distribution"
         ],
@@ -581,6 +589,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannels",
+        "summary": "POST /v1/admin/distribution/channels",
         "tags": [
           "distribution"
         ],
@@ -862,6 +872,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/channels/batch-update",
         "tags": [
           "distribution"
         ],
@@ -962,6 +974,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsBatchDelete",
+        "summary": "POST /v1/admin/distribution/channels/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -1122,6 +1136,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannelsById",
+        "summary": "GET /v1/admin/distribution/channels/{id}",
         "tags": [
           "distribution"
         ],
@@ -1382,6 +1398,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionChannelsById",
+        "summary": "PATCH /v1/admin/distribution/channels/{id}",
         "tags": [
           "distribution"
         ],
@@ -1440,6 +1458,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionChannelsById",
+        "summary": "DELETE /v1/admin/distribution/channels/{id}",
         "tags": [
           "distribution"
         ],
@@ -1565,6 +1585,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannelsByIdContactPoints",
+        "summary": "GET /v1/admin/distribution/channels/{id}/contact-points",
         "tags": [
           "distribution"
         ],
@@ -1769,6 +1791,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsByIdContactPoints",
+        "summary": "POST /v1/admin/distribution/channels/{id}/contact-points",
         "tags": [
           "distribution"
         ],
@@ -1981,6 +2005,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionChannelContactPointsByContactPointId",
+        "summary": "PATCH /v1/admin/distribution/channel-contact-points/{contactPointId}",
         "tags": [
           "distribution"
         ],
@@ -2039,6 +2065,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionChannelContactPointsByContactPointId",
+        "summary": "DELETE /v1/admin/distribution/channel-contact-points/{contactPointId}",
         "tags": [
           "distribution"
         ],
@@ -2171,6 +2199,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionChannelsByIdContacts",
+        "summary": "GET /v1/admin/distribution/channels/{id}/contacts",
         "tags": [
           "distribution"
         ],
@@ -2390,6 +2420,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionChannelsByIdContacts",
+        "summary": "POST /v1/admin/distribution/channels/{id}/contacts",
         "tags": [
           "distribution"
         ],
@@ -2618,6 +2650,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionChannelContactsByContactId",
+        "summary": "PATCH /v1/admin/distribution/channel-contacts/{contactId}",
         "tags": [
           "distribution"
         ],
@@ -2676,6 +2710,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionChannelContactsByContactId",
+        "summary": "DELETE /v1/admin/distribution/channel-contacts/{contactId}",
         "tags": [
           "distribution"
         ],
@@ -2888,6 +2924,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionContracts",
+        "summary": "GET /v1/admin/distribution/contracts",
         "tags": [
           "distribution"
         ],
@@ -3121,6 +3159,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionContracts",
+        "summary": "POST /v1/admin/distribution/contracts",
         "tags": [
           "distribution"
         ],
@@ -3399,6 +3439,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionContractsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/contracts/batch-update",
         "tags": [
           "distribution"
         ],
@@ -3499,6 +3541,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionContractsBatchDelete",
+        "summary": "POST /v1/admin/distribution/contracts/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -3668,6 +3712,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionContractsById",
+        "summary": "GET /v1/admin/distribution/contracts/{id}",
         "tags": [
           "distribution"
         ],
@@ -3925,6 +3971,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionContractsById",
+        "summary": "PATCH /v1/admin/distribution/contracts/{id}",
         "tags": [
           "distribution"
         ],
@@ -3983,6 +4031,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionContractsById",
+        "summary": "DELETE /v1/admin/distribution/contracts/{id}",
         "tags": [
           "distribution"
         ],
@@ -4170,6 +4220,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionCommissionRules",
+        "summary": "GET /v1/admin/distribution/commission-rules",
         "tags": [
           "distribution"
         ],
@@ -4384,6 +4436,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionCommissionRules",
+        "summary": "POST /v1/admin/distribution/commission-rules",
         "tags": [
           "distribution"
         ],
@@ -4642,6 +4696,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionCommissionRulesBatchUpdate",
+        "summary": "POST /v1/admin/distribution/commission-rules/batch-update",
         "tags": [
           "distribution"
         ],
@@ -4742,6 +4798,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionCommissionRulesBatchDelete",
+        "summary": "POST /v1/admin/distribution/commission-rules/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -4886,6 +4944,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionCommissionRulesById",
+        "summary": "GET /v1/admin/distribution/commission-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -5123,6 +5183,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionCommissionRulesById",
+        "summary": "PATCH /v1/admin/distribution/commission-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -5181,6 +5243,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionCommissionRulesById",
+        "summary": "DELETE /v1/admin/distribution/commission-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -5378,6 +5442,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionProductMappings",
+        "summary": "GET /v1/admin/distribution/product-mappings",
         "tags": [
           "distribution"
         ],
@@ -5598,6 +5664,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionProductMappings",
+        "summary": "POST /v1/admin/distribution/product-mappings",
         "tags": [
           "distribution"
         ],
@@ -5859,6 +5927,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionProductMappingsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/product-mappings/batch-update",
         "tags": [
           "distribution"
         ],
@@ -5959,6 +6029,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionProductMappingsBatchDelete",
+        "summary": "POST /v1/admin/distribution/product-mappings/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -6113,6 +6185,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionProductMappingsById",
+        "summary": "GET /v1/admin/distribution/product-mappings/{id}",
         "tags": [
           "distribution"
         ],
@@ -6353,6 +6427,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionProductMappingsById",
+        "summary": "PATCH /v1/admin/distribution/product-mappings/{id}",
         "tags": [
           "distribution"
         ],
@@ -6411,6 +6487,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionProductMappingsById",
+        "summary": "DELETE /v1/admin/distribution/product-mappings/{id}",
         "tags": [
           "distribution"
         ],
@@ -6621,6 +6699,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionBookingLinks",
+        "summary": "GET /v1/admin/distribution/booking-links",
         "tags": [
           "distribution"
         ],
@@ -6854,6 +6934,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionBookingLinks",
+        "summary": "POST /v1/admin/distribution/booking-links",
         "tags": [
           "distribution"
         ],
@@ -7114,6 +7196,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionBookingLinksBatchUpdate",
+        "summary": "POST /v1/admin/distribution/booking-links/batch-update",
         "tags": [
           "distribution"
         ],
@@ -7214,6 +7298,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionBookingLinksBatchDelete",
+        "summary": "POST /v1/admin/distribution/booking-links/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -7387,6 +7473,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionBookingLinksById",
+        "summary": "GET /v1/admin/distribution/booking-links/{id}",
         "tags": [
           "distribution"
         ],
@@ -7626,6 +7714,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionBookingLinksById",
+        "summary": "PATCH /v1/admin/distribution/booking-links/{id}",
         "tags": [
           "distribution"
         ],
@@ -7684,6 +7774,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionBookingLinksById",
+        "summary": "DELETE /v1/admin/distribution/booking-links/{id}",
         "tags": [
           "distribution"
         ],
@@ -7844,6 +7936,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionWebhookEvents",
+        "summary": "GET /v1/admin/distribution/webhook-events",
         "tags": [
           "distribution"
         ],
@@ -8013,6 +8107,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionWebhookEvents",
+        "summary": "POST /v1/admin/distribution/webhook-events",
         "tags": [
           "distribution"
         ],
@@ -8226,6 +8322,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionWebhookEventsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/webhook-events/batch-update",
         "tags": [
           "distribution"
         ],
@@ -8326,6 +8424,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionWebhookEventsBatchDelete",
+        "summary": "POST /v1/admin/distribution/webhook-events/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -8443,6 +8543,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionWebhookEventsById",
+        "summary": "GET /v1/admin/distribution/webhook-events/{id}",
         "tags": [
           "distribution"
         ],
@@ -8635,6 +8737,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionWebhookEventsById",
+        "summary": "PATCH /v1/admin/distribution/webhook-events/{id}",
         "tags": [
           "distribution"
         ],
@@ -8693,6 +8797,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionWebhookEventsById",
+        "summary": "DELETE /v1/admin/distribution/webhook-events/{id}",
         "tags": [
           "distribution"
         ],
@@ -8901,6 +9007,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotments",
+        "summary": "GET /v1/admin/distribution/inventory-allotments",
         "tags": [
           "distribution"
         ],
@@ -9108,6 +9216,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotments",
+        "summary": "POST /v1/admin/distribution/inventory-allotments",
         "tags": [
           "distribution"
         ],
@@ -9360,6 +9470,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/inventory-allotments/batch-update",
         "tags": [
           "distribution"
         ],
@@ -9460,6 +9572,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentsBatchDelete",
+        "summary": "POST /v1/admin/distribution/inventory-allotments/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -9601,6 +9715,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotmentsById",
+        "summary": "GET /v1/admin/distribution/inventory-allotments/{id}",
         "tags": [
           "distribution"
         ],
@@ -9832,6 +9948,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryAllotmentsById",
+        "summary": "PATCH /v1/admin/distribution/inventory-allotments/{id}",
         "tags": [
           "distribution"
         ],
@@ -9890,6 +10008,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryAllotmentsById",
+        "summary": "DELETE /v1/admin/distribution/inventory-allotments/{id}",
         "tags": [
           "distribution"
         ],
@@ -10080,6 +10200,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotmentTargets",
+        "summary": "GET /v1/admin/distribution/inventory-allotment-targets",
         "tags": [
           "distribution"
         ],
@@ -10267,6 +10389,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentTargets",
+        "summary": "POST /v1/admin/distribution/inventory-allotment-targets",
         "tags": [
           "distribution"
         ],
@@ -10500,6 +10624,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentTargetsBatchUpdate",
+        "summary": "POST /v1/admin/distribution/inventory-allotment-targets/batch-update",
         "tags": [
           "distribution"
         ],
@@ -10600,6 +10726,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryAllotmentTargetsBatchDelete",
+        "summary": "POST /v1/admin/distribution/inventory-allotment-targets/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -10730,6 +10858,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryAllotmentTargetsById",
+        "summary": "GET /v1/admin/distribution/inventory-allotment-targets/{id}",
         "tags": [
           "distribution"
         ],
@@ -10942,6 +11072,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryAllotmentTargetsById",
+        "summary": "PATCH /v1/admin/distribution/inventory-allotment-targets/{id}",
         "tags": [
           "distribution"
         ],
@@ -11000,6 +11132,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryAllotmentTargetsById",
+        "summary": "DELETE /v1/admin/distribution/inventory-allotment-targets/{id}",
         "tags": [
           "distribution"
         ],
@@ -11148,6 +11282,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseRules",
+        "summary": "GET /v1/admin/distribution/inventory-release-rules",
         "tags": [
           "distribution"
         ],
@@ -11306,6 +11442,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseRules",
+        "summary": "POST /v1/admin/distribution/inventory-release-rules",
         "tags": [
           "distribution"
         ],
@@ -11510,6 +11648,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseRulesBatchUpdate",
+        "summary": "POST /v1/admin/distribution/inventory-release-rules/batch-update",
         "tags": [
           "distribution"
         ],
@@ -11610,6 +11750,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseRulesBatchDelete",
+        "summary": "POST /v1/admin/distribution/inventory-release-rules/batch-delete",
         "tags": [
           "distribution"
         ],
@@ -11725,6 +11867,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseRulesById",
+        "summary": "GET /v1/admin/distribution/inventory-release-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -11908,6 +12052,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryReleaseRulesById",
+        "summary": "PATCH /v1/admin/distribution/inventory-release-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -11966,6 +12112,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryReleaseRulesById",
+        "summary": "DELETE /v1/admin/distribution/inventory-release-rules/{id}",
         "tags": [
           "distribution"
         ],
@@ -12169,6 +12317,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementRuns",
+        "summary": "GET /v1/admin/distribution/settlement-runs",
         "tags": [
           "distribution"
         ],
@@ -12411,6 +12561,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementRuns",
+        "summary": "POST /v1/admin/distribution/settlement-runs",
         "tags": [
           "distribution"
         ],
@@ -12570,6 +12722,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementRunsById",
+        "summary": "GET /v1/admin/distribution/settlement-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -12837,6 +12991,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementRunsById",
+        "summary": "PATCH /v1/admin/distribution/settlement-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -12895,6 +13051,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementRunsById",
+        "summary": "DELETE /v1/admin/distribution/settlement-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -13096,6 +13254,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementItems",
+        "summary": "GET /v1/admin/distribution/settlement-items",
         "tags": [
           "distribution"
         ],
@@ -13318,6 +13478,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementItems",
+        "summary": "POST /v1/admin/distribution/settlement-items",
         "tags": [
           "distribution"
         ],
@@ -13467,6 +13629,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementItemsById",
+        "summary": "GET /v1/admin/distribution/settlement-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -13714,6 +13878,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementItemsById",
+        "summary": "PATCH /v1/admin/distribution/settlement-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -13772,6 +13938,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementItemsById",
+        "summary": "DELETE /v1/admin/distribution/settlement-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -13959,6 +14127,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationRuns",
+        "summary": "GET /v1/admin/distribution/reconciliation-runs",
         "tags": [
           "distribution"
         ],
@@ -14172,6 +14342,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReconciliationRuns",
+        "summary": "POST /v1/admin/distribution/reconciliation-runs",
         "tags": [
           "distribution"
         ],
@@ -14316,6 +14488,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationRunsById",
+        "summary": "GET /v1/admin/distribution/reconciliation-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -14554,6 +14728,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReconciliationRunsById",
+        "summary": "PATCH /v1/admin/distribution/reconciliation-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -14612,6 +14788,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReconciliationRunsById",
+        "summary": "DELETE /v1/admin/distribution/reconciliation-runs/{id}",
         "tags": [
           "distribution"
         ],
@@ -14820,6 +14998,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationItems",
+        "summary": "GET /v1/admin/distribution/reconciliation-items",
         "tags": [
           "distribution"
         ],
@@ -15029,6 +15209,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReconciliationItems",
+        "summary": "POST /v1/admin/distribution/reconciliation-items",
         "tags": [
           "distribution"
         ],
@@ -15171,6 +15353,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationItemsById",
+        "summary": "GET /v1/admin/distribution/reconciliation-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -15405,6 +15589,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReconciliationItemsById",
+        "summary": "PATCH /v1/admin/distribution/reconciliation-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -15463,6 +15649,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReconciliationItemsById",
+        "summary": "DELETE /v1/admin/distribution/reconciliation-items/{id}",
         "tags": [
           "distribution"
         ],
@@ -15669,6 +15857,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseExecutions",
+        "summary": "GET /v1/admin/distribution/inventory-release-executions",
         "tags": [
           "distribution"
         ],
@@ -15887,6 +16077,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionInventoryReleaseExecutions",
+        "summary": "POST /v1/admin/distribution/inventory-release-executions",
         "tags": [
           "distribution"
         ],
@@ -16034,6 +16226,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionInventoryReleaseExecutionsById",
+        "summary": "GET /v1/admin/distribution/inventory-release-executions/{id}",
         "tags": [
           "distribution"
         ],
@@ -16277,6 +16471,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionInventoryReleaseExecutionsById",
+        "summary": "PATCH /v1/admin/distribution/inventory-release-executions/{id}",
         "tags": [
           "distribution"
         ],
@@ -16335,6 +16531,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionInventoryReleaseExecutionsById",
+        "summary": "DELETE /v1/admin/distribution/inventory-release-executions/{id}",
         "tags": [
           "distribution"
         ],
@@ -16534,6 +16732,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementPolicies",
+        "summary": "GET /v1/admin/distribution/settlement-policies",
         "tags": [
           "distribution"
         ],
@@ -16743,6 +16943,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementPolicies",
+        "summary": "POST /v1/admin/distribution/settlement-policies",
         "tags": [
           "distribution"
         ],
@@ -16885,6 +17087,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementPoliciesById",
+        "summary": "GET /v1/admin/distribution/settlement-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17119,6 +17323,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementPoliciesById",
+        "summary": "PATCH /v1/admin/distribution/settlement-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17177,6 +17383,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementPoliciesById",
+        "summary": "DELETE /v1/admin/distribution/settlement-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17370,6 +17578,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationPolicies",
+        "summary": "GET /v1/admin/distribution/reconciliation-policies",
         "tags": [
           "distribution"
         ],
@@ -17568,6 +17778,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReconciliationPolicies",
+        "summary": "POST /v1/admin/distribution/reconciliation-policies",
         "tags": [
           "distribution"
         ],
@@ -17704,6 +17916,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReconciliationPoliciesById",
+        "summary": "GET /v1/admin/distribution/reconciliation-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17927,6 +18141,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReconciliationPoliciesById",
+        "summary": "PATCH /v1/admin/distribution/reconciliation-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -17985,6 +18201,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReconciliationPoliciesById",
+        "summary": "DELETE /v1/admin/distribution/reconciliation-policies/{id}",
         "tags": [
           "distribution"
         ],
@@ -18152,6 +18370,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReleaseSchedules",
+        "summary": "GET /v1/admin/distribution/release-schedules",
         "tags": [
           "distribution"
         ],
@@ -18317,6 +18537,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionReleaseSchedules",
+        "summary": "POST /v1/admin/distribution/release-schedules",
         "tags": [
           "distribution"
         ],
@@ -18436,6 +18658,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionReleaseSchedulesById",
+        "summary": "GET /v1/admin/distribution/release-schedules/{id}",
         "tags": [
           "distribution"
         ],
@@ -18626,6 +18850,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionReleaseSchedulesById",
+        "summary": "PATCH /v1/admin/distribution/release-schedules/{id}",
         "tags": [
           "distribution"
         ],
@@ -18684,6 +18910,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionReleaseSchedulesById",
+        "summary": "DELETE /v1/admin/distribution/release-schedules/{id}",
         "tags": [
           "distribution"
         ],
@@ -18875,6 +19103,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionRemittanceExceptions",
+        "summary": "GET /v1/admin/distribution/remittance-exceptions",
         "tags": [
           "distribution"
         ],
@@ -19084,6 +19314,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionRemittanceExceptions",
+        "summary": "POST /v1/admin/distribution/remittance-exceptions",
         "tags": [
           "distribution"
         ],
@@ -19224,6 +19456,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionRemittanceExceptionsById",
+        "summary": "GET /v1/admin/distribution/remittance-exceptions/{id}",
         "tags": [
           "distribution"
         ],
@@ -19457,6 +19691,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionRemittanceExceptionsById",
+        "summary": "PATCH /v1/admin/distribution/remittance-exceptions/{id}",
         "tags": [
           "distribution"
         ],
@@ -19515,6 +19751,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionRemittanceExceptionsById",
+        "summary": "DELETE /v1/admin/distribution/remittance-exceptions/{id}",
         "tags": [
           "distribution"
         ],
@@ -19664,6 +19902,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementApprovals",
+        "summary": "GET /v1/admin/distribution/settlement-approvals",
         "tags": [
           "distribution"
         ],
@@ -19820,6 +20060,8 @@
             }
           }
         },
+        "operationId": "postAdminDistributionSettlementApprovals",
+        "summary": "POST /v1/admin/distribution/settlement-approvals",
         "tags": [
           "distribution"
         ],
@@ -19935,6 +20177,8 @@
             }
           }
         },
+        "operationId": "getAdminDistributionSettlementApprovalsById",
+        "summary": "GET /v1/admin/distribution/settlement-approvals/{id}",
         "tags": [
           "distribution"
         ],
@@ -20116,6 +20360,8 @@
             }
           }
         },
+        "operationId": "patchAdminDistributionSettlementApprovalsById",
+        "summary": "PATCH /v1/admin/distribution/settlement-approvals/{id}",
         "tags": [
           "distribution"
         ],
@@ -20174,6 +20420,8 @@
             }
           }
         },
+        "operationId": "deleteAdminDistributionSettlementApprovalsById",
+        "summary": "DELETE /v1/admin/distribution/settlement-approvals/{id}",
         "tags": [
           "distribution"
         ],

--- a/starters/operator/openapi/admin/external-refs.json
+++ b/starters/operator/openapi/admin/external-refs.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -352,6 +358,8 @@
             }
           }
         },
+        "operationId": "getAdminExternalRefsRefs",
+        "summary": "GET /v1/admin/external-refs/refs",
         "tags": [
           "external-refs"
         ],
@@ -555,6 +563,8 @@
             }
           }
         },
+        "operationId": "postAdminExternalRefsRefs",
+        "summary": "POST /v1/admin/external-refs/refs",
         "tags": [
           "external-refs"
         ],
@@ -687,6 +697,8 @@
             }
           }
         },
+        "operationId": "getAdminExternalRefsRefsById",
+        "summary": "GET /v1/admin/external-refs/refs/{id}",
         "tags": [
           "external-refs"
         ],
@@ -911,6 +923,8 @@
             }
           }
         },
+        "operationId": "patchAdminExternalRefsRefsById",
+        "summary": "PATCH /v1/admin/external-refs/refs/{id}",
         "tags": [
           "external-refs"
         ],
@@ -969,6 +983,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExternalRefsRefsById",
+        "summary": "DELETE /v1/admin/external-refs/refs/{id}",
         "tags": [
           "external-refs"
         ],
@@ -1196,6 +1212,8 @@
             }
           }
         },
+        "operationId": "getAdminExternalRefsEntitiesByEntityTypeByEntityIdRefs",
+        "summary": "GET /v1/admin/external-refs/entities/{entityType}/{entityId}/refs",
         "tags": [
           "external-refs"
         ],
@@ -1405,6 +1423,8 @@
             }
           }
         },
+        "operationId": "postAdminExternalRefsEntitiesByEntityTypeByEntityIdRefs",
+        "summary": "POST /v1/admin/external-refs/entities/{entityType}/{entityId}/refs",
         "tags": [
           "external-refs"
         ],

--- a/starters/operator/openapi/admin/extras.json
+++ b/starters/operator/openapi/admin/extras.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -390,6 +396,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasProductExtras",
+        "summary": "GET /v1/admin/extras/product-extras",
         "tags": [
           "extras"
         ],
@@ -679,6 +687,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasProductExtras",
+        "summary": "POST /v1/admin/extras/product-extras",
         "tags": [
           "extras"
         ],
@@ -859,6 +869,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasProductExtrasById",
+        "summary": "GET /v1/admin/extras/product-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -1172,6 +1184,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasProductExtrasById",
+        "summary": "PATCH /v1/admin/extras/product-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -1227,6 +1241,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExtrasProductExtrasById",
+        "summary": "DELETE /v1/admin/extras/product-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -1454,6 +1470,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasOptionExtraConfigs",
+        "summary": "GET /v1/admin/extras/option-extra-configs",
         "tags": [
           "extras"
         ],
@@ -1711,6 +1729,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasOptionExtraConfigs",
+        "summary": "POST /v1/admin/extras/option-extra-configs",
         "tags": [
           "extras"
         ],
@@ -1877,6 +1897,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasOptionExtraConfigsById",
+        "summary": "GET /v1/admin/extras/option-extra-configs/{id}",
         "tags": [
           "extras"
         ],
@@ -2158,6 +2180,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasOptionExtraConfigsById",
+        "summary": "PATCH /v1/admin/extras/option-extra-configs/{id}",
         "tags": [
           "extras"
         ],
@@ -2213,6 +2237,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExtrasOptionExtraConfigsById",
+        "summary": "DELETE /v1/admin/extras/option-extra-configs/{id}",
         "tags": [
           "extras"
         ],
@@ -2470,6 +2496,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasBookingExtras",
+        "summary": "GET /v1/admin/extras/booking-extras",
         "tags": [
           "extras"
         ],
@@ -2775,6 +2803,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasBookingExtras",
+        "summary": "POST /v1/admin/extras/booking-extras",
         "tags": [
           "extras"
         ],
@@ -2962,6 +2992,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasBookingExtrasById",
+        "summary": "GET /v1/admin/extras/booking-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -3290,6 +3322,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasBookingExtrasById",
+        "summary": "PATCH /v1/admin/extras/booking-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -3345,6 +3379,8 @@
             }
           }
         },
+        "operationId": "deleteAdminExtrasBookingExtrasById",
+        "summary": "DELETE /v1/admin/extras/booking-extras/{id}",
         "tags": [
           "extras"
         ],
@@ -3897,6 +3933,8 @@
             }
           }
         },
+        "operationId": "getAdminExtrasSlotManifestsBySlotId",
+        "summary": "GET /v1/admin/extras/slot-manifests/{slotId}",
         "tags": [
           "extras"
         ],
@@ -4176,6 +4214,8 @@
             }
           }
         },
+        "operationId": "patchAdminExtrasSlotManifestsBySlotIdSelections",
+        "summary": "PATCH /v1/admin/extras/slot-manifests/{slotId}/selections",
         "tags": [
           "extras"
         ],
@@ -4471,6 +4511,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasSlotManifestsBySlotIdSelectionsBulk",
+        "summary": "POST /v1/admin/extras/slot-manifests/{slotId}/selections/bulk",
         "tags": [
           "extras"
         ],
@@ -4731,6 +4773,8 @@
             }
           }
         },
+        "operationId": "postAdminExtrasSlotManifestsBySlotIdCollectionsBulk",
+        "summary": "POST /v1/admin/extras/slot-manifests/{slotId}/collections/bulk",
         "tags": [
           "extras"
         ],

--- a/starters/operator/openapi/admin/finance.json
+++ b/starters/operator/openapi/admin/finance.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -647,6 +653,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentSessions",
+        "summary": "GET /v1/admin/finance/payment-sessions",
         "tags": [
           "finance"
         ],
@@ -1533,6 +1541,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessions",
+        "summary": "POST /v1/admin/finance/payment-sessions",
         "tags": [
           "finance"
         ],
@@ -1900,6 +1910,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentSessionsById",
+        "summary": "GET /v1/admin/finance/payment-sessions/{id}",
         "tags": [
           "finance"
         ],
@@ -2810,6 +2822,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentSessionsById",
+        "summary": "PATCH /v1/admin/finance/payment-sessions/{id}",
         "tags": [
           "finance"
         ],
@@ -3290,6 +3304,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdRequiresRedirect",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/requires-redirect",
         "tags": [
           "finance"
         ],
@@ -3710,6 +3726,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdComplete",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/complete",
         "tags": [
           "finance"
         ],
@@ -4078,6 +4096,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdFail",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/fail",
         "tags": [
           "finance"
         ],
@@ -4446,6 +4466,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdCancel",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/cancel",
         "tags": [
           "finance"
         ],
@@ -4814,6 +4836,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentSessionsByIdExpire",
+        "summary": "POST /v1/admin/finance/payment-sessions/{id}/expire",
         "tags": [
           "finance"
         ],
@@ -5143,6 +5167,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentInstruments",
+        "summary": "GET /v1/admin/finance/payment-instruments",
         "tags": [
           "finance"
         ],
@@ -5531,6 +5557,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentInstruments",
+        "summary": "POST /v1/admin/finance/payment-instruments",
         "tags": [
           "finance"
         ],
@@ -5758,6 +5786,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentInstrumentsById",
+        "summary": "GET /v1/admin/finance/payment-instruments/{id}",
         "tags": [
           "finance"
         ],
@@ -6170,6 +6200,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentInstrumentsById",
+        "summary": "PATCH /v1/admin/finance/payment-instruments/{id}",
         "tags": [
           "finance"
         ],
@@ -6225,6 +6257,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentInstrumentsById",
+        "summary": "DELETE /v1/admin/finance/payment-instruments/{id}",
         "tags": [
           "finance"
         ],
@@ -6484,6 +6518,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentAuthorizations",
+        "summary": "GET /v1/admin/finance/payment-authorizations",
         "tags": [
           "finance"
         ],
@@ -7020,6 +7056,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentAuthorizations",
+        "summary": "POST /v1/admin/finance/payment-authorizations",
         "tags": [
           "finance"
         ],
@@ -7206,6 +7244,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentAuthorizationsById",
+        "summary": "GET /v1/admin/finance/payment-authorizations/{id}",
         "tags": [
           "finance"
         ],
@@ -7766,6 +7806,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentAuthorizationsById",
+        "summary": "PATCH /v1/admin/finance/payment-authorizations/{id}",
         "tags": [
           "finance"
         ],
@@ -7821,6 +7863,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentAuthorizationsById",
+        "summary": "DELETE /v1/admin/finance/payment-authorizations/{id}",
         "tags": [
           "finance"
         ],
@@ -8006,6 +8050,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentCaptures",
+        "summary": "GET /v1/admin/finance/payment-captures",
         "tags": [
           "finance"
         ],
@@ -8215,6 +8261,8 @@
             }
           }
         },
+        "operationId": "postAdminFinancePaymentCaptures",
+        "summary": "POST /v1/admin/finance/payment-captures",
         "tags": [
           "finance"
         ],
@@ -8356,6 +8404,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentCapturesById",
+        "summary": "GET /v1/admin/finance/payment-captures/{id}",
         "tags": [
           "finance"
         ],
@@ -8589,6 +8639,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentCapturesById",
+        "summary": "PATCH /v1/admin/finance/payment-captures/{id}",
         "tags": [
           "finance"
         ],
@@ -8644,6 +8696,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentCapturesById",
+        "summary": "DELETE /v1/admin/finance/payment-captures/{id}",
         "tags": [
           "finance"
         ],
@@ -8712,6 +8766,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsRevenue",
+        "summary": "GET /v1/admin/finance/reports/revenue",
         "tags": [
           "finance"
         ],
@@ -8770,6 +8826,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsAging",
+        "summary": "GET /v1/admin/finance/reports/aging",
         "tags": [
           "finance"
         ],
@@ -8853,6 +8911,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitability",
+        "summary": "GET /v1/admin/finance/reports/profitability",
         "tags": [
           "finance"
         ],
@@ -9171,6 +9231,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityDepartures",
+        "summary": "GET /v1/admin/finance/reports/profitability/departures",
         "tags": [
           "finance"
         ],
@@ -9439,6 +9501,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityProducts",
+        "summary": "GET /v1/admin/finance/reports/profitability/products",
         "tags": [
           "finance"
         ],
@@ -9558,6 +9622,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityTravelers",
+        "summary": "GET /v1/admin/finance/reports/profitability/travelers",
         "tags": [
           "finance"
         ],
@@ -9629,6 +9695,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityDeparturesExport",
+        "summary": "GET /v1/admin/finance/reports/profitability/departures/export",
         "tags": [
           "finance"
         ],
@@ -9684,6 +9752,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceReportsProfitabilityProductsExport",
+        "summary": "GET /v1/admin/finance/reports/profitability/products/export",
         "tags": [
           "finance"
         ],
@@ -9760,6 +9830,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceCostCategories",
+        "summary": "GET /v1/admin/finance/cost-categories",
         "tags": [
           "finance"
         ],
@@ -9857,6 +9929,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceCostCategories",
+        "summary": "POST /v1/admin/finance/cost-categories",
         "tags": [
           "finance"
         ],
@@ -9984,6 +10058,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceCostCategoriesById",
+        "summary": "PATCH /v1/admin/finance/cost-categories/{id}",
         "tags": [
           "finance"
         ],
@@ -10064,6 +10140,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceAccountantShares",
+        "summary": "GET /v1/admin/finance/accountant-shares",
         "tags": [
           "finance"
         ],
@@ -10175,6 +10253,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceAccountantShares",
+        "summary": "POST /v1/admin/finance/accountant-shares",
         "tags": [
           "finance"
         ],
@@ -10240,6 +10320,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceAccountantSharesByIdRevoke",
+        "summary": "POST /v1/admin/finance/accountant-shares/{id}/revoke",
         "tags": [
           "finance"
         ],
@@ -10351,6 +10433,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingsByBookingIdPaymentSchedules",
+        "summary": "GET /v1/admin/finance/bookings/{bookingId}/payment-schedules",
         "tags": [
           "finance"
         ],
@@ -10594,6 +10678,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdPaymentSchedules",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/payment-schedules",
         "tags": [
           "finance"
         ],
@@ -10807,6 +10893,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdPaymentSchedulesDefaultPlan",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/payment-schedules/default-plan",
         "tags": [
           "finance"
         ],
@@ -11055,6 +11143,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingsByBookingIdPaymentSchedulesByScheduleId",
+        "summary": "PATCH /v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}",
         "tags": [
           "finance"
         ],
@@ -11118,6 +11208,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingsByBookingIdPaymentSchedulesByScheduleId",
+        "summary": "DELETE /v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}",
         "tags": [
           "finance"
         ],
@@ -11901,6 +11993,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdPaymentSchedulesByScheduleIdPaymentSession",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -12073,6 +12167,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingsByBookingIdGuarantees",
+        "summary": "GET /v1/admin/finance/bookings/{bookingId}/guarantees",
         "tags": [
           "finance"
         ],
@@ -12393,6 +12489,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdGuarantees",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/guarantees",
         "tags": [
           "finance"
         ],
@@ -13176,6 +13274,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingsByBookingIdGuaranteesByGuaranteeIdPaymentSession",
+        "summary": "POST /v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -13503,6 +13603,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingsByBookingIdGuaranteesByGuaranteeId",
+        "summary": "PATCH /v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}",
         "tags": [
           "finance"
         ],
@@ -13592,6 +13694,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingsByBookingIdGuaranteesByGuaranteeId",
+        "summary": "DELETE /v1/admin/finance/bookings/{bookingId}/guarantees/{guaranteeId}",
         "tags": [
           "finance"
         ],
@@ -13711,6 +13815,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingItemsByBookingItemIdTaxLines",
+        "summary": "GET /v1/admin/finance/booking-items/{bookingItemId}/tax-lines",
         "tags": [
           "finance"
         ],
@@ -13938,6 +14044,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingItemsByBookingItemIdTaxLines",
+        "summary": "POST /v1/admin/finance/booking-items/{bookingItemId}/tax-lines",
         "tags": [
           "finance"
         ],
@@ -14170,6 +14278,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingItemsByBookingItemIdTaxLinesByTaxLineId",
+        "summary": "PATCH /v1/admin/finance/booking-items/{bookingItemId}/tax-lines/{taxLineId}",
         "tags": [
           "finance"
         ],
@@ -14233,6 +14343,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingItemsByBookingItemIdTaxLinesByTaxLineId",
+        "summary": "DELETE /v1/admin/finance/booking-items/{bookingItemId}/tax-lines/{taxLineId}",
         "tags": [
           "finance"
         ],
@@ -14378,6 +14490,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingItemsByBookingItemIdCommissions",
+        "summary": "GET /v1/admin/finance/booking-items/{bookingItemId}/commissions",
         "tags": [
           "finance"
         ],
@@ -14656,6 +14770,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceBookingItemsByBookingItemIdCommissions",
+        "summary": "POST /v1/admin/finance/booking-items/{bookingItemId}/commissions",
         "tags": [
           "finance"
         ],
@@ -14939,6 +15055,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceBookingItemsByBookingItemIdCommissionsByCommissionId",
+        "summary": "PATCH /v1/admin/finance/booking-items/{bookingItemId}/commissions/{commissionId}",
         "tags": [
           "finance"
         ],
@@ -15002,6 +15120,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceBookingItemsByBookingItemIdCommissionsByCommissionId",
+        "summary": "DELETE /v1/admin/finance/booking-items/{bookingItemId}/commissions/{commissionId}",
         "tags": [
           "finance"
         ],
@@ -15343,6 +15463,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePayments",
+        "summary": "GET /v1/admin/finance/payments",
         "tags": [
           "finance"
         ],
@@ -15543,6 +15665,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentsById",
+        "summary": "GET /v1/admin/finance/payments/{id}",
         "tags": [
           "finance"
         ],
@@ -15848,6 +15972,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinancePaymentsById",
+        "summary": "PATCH /v1/admin/finance/payments/{id}",
         "tags": [
           "finance"
         ],
@@ -16035,6 +16161,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinancePaymentsById",
+        "summary": "DELETE /v1/admin/finance/payments/{id}",
         "tags": [
           "finance"
         ],
@@ -16337,6 +16465,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierPayments",
+        "summary": "GET /v1/admin/finance/supplier-payments",
         "tags": [
           "finance"
         ],
@@ -16647,6 +16777,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierPayments",
+        "summary": "POST /v1/admin/finance/supplier-payments",
         "tags": [
           "finance"
         ],
@@ -16981,6 +17113,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceSupplierPaymentsById",
+        "summary": "PATCH /v1/admin/finance/supplier-payments/{id}",
         "tags": [
           "finance"
         ],
@@ -17381,6 +17515,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoices",
+        "summary": "GET /v1/admin/finance/invoices",
         "tags": [
           "finance"
         ],
@@ -17844,6 +17980,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoices",
+        "summary": "POST /v1/admin/finance/invoices",
         "tags": [
           "finance"
         ],
@@ -18369,6 +18507,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesFromBooking",
+        "summary": "POST /v1/admin/finance/invoices/from-booking",
         "tags": [
           "finance"
         ],
@@ -18663,6 +18803,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdConvertToInvoice",
+        "summary": "POST /v1/admin/finance/invoices/{id}/convert-to-invoice",
         "tags": [
           "finance"
         ],
@@ -18952,6 +19094,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesById",
+        "summary": "GET /v1/admin/finance/invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -19415,6 +19559,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesById",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -19488,6 +19634,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesById",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -19800,6 +19948,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdVoid",
+        "summary": "POST /v1/admin/finance/invoices/{id}/void",
         "tags": [
           "finance"
         ],
@@ -20574,6 +20724,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdPaymentSession",
+        "summary": "POST /v1/admin/finance/invoices/{id}/payment-session",
         "tags": [
           "finance"
         ],
@@ -20673,6 +20825,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdLineItems",
+        "summary": "GET /v1/admin/finance/invoices/{id}/line-items",
         "tags": [
           "finance"
         ],
@@ -20862,6 +21016,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdLineItems",
+        "summary": "POST /v1/admin/finance/invoices/{id}/line-items",
         "tags": [
           "finance"
         ],
@@ -21056,6 +21212,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesByIdLineItemsByLineId",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}/line-items/{lineId}",
         "tags": [
           "finance"
         ],
@@ -21119,6 +21277,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesByIdLineItemsByLineId",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}/line-items/{lineId}",
         "tags": [
           "finance"
         ],
@@ -21274,6 +21434,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdPayments",
+        "summary": "GET /v1/admin/finance/invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -21592,6 +21754,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdPayments",
+        "summary": "POST /v1/admin/finance/invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -21707,6 +21871,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdCreditNotes",
+        "summary": "GET /v1/admin/finance/invoices/{id}/credit-notes",
         "tags": [
           "finance"
         ],
@@ -21944,6 +22110,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdCreditNotes",
+        "summary": "POST /v1/admin/finance/invoices/{id}/credit-notes",
         "tags": [
           "finance"
         ],
@@ -22185,6 +22353,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesByIdCreditNotesByCreditNoteId",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}",
         "tags": [
           "finance"
         ],
@@ -22271,6 +22441,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdCreditNotesByCreditNoteIdLineItems",
+        "summary": "GET /v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}/line-items",
         "tags": [
           "finance"
         ],
@@ -22428,6 +22600,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdCreditNotesByCreditNoteIdLineItems",
+        "summary": "POST /v1/admin/finance/invoices/{id}/credit-notes/{creditNoteId}/line-items",
         "tags": [
           "finance"
         ],
@@ -22494,6 +22668,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdNotes",
+        "summary": "GET /v1/admin/finance/invoices/{id}/notes",
         "tags": [
           "finance"
         ],
@@ -22611,6 +22787,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdNotes",
+        "summary": "POST /v1/admin/finance/invoices/{id}/notes",
         "tags": [
           "finance"
         ],
@@ -22795,6 +22973,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceNumberSeries",
+        "summary": "GET /v1/admin/finance/invoice-number-series",
         "tags": [
           "finance"
         ],
@@ -23029,6 +23209,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoiceNumberSeries",
+        "summary": "POST /v1/admin/finance/invoice-number-series",
         "tags": [
           "finance"
         ],
@@ -23180,6 +23362,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceNumberSeriesById",
+        "summary": "GET /v1/admin/finance/invoice-number-series/{id}",
         "tags": [
           "finance"
         ],
@@ -23445,6 +23629,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoiceNumberSeriesById",
+        "summary": "PATCH /v1/admin/finance/invoice-number-series/{id}",
         "tags": [
           "finance"
         ],
@@ -23507,6 +23693,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoiceNumberSeriesById",
+        "summary": "DELETE /v1/admin/finance/invoice-number-series/{id}",
         "tags": [
           "finance"
         ],
@@ -23608,6 +23796,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoiceNumberSeriesByIdAllocate",
+        "summary": "POST /v1/admin/finance/invoice-number-series/{id}/allocate",
         "tags": [
           "finance"
         ],
@@ -23777,6 +23967,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceTemplates",
+        "summary": "GET /v1/admin/finance/invoice-templates",
         "tags": [
           "finance"
         ],
@@ -23969,6 +24161,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoiceTemplates",
+        "summary": "POST /v1/admin/finance/invoice-templates",
         "tags": [
           "finance"
         ],
@@ -24097,6 +24291,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceTemplatesById",
+        "summary": "GET /v1/admin/finance/invoice-templates/{id}",
         "tags": [
           "finance"
         ],
@@ -24319,6 +24515,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoiceTemplatesById",
+        "summary": "PATCH /v1/admin/finance/invoice-templates/{id}",
         "tags": [
           "finance"
         ],
@@ -24381,6 +24579,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoiceTemplatesById",
+        "summary": "DELETE /v1/admin/finance/invoice-templates/{id}",
         "tags": [
           "finance"
         ],
@@ -24555,6 +24755,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxRegimes",
+        "summary": "GET /v1/admin/finance/tax-regimes",
         "tags": [
           "finance"
         ],
@@ -24748,6 +24950,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxRegimes",
+        "summary": "POST /v1/admin/finance/tax-regimes",
         "tags": [
           "finance"
         ],
@@ -24879,6 +25083,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxRegimesById",
+        "summary": "GET /v1/admin/finance/tax-regimes/{id}",
         "tags": [
           "finance"
         ],
@@ -25103,6 +25309,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxRegimesById",
+        "summary": "PATCH /v1/admin/finance/tax-regimes/{id}",
         "tags": [
           "finance"
         ],
@@ -25165,6 +25373,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxRegimesById",
+        "summary": "DELETE /v1/admin/finance/tax-regimes/{id}",
         "tags": [
           "finance"
         ],
@@ -25327,6 +25537,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxClasses",
+        "summary": "GET /v1/admin/finance/tax-classes",
         "tags": [
           "finance"
         ],
@@ -25520,6 +25732,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxClasses",
+        "summary": "POST /v1/admin/finance/tax-classes",
         "tags": [
           "finance"
         ],
@@ -25654,6 +25868,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxClassesById",
+        "summary": "GET /v1/admin/finance/tax-classes/{id}",
         "tags": [
           "finance"
         ],
@@ -25878,6 +26094,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxClassesById",
+        "summary": "PATCH /v1/admin/finance/tax-classes/{id}",
         "tags": [
           "finance"
         ],
@@ -25940,6 +26158,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxClassesById",
+        "summary": "DELETE /v1/admin/finance/tax-classes/{id}",
         "tags": [
           "finance"
         ],
@@ -26079,6 +26299,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyProfiles",
+        "summary": "GET /v1/admin/finance/tax-policy-profiles",
         "tags": [
           "finance"
         ],
@@ -26217,6 +26439,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxPolicyProfiles",
+        "summary": "POST /v1/admin/finance/tax-policy-profiles",
         "tags": [
           "finance"
         ],
@@ -26323,6 +26547,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyProfilesById",
+        "summary": "GET /v1/admin/finance/tax-policy-profiles/{id}",
         "tags": [
           "finance"
         ],
@@ -26492,6 +26718,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxPolicyProfilesById",
+        "summary": "PATCH /v1/admin/finance/tax-policy-profiles/{id}",
         "tags": [
           "finance"
         ],
@@ -26554,6 +26782,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxPolicyProfilesById",
+        "summary": "DELETE /v1/admin/finance/tax-policy-profiles/{id}",
         "tags": [
           "finance"
         ],
@@ -26717,6 +26947,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyRules",
+        "summary": "GET /v1/admin/finance/tax-policy-rules",
         "tags": [
           "finance"
         ],
@@ -26895,6 +27127,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceTaxPolicyRules",
+        "summary": "POST /v1/admin/finance/tax-policy-rules",
         "tags": [
           "finance"
         ],
@@ -27021,6 +27255,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceTaxPolicyRulesById",
+        "summary": "GET /v1/admin/finance/tax-policy-rules/{id}",
         "tags": [
           "finance"
         ],
@@ -27229,6 +27465,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceTaxPolicyRulesById",
+        "summary": "PATCH /v1/admin/finance/tax-policy-rules/{id}",
         "tags": [
           "finance"
         ],
@@ -27291,6 +27529,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceTaxPolicyRulesById",
+        "summary": "DELETE /v1/admin/finance/tax-policy-rules/{id}",
         "tags": [
           "finance"
         ],
@@ -27423,6 +27663,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdRenditions",
+        "summary": "GET /v1/admin/finance/invoices/{id}/renditions",
         "tags": [
           "finance"
         ],
@@ -27914,6 +28156,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdRender",
+        "summary": "POST /v1/admin/finance/invoices/{id}/render",
         "tags": [
           "finance"
         ],
@@ -28009,6 +28253,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdAttachments",
+        "summary": "GET /v1/admin/finance/invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -28196,6 +28442,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdAttachments",
+        "summary": "POST /v1/admin/finance/invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -28390,6 +28638,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceInvoicesByIdAttachmentsByAttachmentId",
+        "summary": "PATCH /v1/admin/finance/invoices/{id}/attachments/{attachmentId}",
         "tags": [
           "finance"
         ],
@@ -28453,6 +28703,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesByIdAttachmentsByAttachmentId",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}/attachments/{attachmentId}",
         "tags": [
           "finance"
         ],
@@ -28513,6 +28765,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceAttachmentsByIdDownload",
+        "summary": "GET /v1/admin/finance/invoice-attachments/{id}/download",
         "tags": [
           "finance"
         ],
@@ -28622,6 +28876,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdExternalRefs",
+        "summary": "GET /v1/admin/finance/invoices/{id}/external-refs",
         "tags": [
           "finance"
         ],
@@ -28829,6 +29085,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdExternalRefs",
+        "summary": "POST /v1/admin/finance/invoices/{id}/external-refs",
         "tags": [
           "finance"
         ],
@@ -28894,6 +29152,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceInvoicesByIdExternalRefsByRefId",
+        "summary": "DELETE /v1/admin/finance/invoices/{id}/external-refs/{refId}",
         "tags": [
           "finance"
         ],
@@ -29137,6 +29397,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceVouchers",
+        "summary": "GET /v1/admin/finance/vouchers",
         "tags": [
           "finance"
         ],
@@ -29411,6 +29673,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceVouchers",
+        "summary": "POST /v1/admin/finance/vouchers",
         "tags": [
           "finance"
         ],
@@ -29584,6 +29848,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceVouchersById",
+        "summary": "GET /v1/admin/finance/vouchers/{id}",
         "tags": [
           "finance"
         ],
@@ -29833,6 +30099,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceVouchersById",
+        "summary": "PATCH /v1/admin/finance/vouchers/{id}",
         "tags": [
           "finance"
         ],
@@ -30143,6 +30411,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceVouchersByIdRedeem",
+        "summary": "POST /v1/admin/finance/vouchers/{id}/redeem",
         "tags": [
           "finance"
         ],
@@ -30323,6 +30593,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceBookingsByBookingIdPayments",
+        "summary": "GET /v1/admin/finance/bookings/{bookingId}/payments",
         "tags": [
           "finance"
         ],
@@ -30701,6 +30973,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoicesByIdActionLedger",
+        "summary": "GET /v1/admin/finance/invoices/{id}/action-ledger",
         "tags": [
           "finance"
         ],
@@ -31079,6 +31353,8 @@
             }
           }
         },
+        "operationId": "getAdminFinancePaymentSessionsByIdActionLedger",
+        "summary": "GET /v1/admin/finance/payment-sessions/{id}/action-ledger",
         "tags": [
           "finance"
         ],
@@ -31444,6 +31720,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoices",
+        "summary": "GET /v1/admin/finance/supplier-invoices",
         "tags": [
           "finance"
         ],
@@ -32169,6 +32447,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierInvoices",
+        "summary": "POST /v1/admin/finance/supplier-invoices",
         "tags": [
           "finance"
         ],
@@ -32625,6 +32905,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesById",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -33203,6 +33485,8 @@
             }
           }
         },
+        "operationId": "patchAdminFinanceSupplierInvoicesById",
+        "summary": "PATCH /v1/admin/finance/supplier-invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -33266,6 +33550,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceSupplierInvoicesById",
+        "summary": "DELETE /v1/admin/finance/supplier-invoices/{id}",
         "tags": [
           "finance"
         ],
@@ -33829,6 +34115,8 @@
             }
           }
         },
+        "operationId": "putAdminFinanceSupplierInvoicesByIdLines",
+        "summary": "PUT /v1/admin/finance/supplier-invoices/{id}/lines",
         "tags": [
           "finance"
         ],
@@ -34398,6 +34686,8 @@
             }
           }
         },
+        "operationId": "putAdminFinanceSupplierInvoicesByIdAllocations",
+        "summary": "PUT /v1/admin/finance/supplier-invoices/{id}/allocations",
         "tags": [
           "finance"
         ],
@@ -34458,6 +34748,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesByIdDocumentDownload",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}/document/download",
         "tags": [
           "finance"
         ],
@@ -34768,6 +35060,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesByIdPayments",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -35084,6 +35378,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierInvoicesByIdPayments",
+        "summary": "POST /v1/admin/finance/supplier-invoices/{id}/payments",
         "tags": [
           "finance"
         ],
@@ -35179,6 +35475,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoicesByIdAttachments",
+        "summary": "GET /v1/admin/finance/supplier-invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -35355,6 +35653,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceSupplierInvoicesByIdAttachments",
+        "summary": "POST /v1/admin/finance/supplier-invoices/{id}/attachments",
         "tags": [
           "finance"
         ],
@@ -35420,6 +35720,8 @@
             }
           }
         },
+        "operationId": "deleteAdminFinanceSupplierInvoicesByIdAttachmentsByAttachmentId",
+        "summary": "DELETE /v1/admin/finance/supplier-invoices/{id}/attachments/{attachmentId}",
         "tags": [
           "finance"
         ],
@@ -35480,6 +35782,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceSupplierInvoiceAttachmentsByIdDownload",
+        "summary": "GET /v1/admin/finance/supplier-invoice-attachments/{id}/download",
         "tags": [
           "finance"
         ],
@@ -35750,6 +36054,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdGenerateDocument",
+        "summary": "POST /v1/admin/finance/invoices/{id}/generate-document",
         "tags": [
           "finance"
         ],
@@ -36020,6 +36326,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdRegenerateDocument",
+        "summary": "POST /v1/admin/finance/invoices/{id}/regenerate-document",
         "tags": [
           "finance"
         ],
@@ -36080,6 +36388,8 @@
             }
           }
         },
+        "operationId": "getAdminFinanceInvoiceRenditionsByIdDownload",
+        "summary": "GET /v1/admin/finance/invoice-renditions/{id}/download",
         "tags": [
           "finance"
         ],
@@ -36259,6 +36569,8 @@
             }
           }
         },
+        "operationId": "postAdminFinanceInvoicesByIdPollSettlement",
+        "summary": "POST /v1/admin/finance/invoices/{id}/poll-settlement",
         "tags": [
           "finance"
         ],

--- a/starters/operator/openapi/admin/identity.json
+++ b/starters/operator/openapi/admin/identity.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -350,6 +356,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -550,6 +557,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -684,6 +692,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -906,6 +915,7 @@
             }
           }
         },
+        "operationId": "patchAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -965,6 +975,7 @@
             }
           }
         },
+        "operationId": "deleteAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -1221,6 +1232,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -1512,6 +1524,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -1697,6 +1710,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityAddressesById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2012,6 +2026,7 @@
             }
           }
         },
+        "operationId": "patchAdminIdentityAddressesById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2071,6 +2086,7 @@
             }
           }
         },
+        "operationId": "deleteAdminIdentityAddressesById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -2286,6 +2302,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2502,6 +2519,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -2644,6 +2662,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2883,6 +2902,7 @@
             }
           }
         },
+        "operationId": "patchAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -2942,6 +2962,7 @@
             }
           }
         },
+        "operationId": "deleteAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -3069,6 +3090,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -3275,6 +3297,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdContactPoints",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -3453,6 +3476,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -3748,6 +3772,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdAddresses",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }
@@ -3883,6 +3908,7 @@
             }
           }
         },
+        "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       },
@@ -4105,6 +4131,7 @@
             }
           }
         },
+        "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdNamedContacts",
         "x-voyant-module": "identity",
         "x-voyant-surface": "admin"
       }

--- a/starters/operator/openapi/admin/legal.json
+++ b/starters/operator/openapi/admin/legal.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -337,6 +343,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplates",
+        "summary": "GET /v1/admin/legal/contracts/templates",
         "tags": [
           "legal"
         ],
@@ -532,6 +540,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplates",
+        "summary": "POST /v1/admin/legal/contracts/templates",
         "tags": [
           "legal"
         ],
@@ -696,6 +706,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplatesDefault",
+        "summary": "GET /v1/admin/legal/contracts/templates/default",
         "tags": [
           "legal"
         ],
@@ -826,6 +838,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplatesById",
+        "summary": "GET /v1/admin/legal/contracts/templates/{id}",
         "tags": [
           "legal"
         ],
@@ -1043,6 +1057,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsTemplatesById",
+        "summary": "PATCH /v1/admin/legal/contracts/templates/{id}",
         "tags": [
           "legal"
         ],
@@ -1101,6 +1117,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsTemplatesById",
+        "summary": "DELETE /v1/admin/legal/contracts/templates/{id}",
         "tags": [
           "legal"
         ],
@@ -1199,6 +1217,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplatesByIdPreview",
+        "summary": "POST /v1/admin/legal/contracts/templates/{id}/preview",
         "tags": [
           "legal"
         ],
@@ -1297,6 +1317,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplatesByIdRenderPreview",
+        "summary": "POST /v1/admin/legal/contracts/templates/{id}/render-preview",
         "tags": [
           "legal"
         ],
@@ -1378,6 +1400,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplatesByIdVersions",
+        "summary": "GET /v1/admin/legal/contracts/templates/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -1530,6 +1554,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsTemplatesByIdVersions",
+        "summary": "POST /v1/admin/legal/contracts/templates/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -1626,6 +1652,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsTemplateVersionsById",
+        "summary": "GET /v1/admin/legal/contracts/template-versions/{id}",
         "tags": [
           "legal"
         ],
@@ -1774,6 +1802,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsNumberSeries",
+        "summary": "GET /v1/admin/legal/contracts/number-series",
         "tags": [
           "legal"
         ],
@@ -1985,6 +2015,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsNumberSeries",
+        "summary": "POST /v1/admin/legal/contracts/number-series",
         "tags": [
           "legal"
         ],
@@ -2127,6 +2159,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsNumberSeriesById",
+        "summary": "GET /v1/admin/legal/contracts/number-series/{id}",
         "tags": [
           "legal"
         ],
@@ -2356,6 +2390,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsNumberSeriesById",
+        "summary": "PATCH /v1/admin/legal/contracts/number-series/{id}",
         "tags": [
           "legal"
         ],
@@ -2414,6 +2450,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsNumberSeriesById",
+        "summary": "DELETE /v1/admin/legal/contracts/number-series/{id}",
         "tags": [
           "legal"
         ],
@@ -2622,6 +2660,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsBookingsByBookingIdGenerateDocument",
+        "summary": "POST /v1/admin/legal/contracts/bookings/{bookingId}/generate-document",
         "tags": [
           "legal"
         ],
@@ -3121,6 +3161,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContracts",
+        "summary": "GET /v1/admin/legal/contracts",
         "tags": [
           "legal"
         ],
@@ -3748,6 +3790,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContracts",
+        "summary": "POST /v1/admin/legal/contracts",
         "tags": [
           "legal"
         ],
@@ -4077,6 +4121,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsById",
+        "summary": "GET /v1/admin/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -4714,6 +4760,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsById",
+        "summary": "PATCH /v1/admin/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -4790,6 +4838,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsById",
+        "summary": "DELETE /v1/admin/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -5137,6 +5187,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdIssue",
+        "summary": "POST /v1/admin/legal/contracts/{id}/issue",
         "tags": [
           "legal"
         ],
@@ -5502,6 +5554,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdSend",
+        "summary": "POST /v1/admin/legal/contracts/{id}/send",
         "tags": [
           "legal"
         ],
@@ -6213,6 +6267,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdSign",
+        "summary": "POST /v1/admin/legal/contracts/{id}/sign",
         "tags": [
           "legal"
         ],
@@ -6560,6 +6616,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdExecute",
+        "summary": "POST /v1/admin/legal/contracts/{id}/execute",
         "tags": [
           "legal"
         ],
@@ -6907,6 +6965,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdVoid",
+        "summary": "POST /v1/admin/legal/contracts/{id}/void",
         "tags": [
           "legal"
         ],
@@ -7005,6 +7065,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdRender",
+        "summary": "POST /v1/admin/legal/contracts/{id}/render",
         "tags": [
           "legal"
         ],
@@ -7117,6 +7179,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdGenerateDocument",
+        "summary": "POST /v1/admin/legal/contracts/{id}/generate-document",
         "tags": [
           "legal"
         ],
@@ -7229,6 +7293,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdRegenerateDocument",
+        "summary": "POST /v1/admin/legal/contracts/{id}/regenerate-document",
         "tags": [
           "legal"
         ],
@@ -7341,6 +7407,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdRegeneratePdf",
+        "summary": "POST /v1/admin/legal/contracts/{id}/regenerate-pdf",
         "tags": [
           "legal"
         ],
@@ -7526,6 +7594,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsByIdSignatures",
+        "summary": "GET /v1/admin/legal/contracts/{id}/signatures",
         "tags": [
           "legal"
         ],
@@ -7673,6 +7743,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsByIdAttachments",
+        "summary": "GET /v1/admin/legal/contracts/{id}/attachments",
         "tags": [
           "legal"
         ],
@@ -8012,6 +8084,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdAttachments",
+        "summary": "POST /v1/admin/legal/contracts/{id}/attachments",
         "tags": [
           "legal"
         ],
@@ -8222,6 +8296,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdAttachmentsUpload",
+        "summary": "POST /v1/admin/legal/contracts/{id}/attachments/upload",
         "tags": [
           "legal"
         ],
@@ -8432,6 +8508,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalContractsByIdAttachDocument",
+        "summary": "POST /v1/admin/legal/contracts/{id}/attach-document",
         "tags": [
           "legal"
         ],
@@ -8770,6 +8848,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsAttachmentsByAttachmentId",
+        "summary": "PATCH /v1/admin/legal/contracts/attachments/{attachmentId}",
         "tags": [
           "legal"
         ],
@@ -8828,6 +8908,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalContractsAttachmentsByAttachmentId",
+        "summary": "DELETE /v1/admin/legal/contracts/attachments/{attachmentId}",
         "tags": [
           "legal"
         ],
@@ -9038,6 +9120,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalContractsAttachmentsByAttachmentIdUpload",
+        "summary": "PATCH /v1/admin/legal/contracts/attachments/{attachmentId}/upload",
         "tags": [
           "legal"
         ],
@@ -9098,6 +9182,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalContractsAttachmentsByAttachmentIdDownload",
+        "summary": "GET /v1/admin/legal/contracts/attachments/{attachmentId}/download",
         "tags": [
           "legal"
         ],
@@ -9206,6 +9292,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesByIdVersions",
+        "summary": "GET /v1/admin/legal/policies/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -9385,6 +9473,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesByIdVersions",
+        "summary": "POST /v1/admin/legal/policies/{id}/versions",
         "tags": [
           "legal"
         ],
@@ -9508,6 +9598,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesVersionsByVersionId",
+        "summary": "GET /v1/admin/legal/policies/versions/{versionId}",
         "tags": [
           "legal"
         ],
@@ -9684,6 +9776,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesVersionsByVersionId",
+        "summary": "PATCH /v1/admin/legal/policies/versions/{versionId}",
         "tags": [
           "legal"
         ],
@@ -9825,6 +9919,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesVersionsByVersionIdPublish",
+        "summary": "POST /v1/admin/legal/policies/versions/{versionId}/publish",
         "tags": [
           "legal"
         ],
@@ -9948,6 +10044,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesVersionsByVersionIdRetire",
+        "summary": "POST /v1/admin/legal/policies/versions/{versionId}/retire",
         "tags": [
           "legal"
         ],
@@ -10089,6 +10187,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesVersionsByVersionIdRules",
+        "summary": "GET /v1/admin/legal/policies/versions/{versionId}/rules",
         "tags": [
           "legal"
         ],
@@ -10356,6 +10456,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesVersionsByVersionIdRules",
+        "summary": "POST /v1/admin/legal/policies/versions/{versionId}/rules",
         "tags": [
           "legal"
         ],
@@ -10621,6 +10723,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesRulesByRuleId",
+        "summary": "PATCH /v1/admin/legal/policies/rules/{ruleId}",
         "tags": [
           "legal"
         ],
@@ -10676,6 +10780,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalPoliciesRulesByRuleId",
+        "summary": "DELETE /v1/admin/legal/policies/rules/{ruleId}",
         "tags": [
           "legal"
         ],
@@ -10896,6 +11002,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesAssignments",
+        "summary": "GET /v1/admin/legal/policies/assignments",
         "tags": [
           "legal"
         ],
@@ -11110,6 +11218,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesAssignments",
+        "summary": "POST /v1/admin/legal/policies/assignments",
         "tags": [
           "legal"
         ],
@@ -11350,6 +11460,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesAssignmentsById",
+        "summary": "PATCH /v1/admin/legal/policies/assignments/{id}",
         "tags": [
           "legal"
         ],
@@ -11405,6 +11517,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalPoliciesAssignmentsById",
+        "summary": "DELETE /v1/admin/legal/policies/assignments/{id}",
         "tags": [
           "legal"
         ],
@@ -11681,6 +11795,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesAcceptances",
+        "summary": "GET /v1/admin/legal/policies/acceptances",
         "tags": [
           "legal"
         ],
@@ -12010,6 +12126,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesAcceptances",
+        "summary": "POST /v1/admin/legal/policies/acceptances",
         "tags": [
           "legal"
         ],
@@ -12444,6 +12562,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesResolve",
+        "summary": "GET /v1/admin/legal/policies/resolve",
         "tags": [
           "legal"
         ],
@@ -12605,6 +12725,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPolicies",
+        "summary": "GET /v1/admin/legal/policies",
         "tags": [
           "legal"
         ],
@@ -12768,6 +12890,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPolicies",
+        "summary": "POST /v1/admin/legal/policies",
         "tags": [
           "legal"
         ],
@@ -12882,6 +13006,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalPoliciesById",
+        "summary": "GET /v1/admin/legal/policies/{id}",
         "tags": [
           "legal"
         ],
@@ -13067,6 +13193,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalPoliciesById",
+        "summary": "PATCH /v1/admin/legal/policies/{id}",
         "tags": [
           "legal"
         ],
@@ -13140,6 +13268,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalPoliciesById",
+        "summary": "DELETE /v1/admin/legal/policies/{id}",
         "tags": [
           "legal"
         ],
@@ -13265,6 +13395,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalPoliciesByIdEvaluate",
+        "summary": "POST /v1/admin/legal/policies/{id}/evaluate",
         "tags": [
           "legal"
         ],
@@ -13582,6 +13714,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalTerms",
+        "summary": "GET /v1/admin/legal/terms",
         "tags": [
           "legal"
         ],
@@ -13985,6 +14119,8 @@
             }
           }
         },
+        "operationId": "postAdminLegalTerms",
+        "summary": "POST /v1/admin/legal/terms",
         "tags": [
           "legal"
         ],
@@ -14185,6 +14321,8 @@
             }
           }
         },
+        "operationId": "getAdminLegalTermsById",
+        "summary": "GET /v1/admin/legal/terms/{id}",
         "tags": [
           "legal"
         ],
@@ -14612,6 +14750,8 @@
             }
           }
         },
+        "operationId": "patchAdminLegalTermsById",
+        "summary": "PATCH /v1/admin/legal/terms/{id}",
         "tags": [
           "legal"
         ],
@@ -14667,6 +14807,8 @@
             }
           }
         },
+        "operationId": "deleteAdminLegalTermsById",
+        "summary": "DELETE /v1/admin/legal/terms/{id}",
         "tags": [
           "legal"
         ],

--- a/starters/operator/openapi/admin/markets.json
+++ b/starters/operator/openapi/admin/markets.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -317,6 +323,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarkets",
+        "summary": "GET /v1/admin/markets/markets",
         "tags": [
           "markets"
         ],
@@ -523,6 +531,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsMarkets",
+        "summary": "POST /v1/admin/markets/markets",
         "tags": [
           "markets"
         ],
@@ -657,6 +667,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarketsById",
+        "summary": "GET /v1/admin/markets/markets/{id}",
         "tags": [
           "markets"
         ],
@@ -885,6 +897,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsMarketsById",
+        "summary": "PATCH /v1/admin/markets/markets/{id}",
         "tags": [
           "markets"
         ],
@@ -943,6 +957,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsMarketsById",
+        "summary": "DELETE /v1/admin/markets/markets/{id}",
         "tags": [
           "markets"
         ],
@@ -1082,6 +1098,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarketLocales",
+        "summary": "GET /v1/admin/markets/market-locales",
         "tags": [
           "markets"
         ],
@@ -1227,6 +1245,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsMarketsByIdLocales",
+        "summary": "POST /v1/admin/markets/markets/{id}/locales",
         "tags": [
           "markets"
         ],
@@ -1369,6 +1389,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsMarketLocalesById",
+        "summary": "PATCH /v1/admin/markets/market-locales/{id}",
         "tags": [
           "markets"
         ],
@@ -1427,6 +1449,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsMarketLocalesById",
+        "summary": "DELETE /v1/admin/markets/market-locales/{id}",
         "tags": [
           "markets"
         ],
@@ -1574,6 +1598,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsMarketCurrencies",
+        "summary": "GET /v1/admin/markets/market-currencies",
         "tags": [
           "markets"
         ],
@@ -1735,6 +1761,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsMarketsByIdCurrencies",
+        "summary": "POST /v1/admin/markets/markets/{id}/currencies",
         "tags": [
           "markets"
         ],
@@ -1893,6 +1921,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsMarketCurrenciesById",
+        "summary": "PATCH /v1/admin/markets/market-currencies/{id}",
         "tags": [
           "markets"
         ],
@@ -1951,6 +1981,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsMarketCurrenciesById",
+        "summary": "DELETE /v1/admin/markets/market-currencies/{id}",
         "tags": [
           "markets"
         ],
@@ -2109,6 +2141,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsFxRateSets",
+        "summary": "GET /v1/admin/markets/fx-rate-sets",
         "tags": [
           "markets"
         ],
@@ -2280,6 +2314,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsFxRateSets",
+        "summary": "POST /v1/admin/markets/fx-rate-sets",
         "tags": [
           "markets"
         ],
@@ -2398,6 +2434,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsFxRateSetsById",
+        "summary": "GET /v1/admin/markets/fx-rate-sets/{id}",
         "tags": [
           "markets"
         ],
@@ -2593,6 +2631,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsFxRateSetsById",
+        "summary": "PATCH /v1/admin/markets/fx-rate-sets/{id}",
         "tags": [
           "markets"
         ],
@@ -2651,6 +2691,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsFxRateSetsById",
+        "summary": "DELETE /v1/admin/markets/fx-rate-sets/{id}",
         "tags": [
           "markets"
         ],
@@ -2793,6 +2835,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsExchangeRates",
+        "summary": "GET /v1/admin/markets/exchange-rates",
         "tags": [
           "markets"
         ],
@@ -2957,6 +3001,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsFxRateSetsByIdExchangeRates",
+        "summary": "POST /v1/admin/markets/fx-rate-sets/{id}/exchange-rates",
         "tags": [
           "markets"
         ],
@@ -3116,6 +3162,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsExchangeRatesById",
+        "summary": "PATCH /v1/admin/markets/exchange-rates/{id}",
         "tags": [
           "markets"
         ],
@@ -3174,6 +3222,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsExchangeRatesById",
+        "summary": "DELETE /v1/admin/markets/exchange-rates/{id}",
         "tags": [
           "markets"
         ],
@@ -3325,6 +3375,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsPriceCatalogs",
+        "summary": "GET /v1/admin/markets/price-catalogs",
         "tags": [
           "markets"
         ],
@@ -3486,6 +3538,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsPriceCatalogs",
+        "summary": "POST /v1/admin/markets/price-catalogs",
         "tags": [
           "markets"
         ],
@@ -3594,6 +3648,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsPriceCatalogsById",
+        "summary": "GET /v1/admin/markets/price-catalogs/{id}",
         "tags": [
           "markets"
         ],
@@ -3761,6 +3817,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsPriceCatalogsById",
+        "summary": "PATCH /v1/admin/markets/price-catalogs/{id}",
         "tags": [
           "markets"
         ],
@@ -3819,6 +3877,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsPriceCatalogsById",
+        "summary": "DELETE /v1/admin/markets/price-catalogs/{id}",
         "tags": [
           "markets"
         ],
@@ -4031,6 +4091,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsProductRules",
+        "summary": "GET /v1/admin/markets/product-rules",
         "tags": [
           "markets"
         ],
@@ -4271,6 +4333,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsProductRules",
+        "summary": "POST /v1/admin/markets/product-rules",
         "tags": [
           "markets"
         ],
@@ -4419,6 +4483,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsProductRulesById",
+        "summary": "GET /v1/admin/markets/product-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -4665,6 +4731,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsProductRulesById",
+        "summary": "PATCH /v1/admin/markets/product-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -4723,6 +4791,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsProductRulesById",
+        "summary": "DELETE /v1/admin/markets/product-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -4900,6 +4970,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsChannelRules",
+        "summary": "GET /v1/admin/markets/channel-rules",
         "tags": [
           "markets"
         ],
@@ -5087,6 +5159,8 @@
             }
           }
         },
+        "operationId": "postAdminMarketsChannelRules",
+        "summary": "POST /v1/admin/markets/channel-rules",
         "tags": [
           "markets"
         ],
@@ -5208,6 +5282,8 @@
             }
           }
         },
+        "operationId": "getAdminMarketsChannelRulesById",
+        "summary": "GET /v1/admin/markets/channel-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -5401,6 +5477,8 @@
             }
           }
         },
+        "operationId": "patchAdminMarketsChannelRulesById",
+        "summary": "PATCH /v1/admin/markets/channel-rules/{id}",
         "tags": [
           "markets"
         ],
@@ -5459,6 +5537,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMarketsChannelRulesById",
+        "summary": "DELETE /v1/admin/markets/channel-rules/{id}",
         "tags": [
           "markets"
         ],

--- a/starters/operator/openapi/admin/media.json
+++ b/starters/operator/openapi/admin/media.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -353,6 +359,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdBrochureGenerate",
+        "summary": "POST /v1/admin/products/{id}/brochure/generate",
         "tags": [
           "media"
         ],

--- a/starters/operator/openapi/admin/mice.json
+++ b/starters/operator/openapi/admin/mice.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -375,6 +381,8 @@
             }
           }
         },
+        "operationId": "getAdminMicePrograms",
+        "summary": "GET /v1/admin/mice/programs",
         "tags": [
           "mice"
         ],
@@ -631,6 +639,8 @@
             }
           }
         },
+        "operationId": "postAdminMicePrograms",
+        "summary": "POST /v1/admin/mice/programs",
         "tags": [
           "mice"
         ],
@@ -778,6 +788,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceProgramsByIdCostSheet",
+        "summary": "GET /v1/admin/mice/programs/{id}/cost-sheet",
         "tags": [
           "mice"
         ],
@@ -963,6 +975,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceProgramsById",
+        "summary": "GET /v1/admin/mice/programs/{id}",
         "tags": [
           "mice"
         ],
@@ -1277,6 +1291,8 @@
             }
           }
         },
+        "operationId": "patchAdminMiceProgramsById",
+        "summary": "PATCH /v1/admin/mice/programs/{id}",
         "tags": [
           "mice"
         ],
@@ -1467,6 +1483,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceSessions",
+        "summary": "GET /v1/admin/mice/sessions",
         "tags": [
           "mice"
         ],
@@ -1694,6 +1712,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceSessions",
+        "summary": "POST /v1/admin/mice/sessions",
         "tags": [
           "mice"
         ],
@@ -1912,6 +1932,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceSessionsById",
+        "summary": "GET /v1/admin/mice/sessions/{id}",
         "tags": [
           "mice"
         ],
@@ -2141,6 +2163,8 @@
             }
           }
         },
+        "operationId": "patchAdminMiceSessionsById",
+        "summary": "PATCH /v1/admin/mice/sessions/{id}",
         "tags": [
           "mice"
         ],
@@ -2199,6 +2223,8 @@
             }
           }
         },
+        "operationId": "deleteAdminMiceSessionsById",
+        "summary": "DELETE /v1/admin/mice/sessions/{id}",
         "tags": [
           "mice"
         ],
@@ -2384,6 +2410,8 @@
             }
           }
         },
+        "operationId": "putAdminMiceSessionsByIdInclusions",
+        "summary": "PUT /v1/admin/mice/sessions/{id}/inclusions",
         "tags": [
           "mice"
         ],
@@ -2580,6 +2608,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceDelegates",
+        "summary": "GET /v1/admin/mice/delegates",
         "tags": [
           "mice"
         ],
@@ -2794,6 +2824,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceDelegates",
+        "summary": "POST /v1/admin/mice/delegates",
         "tags": [
           "mice"
         ],
@@ -2980,6 +3012,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceDelegatesById",
+        "summary": "GET /v1/admin/mice/delegates/{id}",
         "tags": [
           "mice"
         ],
@@ -3197,6 +3231,8 @@
             }
           }
         },
+        "operationId": "patchAdminMiceDelegatesById",
+        "summary": "PATCH /v1/admin/mice/delegates/{id}",
         "tags": [
           "mice"
         ],
@@ -3405,6 +3441,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceDelegatesByIdEnrollments",
+        "summary": "POST /v1/admin/mice/delegates/{id}/enrollments",
         "tags": [
           "mice"
         ],
@@ -3557,6 +3595,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceRoomingAssignments",
+        "summary": "GET /v1/admin/mice/rooming-assignments",
         "tags": [
           "mice"
         ],
@@ -3741,6 +3781,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceRoomingAssignments",
+        "summary": "POST /v1/admin/mice/rooming-assignments",
         "tags": [
           "mice"
         ],
@@ -3913,6 +3955,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceRoomingAssignmentsById",
+        "summary": "GET /v1/admin/mice/rooming-assignments/{id}",
         "tags": [
           "mice"
         ],
@@ -4100,6 +4144,8 @@
             }
           }
         },
+        "operationId": "patchAdminMiceRoomingAssignmentsById",
+        "summary": "PATCH /v1/admin/mice/rooming-assignments/{id}",
         "tags": [
           "mice"
         ],
@@ -4291,6 +4337,8 @@
             }
           }
         },
+        "operationId": "putAdminMiceRoomingAssignmentsByIdDelegates",
+        "summary": "PUT /v1/admin/mice/rooming-assignments/{id}/delegates",
         "tags": [
           "mice"
         ],
@@ -4445,6 +4493,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceRfps",
+        "summary": "GET /v1/admin/mice/rfps",
         "tags": [
           "mice"
         ],
@@ -4621,6 +4671,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceRfps",
+        "summary": "POST /v1/admin/mice/rfps",
         "tags": [
           "mice"
         ],
@@ -4801,6 +4853,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceRfpsByIdInvitations",
+        "summary": "POST /v1/admin/mice/rfps/{id}/invitations",
         "tags": [
           "mice"
         ],
@@ -4991,6 +5045,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceRfpsByIdBids",
+        "summary": "POST /v1/admin/mice/rfps/{id}/bids",
         "tags": [
           "mice"
         ],
@@ -5249,6 +5305,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceRfpsByIdAward",
+        "summary": "POST /v1/admin/mice/rfps/{id}/award",
         "tags": [
           "mice"
         ],
@@ -5488,6 +5546,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceRfpsById",
+        "summary": "GET /v1/admin/mice/rfps/{id}",
         "tags": [
           "mice"
         ],
@@ -5666,6 +5726,8 @@
             }
           }
         },
+        "operationId": "patchAdminMiceRfpsById",
+        "summary": "PATCH /v1/admin/mice/rfps/{id}",
         "tags": [
           "mice"
         ],
@@ -5834,6 +5896,8 @@
             }
           }
         },
+        "operationId": "putAdminMiceBidsByIdLines",
+        "summary": "PUT /v1/admin/mice/bids/{id}/lines",
         "tags": [
           "mice"
         ],
@@ -5990,6 +6054,8 @@
             }
           }
         },
+        "operationId": "postAdminMiceBidsByIdEvaluations",
+        "summary": "POST /v1/admin/mice/bids/{id}/evaluations",
         "tags": [
           "mice"
         ],
@@ -6227,6 +6293,8 @@
             }
           }
         },
+        "operationId": "getAdminMiceBidsById",
+        "summary": "GET /v1/admin/mice/bids/{id}",
         "tags": [
           "mice"
         ],
@@ -6408,6 +6476,8 @@
             }
           }
         },
+        "operationId": "patchAdminMiceBidsById",
+        "summary": "PATCH /v1/admin/mice/bids/{id}",
         "tags": [
           "mice"
         ],

--- a/starters/operator/openapi/admin/notifications.json
+++ b/starters/operator/openapi/admin/notifications.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -340,6 +346,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsTemplates",
+        "summary": "GET /v1/admin/notifications/templates",
         "tags": [
           "notifications"
         ],
@@ -560,6 +568,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsTemplates",
+        "summary": "POST /v1/admin/notifications/templates",
         "tags": [
           "notifications"
         ],
@@ -705,6 +715,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsTemplatesById",
+        "summary": "GET /v1/admin/notifications/templates/{id}",
         "tags": [
           "notifications"
         ],
@@ -948,6 +960,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsTemplatesById",
+        "summary": "PATCH /v1/admin/notifications/templates/{id}",
         "tags": [
           "notifications"
         ],
@@ -988,6 +1002,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsTemplatesById",
+        "summary": "DELETE /v1/admin/notifications/templates/{id}",
         "tags": [
           "notifications"
         ],
@@ -1143,6 +1159,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsPreview",
+        "summary": "POST /v1/admin/notifications/preview",
         "tags": [
           "notifications"
         ],
@@ -1512,6 +1530,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsDeliveries",
+        "summary": "GET /v1/admin/notifications/deliveries",
         "tags": [
           "notifications"
         ],
@@ -1760,6 +1780,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsDeliveriesById",
+        "summary": "GET /v1/admin/notifications/deliveries/{id}",
         "tags": [
           "notifications"
         ],
@@ -2026,6 +2048,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsDeliveriesByIdResend",
+        "summary": "POST /v1/admin/notifications/deliveries/{id}/resend",
         "tags": [
           "notifications"
         ],
@@ -2240,6 +2264,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRules",
+        "summary": "GET /v1/admin/notifications/reminder-rules",
         "tags": [
           "notifications"
         ],
@@ -2482,6 +2508,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRules",
+        "summary": "POST /v1/admin/notifications/reminder-rules",
         "tags": [
           "notifications"
         ],
@@ -2999,6 +3027,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesCompose",
+        "summary": "POST /v1/admin/notifications/reminder-rules/compose",
         "tags": [
           "notifications"
         ],
@@ -3152,6 +3182,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRulesById",
+        "summary": "GET /v1/admin/notifications/reminder-rules/{id}",
         "tags": [
           "notifications"
         ],
@@ -3416,6 +3448,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsReminderRulesById",
+        "summary": "PATCH /v1/admin/notifications/reminder-rules/{id}",
         "tags": [
           "notifications"
         ],
@@ -3456,6 +3490,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsReminderRulesById",
+        "summary": "DELETE /v1/admin/notifications/reminder-rules/{id}",
         "tags": [
           "notifications"
         ],
@@ -3615,6 +3651,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRulesByIdStages",
+        "summary": "GET /v1/admin/notifications/reminder-rules/{id}/stages",
         "tags": [
           "notifications"
         ],
@@ -3915,6 +3953,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesByIdStages",
+        "summary": "POST /v1/admin/notifications/reminder-rules/{id}/stages",
         "tags": [
           "notifications"
         ],
@@ -4116,6 +4156,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesByIdStagesReorder",
+        "summary": "POST /v1/admin/notifications/reminder-rules/{id}/stages/reorder",
         "tags": [
           "notifications"
         ],
@@ -4437,6 +4479,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsReminderRulesByIdStagesByStageId",
+        "summary": "PATCH /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}",
         "tags": [
           "notifications"
         ],
@@ -4485,6 +4529,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsReminderRulesByIdStagesByStageId",
+        "summary": "DELETE /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}",
         "tags": [
           "notifications"
         ],
@@ -4612,6 +4658,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRulesByIdStagesByStageIdChannels",
+        "summary": "GET /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels",
         "tags": [
           "notifications"
         ],
@@ -4826,6 +4874,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsReminderRulesByIdStagesByStageIdChannels",
+        "summary": "POST /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels",
         "tags": [
           "notifications"
         ],
@@ -5065,6 +5115,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsReminderRulesByIdStagesByStageIdChannelsByChannelId",
+        "summary": "PATCH /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels/{channelId}",
         "tags": [
           "notifications"
         ],
@@ -5121,6 +5173,8 @@
             }
           }
         },
+        "operationId": "deleteAdminNotificationsReminderRulesByIdStagesByStageIdChannelsByChannelId",
+        "summary": "DELETE /v1/admin/notifications/reminder-rules/{id}/stages/{stageId}/channels/{channelId}",
         "tags": [
           "notifications"
         ],
@@ -5226,6 +5280,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsNotificationSettings",
+        "summary": "GET /v1/admin/notifications/notification-settings",
         "tags": [
           "notifications"
         ],
@@ -5430,6 +5486,8 @@
             }
           }
         },
+        "operationId": "patchAdminNotificationsNotificationSettings",
+        "summary": "PATCH /v1/admin/notifications/notification-settings",
         "tags": [
           "notifications"
         ],
@@ -5555,6 +5613,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsRemindersPreview",
+        "summary": "GET /v1/admin/notifications/reminders/preview",
         "tags": [
           "notifications"
         ],
@@ -6010,6 +6070,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRuns",
+        "summary": "GET /v1/admin/notifications/reminder-runs",
         "tags": [
           "notifications"
         ],
@@ -6342,6 +6404,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsReminderRunsById",
+        "summary": "GET /v1/admin/notifications/reminder-runs/{id}",
         "tags": [
           "notifications"
         ],
@@ -6409,6 +6473,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsRemindersRunDue",
+        "summary": "POST /v1/admin/notifications/reminders/run-due",
         "tags": [
           "notifications"
         ],
@@ -6831,6 +6897,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsPaymentSessionsByIdSend",
+        "summary": "POST /v1/admin/notifications/payment-sessions/{id}/send",
         "tags": [
           "notifications"
         ],
@@ -7253,6 +7321,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsInvoicesByIdSend",
+        "summary": "POST /v1/admin/notifications/invoices/{id}/send",
         "tags": [
           "notifications"
         ],
@@ -7443,6 +7513,8 @@
             }
           }
         },
+        "operationId": "getAdminNotificationsBookingsByIdDocumentBundle",
+        "summary": "GET /v1/admin/notifications/bookings/{id}/document-bundle",
         "tags": [
           "notifications"
         ],
@@ -7906,6 +7978,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsBookingsByIdConfirmAndDispatch",
+        "summary": "POST /v1/admin/notifications/bookings/{id}/confirm-and-dispatch",
         "tags": [
           "notifications"
         ],
@@ -8140,6 +8214,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsBookingsByIdSendDocuments",
+        "summary": "POST /v1/admin/notifications/bookings/{id}/send-documents",
         "tags": [
           "notifications"
         ],
@@ -8577,6 +8653,8 @@
             }
           }
         },
+        "operationId": "postAdminNotificationsSend",
+        "summary": "POST /v1/admin/notifications/send",
         "tags": [
           "notifications"
         ],

--- a/starters/operator/openapi/admin/operations.json
+++ b/starters/operator/openapi/admin/operations.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -251,6 +257,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityAggregates",
+        "summary": "GET /v1/admin/operations/availability/aggregates",
         "tags": [
           "operations"
         ],
@@ -511,6 +519,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityOverview",
+        "summary": "GET /v1/admin/operations/availability/overview",
         "tags": [
           "operations"
         ],
@@ -703,6 +713,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityRules",
+        "summary": "GET /v1/admin/operations/availability/rules",
         "tags": [
           "operations"
         ],
@@ -903,6 +915,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityRules",
+        "summary": "POST /v1/admin/operations/availability/rules",
         "tags": [
           "operations"
         ],
@@ -1146,6 +1160,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityRulesBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/rules/batch-update",
         "tags": [
           "operations"
         ],
@@ -1246,6 +1262,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityRulesBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/rules/batch-delete",
         "tags": [
           "operations"
         ],
@@ -1381,6 +1399,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityRulesById",
+        "summary": "GET /v1/admin/operations/availability/rules/{id}",
         "tags": [
           "operations"
         ],
@@ -1603,6 +1623,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityRulesById",
+        "summary": "PATCH /v1/admin/operations/availability/rules/{id}",
         "tags": [
           "operations"
         ],
@@ -1661,6 +1683,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityRulesById",
+        "summary": "DELETE /v1/admin/operations/availability/rules/{id}",
         "tags": [
           "operations"
         ],
@@ -1835,6 +1859,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityStartTimes",
+        "summary": "GET /v1/admin/operations/availability/start-times",
         "tags": [
           "operations"
         ],
@@ -1996,6 +2022,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityStartTimes",
+        "summary": "POST /v1/admin/operations/availability/start-times",
         "tags": [
           "operations"
         ],
@@ -2202,6 +2230,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityStartTimesBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/start-times/batch-update",
         "tags": [
           "operations"
         ],
@@ -2302,6 +2332,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityStartTimesBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/start-times/batch-delete",
         "tags": [
           "operations"
         ],
@@ -2419,6 +2451,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityStartTimesById",
+        "summary": "GET /v1/admin/operations/availability/start-times/{id}",
         "tags": [
           "operations"
         ],
@@ -2604,6 +2638,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityStartTimesById",
+        "summary": "PATCH /v1/admin/operations/availability/start-times/{id}",
         "tags": [
           "operations"
         ],
@@ -2662,6 +2698,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityStartTimesById",
+        "summary": "DELETE /v1/admin/operations/availability/start-times/{id}",
         "tags": [
           "operations"
         ],
@@ -2977,6 +3015,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlots",
+        "summary": "GET /v1/admin/operations/availability/slots",
         "tags": [
           "operations"
         ],
@@ -3328,6 +3368,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlots",
+        "summary": "POST /v1/admin/operations/availability/slots",
         "tags": [
           "operations"
         ],
@@ -3722,6 +3764,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/slots/batch-update",
         "tags": [
           "operations"
         ],
@@ -3822,6 +3866,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/slots/batch-delete",
         "tags": [
           "operations"
         ],
@@ -4038,6 +4084,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsById",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}",
         "tags": [
           "operations"
         ],
@@ -4411,6 +4459,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsById",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}",
         "tags": [
           "operations"
         ],
@@ -4469,6 +4519,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsById",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}",
         "tags": [
           "operations"
         ],
@@ -4566,6 +4618,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdUnitAvailability",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/unit-availability",
         "tags": [
           "operations"
         ],
@@ -4709,6 +4763,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCloseouts",
+        "summary": "GET /v1/admin/operations/availability/closeouts",
         "tags": [
           "operations"
         ],
@@ -4836,6 +4892,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCloseouts",
+        "summary": "POST /v1/admin/operations/availability/closeouts",
         "tags": [
           "operations"
         ],
@@ -5008,6 +5066,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCloseoutsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/closeouts/batch-update",
         "tags": [
           "operations"
         ],
@@ -5108,6 +5168,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCloseoutsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/closeouts/batch-delete",
         "tags": [
           "operations"
         ],
@@ -5206,6 +5268,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCloseoutsById",
+        "summary": "GET /v1/admin/operations/availability/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -5357,6 +5421,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityCloseoutsById",
+        "summary": "PATCH /v1/admin/operations/availability/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -5415,6 +5481,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityCloseoutsById",
+        "summary": "DELETE /v1/admin/operations/availability/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -5839,6 +5907,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocation",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation",
         "tags": [
           "operations"
         ],
@@ -6037,6 +6107,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationResources",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/resources",
         "tags": [
           "operations"
         ],
@@ -6275,6 +6347,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationResourcesByResourceId",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}",
         "tags": [
           "operations"
         ],
@@ -6361,6 +6435,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsByIdAllocationResourcesByResourceId",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}/allocation/resources/{resourceId}",
         "tags": [
           "operations"
         ],
@@ -6530,6 +6606,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationTravelersByTravelerId",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}",
         "tags": [
           "operations"
         ],
@@ -6690,6 +6768,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotsByIdAllocationTravelersByTravelerIdSharingGroup",
+        "summary": "PATCH /v1/admin/operations/availability/slots/{id}/allocation/travelers/{travelerId}/sharing-group",
         "tags": [
           "operations"
         ],
@@ -6848,6 +6928,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationSharingGroupsPair",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/pair",
         "tags": [
           "operations"
         ],
@@ -7011,6 +7093,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsAvailabilitySlotsByIdAllocationSharingGroupsByGroupIdLabel",
+        "summary": "PUT /v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/{groupId}/label",
         "tags": [
           "operations"
         ],
@@ -7152,6 +7236,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotsByIdAllocationSharingGroupsByGroupIdLabel",
+        "summary": "DELETE /v1/admin/operations/availability/slots/{id}/allocation/sharing-groups/{groupId}/label",
         "tags": [
           "operations"
         ],
@@ -7262,6 +7348,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocationAuditLog",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation/audit-log",
         "tags": [
           "operations"
         ],
@@ -7311,6 +7399,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocationExportPassengers",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation/export-passengers",
         "tags": [
           "operations"
         ],
@@ -7360,6 +7450,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotsByIdAllocationExportRoomingList",
+        "summary": "GET /v1/admin/operations/availability/slots/{id}/allocation/export-rooming-list",
         "tags": [
           "operations"
         ],
@@ -7581,6 +7673,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationAutoMaterialize",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/auto-materialize",
         "tags": [
           "operations"
         ],
@@ -7704,6 +7798,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationMaterializeTemplates",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/materialize-templates",
         "tags": [
           "operations"
         ],
@@ -7925,6 +8021,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotsByIdAllocationAutoAllocate",
+        "summary": "POST /v1/admin/operations/availability/slots/{id}/allocation/auto-allocate",
         "tags": [
           "operations"
         ],
@@ -8077,6 +8175,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityProductsByProductIdAllocationResourceTemplates",
+        "summary": "GET /v1/admin/operations/availability/products/{productId}/allocation/resource-templates",
         "tags": [
           "operations"
         ],
@@ -8331,6 +8431,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsAvailabilityProductsByProductIdOptionsByOptionIdAllocationResourceTemplatesByKind",
+        "summary": "PUT /v1/admin/operations/availability/products/{productId}/options/{optionId}/allocation/resource-templates/{kind}",
         "tags": [
           "operations"
         ],
@@ -8480,6 +8582,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityProductsByProductIdOptionsByOptionIdAllocationResourceTemplatesByKind",
+        "summary": "DELETE /v1/admin/operations/availability/products/{productId}/options/{optionId}/allocation/resource-templates/{kind}",
         "tags": [
           "operations"
         ],
@@ -8622,6 +8726,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityProductsByIdAllocationMaterializeOpenSlots",
+        "summary": "POST /v1/admin/operations/availability/products/{id}/allocation/materialize-open-slots",
         "tags": [
           "operations"
         ],
@@ -8777,6 +8883,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupPoints",
+        "summary": "GET /v1/admin/operations/availability/pickup-points",
         "tags": [
           "operations"
         ],
@@ -8916,6 +9024,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupPoints",
+        "summary": "POST /v1/admin/operations/availability/pickup-points",
         "tags": [
           "operations"
         ],
@@ -9100,6 +9210,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupPointsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/pickup-points/batch-update",
         "tags": [
           "operations"
         ],
@@ -9200,6 +9312,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupPointsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/pickup-points/batch-delete",
         "tags": [
           "operations"
         ],
@@ -9306,6 +9420,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupPointsById",
+        "summary": "GET /v1/admin/operations/availability/pickup-points/{id}",
         "tags": [
           "operations"
         ],
@@ -9469,6 +9585,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityPickupPointsById",
+        "summary": "PATCH /v1/admin/operations/availability/pickup-points/{id}",
         "tags": [
           "operations"
         ],
@@ -9527,6 +9645,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityPickupPointsById",
+        "summary": "DELETE /v1/admin/operations/availability/pickup-points/{id}",
         "tags": [
           "operations"
         ],
@@ -9651,6 +9771,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotPickups",
+        "summary": "GET /v1/admin/operations/availability/slot-pickups",
         "tags": [
           "operations"
         ],
@@ -9770,6 +9892,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotPickups",
+        "summary": "POST /v1/admin/operations/availability/slot-pickups",
         "tags": [
           "operations"
         ],
@@ -9934,6 +10058,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotPickupsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/slot-pickups/batch-update",
         "tags": [
           "operations"
         ],
@@ -10034,6 +10160,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilitySlotPickupsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/slot-pickups/batch-delete",
         "tags": [
           "operations"
         ],
@@ -10129,6 +10257,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilitySlotPickupsById",
+        "summary": "GET /v1/admin/operations/availability/slot-pickups/{id}",
         "tags": [
           "operations"
         ],
@@ -10272,6 +10402,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilitySlotPickupsById",
+        "summary": "PATCH /v1/admin/operations/availability/slot-pickups/{id}",
         "tags": [
           "operations"
         ],
@@ -10330,6 +10462,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilitySlotPickupsById",
+        "summary": "DELETE /v1/admin/operations/availability/slot-pickups/{id}",
         "tags": [
           "operations"
         ],
@@ -10545,6 +10679,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityMeetingConfigs",
+        "summary": "GET /v1/admin/operations/availability/meeting-configs",
         "tags": [
           "operations"
         ],
@@ -10759,6 +10895,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityMeetingConfigs",
+        "summary": "POST /v1/admin/operations/availability/meeting-configs",
         "tags": [
           "operations"
         ],
@@ -11019,6 +11157,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityMeetingConfigsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/meeting-configs/batch-update",
         "tags": [
           "operations"
         ],
@@ -11119,6 +11259,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityMeetingConfigsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/meeting-configs/batch-delete",
         "tags": [
           "operations"
         ],
@@ -11264,6 +11406,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityMeetingConfigsById",
+        "summary": "GET /v1/admin/operations/availability/meeting-configs/{id}",
         "tags": [
           "operations"
         ],
@@ -11503,6 +11647,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityMeetingConfigsById",
+        "summary": "PATCH /v1/admin/operations/availability/meeting-configs/{id}",
         "tags": [
           "operations"
         ],
@@ -11561,6 +11707,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityMeetingConfigsById",
+        "summary": "DELETE /v1/admin/operations/availability/meeting-configs/{id}",
         "tags": [
           "operations"
         ],
@@ -11714,6 +11862,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupGroups",
+        "summary": "GET /v1/admin/operations/availability/pickup-groups",
         "tags": [
           "operations"
         ],
@@ -11853,6 +12003,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupGroups",
+        "summary": "POST /v1/admin/operations/availability/pickup-groups",
         "tags": [
           "operations"
         ],
@@ -12036,6 +12188,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupGroupsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/pickup-groups/batch-update",
         "tags": [
           "operations"
         ],
@@ -12136,6 +12290,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupGroupsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/pickup-groups/batch-delete",
         "tags": [
           "operations"
         ],
@@ -12241,6 +12397,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupGroupsById",
+        "summary": "GET /v1/admin/operations/availability/pickup-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -12403,6 +12561,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityPickupGroupsById",
+        "summary": "PATCH /v1/admin/operations/availability/pickup-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -12461,6 +12621,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityPickupGroupsById",
+        "summary": "DELETE /v1/admin/operations/availability/pickup-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -12621,6 +12783,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupLocations",
+        "summary": "GET /v1/admin/operations/availability/pickup-locations",
         "tags": [
           "operations"
         ],
@@ -12782,6 +12946,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupLocations",
+        "summary": "POST /v1/admin/operations/availability/pickup-locations",
         "tags": [
           "operations"
         ],
@@ -12988,6 +13154,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupLocationsBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/pickup-locations/batch-update",
         "tags": [
           "operations"
         ],
@@ -13088,6 +13256,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityPickupLocationsBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/pickup-locations/batch-delete",
         "tags": [
           "operations"
         ],
@@ -13205,6 +13375,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityPickupLocationsById",
+        "summary": "GET /v1/admin/operations/availability/pickup-locations/{id}",
         "tags": [
           "operations"
         ],
@@ -13390,6 +13562,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityPickupLocationsById",
+        "summary": "PATCH /v1/admin/operations/availability/pickup-locations/{id}",
         "tags": [
           "operations"
         ],
@@ -13448,6 +13622,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityPickupLocationsById",
+        "summary": "DELETE /v1/admin/operations/availability/pickup-locations/{id}",
         "tags": [
           "operations"
         ],
@@ -13637,6 +13813,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityLocationPickupTimes",
+        "summary": "GET /v1/admin/operations/availability/location-pickup-times",
         "tags": [
           "operations"
         ],
@@ -13837,6 +14015,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityLocationPickupTimes",
+        "summary": "POST /v1/admin/operations/availability/location-pickup-times",
         "tags": [
           "operations"
         ],
@@ -14083,6 +14263,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityLocationPickupTimesBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/location-pickup-times/batch-update",
         "tags": [
           "operations"
         ],
@@ -14183,6 +14365,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityLocationPickupTimesBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/location-pickup-times/batch-delete",
         "tags": [
           "operations"
         ],
@@ -14321,6 +14505,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityLocationPickupTimesById",
+        "summary": "GET /v1/admin/operations/availability/location-pickup-times/{id}",
         "tags": [
           "operations"
         ],
@@ -14546,6 +14732,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityLocationPickupTimesById",
+        "summary": "PATCH /v1/admin/operations/availability/location-pickup-times/{id}",
         "tags": [
           "operations"
         ],
@@ -14604,6 +14792,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityLocationPickupTimesById",
+        "summary": "DELETE /v1/admin/operations/availability/location-pickup-times/{id}",
         "tags": [
           "operations"
         ],
@@ -14738,6 +14928,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCustomPickupAreas",
+        "summary": "GET /v1/admin/operations/availability/custom-pickup-areas",
         "tags": [
           "operations"
         ],
@@ -14864,6 +15056,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCustomPickupAreas",
+        "summary": "POST /v1/admin/operations/availability/custom-pickup-areas",
         "tags": [
           "operations"
         ],
@@ -15035,6 +15229,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCustomPickupAreasBatchUpdate",
+        "summary": "POST /v1/admin/operations/availability/custom-pickup-areas/batch-update",
         "tags": [
           "operations"
         ],
@@ -15135,6 +15331,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAvailabilityCustomPickupAreasBatchDelete",
+        "summary": "POST /v1/admin/operations/availability/custom-pickup-areas/batch-delete",
         "tags": [
           "operations"
         ],
@@ -15234,6 +15432,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAvailabilityCustomPickupAreasById",
+        "summary": "GET /v1/admin/operations/availability/custom-pickup-areas/{id}",
         "tags": [
           "operations"
         ],
@@ -15384,6 +15584,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAvailabilityCustomPickupAreasById",
+        "summary": "PATCH /v1/admin/operations/availability/custom-pickup-areas/{id}",
         "tags": [
           "operations"
         ],
@@ -15442,6 +15644,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAvailabilityCustomPickupAreasById",
+        "summary": "DELETE /v1/admin/operations/availability/custom-pickup-areas/{id}",
         "tags": [
           "operations"
         ],
@@ -15629,6 +15833,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsResources",
+        "summary": "GET /v1/admin/operations/resources",
         "tags": [
           "operations"
         ],
@@ -15811,6 +16017,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsResources",
+        "summary": "POST /v1/admin/operations/resources",
         "tags": [
           "operations"
         ],
@@ -15879,8 +16087,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -16038,6 +16245,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsResourcesBatchUpdate",
+        "summary": "POST /v1/admin/operations/resources/batch-update",
         "tags": [
           "operations"
         ],
@@ -16138,6 +16347,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsResourcesBatchDelete",
+        "summary": "POST /v1/admin/operations/resources/batch-delete",
         "tags": [
           "operations"
         ],
@@ -16266,6 +16477,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsResourcesById",
+        "summary": "GET /v1/admin/operations/resources/{id}",
         "tags": [
           "operations"
         ],
@@ -16331,8 +16544,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -16472,6 +16684,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsResourcesById",
+        "summary": "PATCH /v1/admin/operations/resources/{id}",
         "tags": [
           "operations"
         ],
@@ -16530,6 +16744,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsResourcesById",
+        "summary": "DELETE /v1/admin/operations/resources/{id}",
         "tags": [
           "operations"
         ],
@@ -16695,6 +16911,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPools",
+        "summary": "GET /v1/admin/operations/pools",
         "tags": [
           "operations"
         ],
@@ -16851,6 +17069,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPools",
+        "summary": "POST /v1/admin/operations/pools",
         "tags": [
           "operations"
         ],
@@ -16907,8 +17127,7 @@
                         "minimum": 0
                       },
                       "active": {
-                        "type": "boolean",
-                        "default": true
+                        "type": "boolean"
                       },
                       "notes": {
                         "type": [
@@ -17052,6 +17271,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPoolsBatchUpdate",
+        "summary": "POST /v1/admin/operations/pools/batch-update",
         "tags": [
           "operations"
         ],
@@ -17152,6 +17373,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPoolsBatchDelete",
+        "summary": "POST /v1/admin/operations/pools/batch-delete",
         "tags": [
           "operations"
         ],
@@ -17266,6 +17489,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPoolsById",
+        "summary": "GET /v1/admin/operations/pools/{id}",
         "tags": [
           "operations"
         ],
@@ -17319,8 +17544,7 @@
                     "minimum": 0
                   },
                   "active": {
-                    "type": "boolean",
-                    "default": true
+                    "type": "boolean"
                   },
                   "notes": {
                     "type": [
@@ -17446,6 +17670,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPoolsById",
+        "summary": "PATCH /v1/admin/operations/pools/{id}",
         "tags": [
           "operations"
         ],
@@ -17504,6 +17730,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPoolsById",
+        "summary": "DELETE /v1/admin/operations/pools/{id}",
         "tags": [
           "operations"
         ],
@@ -17610,6 +17838,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPoolMembers",
+        "summary": "GET /v1/admin/operations/pool-members",
         "tags": [
           "operations"
         ],
@@ -17733,6 +17963,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPoolMembers",
+        "summary": "POST /v1/admin/operations/pool-members",
         "tags": [
           "operations"
         ],
@@ -17793,6 +18025,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPoolMembersById",
+        "summary": "DELETE /v1/admin/operations/pool-members/{id}",
         "tags": [
           "operations"
         ],
@@ -17949,6 +18183,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsRequirements",
+        "summary": "GET /v1/admin/operations/requirements",
         "tags": [
           "operations"
         ],
@@ -18117,6 +18353,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsRequirements",
+        "summary": "POST /v1/admin/operations/requirements",
         "tags": [
           "operations"
         ],
@@ -18164,20 +18402,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -18312,6 +18547,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsRequirementsBatchUpdate",
+        "summary": "POST /v1/admin/operations/requirements/batch-update",
         "tags": [
           "operations"
         ],
@@ -18412,6 +18649,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsRequirementsBatchDelete",
+        "summary": "POST /v1/admin/operations/requirements/batch-delete",
         "tags": [
           "operations"
         ],
@@ -18523,6 +18762,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsRequirementsById",
+        "summary": "GET /v1/admin/operations/requirements/{id}",
         "tags": [
           "operations"
         ],
@@ -18567,20 +18808,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -18697,6 +18935,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsRequirementsById",
+        "summary": "PATCH /v1/admin/operations/requirements/{id}",
         "tags": [
           "operations"
         ],
@@ -18755,6 +18995,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsRequirementsById",
+        "summary": "DELETE /v1/admin/operations/requirements/{id}",
         "tags": [
           "operations"
         ],
@@ -18911,6 +19153,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAllocations",
+        "summary": "GET /v1/admin/operations/allocations",
         "tags": [
           "operations"
         ],
@@ -19079,6 +19323,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAllocations",
+        "summary": "POST /v1/admin/operations/allocations",
         "tags": [
           "operations"
         ],
@@ -19126,20 +19372,17 @@
                       },
                       "quantityRequired": {
                         "type": "integer",
-                        "minimum": 1,
-                        "default": 1
+                        "minimum": 1
                       },
                       "allocationMode": {
                         "type": "string",
                         "enum": [
                           "shared",
                           "exclusive"
-                        ],
-                        "default": "shared"
+                        ]
                       },
                       "priority": {
-                        "type": "integer",
-                        "default": 0
+                        "type": "integer"
                       }
                     }
                   }
@@ -19274,6 +19517,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAllocationsBatchUpdate",
+        "summary": "POST /v1/admin/operations/allocations/batch-update",
         "tags": [
           "operations"
         ],
@@ -19374,6 +19619,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsAllocationsBatchDelete",
+        "summary": "POST /v1/admin/operations/allocations/batch-delete",
         "tags": [
           "operations"
         ],
@@ -19485,6 +19732,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsAllocationsById",
+        "summary": "GET /v1/admin/operations/allocations/{id}",
         "tags": [
           "operations"
         ],
@@ -19529,20 +19778,17 @@
                   },
                   "quantityRequired": {
                     "type": "integer",
-                    "minimum": 1,
-                    "default": 1
+                    "minimum": 1
                   },
                   "allocationMode": {
                     "type": "string",
                     "enum": [
                       "shared",
                       "exclusive"
-                    ],
-                    "default": "shared"
+                    ]
                   },
                   "priority": {
-                    "type": "integer",
-                    "default": 0
+                    "type": "integer"
                   }
                 }
               }
@@ -19659,6 +19905,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAllocationsById",
+        "summary": "PATCH /v1/admin/operations/allocations/{id}",
         "tags": [
           "operations"
         ],
@@ -19717,6 +19965,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAllocationsById",
+        "summary": "DELETE /v1/admin/operations/allocations/{id}",
         "tags": [
           "operations"
         ],
@@ -19903,6 +20153,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsSlotAssignments",
+        "summary": "GET /v1/admin/operations/slot-assignments",
         "tags": [
           "operations"
         ],
@@ -20105,6 +20357,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSlotAssignments",
+        "summary": "POST /v1/admin/operations/slot-assignments",
         "tags": [
           "operations"
         ],
@@ -20161,8 +20415,7 @@
                           "released",
                           "cancelled",
                           "completed"
-                        ],
-                        "default": "reserved"
+                        ]
                       },
                       "assignedAt": {
                         "type": "string",
@@ -20335,6 +20588,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSlotAssignmentsBatchUpdate",
+        "summary": "POST /v1/admin/operations/slot-assignments/batch-update",
         "tags": [
           "operations"
         ],
@@ -20435,6 +20690,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSlotAssignmentsBatchDelete",
+        "summary": "POST /v1/admin/operations/slot-assignments/batch-delete",
         "tags": [
           "operations"
         ],
@@ -20561,6 +20818,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsSlotAssignmentsById",
+        "summary": "GET /v1/admin/operations/slot-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -20614,8 +20873,7 @@
                       "released",
                       "cancelled",
                       "completed"
-                    ],
-                    "default": "reserved"
+                    ]
                   },
                   "assignedAt": {
                     "type": "string",
@@ -20770,6 +21028,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsSlotAssignmentsById",
+        "summary": "PATCH /v1/admin/operations/slot-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -20828,6 +21088,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsSlotAssignmentsById",
+        "summary": "DELETE /v1/admin/operations/slot-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -20963,6 +21225,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsCloseouts",
+        "summary": "GET /v1/admin/operations/closeouts",
         "tags": [
           "operations"
         ],
@@ -21141,6 +21405,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsCloseouts",
+        "summary": "POST /v1/admin/operations/closeouts",
         "tags": [
           "operations"
         ],
@@ -21328,6 +21594,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsCloseoutsBatchUpdate",
+        "summary": "POST /v1/admin/operations/closeouts/batch-update",
         "tags": [
           "operations"
         ],
@@ -21428,6 +21696,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsCloseoutsBatchDelete",
+        "summary": "POST /v1/admin/operations/closeouts/batch-delete",
         "tags": [
           "operations"
         ],
@@ -21533,6 +21803,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsCloseoutsById",
+        "summary": "GET /v1/admin/operations/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -21717,6 +21989,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsCloseoutsById",
+        "summary": "PATCH /v1/admin/operations/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -21775,6 +22049,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsCloseoutsById",
+        "summary": "DELETE /v1/admin/operations/closeouts/{id}",
         "tags": [
           "operations"
         ],
@@ -21927,6 +22203,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsOperators",
+        "summary": "GET /v1/admin/operations/operators",
         "tags": [
           "operations"
         ],
@@ -22073,6 +22351,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsOperators",
+        "summary": "POST /v1/admin/operations/operators",
         "tags": [
           "operations"
         ],
@@ -22182,6 +22462,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsOperatorsById",
+        "summary": "GET /v1/admin/operations/operators/{id}",
         "tags": [
           "operations"
         ],
@@ -22353,6 +22635,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsOperatorsById",
+        "summary": "PATCH /v1/admin/operations/operators/{id}",
         "tags": [
           "operations"
         ],
@@ -22411,6 +22695,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsOperatorsById",
+        "summary": "DELETE /v1/admin/operations/operators/{id}",
         "tags": [
           "operations"
         ],
@@ -22634,6 +22920,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsVehicles",
+        "summary": "GET /v1/admin/operations/vehicles",
         "tags": [
           "operations"
         ],
@@ -22883,6 +23171,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsVehicles",
+        "summary": "POST /v1/admin/operations/vehicles",
         "tags": [
           "operations"
         ],
@@ -23044,6 +23334,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsVehiclesById",
+        "summary": "GET /v1/admin/operations/vehicles/{id}",
         "tags": [
           "operations"
         ],
@@ -23318,6 +23610,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsVehiclesById",
+        "summary": "PATCH /v1/admin/operations/vehicles/{id}",
         "tags": [
           "operations"
         ],
@@ -23376,6 +23670,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsVehiclesById",
+        "summary": "DELETE /v1/admin/operations/vehicles/{id}",
         "tags": [
           "operations"
         ],
@@ -23536,6 +23832,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDrivers",
+        "summary": "GET /v1/admin/operations/drivers",
         "tags": [
           "operations"
         ],
@@ -23699,6 +23997,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDrivers",
+        "summary": "POST /v1/admin/operations/drivers",
         "tags": [
           "operations"
         ],
@@ -23816,6 +24116,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDriversById",
+        "summary": "GET /v1/admin/operations/drivers/{id}",
         "tags": [
           "operations"
         ],
@@ -24004,6 +24306,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDriversById",
+        "summary": "PATCH /v1/admin/operations/drivers/{id}",
         "tags": [
           "operations"
         ],
@@ -24062,6 +24366,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDriversById",
+        "summary": "DELETE /v1/admin/operations/drivers/{id}",
         "tags": [
           "operations"
         ],
@@ -24338,6 +24644,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsTransferPreferences",
+        "summary": "GET /v1/admin/operations/transfer-preferences",
         "tags": [
           "operations"
         ],
@@ -24720,6 +25028,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsTransferPreferences",
+        "summary": "POST /v1/admin/operations/transfer-preferences",
         "tags": [
           "operations"
         ],
@@ -24952,6 +25262,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsTransferPreferencesById",
+        "summary": "GET /v1/admin/operations/transfer-preferences/{id}",
         "tags": [
           "operations"
         ],
@@ -25359,6 +25671,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsTransferPreferencesById",
+        "summary": "PATCH /v1/admin/operations/transfer-preferences/{id}",
         "tags": [
           "operations"
         ],
@@ -25417,6 +25731,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsTransferPreferencesById",
+        "summary": "DELETE /v1/admin/operations/transfer-preferences/{id}",
         "tags": [
           "operations"
         ],
@@ -25693,6 +26009,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatches",
+        "summary": "GET /v1/admin/operations/dispatches",
         "tags": [
           "operations"
         ],
@@ -25991,6 +26309,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatches",
+        "summary": "POST /v1/admin/operations/dispatches",
         "tags": [
           "operations"
         ],
@@ -26178,6 +26498,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchesById",
+        "summary": "GET /v1/admin/operations/dispatches/{id}",
         "tags": [
           "operations"
         ],
@@ -26500,6 +26822,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchesById",
+        "summary": "PATCH /v1/admin/operations/dispatches/{id}",
         "tags": [
           "operations"
         ],
@@ -26558,6 +26882,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchesById",
+        "summary": "DELETE /v1/admin/operations/dispatches/{id}",
         "tags": [
           "operations"
         ],
@@ -26719,6 +27045,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsExecutionEvents",
+        "summary": "GET /v1/admin/operations/execution-events",
         "tags": [
           "operations"
         ],
@@ -26893,6 +27221,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsExecutionEvents",
+        "summary": "POST /v1/admin/operations/execution-events",
         "tags": [
           "operations"
         ],
@@ -27014,6 +27344,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsExecutionEventsById",
+        "summary": "GET /v1/admin/operations/execution-events/{id}",
         "tags": [
           "operations"
         ],
@@ -27213,6 +27545,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsExecutionEventsById",
+        "summary": "PATCH /v1/admin/operations/execution-events/{id}",
         "tags": [
           "operations"
         ],
@@ -27271,6 +27605,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsExecutionEventsById",
+        "summary": "DELETE /v1/admin/operations/execution-events/{id}",
         "tags": [
           "operations"
         ],
@@ -27462,6 +27798,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchAssignments",
+        "summary": "GET /v1/admin/operations/dispatch-assignments",
         "tags": [
           "operations"
         ],
@@ -27655,6 +27993,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchAssignments",
+        "summary": "POST /v1/admin/operations/dispatch-assignments",
         "tags": [
           "operations"
         ],
@@ -27788,6 +28128,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchAssignmentsById",
+        "summary": "GET /v1/admin/operations/dispatch-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -28006,6 +28348,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchAssignmentsById",
+        "summary": "PATCH /v1/admin/operations/dispatch-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -28064,6 +28408,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchAssignmentsById",
+        "summary": "DELETE /v1/admin/operations/dispatch-assignments/{id}",
         "tags": [
           "operations"
         ],
@@ -28233,6 +28579,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchLegs",
+        "summary": "GET /v1/admin/operations/dispatch-legs",
         "tags": [
           "operations"
         ],
@@ -28427,6 +28775,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchLegs",
+        "summary": "POST /v1/admin/operations/dispatch-legs",
         "tags": [
           "operations"
         ],
@@ -28561,6 +28911,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchLegsById",
+        "summary": "GET /v1/admin/operations/dispatch-legs/{id}",
         "tags": [
           "operations"
         ],
@@ -28780,6 +29132,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchLegsById",
+        "summary": "PATCH /v1/admin/operations/dispatch-legs/{id}",
         "tags": [
           "operations"
         ],
@@ -28838,6 +29192,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchLegsById",
+        "summary": "DELETE /v1/admin/operations/dispatch-legs/{id}",
         "tags": [
           "operations"
         ],
@@ -28972,6 +29328,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchPassengers",
+        "summary": "GET /v1/admin/operations/dispatch-passengers",
         "tags": [
           "operations"
         ],
@@ -29107,6 +29465,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchPassengers",
+        "summary": "POST /v1/admin/operations/dispatch-passengers",
         "tags": [
           "operations"
         ],
@@ -29212,6 +29572,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchPassengersById",
+        "summary": "GET /v1/admin/operations/dispatch-passengers/{id}",
         "tags": [
           "operations"
         ],
@@ -29372,6 +29734,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchPassengersById",
+        "summary": "PATCH /v1/admin/operations/dispatch-passengers/{id}",
         "tags": [
           "operations"
         ],
@@ -29430,6 +29794,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchPassengersById",
+        "summary": "DELETE /v1/admin/operations/dispatch-passengers/{id}",
         "tags": [
           "operations"
         ],
@@ -29607,6 +29973,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDriverShifts",
+        "summary": "GET /v1/admin/operations/driver-shifts",
         "tags": [
           "operations"
         ],
@@ -29784,6 +30152,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDriverShifts",
+        "summary": "POST /v1/admin/operations/driver-shifts",
         "tags": [
           "operations"
         ],
@@ -29909,6 +30279,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDriverShiftsById",
+        "summary": "GET /v1/admin/operations/driver-shifts/{id}",
         "tags": [
           "operations"
         ],
@@ -30109,6 +30481,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDriverShiftsById",
+        "summary": "PATCH /v1/admin/operations/driver-shifts/{id}",
         "tags": [
           "operations"
         ],
@@ -30167,6 +30541,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDriverShiftsById",
+        "summary": "DELETE /v1/admin/operations/driver-shifts/{id}",
         "tags": [
           "operations"
         ],
@@ -30341,6 +30717,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsServiceIncidents",
+        "summary": "GET /v1/admin/operations/service-incidents",
         "tags": [
           "operations"
         ],
@@ -30524,6 +30902,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsServiceIncidents",
+        "summary": "POST /v1/admin/operations/service-incidents",
         "tags": [
           "operations"
         ],
@@ -30650,6 +31030,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsServiceIncidentsById",
+        "summary": "GET /v1/admin/operations/service-incidents/{id}",
         "tags": [
           "operations"
         ],
@@ -30857,6 +31239,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsServiceIncidentsById",
+        "summary": "PATCH /v1/admin/operations/service-incidents/{id}",
         "tags": [
           "operations"
         ],
@@ -30915,6 +31299,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsServiceIncidentsById",
+        "summary": "DELETE /v1/admin/operations/service-incidents/{id}",
         "tags": [
           "operations"
         ],
@@ -31088,6 +31474,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchCheckpoints",
+        "summary": "GET /v1/admin/operations/dispatch-checkpoints",
         "tags": [
           "operations"
         ],
@@ -31291,6 +31679,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsDispatchCheckpoints",
+        "summary": "POST /v1/admin/operations/dispatch-checkpoints",
         "tags": [
           "operations"
         ],
@@ -31429,6 +31819,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsDispatchCheckpointsById",
+        "summary": "GET /v1/admin/operations/dispatch-checkpoints/{id}",
         "tags": [
           "operations"
         ],
@@ -31656,6 +32048,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsDispatchCheckpointsById",
+        "summary": "PATCH /v1/admin/operations/dispatch-checkpoints/{id}",
         "tags": [
           "operations"
         ],
@@ -31714,6 +32108,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsDispatchCheckpointsById",
+        "summary": "DELETE /v1/admin/operations/dispatch-checkpoints/{id}",
         "tags": [
           "operations"
         ],
@@ -32037,6 +32433,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilities",
+        "summary": "GET /v1/admin/operations/facilities",
         "tags": [
           "operations"
         ],
@@ -32401,6 +32799,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilities",
+        "summary": "POST /v1/admin/operations/facilities",
         "tags": [
           "operations"
         ],
@@ -32627,6 +33027,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilitiesById",
+        "summary": "GET /v1/admin/operations/facilities/{id}",
         "tags": [
           "operations"
         ],
@@ -33015,6 +33417,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilitiesById",
+        "summary": "PATCH /v1/admin/operations/facilities/{id}",
         "tags": [
           "operations"
         ],
@@ -33073,6 +33477,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilitiesById",
+        "summary": "DELETE /v1/admin/operations/facilities/{id}",
         "tags": [
           "operations"
         ],
@@ -33191,6 +33597,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilitiesByIdContactPoints",
+        "summary": "GET /v1/admin/operations/facilities/{id}/contact-points",
         "tags": [
           "operations"
         ],
@@ -33406,6 +33814,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdContactPoints",
+        "summary": "POST /v1/admin/operations/facilities/{id}/contact-points",
         "tags": [
           "operations"
         ],
@@ -33629,6 +34039,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsContactPointsById",
+        "summary": "PATCH /v1/admin/operations/contact-points/{id}",
         "tags": [
           "operations"
         ],
@@ -33687,6 +34099,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsContactPointsById",
+        "summary": "DELETE /v1/admin/operations/contact-points/{id}",
         "tags": [
           "operations"
         ],
@@ -33856,6 +34270,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilitiesByIdAddresses",
+        "summary": "GET /v1/admin/operations/facilities/{id}/addresses",
         "tags": [
           "operations"
         ],
@@ -34160,6 +34576,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdAddresses",
+        "summary": "POST /v1/admin/operations/facilities/{id}/addresses",
         "tags": [
           "operations"
         ],
@@ -34476,6 +34894,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsAddressesById",
+        "summary": "PATCH /v1/admin/operations/addresses/{id}",
         "tags": [
           "operations"
         ],
@@ -34534,6 +34954,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsAddressesById",
+        "summary": "DELETE /v1/admin/operations/addresses/{id}",
         "tags": [
           "operations"
         ],
@@ -34713,6 +35135,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilityContacts",
+        "summary": "GET /v1/admin/operations/facility-contacts",
         "tags": [
           "operations"
         ],
@@ -34929,6 +35353,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdContacts",
+        "summary": "POST /v1/admin/operations/facilities/{id}/contacts",
         "tags": [
           "operations"
         ],
@@ -35142,6 +35568,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilityContactsById",
+        "summary": "PATCH /v1/admin/operations/facility-contacts/{id}",
         "tags": [
           "operations"
         ],
@@ -35200,6 +35628,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilityContactsById",
+        "summary": "DELETE /v1/admin/operations/facility-contacts/{id}",
         "tags": [
           "operations"
         ],
@@ -35359,6 +35789,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilityFeatures",
+        "summary": "GET /v1/admin/operations/facility-features",
         "tags": [
           "operations"
         ],
@@ -35558,6 +35990,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdFeatures",
+        "summary": "POST /v1/admin/operations/facilities/{id}/features",
         "tags": [
           "operations"
         ],
@@ -35754,6 +36188,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilityFeaturesById",
+        "summary": "PATCH /v1/admin/operations/facility-features/{id}",
         "tags": [
           "operations"
         ],
@@ -35812,6 +36248,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilityFeaturesById",
+        "summary": "DELETE /v1/admin/operations/facility-features/{id}",
         "tags": [
           "operations"
         ],
@@ -35983,6 +36421,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFacilityOperationSchedules",
+        "summary": "GET /v1/admin/operations/facility-operation-schedules",
         "tags": [
           "operations"
         ],
@@ -36198,6 +36638,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFacilitiesByIdOperationSchedules",
+        "summary": "POST /v1/admin/operations/facilities/{id}/operation-schedules",
         "tags": [
           "operations"
         ],
@@ -36413,6 +36855,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFacilityOperationSchedulesById",
+        "summary": "PATCH /v1/admin/operations/facility-operation-schedules/{id}",
         "tags": [
           "operations"
         ],
@@ -36471,6 +36915,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsFacilityOperationSchedulesById",
+        "summary": "DELETE /v1/admin/operations/facility-operation-schedules/{id}",
         "tags": [
           "operations"
         ],
@@ -36673,6 +37119,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsProperties",
+        "summary": "GET /v1/admin/operations/properties",
         "tags": [
           "operations"
         ],
@@ -36910,6 +37358,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsProperties",
+        "summary": "POST /v1/admin/operations/properties",
         "tags": [
           "operations"
         ],
@@ -37057,6 +37507,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertiesById",
+        "summary": "GET /v1/admin/operations/properties/{id}",
         "tags": [
           "operations"
         ],
@@ -37301,6 +37753,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPropertiesById",
+        "summary": "PATCH /v1/admin/operations/properties/{id}",
         "tags": [
           "operations"
         ],
@@ -37359,6 +37813,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPropertiesById",
+        "summary": "DELETE /v1/admin/operations/properties/{id}",
         "tags": [
           "operations"
         ],
@@ -37567,6 +38023,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroups",
+        "summary": "GET /v1/admin/operations/property-groups",
         "tags": [
           "operations"
         ],
@@ -37791,6 +38249,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPropertyGroups",
+        "summary": "POST /v1/admin/operations/property-groups",
         "tags": [
           "operations"
         ],
@@ -37940,6 +38400,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroupsById",
+        "summary": "GET /v1/admin/operations/property-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -38189,6 +38651,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPropertyGroupsById",
+        "summary": "PATCH /v1/admin/operations/property-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -38247,6 +38711,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPropertyGroupsById",
+        "summary": "DELETE /v1/admin/operations/property-groups/{id}",
         "tags": [
           "operations"
         ],
@@ -38408,6 +38874,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroupMembers",
+        "summary": "GET /v1/admin/operations/property-group-members",
         "tags": [
           "operations"
         ],
@@ -38588,6 +39056,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsPropertyGroupMembers",
+        "summary": "POST /v1/admin/operations/property-group-members",
         "tags": [
           "operations"
         ],
@@ -38705,6 +39175,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsPropertyGroupMembersById",
+        "summary": "GET /v1/admin/operations/property-group-members/{id}",
         "tags": [
           "operations"
         ],
@@ -38891,6 +39363,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsPropertyGroupMembersById",
+        "summary": "PATCH /v1/admin/operations/property-group-members/{id}",
         "tags": [
           "operations"
         ],
@@ -38949,6 +39423,8 @@
             }
           }
         },
+        "operationId": "deleteAdminOperationsPropertyGroupMembersById",
+        "summary": "DELETE /v1/admin/operations/property-group-members/{id}",
         "tags": [
           "operations"
         ],
@@ -39123,6 +39599,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFunctionSpaces",
+        "summary": "GET /v1/admin/operations/function-spaces",
         "tags": [
           "operations"
         ],
@@ -39334,6 +39812,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsFunctionSpaces",
+        "summary": "POST /v1/admin/operations/function-spaces",
         "tags": [
           "operations"
         ],
@@ -39518,6 +39998,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsFunctionSpacesById",
+        "summary": "GET /v1/admin/operations/function-spaces/{id}",
         "tags": [
           "operations"
         ],
@@ -39738,6 +40220,8 @@
             }
           }
         },
+        "operationId": "patchAdminOperationsFunctionSpacesById",
+        "summary": "PATCH /v1/admin/operations/function-spaces/{id}",
         "tags": [
           "operations"
         ],
@@ -39890,6 +40374,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsFunctionSpacesByIdCapacities",
+        "summary": "PUT /v1/admin/operations/function-spaces/{id}/capacities",
         "tags": [
           "operations"
         ],
@@ -40131,6 +40617,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocks",
+        "summary": "POST /v1/admin/operations/space-blocks",
         "tags": [
           "operations"
         ],
@@ -40354,6 +40842,8 @@
             }
           }
         },
+        "operationId": "getAdminOperationsSpaceBlocksById",
+        "summary": "GET /v1/admin/operations/space-blocks/{id}",
         "tags": [
           "operations"
         ],
@@ -40513,6 +41003,8 @@
             }
           }
         },
+        "operationId": "putAdminOperationsSpaceBlocksByIdSlots",
+        "summary": "PUT /v1/admin/operations/space-blocks/{id}/slots",
         "tags": [
           "operations"
         ],
@@ -40786,6 +41278,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocksByIdPickups",
+        "summary": "POST /v1/admin/operations/space-blocks/{id}/pickups",
         "tags": [
           "operations"
         ],
@@ -40934,6 +41428,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocksByIdPickupsReverse",
+        "summary": "POST /v1/admin/operations/space-blocks/{id}/pickups/reverse",
         "tags": [
           "operations"
         ],
@@ -41117,6 +41613,8 @@
             }
           }
         },
+        "operationId": "postAdminOperationsSpaceBlocksByIdRelease",
+        "summary": "POST /v1/admin/operations/space-blocks/{id}/release",
         "tags": [
           "operations"
         ],

--- a/starters/operator/openapi/admin/operator-settings.json
+++ b/starters/operator/openapi/admin/operator-settings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -273,6 +279,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperatorProfile",
+        "summary": "GET /v1/admin/settings/operator-profile",
         "tags": [
           "operator-settings"
         ],
@@ -515,6 +523,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperatorProfile",
+        "summary": "PATCH /v1/admin/settings/operator-profile",
         "tags": [
           "operator-settings"
         ],
@@ -591,6 +601,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperatorPaymentInstructions",
+        "summary": "GET /v1/admin/settings/operator-payment-instructions",
         "tags": [
           "operator-settings"
         ],
@@ -701,6 +713,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperatorPaymentInstructions",
+        "summary": "PATCH /v1/admin/settings/operator-payment-instructions",
         "tags": [
           "operator-settings"
         ],
@@ -764,6 +778,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperatorPaymentDefaults",
+        "summary": "GET /v1/admin/settings/operator-payment-defaults",
         "tags": [
           "operator-settings"
         ],
@@ -900,6 +916,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperatorPaymentDefaults",
+        "summary": "PATCH /v1/admin/settings/operator-payment-defaults",
         "tags": [
           "operator-settings"
         ],
@@ -1060,6 +1078,8 @@
             }
           }
         },
+        "operationId": "getAdminSettingsOperator",
+        "summary": "GET /v1/admin/settings/operator",
         "tags": [
           "operator-settings"
         ],
@@ -1417,6 +1437,8 @@
             }
           }
         },
+        "operationId": "patchAdminSettingsOperator",
+        "summary": "PATCH /v1/admin/settings/operator",
         "tags": [
           "operator-settings"
         ],

--- a/starters/operator/openapi/admin/pricing.json
+++ b/starters/operator/openapi/admin/pricing.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -388,6 +394,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategories",
+        "summary": "GET /v1/admin/pricing/pricing-categories",
         "tags": [
           "pricing"
         ],
@@ -636,6 +644,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPricingCategories",
+        "summary": "POST /v1/admin/pricing/pricing-categories",
         "tags": [
           "pricing"
         ],
@@ -805,6 +815,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategoriesById",
+        "summary": "GET /v1/admin/pricing/pricing-categories/{id}",
         "tags": [
           "pricing"
         ],
@@ -1072,6 +1084,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPricingCategoriesById",
+        "summary": "PATCH /v1/admin/pricing/pricing-categories/{id}",
         "tags": [
           "pricing"
         ],
@@ -1127,6 +1141,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPricingCategoriesById",
+        "summary": "DELETE /v1/admin/pricing/pricing-categories/{id}",
         "tags": [
           "pricing"
         ],
@@ -1300,6 +1316,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategoryDependencies",
+        "summary": "GET /v1/admin/pricing/pricing-category-dependencies",
         "tags": [
           "pricing"
         ],
@@ -1442,6 +1460,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPricingCategoryDependencies",
+        "summary": "POST /v1/admin/pricing/pricing-category-dependencies",
         "tags": [
           "pricing"
         ],
@@ -1558,6 +1578,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPricingCategoryDependenciesById",
+        "summary": "GET /v1/admin/pricing/pricing-category-dependencies/{id}",
         "tags": [
           "pricing"
         ],
@@ -1722,6 +1744,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPricingCategoryDependenciesById",
+        "summary": "PATCH /v1/admin/pricing/pricing-category-dependencies/{id}",
         "tags": [
           "pricing"
         ],
@@ -1777,6 +1801,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPricingCategoryDependenciesById",
+        "summary": "DELETE /v1/admin/pricing/pricing-category-dependencies/{id}",
         "tags": [
           "pricing"
         ],
@@ -1964,6 +1990,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPolicies",
+        "summary": "GET /v1/admin/pricing/cancellation-policies",
         "tags": [
           "pricing"
         ],
@@ -2123,6 +2151,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingCancellationPolicies",
+        "summary": "POST /v1/admin/pricing/cancellation-policies",
         "tags": [
           "pricing"
         ],
@@ -2247,6 +2277,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPoliciesById",
+        "summary": "GET /v1/admin/pricing/cancellation-policies/{id}",
         "tags": [
           "pricing"
         ],
@@ -2428,6 +2460,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingCancellationPoliciesById",
+        "summary": "PATCH /v1/admin/pricing/cancellation-policies/{id}",
         "tags": [
           "pricing"
         ],
@@ -2483,6 +2517,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingCancellationPoliciesById",
+        "summary": "DELETE /v1/admin/pricing/cancellation-policies/{id}",
         "tags": [
           "pricing"
         ],
@@ -2640,6 +2676,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPolicyRules",
+        "summary": "GET /v1/admin/pricing/cancellation-policy-rules",
         "tags": [
           "pricing"
         ],
@@ -2795,6 +2833,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingCancellationPolicyRules",
+        "summary": "POST /v1/admin/pricing/cancellation-policy-rules",
         "tags": [
           "pricing"
         ],
@@ -2917,6 +2957,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingCancellationPolicyRulesById",
+        "summary": "GET /v1/admin/pricing/cancellation-policy-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -3094,6 +3136,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingCancellationPolicyRulesById",
+        "summary": "PATCH /v1/admin/pricing/cancellation-policy-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -3149,6 +3193,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingCancellationPolicyRulesById",
+        "summary": "DELETE /v1/admin/pricing/cancellation-policy-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -3336,6 +3382,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceCatalogs",
+        "summary": "GET /v1/admin/pricing/price-catalogs",
         "tags": [
           "pricing"
         ],
@@ -3499,6 +3547,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPriceCatalogs",
+        "summary": "POST /v1/admin/pricing/price-catalogs",
         "tags": [
           "pricing"
         ],
@@ -3623,6 +3673,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceCatalogsById",
+        "summary": "GET /v1/admin/pricing/price-catalogs/{id}",
         "tags": [
           "pricing"
         ],
@@ -3807,6 +3859,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPriceCatalogsById",
+        "summary": "PATCH /v1/admin/pricing/price-catalogs/{id}",
         "tags": [
           "pricing"
         ],
@@ -3862,6 +3916,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPriceCatalogsById",
+        "summary": "DELETE /v1/admin/pricing/price-catalogs/{id}",
         "tags": [
           "pricing"
         ],
@@ -4051,6 +4107,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceSchedules",
+        "summary": "GET /v1/admin/pricing/price-schedules",
         "tags": [
           "pricing"
         ],
@@ -4263,6 +4321,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPriceSchedules",
+        "summary": "POST /v1/admin/pricing/price-schedules",
         "tags": [
           "pricing"
         ],
@@ -4409,6 +4469,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPriceSchedulesById",
+        "summary": "GET /v1/admin/pricing/price-schedules/{id}",
         "tags": [
           "pricing"
         ],
@@ -4642,6 +4704,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPriceSchedulesById",
+        "summary": "PATCH /v1/admin/pricing/price-schedules/{id}",
         "tags": [
           "pricing"
         ],
@@ -4697,6 +4761,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPriceSchedulesById",
+        "summary": "DELETE /v1/admin/pricing/price-schedules/{id}",
         "tags": [
           "pricing"
         ],
@@ -4962,6 +5028,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionPriceRules",
+        "summary": "GET /v1/admin/pricing/option-price-rules",
         "tags": [
           "pricing"
         ],
@@ -5236,6 +5304,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionPriceRules",
+        "summary": "POST /v1/admin/pricing/option-price-rules",
         "tags": [
           "pricing"
         ],
@@ -5419,6 +5489,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionPriceRulesById",
+        "summary": "GET /v1/admin/pricing/option-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -5711,6 +5783,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/option-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -5766,6 +5840,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/option-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -5980,6 +6056,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitPriceRules",
+        "summary": "GET /v1/admin/pricing/option-unit-price-rules",
         "tags": [
           "pricing"
         ],
@@ -6198,6 +6276,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionUnitPriceRules",
+        "summary": "POST /v1/admin/pricing/option-unit-price-rules",
         "tags": [
           "pricing"
         ],
@@ -6353,6 +6433,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitPriceRulesById",
+        "summary": "GET /v1/admin/pricing/option-unit-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -6591,6 +6673,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionUnitPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/option-unit-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -6646,6 +6730,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionUnitPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/option-unit-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -6836,6 +6922,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionStartTimeRules",
+        "summary": "GET /v1/admin/pricing/option-start-time-rules",
         "tags": [
           "pricing"
         ],
@@ -7024,6 +7112,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionStartTimeRules",
+        "summary": "POST /v1/admin/pricing/option-start-time-rules",
         "tags": [
           "pricing"
         ],
@@ -7163,6 +7253,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionStartTimeRulesById",
+        "summary": "GET /v1/admin/pricing/option-start-time-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -7372,6 +7464,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionStartTimeRulesById",
+        "summary": "PATCH /v1/admin/pricing/option-start-time-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -7427,6 +7521,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionStartTimeRulesById",
+        "summary": "DELETE /v1/admin/pricing/option-start-time-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -7572,6 +7668,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitTiers",
+        "summary": "GET /v1/admin/pricing/option-unit-tiers",
         "tags": [
           "pricing"
         ],
@@ -7704,6 +7802,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingOptionUnitTiers",
+        "summary": "POST /v1/admin/pricing/option-unit-tiers",
         "tags": [
           "pricing"
         ],
@@ -7814,6 +7914,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingOptionUnitTiersById",
+        "summary": "GET /v1/admin/pricing/option-unit-tiers/{id}",
         "tags": [
           "pricing"
         ],
@@ -7968,6 +8070,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingOptionUnitTiersById",
+        "summary": "PATCH /v1/admin/pricing/option-unit-tiers/{id}",
         "tags": [
           "pricing"
         ],
@@ -8023,6 +8127,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingOptionUnitTiersById",
+        "summary": "DELETE /v1/admin/pricing/option-unit-tiers/{id}",
         "tags": [
           "pricing"
         ],
@@ -8199,6 +8305,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPickupPriceRules",
+        "summary": "GET /v1/admin/pricing/pickup-price-rules",
         "tags": [
           "pricing"
         ],
@@ -8359,6 +8467,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingPickupPriceRules",
+        "summary": "POST /v1/admin/pricing/pickup-price-rules",
         "tags": [
           "pricing"
         ],
@@ -8484,6 +8594,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingPickupPriceRulesById",
+        "summary": "GET /v1/admin/pricing/pickup-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -8664,6 +8776,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingPickupPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/pickup-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -8719,6 +8833,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingPickupPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/pickup-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -8909,6 +9025,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDropoffPriceRules",
+        "summary": "GET /v1/admin/pricing/dropoff-price-rules",
         "tags": [
           "pricing"
         ],
@@ -9098,6 +9216,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingDropoffPriceRules",
+        "summary": "POST /v1/admin/pricing/dropoff-price-rules",
         "tags": [
           "pricing"
         ],
@@ -9237,6 +9357,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDropoffPriceRulesById",
+        "summary": "GET /v1/admin/pricing/dropoff-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -9446,6 +9568,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingDropoffPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/dropoff-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -9501,6 +9625,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingDropoffPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/dropoff-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -9703,6 +9829,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingExtraPriceRules",
+        "summary": "GET /v1/admin/pricing/extra-price-rules",
         "tags": [
           "pricing"
         ],
@@ -9897,6 +10025,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingExtraPriceRules",
+        "summary": "POST /v1/admin/pricing/extra-price-rules",
         "tags": [
           "pricing"
         ],
@@ -10040,6 +10170,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingExtraPriceRulesById",
+        "summary": "GET /v1/admin/pricing/extra-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -10255,6 +10387,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingExtraPriceRulesById",
+        "summary": "PATCH /v1/admin/pricing/extra-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -10310,6 +10444,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingExtraPriceRulesById",
+        "summary": "DELETE /v1/admin/pricing/extra-price-rules/{id}",
         "tags": [
           "pricing"
         ],
@@ -10488,6 +10624,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDeparturePriceOverrides",
+        "summary": "GET /v1/admin/pricing/departure-price-overrides",
         "tags": [
           "pricing"
         ],
@@ -10636,6 +10774,8 @@
             }
           }
         },
+        "operationId": "postAdminPricingDeparturePriceOverrides",
+        "summary": "POST /v1/admin/pricing/departure-price-overrides",
         "tags": [
           "pricing"
         ],
@@ -10755,6 +10895,8 @@
             }
           }
         },
+        "operationId": "getAdminPricingDeparturePriceOverridesById",
+        "summary": "GET /v1/admin/pricing/departure-price-overrides/{id}",
         "tags": [
           "pricing"
         ],
@@ -10923,6 +11065,8 @@
             }
           }
         },
+        "operationId": "patchAdminPricingDeparturePriceOverridesById",
+        "summary": "PATCH /v1/admin/pricing/departure-price-overrides/{id}",
         "tags": [
           "pricing"
         ],
@@ -10978,6 +11122,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPricingDeparturePriceOverridesById",
+        "summary": "DELETE /v1/admin/pricing/departure-price-overrides/{id}",
         "tags": [
           "pricing"
         ],

--- a/starters/operator/openapi/admin/products.json
+++ b/starters/operator/openapi/admin/products.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -289,6 +295,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsActivationSettings",
+        "summary": "GET /v1/admin/products/activation-settings",
         "tags": [
           "products"
         ],
@@ -403,6 +411,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsActivationSettingsById",
+        "summary": "GET /v1/admin/products/activation-settings/{id}",
         "tags": [
           "products"
         ],
@@ -582,6 +592,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsActivationSettingsById",
+        "summary": "PATCH /v1/admin/products/activation-settings/{id}",
         "tags": [
           "products"
         ],
@@ -637,6 +649,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsActivationSettingsById",
+        "summary": "DELETE /v1/admin/products/activation-settings/{id}",
         "tags": [
           "products"
         ],
@@ -818,6 +832,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdActivationSettings",
+        "summary": "POST /v1/admin/products/{id}/activation-settings",
         "tags": [
           "products"
         ],
@@ -979,6 +995,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTicketSettings",
+        "summary": "GET /v1/admin/products/ticket-settings",
         "tags": [
           "products"
         ],
@@ -1105,6 +1123,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTicketSettingsById",
+        "summary": "GET /v1/admin/products/ticket-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1306,6 +1326,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsTicketSettingsById",
+        "summary": "PATCH /v1/admin/products/ticket-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1361,6 +1383,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsTicketSettingsById",
+        "summary": "DELETE /v1/admin/products/ticket-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1564,6 +1588,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdTicketSettings",
+        "summary": "POST /v1/admin/products/{id}/ticket-settings",
         "tags": [
           "products"
         ],
@@ -1706,6 +1732,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsVisibilitySettings",
+        "summary": "GET /v1/admin/products/visibility-settings",
         "tags": [
           "products"
         ],
@@ -1799,6 +1827,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsVisibilitySettingsById",
+        "summary": "GET /v1/admin/products/visibility-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1936,6 +1966,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsVisibilitySettingsById",
+        "summary": "PATCH /v1/admin/products/visibility-settings/{id}",
         "tags": [
           "products"
         ],
@@ -1991,6 +2023,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsVisibilitySettingsById",
+        "summary": "DELETE /v1/admin/products/visibility-settings/{id}",
         "tags": [
           "products"
         ],
@@ -2130,6 +2164,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdVisibilitySettings",
+        "summary": "POST /v1/admin/products/{id}/visibility-settings",
         "tags": [
           "products"
         ],
@@ -2295,6 +2331,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsCapabilities",
+        "summary": "GET /v1/admin/products/capabilities",
         "tags": [
           "products"
         ],
@@ -2402,6 +2440,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsCapabilitiesById",
+        "summary": "GET /v1/admin/products/capabilities/{id}",
         "tags": [
           "products"
         ],
@@ -2565,6 +2605,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsCapabilitiesById",
+        "summary": "PATCH /v1/admin/products/capabilities/{id}",
         "tags": [
           "products"
         ],
@@ -2620,6 +2662,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsCapabilitiesById",
+        "summary": "DELETE /v1/admin/products/capabilities/{id}",
         "tags": [
           "products"
         ],
@@ -2788,6 +2832,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdCapabilities",
+        "summary": "POST /v1/admin/products/{id}/capabilities",
         "tags": [
           "products"
         ],
@@ -2922,6 +2968,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDeliveryFormats",
+        "summary": "GET /v1/admin/products/delivery-formats",
         "tags": [
           "products"
         ],
@@ -3017,6 +3065,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDeliveryFormatsById",
+        "summary": "GET /v1/admin/products/delivery-formats/{id}",
         "tags": [
           "products"
         ],
@@ -3157,6 +3207,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsDeliveryFormatsById",
+        "summary": "PATCH /v1/admin/products/delivery-formats/{id}",
         "tags": [
           "products"
         ],
@@ -3212,6 +3264,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsDeliveryFormatsById",
+        "summary": "DELETE /v1/admin/products/delivery-formats/{id}",
         "tags": [
           "products"
         ],
@@ -3357,6 +3411,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDeliveryFormats",
+        "summary": "POST /v1/admin/products/{id}/delivery-formats",
         "tags": [
           "products"
         ],
@@ -3496,6 +3552,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFeatures",
+        "summary": "GET /v1/admin/products/features",
         "tags": [
           "products"
         ],
@@ -3599,6 +3657,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFeaturesById",
+        "summary": "GET /v1/admin/products/features/{id}",
         "tags": [
           "products"
         ],
@@ -3756,6 +3816,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsFeaturesById",
+        "summary": "PATCH /v1/admin/products/features/{id}",
         "tags": [
           "products"
         ],
@@ -3811,6 +3873,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsFeaturesById",
+        "summary": "DELETE /v1/admin/products/features/{id}",
         "tags": [
           "products"
         ],
@@ -3973,6 +4037,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdFeatures",
+        "summary": "POST /v1/admin/products/{id}/features",
         "tags": [
           "products"
         ],
@@ -4083,6 +4149,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFaqs",
+        "summary": "GET /v1/admin/products/faqs",
         "tags": [
           "products"
         ],
@@ -4172,6 +4240,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsFaqsById",
+        "summary": "GET /v1/admin/products/faqs/{id}",
         "tags": [
           "products"
         ],
@@ -4303,6 +4373,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsFaqsById",
+        "summary": "PATCH /v1/admin/products/faqs/{id}",
         "tags": [
           "products"
         ],
@@ -4358,6 +4430,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsFaqsById",
+        "summary": "DELETE /v1/admin/products/faqs/{id}",
         "tags": [
           "products"
         ],
@@ -4495,6 +4569,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdFaqs",
+        "summary": "POST /v1/admin/products/{id}/faqs",
         "tags": [
           "products"
         ],
@@ -4687,6 +4763,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsLocations",
+        "summary": "GET /v1/admin/products/locations",
         "tags": [
           "products"
         ],
@@ -4841,6 +4919,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsLocationsById",
+        "summary": "GET /v1/admin/products/locations/{id}",
         "tags": [
           "products"
         ],
@@ -5104,6 +5184,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsLocationsById",
+        "summary": "PATCH /v1/admin/products/locations/{id}",
         "tags": [
           "products"
         ],
@@ -5159,6 +5241,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsLocationsById",
+        "summary": "DELETE /v1/admin/products/locations/{id}",
         "tags": [
           "products"
         ],
@@ -5427,6 +5511,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdLocations",
+        "summary": "POST /v1/admin/products/{id}/locations",
         "tags": [
           "products"
         ],
@@ -5643,6 +5729,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinations",
+        "summary": "GET /v1/admin/products/destinations",
         "tags": [
           "products"
         ],
@@ -5851,6 +5939,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsDestinations",
+        "summary": "POST /v1/admin/products/destinations",
         "tags": [
           "products"
         ],
@@ -5983,6 +6073,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinationsById",
+        "summary": "GET /v1/admin/products/destinations/{id}",
         "tags": [
           "products"
         ],
@@ -6216,6 +6308,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsDestinationsById",
+        "summary": "PATCH /v1/admin/products/destinations/{id}",
         "tags": [
           "products"
         ],
@@ -6271,6 +6365,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsDestinationsById",
+        "summary": "DELETE /v1/admin/products/destinations/{id}",
         "tags": [
           "products"
         ],
@@ -6409,6 +6505,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinationTranslations",
+        "summary": "GET /v1/admin/products/destination-translations",
         "tags": [
           "products"
         ],
@@ -6579,6 +6677,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsDestinationsByIdTranslations",
+        "summary": "POST /v1/admin/products/destinations/{id}/translations",
         "tags": [
           "products"
         ],
@@ -6745,6 +6845,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsDestinationTranslationsById",
+        "summary": "PATCH /v1/admin/products/destination-translations/{id}",
         "tags": [
           "products"
         ],
@@ -6800,6 +6902,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsDestinationTranslationsById",
+        "summary": "DELETE /v1/admin/products/destination-translations/{id}",
         "tags": [
           "products"
         ],
@@ -6938,6 +7042,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductCategoryTranslations",
+        "summary": "GET /v1/admin/products/product-category-translations",
         "tags": [
           "products"
         ],
@@ -7108,6 +7214,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductCategoriesByIdTranslations",
+        "summary": "POST /v1/admin/products/product-categories/{id}/translations",
         "tags": [
           "products"
         ],
@@ -7274,6 +7382,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductCategoryTranslationsById",
+        "summary": "PATCH /v1/admin/products/product-category-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7329,6 +7439,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductCategoryTranslationsById",
+        "summary": "DELETE /v1/admin/products/product-category-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7446,6 +7558,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTagTranslations",
+        "summary": "GET /v1/admin/products/product-tag-translations",
         "tags": [
           "products"
         ],
@@ -7576,6 +7690,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductTagsByIdTranslations",
+        "summary": "POST /v1/admin/products/product-tags/{id}/translations",
         "tags": [
           "products"
         ],
@@ -7702,6 +7818,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductTagTranslationsById",
+        "summary": "PATCH /v1/admin/products/product-tag-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7757,6 +7875,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductTagTranslationsById",
+        "summary": "DELETE /v1/admin/products/product-tag-translations/{id}",
         "tags": [
           "products"
         ],
@@ -7879,6 +7999,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsDestinationLinks",
+        "summary": "GET /v1/admin/products/destination-links",
         "tags": [
           "products"
         ],
@@ -8000,6 +8122,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDestinations",
+        "summary": "POST /v1/admin/products/{id}/destinations",
         "tags": [
           "products"
         ],
@@ -8065,6 +8189,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDestinationsByDestinationId",
+        "summary": "DELETE /v1/admin/products/{id}/destinations/{destinationId}",
         "tags": [
           "products"
         ],
@@ -8225,6 +8351,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptions",
+        "summary": "GET /v1/admin/products/options",
         "tags": [
           "products"
         ],
@@ -8351,6 +8479,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptionsByOptionId",
+        "summary": "GET /v1/admin/products/options/{optionId}",
         "tags": [
           "products"
         ],
@@ -8549,6 +8679,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsOptionsByOptionId",
+        "summary": "PATCH /v1/admin/products/options/{optionId}",
         "tags": [
           "products"
         ],
@@ -8604,6 +8736,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsOptionsByOptionId",
+        "summary": "DELETE /v1/admin/products/options/{optionId}",
         "tags": [
           "products"
         ],
@@ -8810,6 +8944,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdOptions",
+        "summary": "POST /v1/admin/products/{id}/options",
         "tags": [
           "products"
         ],
@@ -9008,6 +9144,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnits",
+        "summary": "GET /v1/admin/products/units",
         "tags": [
           "products"
         ],
@@ -9169,6 +9307,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnitsByUnitId",
+        "summary": "GET /v1/admin/products/units/{unitId}",
         "tags": [
           "products"
         ],
@@ -9438,6 +9578,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsUnitsByUnitId",
+        "summary": "PATCH /v1/admin/products/units/{unitId}",
         "tags": [
           "products"
         ],
@@ -9493,6 +9635,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsUnitsByUnitId",
+        "summary": "DELETE /v1/admin/products/units/{unitId}",
         "tags": [
           "products"
         ],
@@ -9771,6 +9915,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsOptionsByOptionIdUnits",
+        "summary": "POST /v1/admin/products/options/{optionId}/units",
         "tags": [
           "products"
         ],
@@ -9944,6 +10090,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTranslations",
+        "summary": "GET /v1/admin/products/translations",
         "tags": [
           "products"
         ],
@@ -10085,6 +10233,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsTranslationsByTranslationId",
+        "summary": "GET /v1/admin/products/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10315,6 +10465,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10370,6 +10522,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10606,6 +10760,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/translations",
         "tags": [
           "products"
         ],
@@ -10737,6 +10893,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptionTranslations",
+        "summary": "GET /v1/admin/products/option-translations",
         "tags": [
           "products"
         ],
@@ -10836,6 +10994,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsOptionTranslationsByTranslationId",
+        "summary": "GET /v1/admin/products/option-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -10986,6 +11146,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsOptionTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/option-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11041,6 +11203,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsOptionTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/option-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11197,6 +11361,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsOptionsByOptionIdTranslations",
+        "summary": "POST /v1/admin/products/options/{optionId}/translations",
         "tags": [
           "products"
         ],
@@ -11328,6 +11494,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnitTranslations",
+        "summary": "GET /v1/admin/products/unit-translations",
         "tags": [
           "products"
         ],
@@ -11427,6 +11595,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsUnitTranslationsByTranslationId",
+        "summary": "GET /v1/admin/products/unit-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11577,6 +11747,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsUnitTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/unit-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11632,6 +11804,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsUnitTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/unit-translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -11788,6 +11962,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsUnitsByUnitIdTranslations",
+        "summary": "POST /v1/admin/products/units/{unitId}/translations",
         "tags": [
           "products"
         ],
@@ -11927,6 +12103,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTypes",
+        "summary": "GET /v1/admin/products/product-types",
         "tags": [
           "products"
         ],
@@ -12066,6 +12244,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductTypes",
+        "summary": "POST /v1/admin/products/product-types",
         "tags": [
           "products"
         ],
@@ -12170,6 +12350,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTypesByTypeId",
+        "summary": "GET /v1/admin/products/product-types/{typeId}",
         "tags": [
           "products"
         ],
@@ -12333,6 +12515,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductTypesByTypeId",
+        "summary": "PATCH /v1/admin/products/product-types/{typeId}",
         "tags": [
           "products"
         ],
@@ -12388,6 +12572,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductTypesByTypeId",
+        "summary": "DELETE /v1/admin/products/product-types/{typeId}",
         "tags": [
           "products"
         ],
@@ -12543,6 +12729,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductCategories",
+        "summary": "GET /v1/admin/products/product-categories",
         "tags": [
           "products"
         ],
@@ -12747,6 +12935,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductCategories",
+        "summary": "POST /v1/admin/products/product-categories",
         "tags": [
           "products"
         ],
@@ -12859,6 +13049,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductCategoriesByCategoryId",
+        "summary": "GET /v1/admin/products/product-categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -13087,6 +13279,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductCategoriesByCategoryId",
+        "summary": "PATCH /v1/admin/products/product-categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -13142,6 +13336,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductCategoriesByCategoryId",
+        "summary": "DELETE /v1/admin/products/product-categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -13240,6 +13436,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTags",
+        "summary": "GET /v1/admin/products/product-tags",
         "tags": [
           "products"
         ],
@@ -13325,6 +13523,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsProductTags",
+        "summary": "POST /v1/admin/products/product-tags",
         "tags": [
           "products"
         ],
@@ -13402,6 +13602,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsProductTagsByTagId",
+        "summary": "GET /v1/admin/products/product-tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -13512,6 +13714,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsProductTagsByTagId",
+        "summary": "PATCH /v1/admin/products/product-tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -13567,6 +13771,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsProductTagsByTagId",
+        "summary": "DELETE /v1/admin/products/product-tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -13719,6 +13925,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsMediaByMediaId",
+        "summary": "GET /v1/admin/products/media/{mediaId}",
         "tags": [
           "products"
         ],
@@ -13968,6 +14176,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsMediaByMediaId",
+        "summary": "PATCH /v1/admin/products/media/{mediaId}",
         "tags": [
           "products"
         ],
@@ -14118,6 +14328,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsMediaByMediaId",
+        "summary": "DELETE /v1/admin/products/media/{mediaId}",
         "tags": [
           "products"
         ],
@@ -14306,6 +14518,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsMediaByMediaIdSetCover",
+        "summary": "PATCH /v1/admin/products/media/{mediaId}/set-cover",
         "tags": [
           "products"
         ],
@@ -14443,6 +14657,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdBrochureVersions",
+        "summary": "GET /v1/admin/products/{id}/brochure/versions",
         "tags": [
           "products"
         ],
@@ -14603,6 +14819,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdBrochureVersionsByBrochureIdSetCurrent",
+        "summary": "POST /v1/admin/products/{id}/brochure/versions/{brochureId}/set-current",
         "tags": [
           "products"
         ],
@@ -14763,6 +14981,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdBrochureVersionsByBrochureId",
+        "summary": "DELETE /v1/admin/products/{id}/brochure/versions/{brochureId}",
         "tags": [
           "products"
         ],
@@ -14915,6 +15135,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdBrochure",
+        "summary": "GET /v1/admin/products/{id}/brochure",
         "tags": [
           "products"
         ],
@@ -15142,6 +15364,8 @@
             }
           }
         },
+        "operationId": "putAdminProductsByIdBrochure",
+        "summary": "PUT /v1/admin/products/{id}/brochure",
         "tags": [
           "products"
         ],
@@ -15292,6 +15516,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdBrochure",
+        "summary": "DELETE /v1/admin/products/{id}/brochure",
         "tags": [
           "products"
         ],
@@ -15393,6 +15619,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdMediaReorder",
+        "summary": "POST /v1/admin/products/{id}/media/reorder",
         "tags": [
           "products"
         ],
@@ -15615,6 +15843,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdMedia",
+        "summary": "GET /v1/admin/products/{id}/media",
         "tags": [
           "products"
         ],
@@ -15875,6 +16105,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdMedia",
+        "summary": "POST /v1/admin/products/{id}/media",
         "tags": [
           "products"
         ],
@@ -16105,6 +16337,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdMedia",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/media",
         "tags": [
           "products"
         ],
@@ -16373,6 +16607,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdMedia",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/media",
         "tags": [
           "products"
         ],
@@ -16447,6 +16683,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdItineraries",
+        "summary": "GET /v1/admin/products/{id}/itineraries",
         "tags": [
           "products"
         ],
@@ -16580,6 +16818,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdItineraries",
+        "summary": "POST /v1/admin/products/{id}/itineraries",
         "tags": [
           "products"
         ],
@@ -16712,6 +16952,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsItinerariesByItineraryId",
+        "summary": "PATCH /v1/admin/products/itineraries/{itineraryId}",
         "tags": [
           "products"
         ],
@@ -16767,6 +17009,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsItinerariesByItineraryId",
+        "summary": "DELETE /v1/admin/products/itineraries/{itineraryId}",
         "tags": [
           "products"
         ],
@@ -16891,6 +17135,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsItinerariesByItineraryIdDuplicate",
+        "summary": "POST /v1/admin/products/itineraries/{itineraryId}/duplicate",
         "tags": [
           "products"
         ],
@@ -16986,6 +17232,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdItinerariesByItineraryIdDays",
+        "summary": "GET /v1/admin/products/{id}/itineraries/{itineraryId}/days",
         "tags": [
           "products"
         ],
@@ -17151,6 +17399,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdItinerariesByItineraryIdDays",
+        "summary": "POST /v1/admin/products/{id}/itineraries/{itineraryId}/days",
         "tags": [
           "products"
         ],
@@ -17238,6 +17488,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDays",
+        "summary": "GET /v1/admin/products/{id}/days",
         "tags": [
           "products"
         ],
@@ -17395,6 +17647,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDays",
+        "summary": "POST /v1/admin/products/{id}/days",
         "tags": [
           "products"
         ],
@@ -17559,6 +17813,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}",
         "tags": [
           "products"
         ],
@@ -17622,6 +17878,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}",
         "tags": [
           "products"
         ],
@@ -17751,6 +18009,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdServices",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/services",
         "tags": [
           "products"
         ],
@@ -17991,6 +18251,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdServices",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/services",
         "tags": [
           "products"
         ],
@@ -18235,6 +18497,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayIdServicesByServiceId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}/services/{serviceId}",
         "tags": [
           "products"
         ],
@@ -18306,6 +18570,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayIdServicesByServiceId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}/services/{serviceId}",
         "tags": [
           "products"
         ],
@@ -18413,6 +18679,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdTranslations",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/translations",
         "tags": [
           "products"
         ],
@@ -18580,6 +18848,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/translations",
         "tags": [
           "products"
         ],
@@ -18754,6 +19024,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayIdTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -18825,6 +19097,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayIdTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -18899,6 +19173,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdVersions",
+        "summary": "GET /v1/admin/products/{id}/versions",
         "tags": [
           "products"
         ],
@@ -18986,6 +19262,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdVersions",
+        "summary": "POST /v1/admin/products/{id}/versions",
         "tags": [
           "products"
         ],
@@ -19052,6 +19330,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdNotes",
+        "summary": "GET /v1/admin/products/{id}/notes",
         "tags": [
           "products"
         ],
@@ -19169,6 +19449,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdNotes",
+        "summary": "POST /v1/admin/products/{id}/notes",
         "tags": [
           "products"
         ],
@@ -19259,6 +19541,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdItinerariesByItineraryIdTranslations",
+        "summary": "GET /v1/admin/products/{id}/itineraries/{itineraryId}/translations",
         "tags": [
           "products"
         ],
@@ -19395,6 +19679,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdItinerariesByItineraryIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/itineraries/{itineraryId}/translations",
         "tags": [
           "products"
         ],
@@ -19537,6 +19823,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdItinerariesByItineraryIdTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/{id}/itineraries/{itineraryId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -19608,6 +19896,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdItinerariesByItineraryIdTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/{id}/itineraries/{itineraryId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -19720,6 +20010,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdDaysByDayIdServicesByServiceIdTranslations",
+        "summary": "GET /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations",
         "tags": [
           "products"
         ],
@@ -19890,6 +20182,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdDaysByDayIdServicesByServiceIdTranslations",
+        "summary": "POST /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations",
         "tags": [
           "products"
         ],
@@ -20066,6 +20360,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsByIdDaysByDayIdServicesByServiceIdTranslationsByTranslationId",
+        "summary": "PATCH /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -20145,6 +20441,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdDaysByDayIdServicesByServiceIdTranslationsByTranslationId",
+        "summary": "DELETE /v1/admin/products/{id}/days/{dayId}/services/{serviceId}/translations/{translationId}",
         "tags": [
           "products"
         ],
@@ -20242,6 +20540,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdCategories",
+        "summary": "GET /v1/admin/products/{id}/categories",
         "tags": [
           "products"
         ],
@@ -20336,6 +20636,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdCategories",
+        "summary": "POST /v1/admin/products/{id}/categories",
         "tags": [
           "products"
         ],
@@ -20401,6 +20703,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdCategoriesByCategoryId",
+        "summary": "DELETE /v1/admin/products/{id}/categories/{categoryId}",
         "tags": [
           "products"
         ],
@@ -20463,6 +20767,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdTags",
+        "summary": "GET /v1/admin/products/{id}/tags",
         "tags": [
           "products"
         ],
@@ -20554,6 +20860,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdTags",
+        "summary": "POST /v1/admin/products/{id}/tags",
         "tags": [
           "products"
         ],
@@ -20619,6 +20927,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsByIdTagsByTagId",
+        "summary": "DELETE /v1/admin/products/{id}/tags/{tagId}",
         "tags": [
           "products"
         ],
@@ -20688,6 +20998,8 @@
             }
           }
         },
+        "operationId": "postAdminProductsByIdRecalculate",
+        "summary": "POST /v1/admin/products/{id}/recalculate",
         "tags": [
           "products"
         ],
@@ -20796,6 +21108,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsAggregates",
+        "summary": "GET /v1/admin/products/aggregates",
         "tags": [
           "products"
         ],
@@ -21304,6 +21618,8 @@
             }
           }
         },
+        "operationId": "getAdminProducts",
+        "summary": "GET /v1/admin/products",
         "tags": [
           "products"
         ],
@@ -21867,6 +22183,8 @@
             }
           }
         },
+        "operationId": "postAdminProducts",
+        "summary": "POST /v1/admin/products",
         "tags": [
           "products"
         ],
@@ -22168,6 +22486,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsById",
+        "summary": "GET /v1/admin/products/{id}",
         "tags": [
           "products"
         ],
@@ -22748,6 +23068,8 @@
             }
           }
         },
+        "operationId": "patchAdminProductsById",
+        "summary": "PATCH /v1/admin/products/{id}",
         "tags": [
           "products"
         ],
@@ -22803,6 +23125,8 @@
             }
           }
         },
+        "operationId": "deleteAdminProductsById",
+        "summary": "DELETE /v1/admin/products/{id}",
         "tags": [
           "products"
         ],
@@ -22919,6 +23243,8 @@
             }
           }
         },
+        "operationId": "getAdminProductsByIdActionLedger",
+        "summary": "GET /v1/admin/products/{id}/action-ledger",
         "tags": [
           "products"
         ],

--- a/starters/operator/openapi/admin/promotions.json
+++ b/starters/operator/openapi/admin/promotions.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -611,6 +617,8 @@
             }
           }
         },
+        "operationId": "getAdminPromotions",
+        "summary": "GET /v1/admin/promotions",
         "tags": [
           "promotions"
         ],
@@ -1274,6 +1282,8 @@
             }
           }
         },
+        "operationId": "postAdminPromotions",
+        "summary": "POST /v1/admin/promotions",
         "tags": [
           "promotions"
         ],
@@ -1628,6 +1638,8 @@
             }
           }
         },
+        "operationId": "getAdminPromotionsById",
+        "summary": "GET /v1/admin/promotions/{id}",
         "tags": [
           "promotions"
         ],
@@ -2313,6 +2325,8 @@
             }
           }
         },
+        "operationId": "patchAdminPromotionsById",
+        "summary": "PATCH /v1/admin/promotions/{id}",
         "tags": [
           "promotions"
         ],
@@ -2394,6 +2408,8 @@
             }
           }
         },
+        "operationId": "deleteAdminPromotionsById",
+        "summary": "DELETE /v1/admin/promotions/{id}",
         "tags": [
           "promotions"
         ],
@@ -2748,6 +2764,8 @@
             }
           }
         },
+        "operationId": "postAdminPromotionsByIdArchive",
+        "summary": "POST /v1/admin/promotions/{id}/archive",
         "tags": [
           "promotions"
         ],

--- a/starters/operator/openapi/admin/quotes.json
+++ b/starters/operator/openapi/admin/quotes.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -263,6 +269,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesPipelines",
+        "summary": "GET /v1/admin/quotes/pipelines",
         "tags": [
           "quotes"
         ],
@@ -383,6 +391,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesPipelines",
+        "summary": "POST /v1/admin/quotes/pipelines",
         "tags": [
           "quotes"
         ],
@@ -478,6 +488,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesPipelinesById",
+        "summary": "GET /v1/admin/quotes/pipelines/{id}",
         "tags": [
           "quotes"
         ],
@@ -623,6 +635,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesPipelinesById",
+        "summary": "PATCH /v1/admin/quotes/pipelines/{id}",
         "tags": [
           "quotes"
         ],
@@ -699,6 +713,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesPipelinesById",
+        "summary": "DELETE /v1/admin/quotes/pipelines/{id}",
         "tags": [
           "quotes"
         ],
@@ -824,6 +840,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesStages",
+        "summary": "GET /v1/admin/quotes/stages",
         "tags": [
           "quotes"
         ],
@@ -963,6 +981,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesStages",
+        "summary": "POST /v1/admin/quotes/stages",
         "tags": [
           "quotes"
         ],
@@ -1067,6 +1087,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesStagesById",
+        "summary": "GET /v1/admin/quotes/stages/{id}",
         "tags": [
           "quotes"
         ],
@@ -1230,6 +1252,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesStagesById",
+        "summary": "PATCH /v1/admin/quotes/stages/{id}",
         "tags": [
           "quotes"
         ],
@@ -1288,6 +1312,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesStagesById",
+        "summary": "DELETE /v1/admin/quotes/stages/{id}",
         "tags": [
           "quotes"
         ],
@@ -1579,6 +1605,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotes",
+        "summary": "GET /v1/admin/quotes/quotes",
         "tags": [
           "quotes"
         ],
@@ -1901,6 +1929,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotes",
+        "summary": "POST /v1/admin/quotes/quotes",
         "tags": [
           "quotes"
         ],
@@ -2117,6 +2147,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesById",
+        "summary": "GET /v1/admin/quotes/quotes/{id}",
         "tags": [
           "quotes"
         ],
@@ -2462,6 +2494,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuotesById",
+        "summary": "PATCH /v1/admin/quotes/quotes/{id}",
         "tags": [
           "quotes"
         ],
@@ -2520,6 +2554,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuotesById",
+        "summary": "DELETE /v1/admin/quotes/quotes/{id}",
         "tags": [
           "quotes"
         ],
@@ -2597,6 +2633,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesByIdParticipants",
+        "summary": "GET /v1/admin/quotes/quotes/{id}/participants",
         "tags": [
           "quotes"
         ],
@@ -2720,6 +2758,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdParticipants",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/participants",
         "tags": [
           "quotes"
         ],
@@ -2780,6 +2820,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteParticipantsById",
+        "summary": "DELETE /v1/admin/quotes/quote-participants/{id}",
         "tags": [
           "quotes"
         ],
@@ -2899,6 +2941,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesByIdProducts",
+        "summary": "GET /v1/admin/quotes/quotes/{id}/products",
         "tags": [
           "quotes"
         ],
@@ -3097,6 +3141,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdProducts",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/products",
         "tags": [
           "quotes"
         ],
@@ -3312,6 +3358,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteProductsById",
+        "summary": "PATCH /v1/admin/quotes/quote-products/{id}",
         "tags": [
           "quotes"
         ],
@@ -3370,6 +3418,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteProductsById",
+        "summary": "DELETE /v1/admin/quotes/quote-products/{id}",
         "tags": [
           "quotes"
         ],
@@ -3476,6 +3526,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuotesByIdMedia",
+        "summary": "GET /v1/admin/quotes/quotes/{id}/media",
         "tags": [
           "quotes"
         ],
@@ -3655,6 +3707,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdMedia",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/media",
         "tags": [
           "quotes"
         ],
@@ -3715,6 +3769,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteMediaById",
+        "summary": "DELETE /v1/admin/quotes/quote-media/{id}",
         "tags": [
           "quotes"
         ],
@@ -3920,6 +3976,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuoteVersions",
+        "summary": "GET /v1/admin/quotes/quote-versions",
         "tags": [
           "quotes"
         ],
@@ -4219,6 +4277,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdVersions",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/versions",
         "tags": [
           "quotes"
         ],
@@ -4427,6 +4487,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteVersionsByIdValidity",
+        "summary": "PATCH /v1/admin/quotes/quote-versions/{id}/validity",
         "tags": [
           "quotes"
         ],
@@ -4613,6 +4675,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuotesByIdVersionsSnapshot",
+        "summary": "POST /v1/admin/quotes/quotes/{id}/versions/snapshot",
         "tags": [
           "quotes"
         ],
@@ -4757,6 +4821,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsExpire",
+        "summary": "POST /v1/admin/quotes/quote-versions/expire",
         "tags": [
           "quotes"
         ],
@@ -4925,6 +4991,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuoteVersionsById",
+        "summary": "GET /v1/admin/quotes/quote-versions/{id}",
         "tags": [
           "quotes"
         ],
@@ -5218,6 +5286,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteVersionsById",
+        "summary": "PATCH /v1/admin/quotes/quote-versions/{id}",
         "tags": [
           "quotes"
         ],
@@ -5294,6 +5364,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteVersionsById",
+        "summary": "DELETE /v1/admin/quotes/quote-versions/{id}",
         "tags": [
           "quotes"
         ],
@@ -5655,6 +5727,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdTripSnapshot",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/trip-snapshot",
         "tags": [
           "quotes"
         ],
@@ -5842,6 +5916,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdSend",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/send",
         "tags": [
           "quotes"
         ],
@@ -6010,6 +6086,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdView",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/view",
         "tags": [
           "quotes"
         ],
@@ -6486,6 +6564,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdAccept",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/accept",
         "tags": [
           "quotes"
         ],
@@ -6673,6 +6753,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdDecline",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/decline",
         "tags": [
           "quotes"
         ],
@@ -6769,6 +6851,8 @@
             }
           }
         },
+        "operationId": "getAdminQuotesQuoteVersionsByIdLines",
+        "summary": "GET /v1/admin/quotes/quote-versions/{id}/lines",
         "tags": [
           "quotes"
         ],
@@ -6963,6 +7047,8 @@
             }
           }
         },
+        "operationId": "postAdminQuotesQuoteVersionsByIdLines",
+        "summary": "POST /v1/admin/quotes/quote-versions/{id}/lines",
         "tags": [
           "quotes"
         ],
@@ -7155,6 +7241,8 @@
             }
           }
         },
+        "operationId": "patchAdminQuotesQuoteVersionLinesById",
+        "summary": "PATCH /v1/admin/quotes/quote-version-lines/{id}",
         "tags": [
           "quotes"
         ],
@@ -7231,6 +7319,8 @@
             }
           }
         },
+        "operationId": "deleteAdminQuotesQuoteVersionLinesById",
+        "summary": "DELETE /v1/admin/quotes/quote-version-lines/{id}",
         "tags": [
           "quotes"
         ],

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -439,6 +445,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizations",
+        "summary": "GET /v1/admin/relationships/organizations",
         "tags": [
           "relationships"
         ],
@@ -756,6 +764,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizations",
+        "summary": "POST /v1/admin/relationships/organizations",
         "tags": [
           "relationships"
         ],
@@ -952,6 +962,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsById",
+        "summary": "GET /v1/admin/relationships/organizations/{id}",
         "tags": [
           "relationships"
         ],
@@ -1294,6 +1306,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsOrganizationsById",
+        "summary": "PATCH /v1/admin/relationships/organizations/{id}",
         "tags": [
           "relationships"
         ],
@@ -1352,6 +1366,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsOrganizationsById",
+        "summary": "DELETE /v1/admin/relationships/organizations/{id}",
         "tags": [
           "relationships"
         ],
@@ -1585,6 +1601,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdMerge",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/merge",
         "tags": [
           "relationships"
         ],
@@ -1692,6 +1710,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsByIdContactMethods",
+        "summary": "GET /v1/admin/relationships/organizations/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -1890,6 +1910,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdContactMethods",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -2049,6 +2071,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsByIdAddresses",
+        "summary": "GET /v1/admin/relationships/organizations/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -2339,6 +2363,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdAddresses",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -2405,6 +2431,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsOrganizationsByIdNotes",
+        "summary": "GET /v1/admin/relationships/organizations/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -2522,6 +2550,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsOrganizationsByIdNotes",
+        "summary": "POST /v1/admin/relationships/organizations/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -2641,6 +2671,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsOrganizationNotesById",
+        "summary": "PATCH /v1/admin/relationships/organization-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -2699,6 +2731,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsOrganizationNotesById",
+        "summary": "DELETE /v1/admin/relationships/organization-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -3017,6 +3051,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeople",
+        "summary": "GET /v1/admin/relationships/people",
         "tags": [
           "relationships"
         ],
@@ -3453,6 +3489,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeople",
+        "summary": "POST /v1/admin/relationships/people",
         "tags": [
           "relationships"
         ],
@@ -3678,6 +3716,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleById",
+        "summary": "GET /v1/admin/relationships/people/{id}",
         "tags": [
           "relationships"
         ],
@@ -4138,6 +4178,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPeopleById",
+        "summary": "PATCH /v1/admin/relationships/people/{id}",
         "tags": [
           "relationships"
         ],
@@ -4196,6 +4238,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPeopleById",
+        "summary": "DELETE /v1/admin/relationships/people/{id}",
         "tags": [
           "relationships"
         ],
@@ -4458,6 +4502,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdMerge",
+        "summary": "POST /v1/admin/relationships/people/{id}/merge",
         "tags": [
           "relationships"
         ],
@@ -4565,6 +4611,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdContactMethods",
+        "summary": "GET /v1/admin/relationships/people/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -4763,6 +4811,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdContactMethods",
+        "summary": "POST /v1/admin/relationships/people/{id}/contact-methods",
         "tags": [
           "relationships"
         ],
@@ -4922,6 +4972,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdAddresses",
+        "summary": "GET /v1/admin/relationships/people/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -5212,6 +5264,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdAddresses",
+        "summary": "POST /v1/admin/relationships/people/{id}/addresses",
         "tags": [
           "relationships"
         ],
@@ -5278,6 +5332,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdNotes",
+        "summary": "GET /v1/admin/relationships/people/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -5395,6 +5451,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdNotes",
+        "summary": "POST /v1/admin/relationships/people/{id}/notes",
         "tags": [
           "relationships"
         ],
@@ -5514,6 +5572,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonNotesById",
+        "summary": "PATCH /v1/admin/relationships/person-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -5572,6 +5632,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonNotesById",
+        "summary": "DELETE /v1/admin/relationships/person-notes/{id}",
         "tags": [
           "relationships"
         ],
@@ -5670,6 +5732,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdPaymentMethods",
+        "summary": "GET /v1/admin/relationships/people/{id}/payment-methods",
         "tags": [
           "relationships"
         ],
@@ -5863,6 +5927,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdPaymentMethods",
+        "summary": "POST /v1/admin/relationships/people/{id}/payment-methods",
         "tags": [
           "relationships"
         ],
@@ -6054,6 +6120,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonPaymentMethodsById",
+        "summary": "PATCH /v1/admin/relationships/person-payment-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -6112,6 +6180,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonPaymentMethodsById",
+        "summary": "DELETE /v1/admin/relationships/person-payment-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -6286,6 +6356,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdCommunications",
+        "summary": "GET /v1/admin/relationships/people/{id}/communications",
         "tags": [
           "relationships"
         ],
@@ -6482,6 +6554,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdCommunications",
+        "summary": "POST /v1/admin/relationships/people/{id}/communications",
         "tags": [
           "relationships"
         ],
@@ -6549,6 +6623,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsSegments",
+        "summary": "GET /v1/admin/relationships/segments",
         "tags": [
           "relationships"
         ],
@@ -6662,6 +6738,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsSegments",
+        "summary": "POST /v1/admin/relationships/segments",
         "tags": [
           "relationships"
         ],
@@ -6722,6 +6800,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsSegmentsBySegmentId",
+        "summary": "DELETE /v1/admin/relationships/segments/{segmentId}",
         "tags": [
           "relationships"
         ],
@@ -6743,6 +6823,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleExport",
+        "summary": "POST /v1/admin/relationships/people/export",
         "tags": [
           "relationships"
         ],
@@ -6819,6 +6901,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleImport",
+        "summary": "POST /v1/admin/relationships/people/import",
         "tags": [
           "relationships"
         ],
@@ -7031,6 +7115,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsContactMethodsById",
+        "summary": "PATCH /v1/admin/relationships/contact-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -7089,6 +7175,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsContactMethodsById",
+        "summary": "DELETE /v1/admin/relationships/contact-methods/{id}",
         "tags": [
           "relationships"
         ],
@@ -7395,6 +7483,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsAddressesById",
+        "summary": "PATCH /v1/admin/relationships/addresses/{id}",
         "tags": [
           "relationships"
         ],
@@ -7453,6 +7543,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsAddressesById",
+        "summary": "DELETE /v1/admin/relationships/addresses/{id}",
         "tags": [
           "relationships"
         ],
@@ -7629,6 +7721,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdDocuments",
+        "summary": "GET /v1/admin/relationships/people/{id}/documents",
         "tags": [
           "relationships"
         ],
@@ -7877,6 +7971,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdDocuments",
+        "summary": "POST /v1/admin/relationships/people/{id}/documents",
         "tags": [
           "relationships"
         ],
@@ -8020,6 +8116,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPersonDocumentsById",
+        "summary": "GET /v1/admin/relationships/person-documents/{id}",
         "tags": [
           "relationships"
         ],
@@ -8265,6 +8363,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonDocumentsById",
+        "summary": "PATCH /v1/admin/relationships/person-documents/{id}",
         "tags": [
           "relationships"
         ],
@@ -8323,6 +8423,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonDocumentsById",
+        "summary": "DELETE /v1/admin/relationships/person-documents/{id}",
         "tags": [
           "relationships"
         ],
@@ -8466,6 +8568,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPersonDocumentsByIdSetPrimary",
+        "summary": "POST /v1/admin/relationships/person-documents/{id}/set-primary",
         "tags": [
           "relationships"
         ],
@@ -8616,6 +8720,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdTravelSnapshot",
+        "summary": "GET /v1/admin/relationships/people/{id}/travel-snapshot",
         "tags": [
           "relationships"
         ],
@@ -8752,6 +8858,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPeopleByIdProfilePii",
+        "summary": "PATCH /v1/admin/relationships/people/{id}/profile-pii",
         "tags": [
           "relationships"
         ],
@@ -9012,6 +9120,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdDocumentsFromPlaintext",
+        "summary": "POST /v1/admin/relationships/people/{id}/documents/from-plaintext",
         "tags": [
           "relationships"
         ],
@@ -9269,6 +9379,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonDocumentsByIdFromPlaintext",
+        "summary": "PATCH /v1/admin/relationships/person-documents/{id}/from-plaintext",
         "tags": [
           "relationships"
         ],
@@ -9381,6 +9493,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPersonDocumentsByIdReveal",
+        "summary": "GET /v1/admin/relationships/person-documents/{id}/reveal",
         "tags": [
           "relationships"
         ],
@@ -9577,6 +9691,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdRelationships",
+        "summary": "GET /v1/admin/relationships/people/{id}/relationships",
         "tags": [
           "relationships"
         ],
@@ -9817,6 +9933,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsPeopleByIdRelationships",
+        "summary": "POST /v1/admin/relationships/people/{id}/relationships",
         "tags": [
           "relationships"
         ],
@@ -9969,6 +10087,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPersonRelationshipsById",
+        "summary": "GET /v1/admin/relationships/person-relationships/{id}",
         "tags": [
           "relationships"
         ],
@@ -10216,6 +10336,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsPersonRelationshipsById",
+        "summary": "PATCH /v1/admin/relationships/person-relationships/{id}",
         "tags": [
           "relationships"
         ],
@@ -10274,6 +10396,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsPersonRelationshipsById",
+        "summary": "DELETE /v1/admin/relationships/person-relationships/{id}",
         "tags": [
           "relationships"
         ],
@@ -10530,6 +10654,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomerSignals",
+        "summary": "GET /v1/admin/relationships/customer-signals",
         "tags": [
           "relationships"
         ],
@@ -10837,6 +10963,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsCustomerSignals",
+        "summary": "POST /v1/admin/relationships/customer-signals",
         "tags": [
           "relationships"
         ],
@@ -11017,6 +11145,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomerSignalsById",
+        "summary": "GET /v1/admin/relationships/customer-signals/{id}",
         "tags": [
           "relationships"
         ],
@@ -11325,6 +11455,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsCustomerSignalsById",
+        "summary": "PATCH /v1/admin/relationships/customer-signals/{id}",
         "tags": [
           "relationships"
         ],
@@ -11383,6 +11515,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsCustomerSignalsById",
+        "summary": "DELETE /v1/admin/relationships/customer-signals/{id}",
         "tags": [
           "relationships"
         ],
@@ -11600,6 +11734,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsCustomerSignalsByIdResolve",
+        "summary": "POST /v1/admin/relationships/customer-signals/{id}/resolve",
         "tags": [
           "relationships"
         ],
@@ -11765,6 +11901,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsPeopleByIdSignals",
+        "summary": "GET /v1/admin/relationships/people/{id}/signals",
         "tags": [
           "relationships"
         ],
@@ -11983,6 +12121,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivities",
+        "summary": "GET /v1/admin/relationships/activities",
         "tags": [
           "relationships"
         ],
@@ -12181,6 +12321,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsActivities",
+        "summary": "POST /v1/admin/relationships/activities",
         "tags": [
           "relationships"
         ],
@@ -12319,6 +12461,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivitiesById",
+        "summary": "GET /v1/admin/relationships/activities/{id}",
         "tags": [
           "relationships"
         ],
@@ -12541,6 +12685,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsActivitiesById",
+        "summary": "PATCH /v1/admin/relationships/activities/{id}",
         "tags": [
           "relationships"
         ],
@@ -12599,6 +12745,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsActivitiesById",
+        "summary": "DELETE /v1/admin/relationships/activities/{id}",
         "tags": [
           "relationships"
         ],
@@ -12679,6 +12827,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivitiesByIdLinks",
+        "summary": "GET /v1/admin/relationships/activities/{id}/links",
         "tags": [
           "relationships"
         ],
@@ -12808,6 +12958,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsActivitiesByIdLinks",
+        "summary": "POST /v1/admin/relationships/activities/{id}/links",
         "tags": [
           "relationships"
         ],
@@ -12868,6 +13020,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsActivityLinksById",
+        "summary": "DELETE /v1/admin/relationships/activity-links/{id}",
         "tags": [
           "relationships"
         ],
@@ -12934,6 +13088,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsActivitiesByIdParticipants",
+        "summary": "GET /v1/admin/relationships/activities/{id}/participants",
         "tags": [
           "relationships"
         ],
@@ -13035,6 +13191,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsActivitiesByIdParticipants",
+        "summary": "POST /v1/admin/relationships/activities/{id}/participants",
         "tags": [
           "relationships"
         ],
@@ -13095,6 +13253,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsActivityParticipantsById",
+        "summary": "DELETE /v1/admin/relationships/activity-participants/{id}",
         "tags": [
           "relationships"
         ],
@@ -13260,6 +13420,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomFields",
+        "summary": "GET /v1/admin/relationships/custom-fields",
         "tags": [
           "relationships"
         ],
@@ -13466,6 +13628,8 @@
             }
           }
         },
+        "operationId": "postAdminRelationshipsCustomFields",
+        "summary": "POST /v1/admin/relationships/custom-fields",
         "tags": [
           "relationships"
         ],
@@ -13604,6 +13768,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomFieldsById",
+        "summary": "GET /v1/admin/relationships/custom-fields/{id}",
         "tags": [
           "relationships"
         ],
@@ -13807,6 +13973,8 @@
             }
           }
         },
+        "operationId": "patchAdminRelationshipsCustomFieldsById",
+        "summary": "PATCH /v1/admin/relationships/custom-fields/{id}",
         "tags": [
           "relationships"
         ],
@@ -13865,6 +14033,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsCustomFieldsById",
+        "summary": "DELETE /v1/admin/relationships/custom-fields/{id}",
         "tags": [
           "relationships"
         ],
@@ -14045,6 +14215,8 @@
             }
           }
         },
+        "operationId": "getAdminRelationshipsCustomFieldValues",
+        "summary": "GET /v1/admin/relationships/custom-field-values",
         "tags": [
           "relationships"
         ],
@@ -14264,6 +14436,8 @@
             }
           }
         },
+        "operationId": "putAdminRelationshipsCustomFieldsByIdValue",
+        "summary": "PUT /v1/admin/relationships/custom-fields/{id}/value",
         "tags": [
           "relationships"
         ],
@@ -14324,6 +14498,8 @@
             }
           }
         },
+        "operationId": "deleteAdminRelationshipsCustomFieldValuesById",
+        "summary": "DELETE /v1/admin/relationships/custom-field-values/{id}",
         "tags": [
           "relationships"
         ],

--- a/starters/operator/openapi/admin/sellability.json
+++ b/starters/operator/openapi/admin/sellability.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -282,6 +288,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityResolve",
+        "summary": "POST /v1/admin/sellability/resolve",
         "tags": [
           "sellability"
         ],
@@ -555,6 +563,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityResolveAndPersist",
+        "summary": "POST /v1/admin/sellability/resolve-and-persist",
         "tags": [
           "sellability"
         ],
@@ -791,6 +801,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilitySnapshots",
+        "summary": "GET /v1/admin/sellability/snapshots",
         "tags": [
           "sellability"
         ],
@@ -953,6 +965,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilitySnapshotsById",
+        "summary": "GET /v1/admin/sellability/snapshots/{id}",
         "tags": [
           "sellability"
         ],
@@ -1202,6 +1216,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilitySnapshotItems",
+        "summary": "GET /v1/admin/sellability/snapshot-items",
         "tags": [
           "sellability"
         ],
@@ -1457,6 +1473,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPolicies",
+        "summary": "GET /v1/admin/sellability/policies",
         "tags": [
           "sellability"
         ],
@@ -1708,6 +1726,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityPolicies",
+        "summary": "POST /v1/admin/sellability/policies",
         "tags": [
           "sellability"
         ],
@@ -1871,6 +1891,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPoliciesById",
+        "summary": "GET /v1/admin/sellability/policies/{id}",
         "tags": [
           "sellability"
         ],
@@ -2147,6 +2169,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityPoliciesById",
+        "summary": "PATCH /v1/admin/sellability/policies/{id}",
         "tags": [
           "sellability"
         ],
@@ -2202,6 +2226,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityPoliciesById",
+        "summary": "DELETE /v1/admin/sellability/policies/{id}",
         "tags": [
           "sellability"
         ],
@@ -2369,6 +2395,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPolicyResults",
+        "summary": "GET /v1/admin/sellability/policy-results",
         "tags": [
           "sellability"
         ],
@@ -2531,6 +2559,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityPolicyResults",
+        "summary": "POST /v1/admin/sellability/policy-results",
         "tags": [
           "sellability"
         ],
@@ -2647,6 +2677,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityPolicyResultsById",
+        "summary": "GET /v1/admin/sellability/policy-results/{id}",
         "tags": [
           "sellability"
         ],
@@ -2834,6 +2866,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityPolicyResultsById",
+        "summary": "PATCH /v1/admin/sellability/policy-results/{id}",
         "tags": [
           "sellability"
         ],
@@ -2889,6 +2923,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityPolicyResultsById",
+        "summary": "DELETE /v1/admin/sellability/policy-results/{id}",
         "tags": [
           "sellability"
         ],
@@ -3054,6 +3090,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferRefreshRuns",
+        "summary": "GET /v1/admin/sellability/offer-refresh-runs",
         "tags": [
           "sellability"
         ],
@@ -3225,6 +3263,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityOfferRefreshRuns",
+        "summary": "POST /v1/admin/sellability/offer-refresh-runs",
         "tags": [
           "sellability"
         ],
@@ -3346,6 +3386,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferRefreshRunsById",
+        "summary": "GET /v1/admin/sellability/offer-refresh-runs/{id}",
         "tags": [
           "sellability"
         ],
@@ -3542,6 +3584,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityOfferRefreshRunsById",
+        "summary": "PATCH /v1/admin/sellability/offer-refresh-runs/{id}",
         "tags": [
           "sellability"
         ],
@@ -3597,6 +3641,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityOfferRefreshRunsById",
+        "summary": "DELETE /v1/admin/sellability/offer-refresh-runs/{id}",
         "tags": [
           "sellability"
         ],
@@ -3760,6 +3806,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferExpirationEvents",
+        "summary": "GET /v1/admin/sellability/offer-expiration-events",
         "tags": [
           "sellability"
         ],
@@ -3927,6 +3975,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityOfferExpirationEvents",
+        "summary": "POST /v1/admin/sellability/offer-expiration-events",
         "tags": [
           "sellability"
         ],
@@ -4047,6 +4097,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityOfferExpirationEventsById",
+        "summary": "GET /v1/admin/sellability/offer-expiration-events/{id}",
         "tags": [
           "sellability"
         ],
@@ -4238,6 +4290,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityOfferExpirationEventsById",
+        "summary": "PATCH /v1/admin/sellability/offer-expiration-events/{id}",
         "tags": [
           "sellability"
         ],
@@ -4293,6 +4347,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityOfferExpirationEventsById",
+        "summary": "DELETE /v1/admin/sellability/offer-expiration-events/{id}",
         "tags": [
           "sellability"
         ],
@@ -4455,6 +4511,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityExplanations",
+        "summary": "GET /v1/admin/sellability/explanations",
         "tags": [
           "sellability"
         ],
@@ -4619,6 +4677,8 @@
             }
           }
         },
+        "operationId": "postAdminSellabilityExplanations",
+        "summary": "POST /v1/admin/sellability/explanations",
         "tags": [
           "sellability"
         ],
@@ -4735,6 +4795,8 @@
             }
           }
         },
+        "operationId": "getAdminSellabilityExplanationsById",
+        "summary": "GET /v1/admin/sellability/explanations/{id}",
         "tags": [
           "sellability"
         ],
@@ -4923,6 +4985,8 @@
             }
           }
         },
+        "operationId": "patchAdminSellabilityExplanationsById",
+        "summary": "PATCH /v1/admin/sellability/explanations/{id}",
         "tags": [
           "sellability"
         ],
@@ -4978,6 +5042,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSellabilityExplanationsById",
+        "summary": "DELETE /v1/admin/sellability/explanations/{id}",
         "tags": [
           "sellability"
         ],

--- a/starters/operator/openapi/admin/storefront.json
+++ b/starters/operator/openapi/admin/storefront.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -769,6 +775,8 @@
             }
           }
         },
+        "operationId": "getAdminStorefrontSettings",
+        "summary": "GET /v1/admin/storefront/settings",
         "tags": [
           "storefront"
         ],
@@ -1951,6 +1959,8 @@
             }
           }
         },
+        "operationId": "patchAdminStorefrontSettings",
+        "summary": "PATCH /v1/admin/storefront/settings",
         "tags": [
           "storefront"
         ],

--- a/starters/operator/openapi/admin/suppliers.json
+++ b/starters/operator/openapi/admin/suppliers.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -259,6 +265,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdContactPoints",
+        "summary": "GET /v1/admin/suppliers/{id}/contact-points",
         "tags": [
           "suppliers"
         ],
@@ -474,6 +482,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdContactPoints",
+        "summary": "POST /v1/admin/suppliers/{id}/contact-points",
         "tags": [
           "suppliers"
         ],
@@ -697,6 +707,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersContactPointsByContactPointId",
+        "summary": "PATCH /v1/admin/suppliers/contact-points/{contactPointId}",
         "tags": [
           "suppliers"
         ],
@@ -752,6 +764,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersContactPointsByContactPointId",
+        "summary": "DELETE /v1/admin/suppliers/contact-points/{contactPointId}",
         "tags": [
           "suppliers"
         ],
@@ -878,6 +892,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdContacts",
+        "summary": "GET /v1/admin/suppliers/{id}/contacts",
         "tags": [
           "suppliers"
         ],
@@ -1109,6 +1125,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdContacts",
+        "summary": "POST /v1/admin/suppliers/{id}/contacts",
         "tags": [
           "suppliers"
         ],
@@ -1349,6 +1367,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersContactsByContactId",
+        "summary": "PATCH /v1/admin/suppliers/contacts/{contactId}",
         "tags": [
           "suppliers"
         ],
@@ -1404,6 +1424,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersContactsByContactId",
+        "summary": "DELETE /v1/admin/suppliers/contacts/{contactId}",
         "tags": [
           "suppliers"
         ],
@@ -1573,6 +1595,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdAddresses",
+        "summary": "GET /v1/admin/suppliers/{id}/addresses",
         "tags": [
           "suppliers"
         ],
@@ -1877,6 +1901,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdAddresses",
+        "summary": "POST /v1/admin/suppliers/{id}/addresses",
         "tags": [
           "suppliers"
         ],
@@ -2193,6 +2219,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersAddressesByAddressId",
+        "summary": "PATCH /v1/admin/suppliers/addresses/{addressId}",
         "tags": [
           "suppliers"
         ],
@@ -2248,6 +2276,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersAddressesByAddressId",
+        "summary": "DELETE /v1/admin/suppliers/addresses/{addressId}",
         "tags": [
           "suppliers"
         ],
@@ -2368,6 +2398,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdServices",
+        "summary": "GET /v1/admin/suppliers/{id}/services",
         "tags": [
           "suppliers"
         ],
@@ -2587,6 +2619,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdServices",
+        "summary": "POST /v1/admin/suppliers/{id}/services",
         "tags": [
           "suppliers"
         ],
@@ -2812,6 +2846,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersByIdServicesByServiceId",
+        "summary": "PATCH /v1/admin/suppliers/{id}/services/{serviceId}",
         "tags": [
           "suppliers"
         ],
@@ -2875,6 +2911,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersByIdServicesByServiceId",
+        "summary": "DELETE /v1/admin/suppliers/{id}/services/{serviceId}",
         "tags": [
           "suppliers"
         ],
@@ -2999,6 +3037,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdServicesByServiceIdRates",
+        "summary": "GET /v1/admin/suppliers/{id}/services/{serviceId}/rates",
         "tags": [
           "suppliers"
         ],
@@ -3228,6 +3268,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdServicesByServiceIdRates",
+        "summary": "POST /v1/admin/suppliers/{id}/services/{serviceId}/rates",
         "tags": [
           "suppliers"
         ],
@@ -3461,6 +3503,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersByIdServicesByServiceIdRatesByRateId",
+        "summary": "PATCH /v1/admin/suppliers/{id}/services/{serviceId}/rates/{rateId}",
         "tags": [
           "suppliers"
         ],
@@ -3532,6 +3576,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersByIdServicesByServiceIdRatesByRateId",
+        "summary": "DELETE /v1/admin/suppliers/{id}/services/{serviceId}/rates/{rateId}",
         "tags": [
           "suppliers"
         ],
@@ -3598,6 +3644,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdNotes",
+        "summary": "GET /v1/admin/suppliers/{id}/notes",
         "tags": [
           "suppliers"
         ],
@@ -3715,6 +3763,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdNotes",
+        "summary": "POST /v1/admin/suppliers/{id}/notes",
         "tags": [
           "suppliers"
         ],
@@ -3804,6 +3854,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdAvailability",
+        "summary": "GET /v1/admin/suppliers/{id}/availability",
         "tags": [
           "suppliers"
         ],
@@ -3970,6 +4022,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdAvailability",
+        "summary": "POST /v1/admin/suppliers/{id}/availability",
         "tags": [
           "suppliers"
         ],
@@ -4074,6 +4128,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersByIdContracts",
+        "summary": "GET /v1/admin/suppliers/{id}/contracts",
         "tags": [
           "suppliers"
         ],
@@ -4263,6 +4319,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliersByIdContracts",
+        "summary": "POST /v1/admin/suppliers/{id}/contracts",
         "tags": [
           "suppliers"
         ],
@@ -4459,6 +4517,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersByIdContractsByContractId",
+        "summary": "PATCH /v1/admin/suppliers/{id}/contracts/{contractId}",
         "tags": [
           "suppliers"
         ],
@@ -4522,6 +4582,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersByIdContractsByContractId",
+        "summary": "DELETE /v1/admin/suppliers/{id}/contracts/{contractId}",
         "tags": [
           "suppliers"
         ],
@@ -4635,6 +4697,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersAggregates",
+        "summary": "GET /v1/admin/suppliers/aggregates",
         "tags": [
           "suppliers"
         ],
@@ -4947,6 +5011,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliers",
+        "summary": "GET /v1/admin/suppliers",
         "tags": [
           "suppliers"
         ],
@@ -5334,6 +5400,8 @@
             }
           }
         },
+        "operationId": "postAdminSuppliers",
+        "summary": "POST /v1/admin/suppliers",
         "tags": [
           "suppliers"
         ],
@@ -5542,6 +5610,8 @@
             }
           }
         },
+        "operationId": "getAdminSuppliersById",
+        "summary": "GET /v1/admin/suppliers/{id}",
         "tags": [
           "suppliers"
         ],
@@ -5953,6 +6023,8 @@
             }
           }
         },
+        "operationId": "patchAdminSuppliersById",
+        "summary": "PATCH /v1/admin/suppliers/{id}",
         "tags": [
           "suppliers"
         ],
@@ -6008,6 +6080,8 @@
             }
           }
         },
+        "operationId": "deleteAdminSuppliersById",
+        "summary": "DELETE /v1/admin/suppliers/{id}",
         "tags": [
           "suppliers"
         ],

--- a/starters/operator/openapi/admin/trips.json
+++ b/starters/operator/openapi/admin/trips.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -188,6 +194,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsHealth",
+        "summary": "GET /v1/admin/trips/health",
         "tags": [
           "trips"
         ],
@@ -800,6 +808,8 @@
             }
           }
         },
+        "operationId": "getAdminTrips",
+        "summary": "GET /v1/admin/trips",
         "tags": [
           "trips"
         ],
@@ -1319,6 +1329,8 @@
             }
           }
         },
+        "operationId": "postAdminTrips",
+        "summary": "POST /v1/admin/trips",
         "tags": [
           "trips"
         ],
@@ -1778,6 +1790,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsByEnvelopeId",
+        "summary": "GET /v1/admin/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2105,6 +2119,8 @@
             }
           }
         },
+        "operationId": "patchAdminTripsByEnvelopeId",
+        "summary": "PATCH /v1/admin/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2476,6 +2492,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdReshop",
+        "summary": "POST /v1/admin/trips/{envelopeId}/reshop",
         "tags": [
           "trips"
         ],
@@ -2619,6 +2637,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsByEnvelopeIdSnapshots",
+        "summary": "GET /v1/admin/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2833,6 +2853,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdSnapshots",
+        "summary": "POST /v1/admin/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2992,6 +3014,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsSnapshotsBySnapshotId",
+        "summary": "GET /v1/admin/trips/snapshots/{snapshotId}",
         "tags": [
           "trips"
         ],
@@ -3418,6 +3442,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdComponents",
+        "summary": "POST /v1/admin/trips/{envelopeId}/components",
         "tags": [
           "trips"
         ],
@@ -3785,6 +3811,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdComponentsReorder",
+        "summary": "POST /v1/admin/trips/{envelopeId}/components/reorder",
         "tags": [
           "trips"
         ],
@@ -4206,6 +4234,8 @@
             }
           }
         },
+        "operationId": "patchAdminTripsComponentsByComponentId",
+        "summary": "PATCH /v1/admin/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4545,6 +4575,8 @@
             }
           }
         },
+        "operationId": "deleteAdminTripsComponentsByComponentId",
+        "summary": "DELETE /v1/admin/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4935,6 +4967,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsComponentsByComponentIdRefs",
+        "summary": "POST /v1/admin/trips/components/{componentId}/refs",
         "tags": [
           "trips"
         ],
@@ -5184,6 +5218,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdRequirements",
+        "summary": "POST /v1/admin/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5385,6 +5421,8 @@
             }
           }
         },
+        "operationId": "getAdminTripsByEnvelopeIdRequirements",
+        "summary": "GET /v1/admin/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5758,6 +5796,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsRequirementsByRequirementIdCandidates",
+        "summary": "POST /v1/admin/trips/requirements/{requirementId}/candidates",
         "tags": [
           "trips"
         ],
@@ -6302,6 +6342,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsRequirementsByRequirementIdSelect",
+        "summary": "POST /v1/admin/trips/requirements/{requirementId}/select",
         "tags": [
           "trips"
         ],
@@ -6675,6 +6717,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsRequirementsByRequirementIdReshop",
+        "summary": "POST /v1/admin/trips/requirements/{requirementId}/reshop",
         "tags": [
           "trips"
         ],
@@ -7243,6 +7287,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdPrice",
+        "summary": "POST /v1/admin/trips/{envelopeId}/price",
         "tags": [
           "trips"
         ],
@@ -7809,6 +7855,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdReserve",
+        "summary": "POST /v1/admin/trips/{envelopeId}/reserve",
         "tags": [
           "trips"
         ],
@@ -8358,6 +8406,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdCheckout",
+        "summary": "POST /v1/admin/trips/{envelopeId}/checkout",
         "tags": [
           "trips"
         ],
@@ -8909,6 +8959,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdCancellationPreview",
+        "summary": "POST /v1/admin/trips/{envelopeId}/cancellation-preview",
         "tags": [
           "trips"
         ],
@@ -9465,6 +9517,8 @@
             }
           }
         },
+        "operationId": "postAdminTripsByEnvelopeIdCancelComponents",
+        "summary": "POST /v1/admin/trips/{envelopeId}/cancel-components",
         "tags": [
           "trips"
         ],

--- a/starters/operator/openapi/admin/workflow-runs.json
+++ b/starters/operator/openapi/admin/workflow-runs.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -350,6 +356,8 @@
             }
           }
         },
+        "operationId": "getAdminWorkflowRuns",
+        "summary": "GET /v1/admin/workflow-runs",
         "tags": [
           "workflow-runs"
         ],
@@ -650,6 +658,8 @@
             }
           }
         },
+        "operationId": "getAdminWorkflowRunsById",
+        "summary": "GET /v1/admin/workflow-runs/{id}",
         "tags": [
           "workflow-runs"
         ],
@@ -815,6 +825,8 @@
             }
           }
         },
+        "operationId": "postAdminWorkflowRunsByIdRerun",
+        "summary": "POST /v1/admin/workflow-runs/{id}/rerun",
         "tags": [
           "workflow-runs"
         ],
@@ -965,6 +977,8 @@
             }
           }
         },
+        "operationId": "postAdminWorkflowRunsByIdResume",
+        "summary": "POST /v1/admin/workflow-runs/{id}/resume",
         "tags": [
           "workflow-runs"
         ],

--- a/starters/operator/openapi/admin/workflows.json
+++ b/starters/operator/openapi/admin/workflows.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -291,6 +297,8 @@
             }
           }
         },
+        "operationId": "postAdminWorkflowsByNameRuns",
+        "summary": "POST /v1/admin/workflows/{name}/runs",
         "tags": [
           "workflows"
         ],

--- a/starters/operator/openapi/storefront/booking-requirements.json
+++ b/starters/operator/openapi/storefront/booking-requirements.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -360,6 +366,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingRequirementsProductsByProductIdTransportRequirements",
+        "summary": "GET /v1/public/booking-requirements/products/{productId}/transport-requirements",
         "tags": [
           "booking-requirements"
         ],

--- a/starters/operator/openapi/storefront/bookings.json
+++ b/starters/operator/openapi/storefront/bookings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -1139,6 +1145,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessions",
+        "summary": "POST /v1/public/bookings/sessions",
         "tags": [
           "bookings"
         ],
@@ -1791,6 +1799,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsSessionsBySessionId",
+        "summary": "GET /v1/public/bookings/sessions/{sessionId}",
         "tags": [
           "bookings"
         ],
@@ -2594,6 +2604,8 @@
             }
           }
         },
+        "operationId": "patchPublicBookingsSessionsBySessionId",
+        "summary": "PATCH /v1/public/bookings/sessions/{sessionId}",
         "tags": [
           "bookings"
         ],
@@ -2698,6 +2710,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsSessionsBySessionIdState",
+        "summary": "GET /v1/public/bookings/sessions/{sessionId}/state",
         "tags": [
           "bookings"
         ],
@@ -2836,6 +2850,8 @@
             }
           }
         },
+        "operationId": "putPublicBookingsSessionsBySessionIdState",
+        "summary": "PUT /v1/public/bookings/sessions/{sessionId}/state",
         "tags": [
           "bookings"
         ],
@@ -3722,6 +3738,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessionsBySessionIdReprice",
+        "summary": "POST /v1/public/bookings/sessions/{sessionId}/reprice",
         "tags": [
           "bookings"
         ],
@@ -4410,6 +4428,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessionsBySessionIdConfirm",
+        "summary": "POST /v1/public/bookings/sessions/{sessionId}/confirm",
         "tags": [
           "bookings"
         ],
@@ -5098,6 +5118,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsSessionsBySessionIdExpire",
+        "summary": "POST /v1/public/bookings/sessions/{sessionId}/expire",
         "tags": [
           "bookings"
         ],
@@ -5635,6 +5657,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsOverview",
+        "summary": "GET /v1/public/bookings/overview",
         "tags": [
           "bookings"
         ],
@@ -6175,6 +6199,8 @@
             }
           }
         },
+        "operationId": "postPublicBookingsGuestLookup",
+        "summary": "POST /v1/public/bookings/guest-lookup",
         "tags": [
           "bookings"
         ],
@@ -6299,6 +6325,8 @@
             }
           }
         },
+        "operationId": "postPublicPaymentPolicyResolve",
+        "summary": "POST /v1/public/payment-policy/resolve",
         "tags": [
           "bookings"
         ],

--- a/starters/operator/openapi/storefront/catalog-booking.json
+++ b/starters/operator/openapi/storefront/catalog-booking.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -1559,6 +1565,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogQuote",
+        "summary": "POST /v1/public/catalog/quote",
         "tags": [
           "catalog-booking"
         ],
@@ -1939,6 +1947,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogBook",
+        "summary": "POST /v1/public/catalog/book",
         "tags": [
           "catalog-booking"
         ],
@@ -2242,6 +2252,8 @@
             }
           }
         },
+        "operationId": "putPublicCatalogDraftsById",
+        "summary": "PUT /v1/public/catalog/drafts/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -2389,6 +2401,8 @@
             }
           }
         },
+        "operationId": "getPublicCatalogDraftsById",
+        "summary": "GET /v1/public/catalog/drafts/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -2411,6 +2425,8 @@
             "description": "Draft deleted (idempotent)"
           }
         },
+        "operationId": "deletePublicCatalogDraftsById",
+        "summary": "DELETE /v1/public/catalog/drafts/{id}",
         "tags": [
           "catalog-booking"
         ],
@@ -2606,6 +2622,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogHoldsPlace",
+        "summary": "POST /v1/public/catalog/holds/place",
         "tags": [
           "catalog-booking"
         ],
@@ -2744,6 +2762,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogHoldsRelease",
+        "summary": "POST /v1/public/catalog/holds/release",
         "tags": [
           "catalog-booking"
         ],
@@ -2882,6 +2902,8 @@
             }
           }
         },
+        "operationId": "getPublicCatalogSlots",
+        "summary": "GET /v1/public/catalog/slots",
         "tags": [
           "catalog-booking"
         ],

--- a/starters/operator/openapi/storefront/catalog-content.json
+++ b/starters/operator/openapi/storefront/catalog-content.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -640,6 +646,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByIdContent",
+        "summary": "GET /v1/public/products/{id}/content",
         "tags": [
           "catalog-content"
         ],

--- a/starters/operator/openapi/storefront/catalog.json
+++ b/starters/operator/openapi/storefront/catalog.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -683,6 +689,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogSearch",
+        "summary": "POST /v1/public/catalog/search",
         "tags": [
           "catalog"
         ],
@@ -1041,6 +1049,8 @@
             }
           }
         },
+        "operationId": "postPublicCatalogCheckoutStart",
+        "summary": "POST /v1/public/catalog/checkout/start",
         "tags": [
           "catalog"
         ],

--- a/starters/operator/openapi/storefront/charters.json
+++ b/starters/operator/openapi/storefront/charters.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -274,6 +280,8 @@
             }
           }
         },
+        "operationId": "getPublicCharters",
+        "summary": "GET /v1/public/charters",
         "tags": [
           "charters"
         ],
@@ -558,6 +566,8 @@
             }
           }
         },
+        "operationId": "getPublicChartersVoyages",
+        "summary": "GET /v1/public/charters/voyages",
         "tags": [
           "charters"
         ],
@@ -842,6 +852,8 @@
             }
           }
         },
+        "operationId": "getPublicChartersVoyagesByKey",
+        "summary": "GET /v1/public/charters/voyages/{key}",
         "tags": [
           "charters"
         ],
@@ -1005,6 +1017,8 @@
             }
           }
         },
+        "operationId": "postPublicChartersVoyagesByKeyQuotePerSuite",
+        "summary": "POST /v1/public/charters/voyages/{key}/quote/per-suite",
         "tags": [
           "charters"
         ],
@@ -1157,6 +1171,8 @@
             }
           }
         },
+        "operationId": "postPublicChartersVoyagesByKeyQuoteWholeYacht",
+        "summary": "POST /v1/public/charters/voyages/{key}/quote/whole-yacht",
         "tags": [
           "charters"
         ],
@@ -1248,6 +1264,8 @@
             }
           }
         },
+        "operationId": "getPublicChartersYachtsByKey",
+        "summary": "GET /v1/public/charters/yachts/{key}",
         "tags": [
           "charters"
         ],
@@ -1320,6 +1338,8 @@
             }
           }
         },
+        "operationId": "getPublicChartersProductsByKey",
+        "summary": "GET /v1/public/charters/products/{key}",
         "tags": [
           "charters"
         ],

--- a/starters/operator/openapi/storefront/cruises.json
+++ b/starters/operator/openapi/storefront/cruises.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -587,6 +593,8 @@
             }
           }
         },
+        "operationId": "getPublicCruises",
+        "summary": "GET /v1/public/cruises",
         "tags": [
           "cruises"
         ],
@@ -703,6 +711,8 @@
             }
           }
         },
+        "operationId": "getPublicCruisesSailingsByKey",
+        "summary": "GET /v1/public/cruises/sailings/{key}",
         "tags": [
           "cruises"
         ],
@@ -1017,6 +1027,8 @@
             }
           }
         },
+        "operationId": "postPublicCruisesSailingsByKeyQuote",
+        "summary": "POST /v1/public/cruises/sailings/{key}/quote",
         "tags": [
           "cruises"
         ],
@@ -1108,6 +1120,8 @@
             }
           }
         },
+        "operationId": "getPublicCruisesShipsByKey",
+        "summary": "GET /v1/public/cruises/ships/{key}",
         "tags": [
           "cruises"
         ],
@@ -1470,6 +1484,8 @@
             }
           }
         },
+        "operationId": "getPublicCruisesBySlug",
+        "summary": "GET /v1/public/cruises/{slug}",
         "tags": [
           "cruises"
         ],

--- a/starters/operator/openapi/storefront/customer-portal.json
+++ b/starters/operator/openapi/storefront/customer-portal.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -540,6 +546,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalMe",
+        "summary": "GET /v1/public/customer-portal/me",
         "tags": [
           "customer-portal"
         ],
@@ -1216,6 +1224,8 @@
             }
           }
         },
+        "operationId": "patchPublicCustomerPortalMe",
+        "summary": "PATCH /v1/public/customer-portal/me",
         "tags": [
           "customer-portal"
         ],
@@ -1328,6 +1338,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalMeDocuments",
+        "summary": "GET /v1/public/customer-portal/me/documents",
         "tags": [
           "customer-portal"
         ],
@@ -1531,6 +1543,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalMeDocuments",
+        "summary": "POST /v1/public/customer-portal/me/documents",
         "tags": [
           "customer-portal"
         ],
@@ -1668,6 +1682,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalMeDocumentsByIdSetPrimary",
+        "summary": "POST /v1/public/customer-portal/me/documents/{id}/set-primary",
         "tags": [
           "customer-portal"
         ],
@@ -1880,6 +1896,8 @@
             }
           }
         },
+        "operationId": "patchPublicCustomerPortalMeDocumentsById",
+        "summary": "PATCH /v1/public/customer-portal/me/documents/{id}",
         "tags": [
           "customer-portal"
         ],
@@ -1938,6 +1956,8 @@
             }
           }
         },
+        "operationId": "deletePublicCustomerPortalMeDocumentsById",
+        "summary": "DELETE /v1/public/customer-portal/me/documents/{id}",
         "tags": [
           "customer-portal"
         ],
@@ -3222,6 +3242,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalBootstrap",
+        "summary": "POST /v1/public/customer-portal/bootstrap",
         "tags": [
           "customer-portal"
         ],
@@ -3474,6 +3496,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalCompanions",
+        "summary": "GET /v1/public/customer-portal/companions",
         "tags": [
           "customer-portal"
         ],
@@ -3969,6 +3993,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalCompanions",
+        "summary": "POST /v1/public/customer-portal/companions",
         "tags": [
           "customer-portal"
         ],
@@ -4271,6 +4297,8 @@
             }
           }
         },
+        "operationId": "postPublicCustomerPortalCompanionsImportBookingTravelers",
+        "summary": "POST /v1/public/customer-portal/companions/import-booking-travelers",
         "tags": [
           "customer-portal"
         ],
@@ -4793,6 +4821,8 @@
             }
           }
         },
+        "operationId": "patchPublicCustomerPortalCompanionsByCompanionId",
+        "summary": "PATCH /v1/public/customer-portal/companions/{companionId}",
         "tags": [
           "customer-portal"
         ],
@@ -4869,6 +4899,8 @@
             }
           }
         },
+        "operationId": "deletePublicCustomerPortalCompanionsByCompanionId",
+        "summary": "DELETE /v1/public/customer-portal/companions/{companionId}",
         "tags": [
           "customer-portal"
         ],
@@ -5019,6 +5051,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookings",
+        "summary": "GET /v1/public/customer-portal/bookings",
         "tags": [
           "customer-portal"
         ],
@@ -5743,6 +5777,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookingsByBookingId",
+        "summary": "GET /v1/public/customer-portal/bookings/{bookingId}",
         "tags": [
           "customer-portal"
         ],
@@ -5864,6 +5900,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookingsByBookingIdDocuments",
+        "summary": "GET /v1/public/customer-portal/bookings/{bookingId}/documents",
         "tags": [
           "customer-portal"
         ],
@@ -5995,6 +6033,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalBookingsByBookingIdBillingContact",
+        "summary": "GET /v1/public/customer-portal/bookings/{bookingId}/billing-contact",
         "tags": [
           "customer-portal"
         ],
@@ -6056,6 +6096,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalContactExists",
+        "summary": "GET /v1/public/customer-portal/contact-exists",
         "tags": [
           "customer-portal"
         ],
@@ -6121,6 +6163,8 @@
             }
           }
         },
+        "operationId": "getPublicCustomerPortalContactExistsPhone",
+        "summary": "GET /v1/public/customer-portal/contact-exists/phone",
         "tags": [
           "customer-portal"
         ],

--- a/starters/operator/openapi/storefront/finance.json
+++ b/starters/operator/openapi/storefront/finance.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -304,6 +310,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceVouchersValidate",
+        "summary": "POST /v1/public/finance/vouchers/validate",
         "tags": [
           "finance"
         ],
@@ -505,6 +513,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceDocumentsByReference",
+        "summary": "GET /v1/public/finance/documents/by-reference",
         "tags": [
           "finance"
         ],
@@ -702,6 +712,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdDocuments",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/documents",
         "tags": [
           "finance"
         ],
@@ -911,6 +923,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdDocumentsByReference",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/documents/by-reference",
         "tags": [
           "finance"
         ],
@@ -1091,6 +1105,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdPayments",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/payments",
         "tags": [
           "finance"
         ],
@@ -1452,6 +1468,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceBookingsByBookingIdPaymentOptions",
+        "summary": "GET /v1/public/finance/bookings/{bookingId}/payment-options",
         "tags": [
           "finance"
         ],
@@ -1963,6 +1981,8 @@
             }
           }
         },
+        "operationId": "getPublicFinancePaymentSessionsBySessionId",
+        "summary": "GET /v1/public/finance/payment-sessions/{sessionId}",
         "tags": [
           "finance"
         ],
@@ -2877,6 +2897,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceBookingsByBookingIdPaymentSchedulesByScheduleIdPaymentSession",
+        "summary": "POST /v1/public/finance/bookings/{bookingId}/payment-schedules/{scheduleId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -3791,6 +3813,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceBookingsByBookingIdGuaranteesByGuaranteeIdPaymentSession",
+        "summary": "POST /v1/public/finance/bookings/{bookingId}/guarantees/{guaranteeId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -4697,6 +4721,8 @@
             }
           }
         },
+        "operationId": "postPublicFinanceInvoicesByInvoiceIdPaymentSession",
+        "summary": "POST /v1/public/finance/invoices/{invoiceId}/payment-session",
         "tags": [
           "finance"
         ],
@@ -4796,6 +4822,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceAccountantByTokenSummary",
+        "summary": "GET /v1/public/finance/accountant/{token}/summary",
         "tags": [
           "finance"
         ],
@@ -4872,6 +4900,8 @@
             }
           }
         },
+        "operationId": "getPublicFinanceAccountantByTokenInvoices",
+        "summary": "GET /v1/public/finance/accountant/{token}/invoices",
         "tags": [
           "finance"
         ],

--- a/starters/operator/openapi/storefront/legal.json
+++ b/starters/operator/openapi/storefront/legal.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -305,6 +311,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalContractsTemplatesDefault",
+        "summary": "GET /v1/public/legal/contracts/templates/default",
         "tags": [
           "legal"
         ],
@@ -400,6 +408,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesByIdPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/{id}/preview",
         "tags": [
           "legal"
         ],
@@ -495,6 +505,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesByIdRenderPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/{id}/render-preview",
         "tags": [
           "legal"
         ],
@@ -590,6 +602,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesBySlugBySlugPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/by-slug/{slug}/preview",
         "tags": [
           "legal"
         ],
@@ -685,6 +699,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsTemplatesBySlugBySlugRenderPreview",
+        "summary": "POST /v1/public/legal/contracts/templates/by-slug/{slug}/render-preview",
         "tags": [
           "legal"
         ],
@@ -862,6 +878,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalContractsById",
+        "summary": "GET /v1/public/legal/contracts/{id}",
         "tags": [
           "legal"
         ],
@@ -1075,6 +1093,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalContractsByIdSign",
+        "summary": "POST /v1/public/legal/contracts/{id}/sign",
         "tags": [
           "legal"
         ],
@@ -1267,6 +1287,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalPoliciesBySlug",
+        "summary": "GET /v1/public/legal/policies/{slug}",
         "tags": [
           "legal"
         ],
@@ -1608,6 +1630,8 @@
             }
           }
         },
+        "operationId": "postPublicLegalPoliciesByIdAccept",
+        "summary": "POST /v1/public/legal/policies/{id}/accept",
         "tags": [
           "legal"
         ],
@@ -1925,6 +1949,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalTerms",
+        "summary": "GET /v1/public/legal/terms",
         "tags": [
           "legal"
         ],
@@ -2125,6 +2151,8 @@
             }
           }
         },
+        "operationId": "getPublicLegalTermsById",
+        "summary": "GET /v1/public/legal/terms/{id}",
         "tags": [
           "legal"
         ],

--- a/starters/operator/openapi/storefront/markets.json
+++ b/starters/operator/openapi/storefront/markets.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -249,6 +255,8 @@
             }
           }
         },
+        "operationId": "getPublicMarkets",
+        "summary": "GET /v1/public/markets",
         "tags": [
           "markets"
         ],

--- a/starters/operator/openapi/storefront/operator-settings.json
+++ b/starters/operator/openapi/storefront/operator-settings.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -224,6 +230,8 @@
             }
           }
         },
+        "operationId": "getPublicOperatorProfile",
+        "summary": "GET /v1/public/operator-profile",
         "tags": [
           "operator-settings"
         ],
@@ -307,6 +315,8 @@
             }
           }
         },
+        "operationId": "getPublicSettingsOperator",
+        "summary": "GET /v1/public/settings/operator",
         "tags": [
           "operator-settings"
         ],

--- a/starters/operator/openapi/storefront/payment-link.json
+++ b/starters/operator/openapi/storefront/payment-link.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -206,6 +212,8 @@
             }
           }
         },
+        "operationId": "getPublicPaymentLinkConfig",
+        "summary": "GET /v1/public/payment-link-config",
         "tags": [
           "payment-link"
         ],
@@ -292,6 +300,8 @@
             }
           }
         },
+        "operationId": "postPublicPaymentLinkBySessionIdRetry",
+        "summary": "POST /v1/public/payment-link/{sessionId}/retry",
         "tags": [
           "payment-link"
         ],
@@ -375,6 +385,8 @@
             }
           }
         },
+        "operationId": "getPublicPaymentLinkResolve",
+        "summary": "GET /v1/public/payment-link/resolve",
         "tags": [
           "payment-link"
         ],
@@ -479,6 +491,8 @@
             }
           }
         },
+        "operationId": "postPublicPaymentLinkBySessionIdStartCard",
+        "summary": "POST /v1/public/payment-link/{sessionId}/start-card",
         "tags": [
           "payment-link"
         ],
@@ -654,6 +668,8 @@
             }
           }
         },
+        "operationId": "getPublicPaymentLinkBySessionIdTripSummary",
+        "summary": "GET /v1/public/payment-link/{sessionId}/trip-summary",
         "tags": [
           "payment-link"
         ],
@@ -850,6 +866,8 @@
             }
           }
         },
+        "operationId": "getPublicPaymentLinkBySessionIdBookingSummary",
+        "summary": "GET /v1/public/payment-link/{sessionId}/booking-summary",
         "tags": [
           "payment-link"
         ],
@@ -1074,6 +1092,8 @@
             }
           }
         },
+        "operationId": "getPublicBookingsByBookingIdCheckoutStatus",
+        "summary": "GET /v1/public/bookings/{bookingId}/checkout-status",
         "tags": [
           "payment-link"
         ],

--- a/starters/operator/openapi/storefront/pricing.json
+++ b/starters/operator/openapi/storefront/pricing.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -578,6 +584,8 @@
             }
           }
         },
+        "operationId": "getPublicPricingProductsByProductIdPricing",
+        "summary": "GET /v1/public/pricing/products/{productId}/pricing",
         "tags": [
           "pricing"
         ],

--- a/starters/operator/openapi/storefront/products.json
+++ b/starters/operator/openapi/storefront/products.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -229,6 +235,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsTags",
+        "summary": "GET /v1/public/products/tags",
         "tags": [
           "products"
         ],
@@ -347,6 +355,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsCategories",
+        "summary": "GET /v1/public/products/categories",
         "tags": [
           "products"
         ],
@@ -559,6 +569,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsDestinations",
+        "summary": "GET /v1/public/products/destinations",
         "tags": [
           "products"
         ],
@@ -1436,6 +1448,8 @@
             }
           }
         },
+        "operationId": "getPublicProducts",
+        "summary": "GET /v1/public/products",
         "tags": [
           "products"
         ],
@@ -2122,6 +2136,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsSlugBySlug",
+        "summary": "GET /v1/public/products/slug/{slug}",
         "tags": [
           "products"
         ],
@@ -2808,6 +2824,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsById",
+        "summary": "GET /v1/public/products/{id}",
         "tags": [
           "products"
         ],
@@ -2933,6 +2951,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByIdBrochure",
+        "summary": "GET /v1/public/products/{id}/brochure",
         "tags": [
           "products"
         ],

--- a/starters/operator/openapi/storefront/storefront-verification.json
+++ b/starters/operator/openapi/storefront/storefront-verification.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -331,6 +337,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationEmailStart",
+        "summary": "POST /v1/public/storefront-verification/email/start",
         "tags": [
           "storefront-verification"
         ],
@@ -522,6 +530,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationSmsStart",
+        "summary": "POST /v1/public/storefront-verification/sms/start",
         "tags": [
           "storefront-verification"
         ],
@@ -719,6 +729,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationEmailConfirm",
+        "summary": "POST /v1/public/storefront-verification/email/confirm",
         "tags": [
           "storefront-verification"
         ],
@@ -917,6 +929,8 @@
             }
           }
         },
+        "operationId": "postPublicStorefrontVerificationSmsConfirm",
+        "summary": "POST /v1/public/storefront-verification/sms/confirm",
         "tags": [
           "storefront-verification"
         ],

--- a/starters/operator/openapi/storefront/storefront.json
+++ b/starters/operator/openapi/storefront/storefront.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -306,6 +312,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdOffers",
+        "summary": "GET /v1/public/products/{productId}/offers",
         "tags": [
           "storefront"
         ],
@@ -486,6 +494,8 @@
             }
           }
         },
+        "operationId": "getPublicOffersBySlug",
+        "summary": "GET /v1/public/offers/{slug}",
         "tags": [
           "storefront"
         ],
@@ -938,6 +948,8 @@
             }
           }
         },
+        "operationId": "postPublicOffersBySlugApply",
+        "summary": "POST /v1/public/offers/{slug}/apply",
         "tags": [
           "storefront"
         ],
@@ -1386,6 +1398,8 @@
             }
           }
         },
+        "operationId": "postPublicOffersRedeem",
+        "summary": "POST /v1/public/offers/redeem",
         "tags": [
           "storefront"
         ],
@@ -1682,6 +1696,8 @@
             }
           }
         },
+        "operationId": "postPublicLeads",
+        "summary": "POST /v1/public/leads",
         "tags": [
           "storefront"
         ],
@@ -1943,6 +1959,8 @@
             }
           }
         },
+        "operationId": "postPublicNewsletterSubscribe",
+        "summary": "POST /v1/public/newsletter/subscribe",
         "tags": [
           "storefront"
         ],
@@ -2571,6 +2589,8 @@
             }
           }
         },
+        "operationId": "getPublicSettings",
+        "summary": "GET /v1/public/settings",
         "tags": [
           "storefront"
         ],
@@ -2961,6 +2981,8 @@
             }
           }
         },
+        "operationId": "getPublicDeparturesByDepartureId",
+        "summary": "GET /v1/public/departures/{departureId}",
         "tags": [
           "storefront"
         ],
@@ -3406,6 +3428,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdDepartures",
+        "summary": "GET /v1/public/products/{productId}/departures",
         "tags": [
           "storefront"
         ],
@@ -3689,6 +3713,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdAvailability",
+        "summary": "GET /v1/public/products/{productId}/availability",
         "tags": [
           "storefront"
         ],
@@ -3834,6 +3860,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdDeparturesByDepartureIdItinerary",
+        "summary": "GET /v1/public/products/{productId}/departures/{departureId}/itinerary",
         "tags": [
           "storefront"
         ],
@@ -4115,6 +4143,8 @@
             }
           }
         },
+        "operationId": "getPublicProductsByProductIdExtensions",
+        "summary": "GET /v1/public/products/{productId}/extensions",
         "tags": [
           "storefront"
         ],

--- a/starters/operator/openapi/storefront/trips.json
+++ b/starters/operator/openapi/storefront/trips.json
@@ -5,6 +5,12 @@
     "version": "0.0.0",
     "description": "Generated from the composed operator app. Do not edit by hand."
   },
+  "servers": [
+    {
+      "url": "/",
+      "description": "This deployment (same origin)"
+    }
+  ],
   "components": {
     "schemas": {
       "CatalogSearchFilter": {
@@ -188,6 +194,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsHealth",
+        "summary": "GET /v1/public/trips/health",
         "tags": [
           "trips"
         ],
@@ -800,6 +808,8 @@
             }
           }
         },
+        "operationId": "getPublicTrips",
+        "summary": "GET /v1/public/trips",
         "tags": [
           "trips"
         ],
@@ -1319,6 +1329,8 @@
             }
           }
         },
+        "operationId": "postPublicTrips",
+        "summary": "POST /v1/public/trips",
         "tags": [
           "trips"
         ],
@@ -1778,6 +1790,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsByEnvelopeId",
+        "summary": "GET /v1/public/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2105,6 +2119,8 @@
             }
           }
         },
+        "operationId": "patchPublicTripsByEnvelopeId",
+        "summary": "PATCH /v1/public/trips/{envelopeId}",
         "tags": [
           "trips"
         ],
@@ -2476,6 +2492,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdReshop",
+        "summary": "POST /v1/public/trips/{envelopeId}/reshop",
         "tags": [
           "trips"
         ],
@@ -2619,6 +2637,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsByEnvelopeIdSnapshots",
+        "summary": "GET /v1/public/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2833,6 +2853,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdSnapshots",
+        "summary": "POST /v1/public/trips/{envelopeId}/snapshots",
         "tags": [
           "trips"
         ],
@@ -2992,6 +3014,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsSnapshotsBySnapshotId",
+        "summary": "GET /v1/public/trips/snapshots/{snapshotId}",
         "tags": [
           "trips"
         ],
@@ -3418,6 +3442,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdComponents",
+        "summary": "POST /v1/public/trips/{envelopeId}/components",
         "tags": [
           "trips"
         ],
@@ -3785,6 +3811,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdComponentsReorder",
+        "summary": "POST /v1/public/trips/{envelopeId}/components/reorder",
         "tags": [
           "trips"
         ],
@@ -4206,6 +4234,8 @@
             }
           }
         },
+        "operationId": "patchPublicTripsComponentsByComponentId",
+        "summary": "PATCH /v1/public/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4545,6 +4575,8 @@
             }
           }
         },
+        "operationId": "deletePublicTripsComponentsByComponentId",
+        "summary": "DELETE /v1/public/trips/components/{componentId}",
         "tags": [
           "trips"
         ],
@@ -4935,6 +4967,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsComponentsByComponentIdRefs",
+        "summary": "POST /v1/public/trips/components/{componentId}/refs",
         "tags": [
           "trips"
         ],
@@ -5184,6 +5218,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdRequirements",
+        "summary": "POST /v1/public/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5385,6 +5421,8 @@
             }
           }
         },
+        "operationId": "getPublicTripsByEnvelopeIdRequirements",
+        "summary": "GET /v1/public/trips/{envelopeId}/requirements",
         "tags": [
           "trips"
         ],
@@ -5758,6 +5796,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsRequirementsByRequirementIdCandidates",
+        "summary": "POST /v1/public/trips/requirements/{requirementId}/candidates",
         "tags": [
           "trips"
         ],
@@ -6302,6 +6342,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsRequirementsByRequirementIdSelect",
+        "summary": "POST /v1/public/trips/requirements/{requirementId}/select",
         "tags": [
           "trips"
         ],
@@ -6675,6 +6717,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsRequirementsByRequirementIdReshop",
+        "summary": "POST /v1/public/trips/requirements/{requirementId}/reshop",
         "tags": [
           "trips"
         ],
@@ -7243,6 +7287,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdPrice",
+        "summary": "POST /v1/public/trips/{envelopeId}/price",
         "tags": [
           "trips"
         ],
@@ -7809,6 +7855,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdReserve",
+        "summary": "POST /v1/public/trips/{envelopeId}/reserve",
         "tags": [
           "trips"
         ],
@@ -8358,6 +8406,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdCheckout",
+        "summary": "POST /v1/public/trips/{envelopeId}/checkout",
         "tags": [
           "trips"
         ],
@@ -8909,6 +8959,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdCancellationPreview",
+        "summary": "POST /v1/public/trips/{envelopeId}/cancellation-preview",
         "tags": [
           "trips"
         ],
@@ -9465,6 +9517,8 @@
             }
           }
         },
+        "operationId": "postPublicTripsByEnvelopeIdCancelComponents",
+        "summary": "POST /v1/public/trips/{envelopeId}/cancel-components",
         "tags": [
           "trips"
         ],

--- a/starters/operator/src/api/openapi.ts
+++ b/starters/operator/src/api/openapi.ts
@@ -1,5 +1,6 @@
 import {
   buildModulePathOwnership,
+  type GenerateOpenApiOptions,
   generateOpenApiDocument,
   mergeLazyOpenApiPaths,
   type OpenApiDocument,
@@ -9,11 +10,16 @@ import {
 } from "@voyant-travel/hono/openapi"
 import { app } from "./app.js"
 
-const OPENAPI_INFO = {
-  title: "Voyant Operator API",
-  version: "0.0.0",
-  description: "Generated from the composed operator app. Do not edit by hand.",
-} as const
+const OPENAPI_OPTIONS: GenerateOpenApiOptions = {
+  info: {
+    title: "Voyant Operator API",
+    version: "0.0.0",
+    description: "Generated from the composed operator app. Do not edit by hand.",
+  },
+  // Relative server so Swagger/Scalar "try it out" targets this deployment's
+  // own origin (voyant#2729).
+  servers: [{ url: "/", description: "This deployment (same origin)" }],
+}
 
 /**
  * Build-time OpenAPI generation for the operator deployment (voyant#2114).
@@ -42,7 +48,7 @@ export interface OperatorOpenApiDocuments {
 }
 
 export async function buildOperatorOpenApiDocuments(): Promise<OperatorOpenApiDocuments> {
-  const options = { info: OPENAPI_INFO }
+  const options = OPENAPI_OPTIONS
   const eager = generateOpenApiDocument(app, options)
   // Lazy route families mount as wildcard dispatch stubs at runtime, so their
   // `.openapi()` operations never reach the composed registry — replay their


### PR DESCRIPTION
Completes the remaining metadata items in #2729. With this, every generated operation carries what Redocly/Swagger/client tooling expect.

## What

Stamped by `stampModuleMetadata` (same pass that adds tags + `x-voyant-*`), all **non-destructive** — a value a route already declares is never overwritten:

- **`servers`** — a relative `[{ url: "/", description: "This deployment (same origin)" }]` entry on every doc, so Swagger/Scalar "try it out" targets whatever origin serves the contract (no hardcoded host; a deployment can override). Fixes the issue's "no top-level servers" / "try-it-out targets the docs host" finding.
- **`operationId`** — stable camelCase derived from method + path, unique per document: `GET /v1/admin/bookings/{id}` → `getAdminBookingsById`, `GET /v1/admin/bookings/sharing-groups/{groupId}/travelers` → `getAdminBookingsSharingGroupsByGroupIdTravelers`. Gives generated clients readable, deterministic method names instead of derived guesses.
- **`summary`** — the method + path signature on every operation (`GET /v1/admin/bookings/{id}`), so viewers and linters have a title. Deliberately mechanical rather than guessed prose across ~1,500 heterogeneous routes; hand-authored per-route summaries override it (forward-only).

## Verification

Regenerated `admin/bookings.json` sample:
```
servers: [{"url":"/","description":"This deployment (same origin)"}]
ops: 68 | missing operationId: 0 | unique ids: 68 | missing summary: 0
```

- `pnpm --filter @voyant-travel/hono {typecheck,test}` — 260 pass (added: operationId/summary assertions + "doesn't clobber declared operationId/summary").
- `pnpm --filter @voyant-travel/openapi test` + `pnpm --filter operator test` — drift gates green (43 / 186), all specs regenerated.
- `pnpm release:plan` — clean.

## Closes #2729

With this the issue's full "Expected" list is met:
- ✅ drift gate passes from a clean checkout (the stale committed giants are gone — #2766 — so they can't drift)
- ✅ `servers`, `operationId`, `summary` present
- ✅ readable grouping via `tags` (#2770)

The only forward-only remainder is richer hand-authored prose `summary`/`description` per route, which overrides the derived signature as routes are touched.