### PR TITLE
Agent tools: docs for the tool library + MCP model

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -193,6 +193,23 @@ For travel-native bespoke sales, the ladder is **Quote -> accepted Quote Version
 
 ---
 
+## Agent tooling & MCP
+
+See [agent tool library](docs/architecture/agent-tool-library.md) and
+[ADR-0011](docs/adr/0011-agent-tool-library-and-mcp.md).
+
+| Term               | Definition                                                                                                                            | Aliases to avoid            |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------- |
+| **Tool**           | An authored-once, headless, scope-gated capability an agent can invoke; validates input + output and returns typed **pure data**.       | *command, action, function* |
+| **Tool Registry**  | The in-deployment collection of registered Tools; dispatches by name and emits the discovery manifest. Holds no authorization logic.    | *tool list*                 |
+| **Tool Manifest**  | The contract-versioned, pure-data description of available Tools (name, JSON-Schema input, `requiredScopes`, risk) for remote agents.   | *tool catalog, schema dump* |
+| **MCP Server**     | The in-deployment Model Context Protocol adapter (`/v1/admin/mcp`) exposing the Tool Registry to external agent clients. Not an agent.  | *agent, bot, tool worker*   |
+| **Risk Tier**      | A Tool's coarse risk class: `read`, `write`, `sensitive`, or `destructive`. Paired with a declarative **Risk Policy**.                  | *permission level*          |
+| **Required Scopes**| The `resource:action` scopes a caller must hold (AND) to invoke a Tool — the finer-grained gate above the coarse route guard.           | *tool permission*           |
+| **Audience grant** | The `staff`/`customer`/`partner`/`supplier` value carried on an API-key grant (not inferred from scopes), resolved into a resolver scope.| *role, actor (overloaded)*  |
+
+---
+
 ## Lifecycle verbs (canonical actions)
 
 | Verb           | Meaning                                                                                          | Used on                                  |

--- a/docs/adr/0011-agent-tool-library-and-mcp.md
+++ b/docs/adr/0011-agent-tool-library-and-mcp.md
@@ -1,0 +1,87 @@
+# ADR-0011: Transport-neutral agent tool library + in-deployment MCP server
+
+- **Status:** Accepted (2026-07-02)
+- **Relates to:** [#2792](https://github.com/voyant-travel/voyant/issues/2792),
+  [ADR-0007](./0007-module-subsetting-and-capability-ports.md) (module subsetting +
+  capability ports),
+  [ADR-0009](./0009-federated-operating-mode.md) (Voyant as agent control surface),
+  [agent tool library](../architecture/agent-tool-library.md),
+  [AI travel experience composition](../architecture/ai-travel-experience-composition.md),
+  [catalog semantic search + agent access](../architecture/catalog-rag-architecture.md)
+- **Implemented by:** #2792 and its sub-PRs.
+
+## Context
+
+The only agent-facing tool seam lived inside `packages/trips` (`mcp-*.ts`): bespoke,
+trips-only, returning MCP transport envelopes from the core, dispatched over an ad-hoc
+`POST /tools/:tool` (not real MCP), with no `requiredScopes` or risk metadata. We want
+framework capabilities — catalog, products, availability, pricing, bookings, finance,
+notifications, quotes, trips — usable by any agent through one authored-once contract,
+without leaking transport concerns into the domain packages.
+
+Two consumption topologies must both work: an **in-process** MCP mounted in the
+operator app (dispatching to services with the request's DB lease), and a **remote**
+agent client over a versioned protocol.
+
+## Decision
+
+**Capabilities are authored once, headless, and scope-gated; exposure (MCP, remote
+agents, HTTP) is a thin adapter over them.**
+
+1. **`@voyant-travel/tools`** — a transport-neutral, dependency-minimal (zod-only)
+   contract. `defineTool` declares `name`, `description`, zod `inputSchema` +
+   `outputSchema`, `requiredScopes`, a risk `tier`, and a declarative `riskPolicy`, plus
+   a `handler(args, ctx)` returning **typed pure data** — no transport envelopes, no
+   presentation. `createToolRegistry` validates input and output on dispatch and emits a
+   discovery manifest with real JSON Schema (`z.toJSONSchema`). Authorization is **not**
+   done here.
+
+2. **Each module owns its tools.** A domain package exports a tool array via a `./tools`
+   subpath (mirroring how it exports route bundles); the deployment aggregates them into
+   one registry and injects services onto the tool context by intersection. Genuinely
+   **cross-module / composed tools live in the composing layer** (e.g. `trips`), never
+   pushed into leaf packages.
+
+3. **`@voyant-travel/mcp`** — the MCP server is a **Hono route group inside the operator
+   deployment**, mounted at `/v1/admin/mcp` via the `operator/mcp` composition entry. It
+   uses `@modelcontextprotocol/sdk`'s `McpServer` over `@hono/mcp`'s web-standard
+   Streamable-HTTP transport, **stateless** (fresh server + transport per request, no
+   session store, no Durable Object). No separate app/worker is deployed.
+
+4. **Authorization binds at the tool layer (D2):** each tool's `requiredScopes`
+   (`resource:action`, from `@voyant-travel/types`) are checked with **AND** semantics
+   via `hasApiKeyPermission`. Unauthorized tools are neither listed nor registered on the
+   per-request server. The coarse `require-actor` method+path guard exempts the `mcp`
+   surface (like `_meta`), so any authenticated caller reaches it and sees a
+   scope-filtered tool list.
+
+5. **Audience is a grant attribute (D3),** carried on the API-key grant metadata and
+   resolved into the catalog `ResolverScope` at request time — not inferred from scopes.
+
+6. **We ship primitives + a ready-to-use MCP, not an agent.** External clients
+   authenticate with a Bearer scoped `voy_` key. There is no Voyant-hosted agent or
+   runner; the reserved `apps/agent-runner` stubs stay unbuilt.
+
+## Consequences
+
+- Domain packages gain an agent surface with one thin `tools.ts` over their existing
+  service layer; no new domain logic, no transport coupling.
+- The MCP endpoint requires no new deployment binding — it rides the operator's existing
+  auth pipeline, DB lease, and lazy-route `c.var` hydration.
+- Risk/confirmation is declarative data on the manifest, so remote consumers can gate
+  destructive tools (e.g. `reserve_trip`) without executing tool code.
+- Supersedes the sibling `@voyant-travel/catalog-mcp` idea in
+  [catalog-rag-architecture.md](../architecture/catalog-rag-architecture.md): the MCP is
+  framework-level and in-deployment, not a per-catalog package.
+
+## Alternatives considered
+
+- **Keep the bespoke trips `POST /tools/:tool`.** Rejected: not real MCP, no scopes/risk,
+  not reusable across domains.
+- **A separate MCP worker (Durable-Object `McpAgent`, as in the sibling Voyant Cloud
+  repo).** Rejected for the operator: it adds a deployment + binding and splits tenancy;
+  the stateless in-deployment route group fits the single-worker, per-tenant model.
+- **`@modelcontextprotocol/sdk`'s Node-`http` `StreamableHTTPServerTransport`.** Rejected:
+  Node-oriented and fragile on Workers; `@hono/mcp` gives a web-standard transport.
+- **Full-SDK per-request statefulness.** Deferred: stateless JSON responses cover the
+  request/response tool surface; SSE streaming can be added later if needed.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -1,0 +1,115 @@
+# Agent Tool Library & MCP Server
+
+Status: implemented foundation (voyant#2792).
+Audience: anyone adding agent-callable capabilities to a Voyant domain, or wiring the
+MCP server into a deployment.
+
+Voyant exposes framework capabilities to agents through **one authored-once, headless,
+scope-gated tool contract**. Exposure — the MCP server, remote agent clients, HTTP — is
+a thin adapter over that contract. See [ADR-0011](../adr/0011-agent-tool-library-and-mcp.md)
+for the decision record.
+
+## Layers
+
+```
+@voyant-travel/tools      pure contract (zod only): defineTool, ToolContext,
+        ▲                 ToolRegistry, RiskTier/RiskPolicy, ToolManifestEntry
+        │
+   ┌────┴───────────────┐
+domain packages           @voyant-travel/mcp        transport adapter:
+(*/tools: tool arrays)    MCP SDK + @hono/mcp over the registry, scope-enforced
+        ▲                        ▲
+        └──────────┬─────────────┘
+        deployment (operator): aggregates tools into one registry, injects
+        services onto the context, mounts at /v1/admin/mcp via "operator/mcp"
+```
+
+Dependency direction is strictly downward. `@voyant-travel/tools` imports nothing heavy
+(no `hono`, no `catalog`, no domain package). A domain package depends on `tools`; the
+MCP adapter depends on `tools`. No cycles.
+
+## Authoring a domain tool
+
+Add a `src/tools.ts` to the domain package and export it via a `./tools` subpath
+(mirroring how the module exports its route bundle). A tool is a thin wrapper over the
+**existing service layer** — no new domain logic:
+
+```ts
+export const listProductsTool = defineTool({
+  name: "list_products",
+  description: "List products with filters and pagination. Read-only.",
+  inputSchema: productListQuerySchema,     // reuse the domain's zod schema
+  outputSchema: z.custom<ProductListResult>(), // start loose; tighten over time
+  requiredScopes: ["products:read"],        // resource:action, AND-enforced
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return requireService(ctx.inventory, "inventory").listProducts(query)
+  },
+})
+export const inventoryTools = [listProductsTool, getProductTool] as const
+```
+
+Rules:
+
+- **Return typed pure data**, validated by `outputSchema`. Never return MCP envelopes or
+  presentation — the transport wraps data at its boundary.
+- **Inject services by intersecting the context type** (`ToolContext & { inventory?: … }`)
+  and resolve with `requireService`. The tool package never imports the domain's DB or
+  service; the deployment binds services to the request `db`.
+- **Declare risk as data** (`tier` + `riskPolicy`) so remote consumers can gate
+  destructive tools (e.g. a `reserve`-style tool: `tier: "destructive"`,
+  `riskPolicy.confirmationRequired`) without executing the handler.
+- **Cross-module / composed tools** (spanning several domains) live in the composing
+  layer — `trips` — not in a leaf domain package.
+- Keep `inputSchema` serialization-friendly (avoid top-level `.transform()`/`.refine()`)
+  so `z.toJSONSchema` emits a faithful manifest.
+
+## Deployment wiring
+
+The operator builds one registry, registers each domain's tool array, and mounts the MCP
+server (`starters/operator/src/api/runtime/mcp-runtime.ts`):
+
+```ts
+const registry = createToolRegistry()
+registry.registerAll(tripsTools)
+registry.registerAll(inventoryTools)
+return createMcpHonoApp({ registry, buildContext })
+```
+
+`buildContext(c)` maps the request `c.var` (DB lease, `actor`, `audience`, tenant) into a
+`ToolContext` and binds each domain's services to `c.var.db`.
+
+## Authorization
+
+- **Scope (D2):** the MCP adapter checks each tool's `requiredScopes` against the caller's
+  granted scopes with **AND** semantics (`hasApiKeyPermission`). Unauthorized tools are
+  neither listed nor registered, so they cannot be called.
+- **Coarse guard:** `/v1/admin/mcp` is exempt from the `require-actor` method+path guard
+  (like `_meta`) because authorization is per-tool.
+- **Audience (D3):** carried on the API-key grant metadata (`API_KEY_GRANT_PRESETS` bundle
+  a scope subset + audience), resolved into the catalog `ResolverScope`. PII-sensitive
+  resources (`bookings-pii`) are never satisfied by the `*` wildcard.
+
+## Transport
+
+`@modelcontextprotocol/sdk` `McpServer` over `@hono/mcp` `StreamableHTTPTransport`,
+**stateless** (fresh server + transport per request, `sessionIdGenerator: undefined`,
+`enableJsonResponse: true`). No Durable Object; fits the operator's single-worker
+`nodejs_compat` runtime. `GET /v1/admin/mcp/manifest` serves a contract-versioned
+discovery manifest for remote agents.
+
+## Migration status
+
+Migrated: `trips` (composed/destructive) and `inventory`/products (read-only leaf).
+Remaining domains follow the identical pattern and are tracked in voyant#2800: catalog
+(read/search), availability, pricing, bookings (+PII), finance (refund/void),
+notifications (send), quotes.
+
+## Reconciliation
+
+This supersedes the sibling `@voyant-travel/catalog-mcp` package idea in
+[catalog-rag-architecture.md](./catalog-rag-architecture.md): the MCP server is
+framework-level and in-deployment, not a per-catalog package. It is the concrete tool +
+agent surface referenced by [ai-travel-experience-composition.md](./ai-travel-experience-composition.md)
+and the agent control surface posture in [ADR-0009](../adr/0009-federated-operating-mode.md).

--- a/docs/architecture/catalog-rag-architecture.md
+++ b/docs/architecture/catalog-rag-architecture.md
@@ -4,7 +4,9 @@ Status: superseded by the v1 package-structure cleanup.
 
 This document used to define `@voyant-travel/catalog-rag` and
 `@voyant-travel/catalog-mcp` as sibling catalog packages. That package split is no
-longer the target architecture.
+longer the target architecture. The agent tool + MCP surface is now framework-level
+and in-deployment — see [agent tool library](./agent-tool-library.md) and
+[ADR-0011](../adr/0011-agent-tool-library-and-mcp.md).
 
 Current rules:
 


### PR DESCRIPTION
Closes #2803. Part of #2792.

- **ADR-0011** — the transport-neutral tool contract + in-deployment MCP decision, with
  alternatives considered (bespoke dispatcher, separate Durable-Object worker,
  node-http transport, full-SDK statefulness).
- **docs/architecture/agent-tool-library.md** — layering + dependency direction, how to
  author a domain tool, deployment wiring, authorization (scope AND-semantics / audience
  / PII wildcard exclusion), the stateless transport, and migration status.
- **UBIQUITOUS_LANGUAGE.md** — Tool, Tool Registry, Tool Manifest, MCP Server, Risk Tier,
  Required Scopes, Audience grant.
- Reconciled the superseded catalog-rag doc (framework-level MCP, not `catalog-mcp`).

Docs-only; no changeset.