### PR TITLE
Agent tools: @voyant-travel/tools transport-neutral contract + registry

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -1,0 +1,27 @@
+# @voyant-travel/tools
+
+The transport-neutral agent tool contract for the Voyant framework (voyant#2792).
+
+Capabilities are authored **once, headless, and scope-gated**; exposure (MCP, remote
+agents, HTTP) is a thin adapter over this contract. Tool handlers return **typed pure
+data** validated by an `outputSchema` — never transport envelopes or presentation.
+
+## Shape
+
+- `defineTool({ name, description, inputSchema, outputSchema, requiredScopes, tier,
+  riskPolicy, handler })` — a headless tool. `Ctx` widens by intersection so a domain
+  injects its services (`ToolContext & { trips: … }`) without this package depending on
+  the domain.
+- `ToolContext` — `{ db, actor, audience, tenantId, resolverScope, waitUntil? }`.
+- `RiskTier` + `RiskPolicy` — **declarative** risk data (destructive / reversible /
+  dry-run / side effects) so remote consumers and the MCP layer gate approvals without
+  executing tool code (D1).
+- `createToolRegistry()` — `register` / `registerAll` / `get` / `names` / `list` /
+  `dispatch`. `dispatch` validates input, runs the handler, then validates output.
+  `list()` returns the discovery manifest with **real JSON Schema** (zod v4
+  `z.toJSONSchema`), `requiredScopes`, `tier`, and `riskPolicy`.
+- Authorization is **not** enforced in the registry — the transport binds each tool's
+  `requiredScopes` to `hasApiKeyPermission` (AND semantics).
+
+The package depends only on `zod`; it never imports `hono`, `catalog`, or any domain
+package.

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@voyant-travel/tools",
+  "version": "0.0.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+  },
+  "dependencies": {
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/tools"
+  }
+}

--- a/packages/tools/src/binding.ts
+++ b/packages/tools/src/binding.ts
@@ -1,0 +1,32 @@
+import type { RiskPolicy, RiskTier } from "./risk.js"
+
+/**
+ * A single tool as advertised on the discovery manifest — pure data a remote
+ * agent client can read to discover, gate, and (later) invoke the tool over the
+ * wire. This is what `ToolRegistry.list()` returns and what the MCP transport
+ * maps into `tools/list`.
+ */
+export interface ToolManifestEntry {
+  name: string
+  description: string
+  /** JSON Schema (draft 2020-12) for the tool input, from `z.toJSONSchema`. */
+  inputSchema: Record<string, unknown>
+  /** Scopes required to call the tool (AND semantics), `resource:action` form. */
+  requiredScopes: readonly string[]
+  tier: RiskTier
+  riskPolicy: RiskPolicy
+}
+
+/** Version of the manifest contract, carried so consumers degrade gracefully. */
+export const TOOL_CONTRACT_VERSION = "2026-07-01" as const
+
+/**
+ * A tool reachable over a versioned remote protocol rather than dispatched
+ * in-process (design decision D1). Modeled now; remote proxying lands later.
+ */
+export interface RemoteToolRef extends ToolManifestEntry {
+  /** Base URL of the remote tool server exposing the manifest + invocation. */
+  baseUrl: string
+  /** Whether to forward the caller's auth to the remote server. */
+  forwardAuth: boolean
+}

--- a/packages/tools/src/context.ts
+++ b/packages/tools/src/context.ts
@@ -1,0 +1,51 @@
+/**
+ * Per-request context passed to every tool handler.
+ *
+ * A deployment constructs this once per agent request (derived from the
+ * request's auth grant) and the transport passes the same context to every
+ * tool dispatch. Domain packages that need injected services extend this by
+ * intersection — e.g. `ToolContext & { trips: TripsToolServices }` — so the
+ * `tools` package itself stays free of any domain dependency.
+ */
+export interface ToolContext {
+  /**
+   * The leased DB client for this request. Typed `unknown` here so the tools
+   * package takes no `@voyant-travel/db` dependency; domain handlers cast it to
+   * their expected client type.
+   */
+  db: unknown
+  /** The actor making the request. Drives visibility filtering. */
+  actor: Visibility
+  /**
+   * The audience this grant represents. Carried on the key grant, not inferred
+   * from scopes. Usually equal to `actor`; kept distinct so a staff key can act
+   * on behalf of a customer audience.
+   */
+  audience: Visibility
+  /** Tenant / operator identifier — usually synthesized into provenance. */
+  tenantId: string
+  /** Default resolver scope for tools that need locale / audience / market. */
+  resolverScope: ResolverScope
+  /** Optional runtime hook to keep the isolate alive for background work. */
+  waitUntil?(promise: Promise<unknown>): void
+}
+
+/**
+ * Who a request represents. Mirrors the `Actor`/`Visibility` unions in
+ * `@voyant-travel/core` / `@voyant-travel/catalog-contracts`, defined locally so
+ * the `tools` package has no cross-package dependency. Structurally assignable
+ * to/from those types.
+ */
+export type Visibility = "staff" | "customer" | "partner" | "supplier"
+
+/**
+ * Structural mirror of `@voyant-travel/catalog`'s `ResolverScope`. Declared here
+ * (rather than imported) to avoid a runtime dependency on the heavy catalog
+ * package; the operator-built scope is structurally assignable.
+ */
+export interface ResolverScope {
+  locale: string
+  audience: Visibility
+  market: string
+  actor: Visibility
+}

--- a/packages/tools/src/define-tool.ts
+++ b/packages/tools/src/define-tool.ts
@@ -1,0 +1,51 @@
+import type { z } from "zod"
+
+import type { ToolContext } from "./context.js"
+import type { RiskPolicy, RiskTier } from "./risk.js"
+
+/**
+ * A transport-neutral, headless tool definition. The handler returns **typed
+ * pure data** validated by `outputSchema` — no transport envelopes, no
+ * presentation. Exposure (MCP, remote agent, HTTP) is a thin adapter over this.
+ *
+ * @typeParam In - the parsed input type (from `inputSchema`).
+ * @typeParam Out - the pure-data output type (validated by `outputSchema`).
+ * @typeParam Ctx - the context type; domains widen it by intersection to inject
+ *   services, e.g. `ToolContext & { trips: TripsToolServices }`.
+ */
+export interface ToolDefinition<In, Out, Ctx extends ToolContext = ToolContext> {
+  /** Tool name surfaced to the agent. Convention: snake_case. */
+  name: string
+  /** Human-readable description shown to the agent. */
+  description: string
+  /**
+   * Zod schema validating + typing the args. Keep it serialization-friendly
+   * (avoid top-level `.transform()`/`.refine()`) so `z.toJSONSchema` can emit a
+   * faithful manifest for remote consumers.
+   */
+  inputSchema: z.ZodType<In>
+  /** Zod schema validating the handler's return value (pure data). */
+  outputSchema: z.ZodType<Out>
+  /**
+   * Scopes required to call this tool, in `resource:action` form (from
+   * `@voyant-travel/types` `API_KEY_RESOURCES`/`API_KEY_ACTIONS`). Enforced by
+   * the transport with AND semantics — the caller must hold **all** of them.
+   */
+  requiredScopes: readonly string[]
+  /** Coarse risk tier. */
+  tier: RiskTier
+  /** Declarative risk policy (destructive / reversible / dry-run / side effects). */
+  riskPolicy: RiskPolicy
+  /** The implementation — receives parsed args + context, returns pure data. */
+  handler(args: In, ctx: Ctx): Promise<Out>
+}
+
+/**
+ * Identity helper that defines a tool while preserving its generics. Purely for
+ * ergonomics + inference; returns the definition unchanged.
+ */
+export function defineTool<In, Out, Ctx extends ToolContext = ToolContext>(
+  def: ToolDefinition<In, Out, Ctx>,
+): ToolDefinition<In, Out, Ctx> {
+  return def
+}

--- a/packages/tools/src/errors.ts
+++ b/packages/tools/src/errors.ts
@@ -1,0 +1,58 @@
+import type { Visibility } from "./context.js"
+
+export type ToolErrorCode =
+  | "MISSING_SERVICE"
+  | "AUTHORIZATION_DENIED"
+  | "NOT_FOUND"
+  | "INVALID_INPUT"
+  | "INVALID_OUTPUT"
+  | "PROVIDER_ERROR"
+
+/**
+ * Standard error for tool failures. The transport adapter catches these and
+ * translates them into its own error envelope (e.g. an MCP `isError` result).
+ * The core stays transport-neutral — no `content[]` envelope here.
+ */
+export class ToolError extends Error {
+  constructor(
+    message: string,
+    public readonly code: ToolErrorCode,
+    public readonly meta?: Record<string, unknown>,
+  ) {
+    super(message)
+    this.name = "ToolError"
+  }
+}
+
+/**
+ * Assert that a required injected service is present on the context. Throws
+ * `MISSING_SERVICE` if not — the deployment forgot to wire it.
+ */
+export function requireService<T>(service: T | undefined, name: string): T {
+  if (!service) {
+    throw new ToolError(
+      `Tool requires the "${name}" service to be wired into the context, but it was not provided.`,
+      "MISSING_SERVICE",
+      { service: name },
+    )
+  }
+  return service
+}
+
+/**
+ * Enforce per-actor audience authorization. Non-staff actors may only query
+ * their own audience pool; staff may federate across pools.
+ */
+export function enforceAudienceAuthorization(
+  actor: Visibility,
+  requestedAudiences?: readonly string[],
+): void {
+  if (!requestedAudiences || requestedAudiences.length === 0) return
+  if (actor === "staff") return
+  if (requestedAudiences.length === 1 && requestedAudiences[0] === actor) return
+  throw new ToolError(
+    `Actor "${actor}" is not authorized to query audiences ${JSON.stringify(requestedAudiences)}. Non-staff actors may only query their own audience pool.`,
+    "AUTHORIZATION_DENIED",
+    { actor, requestedAudiences },
+  )
+}

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,0 +1,22 @@
+export {
+  type RemoteToolRef,
+  TOOL_CONTRACT_VERSION,
+  type ToolManifestEntry,
+} from "./binding.js"
+export type { ResolverScope, ToolContext, Visibility } from "./context.js"
+export { defineTool, type ToolDefinition } from "./define-tool.js"
+export {
+  enforceAudienceAuthorization,
+  requireService,
+  ToolError,
+  type ToolErrorCode,
+} from "./errors.js"
+export { createToolRegistry, type ToolRegistry } from "./registry.js"
+export {
+  READ_ONLY_RISK,
+  RISK_TIERS,
+  type RiskPolicy,
+  type RiskTier,
+  TOOL_SIDE_EFFECTS,
+  type ToolSideEffect,
+} from "./risk.js"

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -1,0 +1,128 @@
+import { z } from "zod"
+
+import type { ToolManifestEntry } from "./binding.js"
+import type { ToolContext } from "./context.js"
+import type { ToolDefinition } from "./define-tool.js"
+import { ToolError } from "./errors.js"
+
+// biome-ignore lint/suspicious/noExplicitAny: the registry is a heterogeneous container over each tool's distinct input/output/context types.
+type AnyToolDefinition = ToolDefinition<any, any, any>
+
+/**
+ * Transport-neutral registry of headless tools. Any domain package registers a
+ * tool array here (mirroring how modules mount routes); a transport adapter
+ * enumerates `list()` and dispatches by name. Authorization is **not** enforced
+ * here — that stays in the transport, bound to each tool's `requiredScopes`.
+ */
+export interface ToolRegistry {
+  /** Register a tool. Throws on duplicate name. */
+  register(def: AnyToolDefinition): void
+  /** Register many tools. */
+  registerAll(defs: readonly AnyToolDefinition[]): void
+  /** Look up a registered tool by name. */
+  get(name: string): AnyToolDefinition | undefined
+  /** All registered tool names. */
+  names(): string[]
+  /** The discovery manifest — pure data for `tools/list` and remote consumers. */
+  list(): ToolManifestEntry[]
+  /**
+   * Dispatch a tool by name: validate args against `inputSchema`, run the
+   * handler, validate the result against `outputSchema`, return pure data.
+   * Throws {@link ToolError} on unknown tool / invalid input / invalid output /
+   * handler failure.
+   */
+  dispatch<Out = unknown>(name: string, args: unknown, ctx: ToolContext): Promise<Out>
+}
+
+export function createToolRegistry(): ToolRegistry {
+  const tools = new Map<string, AnyToolDefinition>()
+
+  return {
+    register(def) {
+      if (tools.has(def.name)) {
+        throw new Error(`Tool "${def.name}" is already registered`)
+      }
+      tools.set(def.name, def)
+    },
+    registerAll(defs) {
+      for (const def of defs) this.register(def)
+    },
+    get(name) {
+      return tools.get(name)
+    },
+    names() {
+      return Array.from(tools.keys())
+    },
+    list() {
+      return Array.from(tools.values()).map(toManifestEntry)
+    },
+    async dispatch(name, args, ctx) {
+      const tool = tools.get(name)
+      if (!tool) {
+        throw new ToolError(
+          `Tool "${name}" is not registered. Known tools: ${Array.from(tools.keys()).join(", ") || "(none)"}`,
+          "NOT_FOUND",
+          { name },
+        )
+      }
+
+      const input = tool.inputSchema.safeParse(args)
+      if (!input.success) {
+        throw new ToolError(
+          `Invalid input for tool "${name}": ${input.error.message}`,
+          "INVALID_INPUT",
+          {
+            issues: input.error.issues,
+          },
+        )
+      }
+
+      let result: unknown
+      try {
+        result = await tool.handler(input.data, ctx)
+      } catch (err) {
+        if (err instanceof ToolError) throw err
+        const message = err instanceof Error ? err.message : String(err)
+        throw new ToolError(`Tool "${name}" failed: ${message}`, "PROVIDER_ERROR")
+      }
+
+      const output = tool.outputSchema.safeParse(result)
+      if (!output.success) {
+        throw new ToolError(
+          `Tool "${name}" returned output that failed its outputSchema: ${output.error.message}`,
+          "INVALID_OUTPUT",
+          { issues: output.error.issues },
+        )
+      }
+      return output.data as never
+    },
+  }
+}
+
+function toManifestEntry(tool: AnyToolDefinition): ToolManifestEntry {
+  return {
+    name: tool.name,
+    description: tool.description,
+    inputSchema: toInputJsonSchema(tool),
+    requiredScopes: tool.requiredScopes,
+    tier: tool.tier,
+    riskPolicy: tool.riskPolicy,
+  }
+}
+
+/**
+ * Serialize a tool's `inputSchema` to JSON Schema via zod v4's native
+ * `z.toJSONSchema`. A non-serializable schema (e.g. a top-level transform)
+ * degrades to a permissive object rather than breaking the whole manifest.
+ */
+function toInputJsonSchema(tool: AnyToolDefinition): Record<string, unknown> {
+  try {
+    return z.toJSONSchema(tool.inputSchema) as Record<string, unknown>
+  } catch {
+    return {
+      type: "object",
+      description: `Input schema for "${tool.name}" is not JSON-Schema-serializable; validated server-side.`,
+      additionalProperties: true,
+    }
+  }
+}

--- a/packages/tools/src/risk.ts
+++ b/packages/tools/src/risk.ts
@@ -1,0 +1,53 @@
+/**
+ * Declarative risk metadata for a tool (design decision D1).
+ *
+ * Risk/confirmation is **data on the manifest**, not an in-process predicate, so
+ * a remote agent client and the MCP layer can enforce approval gates without
+ * executing tool code. Where a real preview is needed, expose it as a separate
+ * classify/preview tool rather than a serialized function.
+ */
+
+export const RISK_TIERS = ["read", "write", "sensitive", "destructive"] as const
+
+/**
+ * Coarse risk tier:
+ * - `read` — no state change.
+ * - `write` — creates/updates reversible state.
+ * - `sensitive` — exposes or handles PII / privileged data.
+ * - `destructive` — irreversible or externally-committing (payment, booking).
+ */
+export type RiskTier = (typeof RISK_TIERS)[number]
+
+export const TOOL_SIDE_EFFECTS = [
+  "payment",
+  "refund",
+  "email",
+  "sms",
+  "push",
+  "external-booking",
+  "data-write",
+  "data-delete",
+] as const
+
+export type ToolSideEffect = (typeof TOOL_SIDE_EFFECTS)[number]
+
+/** Declarative risk policy carried on the tool manifest. */
+export interface RiskPolicy {
+  /** Whether the tool commits an irreversible or externally-visible change. */
+  destructive: boolean
+  /** Whether the effect can be undone by a later tool call. */
+  reversible: boolean
+  /** Whether the tool offers a dry-run preview mode. */
+  dryRunSupported: boolean
+  /** Whether a client should require explicit user confirmation before calling. */
+  confirmationRequired?: boolean
+  /** The categories of side effect this tool may produce. */
+  sideEffects?: readonly ToolSideEffect[]
+}
+
+/** A conventional read-only, side-effect-free risk policy. */
+export const READ_ONLY_RISK: RiskPolicy = {
+  destructive: false,
+  reversible: true,
+  dryRunSupported: false,
+}

--- a/packages/tools/tests/registry.test.ts
+++ b/packages/tools/tests/registry.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import {
+  createToolRegistry,
+  defineTool,
+  READ_ONLY_RISK,
+  type ToolContext,
+  ToolError,
+} from "../src/index.js"
+
+const ctx: ToolContext = {
+  db: {},
+  actor: "staff",
+  audience: "staff",
+  tenantId: "t1",
+  resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+}
+
+const echoTool = defineTool({
+  name: "echo",
+  description: "Echo the input text back.",
+  inputSchema: z.object({ text: z.string() }),
+  outputSchema: z.object({ text: z.string() }),
+  requiredScopes: ["catalog:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ text }) {
+    return { text: `echo: ${text}` }
+  },
+})
+
+describe("createToolRegistry", () => {
+  it("registers and dispatches a tool, validating input and output", async () => {
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+
+    const result = await registry.dispatch<{ text: string }>("echo", { text: "hi" }, ctx)
+    expect(result).toEqual({ text: "echo: hi" })
+    expect(registry.names()).toEqual(["echo"])
+  })
+
+  it("throws NOT_FOUND for an unregistered tool", async () => {
+    const registry = createToolRegistry()
+    await expect(registry.dispatch("missing", {}, ctx)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    })
+  })
+
+  it("throws INVALID_INPUT when args fail the input schema", async () => {
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+    await expect(registry.dispatch("echo", { text: 42 }, ctx)).rejects.toBeInstanceOf(ToolError)
+    await expect(registry.dispatch("echo", { text: 42 }, ctx)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+    })
+  })
+
+  it("throws INVALID_OUTPUT when a handler returns data failing the output schema", async () => {
+    const registry = createToolRegistry()
+    registry.register(
+      defineTool({
+        name: "bad",
+        description: "Returns the wrong shape.",
+        inputSchema: z.object({}),
+        outputSchema: z.object({ n: z.number() }),
+        requiredScopes: ["catalog:read"],
+        tier: "read",
+        riskPolicy: READ_ONLY_RISK,
+        // @ts-expect-error -- intentionally wrong return shape to exercise output validation
+        async handler() {
+          return { n: "not-a-number" }
+        },
+      }),
+    )
+    await expect(registry.dispatch("bad", {}, ctx)).rejects.toMatchObject({
+      code: "INVALID_OUTPUT",
+    })
+  })
+
+  it("throws on duplicate registration", () => {
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+    expect(() => registry.register(echoTool)).toThrow(/already registered/)
+  })
+
+  it("emits a discovery manifest with real JSON Schema, scopes, tier, and risk", () => {
+    const registry = createToolRegistry()
+    registry.register(echoTool)
+    const [entry] = registry.list()
+    expect(entry?.name).toBe("echo")
+    expect(entry?.requiredScopes).toEqual(["catalog:read"])
+    expect(entry?.tier).toBe("read")
+    expect(entry?.riskPolicy).toEqual(READ_ONLY_RISK)
+    // zod v4 native JSON Schema serialization.
+    expect(entry?.inputSchema).toMatchObject({
+      type: "object",
+      properties: { text: { type: "string" } },
+      required: ["text"],
+    })
+  })
+
+  it("surfaces a ToolError thrown by a handler unchanged", async () => {
+    const registry = createToolRegistry()
+    registry.register(
+      defineTool({
+        name: "denies",
+        description: "Always denies.",
+        inputSchema: z.object({}),
+        outputSchema: z.object({}),
+        requiredScopes: ["catalog:read"],
+        tier: "read",
+        riskPolicy: READ_ONLY_RISK,
+        async handler() {
+          throw new ToolError("nope", "AUTHORIZATION_DENIED")
+        },
+      }),
+    )
+    await expect(registry.dispatch("denies", {}, ctx)).rejects.toMatchObject({
+      code: "AUTHORIZATION_DENIED",
+    })
+  })
+})

--- a/packages/tools/tsconfig.build.json
+++ b/packages/tools/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+}

--- a/packages/tools/tsconfig.json
+++ b/packages/tools/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/tools/tsconfig.typecheck.json
+++ b/packages/tools/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/tools/vitest.config.ts
+++ b/packages/tools/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+    passWithNoTests: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3626,6 +3626,22 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.0(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
 
+  packages/tools:
+    dependencies:
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.0(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/trips:
     dependencies:
       '@hono/zod-openapi':


### PR DESCRIPTION
Closes #2797. Part of #2792.

New headless, **zod-only** package — the transport-neutral tool contract that the
MCP server (#2798) and every domain migration build on.

- `defineTool` / `ToolDefinition<In, Out, Ctx>` returning **typed pure data** (no
  transport envelopes); `Ctx` widens by intersection so domains inject services.
- `ToolContext` (`db`/`actor`/`audience`/`tenantId`/`resolverScope`) with a structural
  `ResolverScope` — no dependency on the heavy catalog package.
- Declarative `RiskTier` + `RiskPolicy` (D1): destructive / reversible / dry-run /
  side-effects as data, so remote consumers and the MCP layer gate approvals without
  executing tool code.
- `createToolRegistry`: `register` / `list` / `dispatch` with input **and** output
  validation; `list()` emits a discovery manifest with real JSON Schema (zod v4
  `z.toJSONSchema`), `requiredScopes`, `tier`, `riskPolicy`. Authorization stays in the
  transport (bound to `requiredScopes`).

Private for now; a publish-readiness pass (private→public, `publishConfig.exports`,
changesets) precedes the umbrella→main merge.

## Verify
`pnpm --filter @voyant-travel/tools test` (7) · `typecheck` · `lint` — all green.