### PR TITLE
Agent tools: MCP transport spike (stateless MCP SDK over Hono)

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,27 @@
+# @voyant-travel/mcp
+
+The in-deployment MCP server for the Voyant framework (voyant#2792). It exposes
+the framework tool registry as a real [Model Context Protocol](https://modelcontextprotocol.io)
+server, mounted as a Hono route group inside the operator deployment at
+`/v1/admin/mcp` — **not** a separate app/worker, and **no Durable Object**.
+
+External MCP clients (Claude, ChatGPT, …) connect to that endpoint over the wire.
+
+## Spike findings (Sub-issue 0)
+
+Validated wiring that the transport adapter (Sub-issue 3) is built on:
+
+- **Transport:** `@hono/mcp`'s `StreamableHTTPTransport` (web-standard `Request`/
+  `Response`) connected to `@modelcontextprotocol/sdk`'s `McpServer`. The SDK's own
+  `StreamableHTTPServerTransport` is Node-`http`-oriented and is **not** used.
+- **Stateless, per request:** create a fresh `McpServer` + transport per request,
+  with `{ sessionIdGenerator: undefined, enableJsonResponse: true }`, then
+  `await server.connect(transport); return transport.handleRequest(c)`. No session
+  store, no Durable Object — fits the operator's single-worker `nodejs_compat`
+  runtime, and survives the lazy-route `c.var` re-hydration at `/v1/admin/mcp`.
+- **No init handshake required per request:** in stateless mode `tools/list` and
+  `tools/call` are each handled independently (verified in `tests/spike.test.ts`).
+- **Client `Accept` header** must include `application/json, text/event-stream`.
+
+`src/spike.ts` is a throwaway proof — it is replaced by `createMcpHonoApp(...)` over
+the `@voyant-travel/tools` registry once that lands.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@voyant-travel/mcp",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "@hono/mcp": "^0.3.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "hono": "catalog:",
+    "hono-rate-limiter": "^0.5.3",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/mcp"
+  }
+}

--- a/packages/mcp/src/spike.ts
+++ b/packages/mcp/src/spike.ts
@@ -1,0 +1,45 @@
+/**
+ * Sub-issue 0 spike (voyant#2792): prove `@modelcontextprotocol/sdk` `McpServer`
+ * serves over `@hono/mcp`'s web-standard Streamable-HTTP transport as a plain
+ * Hono route group — stateless, no Durable Object — so it drops into the
+ * operator's `/v1/admin/mcp` composition seam under `nodejs_compat`.
+ *
+ * Stateless serverless pattern: a fresh `McpServer` + transport per request,
+ * `enableJsonResponse` so the handler returns a JSON body (not an SSE stream),
+ * `sessionIdGenerator: undefined` so no session state is retained across
+ * requests. This is the wiring the real adapter (Sub-issue 3) is built on.
+ *
+ * THROWAWAY — replaced by `createMcpHonoApp` once the tool registry lands.
+ */
+import { StreamableHTTPTransport } from "@hono/mcp"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { Hono } from "hono"
+import { z } from "zod"
+
+function createSpikeServer(): McpServer {
+  const server = new McpServer({ name: "voyant-mcp-spike", version: "0.0.0" })
+  server.tool(
+    "echo",
+    "Echo the provided text back. Spike-only tool.",
+    { text: z.string().describe("Text to echo back.") },
+    async ({ text }) => ({
+      content: [{ type: "text", text: `echo: ${text}` }],
+    }),
+  )
+  return server
+}
+
+/** Build a Hono app exposing the spike MCP server at `POST /` (mount anywhere). */
+export function createSpikeMcpApp(): Hono {
+  const app = new Hono()
+  app.all("/", async (c) => {
+    const server = createSpikeServer()
+    const transport = new StreamableHTTPTransport({
+      sessionIdGenerator: undefined,
+      enableJsonResponse: true,
+    })
+    await server.connect(transport)
+    return transport.handleRequest(c)
+  })
+  return app
+}

--- a/packages/mcp/tests/spike.test.ts
+++ b/packages/mcp/tests/spike.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest"
+
+import { createSpikeMcpApp } from "../src/spike.js"
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  // The Streamable-HTTP transport requires the client to accept both.
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown, id: number | string = 1) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  }
+}
+
+/** The SDK returns Streamable-HTTP JSON bodies; parse either JSON or a single SSE `data:` frame. */
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  const contentType = res.headers.get("content-type") ?? ""
+  if (contentType.includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+const INITIALIZE_PARAMS = {
+  protocolVersion: "2025-06-18",
+  capabilities: {},
+  clientInfo: { name: "spike-test", version: "0.0.0" },
+}
+
+describe("MCP spike — stateless @hono/mcp transport over Hono", () => {
+  it("responds to initialize with server info and capabilities", async () => {
+    const app = createSpikeMcpApp()
+    const res = await app.request("/", rpc("initialize", INITIALIZE_PARAMS))
+    expect(res.status).toBe(200)
+    const body = await readRpc(res)
+    expect(body.jsonrpc).toBe("2.0")
+    const result = body.result as Record<string, unknown> | undefined
+    expect(result?.serverInfo).toMatchObject({ name: "voyant-mcp-spike" })
+    expect(result?.capabilities).toBeDefined()
+  })
+
+  it("lists the echo tool", async () => {
+    const app = createSpikeMcpApp()
+    const res = await app.request("/", rpc("tools/list", {}))
+    expect(res.status).toBe(200)
+    const body = await readRpc(res)
+    const tools = (body.result as { tools?: Array<{ name: string }> } | undefined)?.tools ?? []
+    expect(tools.map((t) => t.name)).toContain("echo")
+  })
+
+  it("calls the echo tool and returns text content", async () => {
+    const app = createSpikeMcpApp()
+    const res = await app.request(
+      "/",
+      rpc("tools/call", { name: "echo", arguments: { text: "hi" } }),
+    )
+    expect(res.status).toBe(200)
+    const body = await readRpc(res)
+    const content = (body.result as { content?: Array<{ type: string; text: string }> } | undefined)
+      ?.content
+    expect(content?.[0]).toMatchObject({ type: "text", text: "echo: hi" })
+  })
+})

--- a/packages/mcp/tsconfig.build.json
+++ b/packages/mcp/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+}

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/mcp/tsconfig.typecheck.json
+++ b/packages/mcp/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2518,6 +2518,34 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  packages/mcp:
+    dependencies:
+      '@hono/mcp':
+        specifier: ^0.3.0
+        version: 0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.4.3)
+      hono:
+        specifier: 4.12.25
+        version: 4.12.25
+      hono-rate-limiter:
+        specifier: ^0.5.3
+        version: 0.5.3(hono@4.12.25)
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.0(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/mice:
     dependencies:
       '@hono/zod-openapi':
@@ -5558,6 +5586,14 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       vue: ^3.2.0
+
+  '@hono/mcp@0.3.0':
+    resolution: {integrity: sha512-UhSWFbZwRxHBdptOn2r1HyB8Vt6gU+BL3AbTis2t8TBW69ZhG4soJQ09yEL/t/ymxszJnWp5Rq6tOXXOjuK1qg==}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.1
+      hono: 4.12.25
+      hono-rate-limiter: ^0.5.3
+      zod: ^3.25.0 || ^4.0.0
 
   '@hono/node-server@2.0.6':
     resolution: {integrity: sha512-7DeRlKG57JDBNZ5Qj2jwVdgwQy4b0tLubRLl3zCf91/rCf9i7p1V5FtW/yWibm1uUHE493ts9ZXH/7g/LQWl+g==}
@@ -8894,6 +8930,15 @@ packages:
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
     engines: {node: '>=0.10.0'}
+
+  hono-rate-limiter@0.5.3:
+    resolution: {integrity: sha512-M0DxbVMpPELEzLi0AJg1XyBHLGJXz7GySjsPoK+gc5YeeBsdGDGe+2RvVuCAv8ydINiwlbxqYMNxUEyYfRji/A==}
+    peerDependencies:
+      hono: 4.12.25
+      unstorage: ^1.17.3
+    peerDependenciesMeta:
+      unstorage:
+        optional: true
 
   hono@4.12.25:
     resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
@@ -12436,6 +12481,14 @@ snapshots:
       '@tanstack/vue-virtual': 3.13.31(vue@3.5.39(typescript@6.0.3))
       vue: 3.5.39(typescript@6.0.3)
 
+  '@hono/mcp@0.3.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(hono-rate-limiter@0.5.3(hono@4.12.25))(hono@4.12.25)(zod@4.4.3)':
+    dependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      hono: 4.12.25
+      hono-rate-limiter: 0.5.3(hono@4.12.25)
+      pkce-challenge: 5.0.1
+      zod: 4.4.3
+
   '@hono/node-server@2.0.6(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
@@ -12727,6 +12780,28 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 2.0.6(hono@4.12.25)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.25
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -16604,6 +16679,10 @@ snapshots:
     dependencies:
       parse-passwd: 1.0.0
 
+  hono-rate-limiter@0.5.3(hono@4.12.25):
+    dependencies:
+      hono: 4.12.25
+
   hono@4.12.25: {}
 
   hono@4.12.27: {}
@@ -19276,6 +19355,10 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@3.25.76):
     dependencies:
       zod: 3.25.76
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Closes #2795. Part of #2792.

Proves the operator single-worker can serve a real MCP server as a Hono route
group — **stateless, no Durable Object** — using `@modelcontextprotocol/sdk`
`McpServer` + `@hono/mcp`'s web-standard `StreamableHTTPTransport`, under
`nodejs_compat`.

## What
- New `packages/mcp` (private for now) with `src/spike.ts`: a fresh `McpServer` +
  `StreamableHTTPTransport({ sessionIdGenerator: undefined, enableJsonResponse: true })`
  per request, `server.connect(transport)` then `transport.handleRequest(c)`.
- `tests/spike.test.ts`: drives `initialize` / `tools/list` / `tools/call` through
  `app.request()` — all green. No prior init handshake needed per request in
  stateless mode.
- `README.md` records the exact transport wiring the in-deployment adapter (#2798)
  is built on.

## Why this shape
The SDK's own `StreamableHTTPServerTransport` is Node-`http`-oriented; `@hono/mcp`
gives a web-standard transport that mounts cleanly at `/v1/admin/mcp` and survives
the lazy-route `c.var` re-hydration. No Durable Object, no separate worker.

## Verify
`pnpm --filter @voyant-travel/mcp test` · `... typecheck` · `... lint` — all pass.

`src/spike.ts` is throwaway; replaced by `createMcpHonoApp(...)` over the tool
registry in #2798.