### PR TITLE
Validate organization commercial fields

### DIFF
--- a/.changeset/organization-commercial-validation.md
+++ b/.changeset/organization-commercial-validation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/relationships-contracts": patch
+---
+
+Validate organization default currency codes and cap payment terms.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -526,7 +526,10 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "preferredLanguage": {
                     "type": [
@@ -539,7 +542,8 @@
                       "integer",
                       "null"
                     ],
-                    "exclusiveMinimum": 0
+                    "exclusiveMinimum": 0,
+                    "maximum": 365
                   },
                   "status": {
                     "type": "string",
@@ -1053,7 +1057,10 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "preferredLanguage": {
                     "type": [
@@ -1066,7 +1073,8 @@
                       "integer",
                       "null"
                     ],
-                    "exclusiveMinimum": 0
+                    "exclusiveMinimum": 0,
+                    "maximum": 365
                   },
                   "status": {
                     "type": "string",

--- a/packages/relationships-contracts/src/validation/accounts.ts
+++ b/packages/relationships-contracts/src/validation/accounts.ts
@@ -8,6 +8,11 @@ import {
   relationTypeSchema,
 } from "./common.js"
 
+const currencyCodeSchema = z
+  .string()
+  .length(3)
+  .regex(/^[A-Z]{3}$/, "Expected ISO 4217 code")
+
 export const organizationCoreSchema = z.object({
   name: z.string().min(1),
   legalName: z.string().nullable().optional(),
@@ -22,9 +27,9 @@ export const organizationCoreSchema = z.object({
   industry: z.string().nullable().optional(),
   relation: relationTypeSchema.nullable().optional(),
   ownerId: z.string().nullable().optional(),
-  defaultCurrency: z.string().nullable().optional(),
+  defaultCurrency: currencyCodeSchema.nullable().optional(),
   preferredLanguage: z.string().nullable().optional(),
-  paymentTerms: z.number().int().positive().nullable().optional(),
+  paymentTerms: z.number().int().positive().max(365).nullable().optional(),
   status: recordStatusSchema.default("active"),
   source: z.string().nullable().optional(),
   sourceRef: z.string().nullable().optional(),

--- a/packages/relationships/tests/unit/validation-accounts.test.ts
+++ b/packages/relationships/tests/unit/validation-accounts.test.ts
@@ -73,12 +73,26 @@ describe("Organization schemas", () => {
     expect(result.paymentTerms).toBe(30)
   })
 
+  it("rejects excessive paymentTerms", () => {
+    expect(() => insertOrganizationSchema.parse({ name: "Acme", paymentTerms: 999 })).toThrow()
+  })
+
   it("rejects negative paymentTerms", () => {
     expect(() => insertOrganizationSchema.parse({ name: "Acme", paymentTerms: -1 })).toThrow()
   })
 
   it("rejects zero paymentTerms", () => {
     expect(() => insertOrganizationSchema.parse({ name: "Acme", paymentTerms: 0 })).toThrow()
+  })
+
+  it("accepts ISO currency code", () => {
+    const result = insertOrganizationSchema.parse({ name: "Acme", defaultCurrency: "EUR" })
+    expect(result.defaultCurrency).toBe("EUR")
+  })
+
+  it("rejects invalid defaultCurrency", () => {
+    expect(() => insertOrganizationSchema.parse({ name: "Acme", defaultCurrency: "X" })).toThrow()
+    expect(() => insertOrganizationSchema.parse({ name: "Acme", defaultCurrency: "usd" })).toThrow()
   })
 
   it("accepts preferredLanguage", () => {

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -526,7 +526,10 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "preferredLanguage": {
                     "type": [
@@ -539,7 +542,8 @@
                       "integer",
                       "null"
                     ],
-                    "exclusiveMinimum": 0
+                    "exclusiveMinimum": 0,
+                    "maximum": 365
                   },
                   "status": {
                     "type": "string",
@@ -1053,7 +1057,10 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "preferredLanguage": {
                     "type": [
@@ -1066,7 +1073,8 @@
                       "integer",
                       "null"
                     ],
-                    "exclusiveMinimum": 0
+                    "exclusiveMinimum": 0,
+                    "maximum": 365
                   },
                   "status": {
                     "type": "string",


### PR DESCRIPTION
## Summary
- validate organization default currency as an uppercase 3-letter ISO-style code
- cap organization payment terms at 365 days
- add unit coverage and generated relationships OpenAPI updates

Fixes #2562

## Verification
- pnpm --filter @voyant-travel/relationships-contracts typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships exec vitest run tests/unit/validation-accounts.test.ts
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check .changeset/organization-commercial-validation.md packages/relationships-contracts/src/validation/accounts.ts packages/relationships/tests/unit/validation-accounts.test.ts packages/openapi/spec/admin/relationships.json starters/operator/openapi/admin/relationships.json && git diff --check