### PR TITLE
Use owned unit pax tiers in booking quotes

### DIFF
--- a/.changeset/priced-owned-unit-pax-tiers.md
+++ b/.changeset/priced-owned-unit-pax-tiers.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Use owned product option-unit pax pricing tiers when booking journey quotes include explicit unit selections.

--- a/packages/inventory/src/booking-engine/handler-support.ts
+++ b/packages/inventory/src/booking-engine/handler-support.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- booking-engine pricing, commit, and draft helpers stay together until the owned products handler support layer is split.
 import type {
   AddonOffer,
   CommitOwnedRequest,
@@ -5,15 +6,16 @@ import type {
   ProductVariantOption,
 } from "@voyant-travel/catalog/booking-engine"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { eq } from "drizzle-orm"
+import { and, eq, gte, isNull, lte, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { products } from "../schema-core.js"
+import { productPaxPricingTiers, products } from "../schema-core.js"
 import type {
   BookingCreateBridgeInput,
   CreateProductsBookingHandlerOptions,
   DraftLike,
   ResolvedOptionPrice,
+  ResolvedPaxPricingTier,
 } from "./handler.js"
 
 export async function loadProduct(
@@ -104,10 +106,27 @@ export async function priceOptionSelections(input: {
   productOptions: ReadonlyArray<ProductVariantOption>
   selections: ReadonlyArray<NormalizedOptionSelection>
   slotDate: string | null
+  effectivePax: number
 }): Promise<PricedQuote> {
   const lines: PricedLine[] = []
   let totalCents = 0
   const optionsById = new Map(input.productOptions.map((option) => [option.id, option]))
+  const totalInventoryUnits = input.selections.reduce((sum, selection) => {
+    const unit = findProductOptionUnit(
+      input.productOptions,
+      selection.optionId,
+      selection.optionUnitId,
+    )
+    return unit && unit.unitType !== "person" ? sum + selection.quantity : sum
+  }, 0)
+  const totalPersonUnits = input.selections.reduce((sum, selection) => {
+    const unit = findProductOptionUnit(
+      input.productOptions,
+      selection.optionId,
+      selection.optionUnitId,
+    )
+    return unit?.unitType === "person" ? sum + selection.quantity : sum
+  }, 0)
 
   for (const selection of input.selections) {
     const resolvedPrice =
@@ -123,8 +142,37 @@ export async function priceOptionSelections(input: {
         ? resolvedPrice.unitPrices.find((unit) => unit.unitId === selection.optionUnitId)
             ?.sellAmountCents
         : null
+    const paxTier =
+      unitPrice == null && selection.optionUnitId
+        ? await resolveSelectionPaxTier({
+            ctx: input.ctx,
+            options: input.options,
+            productId: input.product.id,
+            optionUnitId: selection.optionUnitId,
+            tierPax: tierPaxForSelection({
+              productOptions: input.productOptions,
+              selection,
+              effectivePax: input.effectivePax,
+              totalInventoryUnits,
+              totalPersonUnits,
+            }),
+            date: input.slotDate,
+          })
+        : null
+    const paxTierUnitAmount = paxTier
+      ? unitAmountForPaxTier({
+          productOptions: input.productOptions,
+          selection,
+          tierPax: paxTier.tierPax,
+          pricePerPaxCents: paxTier.price.pricePerPaxCents,
+        })
+      : null
     const unitAmount =
-      unitPrice ?? resolvedPrice?.baseSellAmountCents ?? input.product.sellAmountCents ?? 0
+      unitPrice ??
+      paxTierUnitAmount ??
+      resolvedPrice?.baseSellAmountCents ??
+      input.product.sellAmountCents ??
+      0
     if (unitAmount <= 0) continue
     const totalAmount = unitAmount * selection.quantity
     totalCents += totalAmount
@@ -141,6 +189,128 @@ export async function priceOptionSelections(input: {
   }
 
   return { totalCents, lines }
+}
+
+interface SelectionPaxTier {
+  tierPax: number
+  price: ResolvedPaxPricingTier
+}
+
+async function resolveSelectionPaxTier(input: {
+  ctx: OwnedHandlerContext
+  options: CreateProductsBookingHandlerOptions
+  productId: string
+  optionUnitId: string
+  tierPax: number
+  date: string | null
+}): Promise<SelectionPaxTier | null> {
+  if (input.tierPax <= 0) return null
+  const loader = input.options.loadPaxPricingTier ?? loadProductPaxPricingTier
+  const price = await loader(input.ctx, {
+    productId: input.productId,
+    optionUnitId: input.optionUnitId,
+    tierPax: input.tierPax,
+    date: input.date,
+  })
+  return price ? { tierPax: input.tierPax, price } : null
+}
+
+export async function loadProductPaxPricingTier(
+  ctx: OwnedHandlerContext,
+  args: {
+    productId: string
+    optionUnitId: string
+    tierPax: number
+    date?: string | null
+  },
+): Promise<ResolvedPaxPricingTier | null> {
+  const drizzle = ctx.db as PostgresJsDatabase
+  const predicates = [
+    eq(productPaxPricingTiers.productId, args.productId),
+    eq(productPaxPricingTiers.tierPax, args.tierPax),
+    ...paxTierDatePredicates(args.date),
+  ]
+
+  const [unitTier] = await drizzle
+    .select({
+      pricePerPaxCents: productPaxPricingTiers.pricePerPaxCents,
+    })
+    .from(productPaxPricingTiers)
+    .where(and(...predicates, eq(productPaxPricingTiers.optionUnitId, args.optionUnitId)))
+    .limit(1)
+  if (unitTier) return unitTier
+
+  const [productTier] = await drizzle
+    .select({
+      pricePerPaxCents: productPaxPricingTiers.pricePerPaxCents,
+    })
+    .from(productPaxPricingTiers)
+    .where(and(...predicates, isNull(productPaxPricingTiers.optionUnitId)))
+    .limit(1)
+  return productTier ?? null
+}
+
+function paxTierDatePredicates(date: string | null | undefined) {
+  if (!date) {
+    return [
+      isNull(productPaxPricingTiers.effectiveFrom),
+      isNull(productPaxPricingTiers.effectiveTo),
+    ]
+  }
+  return [
+    or(
+      isNull(productPaxPricingTiers.effectiveFrom),
+      lte(productPaxPricingTiers.effectiveFrom, date),
+    ),
+    or(isNull(productPaxPricingTiers.effectiveTo), gte(productPaxPricingTiers.effectiveTo, date)),
+  ]
+}
+
+function findProductOptionUnit(
+  productOptions: ReadonlyArray<ProductVariantOption>,
+  optionId: string,
+  optionUnitId: string | undefined,
+) {
+  if (!optionUnitId) return undefined
+  return productOptions
+    .find((option) => option.id === optionId)
+    ?.units?.find((unit) => unit.id === optionUnitId)
+}
+
+function tierPaxForSelection(input: {
+  productOptions: ReadonlyArray<ProductVariantOption>
+  selection: NormalizedOptionSelection
+  effectivePax: number
+  totalInventoryUnits: number
+  totalPersonUnits: number
+}): number {
+  const unit = findProductOptionUnit(
+    input.productOptions,
+    input.selection.optionId,
+    input.selection.optionUnitId,
+  )
+  if (!unit) return input.effectivePax > 0 ? input.effectivePax : input.selection.quantity
+  if (unit.unitType === "person") {
+    return Math.max(1, input.effectivePax, input.totalPersonUnits)
+  }
+  if (input.effectivePax <= 0) return input.selection.quantity
+  return Math.max(1, Math.ceil(input.effectivePax / Math.max(1, input.totalInventoryUnits)))
+}
+
+function unitAmountForPaxTier(input: {
+  productOptions: ReadonlyArray<ProductVariantOption>
+  selection: NormalizedOptionSelection
+  tierPax: number
+  pricePerPaxCents: number
+}): number {
+  const unit = findProductOptionUnit(
+    input.productOptions,
+    input.selection.optionId,
+    input.selection.optionUnitId,
+  )
+  return unit && unit.unitType !== "person"
+    ? input.pricePerPaxCents * input.tierPax
+    : input.pricePerPaxCents
 }
 
 export function bookingItemLinesFromOptionSelections(

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -7,8 +7,8 @@
  *
  *   - The products vertical's existing pricing primitives
  *     (`products.sellAmountCents` / `sellCurrency`) for pricing
- *     basis. Per-pax / per-band pricing layered in Phase C+ via
- *     `product_pax_pricing_tiers`.
+ *     basis, with option/unit-specific pax tiers from
+ *     `product_pax_pricing_tiers` when the draft selects units.
  *   - `getProductContent` + `buildProductDraftShape` for the journey
  *     wizard's step descriptor.
  *   - An injected `createBooking` function for the commit path
@@ -16,8 +16,8 @@
  *     `@voyant-travel/finance` (no workspace cycle).
  *
  * Phase A scope (deliberately narrow):
- *   - Price = product.sellAmountCents × pax_count, no taxes / addons /
- *     accommodation / vouchers.
+ *   - Price = product.sellAmountCents × pax_count unless option/unit
+ *     pricing, taxes, addons, or vouchers are present.
  *   - Commit goes through the bridge into `bookingsCreate`'s input
  *     shape — products-only, no extras / accommodations / cruises / encrypted
  *     travel details / snapshot graph.
@@ -374,6 +374,11 @@ export interface ResolvedOptionPrice {
   unitPrices: ReadonlyArray<ResolvedUnitPrice>
 }
 
+/** Option/unit-specific pax-tier price from `product_pax_pricing_tiers`. */
+export interface ResolvedPaxPricingTier {
+  pricePerPaxCents: number
+}
+
 /** A resolved tax-rate decision — resolved from `tax_classes` ×
  *  `tax_regimes` × buyer country at quote time. */
 export interface ResolvedTaxRate {
@@ -485,6 +490,22 @@ export interface OwnedProductsShapeLoaders {
       catalogId?: string
     },
   ) => Promise<ResolvedOptionPrice | null>
+
+  /**
+   * Resolve Inventory-owned pax pricing for a selected option unit.
+   * Defaults to `product_pax_pricing_tiers`, with the selected unit's
+   * tier winning over product-level tiers.
+   */
+  loadPaxPricingTier?: (
+    ctx: OwnedHandlerContext,
+    args: {
+      productId: string
+      optionUnitId: string
+      tierPax: number
+      /** ISO yyyy-mm-dd when the quote is tied to a departure. */
+      date?: string | null
+    },
+  ) => Promise<ResolvedPaxPricingTier | null>
 
   /**
    * Look up the local date of a departure slot (`availability_slots`).
@@ -676,6 +697,7 @@ export function createProductsBookingHandler(
                 productOptions: productOptionCatalog ?? [],
                 selections: optionSelections,
                 slotDate,
+                effectivePax,
               })
             : priceQuote({
                 product,

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -10,6 +10,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   createProductsBookingHandler,
   type ResolvedOptionPrice,
+  type ResolvedPaxPricingTier,
 } from "../../src/booking-engine/handler.js"
 
 const product = {
@@ -208,6 +209,141 @@ describe("createProductsBookingHandler.computeQuote", () => {
         unitAmount: 32000,
       }),
     )
+  })
+
+  it("uses selected option-unit pax tiers before falling back to the product base price", async () => {
+    const loadPaxPricingTier = vi.fn(
+      async (
+        _ctx: OwnedHandlerContext,
+        args: {
+          productId: string
+          optionUnitId: string
+          tierPax: number
+          date?: string | null
+        },
+      ): Promise<ResolvedPaxPricingTier | null> => {
+        if (args.tierPax !== 2) return null
+        if (args.optionUnitId === "unit_standard_adult") return { pricePerPaxCents: 12000 }
+        if (args.optionUnitId === "unit_champagne_adult") return { pricePerPaxCents: 18000 }
+        return null
+      },
+    )
+    const handler = createProductsBookingHandler({
+      createBooking: vi.fn(),
+      loadProductOptions: async () => [
+        {
+          id: "opt_standard",
+          name: "Standard",
+          units: [{ id: "unit_standard_adult", name: "Adult", unitType: "person" }],
+        },
+        {
+          id: "opt_champagne",
+          name: "Champagne",
+          units: [{ id: "unit_champagne_adult", name: "Adult", unitType: "person" }],
+        },
+      ],
+      loadPaxPricingTier,
+    })
+
+    const standard = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          optionSelections: [
+            { optionId: "opt_standard", optionUnitId: "unit_standard_adult", quantity: 2 },
+          ],
+        },
+      }),
+    )
+    const champagne = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          optionSelections: [
+            { optionId: "opt_champagne", optionUnitId: "unit_champagne_adult", quantity: 2 },
+          ],
+        },
+      }),
+    )
+
+    expect(loadPaxPricingTier).toHaveBeenCalledWith(expect.anything(), {
+      productId: product.id,
+      optionUnitId: "unit_standard_adult",
+      tierPax: 2,
+      date: null,
+    })
+    expect(loadPaxPricingTier).toHaveBeenCalledWith(expect.anything(), {
+      productId: product.id,
+      optionUnitId: "unit_champagne_adult",
+      tierPax: 2,
+      date: null,
+    })
+    const standardBreakdown = standard.pricing?.breakdown as Record<string, unknown>
+    const champagneBreakdown = champagne.pricing?.breakdown as Record<string, unknown>
+    expect(standardBreakdown?.total).toBe(24000)
+    expect(champagneBreakdown?.total).toBe(36000)
+    expect(standardBreakdown?.total).not.toBe(champagneBreakdown?.total)
+  })
+
+  it("uses total person occupancy for mixed option-unit pax tier lookups", async () => {
+    const loadPaxPricingTier = vi.fn(
+      async (
+        _ctx: OwnedHandlerContext,
+        args: {
+          productId: string
+          optionUnitId: string
+          tierPax: number
+          date?: string | null
+        },
+      ): Promise<ResolvedPaxPricingTier | null> => {
+        if (args.tierPax !== 3) return null
+        if (args.optionUnitId === "unit_adult") return { pricePerPaxCents: 11000 }
+        if (args.optionUnitId === "unit_child") return { pricePerPaxCents: 7000 }
+        return null
+      },
+    )
+    const handler = createProductsBookingHandler({
+      createBooking: vi.fn(),
+      loadProductOptions: async () => [
+        {
+          id: "opt_tour",
+          name: "Tour",
+          units: [
+            { id: "unit_adult", name: "Adult", unitType: "person" },
+            { id: "unit_child", name: "Child", unitType: "person" },
+          ],
+        },
+      ],
+      loadPaxPricingTier,
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          pax: { adult: 2, child: 1 },
+          optionSelections: [
+            { optionId: "opt_tour", optionUnitId: "unit_adult", quantity: 2 },
+            { optionId: "opt_tour", optionUnitId: "unit_child", quantity: 1 },
+          ],
+        },
+      }),
+    )
+
+    expect(loadPaxPricingTier).toHaveBeenCalledWith(expect.anything(), {
+      productId: product.id,
+      optionUnitId: "unit_adult",
+      tierPax: 3,
+      date: null,
+    })
+    expect(loadPaxPricingTier).toHaveBeenCalledWith(expect.anything(), {
+      productId: product.id,
+      optionUnitId: "unit_child",
+      tierPax: 3,
+      date: null,
+    })
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(29000)
   })
 
   it("falls through to product.sellAmountCents when the resolver returns null", async () => {


### PR DESCRIPTION
## Summary
- resolve selected option-unit pax tiers from `product_pax_pricing_tiers` during owned product quote pricing
- prefer unit-specific tiers before product-level tier fallback, then existing option/base/product fallbacks
- add a changeset for `@voyant-travel/inventory`

Closes #2429

## Verification
- `pnpm --filter @voyant-travel/inventory test -- tests/unit/booking-engine-quote.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/inventory typecheck`
- `pnpm --filter @voyant-travel/inventory lint`