### PR TITLE
Agent tools: external MCP-client auth for /v1/admin/mcp

### DIFF
--- a/.changeset/mcp-client-auth-guard.md
+++ b/.changeset/mcp-client-auth-guard.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Exempt the `/v1/admin/mcp` surface from the coarse `require-actor` method+path
+permission guard (alongside `_meta`). The in-deployment MCP server authorizes at a
+finer grain — each tool is gated by its own `requiredScopes` — so any authenticated
+API key or staff session reaches the endpoint and simply sees a scope-filtered tool
+list. This lets external MCP clients authenticate with a Bearer scoped key
+(voyant#2801) without needing a wildcard grant.

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -5,6 +5,18 @@ import type { MiddlewareHandler } from "hono"
 import { normalizePathname } from "../lib/public-paths.js"
 import type { VoyantBindings, VoyantVariables } from "../types.js"
 
+/**
+ * Route surfaces exempt from the coarse method+path permission guard because
+ * they enforce authorization at a finer grain internally: `_meta` (capability
+ * discovery) and `mcp` (the agent tool server, which gates every tool by its own
+ * `requiredScopes`). Neither is a real module name.
+ */
+const COARSE_GUARD_EXEMPT_RESOURCES = new Set(["_meta", "mcp"])
+
+function isCoarseGuardExempt(resource: string | null): boolean {
+  return resource !== null && COARSE_GUARD_EXEMPT_RESOURCES.has(resource)
+}
+
 function apiKeyResourceFromPath(pathname: string): string | null {
   const surfaceMatch = pathname.match(/^\/v1\/(?:admin|public)\/([^/]+)/)
   if (surfaceMatch?.[1]) return surfaceMatch[1]
@@ -146,11 +158,13 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       })
       const resource = apiKeyResourceFromPath(pathname)
 
-      // Meta/discovery endpoints (e.g. `/v1/admin/_meta/capabilities`) report
-      // what the caller can do — including the key's own granted scopes — so any
-      // authenticated API key may read them, regardless of module scope. `_meta`
-      // is a reserved namespace (no module is named `_meta`).
-      if (resource === "_meta") return next()
+      // Coarse-guard-exempt surfaces. `_meta` (capability discovery) and `mcp`
+      // (the agent tool server) are dispatch surfaces where authorization is
+      // enforced at a finer grain than method+path: the MCP server filters and
+      // gates each tool by its own `requiredScopes` (voyant#2792, D2). So any
+      // authenticated key reaches them; a key with no relevant scopes simply
+      // sees an empty tool list. Neither is a real module name.
+      if (isCoarseGuardExempt(resource)) return next()
 
       const actions = apiKeyPermissionActionsForMethod(c.req.method, pathname)
 
@@ -189,7 +203,7 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
         basePath: options.basePath,
       })
       const resource = apiKeyResourceFromPath(pathname)
-      if (resource && resource !== "_meta") {
+      if (resource && !isCoarseGuardExempt(resource)) {
         const actions = apiKeyPermissionActionsForMethod(c.req.method, pathname)
         if (!hasAnyApiKeyPermission(scopes, resource, actions)) {
           return c.json({ error: "Forbidden: missing required permission" }, 403)

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -43,6 +43,18 @@ describe("requireActor", () => {
     expect(res.status).toBe(200)
   })
 
+  it("lets any authenticated API key reach /v1/admin/mcp (per-tool scopes gate inside)", async () => {
+    const app = makeApp((c) => {
+      c.set("callerType", "api_key")
+      c.set("scopes", ["catalog:read"]) // no mcp or wildcard scope
+    })
+    app.use("*", requireActor("staff"))
+    app.post("/v1/admin/mcp", (c) => c.json({ ok: true }))
+
+    const res = await app.request("/v1/admin/mcp", { method: "POST" })
+    expect(res.status).toBe(200)
+  })
+
   it("still enforces module scopes for an API key on non-_meta admin routes", async () => {
     const app = makeApp((c) => {
       c.set("callerType", "api_key")

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -18,6 +18,24 @@ at `/v1/admin/mcp` (the `"operator/mcp"` composition entry):
 `buildContext(c)` maps the request's `c.var` (db lease / actor / audience / scope) into
 a `@voyant-travel/tools` `ToolContext`.
 
+## Authentication (external MCP clients)
+
+External MCP clients (Claude Desktop, ChatGPT, …) authenticate with a **Bearer
+scoped API key** — the operator's existing `voy_` key pipeline — sent as
+`Authorization: <key>`. No separate OAuth/runner is introduced (voyant#2801): the
+request auth middleware resolves the key into `scopes` + `audience` on `c.var`, and
+this server gates every tool by its `requiredScopes`.
+
+Because authorization is per-tool, the `/v1/admin/mcp` surface is exempt from the
+coarse method+path permission guard (`require-actor`, like `_meta`): any
+authenticated key reaches the endpoint, and a key with no relevant scopes simply
+sees an empty `tools/list`. Mint keys with a grant preset (e.g. `agent-customer`)
+to bundle a scope subset with an `audience`.
+
+The reserved `apps/agent-runner` / `apps/agent-control-plane` stubs are intentionally
+**not** built out — Voyant ships the tool primitives + this ready-to-use MCP, not an
+agent.
+
 ## How it works
 
 - **Transport:** `@hono/mcp`'s `StreamableHTTPTransport` (web-standard `Request`/


### PR DESCRIPTION
Closes #2801. Part of #2792.

**Decision:** external MCP clients authenticate with a **Bearer scoped `voy_` API
key** — the operator's existing key pipeline — not a separate OAuth server or runner.
The request auth middleware resolves the key into `scopes` + `audience`; the MCP
server gates every tool by its `requiredScopes`.

Because authorization is per-tool, `/v1/admin/mcp` is exempt from the coarse
`require-actor` method+path guard (like `_meta`): any authenticated key/session
reaches the endpoint and sees a **scope-filtered** `tools/list`. Without this, no key
could reach the MCP surface unless it held a wildcard, since no key grants the
synthetic `mcp` resource.

The reserved `apps/agent-runner` / `apps/agent-control-plane` stubs are intentionally
**not** built out — Voyant ships tool primitives + a ready-to-use MCP, not an agent.

## Verify
Hono require-actor tests (30, incl. the new mcp-exempt case) + typecheck + lint.
Changeset included (hono patch).