### PR TITLE
Persist B2B organization contact in booking journey

### DIFF
--- a/.changeset/company-billing-contact.md
+++ b/.changeset/company-billing-contact.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Persist and display the selected B2B organization as the booking contact when the admin booking journey uses company-only billing.

--- a/packages/bookings-react/src/admin/booking-journey-host.tsx
+++ b/packages/bookings-react/src/admin/booking-journey-host.tsx
@@ -326,9 +326,10 @@ function CrmLeadPicker({
     const org = orgQuery.data
     if (!org || appliedOrgId.current === org.id) return
     appliedOrgId.current = org.id
+    const companyName = org.legalName ?? org.name
     apply({
       organizationId: org.id,
-      companyName: org.legalName ?? org.name,
+      companyName,
       taxId: org.taxId ?? undefined,
     })
   }, [orgQuery.data])

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -21,19 +21,25 @@ import type { JourneyStep } from "../types.js"
  */
 export function buildCommitParty(draft: Draft): Record<string, unknown> {
   const c = draft.billing.contact
+  const companyName = draft.billing.company?.name?.trim()
+  const contactFirstName =
+    draft.billing.buyerType === "B2B" && companyName ? companyName : c.firstName
+  const contactLastName =
+    draft.billing.buyerType === "B2B" && contactFirstName === companyName ? "" : c.lastName
+  const personId = draft.billing.buyerType === "B2B" ? undefined : c.personId
   const organizationId =
     draft.billing.buyerType === "B2B" ? draft.billing.organizationId : undefined
   return {
-    personId: c.personId,
+    personId,
     organizationId,
     billing: {
-      personId: c.personId,
+      personId,
       organizationId,
       contact: {
-        firstName: c.firstName,
-        lastName: c.lastName,
-        email: c.email,
-        phone: c.phone,
+        firstName: contactFirstName,
+        lastName: contactLastName,
+        email: draft.billing.buyerType === "B2B" && companyName ? "" : c.email,
+        phone: draft.billing.buyerType === "B2B" && companyName ? undefined : c.phone,
       },
     },
     travelerParty: {

--- a/packages/bookings-react/src/journey/components/journey-steps/review-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/review-step.tsx
@@ -47,6 +47,11 @@ export function ReviewStep({
 }): React.ReactElement {
   const messages = useBookingsUiMessagesOrDefault()
   const isPublic = surface === "public"
+  const leadName =
+    (draft.billing.buyerType === "B2B" ? draft.billing.company?.name : undefined) ||
+    [draft.billing.contact.firstName, draft.billing.contact.lastName].filter(Boolean).join(" ") ||
+    messages.bookingJourney.values.noValue
+  const leadEmail = draft.billing.contact.email || messages.bookingJourney.values.noValue
   return (
     <Card>
       <CardHeader>
@@ -57,8 +62,7 @@ export function ReviewStep({
         <div>
           <div className="font-medium">{messages.bookingJourney.review.leadContact}</div>
           <div className="text-muted-foreground text-sm">
-            {draft.billing.contact.firstName} {draft.billing.contact.lastName} ·{" "}
-            {draft.billing.contact.email}
+            {leadName} · {leadEmail}
           </div>
         </div>
         <div>

--- a/packages/bookings-react/src/journey/components/side-panel.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.tsx
@@ -239,7 +239,9 @@ export function stepHeadline(
     case "billing": {
       const c = draft.billing.contact
       const name = [c.firstName, c.lastName].filter(Boolean).join(" ").trim()
-      return name || c.email || messages.bookingJourney.values.notSet
+      const companyName =
+        draft.billing.buyerType === "B2B" ? draft.billing.company?.name?.trim() : undefined
+      return companyName || name || c.email || messages.bookingJourney.values.notSet
     }
     case "travelers": {
       const filled = draft.travelers.filter((t) => t.firstName && t.lastName).length
@@ -374,14 +376,14 @@ function BillingDetails({
   const c = draft.billing.contact
   const a = draft.billing.address
   const addressLine = [a.line1, a.line2, a.city, a.postal, a.country].filter(Boolean).join(", ")
+  const contactName =
+    (draft.billing.buyerType === "B2B" ? draft.billing.company?.name : undefined) ||
+    [c.firstName, c.lastName].filter(Boolean).join(" ")
   return (
     <dl className="space-y-1 text-xs">
       <Row
         label={messages.bookingJourney.sidePanel.name}
-        value={
-          [c.firstName, c.lastName].filter(Boolean).join(" ") ||
-          messages.bookingJourney.values.noValue
-        }
+        value={contactName || messages.bookingJourney.values.noValue}
       />
       <Row
         label={messages.bookingJourney.sidePanel.email}

--- a/packages/bookings-react/src/journey/lib/draft-state.ts
+++ b/packages/bookings-react/src/journey/lib/draft-state.ts
@@ -63,7 +63,10 @@ export function setBillingBuyerType(draft: Draft, buyerType: "B2C" | "B2B"): Dra
     }
   }
 
-  return patchBilling(draft, { buyerType })
+  return patchBilling(draft, {
+    buyerType,
+    contact: { firstName: "", lastName: "", email: "" },
+  })
 }
 
 export function canCopyBillingContactToTraveler(contact: Draft["billing"]["contact"]): boolean {

--- a/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
+++ b/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
@@ -67,6 +67,40 @@ describe("booking-journey-rules", () => {
     })
   })
 
+  it("allows B2B organization-only billing and commits the company as the contact display name", () => {
+    const shape = defaultMinimalShape()
+    const draft = patchConfigure(
+      patchBilling(emptyDraft(ENTITY, { buyerType: "B2B" }), {
+        organizationId: "org_1",
+        company: { name: "Acme Travel SRL", vatId: "RO123456" },
+        contact: {
+          firstName: "Stale",
+          lastName: "Person",
+          email: "stale@example.com",
+          phone: "+40700111222",
+          personId: "person_stale",
+        },
+      }),
+      { departureSlotId: "slot_1" },
+    )
+
+    expect(canAdvanceFromStep("billing", draft, shape, true)).toBe(true)
+    expect(buildCommitParty(draft)).toMatchObject({
+      personId: undefined,
+      organizationId: "org_1",
+      billing: {
+        personId: undefined,
+        organizationId: "org_1",
+        contact: {
+          firstName: "Acme Travel SRL",
+          lastName: "",
+          email: "",
+          phone: undefined,
+        },
+      },
+    })
+  })
+
   it("blocks payment advancement when an already-paid row has no payment date", () => {
     const shape = defaultMinimalShape()
     const draft = {

--- a/packages/bookings-react/tests/unit/draft-state.test.ts
+++ b/packages/bookings-react/tests/unit/draft-state.test.ts
@@ -92,6 +92,28 @@ describe("draft-state", () => {
     expect(next.billing.contact).toEqual(draft.billing.contact)
   })
 
+  it("setBillingBuyerType clears person contact state when switching to B2B", () => {
+    const draft = patchBilling(emptyDraft(ENTITY, { buyerType: "B2C" }), {
+      contact: {
+        firstName: "Ana",
+        lastName: "Pop",
+        email: "ana@example.com",
+        phone: "+40700111222",
+        personId: "person_1",
+      },
+    })
+
+    const next = setBillingBuyerType(draft, "B2B")
+
+    expect(next.billing.buyerType).toBe("B2B")
+    expect(next.billing.contact).toEqual({
+      firstName: "",
+      lastName: "",
+      email: "",
+    })
+    expect(canCopyBillingContactToTraveler(next.billing.contact)).toBe(false)
+  })
+
   it("allows copying billing contact when any traveler contact field is present", () => {
     expect(
       canCopyBillingContactToTraveler({


### PR DESCRIPTION
## Summary
- hydrate B2B organization selections into the booking journey contact display fields
- persist company-only B2B billing using the organization name as the booking contact fallback and drop stale person ids
- show the company name in billing summaries/review when no person contact is present
- add a changeset for `@voyant-travel/bookings-react`

Closes #2428

## Verification
- `pnpm --filter @voyant-travel/bookings-react test -- tests/unit/booking-journey-rules.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck`
- `pnpm --filter @voyant-travel/bookings-react lint`