### PR TITLE
Require payment dates for already-paid booking schedules

### DIFF
--- a/.changeset/require-paid-payment-date.md
+++ b/.changeset/require-paid-payment-date.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/finance": patch
+---
+
+Require an explicit payment date when booking payment schedules are marked already paid.

--- a/packages/bookings-react/src/components/booking-create-form-utils.ts
+++ b/packages/bookings-react/src/components/booking-create-form-utils.ts
@@ -104,6 +104,15 @@ export function hasAnyPaidPayment(schedule: PaymentScheduleValue): boolean {
   return schedule.installments.some((installment) => installment.alreadyPaid)
 }
 
+export function findAlreadyPaidInstallmentMissingPaymentDate(
+  schedule: PaymentScheduleValue,
+): number | null {
+  const index = schedule.installments.findIndex(
+    (installment) => installment.alreadyPaid && !installment.paymentDate?.trim(),
+  )
+  return index >= 0 ? index : null
+}
+
 /**
  * Inverse of stripUnitSuffix — strip the leading "Option name - " so
  * the per-unit label stands alone for category buttons.

--- a/packages/bookings-react/src/components/booking-create-sheet.tsx
+++ b/packages/bookings-react/src/components/booking-create-sheet.tsx
@@ -51,6 +51,7 @@ import {
   VoyantApiError,
 } from "../index.js"
 import {
+  findAlreadyPaidInstallmentMissingPaymentDate,
   formatPayloadResolverMismatchError,
   generateBookingNumber,
   hasAnyPaidPayment,
@@ -757,6 +758,11 @@ export function BookingCreateForm({
 
       if (pricing?.requiresReason) {
         setError(messages.bookingCreateDialog.labels.breakdownOverrideReasonRequired)
+        return
+      }
+
+      if (findAlreadyPaidInstallmentMissingPaymentDate(paymentSchedule) !== null) {
+        setError(messages.bookingCreateDialog.validation.paidPaymentDateRequired)
         return
       }
 

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -65,6 +65,7 @@ export const bookingsUiEnCreateList = {
       payloadResolverMismatchFallback:
         "Booking options are out of sync. Review the selected traveler and option lines.",
       payloadResolverMismatchLine: "{label}: sent {submittedQuantity}, expected {resolvedQuantity}",
+      paidPaymentDateRequired: "Payment date is required when Already paid is checked.",
     },
     actions: {
       createDraftBooking: "Create draft booking",

--- a/packages/bookings-react/src/i18n/en-journey.ts
+++ b/packages/bookings-react/src/i18n/en-journey.ts
@@ -40,6 +40,7 @@ export const bookingsUiEnJourney = {
       pricingUnavailable:
         "This selection can't be priced right now. Please adjust your choice before confirming your booking.",
       checkoutFailed: "We couldn't complete your booking. Please try again.",
+      paidPaymentDateRequired: "Payment date is required when Already paid is checked.",
       addAtLeastTravelers: "Add at least {count} traveler{plural} to continue.",
       maxTravelersPerBooking: "Max {count} travelers per booking.",
       ageOutOfRange: "Age {age} is outside the accepted range for this product.",

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -58,6 +58,7 @@ export type BookingsUiCreateListMessages = {
       payloadResolverMismatchDetails: string
       payloadResolverMismatchFallback: string
       payloadResolverMismatchLine: string
+      paidPaymentDateRequired: string
     }
     actions: {
       createDraftBooking: string

--- a/packages/bookings-react/src/i18n/messages-journey.ts
+++ b/packages/bookings-react/src/i18n/messages-journey.ts
@@ -38,6 +38,7 @@ export type BookingsUiJourneyMessages = {
       quoteUnavailable: string
       pricingUnavailable: string
       checkoutFailed: string
+      paidPaymentDateRequired: string
       addAtLeastTravelers: string
       maxTravelersPerBooking: string
       ageOutOfRange: string

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -66,6 +66,8 @@ export const bookingsUiRoCreateList = {
         "Optiunile rezervarii nu sunt sincronizate. Verifica randurile de calator si optiune selectate.",
       payloadResolverMismatchLine:
         "{label}: trimis {submittedQuantity}, asteptat {resolvedQuantity}",
+      paidPaymentDateRequired:
+        "Data platii este obligatorie cand plata este marcata ca deja achitata.",
     },
     actions: {
       createDraftBooking: "Creeaza rezervare draft",

--- a/packages/bookings-react/src/i18n/ro-journey.ts
+++ b/packages/bookings-react/src/i18n/ro-journey.ts
@@ -40,6 +40,8 @@ export const bookingsUiRoJourney = {
       pricingUnavailable:
         "Aceasta selectie nu poate fi cotata acum. Ajusteaza alegerea inainte de a confirma rezervarea.",
       checkoutFailed: "Nu am putut finaliza rezervarea. Incearca din nou.",
+      paidPaymentDateRequired:
+        "Data platii este obligatorie cand plata este marcata ca deja achitata.",
       addAtLeastTravelers: "Adauga cel putin {count} calator{plural} pentru a continua.",
       maxTravelersPerBooking: "Maximum {count} calatori per rezervare.",
       ageOutOfRange: "Varsta {age} este in afara intervalului acceptat pentru acest produs.",

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -10,6 +10,7 @@ import {
 import { type BookingsUiMessages, formatMessage } from "../../i18n/index.js"
 import { type Draft, totalPax } from "../lib/draft-state.js"
 import { evaluatePaxBandDependencies } from "../lib/pax-band-dependencies.js"
+import { findPaidScheduleRowsMissingPaymentDate } from "../lib/payment-schedule.js"
 import type { JourneyStep } from "../types.js"
 
 /**
@@ -146,6 +147,8 @@ export function canAdvanceFromStep(
       // other required fields surface as warnings, fillable later.
       return draft.travelers.every((t) => t.firstName && t.lastName)
     }
+    case "payment":
+      return findPaidScheduleRowsMissingPaymentDate(draft.paymentSchedules) === null
     default:
       return true
   }
@@ -173,7 +176,10 @@ export function stackedStepComplete(
       return hasOptions ? Boolean(draft.configure.variantId) : true
     }
     case "payment":
-      return Boolean(draft.payment.intent)
+      return (
+        Boolean(draft.payment.intent) &&
+        findPaidScheduleRowsMissingPaymentDate(draft.paymentSchedules) === null
+      )
     default:
       return canAdvanceFromStep(step, draft, shape, available)
   }
@@ -233,7 +239,16 @@ export function warningsForStep(
       }
       break
     }
+    case "payment": {
+      if (findPaidScheduleRowsMissingPaymentDate(draft.paymentSchedules) !== null) {
+        warnings.push(messages.bookingJourney.validation.paidPaymentDateRequired)
+      }
+      break
+    }
     case "review": {
+      if (findPaidScheduleRowsMissingPaymentDate(draft.paymentSchedules) !== null) {
+        warnings.push(messages.bookingJourney.validation.paidPaymentDateRequired)
+      }
       if (!draft.payment.intent) {
         warnings.push(messages.bookingJourney.warnings.paymentIntentMissing)
       }

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -29,6 +29,7 @@ import { Button } from "@voyant-travel/ui/components/button"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useBookingsUiMessagesOrDefault } from "../../i18n/index.js"
 import { type Draft, emptyDraft, totalPax } from "../lib/draft-state.js"
+import { findPaidScheduleRowsMissingPaymentDate } from "../lib/payment-schedule.js"
 import {
   type BookingJourneyProps,
   type ContractAcceptanceEvent,
@@ -424,6 +425,10 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
           ? messages.bookingJourney.validation.pricingUnavailable
           : messages.bookingJourney.validation.quoteUnavailable,
       )
+      return
+    }
+    if (findPaidScheduleRowsMissingPaymentDate(draft.paymentSchedules) !== null) {
+      setConfirmError(messages.bookingJourney.validation.paidPaymentDateRequired)
       return
     }
     setConfirmError(null)

--- a/packages/bookings-react/src/journey/lib/payment-schedule.ts
+++ b/packages/bookings-react/src/journey/lib/payment-schedule.ts
@@ -73,6 +73,18 @@ export function paymentScheduleValueToRows(
   return rows
 }
 
+export function findPaidScheduleRowsMissingPaymentDate(
+  rows: PaymentScheduleRow[] | undefined,
+): number | null {
+  if (!rows) return null
+  const index = rows.findIndex((row) => {
+    const meta = parsePaidNotes(row.notes)
+    if (row.status !== "paid" && meta?.alreadyPaid !== true) return false
+    return !hasExplicitPaymentDate(meta)
+  })
+  return index >= 0 ? index : null
+}
+
 /** Draft rows → editor value (re-init on step remount; preserves paid metadata). */
 export function rowsToPaymentScheduleValue(
   rows: PaymentScheduleRow[] | undefined,
@@ -84,18 +96,12 @@ export function rowsToPaymentScheduleValue(
     let paymentDate: string | null = null
     let paymentMethod = "bank_transfer"
     let paymentReference = ""
-    if (row.notes) {
-      try {
-        const meta = JSON.parse(row.notes) as Partial<PaidNotesPayload>
-        if (meta.alreadyPaid) {
-          alreadyPaid = true
-          paymentDate = meta.paymentDate ?? null
-          paymentMethod = meta.paymentMethod ?? "bank_transfer"
-          paymentReference = meta.paymentReference ?? ""
-        }
-      } catch {
-        // `notes` wasn't our JSON payload (e.g. a free-text note) — ignore.
-      }
+    const meta = parsePaidNotes(row.notes)
+    if (meta?.alreadyPaid) {
+      alreadyPaid = true
+      paymentDate = meta.paymentDate ?? null
+      paymentMethod = meta.paymentMethod ?? "bank_transfer"
+      paymentReference = meta.paymentReference ?? ""
     }
     return createInstallment({
       amountCents: row.amountCents,
@@ -107,4 +113,19 @@ export function rowsToPaymentScheduleValue(
     })
   })
   return { mode: rows.length > 1 ? "split" : "full", installments }
+}
+
+function parsePaidNotes(notes: string | null | undefined): Partial<PaidNotesPayload> | null {
+  if (!notes) return null
+  try {
+    const parsed = JSON.parse(notes) as Partial<PaidNotesPayload>
+    return parsed && typeof parsed === "object" ? parsed : null
+  } catch {
+    // `notes` wasn't our JSON payload (e.g. a free-text note) — ignore.
+    return null
+  }
+}
+
+function hasExplicitPaymentDate(meta: Partial<PaidNotesPayload> | null): boolean {
+  return typeof meta?.paymentDate === "string" && meta.paymentDate.trim().length > 0
 }

--- a/packages/bookings-react/tests/unit/booking-create-utils.test.ts
+++ b/packages/bookings-react/tests/unit/booking-create-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { findAlreadyPaidInstallmentMissingPaymentDate } from "../../src/components/booking-create-form-utils.js"
 import {
   getBookableDepartureSlots,
   getOverCapacityInventoryAssignments,
@@ -12,6 +13,42 @@ import {
 import { clearSharedRoomValue } from "../../src/components/shared-room-section.js"
 
 describe("booking create helpers", () => {
+  it("requires a payment date when an installment is marked already paid", () => {
+    expect(
+      findAlreadyPaidInstallmentMissingPaymentDate({
+        mode: "full",
+        installments: [
+          {
+            id: "inst_1",
+            amountCents: null,
+            dueDate: "2026-06-15",
+            alreadyPaid: true,
+            paymentDate: null,
+            paymentMethod: "bank_transfer",
+            paymentReference: "",
+          },
+        ],
+      }),
+    ).toBe(0)
+
+    expect(
+      findAlreadyPaidInstallmentMissingPaymentDate({
+        mode: "full",
+        installments: [
+          {
+            id: "inst_1",
+            amountCents: null,
+            dueDate: "2026-06-15",
+            alreadyPaid: true,
+            paymentDate: "2026-06-10",
+            paymentMethod: "bank_transfer",
+            paymentReference: "",
+          },
+        ],
+      }),
+    ).toBeNull()
+  })
+
   it("matches product picker search case-insensitively", () => {
     expect(
       productMatchesPickerSearch(

--- a/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
+++ b/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
@@ -66,4 +66,76 @@ describe("booking-journey-rules", () => {
       },
     })
   })
+
+  it("blocks payment advancement when an already-paid row has no payment date", () => {
+    const shape = defaultMinimalShape()
+    const draft = {
+      ...emptyDraft(ENTITY),
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          status: "paid",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 50_000,
+          notes: JSON.stringify({
+            alreadyPaid: true,
+            paymentDate: null,
+            paymentMethod: "bank_transfer",
+            paymentReference: null,
+          }),
+        } as const,
+      ],
+    }
+
+    expect(canAdvanceFromStep("payment", draft, shape, true)).toBe(false)
+  })
+
+  it("blocks payment advancement when an already-paid row has a non-string payment date", () => {
+    const shape = defaultMinimalShape()
+    const draft = {
+      ...emptyDraft(ENTITY),
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          status: "paid",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 50_000,
+          notes: JSON.stringify({
+            alreadyPaid: true,
+            paymentDate: 123,
+            paymentMethod: "bank_transfer",
+            paymentReference: null,
+          }),
+        } as const,
+      ],
+    }
+
+    expect(canAdvanceFromStep("payment", draft, shape, true)).toBe(false)
+  })
+
+  it("allows payment advancement when already-paid rows include payment dates", () => {
+    const shape = defaultMinimalShape()
+    const draft = {
+      ...emptyDraft(ENTITY),
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          status: "paid",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 50_000,
+          notes: JSON.stringify({
+            alreadyPaid: true,
+            paymentDate: "2026-06-10",
+            paymentMethod: "bank_transfer",
+            paymentReference: null,
+          }),
+        } as const,
+      ],
+    }
+
+    expect(canAdvanceFromStep("payment", draft, shape, true)).toBe(true)
+  })
 })

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -597,6 +597,10 @@ function isAlreadyPaidSchedule(schedule: BookingCreatePaymentScheduleInput) {
   return schedule.status === "paid" || metadata?.alreadyPaid === true
 }
 
+function hasExplicitPaymentDate(metadata: AlreadyPaidScheduleMetadata | null): boolean {
+  return typeof metadata?.paymentDate === "string" && metadata.paymentDate.trim().length > 0
+}
+
 function duplicateBookingGuardKey(input: BookingCreateInput) {
   if (!input.slotId) return null
   if (input.personId) return `booking-create:person:${input.personId}:slot:${input.slotId}`
@@ -1038,6 +1042,16 @@ function validatePaymentSchedules(
         path: ["paymentSchedules", index, "currency"],
         message: `paymentSchedules[${index}].currency must equal the booking's sellCurrency (${expectedCurrency}); got ${schedule.currency}`,
       })
+    }
+
+    if (isAlreadyPaidSchedule(schedule)) {
+      const metadata = parseAlreadyPaidScheduleMetadata(schedule.notes)
+      if (!hasExplicitPaymentDate(metadata)) {
+        issues.push({
+          path: ["paymentSchedules", index, "notes", "paymentDate"],
+          message: `paymentSchedules[${index}] marked paid requires notes.paymentDate`,
+        })
+      }
     }
   })
 

--- a/packages/finance/tests/integration/booking-create.test.ts
+++ b/packages/finance/tests/integration/booking-create.test.ts
@@ -774,6 +774,76 @@ describe.skipIf(!DB_AVAILABLE)("createBooking", () => {
     expect(bookingsRows).toHaveLength(0)
   })
 
+  it("rejects already-paid schedules without an explicit payment date", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          status: "paid",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 50000,
+          notes: JSON.stringify({
+            alreadyPaid: true,
+            paymentDate: null,
+            paymentMethod: "bank_transfer",
+            paymentReference: "BT-PAID-1",
+          }),
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("invalid_payment_schedules")
+    if (outcome.status !== "invalid_payment_schedules") return
+    expect(outcome.issues).toContainEqual({
+      path: ["paymentSchedules", 0, "notes", "paymentDate"],
+      message: "paymentSchedules[0] marked paid requires notes.paymentDate",
+    })
+
+    const bookingsRows = await db.select().from(bookings)
+    expect(bookingsRows).toHaveLength(0)
+  })
+
+  it("rejects already-paid schedules with non-string payment dates", async () => {
+    const { productId } = await seedProduct()
+
+    const outcome = await createBooking(db, {
+      productId,
+      bookingNumber: nextBookingNumber(),
+      ...bookingParty(),
+      paymentSchedules: [
+        {
+          scheduleType: "balance",
+          status: "paid",
+          dueDate: "2026-06-15",
+          currency: "EUR",
+          amountCents: 50000,
+          notes: JSON.stringify({
+            alreadyPaid: true,
+            paymentDate: 123,
+            paymentMethod: "bank_transfer",
+            paymentReference: "BT-PAID-1",
+          }),
+        },
+      ],
+    })
+
+    expect(outcome.status).toBe("invalid_payment_schedules")
+    if (outcome.status !== "invalid_payment_schedules") return
+    expect(outcome.issues).toContainEqual({
+      path: ["paymentSchedules", 0, "notes", "paymentDate"],
+      message: "paymentSchedules[0] marked paid requires notes.paymentDate",
+    })
+
+    const bookingsRows = await db.select().from(bookings)
+    expect(bookingsRows).toHaveLength(0)
+  })
+
   it("creates an invoice and completed payment records for already-paid schedules", async () => {
     const { productId } = await seedProduct()
 


### PR DESCRIPTION
## Summary
- require admin booking create and journey flows to provide a payment date when a schedule is marked already paid
- reject already-paid booking-create schedules without `notes.paymentDate` before finance creates completed payment records
- add focused coverage for UI validation helpers, journey gating, and finance create validation

Fixes #2430.

## Verification
- `pnpm --filter @voyant-travel/bookings-react test -- tests/unit/booking-create-utils.test.ts tests/unit/booking-journey-rules.test.ts`
- `pnpm --filter @voyant-travel/finance test -- tests/integration/booking-create.test.ts`
- `pnpm --filter @voyant-travel/bookings-react lint`
- `pnpm --filter @voyant-travel/finance lint` (passed with one unrelated existing optional-chain warning in `src/service-vouchers-migration.ts`)
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --dir packages/finance exec tsc -p tsconfig.typecheck.json`
- `pnpm lint:changed`

Note: `pnpm verify:fast` and the default commit/push hooks were not completed because the broad affected graph OOM-killed unrelated package builds/tests in this worktree; scoped checks above passed.