### PR TITLE
Validate communication sent timestamps

### DIFF
--- a/.changeset/communication-sent-at-validation.md
+++ b/.changeset/communication-sent-at-validation.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/relationships-contracts": patch
+"@voyant-travel/relationships": patch
+"@voyant-travel/openapi": patch
+---
+
+Reject invalid communication `sentAt` values during request validation instead of failing during persistence.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -6493,7 +6493,8 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "format": "date-time"
                   }
                 },
                 "required": [

--- a/packages/relationships-contracts/src/validation/communication-log.ts
+++ b/packages/relationships-contracts/src/validation/communication-log.ts
@@ -14,7 +14,7 @@ export const insertCommunicationLogSchema = z.object({
   direction: communicationDirectionSchema,
   subject: z.string().max(500).nullable().optional(),
   content: z.string().nullable().optional(),
-  sentAt: z.string().nullable().optional(),
+  sentAt: z.string().datetime({ offset: true }).nullable().optional(),
 })
 
 export const communicationListQuerySchema = paginationSchema.extend({

--- a/packages/relationships/tests/integration/accounts-people.suite.ts
+++ b/packages/relationships/tests/integration/accounts-people.suite.ts
@@ -218,6 +218,27 @@ describe.skipIf(!DB_AVAILABLE)("People account routes", () => {
       expect(invalidPatch.status).toBe(400)
     })
 
+    it("rejects invalid communication sentAt values before persistence", async () => {
+      const personRes = await getApp().request("/people", {
+        method: "POST",
+        ...json({ firstName: "Communication", lastName: "Validation" }),
+      })
+      const person = (await personRes.json()).data
+
+      const res = await getApp().request(`/people/${person.id}/communications`, {
+        method: "POST",
+        ...json({
+          channel: "email",
+          direction: "outbound",
+          subject: "Bad date",
+          content: "Body",
+          sentAt: "not-a-date",
+        }),
+      })
+
+      expect(res.status).toBe(400)
+    })
+
     it("reflects contact-point updates without an explicit rebuild (#446 view)", async () => {
       // Replaces the old projection-cache assertion: the
       // `person_directory` view computes email/phone/website live, so

--- a/packages/relationships/tests/unit/validation-engagement.test.ts
+++ b/packages/relationships/tests/unit/validation-engagement.test.ts
@@ -148,6 +148,26 @@ describe("Communication log schemas", () => {
     expect(result.sentAt).toBe("2024-06-15T14:00:00Z")
   })
 
+  it("accepts sentAt timestamps with numeric offsets", () => {
+    const result = insertCommunicationLogSchema.parse({
+      channel: "email",
+      direction: "outbound",
+      sentAt: "2024-06-15T14:00:00+02:00",
+    })
+
+    expect(result.sentAt).toBe("2024-06-15T14:00:00+02:00")
+  })
+
+  it("rejects invalid sentAt timestamp", () => {
+    expect(() =>
+      insertCommunicationLogSchema.parse({
+        channel: "email",
+        direction: "outbound",
+        sentAt: "not-a-date",
+      }),
+    ).toThrow()
+  })
+
   it("rejects subject over 500 chars", () => {
     expect(() =>
       insertCommunicationLogSchema.parse({

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -6493,7 +6493,8 @@
                     "type": [
                       "string",
                       "null"
-                    ]
+                    ],
+                    "format": "date-time"
                   }
                 },
                 "required": [


### PR DESCRIPTION
## Summary

- validate communication `sentAt` values as RFC3339 date-time strings with numeric offsets allowed
- return request validation errors before persistence for invalid communication timestamps
- regenerate admin relationships OpenAPI specs with `format: date-time` on communication `sentAt`

Fixes #2551

## Validation

- `pnpm --filter @voyant-travel/relationships test -- tests/unit/validation-engagement.test.ts tests/integration/accounts-people.suite.ts`
- `pnpm --filter @voyant-travel/openapi generate`
- `pnpm --filter operator generate:openapi`
- `pnpm --filter @voyant-travel/relationships-contracts typecheck && pnpm --filter @voyant-travel/relationships-contracts build`
- `pnpm --filter @voyant-travel/relationships typecheck && pnpm --filter @voyant-travel/relationships build`
- `pnpm exec biome check --write .changeset/communication-sent-at-validation.md packages/relationships-contracts/src/validation/communication-log.ts packages/relationships/tests/unit/validation-engagement.test.ts packages/relationships/tests/integration/accounts-people.suite.ts`
- `git diff --check`
- pre-push hook `pnpm test`

## Notes

- `pnpm --filter @voyant-travel/openapi typecheck` was attempted but exited with a V8 out-of-memory failure near the configured 14 GB heap limit; OpenAPI generation completed successfully.