### PR TITLE
Validate person relationship creates

### DIFF
--- a/.changeset/person-relationship-validation.md
+++ b/.changeset/person-relationship-validation.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/relationships-contracts": patch
+"@voyant-travel/relationships": patch
+---
+
+Reject reversed person relationship date ranges and return stable conflicts for duplicate creates.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -9963,6 +9963,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Relationship already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "postAdminRelationshipsPeopleByIdRelationships",

--- a/packages/relationships-contracts/src/contracts.test.ts
+++ b/packages/relationships-contracts/src/contracts.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest"
 
-import { activityTypeSchema, entityTypeSchema, personRelationshipKindSchema } from "./index.js"
+import {
+  activityTypeSchema,
+  entityTypeSchema,
+  insertPersonRelationshipSchema,
+  personRelationshipKindSchema,
+  updatePersonRelationshipSchema,
+} from "./index.js"
 
 describe("@voyant-travel/relationships-contracts validation", () => {
   it("accepts valid enum vocabulary values", () => {
@@ -13,5 +19,22 @@ describe("@voyant-travel/relationships-contracts validation", () => {
     expect(entityTypeSchema.safeParse("vendor").success).toBe(false)
     expect(personRelationshipKindSchema.safeParse("delegate").success).toBe(false)
     expect(activityTypeSchema.safeParse("voicemail").success).toBe(false)
+  })
+
+  it("rejects reversed person relationship date ranges", () => {
+    expect(
+      insertPersonRelationshipSchema.safeParse({
+        toPersonId: "person_b",
+        kind: "travel_companion",
+        startDate: "2026-07-10",
+        endDate: "2026-07-01",
+      }).success,
+    ).toBe(false)
+    expect(
+      updatePersonRelationshipSchema.safeParse({
+        startDate: "2026-07-10",
+        endDate: "2026-07-01",
+      }).success,
+    ).toBe(false)
   })
 })

--- a/packages/relationships-contracts/src/validation/person-relationships.ts
+++ b/packages/relationships-contracts/src/validation/person-relationships.ts
@@ -35,10 +35,25 @@ const personRelationshipCoreSchema = z.object({
   autoInverse: z.boolean().optional(),
 })
 
-export const insertPersonRelationshipSchema = personRelationshipCoreSchema
+function validateDateRange(
+  data: { startDate?: string | null; endDate?: string | null },
+  ctx: z.RefinementCtx,
+) {
+  if (data.startDate && data.endDate && data.endDate < data.startDate) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["endDate"],
+      message: "endDate must be on or after startDate",
+    })
+  }
+}
+
+export const insertPersonRelationshipSchema =
+  personRelationshipCoreSchema.superRefine(validateDateRange)
 export const updatePersonRelationshipSchema = personRelationshipCoreSchema
   .partial()
   .omit({ toPersonId: true, autoInverse: true })
+  .superRefine(validateDateRange)
 
 export const personRelationshipListQuerySchema = paginationSchema.extend({
   kind: personRelationshipKindSchema.optional(),

--- a/packages/relationships/src/routes/person-relationships.ts
+++ b/packages/relationships/src/routes/person-relationships.ts
@@ -65,6 +65,7 @@ const createPersonRelationshipRoute = createRoute({
       description: "invalid_request, person not found, or self-relationship rejected",
       ...jsonContent(errorResponseSchema),
     },
+    409: { description: "Relationship already exists", ...jsonContent(errorResponseSchema) },
   },
 })
 

--- a/packages/relationships/src/service/person-relationships.ts
+++ b/packages/relationships/src/service/person-relationships.ts
@@ -1,3 +1,4 @@
+import { RequestValidationError } from "@voyant-travel/hono"
 import { and, asc, eq, isNull, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { z } from "zod"
@@ -8,6 +9,7 @@ import type {
   personRelationshipListQuerySchema,
   updatePersonRelationshipSchema,
 } from "../validation.js"
+import { duplicateRelationshipsValueError } from "./duplicate-errors.js"
 
 export type CreatePersonRelationshipInput = z.infer<typeof insertPersonRelationshipSchema>
 export type UpdatePersonRelationshipInput = z.infer<typeof updatePersonRelationshipSchema>
@@ -21,6 +23,14 @@ async function personExists(db: PostgresJsDatabase, personId: string) {
     .where(eq(people.id, personId))
     .limit(1)
   return Boolean(row)
+}
+
+function assertValidDateRange(startDate?: string | null, endDate?: string | null) {
+  if (startDate && endDate && endDate < startDate) {
+    throw new RequestValidationError("endDate must be on or after startDate", {
+      fields: { endDate: ["endDate must be on or after startDate"] },
+    })
+  }
 }
 
 export const personRelationshipsService = {
@@ -106,8 +116,22 @@ export const personRelationshipsService = {
           fromPersonId,
           toPersonId,
         })
+        .onConflictDoNothing({
+          target: [
+            personRelationships.fromPersonId,
+            personRelationships.toPersonId,
+            personRelationships.kind,
+          ],
+        })
         .returning()
-      if (!primary) return null
+      if (!primary) {
+        throw duplicateRelationshipsValueError({
+          code: "duplicate_person_relationship",
+          message: "Person relationship already exists",
+          resource: "person_relationship",
+          fields: [["toPersonId"], ["kind"]],
+        })
+      }
 
       if (autoInverse && inverseKind) {
         await tx
@@ -163,6 +187,8 @@ export const personRelationshipsService = {
       if (!existing) return null
 
       const updatedAt = new Date()
+      assertValidDateRange(data.startDate ?? existing.startDate, data.endDate ?? existing.endDate)
+
       const [row] = await tx
         .update(personRelationships)
         .set({ ...data, updatedAt })

--- a/packages/relationships/tests/integration/person-relationships.test.ts
+++ b/packages/relationships/tests/integration/person-relationships.test.ts
@@ -2,6 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
 import { people } from "../../src/schema.js"
 import { personRelationshipsService } from "../../src/service/person-relationships.js"
+import { insertPersonRelationshipSchema } from "../../src/validation.js"
 
 const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 
@@ -76,7 +77,22 @@ describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
     ).toBeNull()
   })
 
-  it("enforces uniqueness on (from, to, kind)", async () => {
+  it("rejects reversed date ranges", () => {
+    const result = insertPersonRelationshipSchema.safeParse({
+      toPersonId: "person_b",
+      kind: "travel_companion",
+      inverseKind: "travel_companion",
+      startDate: "2026-07-10",
+      endDate: "2026-07-01",
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.error?.flatten().fieldErrors.endDate).toEqual([
+      "endDate must be on or after startDate",
+    ])
+  })
+
+  it("maps duplicate creates to a stable conflict", async () => {
     const a = await seedPerson("Alice")
     const b = await seedPerson("Bob")
     await personRelationshipsService.createPersonRelationship(db, a.id, {
@@ -88,7 +104,18 @@ describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
         toPersonId: b.id,
         kind: "friend",
       }),
-    ).rejects.toThrow()
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "duplicate_person_relationship",
+      message: "Person relationship already exists",
+      details: {
+        resource: "person_relationship",
+        fields: {
+          toPersonId: ["Person relationship already exists"],
+          kind: ["Person relationship already exists"],
+        },
+      },
+    })
     // A different kind on the same pair is fine.
     const second = await personRelationshipsService.createPersonRelationship(db, a.id, {
       toPersonId: b.id,
@@ -315,6 +342,27 @@ describe.skipIf(!DB_AVAILABLE)("personRelationshipsService", () => {
         },
       ]),
     )
+  })
+
+  it("rejects partial updates that would reverse an existing date range", async () => {
+    const a = await seedPerson("A")
+    const b = await seedPerson("B")
+    const created = await personRelationshipsService.createPersonRelationship(db, a.id, {
+      toPersonId: b.id,
+      kind: "travel_companion",
+      startDate: "2026-07-10",
+    })
+    if (!created) throw new Error("seed failure")
+
+    await expect(
+      personRelationshipsService.updatePersonRelationship(db, created.id, {
+        endDate: "2026-07-01",
+      }),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_request",
+      message: "endDate must be on or after startDate",
+    })
   })
 
   it("deletes an auto-inverse pair when either edge is deleted", async () => {

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -9963,6 +9963,24 @@
                 }
               }
             }
+          },
+          "409": {
+            "description": "Relationship already exists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         },
         "operationId": "postAdminRelationshipsPeopleByIdRelationships",


### PR DESCRIPTION
## Summary
- reject person relationship create/update payloads with endDate before startDate
- return a stable 409 duplicate_person_relationship conflict for duplicate directed relationships
- document the 409 create response in generated admin OpenAPI specs

## Verification
- pnpm --filter @voyant-travel/relationships-contracts typecheck
- pnpm --filter @voyant-travel/relationships typecheck
- pnpm --filter @voyant-travel/relationships-contracts test -- src/contracts.test.ts
- pnpm --filter @voyant-travel/relationships test -- tests/integration/person-relationships.test.ts
- pnpm --filter @voyant-travel/openapi generate
- pnpm --filter operator generate:openapi
- pnpm exec biome check .changeset/person-relationship-validation.md packages/relationships-contracts/src/validation/person-relationships.ts packages/relationships-contracts/src/contracts.test.ts packages/relationships/src/service/person-relationships.ts packages/relationships/src/routes/person-relationships.ts packages/relationships/tests/integration/person-relationships.test.ts packages/openapi/spec/admin/relationships.json starters/operator/openapi/admin/relationships.json && git diff --check

Closes #2554