### PR TITLE
Improve resources admin workflows

### DIFF
--- a/.changeset/resources-admin-workflows.md
+++ b/.changeset/resources-admin-workflows.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operations-react": patch
+---
+
+Expose resources admin edit and pool membership workflows, preserve resources list state across detail navigation, and improve assignment slot labels with product context.

--- a/packages/operations-react/src/resources/admin/detail-hosts.tsx
+++ b/packages/operations-react/src/resources/admin/detail-hosts.tsx
@@ -2,12 +2,32 @@
 
 import { useQueryClient } from "@tanstack/react-query"
 import { useAdminNavigate } from "@voyant-travel/admin"
+import { useState } from "react"
 import { ResourceAllocationDetailPage } from "../components/resource-allocation-detail-page.js"
 import { ResourceAssignmentDetailPage } from "../components/resource-assignment-detail-page.js"
 import { ResourceDetailPage } from "../components/resource-detail-page.js"
 import { ResourcePoolDetailPage } from "../components/resource-pool-detail-page.js"
-import { resourcesQueryKeys, useVoyantResourcesContext } from "../index.js"
+import {
+  resourcesQueryKeys,
+  useAllocation,
+  useAssignment,
+  useBookings,
+  usePool,
+  usePools,
+  useProducts,
+  useResource,
+  useResources,
+  useRules,
+  useSlots,
+  useStartTimes,
+  useSuppliers,
+  useVoyantResourcesContext,
+} from "../index.js"
 import { sendResourcesMutation } from "./resources-admin-api.js"
+import { ResourceAllocationDialog } from "./resources-dialog-allocation.js"
+import { ResourceDialog, ResourcePoolDialog } from "./resources-dialogs-core.js"
+import { ResourceSlotAssignmentDialog } from "./resources-dialogs-ops.js"
+import { resourcesPageQueryFilters } from "./resources-page-data.js"
 
 /**
  * Packaged admin hosts for the resource detail pages (packaged-admin RFC
@@ -31,23 +51,49 @@ export function ResourceDetailHost({ id }: ResourceDetailHostProps) {
   const navigateTo = useAdminNavigate()
   const queryClient = useQueryClient()
   const client = useVoyantResourcesContext()
+  const [resourceDialogOpen, setResourceDialogOpen] = useState(false)
+  const resource = useResource(id).data
+  const suppliers = useSuppliers(resourcesPageQueryFilters.suppliers).data?.data ?? []
+
+  const refreshResource = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.resources() }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.resource(id) }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.all }),
+    ])
+  }
 
   return (
-    <ResourceDetailPage
-      id={id}
-      onBack={() => navigateTo("resource.list", {})}
-      onOpenSupplier={(supplierId) => navigateTo("supplier.detail", { supplierId })}
-      onOpenAssignment={(assignmentId) => navigateTo("resourceAssignment.detail", { assignmentId })}
-      onDelete={async (resource) => {
-        await sendResourcesMutation(
-          client,
-          "DELETE",
-          `/v1/admin/operations/resources/${resource.id}`,
-        )
-        await queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.resources() })
-        navigateTo("resource.list", {})
-      }}
-    />
+    <>
+      <ResourceDetailPage
+        id={id}
+        onBack={() => navigateTo("resource.list", {})}
+        onEdit={() => setResourceDialogOpen(true)}
+        onOpenSupplier={(supplierId) => navigateTo("supplier.detail", { supplierId })}
+        onOpenAssignment={(assignmentId) =>
+          navigateTo("resourceAssignment.detail", { assignmentId })
+        }
+        onDelete={async (resource) => {
+          await sendResourcesMutation(
+            client,
+            "DELETE",
+            `/v1/admin/operations/resources/${resource.id}`,
+          )
+          await refreshResource()
+          navigateTo("resource.list", {})
+        }}
+      />
+      <ResourceDialog
+        open={resourceDialogOpen}
+        onOpenChange={setResourceDialogOpen}
+        resource={resource}
+        suppliers={suppliers}
+        onSuccess={() => {
+          setResourceDialogOpen(false)
+          void refreshResource()
+        }}
+      />
+    </>
   )
 }
 
@@ -59,21 +105,65 @@ export function ResourcePoolDetailHost({ id }: ResourcePoolDetailHostProps) {
   const navigateTo = useAdminNavigate()
   const queryClient = useQueryClient()
   const client = useVoyantResourcesContext()
+  const [poolDialogOpen, setPoolDialogOpen] = useState(false)
+  const pool = usePool(id).data
+  const products = useProducts(resourcesPageQueryFilters.products).data?.data ?? []
+
+  const refreshPool = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.pools() }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.pool(id) }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.resources() }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.all }),
+    ])
+  }
 
   return (
-    <ResourcePoolDetailPage
-      id={id}
-      onBack={() => navigateTo("resource.list", {})}
-      onOpenProduct={(productId) => navigateTo("product.detail", { productId })}
-      onOpenResource={(resourceId) => navigateTo("resource.detail", { resourceId })}
-      onOpenAllocation={(allocationId) => navigateTo("resourceAllocation.detail", { allocationId })}
-      onOpenAssignment={(assignmentId) => navigateTo("resourceAssignment.detail", { assignmentId })}
-      onDelete={async (pool) => {
-        await sendResourcesMutation(client, "DELETE", `/v1/admin/operations/pools/${pool.id}`)
-        await queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.pools() })
-        navigateTo("resource.list", {})
-      }}
-    />
+    <>
+      <ResourcePoolDetailPage
+        id={id}
+        onBack={() => navigateTo("resource.list", {})}
+        onEdit={() => setPoolDialogOpen(true)}
+        onAddMember={async (pool, resourceId) => {
+          await sendResourcesMutation(client, "POST", "/v1/admin/operations/pool-members", {
+            poolId: pool.id,
+            resourceId,
+          })
+          await refreshPool()
+        }}
+        onRemoveMember={async (member) => {
+          await sendResourcesMutation(
+            client,
+            "DELETE",
+            `/v1/admin/operations/pool-members/${member.id}`,
+          )
+          await refreshPool()
+        }}
+        onOpenProduct={(productId) => navigateTo("product.detail", { productId })}
+        onOpenResource={(resourceId) => navigateTo("resource.detail", { resourceId })}
+        onOpenAllocation={(allocationId) =>
+          navigateTo("resourceAllocation.detail", { allocationId })
+        }
+        onOpenAssignment={(assignmentId) =>
+          navigateTo("resourceAssignment.detail", { assignmentId })
+        }
+        onDelete={async (pool) => {
+          await sendResourcesMutation(client, "DELETE", `/v1/admin/operations/pools/${pool.id}`)
+          await refreshPool()
+          navigateTo("resource.list", {})
+        }}
+      />
+      <ResourcePoolDialog
+        open={poolDialogOpen}
+        onOpenChange={setPoolDialogOpen}
+        pool={pool}
+        products={products}
+        onSuccess={() => {
+          setPoolDialogOpen(false)
+          void refreshPool()
+        }}
+      />
+    </>
   )
 }
 
@@ -85,23 +175,56 @@ export function ResourceAssignmentDetailHost({ id }: ResourceAssignmentDetailHos
   const navigateTo = useAdminNavigate()
   const queryClient = useQueryClient()
   const client = useVoyantResourcesContext()
+  const [assignmentDialogOpen, setAssignmentDialogOpen] = useState(false)
+  const assignment = useAssignment(id).data
+  const slots = useSlots(resourcesPageQueryFilters.slots).data?.data ?? []
+  const pools = usePools(resourcesPageQueryFilters.pools).data?.data ?? []
+  const resources = useResources(resourcesPageQueryFilters.resources).data?.data ?? []
+  const bookings = useBookings(resourcesPageQueryFilters.bookings).data?.data ?? []
+  const products = useProducts(resourcesPageQueryFilters.products).data?.data ?? []
+
+  const refreshAssignment = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.assignments() }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.assignment(id) }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.resources() }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.pools() }),
+    ])
+  }
 
   return (
-    <ResourceAssignmentDetailPage
-      id={id}
-      onBack={() => navigateTo("resource.list", {})}
-      onOpenSlot={(slotId) => navigateTo("availabilitySlot.detail", { slotId })}
-      onOpenResource={(resourceId) => navigateTo("resource.detail", { resourceId })}
-      onDelete={async (assignment) => {
-        await sendResourcesMutation(
-          client,
-          "DELETE",
-          `/v1/admin/operations/slot-assignments/${assignment.id}`,
-        )
-        await queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.assignments() })
-        navigateTo("resource.list", {})
-      }}
-    />
+    <>
+      <ResourceAssignmentDetailPage
+        id={id}
+        onBack={() => navigateTo("resource.list", {})}
+        onEdit={() => setAssignmentDialogOpen(true)}
+        onOpenSlot={(slotId) => navigateTo("availabilitySlot.detail", { slotId })}
+        onOpenResource={(resourceId) => navigateTo("resource.detail", { resourceId })}
+        onDelete={async (assignment) => {
+          await sendResourcesMutation(
+            client,
+            "DELETE",
+            `/v1/admin/operations/slot-assignments/${assignment.id}`,
+          )
+          await refreshAssignment()
+          navigateTo("resource.list", {})
+        }}
+      />
+      <ResourceSlotAssignmentDialog
+        open={assignmentDialogOpen}
+        onOpenChange={setAssignmentDialogOpen}
+        assignment={assignment}
+        slots={slots}
+        pools={pools}
+        resources={resources}
+        bookings={bookings}
+        products={products}
+        onSuccess={() => {
+          setAssignmentDialogOpen(false)
+          void refreshAssignment()
+        }}
+      />
+    </>
   )
 }
 
@@ -113,22 +236,52 @@ export function ResourceAllocationDetailHost({ id }: ResourceAllocationDetailHos
   const navigateTo = useAdminNavigate()
   const queryClient = useQueryClient()
   const client = useVoyantResourcesContext()
+  const [allocationDialogOpen, setAllocationDialogOpen] = useState(false)
+  const allocation = useAllocation(id).data
+  const pools = usePools(resourcesPageQueryFilters.pools).data?.data ?? []
+  const products = useProducts(resourcesPageQueryFilters.products).data?.data ?? []
+  const rules = useRules(resourcesPageQueryFilters.rules).data?.data ?? []
+  const startTimes = useStartTimes(resourcesPageQueryFilters.startTimes).data?.data ?? []
+
+  const refreshAllocation = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.allocations() }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.allocation(id) }),
+      queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.pools() }),
+    ])
+  }
 
   return (
-    <ResourceAllocationDetailPage
-      id={id}
-      onBack={() => navigateTo("resource.list", {})}
-      onOpenPool={(poolId) => navigateTo("resourcePool.detail", { poolId })}
-      onOpenProduct={(productId) => navigateTo("product.detail", { productId })}
-      onDelete={async (allocation) => {
-        await sendResourcesMutation(
-          client,
-          "DELETE",
-          `/v1/admin/operations/allocations/${allocation.id}`,
-        )
-        await queryClient.invalidateQueries({ queryKey: resourcesQueryKeys.allocations() })
-        navigateTo("resource.list", {})
-      }}
-    />
+    <>
+      <ResourceAllocationDetailPage
+        id={id}
+        onBack={() => navigateTo("resource.list", {})}
+        onEdit={() => setAllocationDialogOpen(true)}
+        onOpenPool={(poolId) => navigateTo("resourcePool.detail", { poolId })}
+        onOpenProduct={(productId) => navigateTo("product.detail", { productId })}
+        onDelete={async (allocation) => {
+          await sendResourcesMutation(
+            client,
+            "DELETE",
+            `/v1/admin/operations/allocations/${allocation.id}`,
+          )
+          await refreshAllocation()
+          navigateTo("resource.list", {})
+        }}
+      />
+      <ResourceAllocationDialog
+        open={allocationDialogOpen}
+        onOpenChange={setAllocationDialogOpen}
+        allocation={allocation}
+        pools={pools}
+        products={products}
+        rules={rules}
+        startTimes={startTimes}
+        onSuccess={() => {
+          setAllocationDialogOpen(false)
+          void refreshAllocation()
+        }}
+      />
+    </>
   )
 }

--- a/packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx
+++ b/packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx
@@ -25,17 +25,19 @@ import { Loader2 } from "lucide-react"
 import { useEffect } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
+import { useResourcesUiI18nOrDefault } from "../i18n/index.js"
+import { formatResourceSlotLabel } from "../i18n/utils.js"
 import {
   assignmentStatusOptions,
   type BookingOption,
   NONE_VALUE,
   nullableString,
+  type ProductOption,
   type ResourceCloseoutRow,
   type ResourcePoolRow,
   type ResourceRow,
   type ResourceSlotAssignmentRow,
   type SlotOption,
-  slotLabel,
   toIsoDateTime,
   toLocalDateTimeInput,
   useVoyantResourcesContext,
@@ -78,6 +80,7 @@ export function ResourceSlotAssignmentDialog({
   pools,
   resources,
   bookings,
+  products,
   onSuccess,
 }: {
   open: boolean
@@ -87,11 +90,19 @@ export function ResourceSlotAssignmentDialog({
   pools: ResourcePoolRow[]
   resources: ResourceRow[]
   bookings: BookingOption[]
+  products: ProductOption[]
   onSuccess: () => void
 }) {
   const client = useVoyantResourcesContext()
   const messages = useOperatorAdminMessages()
+  const i18n = useResourcesUiI18nOrDefault()
   const dialogMessages = messages.resources.dialogs.assignment
+  const slotLabel = (slot: SlotOption) =>
+    formatResourceSlotLabel(slot, {
+      template: i18n.messages.common.slotLabel,
+      formatDate: i18n.formatDate,
+      products,
+    })
   const assignmentFormSchema = getAssignmentFormSchema(messages)
   const form = useForm({
     resolver: zodResolver(assignmentFormSchema),

--- a/packages/operations-react/src/resources/admin/resources-dialogs.tsx
+++ b/packages/operations-react/src/resources/admin/resources-dialogs.tsx
@@ -112,6 +112,7 @@ export function ResourcesDialogs({
         pools={pools}
         resources={resources}
         bookings={bookings}
+        products={products}
         onSuccess={() => {
           setAssignmentDialogOpen(false)
           void refreshAll()

--- a/packages/operations-react/src/resources/components/resource-allocation-detail-page.tsx
+++ b/packages/operations-react/src/resources/components/resource-allocation-detail-page.tsx
@@ -33,6 +33,7 @@ export interface ResourceAllocationDetailPageProps {
   deleting?: boolean
   onBack?: () => void
   onDelete?: (allocation: ResourceAllocationDetail) => Promise<void> | void
+  onEdit?: (allocation: ResourceAllocationDetail) => void
   onOpenPool?: (poolId: string) => void
   onOpenProduct?: (productId: string) => void
   confirmAction?: ConfirmAction
@@ -45,6 +46,7 @@ export function ResourceAllocationDetailPage({
   id,
   onBack,
   onDelete,
+  onEdit,
   onOpenPool,
   onOpenProduct,
 }: ResourceAllocationDetailPageProps) {
@@ -107,6 +109,7 @@ export function ResourceAllocationDetailPage({
         confirmAction={confirmAction}
         onBack={onBack}
         onDelete={onDelete ? () => onDelete(allocation) : undefined}
+        onEdit={onEdit ? () => onEdit(allocation) : undefined}
         badges={
           <>
             <Badge variant="outline">

--- a/packages/operations-react/src/resources/components/resource-assignment-detail-page.tsx
+++ b/packages/operations-react/src/resources/components/resource-assignment-detail-page.tsx
@@ -35,6 +35,7 @@ export interface ResourceAssignmentDetailPageProps {
   deleting?: boolean
   onBack?: () => void
   onDelete?: (assignment: ResourceSlotAssignmentDetail) => Promise<void> | void
+  onEdit?: (assignment: ResourceSlotAssignmentDetail) => void
   onOpenResource?: (resourceId: string) => void
   onOpenSlot?: (slotId: string) => void
   confirmAction?: ConfirmAction
@@ -47,6 +48,7 @@ export function ResourceAssignmentDetailPage({
   id,
   onBack,
   onDelete,
+  onEdit,
   onOpenResource,
   onOpenSlot,
 }: ResourceAssignmentDetailPageProps) {
@@ -90,6 +92,7 @@ export function ResourceAssignmentDetailPage({
     ? formatResourceSlotLabel(slot, {
         template: m.common.slotLabel,
         formatDate: i18n.formatDate,
+        products: productsQuery.data?.data ?? [],
       })
     : assignment.slotId
 
@@ -107,6 +110,7 @@ export function ResourceAssignmentDetailPage({
         confirmAction={confirmAction}
         onBack={onBack}
         onDelete={onDelete ? () => onDelete(assignment) : undefined}
+        onEdit={onEdit ? () => onEdit(assignment) : undefined}
         badges={
           <>
             <Badge variant="outline">{m.common.assignmentStatusLabels[assignment.status]}</Badge>

--- a/packages/operations-react/src/resources/components/resource-detail-page.tsx
+++ b/packages/operations-react/src/resources/components/resource-detail-page.tsx
@@ -21,6 +21,7 @@ import {
   useBookings,
   useCloseouts,
   usePools,
+  useProducts,
   useResource,
   useSlots,
   useSuppliers,
@@ -47,6 +48,7 @@ export interface ResourceDetailPageProps {
   deleting?: boolean
   onBack?: () => void
   onDelete?: (resource: ResourceDetail) => Promise<void> | void
+  onEdit?: (resource: ResourceDetail) => void
   onOpenSupplier?: (supplierId: string) => void
   onOpenAssignment?: (assignmentId: string) => void
   confirmAction?: ConfirmAction
@@ -59,6 +61,7 @@ export function ResourceDetailPage({
   id,
   onBack,
   onDelete,
+  onEdit,
   onOpenAssignment,
   onOpenSupplier,
 }: ResourceDetailPageProps) {
@@ -72,6 +75,7 @@ export function ResourceDetailPage({
   const assignmentsQuery = useAssignmentsByResource(id)
   const slotsQuery = useSlots({ limit: 25 })
   const bookingsQuery = useBookings({ limit: 25 })
+  const productsQuery = useProducts({ limit: 25 })
   const closeoutsQuery = useCloseouts({ resourceId: id, limit: 25 })
 
   if (resourceQuery.isPending) {
@@ -98,6 +102,7 @@ export function ResourceDetailPage({
   const pools = poolsQuery.data?.data ?? []
   const slots = slotsQuery.data?.data ?? []
   const bookings = bookingsQuery.data?.data ?? []
+  const products = productsQuery.data?.data ?? []
   const poolsById = new Map(pools.map((pool) => [pool.id, pool]))
   const slotsById = new Map(slots.map((slot) => [slot.id, slot]))
   const bookingsById = new Map(bookings.map((booking) => [booking.id, booking]))
@@ -116,6 +121,7 @@ export function ResourceDetailPage({
         confirmAction={confirmAction}
         onBack={onBack}
         onDelete={onDelete ? () => onDelete(resource) : undefined}
+        onEdit={onEdit ? () => onEdit(resource) : undefined}
         badges={
           <>
             <Badge variant="outline">{m.common.resourceKindLabels[resource.kind]}</Badge>
@@ -205,6 +211,7 @@ export function ResourceDetailPage({
                     ? formatResourceSlotLabel(slotsById.get(assignment.slotId)!, {
                         template: m.common.slotLabel,
                         formatDate: i18n.formatDate,
+                        products,
                       })
                     : assignment.slotId
                 }

--- a/packages/operations-react/src/resources/components/resource-detail-shared.tsx
+++ b/packages/operations-react/src/resources/components/resource-detail-shared.tsx
@@ -3,7 +3,7 @@
 import { formatMessage } from "@voyant-travel/i18n"
 import { Button, Card, CardContent, CardHeader, CardTitle, cn } from "@voyant-travel/ui/components"
 import { Skeleton } from "@voyant-travel/ui/components/skeleton"
-import { ArrowLeft, Loader2, Trash2 } from "lucide-react"
+import { ArrowLeft, Loader2, Pencil, Trash2 } from "lucide-react"
 import type { ReactNode } from "react"
 import { useState } from "react"
 
@@ -76,6 +76,7 @@ export function ResourceDetailHeader({
   deleting: deletingProp,
   onBack,
   onDelete,
+  onEdit,
   title,
 }: {
   actions?: ReactNode
@@ -88,6 +89,7 @@ export function ResourceDetailHeader({
   deleting?: boolean
   onBack?: () => void
   onDelete?: () => Promise<void> | void
+  onEdit?: () => void
   title: string
 }) {
   const messages = useResourcesUiMessagesOrDefault()
@@ -130,6 +132,12 @@ export function ResourceDetailHeader({
         </div>
         <div className="flex flex-wrap items-center gap-2">
           {actions}
+          {onEdit ? (
+            <Button type="button" variant="outline" onClick={onEdit}>
+              <Pencil data-icon="inline-start" aria-hidden="true" />
+              {messages.detailPages.common.edit}
+            </Button>
+          ) : null}
           {onDelete ? (
             <Button
               type="button"

--- a/packages/operations-react/src/resources/components/resource-pool-detail-page.tsx
+++ b/packages/operations-react/src/resources/components/resource-pool-detail-page.tsx
@@ -8,8 +8,14 @@ import {
   CardHeader,
   CardTitle,
   cn,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
 } from "@voyant-travel/ui/components"
-import { Package, Users, Wrench } from "lucide-react"
+import { Loader2, Package, Plus, Trash2, Users, Wrench } from "lucide-react"
+import { useState } from "react"
 import { useResourcesUiI18nOrDefault } from "../i18n/index.js"
 import { formatResourceSlotLabel } from "../i18n/utils.js"
 import {
@@ -24,6 +30,7 @@ import {
   useResources,
   useSlots,
 } from "../index.js"
+import type { ResourcePoolMemberRow } from "./resource-detail-data.js"
 import { useResourcePoolMembers } from "./resource-detail-data.js"
 import { ResourceAssignmentSummary } from "./resource-detail-page.js"
 import {
@@ -47,6 +54,9 @@ export interface ResourcePoolDetailPageProps {
   deleting?: boolean
   onBack?: () => void
   onDelete?: (pool: ResourcePoolDetail) => Promise<void> | void
+  onEdit?: (pool: ResourcePoolDetail) => void
+  onAddMember?: (pool: ResourcePoolDetail, resourceId: string) => Promise<void> | void
+  onRemoveMember?: (member: ResourcePoolMemberRow) => Promise<void> | void
   onOpenAllocation?: (allocationId: string) => void
   onOpenProduct?: (productId: string) => void
   onOpenResource?: (resourceId: string) => void
@@ -61,10 +71,13 @@ export function ResourcePoolDetailPage({
   id,
   onBack,
   onDelete,
+  onEdit,
+  onAddMember,
   onOpenAllocation,
   onOpenAssignment,
   onOpenProduct,
   onOpenResource,
+  onRemoveMember,
 }: ResourcePoolDetailPageProps) {
   const i18n = useResourcesUiI18nOrDefault()
   const m = i18n.messages
@@ -77,6 +90,8 @@ export function ResourcePoolDetailPage({
   const assignmentsQuery = useAssignments({ poolId: id, limit: 25 })
   const slotsQuery = useSlots({ limit: 25 })
   const bookingsQuery = useBookings({ limit: 25 })
+  const [selectedResourceId, setSelectedResourceId] = useState("")
+  const [memberMutationId, setMemberMutationId] = useState<string | null>(null)
 
   if (poolQuery.isPending) {
     return <ResourcePoolDetailSkeleton />
@@ -102,6 +117,30 @@ export function ResourcePoolDetailPage({
   const resourcesById = new Map(resources.map((resource) => [resource.id, resource]))
   const slotsById = new Map(slots.map((slot) => [slot.id, slot]))
   const bookingsById = new Map(bookings.map((booking) => [booking.id, booking]))
+  const members = membersQuery.data?.data ?? []
+  const memberResourceIds = new Set(members.map((member) => member.resourceId))
+  const addableResources = resources.filter((resource) => !memberResourceIds.has(resource.id))
+
+  async function handleAddMember() {
+    if (!onAddMember || !selectedResourceId) return
+    setMemberMutationId("add")
+    try {
+      await onAddMember(pool, selectedResourceId)
+      setSelectedResourceId("")
+    } finally {
+      setMemberMutationId(null)
+    }
+  }
+
+  async function handleRemoveMember(member: ResourcePoolMemberRow) {
+    if (!onRemoveMember) return
+    setMemberMutationId(member.id)
+    try {
+      await onRemoveMember(member)
+    } finally {
+      setMemberMutationId(null)
+    }
+  }
 
   return (
     <div data-slot="resource-pool-detail-page" className={cn("flex flex-col gap-6 p-6", className)}>
@@ -114,6 +153,7 @@ export function ResourcePoolDetailPage({
         confirmAction={confirmAction}
         onBack={onBack}
         onDelete={onDelete ? () => onDelete(pool) : undefined}
+        onEdit={onEdit ? () => onEdit(pool) : undefined}
         badges={
           <>
             <Badge variant="outline">{m.common.resourceKindLabels[pool.kind]}</Badge>
@@ -161,10 +201,47 @@ export function ResourcePoolDetailPage({
           <CardTitle>{page.pool.membersTitle}</CardTitle>
         </CardHeader>
         <CardContent className="flex flex-col gap-3 text-sm">
-          {(membersQuery.data?.data.length ?? 0) === 0 ? (
+          {onAddMember ? (
+            <div className="flex flex-col gap-2 rounded-md border p-3 sm:flex-row sm:items-center">
+              <Select
+                value={selectedResourceId}
+                onValueChange={(value) => setSelectedResourceId(value ?? "")}
+              >
+                <SelectTrigger className="min-w-0 flex-1">
+                  <SelectValue placeholder={page.pool.addMemberPlaceholder} />
+                </SelectTrigger>
+                <SelectContent>
+                  {addableResources.length === 0 ? (
+                    <SelectItem value="__none" disabled>
+                      {page.pool.memberAlreadyAssigned}
+                    </SelectItem>
+                  ) : (
+                    addableResources.map((resource) => (
+                      <SelectItem key={resource.id} value={resource.id}>
+                        {resource.name}
+                      </SelectItem>
+                    ))
+                  )}
+                </SelectContent>
+              </Select>
+              <Button
+                type="button"
+                onClick={() => void handleAddMember()}
+                disabled={!selectedResourceId || memberMutationId === "add"}
+              >
+                {memberMutationId === "add" ? (
+                  <Loader2 data-icon="inline-start" className="animate-spin" aria-hidden="true" />
+                ) : (
+                  <Plus data-icon="inline-start" aria-hidden="true" />
+                )}
+                {page.pool.addMember}
+              </Button>
+            </div>
+          ) : null}
+          {members.length === 0 ? (
             <p className="text-muted-foreground">{page.pool.membersEmpty}</p>
           ) : (
-            membersQuery.data?.data.map((member) => {
+            members.map((member) => {
               const resource = resourcesById.get(member.resourceId)
               const body = (
                 <>
@@ -177,18 +254,39 @@ export function ResourcePoolDetailPage({
                 </>
               )
 
-              return onOpenResource && resource ? (
-                <button
-                  key={member.id}
-                  type="button"
-                  className="block w-full rounded-md border p-3 text-left hover:bg-muted/40"
-                  onClick={() => onOpenResource(resource.id)}
-                >
-                  {body}
-                </button>
-              ) : (
-                <div key={member.id} className="rounded-md border p-3">
-                  {body}
+              return (
+                <div key={member.id} className="flex items-start gap-2 rounded-md border p-3">
+                  {onOpenResource && resource ? (
+                    <button
+                      type="button"
+                      className="min-w-0 flex-1 text-left hover:text-primary"
+                      onClick={() => onOpenResource(resource.id)}
+                    >
+                      {body}
+                    </button>
+                  ) : (
+                    <div className="min-w-0 flex-1">{body}</div>
+                  )}
+                  {onRemoveMember ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => void handleRemoveMember(member)}
+                      disabled={memberMutationId === member.id}
+                    >
+                      {memberMutationId === member.id ? (
+                        <Loader2
+                          data-icon="inline-start"
+                          className="animate-spin"
+                          aria-hidden="true"
+                        />
+                      ) : (
+                        <Trash2 data-icon="inline-start" aria-hidden="true" />
+                      )}
+                      {page.pool.removeMember}
+                    </Button>
+                  ) : null}
                 </div>
               )
             })
@@ -240,6 +338,7 @@ export function ResourcePoolDetailPage({
                     ? formatResourceSlotLabel(slotsById.get(assignment.slotId)!, {
                         template: m.common.slotLabel,
                         formatDate: i18n.formatDate,
+                        products,
                       })
                     : assignment.slotId
                 }

--- a/packages/operations-react/src/resources/components/resources-overview.tsx
+++ b/packages/operations-react/src/resources/components/resources-overview.tsx
@@ -18,6 +18,7 @@ import { useResourcesUiI18nOrDefault } from "../i18n/index.js"
 import { formatResourceSlotLabel, RESOURCE_KIND_VALUES } from "../i18n/utils.js"
 import type {
   BookingOption,
+  ProductOption,
   ResourceCloseoutRow,
   ResourceRow,
   ResourceSlotAssignmentRow,
@@ -27,6 +28,7 @@ import { labelById } from "../index.js"
 
 export function ResourcesOverview({
   bookings,
+  products = [],
   slots,
   closeouts,
   filteredResources,
@@ -45,6 +47,7 @@ export function ResourcesOverview({
   showFilters = true,
 }: {
   bookings: BookingOption[]
+  products?: ProductOption[]
   slots: SlotOption[]
   closeouts: ResourceCloseoutRow[]
   filteredResources: ResourceRow[]
@@ -132,6 +135,7 @@ export function ResourcesOverview({
                       {
                         template: m.common.slotLabel,
                         formatDate: i18n.formatDate,
+                        products,
                       },
                     )}
                   </div>

--- a/packages/operations-react/src/resources/components/resources-page.tsx
+++ b/packages/operations-react/src/resources/components/resources-page.tsx
@@ -14,7 +14,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@voyant-travel/ui/components/tabs"
 import { ListFilter, Search, X } from "lucide-react"
 import type { ReactNode } from "react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useResourcesUiI18nOrDefault } from "../i18n/index.js"
 import { formatResourceSlotLabel, RESOURCE_KIND_VALUES } from "../i18n/utils.js"
 import {
@@ -139,6 +139,28 @@ export interface ResourcesPageProps {
 const noop = () => undefined
 const noopId = (_id: string) => undefined
 const noopRow = (_row: unknown) => undefined
+const RESOURCE_PAGE_STATE_KEY = "voyant.resources.pageState"
+
+type PersistedResourcesPageState = {
+  activeTab?: ResourcesPageTab
+  search?: string
+  kindFilter?: string
+  activeFilter?: ResourcesPageActiveFilter
+  supplierFilter?: string | null
+  productFilter?: string | null
+  assignmentStatusFilter?: string
+}
+
+function loadPersistedPageState(): PersistedResourcesPageState {
+  if (typeof window === "undefined") return {}
+
+  try {
+    const raw = window.sessionStorage.getItem(RESOURCE_PAGE_STATE_KEY)
+    return raw ? (JSON.parse(raw) as PersistedResourcesPageState) : {}
+  } catch {
+    return {}
+  }
+}
 
 export function ResourcesPage({
   className,
@@ -167,16 +189,27 @@ export function ResourcesPage({
   const i18n = useResourcesUiI18nOrDefault()
   const m = i18n.messages
   const page = m.resourcesPage
-  const [search, setSearch] = useState("")
-  const [kindFilter, setKindFilter] = useState("all")
-  const [activeTab, setActiveTab] = useState<ResourcesPageTab>(defaultTab)
+  const [persistedPageState] = useState(loadPersistedPageState)
+  const [search, setSearch] = useState(persistedPageState.search ?? "")
+  const [kindFilter, setKindFilter] = useState(persistedPageState.kindFilter ?? "all")
+  const [activeTab, setActiveTab] = useState<ResourcesPageTab>(
+    persistedPageState.activeTab ?? defaultTab,
+  )
   const [filterPopoverOpen, setFilterPopoverOpen] = useState(false)
-  const [supplierFilter, setSupplierFilter] = useState<string | null>(null)
+  const [supplierFilter, setSupplierFilter] = useState<string | null>(
+    persistedPageState.supplierFilter ?? null,
+  )
   const [selectedSupplierOption, setSelectedSupplierOption] = useState<SupplierOption | null>(null)
-  const [productFilter, setProductFilter] = useState<string | null>(null)
+  const [productFilter, setProductFilter] = useState<string | null>(
+    persistedPageState.productFilter ?? null,
+  )
   const [selectedProductOption, setSelectedProductOption] = useState<ProductOption | null>(null)
-  const [activeFilter, setActiveFilter] = useState<ResourcesPageActiveFilter>("all")
-  const [assignmentStatusFilter, setAssignmentStatusFilter] = useState<string>("all")
+  const [activeFilter, setActiveFilter] = useState<ResourcesPageActiveFilter>(
+    persistedPageState.activeFilter ?? "all",
+  )
+  const [assignmentStatusFilter, setAssignmentStatusFilter] = useState<string>(
+    persistedPageState.assignmentStatusFilter ?? "all",
+  )
   const [resourceSelection, setResourceSelectionState] = useState<RowSelectionState>({})
   const [poolSelection, setPoolSelectionState] = useState<RowSelectionState>({})
   const [allocationSelection, setAllocationSelectionState] = useState<RowSelectionState>({})
@@ -206,6 +239,29 @@ export function ResourcesPage({
   const allocations = allocationsQuery.data?.data ?? []
   const assignments = assignmentsQuery.data?.data ?? []
   const closeouts = closeoutsQuery.data?.data ?? []
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const nextState: PersistedResourcesPageState = {
+      activeTab,
+      search,
+      kindFilter,
+      activeFilter,
+      supplierFilter,
+      productFilter,
+      assignmentStatusFilter,
+    }
+    window.sessionStorage.setItem(RESOURCE_PAGE_STATE_KEY, JSON.stringify(nextState))
+  }, [
+    activeFilter,
+    activeTab,
+    assignmentStatusFilter,
+    kindFilter,
+    productFilter,
+    search,
+    supplierFilter,
+  ])
 
   const kindOptions = useMemo(
     () =>
@@ -286,6 +342,7 @@ export function ResourcesPage({
           {
             template: m.common.slotLabel,
             formatDate: i18n.formatDate,
+            products,
           },
         ),
       )
@@ -441,6 +498,7 @@ export function ResourcesPage({
         <>
           <ResourcesOverview
             bookings={bookings}
+            products={products}
             slots={slotsData}
             closeouts={closeouts}
             filteredResources={filteredResources}
@@ -510,6 +568,7 @@ export function ResourcesPage({
             />
             <AssignmentsTab
               slots={slotsData}
+              products={products}
               resources={resources}
               bookings={bookings}
               filteredAssignments={filteredAssignments}

--- a/packages/operations-react/src/resources/components/resources-tabs-primary.tsx
+++ b/packages/operations-react/src/resources/components/resources-tabs-primary.tsx
@@ -10,7 +10,7 @@ import {
 import { DataTable } from "@voyant-travel/ui/components/data-table"
 import { DataTableColumnHeader } from "@voyant-travel/ui/components/data-table-column-header"
 import { TabsContent } from "@voyant-travel/ui/components/tabs"
-import { ExternalLink } from "lucide-react"
+import { ExternalLink, Pencil } from "lucide-react"
 import { useResourcesUiI18nOrDefault } from "../i18n/index.js"
 import { formatSelectionLabel, formatSelectionSummary } from "../i18n/utils.js"
 import {
@@ -47,6 +47,7 @@ const resourceColumns = (
   i18n: ReturnType<typeof useResourcesUiI18nOrDefault>,
   suppliers: SupplierOption[],
   onView: (resourceId: string) => void,
+  onEdit: (resource: ResourceRow) => void,
 ): ColumnDef<ResourceRow>[] => [
   {
     accessorKey: "name",
@@ -108,17 +109,30 @@ const resourceColumns = (
     id: "view",
     header: i18n.messages.tabsPrimary.columns.resources.view,
     cell: ({ row }) => (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onView(row.original.id)
-        }}
-      >
-        <ExternalLink className="mr-2 h-4 w-4" />
-        {i18n.messages.common.open}
-      </Button>
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onView(row.original.id)
+          }}
+        >
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {i18n.messages.common.open}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onEdit(row.original)
+          }}
+        >
+          <Pencil className="mr-2 h-4 w-4" />
+          {i18n.messages.common.edit}
+        </Button>
+      </div>
     ),
   },
 ]
@@ -127,6 +141,7 @@ const poolColumns = (
   i18n: ReturnType<typeof useResourcesUiI18nOrDefault>,
   products: ProductOption[],
   onView: (poolId: string) => void,
+  onEdit: (pool: ResourcePoolRow) => void,
 ): ColumnDef<ResourcePoolRow>[] => [
   {
     accessorKey: "name",
@@ -168,17 +183,30 @@ const poolColumns = (
     id: "view",
     header: i18n.messages.tabsPrimary.columns.pools.view,
     cell: ({ row }) => (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onView(row.original.id)
-        }}
-      >
-        <ExternalLink className="mr-2 h-4 w-4" />
-        {i18n.messages.common.open}
-      </Button>
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onView(row.original.id)
+          }}
+        >
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {i18n.messages.common.open}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onEdit(row.original)
+          }}
+        >
+          <Pencil className="mr-2 h-4 w-4" />
+          {i18n.messages.common.edit}
+        </Button>
+      </div>
     ),
   },
 ]
@@ -188,6 +216,7 @@ const allocationColumns = (
   pools: ResourcePoolRow[],
   products: ProductOption[],
   onView: (allocationId: string) => void,
+  onEdit: (allocation: ResourceAllocationRow) => void,
 ): ColumnDef<ResourceAllocationRow>[] => [
   {
     accessorKey: "poolId",
@@ -247,17 +276,30 @@ const allocationColumns = (
     id: "view",
     header: i18n.messages.tabsPrimary.columns.allocations.view,
     cell: ({ row }) => (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onView(row.original.id)
-        }}
-      >
-        <ExternalLink className="mr-2 h-4 w-4" />
-        {i18n.messages.common.open}
-      </Button>
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onView(row.original.id)
+          }}
+        >
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {i18n.messages.common.open}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onEdit(row.original)
+          }}
+        >
+          <Pencil className="mr-2 h-4 w-4" />
+          {i18n.messages.common.edit}
+        </Button>
+      </div>
     ),
   },
 ]
@@ -288,7 +330,7 @@ export function ResourcesTab(props: {
         onAction={props.onCreate}
       />
       <DataTable
-        columns={resourceColumns(i18n, props.suppliers, props.onOpenRoute)}
+        columns={resourceColumns(i18n, props.suppliers, props.onOpenRoute, props.onEdit)}
         data={props.filteredResources}
         emptyMessage={section.emptyMessage}
         enableRowSelection
@@ -417,7 +459,7 @@ export function PoolsTab(props: {
         onAction={props.onCreate}
       />
       <DataTable
-        columns={poolColumns(i18n, props.products, props.onOpenRoute)}
+        columns={poolColumns(i18n, props.products, props.onOpenRoute, props.onEdit)}
         data={props.filteredPools}
         emptyMessage={section.emptyMessage}
         enableRowSelection
@@ -546,7 +588,13 @@ export function AllocationsTab(props: {
         onAction={props.onCreate}
       />
       <DataTable
-        columns={allocationColumns(i18n, props.pools, props.products, props.onOpenRoute)}
+        columns={allocationColumns(
+          i18n,
+          props.pools,
+          props.products,
+          props.onOpenRoute,
+          props.onEdit,
+        )}
         data={props.filteredAllocations}
         emptyMessage={section.emptyMessage}
         enableRowSelection

--- a/packages/operations-react/src/resources/components/resources-tabs-secondary.tsx
+++ b/packages/operations-react/src/resources/components/resources-tabs-secondary.tsx
@@ -9,7 +9,7 @@ import {
 import { DataTable } from "@voyant-travel/ui/components/data-table"
 import { DataTableColumnHeader } from "@voyant-travel/ui/components/data-table-column-header"
 import { TabsContent } from "@voyant-travel/ui/components/tabs"
-import { ExternalLink } from "lucide-react"
+import { ExternalLink, Pencil } from "lucide-react"
 import { useResourcesUiI18nOrDefault } from "../i18n/index.js"
 import {
   formatDateTimeOrFallback,
@@ -20,6 +20,7 @@ import {
 import {
   type BookingOption,
   labelById,
+  type ProductOption,
   type ResourceCloseoutRow,
   type ResourceRow,
   type ResourceSlotAssignmentRow,
@@ -50,9 +51,11 @@ type DeleteFn = (args: {
 const assignmentColumns = (
   i18n: ReturnType<typeof useResourcesUiI18nOrDefault>,
   slots: SlotOption[],
+  products: ProductOption[],
   resources: ResourceRow[],
   bookings: BookingOption[],
   onView: (assignmentId: string) => void,
+  onEdit: (assignment: ResourceSlotAssignmentRow) => void,
 ): ColumnDef<ResourceSlotAssignmentRow>[] => [
   {
     accessorKey: "slotId",
@@ -73,6 +76,7 @@ const assignmentColumns = (
         {
           template: i18n.messages.common.slotLabel,
           formatDate: i18n.formatDate,
+          products,
         },
       ),
   },
@@ -128,17 +132,30 @@ const assignmentColumns = (
     id: "view",
     header: i18n.messages.tabsSecondary.columns.assignments.view,
     cell: ({ row }) => (
-      <Button
-        variant="ghost"
-        size="sm"
-        onClick={(event) => {
-          event.stopPropagation()
-          onView(row.original.id)
-        }}
-      >
-        <ExternalLink className="mr-2 h-4 w-4" />
-        {i18n.messages.common.open}
-      </Button>
+      <div className="flex flex-wrap items-center gap-1">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onView(row.original.id)
+          }}
+        >
+          <ExternalLink className="mr-2 h-4 w-4" />
+          {i18n.messages.common.open}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={(event) => {
+            event.stopPropagation()
+            onEdit(row.original)
+          }}
+        >
+          <Pencil className="mr-2 h-4 w-4" />
+          {i18n.messages.common.edit}
+        </Button>
+      </div>
     ),
   },
 ]
@@ -146,6 +163,7 @@ const assignmentColumns = (
 const closeoutColumns = (
   i18n: ReturnType<typeof useResourcesUiI18nOrDefault>,
   resources: ResourceRow[],
+  onEdit: (closeout: ResourceCloseoutRow) => void,
 ): ColumnDef<ResourceCloseoutRow>[] => [
   {
     accessorKey: "resourceId",
@@ -204,10 +222,28 @@ const closeoutColumns = (
     ),
     cell: ({ row }) => row.original.reason ?? "-",
   },
+  {
+    id: "edit",
+    header: i18n.messages.common.edit,
+    cell: ({ row }) => (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={(event) => {
+          event.stopPropagation()
+          onEdit(row.original)
+        }}
+      >
+        <Pencil className="mr-2 h-4 w-4" />
+        {i18n.messages.common.edit}
+      </Button>
+    ),
+  },
 ]
 
 export function AssignmentsTab(props: {
   slots: SlotOption[]
+  products?: ProductOption[]
   resources: ResourceRow[]
   bookings: BookingOption[]
   filteredAssignments: ResourceSlotAssignmentRow[]
@@ -224,6 +260,7 @@ export function AssignmentsTab(props: {
   const m = i18n.messages
   const section = m.tabsSecondary.sections.assignments
   const selection = m.common.selectionNouns.assignment
+  const products = props.products ?? []
 
   return (
     <TabsContent value="assignments" className="space-y-4">
@@ -237,9 +274,11 @@ export function AssignmentsTab(props: {
         columns={assignmentColumns(
           i18n,
           props.slots,
+          products,
           props.resources,
           props.bookings,
           props.onOpenRoute,
+          props.onEdit,
         )}
         data={props.filteredAssignments}
         emptyMessage={section.emptyMessage}
@@ -367,7 +406,7 @@ export function CloseoutsTab(props: {
         onAction={props.onCreate}
       />
       <DataTable
-        columns={closeoutColumns(i18n, props.resources)}
+        columns={closeoutColumns(i18n, props.resources, props.onEdit)}
         data={props.filteredCloseouts}
         emptyMessage={section.emptyMessage}
         enableRowSelection

--- a/packages/operations-react/src/resources/i18n.test.tsx
+++ b/packages/operations-react/src/resources/i18n.test.tsx
@@ -40,6 +40,7 @@ describe("resources-ui i18n", () => {
     const html = renderToStaticMarkup(
       <ResourcesOverview
         bookings={[]}
+        products={[]}
         slots={[]}
         closeouts={[]}
         filteredResources={[]}
@@ -68,6 +69,7 @@ describe("resources-ui i18n", () => {
       <ResourcesUiMessagesProvider locale="ro-RO">
         <ResourcesOverview
           bookings={[]}
+          products={[]}
           slots={[]}
           closeouts={[]}
           filteredResources={[]}

--- a/packages/operations-react/src/resources/i18n/en.ts
+++ b/packages/operations-react/src/resources/i18n/en.ts
@@ -2,6 +2,7 @@ import type { ResourcesUiMessages } from "./messages.js"
 
 export const resourcesUiEn: ResourcesUiMessages = {
   common: {
+    edit: "Edit",
     open: "Open",
     view: "View",
     cancel: "Cancel",
@@ -298,6 +299,7 @@ export const resourcesUiEn: ResourcesUiMessages = {
       code: "Code",
       created: "Created",
       delete: "Delete",
+      edit: "Edit",
       noBooking: "No booking",
       noPool: "No pool",
       noResource: "No resource",
@@ -334,6 +336,7 @@ export const resourcesUiEn: ResourcesUiMessages = {
       notFound: "Resource not found.",
       poolMembershipsEmpty: "This resource is not assigned to any pool.",
       poolMembershipsTitle: "Pool Memberships",
+      removePoolMember: "Remove",
       released: "Released",
     },
     pool: {
@@ -347,6 +350,10 @@ export const resourcesUiEn: ResourcesUiMessages = {
       loadFailed: "Pool could not be loaded.",
       membersEmpty: "No resources are assigned to this pool.",
       membersTitle: "Members",
+      addMember: "Add member",
+      addMemberPlaceholder: "Select a resource",
+      memberAlreadyAssigned: "All listed resources are already assigned.",
+      removeMember: "Remove",
       noResource: "Resource unavailable",
       notFound: "Resource pool not found.",
       sharedCapacity: "Shared Capacity",

--- a/packages/operations-react/src/resources/i18n/messages.ts
+++ b/packages/operations-react/src/resources/i18n/messages.ts
@@ -19,6 +19,7 @@ type BulkActionMessages = {
 
 export type ResourcesUiMessages = {
   common: {
+    edit: string
     open: string
     view: string
     cancel: string
@@ -222,6 +223,7 @@ export type ResourcesUiMessages = {
       code: string
       created: string
       delete: string
+      edit: string
       noBooking: string
       noPool: string
       noResource: string
@@ -258,6 +260,7 @@ export type ResourcesUiMessages = {
       notFound: string
       poolMembershipsEmpty: string
       poolMembershipsTitle: string
+      removePoolMember: string
       released: string
     }
     pool: {
@@ -271,6 +274,10 @@ export type ResourcesUiMessages = {
       loadFailed: string
       membersEmpty: string
       membersTitle: string
+      addMember: string
+      addMemberPlaceholder: string
+      memberAlreadyAssigned: string
+      removeMember: string
       noResource: string
       notFound: string
       sharedCapacity: string

--- a/packages/operations-react/src/resources/i18n/ro.ts
+++ b/packages/operations-react/src/resources/i18n/ro.ts
@@ -2,6 +2,7 @@ import type { ResourcesUiMessages } from "./messages.js"
 
 export const resourcesUiRo: ResourcesUiMessages = {
   common: {
+    edit: "Editeaza",
     open: "Deschide",
     view: "Vizualizare",
     cancel: "Anuleaza",
@@ -299,6 +300,7 @@ export const resourcesUiRo: ResourcesUiMessages = {
       code: "Cod",
       created: "Creat",
       delete: "Sterge",
+      edit: "Editeaza",
       noBooking: "Fara rezervare",
       noPool: "Fara pool",
       noResource: "Fara resursa",
@@ -335,6 +337,7 @@ export const resourcesUiRo: ResourcesUiMessages = {
       notFound: "Resursa nu a fost gasita.",
       poolMembershipsEmpty: "Aceasta resursa nu este asignata niciunui pool.",
       poolMembershipsTitle: "Apartenenta la Pool-uri",
+      removePoolMember: "Elimina",
       released: "Eliberat",
     },
     pool: {
@@ -348,6 +351,10 @@ export const resourcesUiRo: ResourcesUiMessages = {
       loadFailed: "Pool-ul nu a putut fi incarcat.",
       membersEmpty: "Nicio resursa nu este asignata acestui pool.",
       membersTitle: "Membri",
+      addMember: "Adauga membru",
+      addMemberPlaceholder: "Selecteaza o resursa",
+      memberAlreadyAssigned: "Toate resursele listate sunt deja asignate.",
+      removeMember: "Elimina",
       noResource: "Resursa indisponibila",
       notFound: "Pool-ul de resurse nu a fost gasit.",
       sharedCapacity: "Capacitate Partajata",

--- a/packages/operations-react/src/resources/i18n/utils.ts
+++ b/packages/operations-react/src/resources/i18n/utils.ts
@@ -1,6 +1,6 @@
 import type { PackageI18nValue } from "@voyant-travel/i18n"
 import { formatMessage } from "@voyant-travel/i18n"
-import type { SlotOption } from "../index.js"
+import type { ProductOption, SlotOption } from "../index.js"
 import type { ResourcesUiMessages } from "./messages.js"
 
 export const RESOURCE_KIND_VALUES = [
@@ -32,15 +32,18 @@ export function formatResourceSlotLabel(
   options: {
     template: string
     formatDate: PackageI18nValue<ResourcesUiMessages>["formatDate"]
+    products?: ProductOption[]
   },
 ) {
   const time = slot.startsAt
     ? options.formatDate(slot.startsAt, { timeStyle: "short" })
     : slot.dateLocal
-  return formatMessage(options.template, {
+  const dateTime = formatMessage(options.template, {
     date: slot.dateLocal,
     time,
   })
+  const product = options.products?.find((entry) => entry.id === slot.productId)
+  return product ? `${product.name} · ${dateTime}` : dateTime
 }
 
 export function formatDateTimeOrFallback(


### PR DESCRIPTION
## Summary
- add explicit edit actions to resources admin list rows and detail pages
- wire pool member add/remove workflows from pool detail pages
- preserve resources tab/filter state across detail navigation and refresh admin resource data after mutations
- add product context to assignment slot labels across lists, detail views, and dialogs

Fixes #2570

## Verification
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/operations-react typecheck
- pnpm --filter @voyant-travel/operations-react exec vitest run src/resources/i18n.test.tsx
- pnpm exec biome check .changeset/resources-admin-workflows.md packages/operations-react/src/resources/admin/detail-hosts.tsx packages/operations-react/src/resources/admin/resources-dialogs.tsx packages/operations-react/src/resources/admin/resources-dialogs-ops.tsx packages/operations-react/src/resources/components/resource-allocation-detail-page.tsx packages/operations-react/src/resources/components/resource-assignment-detail-page.tsx packages/operations-react/src/resources/components/resource-detail-page.tsx packages/operations-react/src/resources/components/resource-detail-shared.tsx packages/operations-react/src/resources/components/resource-pool-detail-page.tsx packages/operations-react/src/resources/components/resources-overview.tsx packages/operations-react/src/resources/components/resources-page.tsx packages/operations-react/src/resources/components/resources-tabs-primary.tsx packages/operations-react/src/resources/components/resources-tabs-secondary.tsx packages/operations-react/src/resources/i18n.test.tsx packages/operations-react/src/resources/i18n/en.ts packages/operations-react/src/resources/i18n/messages.ts packages/operations-react/src/resources/i18n/ro.ts packages/operations-react/src/resources/i18n/utils.ts && git diff --check