### PR TITLE
Fix organization nested identity routes

### DIFF
--- a/.changeset/organization-nested-identity-routes.md
+++ b/.changeset/organization-nested-identity-routes.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/relationships": patch
+---
+
+Accept natural payloads on organization nested contact/address routes and prevent dangling identity rows for missing organizations.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -1742,16 +1742,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "kind": {
                     "type": "string",
                     "enum": [
@@ -1804,8 +1794,6 @@
                   }
                 },
                 "required": [
-                  "entityType",
-                  "entityId",
                   "kind",
                   "value"
                 ]
@@ -1899,6 +1887,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2103,16 +2109,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "label": {
                     "type": "string",
                     "enum": [
@@ -2205,11 +2201,7 @@
                     ],
                     "additionalProperties": {}
                   }
-                },
-                "required": [
-                  "entityType",
-                  "entityId"
-                ]
+                }
               }
             }
           }
@@ -2352,6 +2344,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/relationships/src/routes/accounts.ts
+++ b/packages/relationships/src/routes/accounts.ts
@@ -33,7 +33,9 @@ import {
   requireUserId,
 } from "@voyant-travel/hono"
 import {
+  insertAddressForEntitySchema,
   insertAddressSchema,
+  insertContactPointForEntitySchema,
   insertContactPointSchema,
   updateAddressSchema,
   updateContactPointSchema,
@@ -271,13 +273,14 @@ const listOrganizationContactMethodsRoute = createRoute({
 const createOrganizationContactMethodRoute = createRoute({
   method: "post",
   path: "/organizations/{id}/contact-methods",
-  request: { params: idParamSchema, ...requiredJsonBody(insertContactPointSchema) },
+  request: { params: idParamSchema, ...requiredJsonBody(insertContactPointForEntitySchema) },
   responses: {
     201: {
       description: "The created contact method",
       ...jsonContent(z.object({ data: contactMethodSchema })),
     },
     400: { description: "invalid_request", ...jsonContent(errorResponseSchema) },
+    404: { description: "Organization not found", ...jsonContent(errorResponseSchema) },
   },
 })
 
@@ -296,13 +299,14 @@ const listOrganizationAddressesRoute = createRoute({
 const createOrganizationAddressRoute = createRoute({
   method: "post",
   path: "/organizations/{id}/addresses",
-  request: { params: idParamSchema, ...requiredJsonBody(insertAddressSchema) },
+  request: { params: idParamSchema, ...requiredJsonBody(insertAddressForEntitySchema) },
   responses: {
     201: {
       description: "The created address",
       ...jsonContent(z.object({ data: addressSchema })),
     },
     400: { description: "invalid_request", ...jsonContent(errorResponseSchema) },
+    404: { description: "Organization not found", ...jsonContent(errorResponseSchema) },
   },
 })
 
@@ -431,7 +435,7 @@ organizationRoutes
       c.req.valid("param").id,
       c.req.valid("json"),
     )
-    return c.json({ data: row! }, 201)
+    return row ? c.json({ data: row }, 201) : c.json({ error: "Organization not found" }, 404)
   })
   .openapi(listOrganizationAddressesRoute, async (c) =>
     c.json(
@@ -452,7 +456,7 @@ organizationRoutes
       c.req.valid("param").id,
       c.req.valid("json"),
     )
-    return c.json({ data: row! }, 201)
+    return row ? c.json({ data: row }, 201) : c.json({ error: "Organization not found" }, 404)
   })
   .openapi(listOrganizationNotesRoute, async (c) =>
     c.json(

--- a/packages/relationships/src/service/accounts-people.ts
+++ b/packages/relationships/src/service/accounts-people.ts
@@ -22,8 +22,10 @@ import type {
 } from "../validation.js"
 import {
   type CommunicationListQuery,
+  type CreateAddressForEntityInput,
   type CreateAddressInput,
   type CreateCommunicationLogInput,
+  type CreateContactPointForEntityInput,
   type CreateContactPointInput,
   type CreateOrganizationNoteInput,
   type CreatePersonInput,
@@ -45,6 +47,15 @@ import { paginate } from "./helpers.js"
 function unaccentedIlike(column: AnyColumn, term: string): SQL {
   // agent-quality: raw-sql reviewed -- owner: crm; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
   return sql`unaccent(coalesce(${column}, '')) ILIKE unaccent(${term})`
+}
+
+async function organizationExists(db: PostgresJsDatabase, organizationId: string) {
+  const [row] = await db
+    .select({ id: organizations.id })
+    .from(organizations)
+    .where(eq(organizations.id, organizationId))
+    .limit(1)
+  return Boolean(row)
 }
 
 function buildPersonSearchCondition(
@@ -246,8 +257,12 @@ export const peopleAccountsService = {
     db: PostgresJsDatabase,
     entityType: "organization" | "person",
     entityId: string,
-    data: CreateContactPointInput,
+    data: CreateContactPointInput | CreateContactPointForEntityInput,
   ) {
+    if (entityType === "organization" && !(await organizationExists(db, entityId))) {
+      return null
+    }
+
     return identityService.createContactPoint(db, {
       ...data,
       entityType: entityType === "organization" ? organizationEntityType : personEntityType,
@@ -275,8 +290,12 @@ export const peopleAccountsService = {
     db: PostgresJsDatabase,
     entityType: "organization" | "person",
     entityId: string,
-    data: CreateAddressInput,
+    data: CreateAddressInput | CreateAddressForEntityInput,
   ) {
+    if (entityType === "organization" && !(await organizationExists(db, entityId))) {
+      return null
+    }
+
     return identityService.createAddress(db, {
       ...data,
       entityType: entityType === "organization" ? organizationEntityType : personEntityType,

--- a/packages/relationships/src/service/accounts-shared.ts
+++ b/packages/relationships/src/service/accounts-shared.ts
@@ -1,6 +1,8 @@
 import { identityService } from "@voyant-travel/identity/service"
 import type {
+  insertAddressForEntitySchema,
   insertAddressSchema,
+  insertContactPointForEntitySchema,
   insertContactPointSchema,
   updateAddressSchema,
   updateContactPointSchema,
@@ -31,8 +33,10 @@ export type PersonListQuery = z.infer<typeof personListQuerySchema>
 export type CreatePersonInput = z.infer<typeof insertPersonSchema>
 export type UpdatePersonInput = z.infer<typeof updatePersonSchema>
 export type CreateContactPointInput = z.infer<typeof insertContactPointSchema>
+export type CreateContactPointForEntityInput = z.infer<typeof insertContactPointForEntitySchema>
 export type UpdateContactPointInput = z.infer<typeof updateContactPointSchema>
 export type CreateAddressInput = z.infer<typeof insertAddressSchema>
+export type CreateAddressForEntityInput = z.infer<typeof insertAddressForEntitySchema>
 export type UpdateAddressInput = z.infer<typeof updateAddressSchema>
 export type CreatePersonNoteInput = z.infer<typeof insertPersonNoteSchema>
 export type CreateOrganizationNoteInput = z.infer<typeof insertOrganizationNoteSchema>

--- a/packages/relationships/tests/integration/accounts-organizations.suite.ts
+++ b/packages/relationships/tests/integration/accounts-organizations.suite.ts
@@ -298,6 +298,100 @@ describe.skipIf(!DB_AVAILABLE)("Organization account routes", () => {
       expect(res.status).toBe(404)
     })
 
+    it("creates nested contact methods from the organization path", async () => {
+      const createRes = await getApp().request("/organizations", {
+        method: "POST",
+        ...json({ name: "Contact Method Org" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/organizations/${created.id}/contact-methods`, {
+        method: "POST",
+        ...json({
+          entityType: "person",
+          entityId: "pers_wrong_000000000000000000000",
+          kind: "email",
+          value: "ops@example.com",
+          isPrimary: true,
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        entityType: "organization",
+        entityId: created.id,
+        kind: "email",
+        value: "ops@example.com",
+      })
+    })
+
+    it("creates nested addresses from natural organization payloads", async () => {
+      const createRes = await getApp().request("/organizations", {
+        method: "POST",
+        ...json({ name: "Address Org" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/organizations/${created.id}/addresses`, {
+        method: "POST",
+        ...json({
+          label: "billing",
+          line1: "10 Main Street",
+          city: "Bucharest",
+          country: "RO",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        entityType: "organization",
+        entityId: created.id,
+        label: "billing",
+        line1: "10 Main Street",
+      })
+    })
+
+    it("rejects nested identity rows for missing organizations", async () => {
+      const { createTestDb } = await import("@voyant-travel/db/test-utils")
+      const db = createTestDb()
+      const missingOrganizationId = "crm_org_missing_nested_identity_0001"
+
+      const contactRes = await getApp().request(
+        `/organizations/${missingOrganizationId}/contact-methods`,
+        {
+          method: "POST",
+          ...json({ kind: "email", value: "missing@example.com" }),
+        },
+      )
+      const addressRes = await getApp().request(
+        `/organizations/${missingOrganizationId}/addresses`,
+        {
+          method: "POST",
+          ...json({ label: "billing", line1: "Missing Street" }),
+        },
+      )
+
+      expect(contactRes.status).toBe(404)
+      expect(addressRes.status).toBe(404)
+
+      const contactRows = await db.execute<{ count: number }>(sql`
+          SELECT count(*)::int
+          FROM identity_contact_points
+          WHERE entity_type = 'organization'
+            AND entity_id = ${missingOrganizationId}
+        `)
+      const addressRows = await db.execute<{ count: number }>(sql`
+          SELECT count(*)::int
+          FROM identity_addresses
+          WHERE entity_type = 'organization'
+            AND entity_id = ${missingOrganizationId}
+        `)
+      expect(contactRows[0]?.count).toBe(0)
+      expect(addressRows[0]?.count).toBe(0)
+    })
+
     it("creates an organization note", async () => {
       const createRes = await getApp().request("/organizations", {
         method: "POST",

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -1742,16 +1742,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "kind": {
                     "type": "string",
                     "enum": [
@@ -1804,8 +1794,6 @@
                   }
                 },
                 "required": [
-                  "entityType",
-                  "entityId",
                   "kind",
                   "value"
                 ]
@@ -1899,6 +1887,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -2103,16 +2109,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "label": {
                     "type": "string",
                     "enum": [
@@ -2205,11 +2201,7 @@
                     ],
                     "additionalProperties": {}
                   }
-                },
-                "required": [
-                  "entityType",
-                  "entityId"
-                ]
+                }
               }
             }
           }
@@ -2352,6 +2344,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Organization not found",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary
- derive organization nested contact/address entity identity from the path instead of request bodies
- return 404 for missing organization parents before creating identity rows
- add regression coverage and generated relationships OpenAPI updates

Fixes #2563

## Verification
- pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships test -- tests/integration/accounts.test.ts (DB-backed cases skipped locally without TEST_DATABASE_URL)
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check .changeset/organization-nested-identity-routes.md packages/relationships/src/routes/accounts.ts packages/relationships/src/service/accounts-people.ts packages/relationships/src/service/accounts-shared.ts packages/relationships/tests/integration/accounts-organizations.suite.ts packages/openapi/spec/admin/relationships.json starters/operator/openapi/admin/relationships.json && git diff --check