### PR TITLE
Materialize sourced catalog bookings

### DIFF
--- a/starters/operator/src/api/runtime/catalog-booking-runtime.test.ts
+++ b/starters/operator/src/api/runtime/catalog-booking-runtime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest"
+
+import { buildSourcedBookingRows } from "./catalog-booking-runtime"
+
+describe("buildSourcedBookingRows", () => {
+  it("materializes a readable booking row for sourced catalog commits", () => {
+    const rows = buildSourcedBookingRows({
+      actorId: "user_1",
+      request: {
+        quoteId: "quote_1",
+        party: {
+          personId: "person_1",
+          billing: {
+            contact: {
+              firstName: "Ada",
+              lastName: "Lovelace",
+              email: "ada@example.com",
+              phone: "+40 700 000 000",
+            },
+          },
+        },
+        parameters: {
+          draft: {
+            configure: {
+              departureDate: "2026-08-15",
+              pax: { adults: 2, children: 1 },
+            },
+          },
+        },
+      },
+      result: {
+        bookingId: "book_01sourced",
+        orderRef: "upstream_order_1",
+        status: "held",
+        snapshotId: "snap_1",
+        pricing: {
+          base_amount: 10000,
+          taxes: 1900,
+          fees: 500,
+          surcharges: 0,
+          currency: "EUR",
+        },
+      },
+      snapshot: {
+        id: "snap_1",
+        booking_id: "book_01sourced",
+        entity_module: "products",
+        entity_id: "demo_product_1",
+        source_kind: "demo",
+        source_provider: null,
+        source_connection_id: null,
+        source_ref: "demo_ref_1",
+        frozen_payload: { content: { product: { name: "Lisbon package" } } },
+        overlay_state_at_capture: null,
+        pricing_base_amount: "10000",
+        pricing_taxes: "1900",
+        pricing_fees: "500",
+        pricing_surcharges: "0",
+        pricing_currency: "EUR",
+        pricing_breakdown: null,
+        pricing_applied_offers: null,
+        idempotency_key: "idem_1",
+        captured_at: new Date("2026-07-02T08:00:00Z"),
+      },
+    })
+
+    expect(rows.booking).toMatchObject({
+      id: "book_01sourced",
+      status: "on_hold",
+      personId: "person_1",
+      sourceType: "api_partner",
+      externalBookingRef: "upstream_order_1",
+      contactFirstName: "Ada",
+      contactLastName: "Lovelace",
+      sellCurrency: "EUR",
+      sellAmountCents: 12400,
+      startDate: "2026-08-15",
+      endDate: "2026-08-15",
+      pax: 3,
+    })
+    expect(rows.item).toMatchObject({
+      bookingId: "book_01sourced",
+      title: "Lisbon package",
+      status: "on_hold",
+      sellCurrency: "EUR",
+      totalSellAmountCents: 12400,
+      productId: "demo_product_1",
+      sourceSnapshotId: "snap_1",
+      sourceOfferId: "demo_ref_1",
+    })
+    expect(rows.activity).toMatchObject({
+      bookingId: "book_01sourced",
+      actorId: "user_1",
+      activityType: "booking_created",
+    })
+  })
+})

--- a/starters/operator/src/api/runtime/catalog-booking-runtime.ts
+++ b/starters/operator/src/api/runtime/catalog-booking-runtime.ts
@@ -1,8 +1,13 @@
+import { bookingActivityLog, bookingItems, bookings } from "@voyant-travel/bookings/schema"
 import {
+  type BookEntityResult,
+  type CatalogBookingBookBody,
+  type CatalogBookingCommittedEvent,
   type CatalogBookingMountTarget,
   type CatalogBookingRouteModuleOptions,
   type CatalogBookingRoutesOptions,
   catalogQuotesTable,
+  getOrderById,
   mountCatalogBookingRoutes as mountPackageCatalogBookingRoutes,
   OWNED_SOURCE_KIND,
   type QuoteEntityResult,
@@ -10,6 +15,7 @@ import {
 } from "@voyant-travel/catalog/booking-engine"
 import { createCatalogPromotionEvaluator } from "@voyant-travel/commerce"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { newId } from "@voyant-travel/db/lib/typeid"
 import { suppliers } from "@voyant-travel/distribution"
 import { computeBookingItemTaxLine, resolveBookingSellTaxRate } from "@voyant-travel/finance"
 import { products, productsService } from "@voyant-travel/inventory"
@@ -65,10 +71,199 @@ function createOperatorCatalogBookingRoutesOptions(): CatalogBookingRoutesOption
         },
       })
     },
+    onCommitted: materializeSourcedBookingForCatalogCommit,
     onDraftConsumedError: ({ error }) => {
       console.warn("[catalog-booking] markDraftConsumed failed:", error)
     },
   }
+}
+
+export async function materializeSourcedBookingForCatalogCommit({
+  c,
+  db,
+  request,
+  result,
+}: CatalogBookingCommittedEvent): Promise<void> {
+  // Storefront checkout has its own richer materializer after /checkout/start
+  // that reads the consumed draft and writes traveler/payment/provider state.
+  // This hook only repairs the admin in-process commit path, where the host
+  // navigates straight to /bookings/:id after /book.
+  if (c.req.path.startsWith("/v1/public/")) return
+
+  const snapshot = await getOrderById(db, result.snapshotId)
+  if (!snapshot || snapshot.source_kind === OWNED_SOURCE_KIND) return
+
+  const typedDb = db as PostgresJsDatabase
+  const [existing] = await typedDb
+    .select({ id: bookings.id })
+    .from(bookings)
+    .where(eq(bookings.id, result.bookingId))
+    .limit(1)
+  if (existing) return
+
+  const actorId = typeof c.get("userId") === "string" ? c.get("userId") : "system"
+  const rows = buildSourcedBookingRows({ request, result, snapshot, actorId })
+
+  await typedDb.transaction(async (tx) => {
+    await tx.insert(bookings).values(rows.booking)
+    await tx.insert(bookingItems).values(rows.item)
+    await tx.insert(bookingActivityLog).values(rows.activity)
+  })
+}
+
+export function buildSourcedBookingRows({
+  request,
+  result,
+  snapshot,
+  actorId,
+}: {
+  request: CatalogBookingBookBody
+  result: BookEntityResult
+  snapshot: NonNullable<Awaited<ReturnType<typeof getOrderById>>>
+  actorId: string
+}): {
+  booking: typeof bookings.$inferInsert
+  item: typeof bookingItems.$inferInsert
+  activity: typeof bookingActivityLog.$inferInsert
+} {
+  const party = asRecord(request.party)
+  const billing = asRecord(party?.billing)
+  const billingContact = asRecord(billing?.contact)
+  const parameters = asRecord(request.parameters)
+  const draft = asRecord(parameters?.draft)
+  const configure = asRecord(draft?.configure)
+  const dateRange = asRecord(configure?.dateRange)
+  const pricing = result.pricing
+  const currency = pricing?.currency ?? snapshot.pricing_currency ?? "EUR"
+  const totalAmountCents = pricingTotalCents(pricing)
+  const startDate = dateString(configure?.departureDate) ?? dateString(dateRange?.checkIn) ?? null
+  const endDate = dateString(dateRange?.checkOut) ?? startDate
+  const bookingStatus = bookingStatusForSourcedResult(result.status)
+  const itemStatus = bookingStatus === "on_hold" ? "on_hold" : "confirmed"
+  const title = sourcedBookingTitle(snapshot.frozen_payload, snapshot.entity_id)
+  const bookingNumber = localBookingNumber("SRC")
+  const contact = {
+    firstName: stringValue(billingContact?.firstName),
+    lastName: stringValue(billingContact?.lastName),
+    email: stringValue(billingContact?.email),
+    phone: stringValue(billingContact?.phone),
+  }
+
+  return {
+    booking: {
+      id: result.bookingId,
+      bookingNumber,
+      status: bookingStatus,
+      personId: stringValue(party?.personId) ?? stringValue(billing?.personId) ?? null,
+      organizationId:
+        stringValue(party?.organizationId) ?? stringValue(billing?.organizationId) ?? null,
+      sourceType: "api_partner" as const,
+      externalBookingRef: result.orderRef,
+      contactFirstName: contact.firstName ?? null,
+      contactLastName: contact.lastName ?? null,
+      contactEmail: contact.email ?? null,
+      contactPhone: contact.phone ?? null,
+      sellCurrency: currency,
+      sellAmountCents: totalAmountCents,
+      startDate,
+      endDate,
+      pax: totalPaxFromDraft(draft),
+      internalNotes: `Sourced booking committed via ${snapshot.source_kind}. Snapshot: ${snapshot.id}`,
+    },
+    item: {
+      id: newId("booking_items"),
+      bookingId: result.bookingId,
+      title,
+      itemType: "unit" as const,
+      status: itemStatus,
+      serviceDate: startDate,
+      quantity: 1,
+      sellCurrency: currency,
+      unitSellAmountCents: totalAmountCents,
+      totalSellAmountCents: totalAmountCents,
+      productId: snapshot.entity_module === "products" ? snapshot.entity_id : null,
+      sourceSnapshotId: snapshot.id,
+      sourceOfferId: snapshot.source_ref,
+      productNameSnapshot: title,
+      metadata: {
+        entityModule: snapshot.entity_module,
+        entityId: snapshot.entity_id,
+        sourceKind: snapshot.source_kind,
+        sourceConnectionId: snapshot.source_connection_id,
+        upstreamRef: result.orderRef,
+      },
+    },
+    activity: {
+      bookingId: result.bookingId,
+      actorId,
+      activityType: "booking_created" as const,
+      description: `Booking ${bookingNumber} created from sourced catalog order ${result.orderRef}`,
+      metadata: {
+        sourceKind: snapshot.source_kind,
+        snapshotId: snapshot.id,
+        orderRef: result.orderRef,
+      },
+    },
+  }
+}
+
+function bookingStatusForSourcedResult(
+  status: BookEntityResult["status"],
+): "on_hold" | "confirmed" {
+  return status === "held" ? "on_hold" : "confirmed"
+}
+
+function pricingTotalCents(pricing: BookEntityResult["pricing"]): number | null {
+  if (!pricing) return null
+  return Math.round(pricing.base_amount + pricing.taxes + pricing.fees + pricing.surcharges)
+}
+
+function totalPaxFromDraft(draft: Record<string, unknown> | undefined): number | null {
+  const configure = asRecord(draft?.configure)
+  const pax = asRecord(configure?.pax)
+  if (!pax) return null
+  const total = Object.values(pax).reduce<number>(
+    (sum, value) => sum + (typeof value === "number" && Number.isFinite(value) ? value : 0),
+    0,
+  )
+  return total > 0 ? total : null
+}
+
+function sourcedBookingTitle(frozenPayload: unknown, fallback: string): string {
+  const payload = asRecord(frozenPayload)
+  const content = asRecord(payload?.content)
+  const product = asRecord(content?.product)
+  const hotel = asRecord(content?.hotel)
+  const cruise = asRecord(content?.cruise)
+  return (
+    stringValue(product?.name) ??
+    stringValue(hotel?.name) ??
+    stringValue(cruise?.name) ??
+    stringValue(payload?.name) ??
+    fallback
+  )
+}
+
+function dateString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return /^\d{4}-\d{2}-\d{2}/.test(trimmed) ? trimmed.slice(0, 10) : null
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+function localBookingNumber(prefix: string): string {
+  const timestamp = Date.now().toString(36).toUpperCase()
+  const suffix = Math.random().toString(36).slice(2, 6).toUpperCase()
+  return `${prefix}-${timestamp}-${suffix}`
 }
 
 /**


### PR DESCRIPTION
Closes #2424

## Summary
- materialize a minimal Voyant booking row for successful sourced catalog commits using the booking id minted by the catalog engine
- add a booking item tied to the catalog snapshot so booking detail can show the sourced line instead of 404ing
- skip owned commits, since owned handlers already create readable booking rows

## Verification
- pnpm --filter operator test -- src/api/runtime/catalog-booking-runtime.test.ts
- pnpm exec biome check starters/operator/src/api/runtime/catalog-booking-runtime.ts starters/operator/src/api/runtime/catalog-booking-runtime.test.ts
- pnpm --filter operator lint

## Notes
- Local `pnpm --filter operator typecheck` OOMed at the starter command's 14 GB heap limit during `tsc -p tsconfig.server.json`; CI will run the full graph remotely.