### PR TITLE
Fix admin catalog booking source provenance

### DIFF
--- a/.changeset/catalog-booking-sourcekind-gating.md
+++ b/.changeset/catalog-booking-sourcekind-gating.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/catalog-react": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Avoid pinning unscoped Voyant Connect source kinds into admin booking journey links, and keep booking Confirm disabled until live pricing returns a quote id.

--- a/packages/bookings-react/src/journey/components/booking-journey.missing-quote-id.test.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.missing-quote-id.test.tsx
@@ -1,0 +1,38 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@voyant-travel/catalog-react/booking-engine", () => ({
+  useBookingQuote: () => ({
+    data: {
+      available: true,
+      pricing: null,
+    },
+    isQuoting: false,
+    error: null,
+    requote: async () => ({}) as never,
+    refetch: async () => ({}) as never,
+  }),
+  useBookingDraftShape: (opts: { fallback: unknown }) => opts.fallback,
+  useBookingDraft: () => ({ save: { mutate: () => {} } }),
+  useBookingCommit: () => ({ mutateAsync: async () => {}, isPending: false, error: null }),
+  useBookingHold: () => ({ place: async () => ({}), release: async () => ({}) }),
+}))
+
+const { BookingJourney } = await import("./booking-journey.js")
+
+describe("BookingJourney — missing quote id handling (#2425)", () => {
+  it("keeps admin confirm disabled until a successful quote id exists", () => {
+    const html = renderToStaticMarkup(
+      <BookingJourney
+        entityModule="products"
+        entityId="prod-1"
+        draftId="draft-1"
+        surface="admin"
+        renderVoucherPicker={() => null}
+      />,
+    )
+
+    expect(html).toContain("Confirm booking")
+    expect(html).toContain("disabled")
+  })
+})

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -256,6 +256,7 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
     (quote.data.available === false ||
       (quote.data.invalidReason != null && quote.data.invalidReason !== ""))
   const quoteBlocked = hasQuoteError || quoteUnpriceable
+  const quoteReady = Boolean(quote.data?.quoteId)
   // Step navigation only hard-blocks on a thrown quote error (a transient fetch
   // failure that a retry fixes). An un-priceable quote (e.g. `rates_missing`
   // from a preselected room) is *corrected by navigating* — often the room/rate
@@ -277,8 +278,10 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   )
   const canCommit = useMemo(
     () =>
-      stackedSteps.every((s) => canAdvanceFromStep(s, draft, shape, available)) && !quoteBlocked,
-    [stackedSteps, draft, shape, available, quoteBlocked],
+      stackedSteps.every((s) => canAdvanceFromStep(s, draft, shape, available)) &&
+      quoteReady &&
+      !quoteBlocked,
+    [stackedSteps, draft, shape, available, quoteReady, quoteBlocked],
   )
   const [isAdvanceGuardPending, setIsAdvanceGuardPending] = useState(false)
   const [advanceGuardError, setAdvanceGuardError] = useState<string | null>(null)
@@ -373,7 +376,14 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
   }, [contractConfig, draft, quote.data?.pricing])
 
   const commitDraft = async () => {
-    if (!quote.data?.quoteId) return
+    if (!quote.data?.quoteId || quoteBlocked) {
+      setConfirmError(
+        quoteUnpriceable
+          ? messages.bookingJourney.validation.pricingUnavailable
+          : messages.bookingJourney.validation.quoteUnavailable,
+      )
+      return
+    }
     await commit.mutateAsync({
       draft: { ...draft, quoteId: quote.data.quoteId },
       quoteId: quote.data.quoteId,
@@ -741,7 +751,7 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
               // Disable Confirm when the live quote can't be priced (error or
               // rates_missing) so contract acceptance / commit never fires
               // against an unpriced booking (#2638).
-              canConfirm={!quoteBlocked}
+              canConfirm={quoteReady && !quoteBlocked}
               renderExtras={props.renderReviewExtras}
               surface={surface}
               pricing={quote.data?.pricing ?? null}

--- a/packages/catalog-react/src/admin/booking-journey-provenance.ts
+++ b/packages/catalog-react/src/admin/booking-journey-provenance.ts
@@ -1,0 +1,33 @@
+export interface BookingJourneyProvenanceInput {
+  sourceKind?: string | null
+  sourceConnectionId?: string | null
+  sourceRef?: string | null
+}
+
+export function bookingJourneyProvenanceSearchParams(
+  input: BookingJourneyProvenanceInput,
+): Record<string, string> {
+  const sourceKind = cleaned(input.sourceKind)
+  const sourceConnectionId = cleaned(input.sourceConnectionId)
+  const sourceRef = cleaned(input.sourceRef)
+
+  // `voyant-connect` is a catalog provenance kind, but it is not always a
+  // registered booking-engine adapter in local/demo deployments. Without a
+  // connection id, let the booking route resolve the registered source from
+  // (entityModule, entityId) instead of pinning the URL to an adapter kind that
+  // may not exist in this deployment.
+  const shouldPinSourceKind =
+    sourceKind !== undefined &&
+    (sourceKind !== "voyant-connect" || sourceConnectionId !== undefined)
+
+  return {
+    ...(shouldPinSourceKind ? { sourceKind } : {}),
+    ...(sourceConnectionId ? { sourceConnectionId } : {}),
+    ...(sourceRef ? { sourceRef } : {}),
+  }
+}
+
+function cleaned(value: string | null | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/packages/catalog-react/src/admin/catalog-vertical-host.tsx
+++ b/packages/catalog-react/src/admin/catalog-vertical-host.tsx
@@ -24,6 +24,7 @@ import {
   useVoyantCatalogContext,
   type VoyantFetcher,
 } from "../index.js"
+import { bookingJourneyProvenanceSearchParams } from "./booking-journey-provenance.js"
 
 type CatalogBrowserMessages = ReturnType<
   typeof useOperatorAdminMessages
@@ -538,9 +539,7 @@ function goToBookingPage(
   navigateTo("bookingJourney.start", {
     entityModule,
     entityId: hit.id,
-    sourceKind,
-    ...(sourceConnectionId ? { sourceConnectionId } : {}),
-    ...(sourceRef ? { sourceRef } : {}),
+    ...bookingJourneyProvenanceSearchParams({ sourceKind, sourceConnectionId, sourceRef }),
     ...(departure
       ? isSourced
         ? { departureDate: departure.startsAt.slice(0, 10) }

--- a/packages/catalog-react/src/admin/cruise-detail-host.tsx
+++ b/packages/catalog-react/src/admin/cruise-detail-host.tsx
@@ -9,6 +9,7 @@ import {
 import { useState } from "react"
 
 import { CruiseDetailPage } from "../components/cruise-detail-page.js"
+import { bookingJourneyProvenanceSearchParams } from "./booking-journey-provenance.js"
 
 export interface CruiseDetailHostProps {
   id: string
@@ -41,13 +42,10 @@ export function CruiseDetailHost({ id, locale }: CruiseDetailHostProps) {
       // when the content route exposed it; otherwise let the journey APIs
       // resolve provenance server-side from (entityModule, entityId).
       onBook={(cruiseId, opts) => {
-        const sourceKind = opts.sourceKind?.trim()
         return navigateTo("bookingJourney.start", {
           entityModule: "cruises",
           entityId: cruiseId,
-          ...(sourceKind ? { sourceKind } : {}),
-          ...(opts.sourceConnectionId ? { sourceConnectionId: opts.sourceConnectionId } : {}),
-          ...(opts.sourceRef ? { sourceRef: opts.sourceRef } : {}),
+          ...bookingJourneyProvenanceSearchParams(opts),
           ...(opts.departureId ? { departureId: opts.departureId } : {}),
           ...(opts.departureDate ? { departureDate: opts.departureDate.slice(0, 10) } : {}),
           ...(opts.optionId ? { optionId: opts.optionId } : {}),

--- a/packages/catalog-react/src/admin/vertical-detail-host.tsx
+++ b/packages/catalog-react/src/admin/vertical-detail-host.tsx
@@ -14,6 +14,7 @@ import {
   type CatalogVerticalDetailBreadcrumb,
   CatalogVerticalDetailPage,
 } from "../components/catalog-vertical-detail-page.js"
+import { bookingJourneyProvenanceSearchParams } from "./booking-journey-provenance.js"
 
 export interface VerticalDetailHostProps {
   surface: CatalogDetailSurface
@@ -62,13 +63,10 @@ export function VerticalDetailHost({ surface, id, locale }: VerticalDetailHostPr
       // when content enrichment exposed it; otherwise let the journey APIs
       // resolve provenance server-side from (entityModule, entityId).
       onBook={(entityModule, entityId, opts) => {
-        const sourceKind = opts.sourceKind?.trim()
         return navigateTo("bookingJourney.start", {
           entityModule,
           entityId,
-          ...(sourceKind ? { sourceKind } : {}),
-          ...(opts.sourceConnectionId ? { sourceConnectionId: opts.sourceConnectionId } : {}),
-          ...(opts.sourceRef ? { sourceRef: opts.sourceRef } : {}),
+          ...bookingJourneyProvenanceSearchParams(opts),
           ...(opts.departureId ? { departureId: opts.departureId } : {}),
           ...(opts.departureDate ? { departureDate: opts.departureDate.slice(0, 10) } : {}),
           ...(opts.optionId ? { optionId: opts.optionId } : {}),

--- a/packages/catalog-react/tests/booking-journey-provenance.test.ts
+++ b/packages/catalog-react/tests/booking-journey-provenance.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import { bookingJourneyProvenanceSearchParams } from "../src/admin/booking-journey-provenance.js"
+
+describe("bookingJourneyProvenanceSearchParams", () => {
+  it("omits unscoped voyant-connect kind so the booking route resolves provenance", () => {
+    expect(
+      bookingJourneyProvenanceSearchParams({
+        sourceKind: "voyant-connect",
+        sourceRef: "offer_1",
+      }),
+    ).toEqual({ sourceRef: "offer_1" })
+  })
+
+  it("keeps voyant-connect when a connection id can route the adapter", () => {
+    expect(
+      bookingJourneyProvenanceSearchParams({
+        sourceKind: "voyant-connect",
+        sourceConnectionId: "conn_1",
+        sourceRef: "offer_1",
+      }),
+    ).toEqual({
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "conn_1",
+      sourceRef: "offer_1",
+    })
+  })
+
+  it("keeps registered non-connect source kinds", () => {
+    expect(bookingJourneyProvenanceSearchParams({ sourceKind: "demo" })).toEqual({
+      sourceKind: "demo",
+    })
+  })
+})


### PR DESCRIPTION
Closes #2425

## Summary
- sanitize admin catalog booking journey provenance so unscoped `voyant-connect` is not pinned into journey URLs
- share the provenance rule across browse, vertical detail, and cruise detail booking links
- require a live `quoteId` before Confirm can enable or the internal commit path can proceed

## Verification
- pnpm --filter @voyant-travel/catalog-react test -- tests/booking-journey-provenance.test.ts
- pnpm --filter @voyant-travel/bookings-react test -- src/journey/components/booking-journey.missing-quote-id.test.tsx
- pnpm exec biome check packages/catalog-react/src/admin/booking-journey-provenance.ts packages/catalog-react/src/admin/catalog-vertical-host.tsx packages/catalog-react/src/admin/cruise-detail-host.tsx packages/catalog-react/src/admin/vertical-detail-host.tsx packages/catalog-react/tests/booking-journey-provenance.test.ts packages/bookings-react/src/journey/components/booking-journey.tsx packages/bookings-react/src/journey/components/booking-journey.missing-quote-id.test.tsx .changeset/catalog-booking-sourcekind-gating.md
- pnpm --filter @voyant-travel/catalog-react typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/bookings-react typecheck
- pnpm --filter @voyant-travel/catalog-react lint
- pnpm --filter @voyant-travel/bookings-react lint
- pre-push hook: pnpm test