### PR TITLE
Agent tools: make the tool library + MCP packages publishable

### DIFF
--- a/.changeset/publish-tools-and-mcp.md
+++ b/.changeset/publish-tools-and-mcp.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/tools": minor
+"@voyant-travel/mcp": minor
+---
+
+Publish the agent tool library (`@voyant-travel/tools`) and the in-deployment MCP
+server (`@voyant-travel/mcp`). `@voyant-travel/tools` is the transport-neutral,
+headless tool contract (`defineTool`, `createToolRegistry`, risk metadata);
+`@voyant-travel/mcp` exposes a tool registry as a Model Context Protocol server
+mounted at `/v1/admin/mcp`.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,18 +1,33 @@
 {
   "name": "@voyant-travel/mcp",
   "version": "0.0.0",
-  "private": true,
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
   },
   "dependencies": {
     "@hono/mcp": "^0.3.0",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,18 +1,33 @@
 {
   "name": "@voyant-travel/tools",
   "version": "0.0.0",
-  "private": true,
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run",
     "build": "tsc -p tsconfig.build.json",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo"
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
   },
   "dependencies": {
     "zod": "catalog:"


### PR DESCRIPTION
Part of #2792. Publish-readiness pass before the umbrella merges to main.

- Flip `@voyant-travel/tools` and `@voyant-travel/mcp` from private → publishable:
  add `publishConfig.exports` (dist mirror), `files`, and a `prepack` build.
- Changeset (both minor → 0.1.0). `pnpm release:plan` is clean — both packages
  resolve as new (`latestPublishedVersion: null`), no mixed-changeset error, no
  starter release needed.