### PR TITLE
Agent tools: products (inventory) read tools + module-owned pattern

### DIFF
--- a/.changeset/inventory-agent-tools.md
+++ b/.changeset/inventory-agent-tools.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/inventory": minor
+---
+
+Add read-only agent tools for the products domain at
+`@voyant-travel/inventory/tools`: `list_products` and `get_product`, exposed as
+headless `defineTool`s over the existing products service (`products:read` scope,
+read tier). The operator registers them on the in-deployment MCP server alongside
+the trips tools — establishing the module-owned-tools pattern for the remaining
+domains.

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -8,6 +8,7 @@
     "./linkables": "./src/linkables.ts",
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
+    "./tools": "./src/tools.ts",
     "./routes": "./src/routes.ts",
     "./routes-brochure": "./src/routes-brochure.ts",
     "./action-ledger-drift": "./src/action-ledger-drift.ts",
@@ -56,6 +57,7 @@
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/commerce": "workspace:^",
     "@voyant-travel/products-contracts": "workspace:^",
+    "@voyant-travel/tools": "workspace:^",
     "@voyant-travel/storage": "workspace:^",
     "@voyant-travel/utils": "workspace:^",
     "drizzle-orm": "catalog:",
@@ -100,6 +102,11 @@
         "types": "./dist/validation.d.ts",
         "import": "./dist/validation.js",
         "default": "./dist/validation.js"
+      },
+      "./tools": {
+        "types": "./dist/tools.d.ts",
+        "import": "./dist/tools.js",
+        "default": "./dist/tools.js"
       },
       "./routes": {
         "types": "./dist/routes.d.ts",

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -1,0 +1,78 @@
+/**
+ * Inventory (products) agent tools on the framework tool contract.
+ *
+ * Thin, read-only wrappers over the existing products service — no new domain
+ * logic. The service is injected on the context by intersection
+ * (`InventoryToolContext`), so this module stays deployment-agnostic; the
+ * operator binds the service to its request `db` and registers these tools on the
+ * shared MCP registry alongside every other domain's tools.
+ */
+import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import { z } from "zod"
+
+import { productListQuerySchema } from "./validation.js"
+
+/** A paginated product list result (the shape the products service returns). */
+export interface ProductListResult {
+  data: unknown[]
+  total: number
+  limit: number
+  offset: number
+}
+
+/** The products read surface a deployment binds into the tool context. */
+export interface InventoryToolServices {
+  listProducts(query: z.infer<typeof productListQuerySchema>): Promise<ProductListResult>
+  getProductById(id: string): Promise<unknown | null>
+}
+
+/** Tool context with the inventory service injected. */
+export type InventoryToolContext = ToolContext & { inventory?: InventoryToolServices }
+
+function inventory(ctx: InventoryToolContext): InventoryToolServices {
+  return requireService(ctx.inventory, "inventory")
+}
+
+export const listProductsTool = defineTool<
+  z.infer<typeof productListQuerySchema>,
+  ProductListResult,
+  InventoryToolContext
+>({
+  name: "list_products",
+  description:
+    "List products with optional filters (status, booking mode, category, tag, search, " +
+    "date range, price/pax bounds) and pagination. Returns { data, total, limit, offset }. " +
+    "Read-only.",
+  inputSchema: productListQuerySchema,
+  outputSchema: z.custom<ProductListResult>(),
+  requiredScopes: ["products:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return inventory(ctx).listProducts(query)
+  },
+})
+
+const getProductArgs = z.object({ id: z.string().min(1).describe("The product id.") })
+export type GetProductArgs = z.infer<typeof getProductArgs>
+
+export const getProductTool = defineTool<
+  GetProductArgs,
+  { product: unknown | null },
+  InventoryToolContext
+>({
+  name: "get_product",
+  description: "Read a single product by id. Returns null when not found. Read-only.",
+  inputSchema: getProductArgs,
+  outputSchema: z.object({ product: z.unknown().nullable() }),
+  requiredScopes: ["products:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }, ctx) {
+    const product = await inventory(ctx).getProductById(id)
+    return { product: product ?? null }
+  },
+})
+
+/** All inventory agent tools, ready to register on a `ToolRegistry`. */
+export const inventoryTools = [listProductsTool, getProductTool] as const

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -1,0 +1,77 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { type InventoryToolServices, inventoryTools } from "../src/tools.js"
+
+function ctxWith(
+  services?: Partial<InventoryToolServices>,
+): ToolContext & { inventory?: InventoryToolServices } {
+  return {
+    db: {},
+    actor: "customer",
+    audience: "customer",
+    tenantId: "default",
+    resolverScope: { locale: "en-GB", audience: "customer", market: "default", actor: "customer" },
+    inventory: services as InventoryToolServices | undefined,
+  }
+}
+
+function makeRegistry() {
+  const registry = createToolRegistry()
+  registry.registerAll(inventoryTools)
+  return registry
+}
+
+describe("inventory tools", () => {
+  it("registers read-only products tools gated on products:read", () => {
+    const manifest = makeRegistry().list()
+    expect(manifest.map((t) => t.name).sort()).toEqual(["get_product", "list_products"])
+    for (const tool of manifest) {
+      expect(tool.tier).toBe("read")
+      expect(tool.requiredScopes).toEqual(["products:read"])
+      expect(tool.riskPolicy.destructive).toBe(false)
+    }
+  })
+
+  it("lists products through the injected service", async () => {
+    const registry = makeRegistry()
+    const result = await registry.dispatch<{ data: unknown[]; total: number }>(
+      "list_products",
+      { limit: 10 },
+      ctxWith({
+        async listProducts() {
+          return { data: [{ id: "prod_1" }, { id: "prod_2" }], total: 2, limit: 10, offset: 0 }
+        },
+        async getProductById() {
+          return null
+        },
+      }),
+    )
+    expect(result.data).toHaveLength(2)
+    expect(result.total).toBe(2)
+  })
+
+  it("reads a single product and normalizes not-found to null", async () => {
+    const registry = makeRegistry()
+    const result = await registry.dispatch<{ product: unknown }>(
+      "get_product",
+      { id: "missing" },
+      ctxWith({
+        async listProducts() {
+          return { data: [], total: 0, limit: 24, offset: 0 }
+        },
+        async getProductById() {
+          return null
+        },
+      }),
+    )
+    expect(result.product).toBeNull()
+  })
+
+  it("throws MISSING_SERVICE when inventory is not wired", async () => {
+    const registry = makeRegistry()
+    await expect(
+      registry.dispatch("list_products", { limit: 10 }, ctxWith(undefined)),
+    ).rejects.toMatchObject({ code: "MISSING_SERVICE" })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2236,6 +2236,9 @@ importers:
       '@voyant-travel/storage':
         specifier: workspace:^
         version: link:../storage
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       '@voyant-travel/types':
         specifier: workspace:^
         version: link:../types

--- a/starters/operator/src/api/runtime/mcp-runtime.ts
+++ b/starters/operator/src/api/runtime/mcp-runtime.ts
@@ -9,6 +9,9 @@
  *
  * The route mounts at `/v1/admin/mcp` via the `"operator/mcp"` composition entry.
  */
+
+import { productsService } from "@voyant-travel/inventory"
+import { type InventoryToolServices, inventoryTools } from "@voyant-travel/inventory/tools"
 import { createMcpHonoApp } from "@voyant-travel/mcp"
 import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { type TripsToolServices, tripsService, tripsTools } from "@voyant-travel/trips"
@@ -17,14 +20,21 @@ import type { Context, Hono } from "hono"
 import { DEFAULT_SLICES } from "../lib/catalog-runtime"
 import { createOperatorTripsRoutesOptions } from "./trips-runtime"
 
+/** The per-request tool context shape this deployment builds (base + injected services). */
+type OperatorToolContext = ToolContext & {
+  trips: TripsToolServices
+  inventory: InventoryToolServices
+}
+
 /** Build the MCP admin routes wired with this deployment's tools + context. */
 export function buildMcpAdminRoutes(): Hono {
   const registry = createToolRegistry()
   registry.registerAll(tripsTools)
+  registry.registerAll(inventoryTools)
   return createMcpHonoApp({ registry, buildContext: buildToolContext })
 }
 
-function buildToolContext(c: Context): ToolContext & { trips: TripsToolServices } {
+function buildToolContext(c: Context): OperatorToolContext {
   const env = c.env as CloudflareBindings & { TENANT_ID?: string }
   const actor = (c.var.actor ?? "staff") as ToolContext["actor"]
   const audience = (c.var.audience ?? actor) as ToolContext["audience"]
@@ -36,6 +46,14 @@ function buildToolContext(c: Context): ToolContext & { trips: TripsToolServices 
     tenantId: env.TENANT_ID ?? "default",
     resolverScope: { locale, audience, market: "default", actor },
     trips: createTripsToolServices(c),
+    inventory: createInventoryToolServices(c),
+  }
+}
+
+function createInventoryToolServices(c: Context): InventoryToolServices {
+  return {
+    listProducts: (query) => productsService.listProducts(c.var.db, query),
+    getProductById: (id) => productsService.getProductById(c.var.db, id),
   }
 }
 


### PR DESCRIPTION
Part of #2800 and #2792. First leaf-domain migration; establishes the
module-owned-tools pattern that the remaining domains follow.

- **`@voyant-travel/inventory/tools`**: `list_products` + `get_product` as headless
  read-only `defineTool`s over the existing products service (`products:read`, read
  tier), services injected via the tool context.
- **Operator**: registers `inventoryTools` on the shared MCP registry and binds the
  products service to the request `db` — so `/v1/admin/mcp` now serves trips **and**
  products tools, gated per-tool by scope + audience.

This proves the two tool shapes end to end: composed/destructive (trips) and
read-only leaf (products). Remaining domains under #2800 — catalog, availability,
pricing, bookings, finance, notifications, quotes — follow the identical pattern and
are tracked as follow-ups (kept open).

## Verify
inventory: `typecheck` + `tests/tools.test.ts` (4) + `lint`. operator: `typecheck`.
Changeset included (inventory minor).