### PR TITLE
Align admin booking payment intents

### DIFF
--- a/.changeset/admin-booking-hold-only.md
+++ b/.changeset/admin-booking-hold-only.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Limit the packaged admin booking journey to hold-only commits until tokenized card, bank-transfer, and agency-credit checkout flows are wired.

--- a/packages/bookings-react/src/admin/booking-journey-host.tsx
+++ b/packages/bookings-react/src/admin/booking-journey-host.tsx
@@ -179,14 +179,15 @@ export function BookingJourneyHost({
         ...(board ? { board } : {}),
       }}
       defaultBuyerType="B2B"
-      // Operator payment options: hold (reserve, collect later), online payment
-      // link (the customer pays via the hosted PSP page — we never charge a card
-      // instantly here), bank transfer, and agency credit.
+      // The admin in-process commit route can reserve/hold bookings. Tokenized
+      // card charges, bank-transfer checkout instructions, and agency-credit
+      // account collection are separate flows that this packaged host does not
+      // wire yet, so do not advertise them here.
       paymentCapabilities={{
-        acceptsCard: true,
+        acceptsCard: false,
         acceptsHold: true,
-        acceptsBankTransfer: true,
-        acceptsTicketOnCredit: true,
+        acceptsBankTransfer: false,
+        acceptsTicketOnCredit: false,
       }}
       entitySummary={entitySummary}
       className={className}

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -60,6 +60,17 @@ export function resolveInitialStatus(draft: Draft): "draft" | "confirmed" | "awa
   return fullyPaid ? "confirmed" : "awaiting_payment"
 }
 
+/**
+ * The packaged admin journey's in-process commit route can only create a held
+ * booking. Other payment intents need a dedicated checkout/provider flow
+ * because the route contract requires fields the generic draft does not carry
+ * (`tokenizedCard`, `agencyAccount`, bank-transfer instructions, etc.).
+ */
+export function buildCommitPaymentIntent(draft: Draft): { type: "hold" } {
+  if (draft.payment.intent === "hold") return { type: "hold" }
+  throw new Error(`Unsupported booking payment intent: ${draft.payment.intent}`)
+}
+
 export function isStepVisible(step: JourneyStep, shape: BookingDraftShape): boolean {
   const subSteps = shape.configureSubSteps ?? []
   switch (step) {

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -38,6 +38,7 @@ import {
 } from "../types.js"
 import {
   buildCommitParty,
+  buildCommitPaymentIntent,
   canAdvanceFromStep,
   defaultMinimalShape,
   isStepVisible,
@@ -380,7 +381,7 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
       // draft — without this the create rejects with "no billing person/org".
       party: buildCommitParty(draft),
       initialStatus: resolveInitialStatus(draft),
-      paymentIntent: { type: draft.payment.intent === "card" ? "card" : "hold" } as never,
+      paymentIntent: buildCommitPaymentIntent(draft),
     })
   }
 

--- a/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
+++ b/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   buildCommitParty,
+  buildCommitPaymentIntent,
   canAdvanceFromStep,
   defaultMinimalShape,
 } from "../../src/journey/components/booking-journey-rules.js"
@@ -99,6 +100,17 @@ describe("booking-journey-rules", () => {
         },
       },
     })
+  })
+
+  it("builds only supported in-process commit payment intents", () => {
+    expect(buildCommitPaymentIntent(emptyDraft(ENTITY))).toEqual({ type: "hold" })
+
+    expect(() =>
+      buildCommitPaymentIntent({
+        ...emptyDraft(ENTITY),
+        payment: { intent: "card" },
+      }),
+    ).toThrow("Unsupported booking payment intent: card")
   })
 
   it("blocks payment advancement when an already-paid row has no payment date", () => {


### PR DESCRIPTION
## Summary
- limit the packaged admin booking journey to hold-only payment capabilities until card/link, bank-transfer, and agency-credit flows collect the required backend fields
- stop silently coercing non-hold draft intents into hold during in-process commit
- add a changeset for `@voyant-travel/bookings-react`

Closes #2426

## Verification
- `pnpm --filter @voyant-travel/bookings-react test -- tests/unit/booking-journey-rules.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck`
- `pnpm --filter @voyant-travel/bookings-react lint`