### PR TITLE
Preserve person fields on partial patch

### DIFF
--- a/.changeset/people-patch-preserve-fields.md
+++ b/.changeset/people-patch-preserve-fields.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/relationships-contracts": patch
+"@voyant-travel/relationships": patch
+---
+
+Preserve existing person fields when PATCH requests omit create-defaulted status and tags.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -3851,8 +3851,7 @@
                       "active",
                       "inactive",
                       "archived"
-                    ],
-                    "default": "active"
+                    ]
                   },
                   "source": {
                     "type": [
@@ -3870,8 +3869,7 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "default": []
+                    }
                   },
                   "customFields": {
                     "type": "object",

--- a/packages/relationships-contracts/src/validation/accounts.ts
+++ b/packages/relationships-contracts/src/validation/accounts.ts
@@ -121,7 +121,12 @@ export const personCoreSchema = z.object({
 })
 
 export const insertPersonSchema = personCoreSchema
-export const updatePersonSchema = personCoreSchema.partial()
+export const updatePersonSchema = personCoreSchema
+  .extend({
+    status: recordStatusSchema.optional(),
+    tags: z.array(z.string()).optional(),
+  })
+  .partial()
 export const mergePersonSchema = z.object({
   mergeId: z.string().min(1),
 })

--- a/packages/relationships/src/service/accounts-people.ts
+++ b/packages/relationships/src/service/accounts-people.ts
@@ -215,10 +215,13 @@ export const peopleAccountsService = {
   async updatePerson(db: PostgresJsDatabase, id: string, data: UpdatePersonInput) {
     const existing = await this.getPersonById(db, id)
     if (!existing) return null
+    const updates = Object.fromEntries(
+      Object.entries(personBaseFields(data)).filter(([, value]) => value !== undefined),
+    )
 
     await db
       .update(people)
-      .set({ ...personBaseFields(data), updatedAt: new Date() })
+      .set({ ...updates, updatedAt: new Date() })
       .where(eq(people.id, id))
 
     // Pass the request fields through verbatim: syncPersonIdentity leaves

--- a/packages/relationships/tests/integration/accounts-people.suite.ts
+++ b/packages/relationships/tests/integration/accounts-people.suite.ts
@@ -370,6 +370,35 @@ describe.skipIf(!DB_AVAILABLE)("People account routes", () => {
       expect(body.data.firstName).toBe("New")
     })
 
+    it("preserves person status and tags on an empty patch", async () => {
+      const createRes = await getApp().request("/people", {
+        method: "POST",
+        ...json({
+          firstName: "Patch",
+          lastName: "Defaults",
+          relation: "client",
+          status: "inactive",
+          tags: ["qa", "people", "alpha"],
+        }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/people/${created.id}`, {
+        method: "PATCH",
+        ...json({}),
+      })
+
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        firstName: "Patch",
+        lastName: "Defaults",
+        relation: "client",
+        status: "inactive",
+        tags: ["qa", "people", "alpha"],
+      })
+    })
+
     it("preserves contact points on a partial update that omits them (#1971)", async () => {
       const createRes = await getApp().request("/people", {
         method: "POST",

--- a/packages/relationships/tests/unit/validation-accounts.test.ts
+++ b/packages/relationships/tests/unit/validation-accounts.test.ts
@@ -245,6 +245,12 @@ describe("Person schemas", () => {
       const result = updatePersonSchema.parse({ firstName: "Jane" })
       expect(result.firstName).toBe("Jane")
       expect(result.lastName).toBeUndefined()
+      expect(result.status).toBeUndefined()
+      expect(result.tags).toBeUndefined()
+    })
+
+    it("does not apply create defaults to empty updates", () => {
+      expect(updatePersonSchema.parse({})).toEqual({})
     })
 
     it("allows updating identity fields independently", () => {

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -3851,8 +3851,7 @@
                       "active",
                       "inactive",
                       "archived"
-                    ],
-                    "default": "active"
+                    ]
                   },
                   "source": {
                     "type": [
@@ -3870,8 +3869,7 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "default": []
+                    }
                   },
                   "customFields": {
                     "type": "object",


### PR DESCRIPTION
## Summary
- prevent person PATCH schemas from applying create-time defaults for status and tags
- filter omitted person base fields before persisting partial updates
- add regression coverage for empty PATCH preserving inactive status and tags
- regenerate admin OpenAPI PATCH request schemas

## Verification
- pnpm --filter @voyant-travel/relationships-contracts typecheck
- pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships test -- tests/unit/validation-accounts.test.ts tests/integration/accounts.test.ts
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check .changeset/people-patch-preserve-fields.md packages/relationships-contracts/src/validation/accounts.ts packages/relationships/src/service/accounts-people.ts packages/relationships/tests/unit/validation-accounts.test.ts packages/relationships/tests/integration/accounts-people.suite.ts packages/openapi/spec/admin/relationships.json starters/operator/openapi/admin/relationships.json && git diff --check

Closes #2556