### PR TITLE
Reject deleting organizations with linked people

### DIFF
--- a/.changeset/organization-delete-linked-people.md
+++ b/.changeset/organization-delete-linked-people.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/relationships": patch
+---
+
+Reject organization deletion with linked people instead of silently unlinking those people.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -1370,6 +1370,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Organization has linked people",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "deleteAdminRelationshipsOrganizationsById",

--- a/packages/relationships/src/routes/accounts.ts
+++ b/packages/relationships/src/routes/accounts.ts
@@ -254,6 +254,7 @@ const deleteOrganizationRoute = createRoute({
   request: { params: idParamSchema },
   responses: {
     200: { description: "Organization deleted", ...jsonContent(successResponseSchema) },
+    409: { description: "Organization has linked people", ...jsonContent(errorResponseSchema) },
     404: { description: "Organization not found", ...jsonContent(errorResponseSchema) },
   },
 })
@@ -412,6 +413,9 @@ organizationRoutes
   .openapi(deleteOrganizationRoute, async (c) => {
     const id = c.req.valid("param").id
     const row = await relationshipsService.deleteOrganization(c.get("db"), id)
+    if (row && "conflict" in row) {
+      return c.json({ error: "Organization has linked people" }, 409)
+    }
     if (!row) return c.json({ error: "Organization not found" }, 404)
     await emitOrganizationChanged(c.get("eventBus"), { id, action: "deleted" })
     return c.json({ success: true } as const, 200)

--- a/packages/relationships/src/service/accounts-organizations.ts
+++ b/packages/relationships/src/service/accounts-organizations.ts
@@ -1,7 +1,7 @@
 import { and, asc, desc, eq, ilike, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { organizations } from "../schema.js"
+import { organizations, people } from "../schema.js"
 import type {
   CreateOrganizationInput,
   OrganizationListQuery,
@@ -87,10 +87,30 @@ export const organizationAccountsService = {
   },
 
   async deleteOrganization(db: PostgresJsDatabase, id: string) {
-    const [row] = await db
-      .delete(organizations)
-      .where(eq(organizations.id, id))
-      .returning({ id: organizations.id })
-    return row ?? null
+    return db.transaction(async (tx) => {
+      const [organization] = await tx
+        .select({ id: organizations.id })
+        .from(organizations)
+        .where(eq(organizations.id, id))
+        .for("update")
+        .limit(1)
+
+      if (!organization) return null
+
+      const [{ count: linkedPeopleCount } = { count: 0 }] = await tx
+        .select({ count: sql<number>`count(*)::int` })
+        .from(people)
+        .where(eq(people.organizationId, id))
+
+      if (linkedPeopleCount > 0) {
+        return { conflict: "linked_people" as const, linkedPeopleCount }
+      }
+
+      const [row] = await tx
+        .delete(organizations)
+        .where(eq(organizations.id, id))
+        .returning({ id: organizations.id })
+      return row ?? null
+    })
   },
 }

--- a/packages/relationships/tests/integration/accounts-organizations.suite.ts
+++ b/packages/relationships/tests/integration/accounts-organizations.suite.ts
@@ -291,6 +291,35 @@ describe.skipIf(!DB_AVAILABLE)("Organization account routes", () => {
       expect(body.success).toBe(true)
     })
 
+    it("rejects deleting an organization while people are linked", async () => {
+      const createRes = await getApp().request("/organizations", {
+        method: "POST",
+        ...json({ name: "Linked People Org" }),
+      })
+      const { data: organization } = await createRes.json()
+
+      const personRes = await getApp().request("/people", {
+        method: "POST",
+        ...json({
+          firstName: "Linked",
+          lastName: "Person",
+          organizationId: organization.id,
+        }),
+      })
+      expect(personRes.status).toBe(201)
+      const { data: person } = await personRes.json()
+
+      const res = await getApp().request(`/organizations/${organization.id}`, { method: "DELETE" })
+
+      expect(res.status).toBe(409)
+      const body = await res.json()
+      expect(body.error).toBe("Organization has linked people")
+
+      const personAfterDelete = await getApp().request(`/people/${person.id}`, { method: "GET" })
+      expect(personAfterDelete.status).toBe(200)
+      expect((await personAfterDelete.json()).data.organizationId).toBe(organization.id)
+    })
+
     it("returns 404 for non-existent organization", async () => {
       const res = await getApp().request("/organizations/crm_org_00000000000000000000000000", {
         method: "GET",

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -1370,6 +1370,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Organization has linked people",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "deleteAdminRelationshipsOrganizationsById",


### PR DESCRIPTION
## Summary
- return 409 when deleting an organization that still has linked people
- keep linked people attached instead of relying on database set-null behavior
- document the new 409 response in generated admin OpenAPI specs

## Verification
- pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships test -- tests/integration/accounts.test.ts
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check .changeset/organization-delete-linked-people.md packages/relationships/src/service/accounts-organizations.ts packages/relationships/src/routes/accounts.ts packages/relationships/tests/integration/accounts-organizations.suite.ts packages/openapi/spec/admin/relationships.json starters/operator/openapi/admin/relationships.json && git diff --check

Closes #2561