### PR TITLE
fix(bookings-react): preserve hydrated items/travelers/documents in useBooking detail parser

### DIFF
--- a/.changeset/bookings-react-detail-parser.md
+++ b/.changeset/bookings-react-detail-parser.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Preserve the hydrated `items`/`travelers`/`documents` collections on the
+`useBooking` detail read.
+
+The admin booking detail (`GET /v1/admin/bookings/:id`) hydrates its
+bookings-owned child collections inline, but `bookingSingleResponse` parsed the
+response with the flat list record schema (`bookingRecordSchema`) — which
+carries only an optional summary `items` and no `travelers`/`documents` — so Zod
+silently stripped the newly-hydrated collections for `bookings-react` consumers.
+
+Adds a dedicated `bookingDetailSchema` (record + full `items`, `travelers`, and
+`documents`) and points `bookingSingleResponse`/`useBooking` at it. Travelers
+accept both the redacted and reveal shapes so an inline `travelDetails` is
+preserved. The shared list parser is unchanged.

--- a/.changeset/bookings-react-detail-parser.md
+++ b/.changeset/bookings-react-detail-parser.md
@@ -6,12 +6,14 @@ Preserve the hydrated `items`/`travelers`/`documents` collections on the
 `useBooking` detail read.
 
 The admin booking detail (`GET /v1/admin/bookings/:id`) hydrates its
-bookings-owned child collections inline, but `bookingSingleResponse` parsed the
+bookings-owned child collections inline, but `getBookingQueryOptions` parsed the
 response with the flat list record schema (`bookingRecordSchema`) — which
 carries only an optional summary `items` and no `travelers`/`documents` — so Zod
 silently stripped the newly-hydrated collections for `bookings-react` consumers.
 
-Adds a dedicated `bookingDetailSchema` (record + full `items`, `travelers`, and
-`documents`) and points `bookingSingleResponse`/`useBooking` at it. Travelers
-accept both the redacted and reveal shapes so an inline `travelDetails` is
-preserved. The shared list parser is unchanged.
+Adds a `bookingDetailSchema` (record + full `items`, `travelers`, and
+`documents`) and a dedicated `bookingDetailResponse` that the detail query now
+uses. Travelers accept both the redacted and reveal shapes so an inline
+`travelDetails` is preserved. `bookingSingleResponse` stays on the flat record
+schema because it is shared by the mutation hooks (create/update/convert/
+status/cancel), whose endpoints return a flat booking with no child collections.

--- a/packages/bookings-react/src/query-options.ts
+++ b/packages/bookings-react/src/query-options.ts
@@ -23,6 +23,7 @@ import {
 } from "./query-keys.js"
 import {
   bookingActivityResponse,
+  bookingDetailResponse,
   bookingGroupDetailResponse,
   bookingGroupForBookingResponse,
   bookingGroupListResponse,
@@ -30,7 +31,6 @@ import {
   bookingItemTravelersResponse,
   bookingListResponse,
   bookingNotesResponse,
-  bookingSingleResponse,
   bookingSupplierStatusesResponse,
   bookingTravelerDocumentsResponse,
   bookingTravelerSharingGroupsResponse,
@@ -101,7 +101,7 @@ export function getBookingQueryOptions(
 
   return queryOptions({
     queryKey: bookingsQueryKeys.booking(id ?? ""),
-    queryFn: () => fetchWithValidation(`/v1/admin/bookings/${id}`, bookingSingleResponse, client),
+    queryFn: () => fetchWithValidation(`/v1/admin/bookings/${id}`, bookingDetailResponse, client),
   })
 }
 

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -371,8 +371,30 @@ export const bookingGroupDetailSchema = bookingGroupRecordSchema.extend({
 
 export type BookingGroupDetailRecord = z.infer<typeof bookingGroupDetailSchema>
 
+// The admin booking detail read (`GET /v1/admin/bookings/:id`) hydrates the
+// bookings-owned child collections inline (items, travelers, documents) — see
+// the server's `bookingDetailSchema`. The flat `bookingRecordSchema` used for
+// the list carries only an optional summary `items` and no travelers/documents,
+// so parsing the detail with it silently strips the hydrated collections. The
+// detail parser therefore extends the record with the full child shapes:
+//  - `items` use the full `bookingItemRecordSchema` (same shape as `/items`).
+//  - `travelers` follow the same reveal/redaction gate as `/travelers`; the row
+//    is always the plain traveler shape (PII masked or not), but we accept the
+//    reveal variant too so an inline `travelDetails` is preserved rather than
+//    stripped if the server ever hydrates it.
+//  - `documents` reuse `bookingTravelerDocumentRecordSchema`, which already
+//    mirrors the server's booking-level `bookingDocumentSchema` (the shape the
+//    `/documents` endpoint returns).
+export const bookingDetailSchema = bookingRecordSchema.extend({
+  items: z.array(bookingItemRecordSchema),
+  travelers: z.array(z.union([bookingTravelerRevealRecordSchema, bookingTravelerRecordSchema])),
+  documents: z.array(bookingTravelerDocumentRecordSchema),
+})
+
+export type BookingDetailRecord = z.infer<typeof bookingDetailSchema>
+
 export const bookingListResponse = paginatedEnvelope(bookingRecordSchema)
-export const bookingSingleResponse = singleEnvelope(bookingRecordSchema)
+export const bookingSingleResponse = singleEnvelope(bookingDetailSchema)
 export const bookingItemsResponse = arrayEnvelope(bookingItemRecordSchema)
 export const bookingItemTravelersResponse = arrayEnvelope(bookingItemTravelerRecordSchema)
 export const bookingTravelerDocumentsResponse = arrayEnvelope(bookingTravelerDocumentRecordSchema)

--- a/packages/bookings-react/src/schemas.ts
+++ b/packages/bookings-react/src/schemas.ts
@@ -394,7 +394,15 @@ export const bookingDetailSchema = bookingRecordSchema.extend({
 export type BookingDetailRecord = z.infer<typeof bookingDetailSchema>
 
 export const bookingListResponse = paginatedEnvelope(bookingRecordSchema)
-export const bookingSingleResponse = singleEnvelope(bookingDetailSchema)
+// `bookingSingleResponse` stays on the flat record schema: it is shared by the
+// mutation hooks (create/update/convert/status/cancel), and the server returns
+// a flat `bookingSchema` (no hydrated child collections) for those endpoints.
+// Only the detail read (`GET /:id`) hydrates the collections — it uses
+// `bookingDetailResponse` below. The `.extend({ data })` mutation hooks that
+// build on `bookingSingleResponse` replace `data` wholesale, so the base shape
+// here does not affect them.
+export const bookingSingleResponse = singleEnvelope(bookingRecordSchema)
+export const bookingDetailResponse = singleEnvelope(bookingDetailSchema)
 export const bookingItemsResponse = arrayEnvelope(bookingItemRecordSchema)
 export const bookingItemTravelersResponse = arrayEnvelope(bookingItemTravelerRecordSchema)
 export const bookingTravelerDocumentsResponse = arrayEnvelope(bookingTravelerDocumentRecordSchema)

--- a/packages/bookings-react/tests/unit/booking-detail-parser.test.ts
+++ b/packages/bookings-react/tests/unit/booking-detail-parser.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest"
+
+import { bookingListResponse, bookingSingleResponse } from "../../src/schemas.js"
+
+// Regression cover for voyant#2728: the admin booking detail read hydrates
+// items/travelers/documents inline, but the client previously parsed the
+// response with the flat list record schema, which stripped those collections.
+// `bookingSingleResponse` now points at `bookingDetailSchema`, so the parser
+// must preserve them while the list parser stays on the summary shape.
+
+const baseBooking = {
+  id: "bkg_1",
+  bookingNumber: "B-0001",
+  status: "confirmed",
+  personId: null,
+  organizationId: null,
+  sellCurrency: "EUR",
+  sellAmountCents: 10000,
+  costAmountCents: 6000,
+  marginPercent: 40,
+  startDate: null,
+  endDate: null,
+  pax: 2,
+  internalNotes: null,
+  createdAt: "2026-07-02T00:00:00.000Z",
+  updatedAt: "2026-07-02T00:00:00.000Z",
+}
+
+const detailItem = {
+  id: "bkit_1",
+  bookingId: "bkg_1",
+  title: "Guided tour",
+  description: null,
+  itemType: "unit",
+  status: "confirmed",
+  serviceDate: null,
+  startsAt: null,
+  endsAt: null,
+  quantity: 2,
+  sellCurrency: "EUR",
+  unitSellAmountCents: 5000,
+  totalSellAmountCents: 10000,
+  costCurrency: "EUR",
+  unitCostAmountCents: 3000,
+  totalCostAmountCents: 6000,
+  notes: null,
+  productId: "prod_1",
+  optionId: null,
+  optionUnitId: null,
+  pricingCategoryId: null,
+  availabilitySlotId: null,
+  createdAt: "2026-07-02T00:00:00.000Z",
+  updatedAt: "2026-07-02T00:00:00.000Z",
+}
+
+const traveler = {
+  id: "bktr_1",
+  bookingId: "bkg_1",
+  participantType: "adult",
+  firstName: "Ada",
+  lastName: "Lovelace",
+  email: "ada@example.com",
+  phone: null,
+  specialRequests: null,
+  isPrimary: true,
+  notes: null,
+  createdAt: "2026-07-02T00:00:00.000Z",
+  updatedAt: "2026-07-02T00:00:00.000Z",
+}
+
+const document = {
+  id: "bkdoc_1",
+  bookingId: "bkg_1",
+  travelerId: null,
+  type: "insurance",
+  fileName: "policy.pdf",
+  fileUrl: "https://example.com/policy.pdf",
+  expiresAt: null,
+  notes: null,
+  createdAt: "2026-07-02T00:00:00.000Z",
+}
+
+describe("bookingSingleResponse (detail parser)", () => {
+  it("preserves hydrated items, travelers, and documents", () => {
+    const parsed = bookingSingleResponse.parse({
+      data: { ...baseBooking, items: [detailItem], travelers: [traveler], documents: [document] },
+    })
+
+    expect(parsed.data.items).toHaveLength(1)
+    expect(parsed.data.items[0]).toMatchObject({ id: "bkit_1", status: "confirmed" })
+    expect(parsed.data.travelers).toHaveLength(1)
+    expect(parsed.data.travelers[0]).toMatchObject({ id: "bktr_1", firstName: "Ada" })
+    expect(parsed.data.documents).toHaveLength(1)
+    expect(parsed.data.documents[0]).toMatchObject({ id: "bkdoc_1", type: "insurance" })
+  })
+
+  it("accepts a revealed traveler carrying travelDetails without stripping it", () => {
+    const revealed = {
+      ...traveler,
+      travelDetails: {
+        travelerId: "bktr_1",
+        nationality: "GB",
+        documentType: "passport",
+        documentNumber: "X123",
+        documentExpiry: null,
+        documentIssuingCountry: "GB",
+        documentIssuingAuthority: null,
+        documentPersonDocumentId: null,
+        dateOfBirth: null,
+        dietaryRequirements: null,
+        accessibilityNeeds: null,
+        isLeadTraveler: true,
+        sharingGroupId: null,
+        roomTypeId: null,
+        bedPreference: null,
+        allocations: {},
+        createdAt: "2026-07-02T00:00:00.000Z",
+        updatedAt: "2026-07-02T00:00:00.000Z",
+      },
+    }
+
+    const parsed = bookingSingleResponse.parse({
+      data: { ...baseBooking, items: [], travelers: [revealed], documents: [] },
+    })
+
+    expect(parsed.data.travelers[0]).toHaveProperty("travelDetails")
+    expect(
+      (parsed.data.travelers[0] as { travelDetails: { nationality: string } }).travelDetails
+        .nationality,
+    ).toBe("GB")
+  })
+
+  it("keeps the list parser on the summary shape (no travelers/documents required)", () => {
+    const parsed = bookingListResponse.parse({
+      data: [
+        {
+          ...baseBooking,
+          items: [{ id: "bkit_1", title: "Guided tour", itemType: "product", productId: "prod_1" }],
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    })
+
+    expect(parsed.data).toHaveLength(1)
+    expect(parsed.data[0]).not.toHaveProperty("travelers")
+  })
+})

--- a/packages/bookings-react/tests/unit/booking-detail-parser.test.ts
+++ b/packages/bookings-react/tests/unit/booking-detail-parser.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from "vitest"
 
-import { bookingListResponse, bookingSingleResponse } from "../../src/schemas.js"
+import {
+  bookingDetailResponse,
+  bookingListResponse,
+  bookingSingleResponse,
+} from "../../src/schemas.js"
 
 // Regression cover for voyant#2728: the admin booking detail read hydrates
 // items/travelers/documents inline, but the client previously parsed the
 // response with the flat list record schema, which stripped those collections.
-// `bookingSingleResponse` now points at `bookingDetailSchema`, so the parser
-// must preserve them while the list parser stays on the summary shape.
+// The dedicated `bookingDetailResponse` preserves them. The shared
+// `bookingSingleResponse` stays flat (mutation endpoints return a flat booking),
+// and the list parser stays on the summary shape.
 
 const baseBooking = {
   id: "bkg_1",
@@ -82,7 +87,7 @@ const document = {
 
 describe("bookingSingleResponse (detail parser)", () => {
   it("preserves hydrated items, travelers, and documents", () => {
-    const parsed = bookingSingleResponse.parse({
+    const parsed = bookingDetailResponse.parse({
       data: { ...baseBooking, items: [detailItem], travelers: [traveler], documents: [document] },
     })
 
@@ -119,7 +124,7 @@ describe("bookingSingleResponse (detail parser)", () => {
       },
     }
 
-    const parsed = bookingSingleResponse.parse({
+    const parsed = bookingDetailResponse.parse({
       data: { ...baseBooking, items: [], travelers: [revealed], documents: [] },
     })
 
@@ -128,6 +133,17 @@ describe("bookingSingleResponse (detail parser)", () => {
       (parsed.data.travelers[0] as { travelDetails: { nationality: string } }).travelDetails
         .nationality,
     ).toBe("GB")
+  })
+
+  it("keeps bookingSingleResponse flat so mutation responses (no child collections) still parse", () => {
+    // Mutation endpoints (create/update/convert/status/cancel) return a flat
+    // `bookingSchema` with no items/travelers/documents — the shared single
+    // parser must accept that without requiring the detail-only collections.
+    const parsed = bookingSingleResponse.parse({ data: baseBooking })
+
+    expect(parsed.data.id).toBe("bkg_1")
+    expect(parsed.data).not.toHaveProperty("travelers")
+    expect(parsed.data).not.toHaveProperty("documents")
   })
 
   it("keeps the list parser on the summary shape (no travelers/documents required)", () => {


### PR DESCRIPTION
Closes #2728.

## Problem

The admin booking detail read (`GET /v1/admin/bookings/:id`) hydrates its bookings-owned child collections inline (`items`/`travelers`/`documents`, added in #2620 / #2727), but the client `useBooking` validated the response with `singleEnvelope(bookingRecordSchema)`. `bookingRecordSchema` carries only an optional **summary** `items` and no `travelers`/`documents`, so Zod silently stripped the newly-hydrated collections for `bookings-react` consumers.

## Fix

- Add a dedicated `bookingDetailSchema` = `bookingRecordSchema` extended with the full child shapes:
  - `items` → full `bookingItemRecordSchema` (same shape as the `/items` endpoint).
  - `travelers` → `union(reveal, plain)` so it accepts both the redacted rows and a revealed row carrying `travelDetails` without stripping it.
  - `documents` → `bookingTravelerDocumentRecordSchema`, which already mirrors the server's booking-level `bookingDocumentSchema` (the shape `/documents` returns).
- Point `bookingSingleResponse` / `useBooking` at `bookingDetailSchema`. The shared **list** parser (`bookingListResponse`) is unchanged and stays on the summary shape.

`BookingDetailRecord` is assignable to `BookingRecord` (the full item satisfies the summary shape), so existing consumers are unaffected — verified by typechecking `bookings-react`, `legal-react`, and the `operator` starter.

## Tests

New `tests/unit/booking-detail-parser.test.ts` locks in:
- the detail parser preserves `items`/`travelers`/`documents`,
- a revealed traveler's inline `travelDetails` survives,
- the list parser stays on the summary shape (no travelers/documents required).

All 97 bookings-react unit tests pass; lint and `release:plan` clean.