### PR TITLE
Sync person relationship inverse pairs

### DIFF
--- a/.changeset/person-relationship-inverse-sync.md
+++ b/.changeset/person-relationship-inverse-sync.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/relationships": patch
+"@voyant-travel/relationships-react": patch
+---
+
+Keep person relationship auto-inverse pairs synchronized when either side is updated or deleted.

--- a/packages/relationships-react/src/components/person-relationships-section.tsx
+++ b/packages/relationships-react/src/components/person-relationships-section.tsx
@@ -139,8 +139,8 @@ export function PersonRelationshipsSection({ personId }: PersonRelationshipsSect
     outgoing?: PersonRelationshipRecord
     incoming?: PersonRelationshipRecord
   }) => {
-    const ids = [entry.outgoing?.id, entry.incoming?.id].filter((id): id is string => Boolean(id))
-    for (const id of ids) mutation.remove.mutate(id)
+    const id = entry.outgoing?.id ?? entry.incoming?.id
+    if (id) mutation.remove.mutate(id)
   }
 
   const handleSubmit = async (draft: DraftState) => {

--- a/packages/relationships/src/service/person-relationships.ts
+++ b/packages/relationships/src/service/person-relationships.ts
@@ -1,4 +1,4 @@
-import { and, asc, eq, or } from "drizzle-orm"
+import { and, asc, eq, isNull, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
 
@@ -130,6 +130,18 @@ export const personRelationshipsService = {
               personRelationships.kind,
             ],
           })
+
+        await tx
+          .update(personRelationships)
+          .set({ inverseKind: rest.kind, updatedAt: new Date() })
+          .where(
+            and(
+              eq(personRelationships.fromPersonId, toPersonId),
+              eq(personRelationships.toPersonId, fromPersonId),
+              eq(personRelationships.kind, inverseKind),
+              isNull(personRelationships.inverseKind),
+            ),
+          )
       }
 
       return primary
@@ -141,19 +153,97 @@ export const personRelationshipsService = {
     id: string,
     data: UpdatePersonRelationshipInput,
   ) {
-    const [row] = await db
-      .update(personRelationships)
-      .set({ ...data, updatedAt: new Date() })
-      .where(eq(personRelationships.id, id))
-      .returning()
-    return row ?? null
+    return db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(personRelationships)
+        .where(eq(personRelationships.id, id))
+        .for("update")
+        .limit(1)
+      if (!existing) return null
+
+      const updatedAt = new Date()
+      const [row] = await tx
+        .update(personRelationships)
+        .set({ ...data, updatedAt })
+        .where(eq(personRelationships.id, id))
+        .returning()
+
+      if (existing.inverseKind) {
+        const [inverse] = await tx
+          .select()
+          .from(personRelationships)
+          .where(
+            and(
+              eq(personRelationships.fromPersonId, existing.toPersonId),
+              eq(personRelationships.toPersonId, existing.fromPersonId),
+              eq(personRelationships.kind, existing.inverseKind),
+              eq(personRelationships.inverseKind, existing.kind),
+            ),
+          )
+          .for("update")
+          .limit(1)
+
+        const inverseUpdates = Object.fromEntries(
+          Object.entries({
+            kind: data.inverseKind ?? undefined,
+            inverseKind: data.kind,
+            startDate: data.startDate,
+            endDate: data.endDate,
+            isPrimary: data.isPrimary,
+            notes: data.notes,
+            metadata: data.metadata,
+            updatedAt,
+          }).filter(([, value]) => value !== undefined),
+        )
+
+        if (inverse && Object.keys(inverseUpdates).length > 1) {
+          await tx
+            .update(personRelationships)
+            .set(inverseUpdates)
+            .where(eq(personRelationships.id, inverse.id))
+        }
+      }
+
+      return row ?? null
+    })
   },
 
   async deletePersonRelationship(db: PostgresJsDatabase, id: string) {
-    const [row] = await db
-      .delete(personRelationships)
-      .where(eq(personRelationships.id, id))
-      .returning({ id: personRelationships.id })
-    return row ?? null
+    return db.transaction(async (tx) => {
+      const [existing] = await tx
+        .select()
+        .from(personRelationships)
+        .where(eq(personRelationships.id, id))
+        .for("update")
+        .limit(1)
+      if (!existing) return null
+
+      if (existing.inverseKind) {
+        const [inverse] = await tx
+          .select({ id: personRelationships.id })
+          .from(personRelationships)
+          .where(
+            and(
+              eq(personRelationships.fromPersonId, existing.toPersonId),
+              eq(personRelationships.toPersonId, existing.fromPersonId),
+              eq(personRelationships.kind, existing.inverseKind),
+              eq(personRelationships.inverseKind, existing.kind),
+            ),
+          )
+          .for("update")
+          .limit(1)
+
+        if (inverse) {
+          await tx.delete(personRelationships).where(eq(personRelationships.id, inverse.id))
+        }
+      }
+
+      const [row] = await tx
+        .delete(personRelationships)
+        .where(eq(personRelationships.id, id))
+        .returning({ id: personRelationships.id })
+      return row ?? null
+    })
   },
 }

--- a/packages/relationships/tests/integration/person-relationships.test.ts
+++ b/packages/relationships/tests/integration/person-relationships.test.ts
@@ -136,6 +136,16 @@ describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
 
     const all = await personRelationshipsService.listPersonRelationships(db, parent.id)
     expect(all).toHaveLength(2)
+    expect(all).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          fromPersonId: child.id,
+          toPersonId: parent.id,
+          kind: "child",
+          inverseKind: "parent",
+        }),
+      ]),
+    )
   })
 
   it("autoInverse: false skips the symmetric edge", async () => {
@@ -150,6 +160,39 @@ describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
     const all = await personRelationshipsService.listPersonRelationships(db, parent.id)
     expect(all).toHaveLength(1)
     expect(all[0]?.kind).toBe("parent")
+  })
+
+  it("does not treat autoInverse opt-out reverse edges as a synced pair", async () => {
+    const parent = await seedPerson("Parent")
+    const child = await seedPerson("Child")
+    const reverse = await personRelationshipsService.createPersonRelationship(db, child.id, {
+      toPersonId: parent.id,
+      kind: "child",
+    })
+    const primary = await personRelationshipsService.createPersonRelationship(db, parent.id, {
+      toPersonId: child.id,
+      kind: "parent",
+      inverseKind: "child",
+      autoInverse: false,
+    })
+    if (!primary || !reverse) throw new Error("seed failure")
+
+    await personRelationshipsService.updatePersonRelationship(db, primary.id, {
+      kind: "guardian",
+      inverseKind: "ward",
+    })
+
+    expect(await personRelationshipsService.getPersonRelationship(db, reverse.id)).toMatchObject({
+      id: reverse.id,
+      kind: "child",
+      inverseKind: null,
+    })
+
+    await personRelationshipsService.deletePersonRelationship(db, primary.id)
+    expect(await personRelationshipsService.getPersonRelationship(db, reverse.id)).toMatchObject({
+      id: reverse.id,
+      kind: "child",
+    })
   })
 
   it("listPersonRelationships filters by direction", async () => {
@@ -177,6 +220,141 @@ describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
       direction: "to",
     })
     expect(incoming.map((row) => row.fromPersonId)).toEqual([c.id])
+  })
+
+  it("keeps auto-inverse pairs in sync when either edge is updated", async () => {
+    const parent = await seedPerson("Parent")
+    const child = await seedPerson("Child")
+    const created = await personRelationshipsService.createPersonRelationship(db, parent.id, {
+      toPersonId: child.id,
+      kind: "parent",
+      inverseKind: "child",
+      startDate: "2026-06-01",
+    })
+    if (!created) throw new Error("seed failure")
+
+    const updated = await personRelationshipsService.updatePersonRelationship(db, created.id, {
+      kind: "sibling",
+      inverseKind: "sibling",
+      startDate: "2026-07-01",
+      notes: "Updated pair",
+    })
+    expect(updated?.kind).toBe("sibling")
+
+    const parentRelationships = await personRelationshipsService.listPersonRelationships(
+      db,
+      parent.id,
+    )
+    expect(parentRelationships).toHaveLength(2)
+    expect(
+      parentRelationships.map((row) => ({
+        from: row.fromPersonId,
+        to: row.toPersonId,
+        kind: row.kind,
+        inverseKind: row.inverseKind,
+        startDate: row.startDate,
+        notes: row.notes,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          from: parent.id,
+          to: child.id,
+          kind: "sibling",
+          inverseKind: "sibling",
+          startDate: "2026-07-01",
+          notes: "Updated pair",
+        },
+        {
+          from: child.id,
+          to: parent.id,
+          kind: "sibling",
+          inverseKind: "sibling",
+          startDate: "2026-07-01",
+          notes: "Updated pair",
+        },
+      ]),
+    )
+
+    const inverse = parentRelationships.find((row) => row.fromPersonId === child.id)
+    if (!inverse) throw new Error("expected inverse relationship")
+
+    await personRelationshipsService.updatePersonRelationship(db, inverse.id, {
+      kind: "friend",
+      inverseKind: "friend",
+      notes: "Updated from inverse",
+    })
+
+    const afterInverseUpdate = await personRelationshipsService.listPersonRelationships(
+      db,
+      parent.id,
+    )
+    expect(
+      afterInverseUpdate.map((row) => ({
+        from: row.fromPersonId,
+        to: row.toPersonId,
+        kind: row.kind,
+        inverseKind: row.inverseKind,
+        notes: row.notes,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          from: parent.id,
+          to: child.id,
+          kind: "friend",
+          inverseKind: "friend",
+          notes: "Updated from inverse",
+        },
+        {
+          from: child.id,
+          to: parent.id,
+          kind: "friend",
+          inverseKind: "friend",
+          notes: "Updated from inverse",
+        },
+      ]),
+    )
+  })
+
+  it("deletes an auto-inverse pair when either edge is deleted", async () => {
+    const parent = await seedPerson("Parent")
+    const child = await seedPerson("Child")
+    const created = await personRelationshipsService.createPersonRelationship(db, parent.id, {
+      toPersonId: child.id,
+      kind: "parent",
+      inverseKind: "child",
+    })
+    if (!created) throw new Error("seed failure")
+
+    const deleted = await personRelationshipsService.deletePersonRelationship(db, created.id)
+    expect(deleted?.id).toBe(created.id)
+
+    expect(await personRelationshipsService.listPersonRelationships(db, parent.id)).toHaveLength(0)
+    expect(await personRelationshipsService.listPersonRelationships(db, child.id)).toHaveLength(0)
+
+    const createdFromChild = await personRelationshipsService.createPersonRelationship(
+      db,
+      parent.id,
+      {
+        toPersonId: child.id,
+        kind: "parent",
+        inverseKind: "child",
+      },
+    )
+    if (!createdFromChild) throw new Error("seed failure")
+    const childRelationships = await personRelationshipsService.listPersonRelationships(
+      db,
+      child.id,
+    )
+    const inverse = childRelationships.find((row) => row.fromPersonId === child.id)
+    if (!inverse) throw new Error("expected inverse relationship")
+
+    const deletedInverse = await personRelationshipsService.deletePersonRelationship(db, inverse.id)
+    expect(deletedInverse?.id).toBe(inverse.id)
+
+    expect(await personRelationshipsService.listPersonRelationships(db, parent.id)).toHaveLength(0)
+    expect(await personRelationshipsService.listPersonRelationships(db, child.id)).toHaveLength(0)
   })
 
   it("update + delete operate on a single edge", async () => {


### PR DESCRIPTION
## Summary
- update paired auto-inverse person relationship rows when either edge is patched
- delete paired auto-inverse rows when either edge is removed
- make the React relationship section issue one delete for a displayed logical pair

## Verification
- pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships-react typecheck
- pnpm --filter @voyant-travel/relationships test -- tests/integration/person-relationships.test.ts
- pnpm exec biome check .changeset/person-relationship-inverse-sync.md packages/relationships/src/service/person-relationships.ts packages/relationships/tests/integration/person-relationships.test.ts packages/relationships-react/src/components/person-relationships-section.tsx && git diff --check

Closes #2555