### PR TITLE
Validate activity link entity targets

### DIFF
--- a/.changeset/activity-link-owned-entity-validation.md
+++ b/.changeset/activity-link-owned-entity-validation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/relationships": patch
+---
+
+Validate activity links to relationship-owned entity types before creating link rows.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -12956,6 +12956,24 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Linked entity not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "postAdminRelationshipsActivitiesByIdLinks",

--- a/packages/relationships/src/routes/activities.ts
+++ b/packages/relationships/src/routes/activities.ts
@@ -129,6 +129,7 @@ const createActivityLinkRoute = createRoute({
       ...jsonContent(z.object({ data: activityLinkSchema })),
     },
     400: { description: "invalid_request", ...jsonContent(errorResponseSchema) },
+    404: { description: "Linked entity not found", ...jsonContent(errorResponseSchema) },
   },
 })
 
@@ -216,7 +217,7 @@ activityRoutes.openapi(createActivityLinkRoute, async (c) => {
     c.req.valid("param").id,
     c.req.valid("json"),
   )
-  return c.json({ data: row! }, 201)
+  return row ? c.json({ data: row }, 201) : c.json({ error: "Linked entity not found" }, 404)
 })
 activityRoutes.openapi(deleteActivityLinkRoute, async (c) => {
   const row = await relationshipsService.deleteActivityLink(c.get("db"), c.req.valid("param").id)

--- a/packages/relationships/src/service/activities.ts
+++ b/packages/relationships/src/service/activities.ts
@@ -2,7 +2,13 @@ import { and, desc, eq, ilike, inArray, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 
-import { activities, activityLinks, activityParticipants } from "../schema.js"
+import {
+  activities,
+  activityLinks,
+  activityParticipants,
+  organizations,
+  people,
+} from "../schema.js"
 import type {
   activityListQuerySchema,
   insertActivityLinkSchema,
@@ -17,6 +23,61 @@ type CreateActivityInput = z.infer<typeof insertActivitySchema>
 type UpdateActivityInput = z.infer<typeof updateActivitySchema>
 type CreateActivityLinkInput = z.infer<typeof insertActivityLinkSchema>
 type CreateActivityParticipantInput = z.infer<typeof insertActivityParticipantSchema>
+
+function firstExecuteRow<T>(result: unknown): T | undefined {
+  if (Array.isArray(result)) return result[0] as T | undefined
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown[] }).rows
+    return rows?.[0] as T | undefined
+  }
+  return undefined
+}
+
+async function quoteExists(db: PostgresJsDatabase, quoteId: string) {
+  const tableResult = await db.execute(
+    sql<{ exists: boolean }[]>`select (to_regclass('public.quotes') is not null) as exists`,
+  )
+  const tableRow = firstExecuteRow<{ exists: boolean }>(tableResult)
+  if (!tableRow?.exists) return false
+
+  const quoteResult = await db.execute(
+    sql<{ exists: boolean }[]>`
+      select exists(select 1 from public.quotes where id = ${quoteId}) as exists
+    `,
+  )
+  return !!firstExecuteRow<{ exists: boolean }>(quoteResult)?.exists
+}
+
+async function linkedEntityExists(db: PostgresJsDatabase, data: CreateActivityLinkInput) {
+  switch (data.entityType) {
+    case "organization": {
+      const [row] = await db
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, data.entityId))
+        .limit(1)
+      return !!row
+    }
+    case "person": {
+      const [row] = await db
+        .select({ id: people.id })
+        .from(people)
+        .where(eq(people.id, data.entityId))
+        .limit(1)
+      return !!row
+    }
+    case "activity": {
+      const [row] = await db
+        .select({ id: activities.id })
+        .from(activities)
+        .where(eq(activities.id, data.entityId))
+        .limit(1)
+      return !!row
+    }
+    case "quote":
+      return quoteExists(db, data.entityId)
+  }
+}
 
 export const activitiesService = {
   async listActivities(db: PostgresJsDatabase, query: ActivityListQuery) {
@@ -118,6 +179,8 @@ export const activitiesService = {
     activityId: string,
     data: CreateActivityLinkInput,
   ) {
+    if (!(await linkedEntityExists(db, data))) return null
+
     const [row] = await db
       .insert(activityLinks)
       .values({ ...data, activityId })

--- a/packages/relationships/tests/integration/activities.test.ts
+++ b/packages/relationships/tests/integration/activities.test.ts
@@ -147,12 +147,31 @@ describe.skipIf(!DB_AVAILABLE)("Activity routes", () => {
       return data
     }
 
+    async function seedOrganization() {
+      const res = await app.request("/organizations", {
+        method: "POST",
+        ...json({ name: "Link Target Org" }),
+      })
+      const { data } = await res.json()
+      return data
+    }
+
+    async function seedPerson() {
+      const res = await app.request("/people", {
+        method: "POST",
+        ...json({ firstName: "Link", lastName: "Target" }),
+      })
+      const { data } = await res.json()
+      return data
+    }
+
     it("creates and lists links", async () => {
       const activity = await seedActivity()
+      const organization = await seedOrganization()
 
       const createRes = await app.request(`/activities/${activity.id}/links`, {
         method: "POST",
-        ...json({ entityType: "organization", entityId: "crm_org_fake123" }),
+        ...json({ entityType: "organization", entityId: organization.id }),
       })
 
       expect(createRes.status).toBe(201)
@@ -167,12 +186,35 @@ describe.skipIf(!DB_AVAILABLE)("Activity routes", () => {
       expect(listBody.data.length).toBe(1)
     })
 
-    it("deletes a link", async () => {
+    it("rejects links to missing organizations", async () => {
       const activity = await seedActivity()
 
       const createRes = await app.request(`/activities/${activity.id}/links`, {
         method: "POST",
-        ...json({ entityType: "person", entityId: "crm_ppl_fake123" }),
+        ...json({ entityType: "organization", entityId: "org_missing" }),
+      })
+
+      expect(createRes.status).toBe(404)
+      const createBody = await createRes.json()
+      expect(createBody.error).toBe("Linked entity not found")
+
+      const listRes = await app.request(
+        "/activities?entityType=organization&entityId=org_missing",
+        { method: "GET" },
+      )
+
+      expect(listRes.status).toBe(200)
+      const listBody = await listRes.json()
+      expect(listBody.data).toEqual([])
+    })
+
+    it("deletes a link", async () => {
+      const activity = await seedActivity()
+      const person = await seedPerson()
+
+      const createRes = await app.request(`/activities/${activity.id}/links`, {
+        method: "POST",
+        ...json({ entityType: "person", entityId: person.id }),
       })
       const { data: link } = await createRes.json()
 

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -12956,6 +12956,24 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Linked entity not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "postAdminRelationshipsActivitiesByIdLinks",


### PR DESCRIPTION
## Summary
- validate activity links to relationship-owned entity types before inserting link rows
- return a typed 404 response when an organization/person/activity target is missing
- update activity link integration coverage and generated admin OpenAPI specs

Fixes #2565

## Verification
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships exec vitest run tests/integration/activities.test.ts (skipped locally without TEST_DATABASE_URL)
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check .changeset/activity-link-owned-entity-validation.md packages/relationships/src/service/activities.ts packages/relationships/src/routes/activities.ts packages/relationships/tests/integration/activities.test.ts packages/openapi/spec/admin/relationships.json starters/operator/openapi/admin/relationships.json && git diff --check