### PR TITLE
Fix booking party state transitions

### DIFF
--- a/.changeset/fresh-buckets-serve.md
+++ b/.changeset/fresh-buckets-serve.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Clear company billing state when switching booking journeys back to individual buyers and clarify the traveler add action.

--- a/packages/bookings-react/src/admin/booking-journey-host.tsx
+++ b/packages/bookings-react/src/admin/booking-journey-host.tsx
@@ -112,7 +112,7 @@ export function BookingJourneyHost({
     | "onCancelled"
   > = {
     renderLeadContactPicker({ apply, buyerType }) {
-      return <CrmLeadPicker apply={apply} buyerType={buyerType} />
+      return <CrmLeadPicker key={buyerType} apply={apply} buyerType={buyerType} />
     },
     renderBillingExtras(ctx) {
       // Warn if the picked lead already booked this departure.

--- a/packages/bookings-react/src/i18n/en-journey.ts
+++ b/packages/bookings-react/src/i18n/en-journey.ts
@@ -111,7 +111,7 @@ export const bookingsUiEnJourney = {
       decrease: "Decrease {label}",
       increase: "Increase {label}",
       empty: "Pick traveler counts in the Configure step to start adding details.",
-      addTraveler: "Add traveler",
+      addTraveler: "Add another traveler",
       travelerType: "Traveler type",
       travelerNumber: "Traveler {number}",
       ageLabel: "age {age}",

--- a/packages/bookings-react/src/i18n/ro-journey.ts
+++ b/packages/bookings-react/src/i18n/ro-journey.ts
@@ -113,7 +113,7 @@ export const bookingsUiRoJourney = {
       decrease: "Scade {label}",
       increase: "Adauga {label}",
       empty: "Alege numarul de calatori in pasul Configurare pentru a adauga detalii.",
-      addTraveler: "Adauga calator",
+      addTraveler: "Adauga inca un calator",
       travelerType: "Tip calator",
       travelerNumber: "Calator {number}",
       ageLabel: "varsta {age}",

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -20,12 +20,14 @@ import type { JourneyStep } from "../types.js"
  */
 export function buildCommitParty(draft: Draft): Record<string, unknown> {
   const c = draft.billing.contact
+  const organizationId =
+    draft.billing.buyerType === "B2B" ? draft.billing.organizationId : undefined
   return {
     personId: c.personId,
-    organizationId: draft.billing.organizationId,
+    organizationId,
     billing: {
       personId: c.personId,
-      organizationId: draft.billing.organizationId,
+      organizationId,
       contact: {
         firstName: c.firstName,
         lastName: c.lastName,

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -456,7 +456,8 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
         props.renderBillingExtras?.({
           buyerType: draft.billing.buyerType,
           personId: draft.billing.contact.personId,
-          organizationId: draft.billing.organizationId,
+          organizationId:
+            draft.billing.buyerType === "B2B" ? draft.billing.organizationId : undefined,
           productId: props.entityId,
           departureSlotId: draft.configure.departureSlotId,
           departureDate: draft.configure.departureDate,

--- a/packages/bookings-react/src/journey/components/journey-steps/billing-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/billing-step.tsx
@@ -6,7 +6,7 @@ import { CountryCombobox } from "@voyant-travel/ui/components/country-combobox"
 import { Label } from "@voyant-travel/ui/components/label"
 import { RadioGroup, RadioGroupItem } from "@voyant-travel/ui/components/radio-group"
 import { useBookingsUiMessagesOrDefault } from "../../../i18n/index.js"
-import { patchBilling } from "../../lib/draft-state.js"
+import { patchBilling, setBillingBuyerType } from "../../lib/draft-state.js"
 import type { LeadContactPickerProps } from "../../types.js"
 import { Field, JourneyWarnings, PhoneField, type StepCommonProps } from "./shared.js"
 
@@ -72,7 +72,7 @@ export function BillingStep({
           <Label>{messages.bookingJourney.billing.buyerType}</Label>
           <RadioGroup
             value={billing.buyerType}
-            onValueChange={(v) => setDraft(patchBilling(draft, { buyerType: v as "B2C" | "B2B" }))}
+            onValueChange={(v) => setDraft(setBillingBuyerType(draft, v as "B2C" | "B2B"))}
             className="flex gap-4"
           >
             {/* RadioGroupItem from radix wires its own internal label association — biome can't see it */}

--- a/packages/bookings-react/src/journey/components/side-panel.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.tsx
@@ -396,10 +396,10 @@ function BillingDetails({
             : messages.bookingJourney.sidePanel.individual
         }
       />
-      {draft.billing.company?.name ? (
+      {draft.billing.buyerType === "B2B" && draft.billing.company?.name ? (
         <Row label={messages.bookingJourney.sidePanel.company} value={draft.billing.company.name} />
       ) : null}
-      {draft.billing.company?.vatId ? (
+      {draft.billing.buyerType === "B2B" && draft.billing.company?.vatId ? (
         <Row label={messages.bookingJourney.sidePanel.vat} value={draft.billing.company.vatId} />
       ) : null}
       {addressLine ? (

--- a/packages/bookings-react/src/journey/lib/draft-state.ts
+++ b/packages/bookings-react/src/journey/lib/draft-state.ts
@@ -50,6 +50,22 @@ export function patchBilling(draft: Draft, patch: Partial<Draft["billing"]>): Dr
   return { ...draft, billing: { ...draft.billing, ...patch } }
 }
 
+export function setBillingBuyerType(draft: Draft, buyerType: "B2C" | "B2B"): Draft {
+  if (buyerType === "B2C") {
+    const { organizationId: _organizationId, company: _company, ...billing } = draft.billing
+    return {
+      ...draft,
+      billing: {
+        ...billing,
+        buyerType,
+        address: {},
+      },
+    }
+  }
+
+  return patchBilling(draft, { buyerType })
+}
+
 export function canCopyBillingContactToTraveler(contact: Draft["billing"]["contact"]): boolean {
   return Boolean(contact.firstName || contact.lastName || contact.email || contact.phone)
 }

--- a/packages/bookings-react/tests/unit/booking-journey-party-state.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-journey-party-state.test.tsx
@@ -1,0 +1,31 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+import { defaultMinimalShape } from "../../src/journey/components/booking-journey-rules.js"
+import { TravelersStep } from "../../src/journey/components/journey-steps/travelers-step.js"
+import { emptyDraft, setTravelers } from "../../src/journey/lib/draft-state.js"
+
+const ENTITY = {
+  module: "products",
+  id: "prod_1",
+  sourceKind: "owned",
+} as const
+
+describe("booking journey party state", () => {
+  it("labels the traveler row action as adding another required traveler", () => {
+    const draft = setTravelers(emptyDraft(ENTITY), [
+      {
+        rowId: "row_1",
+        firstName: "Ana",
+        lastName: "Pop",
+        band: "adult",
+      },
+    ])
+
+    const html = renderToStaticMarkup(
+      <TravelersStep draft={draft} setDraft={vi.fn()} shape={defaultMinimalShape()} />,
+    )
+
+    expect(html).toContain("Add another traveler")
+  })
+})

--- a/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
+++ b/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildCommitParty,
   canAdvanceFromStep,
   defaultMinimalShape,
 } from "../../src/journey/components/booking-journey-rules.js"
@@ -43,5 +44,26 @@ describe("booking-journey-rules", () => {
     })
 
     expect(canAdvanceFromStep("billing", draft, shape, true)).toBe(false)
+  })
+
+  it("does not commit a stale organization id for an individual buyer", () => {
+    const draft = patchBilling(emptyDraft(ENTITY, { buyerType: "B2C" }), {
+      organizationId: "org_stale",
+      contact: {
+        firstName: "Test",
+        lastName: "Traveler",
+        email: "test@example.com",
+        personId: "person_1",
+      },
+    })
+
+    expect(buildCommitParty(draft)).toMatchObject({
+      personId: "person_1",
+      organizationId: undefined,
+      billing: {
+        personId: "person_1",
+        organizationId: undefined,
+      },
+    })
   })
 })

--- a/packages/bookings-react/tests/unit/draft-state.test.ts
+++ b/packages/bookings-react/tests/unit/draft-state.test.ts
@@ -7,6 +7,7 @@ import {
   patchConfigure,
   patchPaxCount,
   setAddons,
+  setBillingBuyerType,
   setPayment,
   setTravelers,
   totalPax,
@@ -60,6 +61,35 @@ describe("draft-state", () => {
     const next = patchBilling(draft, { buyerType: "B2B" })
     expect(next.billing.buyerType).toBe("B2B")
     expect(next.billing.contact).toBe(draft.billing.contact)
+  })
+
+  it("setBillingBuyerType clears B2B-only billing state when switching to B2C", () => {
+    const draft = patchBilling(emptyDraft(ENTITY, { buyerType: "B2B" }), {
+      organizationId: "org_1",
+      company: {
+        name: "Acme Travel",
+        vatId: "RO123",
+      },
+      address: {
+        line1: "1 Company Way",
+        city: "Bucharest",
+        country: "RO",
+      },
+      contact: {
+        firstName: "Ana",
+        lastName: "Pop",
+        email: "ana@example.com",
+        personId: "person_1",
+      },
+    })
+
+    const next = setBillingBuyerType(draft, "B2C")
+
+    expect(next.billing.buyerType).toBe("B2C")
+    expect(next.billing.organizationId).toBeUndefined()
+    expect(next.billing.company).toBeUndefined()
+    expect(next.billing.address).toEqual({})
+    expect(next.billing.contact).toEqual(draft.billing.contact)
   })
 
   it("allows copying billing contact when any traveler contact field is present", () => {


### PR DESCRIPTION
## Summary
- Clear B2B-only organization, company, VAT, and address state when switching the booking journey back to an individual buyer.
- Prevent stale organization ids from being committed for B2C parties and hide company/VAT rows unless the buyer is B2B.
- Rename the traveler action to make it clear a new required row will be added.

Fixes #2431

## Verification
- pnpm --filter @voyant-travel/bookings-react test -- tests/unit/draft-state.test.ts tests/unit/booking-journey-rules.test.ts tests/unit/booking-journey-party-state.test.tsx
- NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @voyant-travel/bookings-react typecheck
- pnpm --filter @voyant-travel/bookings-react lint
- pnpm exec biome check packages/bookings-react/tests/unit/draft-state.test.ts packages/bookings-react/tests/unit/booking-journey-rules.test.ts packages/bookings-react/tests/unit/booking-journey-party-state.test.tsx .changeset/fresh-buckets-serve.md

## Notes
- pnpm verify:fast was attempted, but the broad affected Turbo build hit Node heap OOMs in unrelated affected packages under the default heap before completing.