### PR TITLE
Validate person document ranges

### DIFF
--- a/.changeset/person-document-date-add.md
+++ b/.changeset/person-document-date-add.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/relationships-contracts": patch
+"@voyant-travel/relationships": patch
+"@voyant-travel/relationships-react": patch
+---
+
+Validate person document issue/expiry date ranges and expose add and primary actions in the person detail documents tab.

--- a/packages/relationships-contracts/src/validation/person-documents.ts
+++ b/packages/relationships-contracts/src/validation/person-documents.ts
@@ -13,6 +13,19 @@ export const personDocumentTypeSchema = z.enum([
   "other",
 ])
 
+function validateDocumentDateRange(
+  data: { issueDate?: string | null; expiryDate?: string | null },
+  ctx: z.RefinementCtx,
+) {
+  if (data.issueDate && data.expiryDate && data.expiryDate < data.issueDate) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["expiryDate"],
+      message: "expiryDate must be on or after issueDate",
+    })
+  }
+}
+
 export const personDocumentCoreSchema = z.object({
   type: personDocumentTypeSchema,
   // `z.lazy` for cross-package init-cycle protection — see #501.
@@ -27,8 +40,11 @@ export const personDocumentCoreSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 })
 
-export const insertPersonDocumentSchema = personDocumentCoreSchema
-export const updatePersonDocumentSchema = personDocumentCoreSchema.partial()
+export const insertPersonDocumentSchema =
+  personDocumentCoreSchema.superRefine(validateDocumentDateRange)
+export const updatePersonDocumentSchema = personDocumentCoreSchema
+  .partial()
+  .superRefine(validateDocumentDateRange)
 export const personDocumentListQuerySchema = paginationSchema.extend({
   type: personDocumentTypeSchema.optional(),
   expiringBefore: z.string().date().optional(),
@@ -53,8 +69,11 @@ const personDocumentPlaintextCoreSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable().optional(),
 })
 
-export const insertPersonDocumentFromPlaintextSchema = personDocumentPlaintextCoreSchema
-export const updatePersonDocumentFromPlaintextSchema = personDocumentPlaintextCoreSchema.partial()
+export const insertPersonDocumentFromPlaintextSchema =
+  personDocumentPlaintextCoreSchema.superRefine(validateDocumentDateRange)
+export const updatePersonDocumentFromPlaintextSchema = personDocumentPlaintextCoreSchema
+  .partial()
+  .superRefine(validateDocumentDateRange)
 
 /**
  * Plaintext input shape for the four free-text PII slots on

--- a/packages/relationships-react/src/components/person-detail-panels.tsx
+++ b/packages/relationships-react/src/components/person-detail-panels.tsx
@@ -714,40 +714,53 @@ export function PersonDocumentsPanel({
 }: PersonDocumentsPanelProps) {
   const i18n = useCrmUiI18nOrDefault()
   const messages = useCrmUiMessagesOrDefault()
+  const [createOpen, setCreateOpen] = useState(false)
+  const canEdit = Boolean(personId)
 
   if (documentsPending) {
     return <LoadingRow />
   }
 
-  if (documents.length === 0) {
-    return <EmptyRow>{messages.personDetail.empty.noDocuments}</EmptyRow>
-  }
-
   return (
     <div className="flex flex-col gap-3">
-      <div className="flex items-center gap-2 text-xs text-muted-foreground">
-        <FileText className="size-3.5" aria-hidden="true" />
-        <span>
-          {primaryCount} {messages.personDetail.sections.primary}
-        </span>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <FileText className="size-3.5" aria-hidden="true" />
+          <span>
+            {primaryCount} {messages.personDetail.sections.primary}
+          </span>
+        </div>
+        {canEdit ? (
+          <Button type="button" variant="ghost" size="sm" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1 size-3.5" aria-hidden="true" />
+            {messages.personDocument.row.addButton}
+          </Button>
+        ) : null}
       </div>
-      <ul className="divide-y">
-        {documents.map((document) => (
-          <PersonDocumentRow
-            key={document.id}
-            document={document}
-            personId={personId}
-            typeLabel={
-              messages.personDetail.documentTypeLabels[
-                document.type as keyof typeof messages.personDetail.documentTypeLabels
-              ] ?? document.type
-            }
-            formattedExpiry={formatCrmDate(i18n, document.expiryDate)}
-            noneLabel={messages.common.none}
-            primaryLabel={messages.personDetail.sections.primary}
-          />
-        ))}
-      </ul>
+      {documents.length === 0 ? (
+        <EmptyRow>{messages.personDetail.empty.noDocuments}</EmptyRow>
+      ) : (
+        <ul className="divide-y">
+          {documents.map((document) => (
+            <PersonDocumentRow
+              key={document.id}
+              document={document}
+              personId={personId}
+              typeLabel={
+                messages.personDetail.documentTypeLabels[
+                  document.type as keyof typeof messages.personDetail.documentTypeLabels
+                ] ?? document.type
+              }
+              formattedExpiry={formatCrmDate(i18n, document.expiryDate)}
+              noneLabel={messages.common.none}
+              primaryLabel={messages.personDetail.sections.primary}
+            />
+          ))}
+        </ul>
+      )}
+      {canEdit && personId ? (
+        <PersonDocumentDialog open={createOpen} onOpenChange={setCreateOpen} personId={personId} />
+      ) : null}
     </div>
   )
 }
@@ -822,6 +835,18 @@ function PersonDocumentRow({
             >
               <Pencil className="size-3.5" />
             </button>
+          ) : null}
+          {editable && !document.isPrimary ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              disabled={mutation.setPrimary.isPending}
+              onClick={() => mutation.setPrimary.mutateAsync(document.id)}
+            >
+              {docMessages.row.makePrimary}
+            </Button>
           ) : null}
           {editable ? (
             <ConfirmActionButton

--- a/packages/relationships-react/src/components/person-document-dialog.tsx
+++ b/packages/relationships-react/src/components/person-document-dialog.tsx
@@ -53,7 +53,7 @@ export interface PersonDocumentDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   personId: string
-  document: PersonDocumentDialogDocument
+  document?: PersonDocumentDialogDocument
 }
 
 interface FormState {
@@ -68,18 +68,18 @@ interface FormState {
 }
 
 function buildInitialState(
-  document: PersonDocumentDialogDocument,
+  document: PersonDocumentDialogDocument | undefined,
   revealedNumber: string | null,
 ): FormState {
   return {
-    type: document.type,
+    type: document?.type ?? "passport",
     number: revealedNumber ?? "",
-    issuingCountry: document.issuingCountry ?? "",
-    issuingAuthority: document.issuingAuthority ?? "",
-    issueDate: document.issueDate ?? "",
-    expiryDate: document.expiryDate ?? "",
-    isPrimary: document.isPrimary,
-    notes: document.notes ?? "",
+    issuingCountry: document?.issuingCountry ?? "",
+    issuingAuthority: document?.issuingAuthority ?? "",
+    issueDate: document?.issueDate ?? "",
+    expiryDate: document?.expiryDate ?? "",
+    isPrimary: document?.isPrimary ?? false,
+    notes: document?.notes ?? "",
   }
 }
 
@@ -89,12 +89,13 @@ export function PersonDocumentDialog({
   personId,
   document,
 }: PersonDocumentDialogProps) {
-  const revealQuery = useRevealPersonDocument(document.id, { enabled: open })
+  const revealQuery = useRevealPersonDocument(document?.id, { enabled: open && Boolean(document) })
   const revealedNumber = revealQuery.data?.data.number ?? null
-  const { updateFromPlaintext } = usePersonDocumentMutation(personId)
+  const { createFromPlaintext, updateFromPlaintext } = usePersonDocumentMutation(personId)
   const messages = useCrmUiMessagesOrDefault()
   const dialog = messages.personDocument.dialog
   const typeLabels = messages.personDetail.documentTypeLabels
+  const isEditing = Boolean(document)
 
   const [state, setState] = React.useState<FormState>(() => buildInitialState(document, null))
   const initializedRef = React.useRef(false)
@@ -115,32 +116,36 @@ export function PersonDocumentDialog({
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault()
-    await updateFromPlaintext.mutateAsync({
-      id: document.id,
-      input: {
-        type: state.type,
-        number: state.number.trim() === "" ? null : state.number.trim(),
-        issuingCountry: state.issuingCountry.trim() === "" ? null : state.issuingCountry.trim(),
-        issuingAuthority:
-          state.issuingAuthority.trim() === "" ? null : state.issuingAuthority.trim(),
-        issueDate: state.issueDate === "" ? null : state.issueDate,
-        expiryDate: state.expiryDate === "" ? null : state.expiryDate,
-        isPrimary: state.isPrimary,
-        notes: state.notes.trim() === "" ? null : state.notes.trim(),
-      },
-    })
+    const input = {
+      type: state.type,
+      number: state.number.trim() === "" ? null : state.number.trim(),
+      issuingCountry: state.issuingCountry.trim() === "" ? null : state.issuingCountry.trim(),
+      issuingAuthority: state.issuingAuthority.trim() === "" ? null : state.issuingAuthority.trim(),
+      issueDate: state.issueDate === "" ? null : state.issueDate,
+      expiryDate: state.expiryDate === "" ? null : state.expiryDate,
+      isPrimary: state.isPrimary,
+      notes: state.notes.trim() === "" ? null : state.notes.trim(),
+    }
+    if (document) {
+      await updateFromPlaintext.mutateAsync({ id: document.id, input })
+    } else {
+      await createFromPlaintext.mutateAsync(input)
+    }
     onOpenChange(false)
   }
 
   const revealError = revealQuery.error
-  const updateError = updateFromPlaintext.error
+  const saveMutation = isEditing ? updateFromPlaintext : createFromPlaintext
+  const saveError = saveMutation.error
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[520px]">
         <DialogHeader>
-          <DialogTitle>{dialog.title}</DialogTitle>
-          <DialogDescription>{dialog.description}</DialogDescription>
+          <DialogTitle>{isEditing ? dialog.title : dialog.addTitle}</DialogTitle>
+          <DialogDescription>
+            {isEditing ? dialog.description : dialog.addDescription}
+          </DialogDescription>
         </DialogHeader>
         {revealQuery.isLoading ? (
           <p className="py-6 text-center text-sm text-muted-foreground">{dialog.loading}</p>
@@ -233,17 +238,17 @@ export function PersonDocumentDialog({
               />
             </div>
           </DialogBody>
-          {updateError ? (
+          {saveError ? (
             <p className="text-sm text-destructive">
-              {updateError instanceof Error ? updateError.message : dialog.saveFailed}
+              {saveError instanceof Error ? saveError.message : dialog.saveFailed}
             </p>
           ) : null}
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               {dialog.cancel}
             </Button>
-            <Button type="submit" disabled={updateFromPlaintext.isPending}>
-              {updateFromPlaintext.isPending ? dialog.saving : dialog.save}
+            <Button type="submit" disabled={saveMutation.isPending}>
+              {saveMutation.isPending ? dialog.saving : dialog.save}
             </Button>
           </DialogFooter>
         </form>

--- a/packages/relationships-react/src/i18n/en/detail.ts
+++ b/packages/relationships-react/src/i18n/en/detail.ts
@@ -236,6 +236,8 @@ export const crmUiEnDetailMessages = {
   },
   personDocument: {
     row: {
+      addButton: "Add document",
+      makePrimary: "Make primary",
       decrypting: "Decrypting…",
       noNumberOnFile: "(no number on file)",
       revealFailed: "Failed to reveal.",
@@ -249,8 +251,11 @@ export const crmUiEnDetailMessages = {
     },
     dialog: {
       title: "Edit document",
+      addTitle: "Add document",
       description:
         "Update document details. Numbers are encrypted at rest and audit-logged on reveal.",
+      addDescription:
+        "Add document details. Numbers are encrypted at rest and audit-logged on reveal.",
       revealFailed: "Failed to reveal document.",
       fields: {
         type: "Type",

--- a/packages/relationships-react/src/i18n/messages.ts
+++ b/packages/relationships-react/src/i18n/messages.ts
@@ -538,6 +538,8 @@ export type CrmUiMessages = {
   personDocument: {
     /** Row-level inline reveal panel + per-row action icons. */
     row: {
+      addButton: string
+      makePrimary: string
       decrypting: string
       noNumberOnFile: string
       revealFailed: string
@@ -552,7 +554,9 @@ export type CrmUiMessages = {
     /** Edit dialog (opens when the operator clicks the pencil). */
     dialog: {
       title: string
+      addTitle: string
       description: string
+      addDescription: string
       revealFailed: string
       fields: {
         type: string

--- a/packages/relationships-react/src/i18n/ro/detail.ts
+++ b/packages/relationships-react/src/i18n/ro/detail.ts
@@ -236,6 +236,8 @@ export const crmUiRoDetailMessages = {
   },
   personDocument: {
     row: {
+      addButton: "Adauga document",
+      makePrimary: "Marcheaza principal",
       decrypting: "Se decripteaza…",
       noNumberOnFile: "(niciun numar inregistrat)",
       revealFailed: "Afisarea a esuat.",
@@ -249,8 +251,11 @@ export const crmUiRoDetailMessages = {
     },
     dialog: {
       title: "Editeaza documentul",
+      addTitle: "Adauga document",
       description:
         "Actualizeaza detaliile documentului. Numerele sunt criptate si fiecare dezvaluire este auditata.",
+      addDescription:
+        "Adauga detaliile documentului. Numerele sunt criptate si fiecare dezvaluire este auditata.",
       revealFailed: "Dezvaluirea documentului a esuat.",
       fields: {
         type: "Tip",

--- a/packages/relationships/src/service/person-documents.ts
+++ b/packages/relationships/src/service/person-documents.ts
@@ -1,3 +1,4 @@
+import { RequestValidationError } from "@voyant-travel/hono"
 import type { KeyRef, KmsProvider } from "@voyant-travel/utils"
 import { decryptOptionalJsonEnvelope } from "@voyant-travel/utils"
 import { and, asc, desc, eq, gte, isNotNull, lte, sql } from "drizzle-orm"
@@ -55,6 +56,14 @@ async function personExists(db: PostgresJsDatabase, personId: string) {
     .where(eq(people.id, personId))
     .limit(1)
   return Boolean(row)
+}
+
+function assertValidDocumentDateRange(issueDate?: string | null, expiryDate?: string | null) {
+  if (issueDate && expiryDate && expiryDate < issueDate) {
+    throw new RequestValidationError("expiryDate must be on or after issueDate", {
+      fields: { expiryDate: ["expiryDate must be on or after issueDate"] },
+    })
+  }
 }
 
 async function clearPrimaryForType(
@@ -159,6 +168,7 @@ export const personDocumentsService = {
     data: CreatePersonDocumentInput,
   ) {
     if (!(await personExists(db, personId))) return null
+    assertValidDocumentDateRange(data.issueDate, data.expiryDate)
 
     return db.transaction(async (tx) => {
       if (data.isPrimary) {
@@ -184,6 +194,11 @@ export const personDocumentsService = {
         .where(eq(personDocuments.id, documentId))
         .limit(1)
       if (!existing) return null
+
+      assertValidDocumentDateRange(
+        data.issueDate !== undefined ? data.issueDate : existing.issueDate,
+        data.expiryDate !== undefined ? data.expiryDate : existing.expiryDate,
+      )
 
       // Clear prior primary of the *target* type whenever the row
       // will end up primary after this update — including the case

--- a/packages/relationships/tests/integration/person-documents.test.ts
+++ b/packages/relationships/tests/integration/person-documents.test.ts
@@ -143,6 +143,31 @@ describe.skipIf(!DB_AVAILABLE)("personDocumentsService", () => {
     expect(refreshed?.isPrimary).toBe(false)
   })
 
+  it("rejects reversed document date ranges on create and merged update", async () => {
+    const person = await seedPerson()
+
+    await expect(
+      personDocumentsService.createPersonDocument(db, person.id, {
+        type: "visa",
+        issueDate: "2031-01-01",
+        expiryDate: "2026-01-01",
+      }),
+    ).rejects.toThrow("expiryDate must be on or after issueDate")
+
+    const created = await personDocumentsService.createPersonDocument(db, person.id, {
+      type: "passport",
+      issueDate: "2026-01-01",
+      expiryDate: "2031-01-01",
+    })
+    if (!created) throw new Error("expected document")
+
+    await expect(
+      personDocumentsService.updatePersonDocument(db, created.id, {
+        issueDate: "2032-01-01",
+      }),
+    ).rejects.toThrow("expiryDate must be on or after issueDate")
+  })
+
   it("getPrimaryPersonDocument returns the matching primary or null", async () => {
     const person = await seedPerson()
     expect(

--- a/packages/relationships/tests/unit/validation-person-documents.test.ts
+++ b/packages/relationships/tests/unit/validation-person-documents.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  insertPersonDocumentFromPlaintextSchema,
+  insertPersonDocumentSchema,
+  updatePersonDocumentFromPlaintextSchema,
+  updatePersonDocumentSchema,
+} from "../../src/validation.js"
+
+describe("Person document schemas", () => {
+  it("accepts valid issue and expiry dates", () => {
+    const result = insertPersonDocumentSchema.parse({
+      type: "passport",
+      issueDate: "2026-01-01",
+      expiryDate: "2031-01-01",
+    })
+
+    expect(result.issueDate).toBe("2026-01-01")
+    expect(result.expiryDate).toBe("2031-01-01")
+  })
+
+  it("rejects reversed issue and expiry dates", () => {
+    expect(() =>
+      insertPersonDocumentSchema.parse({
+        type: "visa",
+        issueDate: "2031-01-01",
+        expiryDate: "2026-01-01",
+      }),
+    ).toThrow()
+  })
+
+  it("validates plaintext document date ranges", () => {
+    expect(() =>
+      insertPersonDocumentFromPlaintextSchema.parse({
+        type: "passport",
+        number: "AA123456",
+        issueDate: "2031-01-01",
+        expiryDate: "2026-01-01",
+      }),
+    ).toThrow()
+  })
+
+  it("allows partial updates for merged service validation", () => {
+    const result = updatePersonDocumentSchema.parse({ expiryDate: "2030-01-01" })
+
+    expect(result.expiryDate).toBe("2030-01-01")
+  })
+
+  it("rejects explicit reversed partial update ranges", () => {
+    expect(() =>
+      updatePersonDocumentFromPlaintextSchema.parse({
+        issueDate: "2031-01-01",
+        expiryDate: "2026-01-01",
+      }),
+    ).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

- validate person document issue/expiry date ranges in contracts and service merged-state updates
- add a Documents tab Add document action using the plaintext create route
- let operators mark existing documents primary directly from the person detail Documents tab
- reuse the document dialog for create and edit, including the primary toggle

Fixes #2552

## Validation

- `pnpm --filter @voyant-travel/relationships test -- tests/unit/validation-person-documents.test.ts tests/integration/person-documents.test.ts`
- `pnpm --filter @voyant-travel/relationships-contracts typecheck`
- `pnpm --filter @voyant-travel/relationships typecheck`
- `pnpm --filter @voyant-travel/relationships-react typecheck`
- `pnpm --filter @voyant-travel/openapi generate`
- `pnpm --filter operator generate:openapi`
- `pnpm --filter @voyant-travel/relationships-contracts build`
- `pnpm --filter @voyant-travel/relationships build`
- `pnpm --filter @voyant-travel/relationships-react build`
- `pnpm exec biome check ...`
- `git diff --check`
- pre-push hook: `pnpm test` (96 tasks passed)
