### PR TITLE
Agent tools: extend api-key scopes + audience grant + mint-time validation

### DIFF
--- a/.changeset/agent-tools-scope-audience.md
+++ b/.changeset/agent-tools-scope-audience.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/types": minor
+"@voyant-travel/core": minor
+"@voyant-travel/hono": minor
+"@voyant-travel/auth": minor
+---
+
+Extend the api-key permission grammar for fine-grained agent operations and carry
+an audience on the key grant.
+
+- `@voyant-travel/types`: add `cancel`/`refund`/`void`/`publish`/`send` actions and
+  `dashboard`/`content`/`media`/`bookings-pii` resources (with descriptor groups);
+  PII resources are never satisfied by the `*` wildcard; add `assertKnownPermissions`
+  and `API_KEY_GRANT_PRESETS` (a scope subset bundled with an audience).
+- `@voyant-travel/core`: add `audience` to `VoyantAuthContext`.
+- `@voyant-travel/hono`: derive an API key's audience from its grant metadata and let
+  the request actor follow it (replacing the hardcoded staff default).
+- `@voyant-travel/auth`: validate permission strings and audience at key-mint time and
+  resolve grant presets.

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -106,6 +106,7 @@
   "dependencies": {
     "@better-auth/api-key": "1.6.22",
     "@voyant-travel/db": "workspace:^",
+    "@voyant-travel/types": "workspace:^",
     "@voyant-travel/utils": "workspace:^",
     "better-auth": "1.6.22",
     "drizzle-orm": "catalog:"

--- a/packages/auth/src/api-token-create.ts
+++ b/packages/auth/src/api-token-create.ts
@@ -1,0 +1,107 @@
+import {
+  API_KEY_AUDIENCES,
+  API_KEY_GRANT_PRESETS,
+  type ApiKeyGrantPresetKey,
+  type ApiKeyPermissions,
+  assertKnownPermissions,
+  UnknownApiKeyPermissionError,
+} from "@voyant-travel/types/api-keys"
+
+/** Fields accepted on a create-API-token request body (allowlist). */
+export const API_TOKEN_CREATE_FIELDS = [
+  "configId",
+  "name",
+  "expiresIn",
+  "remaining",
+  "prefix",
+  "organizationId",
+  "metadata",
+  "permissions",
+] as const
+
+/** Pick an allowlisted subset of a request body. */
+export function pickFields(
+  body: Record<string, unknown>,
+  fields: readonly string[],
+): Record<string, unknown> {
+  const next: Record<string, unknown> = {}
+  for (const field of fields) {
+    if (body[field] !== undefined) next[field] = body[field]
+  }
+  return next
+}
+
+/** Thrown when a create body carries an invalid grant preset, permission, or audience (→ 400). */
+export class ApiTokenValidationError extends Error {}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/** Union two permission maps (used to layer explicit permissions over a preset's). */
+function mergePermissions(
+  base: ApiKeyPermissions,
+  extra: ApiKeyPermissions | undefined,
+): ApiKeyPermissions {
+  const out: ApiKeyPermissions = {}
+  for (const [resource, actions] of Object.entries(base)) out[resource] = [...actions]
+  if (extra) {
+    for (const [resource, actions] of Object.entries(extra)) {
+      out[resource] = Array.from(new Set([...(out[resource] ?? []), ...actions]))
+    }
+  }
+  return out
+}
+
+/**
+ * Build the `createApiKey` body from a request body: resolve an optional
+ * `grantPreset` (permissions subset + audience), validate all permission strings
+ * against the known resource/action taxonomy, and validate the grant audience.
+ * Throws {@link ApiTokenValidationError} (→ 400) on any invalid input.
+ */
+export function buildApiTokenCreateBody(body: Record<string, unknown>): Record<string, unknown> {
+  const fields = pickFields(body, API_TOKEN_CREATE_FIELDS)
+  const metadata: Record<string, unknown> = isPlainObject(fields.metadata)
+    ? { ...fields.metadata }
+    : {}
+
+  const presetKey = typeof body.grantPreset === "string" ? body.grantPreset : undefined
+  if (presetKey !== undefined) {
+    const preset = API_KEY_GRANT_PRESETS[presetKey as ApiKeyGrantPresetKey]
+    if (!preset) {
+      throw new ApiTokenValidationError(
+        `Unknown grant preset "${presetKey}". Known presets: ${Object.keys(API_KEY_GRANT_PRESETS).join(", ")}.`,
+      )
+    }
+    fields.permissions = mergePermissions(
+      preset.permissions,
+      isPlainObject(fields.permissions) ? (fields.permissions as ApiKeyPermissions) : undefined,
+    )
+    if (metadata.audience === undefined) metadata.audience = preset.audience
+  }
+
+  if (fields.permissions !== undefined) {
+    try {
+      assertKnownPermissions(fields.permissions as ApiKeyPermissions)
+    } catch (error) {
+      if (error instanceof UnknownApiKeyPermissionError) {
+        throw new ApiTokenValidationError(error.message)
+      }
+      throw error
+    }
+  }
+
+  if (metadata.audience !== undefined) {
+    if (
+      typeof metadata.audience !== "string" ||
+      !(API_KEY_AUDIENCES as readonly string[]).includes(metadata.audience)
+    ) {
+      throw new ApiTokenValidationError(
+        `Invalid audience "${String(metadata.audience)}". Allowed: ${API_KEY_AUDIENCES.join(", ")}.`,
+      )
+    }
+    fields.metadata = metadata
+  }
+
+  return fields
+}

--- a/packages/auth/src/auth-facades.ts
+++ b/packages/auth/src/auth-facades.ts
@@ -2,6 +2,7 @@ import type { getDb } from "@voyant-travel/db"
 import { authMember, authSession, authUser } from "@voyant-travel/db/schema/iam"
 import { and, asc, eq } from "drizzle-orm"
 
+import { ApiTokenValidationError, buildApiTokenCreateBody, pickFields } from "./api-token-create.js"
 import {
   type ApiTokenRotationOptions,
   type ApiTokenRotationStore,
@@ -104,17 +105,6 @@ const API_TOKEN_QUERY_FIELDS = [
   "offset",
   "sortBy",
   "sortDirection",
-] as const
-
-const API_TOKEN_CREATE_FIELDS = [
-  "configId",
-  "name",
-  "expiresIn",
-  "remaining",
-  "prefix",
-  "organizationId",
-  "metadata",
-  "permissions",
 ] as const
 
 const API_TOKEN_UPDATE_FIELDS = [
@@ -248,17 +238,6 @@ async function readOptionalJson(request: Request): Promise<Record<string, unknow
   return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
     ? (parsed as Record<string, unknown>)
     : {}
-}
-
-function pickFields(
-  body: Record<string, unknown>,
-  fields: readonly string[],
-): Record<string, unknown> {
-  const next: Record<string, unknown> = {}
-  for (const field of fields) {
-    if (body[field] !== undefined) next[field] = body[field]
-  }
-  return next
 }
 
 async function requireApiTokenSession(auth: BetterAuthApiTokenManagement, headers: Headers) {
@@ -473,9 +452,18 @@ export async function handleApiTokenManagementRequest(
       if (request.method === "POST") {
         const body = await readOptionalJson(request)
         const session = await requireApiTokenSession({ api }, request.headers)
+        let createBody: Record<string, unknown>
+        try {
+          createBody = buildApiTokenCreateBody(body)
+        } catch (error) {
+          if (error instanceof ApiTokenValidationError) {
+            return jsonResponse({ error: error.message }, 400)
+          }
+          throw error
+        }
         const result = await api.createApiKey({
           body: {
-            ...pickFields(body, API_TOKEN_CREATE_FIELDS),
+            ...createBody,
             userId: session.user.id,
           },
         })

--- a/packages/auth/tests/unit/api-tokens.test.ts
+++ b/packages/auth/tests/unit/api-tokens.test.ts
@@ -270,6 +270,60 @@ describe("handleApiTokenManagementRequest", () => {
     expect(auth.api.createApiKey).not.toHaveBeenCalled()
   })
 
+  it("rejects an unknown permission at mint time with 400", async () => {
+    const auth = createAuthMock()
+    const response = await handleApiTokenManagementRequest(
+      new Request("https://example.com/auth/api-tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "typo", permissions: { bananas: ["read"] } }),
+      }),
+      auth,
+    )
+
+    expect(response?.status).toBe(400)
+    expect(await responseJson(response)).toMatchObject({
+      error: expect.stringContaining("bananas"),
+    })
+    expect(auth.api.createApiKey).not.toHaveBeenCalled()
+  })
+
+  it("rejects an invalid audience at mint time with 400", async () => {
+    const auth = createAuthMock()
+    const response = await handleApiTokenManagementRequest(
+      new Request("https://example.com/auth/api-tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "bad-aud", metadata: { audience: "robot" } }),
+      }),
+      auth,
+    )
+
+    expect(response?.status).toBe(400)
+    expect(auth.api.createApiKey).not.toHaveBeenCalled()
+  })
+
+  it("resolves a grant preset into permissions + audience metadata", async () => {
+    const auth = createAuthMock()
+    const response = await handleApiTokenManagementRequest(
+      new Request("https://example.com/auth/api-tokens", {
+        method: "POST",
+        body: JSON.stringify({ name: "public reader", grantPreset: "public-catalog-reader" }),
+      }),
+      auth,
+    )
+
+    expect(response?.status).toBe(201)
+    const call = vi.mocked(auth.api.createApiKey).mock.calls[0]?.[0] as {
+      body: {
+        permissions: Record<string, string[]>
+        metadata: { audience: string }
+        userId: string
+      }
+    }
+    expect(call.body.permissions).toMatchObject({ catalog: ["read", "search"], products: ["read"] })
+    expect(call.body.metadata.audience).toBe("customer")
+    expect(call.body.userId).toBe("user_123")
+  })
+
   it("returns 405 for facade paths with unsupported methods", async () => {
     const auth = createAuthMock()
     const response = await handleApiTokenManagementRequest(

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -15,6 +15,13 @@ export interface VoyantAuthContext {
   organizationId?: string | null
   callerType?: VoyantCallerType
   actor?: Actor
+  /**
+   * The audience this grant represents (`staff`/`customer`/`partner`/`supplier`).
+   * Carried on the api-key grant / token claims, not inferred from scopes, and
+   * resolved into the catalog `ResolverScope` at request time. When unset,
+   * middleware falls back to `actor`.
+   */
+  audience?: Actor
   scopes?: string[] | null
   isInternalRequest?: boolean
   apiTokenId?: string

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -1,6 +1,6 @@
-import type { VoyantAuthContext } from "@voyant-travel/core"
+import type { Actor, VoyantAuthContext } from "@voyant-travel/core"
 import { apikeyTable, type SelectApikey } from "@voyant-travel/db/schema/iam"
-import { permissionsToStrings } from "@voyant-travel/types/api-keys"
+import { API_KEY_AUDIENCES, permissionsToStrings } from "@voyant-travel/types/api-keys"
 import type { KVStore } from "@voyant-travel/utils/cache"
 import { and, eq, sql } from "drizzle-orm"
 import type { MiddlewareHandler } from "hono"
@@ -105,6 +105,26 @@ async function writeCachedApiKey(kv: KVStore, keyHash: string, row: SelectApikey
   }
 }
 
+const API_KEY_AUDIENCE_SET = new Set<string>(API_KEY_AUDIENCES)
+
+/**
+ * Extract the grant audience from an API key's `metadata` JSON. Malformed or
+ * absent metadata falls back to `"staff"` (legacy server-to-server default).
+ */
+function resolveApiKeyAudience(metadata: string | null | undefined): Actor {
+  if (!metadata) return "staff"
+  try {
+    const parsed = JSON.parse(metadata) as { audience?: unknown }
+    const value = parsed?.audience
+    if (typeof value === "string" && API_KEY_AUDIENCE_SET.has(value)) {
+      return value as Actor
+    }
+  } catch {
+    // Ignore malformed metadata — fall back to the staff default.
+  }
+  return "staff"
+}
+
 function applyAuthContext(
   c: {
     set: <K extends keyof VoyantVariables>(key: K, value: VoyantVariables[K]) => void
@@ -116,6 +136,7 @@ function applyAuthContext(
   if (auth.organizationId !== undefined) c.set("organizationId", auth.organizationId ?? undefined)
   if (auth.callerType) c.set("callerType", auth.callerType)
   if (auth.actor) c.set("actor", auth.actor)
+  if (auth.audience) c.set("audience", auth.audience)
   if (auth.scopes !== undefined) c.set("scopes", auth.scopes)
   if (auth.isInternalRequest !== undefined) c.set("isInternalRequest", auth.isInternalRequest)
   if (auth.apiTokenId) c.set("apiTokenId", auth.apiTokenId)
@@ -243,6 +264,12 @@ export function requireAuth<TBindings extends VoyantBindings>(
         tryGetExecutionCtx(c)?.waitUntil(counterUpdate)
 
         const scopes = permissionsToStrings(row.permissions)
+        // Audience is a grant attribute carried on the key's `metadata`, not
+        // inferred from scopes (D3). Legacy keys with no audience default to
+        // `staff`, preserving prior server-to-server behaviour. The actor
+        // follows the audience so a non-staff key resolves to its own
+        // visibility pool instead of silently gaining operator privileges.
+        const audience = resolveApiKeyAudience(row.metadata)
 
         applyAuthContext(c, {
           organizationId: row.referenceId,
@@ -250,10 +277,8 @@ export function requireAuth<TBindings extends VoyantBindings>(
           callerType: "api_key",
           apiTokenId: row.id,
           apiKeyId: row.id,
-          // Core-owned API keys (`voy_` prefix) are server-to-server credentials
-          // issued to operator staff. The actor stays explicit here so that
-          // `requireActor` doesn't have to default unset callers to "staff".
-          actor: "staff",
+          actor: audience,
+          audience,
         })
 
         // `await` is load-bearing: with a bare `return next()` the

--- a/packages/types/src/api-keys.ts
+++ b/packages/types/src/api-keys.ts
@@ -1,14 +1,45 @@
 // agent-quality: file-size exception -- owner: types; existing module stays co-located until a dedicated split preserves behavior and tests.
 import { z } from "zod"
 
-export const API_KEY_ACTIONS = ["read", "write", "delete", "trigger", "relay", "search"] as const
+export const API_KEY_ACTIONS = [
+  "read",
+  "write",
+  "delete",
+  "trigger",
+  "relay",
+  "search",
+  // Fine-grained agent operations that used to collapse to `write`/`trigger`.
+  "cancel",
+  "refund",
+  "void",
+  "publish",
+  "send",
+] as const
 
 export type ApiKeyAction = (typeof API_KEY_ACTIONS)[number]
+
+/**
+ * Audiences a grant can represent. Mirrors the `Actor`/`Visibility` unions in
+ * `@voyant-travel/core` / `@voyant-travel/catalog-contracts`, duplicated here so
+ * the low-level `types` package stays dependency-free. Carried on the key grant
+ * and resolved into the catalog `ResolverScope` at request time (never inferred
+ * from the scope set).
+ */
+export const API_KEY_AUDIENCES = ["staff", "customer", "partner", "supplier"] as const
+
+export type ApiKeyAudience = (typeof API_KEY_AUDIENCES)[number]
 
 export const API_KEY_RESOURCES = [
   "availability",
   "bookings",
+  // PII-sensitive booking fields. Split from `bookings` so it can be granted (or
+  // withheld) independently; never covered by the `*` wildcard (see
+  // `PII_API_KEY_RESOURCES` / `hasApiKeyPermission`).
+  "bookings-pii",
   "catalog",
+  "content",
+  "dashboard",
+  "media",
   "crm",
   "cruises",
   "departures",
@@ -33,6 +64,14 @@ export const API_KEY_RESOURCES = [
 ] as const
 
 export type ApiKeyResource = (typeof API_KEY_RESOURCES)[number]
+
+/**
+ * Resources that hold personally-identifiable information. These are **never**
+ * granted through the `*` resource wildcard (not even by a full-access `*:*`
+ * key) — a caller must name the resource explicitly (e.g. `bookings-pii:read`).
+ * Keeps broad read/full grants from silently leaking PII.
+ */
+export const PII_API_KEY_RESOURCES = new Set<string>(["bookings-pii"])
 
 export type ApiKeyPermissions = Record<string, string[]>
 export type ApiKeyPermissionString =
@@ -165,6 +204,25 @@ export const API_KEY_PERMISSION_GROUPS = [
         "delete",
         "Delete bookings",
         "Delete booking-owned records where supported.",
+      ),
+      permission(
+        "bookings",
+        "cancel",
+        "Cancel bookings",
+        "Cancel bookings and trigger cancellation workflows.",
+      ),
+    ],
+  },
+  {
+    resource: "bookings-pii",
+    label: "Booking PII",
+    description: "Personally-identifiable traveller data on bookings. Grant explicitly.",
+    permissions: [
+      permission(
+        "bookings-pii",
+        "read",
+        "Read booking PII",
+        "Read personally-identifiable traveller fields on bookings. Never granted by a wildcard.",
       ),
     ],
   },
@@ -338,6 +396,88 @@ export const API_KEY_PERMISSION_GROUPS = [
       ),
     ],
   },
+  {
+    resource: "finance",
+    label: "Finance",
+    description: "Read and manage invoices, payments, refunds, and voids.",
+    permissions: [
+      permission(
+        "finance",
+        "read",
+        "Read finance",
+        "Read invoices, payments, and settlement state.",
+      ),
+      permission(
+        "finance",
+        "write",
+        "Write finance",
+        "Create or update invoices and payment records.",
+      ),
+      permission(
+        "finance",
+        "refund",
+        "Refund payments",
+        "Issue refunds against captured payments.",
+      ),
+      permission(
+        "finance",
+        "void",
+        "Void documents",
+        "Void invoices or cancel uncaptured payments.",
+      ),
+    ],
+  },
+  {
+    resource: "content",
+    label: "Content",
+    description: "Read, write, and publish editorial content.",
+    permissions: [
+      permission("content", "read", "Read content", "Read editorial content and drafts."),
+      permission("content", "write", "Write content", "Create or update editorial content."),
+      permission("content", "publish", "Publish content", "Publish content to live surfaces."),
+    ],
+  },
+  {
+    resource: "media",
+    label: "Media",
+    description: "Read and manage media assets.",
+    permissions: [
+      permission("media", "read", "Read media", "Read media assets and metadata."),
+      permission("media", "write", "Write media", "Upload or update media assets."),
+    ],
+  },
+  {
+    resource: "notifications",
+    label: "Notifications",
+    description: "Read and send notifications.",
+    permissions: [
+      permission(
+        "notifications",
+        "read",
+        "Read notifications",
+        "Read notification records and status.",
+      ),
+      permission(
+        "notifications",
+        "send",
+        "Send notifications",
+        "Send email/SMS/push notifications.",
+      ),
+    ],
+  },
+  {
+    resource: "dashboard",
+    label: "Dashboard",
+    description: "Read analytics and dashboard data.",
+    permissions: [
+      permission(
+        "dashboard",
+        "read",
+        "Read dashboard",
+        "Read analytics, metrics, and dashboard data.",
+      ),
+    ],
+  },
 ] as const satisfies readonly ApiKeyPermissionGroup[]
 
 export const API_KEY_PERMISSION_PRESETS = {
@@ -390,6 +530,107 @@ export const API_KEY_PERMISSION_PRESETS = {
 >
 
 export type ApiKeyPermissionPresetKey = keyof typeof API_KEY_PERMISSION_PRESETS
+
+/**
+ * Grant presets bundle a scope subset **and** an audience — unlike
+ * `API_KEY_PERMISSION_PRESETS` (permissions only), because audience is a grant
+ * attribute that cannot be inferred from scopes (a `catalog:read` key may be a
+ * `customer` public reader or an internal `staff` tool). Used at key-mint time.
+ */
+export const API_KEY_GRANT_PRESETS = {
+  "agent-customer": {
+    label: "Agent (customer)",
+    description: "Customer-facing agent: read/search catalog + compose trips.",
+    audience: "customer",
+    permissions: {
+      catalog: ["read", "search"],
+      products: ["read"],
+      trips: ["read", "write"],
+    },
+  },
+  "agent-staff": {
+    label: "Agent (staff)",
+    description: "Staff-facing agent: catalog, trips, bookings, quotes.",
+    audience: "staff",
+    permissions: {
+      catalog: ["read", "search"],
+      products: ["read"],
+      trips: ["read", "write"],
+      bookings: ["read", "write"],
+      quotes: ["read", "write"],
+    },
+  },
+  "public-catalog-reader": {
+    label: "Public catalog reader",
+    description: "Read-only, customer-audience catalog access for public surfaces.",
+    audience: "customer",
+    permissions: {
+      catalog: ["read", "search"],
+      products: ["read"],
+    },
+  },
+} as const satisfies Record<
+  string,
+  { label: string; description: string; audience: ApiKeyAudience; permissions: ApiKeyPermissions }
+>
+
+export type ApiKeyGrantPresetKey = keyof typeof API_KEY_GRANT_PRESETS
+
+/** Thrown by `assertKnownPermissions` when a permission names an unknown resource or action. */
+export class UnknownApiKeyPermissionError extends Error {
+  constructor(
+    message: string,
+    public readonly resource?: string,
+    public readonly action?: string,
+  ) {
+    super(message)
+    this.name = "UnknownApiKeyPermissionError"
+  }
+}
+
+const KNOWN_API_KEY_RESOURCES = new Set<string>(API_KEY_RESOURCES)
+const KNOWN_API_KEY_ACTIONS = new Set<string>(API_KEY_ACTIONS)
+
+/**
+ * Validate that every permission names a known resource + action (or a `*`
+ * wildcard). Used at key-mint time so a typo'd scope is rejected instead of
+ * silently accepted (and then never matching anything). Throws
+ * `UnknownApiKeyPermissionError` on the first unknown token.
+ */
+export function assertKnownPermissions(
+  permissions: string | ApiKeyPermissions | null | undefined,
+): void {
+  const normalized = normalizeApiKeyPermissions(permissions)
+  for (const [resource, actions] of Object.entries(normalized)) {
+    if (resource !== "*" && !KNOWN_API_KEY_RESOURCES.has(resource)) {
+      throw new UnknownApiKeyPermissionError(
+        `Unknown API key resource "${resource}". Known resources: ${API_KEY_RESOURCES.join(", ")}.`,
+        resource,
+      )
+    }
+    for (const action of actions) {
+      if (action !== "*" && !KNOWN_API_KEY_ACTIONS.has(action)) {
+        throw new UnknownApiKeyPermissionError(
+          `Unknown API key action "${action}" for resource "${resource}". Known actions: ${API_KEY_ACTIONS.join(", ")}.`,
+          resource,
+          action,
+        )
+      }
+    }
+  }
+}
+
+/** Non-throwing variant of {@link assertKnownPermissions}. */
+export function areKnownPermissions(
+  permissions: string | ApiKeyPermissions | null | undefined,
+): boolean {
+  try {
+    assertKnownPermissions(permissions)
+    return true
+  } catch {
+    return false
+  }
+}
 
 const permissionNamePattern = /^(\*|[a-z][a-z0-9-]*)$/
 const permissionStringPattern = /^(\*|[a-z][a-z0-9-]*):(\*|[a-z][a-z0-9-]*)$/
@@ -492,6 +733,15 @@ export function hasApiKeyPermission(
   const normalized = normalizeApiKeyPermissions(permissions)
   const resourceKey = resource.trim().toLowerCase()
   const actionKey = action.trim().toLowerCase()
+
+  // PII-sensitive resources are never satisfied by the `*` resource wildcard;
+  // only an explicit grant on the resource itself counts.
+  if (PII_API_KEY_RESOURCES.has(resourceKey)) {
+    return (
+      normalized[resourceKey]?.includes("*") === true ||
+      normalized[resourceKey]?.includes(actionKey) === true
+    )
+  }
 
   return (
     normalized["*"]?.includes("*") === true ||

--- a/packages/types/tests/api-keys.test.ts
+++ b/packages/types/tests/api-keys.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest"
 
-import { API_KEY_PERMISSION_GROUPS, API_KEY_RESOURCES } from "../src/api-keys.js"
+import {
+  API_KEY_GRANT_PRESETS,
+  API_KEY_PERMISSION_GROUPS,
+  API_KEY_RESOURCES,
+  areKnownPermissions,
+  assertKnownPermissions,
+  hasApiKeyPermission,
+  UnknownApiKeyPermissionError,
+} from "../src/api-keys.js"
 
 describe("API key permission catalog", () => {
   it("exposes quotes and trips as grantable read/write resources", () => {
@@ -14,6 +22,62 @@ describe("API key permission catalog", () => {
         "read",
         "write",
       ])
+    }
+  })
+
+  it("adds the fine-grained agent resources", () => {
+    for (const resource of ["bookings-pii", "content", "media", "dashboard"]) {
+      expect(API_KEY_RESOURCES).toContain(resource)
+    }
+  })
+})
+
+describe("PII resources are excluded from wildcard grants", () => {
+  it("does not grant bookings-pii via the full-access wildcard", () => {
+    expect(hasApiKeyPermission({ "*": ["*"] }, "bookings-pii", "read")).toBe(false)
+    expect(hasApiKeyPermission({ "*": ["read"] }, "bookings-pii", "read")).toBe(false)
+  })
+
+  it("grants bookings-pii only when named explicitly", () => {
+    expect(hasApiKeyPermission({ "bookings-pii": ["read"] }, "bookings-pii", "read")).toBe(true)
+    expect(hasApiKeyPermission({ "bookings-pii": ["*"] }, "bookings-pii", "read")).toBe(true)
+  })
+
+  it("still grants non-PII resources via the wildcard", () => {
+    expect(hasApiKeyPermission({ "*": ["read"] }, "bookings", "read")).toBe(true)
+    expect(hasApiKeyPermission({ "*": ["*"] }, "finance", "refund")).toBe(true)
+  })
+})
+
+describe("assertKnownPermissions", () => {
+  it("accepts known resources, actions, and wildcards", () => {
+    expect(() =>
+      assertKnownPermissions({
+        bookings: ["read", "cancel"],
+        finance: ["refund", "void"],
+        "*": ["read"],
+      }),
+    ).not.toThrow()
+    expect(() => assertKnownPermissions({ catalog: ["*"] })).not.toThrow()
+  })
+
+  it("rejects an unknown resource", () => {
+    expect(() => assertKnownPermissions({ bananas: ["read"] })).toThrow(
+      UnknownApiKeyPermissionError,
+    )
+    expect(areKnownPermissions({ bananas: ["read"] })).toBe(false)
+  })
+
+  it("rejects an unknown action", () => {
+    expect(() => assertKnownPermissions({ bookings: ["frobnicate"] })).toThrow(
+      UnknownApiKeyPermissionError,
+    )
+  })
+
+  it("validates every grant preset's permissions", () => {
+    for (const preset of Object.values(API_KEY_GRANT_PRESETS)) {
+      expect(() => assertKnownPermissions(preset.permissions)).not.toThrow()
+      expect(["staff", "customer", "partner", "supplier"]).toContain(preset.audience)
     }
   })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -658,6 +658,9 @@ importers:
       '@voyant-travel/db':
         specifier: workspace:^
         version: link:../db
+      '@voyant-travel/types':
+        specifier: workspace:^
+        version: link:../types
       '@voyant-travel/utils':
         specifier: workspace:^
         version: link:../utils


### PR DESCRIPTION
Closes #2796. Part of #2792. Settles design decisions D2 + D3.

## Scope taxonomy (D2) — `@voyant-travel/types`
- New actions: `cancel`, `refund`, `void`, `publish`, `send`.
- New resources: `dashboard`, `content`, `media`, and `bookings-pii` (PII split from
  `bookings`), each with descriptor groups.
- **PII never leaks via wildcards**: `PII_API_KEY_RESOURCES` are excluded from `*`
  (not even `*:*` grants them) — a caller must name `bookings-pii:read` explicitly.
- `assertKnownPermissions` (mint-time validator) + `API_KEY_GRANT_PRESETS` (a scope
  subset bundled with an audience).

## Audience grant (D3)
- `@voyant-travel/core`: `audience` on `VoyantAuthContext`.
- `@voyant-travel/hono`: derive the api-key audience from grant `metadata` and let the
  request `actor` follow it — replacing the hardcoded `actor:"staff"` so a non-staff
  key resolves to its own visibility pool. Legacy keys default to `staff`.

## Mint-time validation — `@voyant-travel/auth`
- Validate permission strings + audience at key creation (400 on unknown), resolve
  grant presets into permissions + audience metadata. Extracted to
  `api-token-create.ts` to keep `auth-facades.ts` within the size gate.

## Verify
Per-package `typecheck` + `test` + `lint` green: types 28, hono 261, auth 86.
Changeset included (minor bump for the four public packages).