### PR TITLE
fix(openapi): pre-seed declared operationIds before deriving

### DIFF
--- a/.changeset/openapi-operationid-preseed.md
+++ b/.changeset/openapi-operationid-preseed.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Fix a latent duplicate-operationId hole in `stampModuleMetadata`.
+
+Declared operationIds were only added to the uniqueness set as the path loop
+reached them, so a route hand-authoring an operationId that matched a string an
+*earlier* path had already derived would leave two operations sharing that id
+(breaking client generators). All route-declared ids are now pre-seeded before
+any id is derived, so derived ids always yield to declared ones. No generated
+spec changes today (no route declares an operationId yet) — this hardens the
+non-destructive override path.

--- a/packages/hono/src/openapi.ts
+++ b/packages/hono/src/openapi.ts
@@ -443,9 +443,21 @@ export function stampModuleMetadata(
   owner: ReadonlyMap<string, string>,
 ): OpenApiDocument {
   const paths: Record<string, unknown> = {}
-  // operationId must be unique across the document; track what we've assigned
-  // (including route-declared ids) so a derived id never collides.
+  // operationId must be unique across the document; track what we've assigned so
+  // a derived id never collides. Pre-seed EVERY route-declared id up front —
+  // otherwise a hand-authored id appearing later in iteration order than an
+  // earlier op that derived the same string would slip through un-suffixed,
+  // leaving duplicate ids in the output (declared ids always win; derived yield).
   const usedOperationIds = new Set<string>()
+  for (const item of Object.values(doc.paths ?? {})) {
+    if (!item || typeof item !== "object") continue
+    for (const method of HTTP_METHODS) {
+      const op = (item as Record<string, unknown>)[method]
+      const declared =
+        op && typeof op === "object" ? (op as Record<string, unknown>).operationId : null
+      if (typeof declared === "string" && declared.length > 0) usedOperationIds.add(declared)
+    }
+  }
   for (const [path, item] of Object.entries(doc.paths ?? {})) {
     if (!item || typeof item !== "object") {
       paths[path] = item

--- a/packages/hono/tests/unit/openapi-modules.test.ts
+++ b/packages/hono/tests/unit/openapi-modules.test.ts
@@ -203,6 +203,27 @@ describe("stampModuleMetadata", () => {
     expect(op["x-voyant-module"]).toBe("legal")
   })
 
+  it("keeps operationIds unique when a later route declares one an earlier op derives", () => {
+    // `/v1/admin/items` GET derives `getAdminItems`; a later route hand-authors
+    // that same id. Pre-seeding declared ids must push the derived one to a
+    // suffix so the document has no duplicate operationIds.
+    const collide = {
+      openapi: "3.1.0",
+      info: INFO,
+      paths: {
+        "/v1/admin/items": { get: { responses: {} } },
+        "/v1/admin/things": { get: { operationId: "getAdminItems", responses: {} } },
+      },
+    } as unknown as OpenApiDocument
+    const stamped = stampModuleMetadata(collide, new Map())
+    const get = (path: string) =>
+      (stamped.paths as Record<string, Record<string, Record<string, unknown>>>)[path].get
+    // Declared id wins; the earlier derived one yields to a suffix.
+    expect(get("/v1/admin/things").operationId).toBe("getAdminItems")
+    expect(get("/v1/admin/items").operationId).toBe("getAdminItems_2")
+    expect(get("/v1/admin/items").operationId).not.toBe(get("/v1/admin/things").operationId)
+  })
+
   it("does not mutate the input document", () => {
     const before = JSON.stringify(doc)
     stampModuleMetadata(doc, owner)


### PR DESCRIPTION
Follow-up to #2776 — fixes a P2 raised in review after that PR merged.

## The bug

`stampModuleMetadata` added declared `operationId`s to the uniqueness set only as the path loop *reached* them. So if a route hand-authors an `operationId` matching a string an **earlier** path already derived, the earlier op claimed it un-suffixed and the later declared one kept it too → **two operations with the same `operationId`**, which breaks client generators.

Declared ids always win (non-destructive), so it's the *derived* id that must yield — but it never got the chance when the collision was declared-later-than-derived.

## Fix

Pre-seed **every** route-declared `operationId` into the uniqueness set before deriving any id. Now a derived id checks against all declared ids (regardless of iteration order) and suffixes to stay unique; declared ids are always kept verbatim.

## Impact

**No generated spec changes today** — no route declares an `operationId` yet, so every id is derived and already unique; regenerating both spec sets produces zero diff (drift gates pass unchanged). This purely hardens the non-destructive override path for when hand-authored ids get added.

## Testing

- New regression test: an earlier path derives `getAdminItems`; a later route declares that exact id → the derived one becomes `getAdminItems_2`, the declared one stays `getAdminItems`, no duplicates.
- `pnpm --filter @voyant-travel/hono test` — 261 pass.
- `pnpm --filter @voyant-travel/openapi test` + `pnpm --filter operator test` — drift gates green (43 / 186), no spec churn.