### PR TITLE
Agent tools: read tools for bookings, finance, quotes, and CRM

### DIFF
--- a/.changeset/domain-read-tools.md
+++ b/.changeset/domain-read-tools.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/bookings": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/quotes": minor
+"@voyant-travel/relationships": minor
+---
+
+Add read-only agent tools (`./tools`) for four more domains, following the
+module-owned-tools pattern over each package's existing service:
+
+- `@voyant-travel/bookings`: `list_bookings` + `get_booking` (non-PII, `bookings:read`).
+- `@voyant-travel/finance`: `list_invoices` + `get_invoice` (`finance:read`).
+- `@voyant-travel/quotes`: `list_quotes` + `get_quote` (`quotes:read`).
+- `@voyant-travel/relationships`: `list_people` / `get_person` / `list_organizations` /
+  `get_organization` (`crm:read`).
+
+The operator registers them on the in-deployment MCP server, so `/v1/admin/mcp` now
+serves trips, products, bookings, finance, quotes, and CRM tools, each gated per-tool
+by scope + audience.

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -27,7 +27,8 @@
     "./extras": "./src/extras.ts",
     "./extensions/suppliers": "./src/extensions/suppliers.ts",
     "./status": "./src/status.ts",
-    "./status-dispatch": "./src/status-dispatch.ts"
+    "./status-dispatch": "./src/status-dispatch.ts",
+    "./tools": "./src/tools.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json",
@@ -49,7 +50,8 @@
     "@voyant-travel/utils": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@voyant-travel/tools": "workspace:^"
   },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",
@@ -183,6 +185,11 @@
         "types": "./dist/status-dispatch.d.ts",
         "import": "./dist/status-dispatch.js",
         "default": "./dist/status-dispatch.js"
+      },
+      "./tools": {
+        "types": "./dist/tools.d.ts",
+        "import": "./dist/tools.js",
+        "default": "./dist/tools.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/bookings/src/tools.ts
+++ b/packages/bookings/src/tools.ts
@@ -1,0 +1,62 @@
+/**
+ * Bookings agent tools on the framework tool contract. Thin, read-only wrappers
+ * over the existing bookings service; the service is injected on the tool context
+ * by intersection so this module stays deployment-agnostic.
+ *
+ * `list_bookings` / `get_booking` return non-PII booking state (`bookings:read`).
+ * PII fields are a separate concern gated on `bookings-pii:read` (see the booking
+ * PII surface) and are not exposed here.
+ */
+import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import { z } from "zod"
+
+import { bookingListQuerySchema } from "./validation.js"
+
+export interface BookingsToolServices {
+  listBookings(query: z.infer<typeof bookingListQuerySchema>): Promise<unknown>
+  getBookingById(id: string): Promise<unknown>
+}
+
+export type BookingsToolContext = ToolContext & { bookings?: BookingsToolServices }
+
+function bookings(ctx: BookingsToolContext): BookingsToolServices {
+  return requireService(ctx.bookings, "bookings")
+}
+
+export const listBookingsTool = defineTool<
+  z.infer<typeof bookingListQuerySchema>,
+  unknown,
+  BookingsToolContext
+>({
+  name: "list_bookings",
+  description: "List bookings with filters and pagination. Non-PII state only. Read-only.",
+  inputSchema: bookingListQuerySchema,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["bookings:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return bookings(ctx).listBookings(query)
+  },
+})
+
+const getBookingArgs = z.object({ id: z.string().min(1).describe("The booking id.") })
+
+export const getBookingTool = defineTool<
+  z.infer<typeof getBookingArgs>,
+  unknown,
+  BookingsToolContext
+>({
+  name: "get_booking",
+  description: "Read a single booking's non-PII state by id. Read-only.",
+  inputSchema: getBookingArgs,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["bookings:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }, ctx) {
+    return bookings(ctx).getBookingById(id)
+  },
+})
+
+export const bookingsTools = [listBookingsTool, getBookingTool] as const

--- a/packages/bookings/tests/tools.test.ts
+++ b/packages/bookings/tests/tools.test.ts
@@ -1,0 +1,56 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { type BookingsToolServices, bookingsTools } from "../src/tools.js"
+
+function ctx(
+  services?: Partial<BookingsToolServices>,
+): ToolContext & { bookings?: BookingsToolServices } {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "default",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+    bookings: services as BookingsToolServices | undefined,
+  }
+}
+
+describe("bookings tools", () => {
+  it("registers read tools gated on bookings:read (non-PII)", () => {
+    const registry = createToolRegistry()
+    registry.registerAll(bookingsTools)
+    const list = registry.list()
+    expect(list.map((t) => t.name).sort()).toEqual(["get_booking", "list_bookings"])
+    for (const t of list) {
+      expect(t.tier).toBe("read")
+      expect(t.requiredScopes).toEqual(["bookings:read"])
+    }
+  })
+
+  it("dispatches through the injected service", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(bookingsTools)
+    const result = await registry.dispatch(
+      "get_booking",
+      { id: "bk_1" },
+      ctx({
+        async listBookings() {
+          return { data: [] }
+        },
+        async getBookingById(id) {
+          return { id }
+        },
+      }),
+    )
+    expect(result).toMatchObject({ id: "bk_1" })
+  })
+
+  it("throws MISSING_SERVICE when unwired", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(bookingsTools)
+    await expect(registry.dispatch("list_bookings", {}, ctx(undefined))).rejects.toMatchObject({
+      code: "MISSING_SERVICE",
+    })
+  })
+})

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -21,7 +21,8 @@
     "./booking-tax": "./src/booking-tax.ts",
     "./routes": "./src/routes.ts",
     "./public-routes": "./src/routes-public.ts",
-    "./public-validation": "./src/validation-public.ts"
+    "./public-validation": "./src/validation-public.ts",
+    "./tools": "./src/tools.ts"
   },
   "scripts": {
     "typecheck": "NODE_OPTIONS=--max-old-space-size=4096 tsc -p tsconfig.typecheck.json",
@@ -48,7 +49,8 @@
     "drizzle-orm": "catalog:",
     "fflate": "^0.8.2",
     "hono": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@voyant-travel/tools": "workspace:^"
   },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",
@@ -152,6 +154,11 @@
         "types": "./dist/validation-public.d.ts",
         "import": "./dist/validation-public.js",
         "default": "./dist/validation-public.js"
+      },
+      "./tools": {
+        "types": "./dist/tools.d.ts",
+        "import": "./dist/tools.js",
+        "default": "./dist/tools.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -1,0 +1,58 @@
+/**
+ * Finance agent tools on the framework tool contract. Thin, read-only wrappers
+ * over the existing finance service; the service is injected on the tool context
+ * by intersection so this module stays deployment-agnostic.
+ */
+import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import { z } from "zod"
+
+import { invoiceListQuerySchema } from "./validation.js"
+
+export interface FinanceToolServices {
+  listInvoices(query: z.infer<typeof invoiceListQuerySchema>): Promise<unknown>
+  getInvoiceById(id: string): Promise<unknown>
+}
+
+export type FinanceToolContext = ToolContext & { finance?: FinanceToolServices }
+
+function finance(ctx: FinanceToolContext): FinanceToolServices {
+  return requireService(ctx.finance, "finance")
+}
+
+export const listInvoicesTool = defineTool<
+  z.infer<typeof invoiceListQuerySchema>,
+  unknown,
+  FinanceToolContext
+>({
+  name: "list_invoices",
+  description: "List invoices with filters and pagination. Read-only.",
+  inputSchema: invoiceListQuerySchema,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["finance:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return finance(ctx).listInvoices(query)
+  },
+})
+
+const getInvoiceArgs = z.object({ id: z.string().min(1).describe("The invoice id.") })
+
+export const getInvoiceTool = defineTool<
+  z.infer<typeof getInvoiceArgs>,
+  unknown,
+  FinanceToolContext
+>({
+  name: "get_invoice",
+  description: "Read a single invoice by id. Read-only.",
+  inputSchema: getInvoiceArgs,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["finance:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }, ctx) {
+    return finance(ctx).getInvoiceById(id)
+  },
+})
+
+export const financeTools = [listInvoicesTool, getInvoiceTool] as const

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -1,0 +1,56 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { type FinanceToolServices, financeTools } from "../src/tools.js"
+
+function ctx(
+  services?: Partial<FinanceToolServices>,
+): ToolContext & { finance?: FinanceToolServices } {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "default",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+    finance: services as FinanceToolServices | undefined,
+  }
+}
+
+describe("finance tools", () => {
+  it("registers read tools gated on finance:read", () => {
+    const registry = createToolRegistry()
+    registry.registerAll(financeTools)
+    const list = registry.list()
+    expect(list.map((t) => t.name).sort()).toEqual(["get_invoice", "list_invoices"])
+    for (const t of list) {
+      expect(t.tier).toBe("read")
+      expect(t.requiredScopes).toEqual(["finance:read"])
+    }
+  })
+
+  it("dispatches through the injected service", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(financeTools)
+    const result = await registry.dispatch(
+      "get_invoice",
+      { id: "inv_1" },
+      ctx({
+        async listInvoices() {
+          return { data: [] }
+        },
+        async getInvoiceById(id) {
+          return { id }
+        },
+      }),
+    )
+    expect(result).toMatchObject({ id: "inv_1" })
+  })
+
+  it("throws MISSING_SERVICE when unwired", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(financeTools)
+    await expect(registry.dispatch("list_invoices", {}, ctx(undefined))).rejects.toMatchObject({
+      code: "MISSING_SERVICE",
+    })
+  })
+})

--- a/packages/quotes/package.json
+++ b/packages/quotes/package.json
@@ -10,7 +10,8 @@
     "./validation": "./src/validation.ts",
     "./routes": "./src/routes/index.ts",
     "./booking-extension": "./src/booking-extension.ts",
-    "./proposal-routes": "./src/proposal-routes.ts"
+    "./proposal-routes": "./src/proposal-routes.ts",
+    "./tools": "./src/tools.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json",
@@ -31,7 +32,8 @@
     "@voyant-travel/trips": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@voyant-travel/tools": "workspace:^"
   },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",
@@ -80,6 +82,11 @@
         "types": "./dist/proposal-routes.d.ts",
         "import": "./dist/proposal-routes.js",
         "default": "./dist/proposal-routes.js"
+      },
+      "./tools": {
+        "types": "./dist/tools.d.ts",
+        "import": "./dist/tools.js",
+        "default": "./dist/tools.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/quotes/src/tools.ts
+++ b/packages/quotes/src/tools.ts
@@ -1,0 +1,54 @@
+/**
+ * Quotes agent tools on the framework tool contract. Thin, read-only wrappers
+ * over the existing quotes service; the service is injected on the tool context
+ * by intersection so this module stays deployment-agnostic.
+ */
+import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import { z } from "zod"
+
+import { quoteListQuerySchema } from "./validation.js"
+
+export interface QuotesToolServices {
+  listQuotes(query: z.infer<typeof quoteListQuerySchema>): Promise<unknown>
+  getQuoteById(id: string): Promise<unknown>
+}
+
+export type QuotesToolContext = ToolContext & { quotes?: QuotesToolServices }
+
+function quotes(ctx: QuotesToolContext): QuotesToolServices {
+  return requireService(ctx.quotes, "quotes")
+}
+
+export const listQuotesTool = defineTool<
+  z.infer<typeof quoteListQuerySchema>,
+  unknown,
+  QuotesToolContext
+>({
+  name: "list_quotes",
+  description: "List quotes with filters and pagination. Read-only.",
+  inputSchema: quoteListQuerySchema,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["quotes:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return quotes(ctx).listQuotes(query)
+  },
+})
+
+const getQuoteArgs = z.object({ id: z.string().min(1).describe("The quote id.") })
+
+export const getQuoteTool = defineTool<z.infer<typeof getQuoteArgs>, unknown, QuotesToolContext>({
+  name: "get_quote",
+  description: "Read a single quote (with its versions) by id. Read-only.",
+  inputSchema: getQuoteArgs,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["quotes:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }, ctx) {
+    return quotes(ctx).getQuoteById(id)
+  },
+})
+
+export const quotesTools = [listQuotesTool, getQuoteTool] as const

--- a/packages/quotes/tests/tools.test.ts
+++ b/packages/quotes/tests/tools.test.ts
@@ -1,0 +1,56 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { type QuotesToolServices, quotesTools } from "../src/tools.js"
+
+function ctx(
+  services?: Partial<QuotesToolServices>,
+): ToolContext & { quotes?: QuotesToolServices } {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "default",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+    quotes: services as QuotesToolServices | undefined,
+  }
+}
+
+describe("quotes tools", () => {
+  it("registers read tools gated on quotes:read", () => {
+    const manifest = createToolRegistry()
+    manifest.registerAll(quotesTools)
+    const list = manifest.list()
+    expect(list.map((t) => t.name).sort()).toEqual(["get_quote", "list_quotes"])
+    for (const t of list) {
+      expect(t.tier).toBe("read")
+      expect(t.requiredScopes).toEqual(["quotes:read"])
+    }
+  })
+
+  it("dispatches through the injected service", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(quotesTools)
+    const result = await registry.dispatch(
+      "get_quote",
+      { id: "quo_1" },
+      ctx({
+        async listQuotes() {
+          return { data: [] }
+        },
+        async getQuoteById(id) {
+          return { id }
+        },
+      }),
+    )
+    expect(result).toMatchObject({ id: "quo_1" })
+  })
+
+  it("throws MISSING_SERVICE when unwired", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(quotesTools)
+    await expect(registry.dispatch("list_quotes", {}, ctx(undefined))).rejects.toMatchObject({
+      code: "MISSING_SERVICE",
+    })
+  })
+})

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -11,7 +11,8 @@
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
     "./routes": "./src/routes/index.ts",
-    "./action-ledger-capabilities": "./src/action-ledger-capabilities.ts"
+    "./action-ledger-capabilities": "./src/action-ledger-capabilities.ts",
+    "./tools": "./src/tools.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json",
@@ -34,7 +35,8 @@
     "@voyant-travel/utils": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@voyant-travel/tools": "workspace:^"
   },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",
@@ -88,6 +90,11 @@
         "types": "./dist/action-ledger-capabilities.d.ts",
         "import": "./dist/action-ledger-capabilities.js",
         "default": "./dist/action-ledger-capabilities.js"
+      },
+      "./tools": {
+        "types": "./dist/tools.d.ts",
+        "import": "./dist/tools.js",
+        "default": "./dist/tools.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/relationships/src/tools.ts
+++ b/packages/relationships/src/tools.ts
@@ -1,0 +1,100 @@
+/**
+ * Relationships (CRM) agent tools on the framework tool contract. Thin, read-only
+ * wrappers over the existing relationships service (people + organizations); the
+ * service is injected on the tool context by intersection so this module stays
+ * deployment-agnostic. Gated on the `crm` api-key resource.
+ */
+import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import { z } from "zod"
+
+import { organizationListQuerySchema, personListQuerySchema } from "./validation.js"
+
+export interface RelationshipsToolServices {
+  listPeople(query: z.infer<typeof personListQuerySchema>): Promise<unknown>
+  getPersonById(id: string): Promise<unknown>
+  listOrganizations(query: z.infer<typeof organizationListQuerySchema>): Promise<unknown>
+  getOrganizationById(id: string): Promise<unknown>
+}
+
+export type RelationshipsToolContext = ToolContext & { relationships?: RelationshipsToolServices }
+
+function crm(ctx: RelationshipsToolContext): RelationshipsToolServices {
+  return requireService(ctx.relationships, "relationships")
+}
+
+export const listPeopleTool = defineTool<
+  z.infer<typeof personListQuerySchema>,
+  unknown,
+  RelationshipsToolContext
+>({
+  name: "list_people",
+  description: "List CRM people with filters and pagination. Read-only.",
+  inputSchema: personListQuerySchema,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["crm:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return crm(ctx).listPeople(query)
+  },
+})
+
+const getByIdArgs = z.object({ id: z.string().min(1).describe("The record id.") })
+
+export const getPersonTool = defineTool<
+  z.infer<typeof getByIdArgs>,
+  unknown,
+  RelationshipsToolContext
+>({
+  name: "get_person",
+  description: "Read a single CRM person by id. Read-only.",
+  inputSchema: getByIdArgs,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["crm:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }, ctx) {
+    return crm(ctx).getPersonById(id)
+  },
+})
+
+export const listOrganizationsTool = defineTool<
+  z.infer<typeof organizationListQuerySchema>,
+  unknown,
+  RelationshipsToolContext
+>({
+  name: "list_organizations",
+  description: "List CRM organizations with filters and pagination. Read-only.",
+  inputSchema: organizationListQuerySchema,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["crm:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(query, ctx) {
+    return crm(ctx).listOrganizations(query)
+  },
+})
+
+export const getOrganizationTool = defineTool<
+  z.infer<typeof getByIdArgs>,
+  unknown,
+  RelationshipsToolContext
+>({
+  name: "get_organization",
+  description: "Read a single CRM organization by id. Read-only.",
+  inputSchema: getByIdArgs,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["crm:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler({ id }, ctx) {
+    return crm(ctx).getOrganizationById(id)
+  },
+})
+
+export const relationshipsTools = [
+  listPeopleTool,
+  getPersonTool,
+  listOrganizationsTool,
+  getOrganizationTool,
+] as const

--- a/packages/relationships/tests/tools.test.ts
+++ b/packages/relationships/tests/tools.test.ts
@@ -1,0 +1,70 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { type RelationshipsToolServices, relationshipsTools } from "../src/tools.js"
+
+function ctx(
+  services?: Partial<RelationshipsToolServices>,
+): ToolContext & { relationships?: RelationshipsToolServices } {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "default",
+    resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+    relationships: services as RelationshipsToolServices | undefined,
+  }
+}
+
+describe("relationships (crm) tools", () => {
+  it("registers people + organization read tools gated on crm:read", () => {
+    const registry = createToolRegistry()
+    registry.registerAll(relationshipsTools)
+    const list = registry.list()
+    expect(list.map((t) => t.name).sort()).toEqual([
+      "get_organization",
+      "get_person",
+      "list_organizations",
+      "list_people",
+    ])
+    for (const t of list) {
+      expect(t.tier).toBe("read")
+      expect(t.requiredScopes).toEqual(["crm:read"])
+    }
+  })
+
+  it("dispatches people + organization reads through the injected service", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(relationshipsTools)
+    const services: RelationshipsToolServices = {
+      async listPeople() {
+        return { data: [{ id: "per_1" }] }
+      },
+      async getPersonById(id) {
+        return { id }
+      },
+      async listOrganizations() {
+        return { data: [] }
+      },
+      async getOrganizationById(id) {
+        return { id }
+      },
+    }
+    expect(await registry.dispatch("get_person", { id: "per_1" }, ctx(services))).toMatchObject({
+      id: "per_1",
+    })
+    expect(
+      await registry.dispatch("get_organization", { id: "org_1" }, ctx(services)),
+    ).toMatchObject({
+      id: "org_1",
+    })
+  })
+
+  it("throws MISSING_SERVICE when unwired", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(relationshipsTools)
+    await expect(registry.dispatch("list_people", {}, ctx(undefined))).rejects.toMatchObject({
+      code: "MISSING_SERVICE",
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,9 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       '@voyant-travel/types':
         specifier: workspace:^
         version: link:../types
@@ -1664,6 +1667,9 @@ importers:
       '@voyant-travel/storage':
         specifier: workspace:^
         version: link:../storage
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       '@voyant-travel/types':
         specifier: workspace:^
         version: link:../types
@@ -3102,6 +3108,9 @@ importers:
       '@voyant-travel/quotes-contracts':
         specifier: workspace:^
         version: link:../quotes-contracts
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       '@voyant-travel/trips':
         specifier: workspace:^
         version: link:../trips
@@ -3304,6 +3313,9 @@ importers:
       '@voyant-travel/relationships-contracts':
         specifier: workspace:^
         version: link:../relationships-contracts
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       '@voyant-travel/types':
         specifier: workspace:^
         version: link:../types

--- a/starters/operator/src/api/runtime/mcp-runtime.ts
+++ b/starters/operator/src/api/runtime/mcp-runtime.ts
@@ -10,9 +10,20 @@
  * The route mounts at `/v1/admin/mcp` via the `"operator/mcp"` composition entry.
  */
 
+import { bookingsService } from "@voyant-travel/bookings"
+import { type BookingsToolServices, bookingsTools } from "@voyant-travel/bookings/tools"
+import { financeService } from "@voyant-travel/finance"
+import { type FinanceToolServices, financeTools } from "@voyant-travel/finance/tools"
 import { productsService } from "@voyant-travel/inventory"
 import { type InventoryToolServices, inventoryTools } from "@voyant-travel/inventory/tools"
 import { createMcpHonoApp } from "@voyant-travel/mcp"
+import { quotesService } from "@voyant-travel/quotes"
+import { type QuotesToolServices, quotesTools } from "@voyant-travel/quotes/tools"
+import { relationshipsService } from "@voyant-travel/relationships"
+import {
+  type RelationshipsToolServices,
+  relationshipsTools,
+} from "@voyant-travel/relationships/tools"
 import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { type TripsToolServices, tripsService, tripsTools } from "@voyant-travel/trips"
 import type { Context, Hono } from "hono"
@@ -24,6 +35,10 @@ import { createOperatorTripsRoutesOptions } from "./trips-runtime"
 type OperatorToolContext = ToolContext & {
   trips: TripsToolServices
   inventory: InventoryToolServices
+  bookings: BookingsToolServices
+  finance: FinanceToolServices
+  quotes: QuotesToolServices
+  relationships: RelationshipsToolServices
 }
 
 /** Build the MCP admin routes wired with this deployment's tools + context. */
@@ -31,6 +46,10 @@ export function buildMcpAdminRoutes(): Hono {
   const registry = createToolRegistry()
   registry.registerAll(tripsTools)
   registry.registerAll(inventoryTools)
+  registry.registerAll(bookingsTools)
+  registry.registerAll(financeTools)
+  registry.registerAll(quotesTools)
+  registry.registerAll(relationshipsTools)
   return createMcpHonoApp({ registry, buildContext: buildToolContext })
 }
 
@@ -47,6 +66,24 @@ function buildToolContext(c: Context): OperatorToolContext {
     resolverScope: { locale, audience, market: "default", actor },
     trips: createTripsToolServices(c),
     inventory: createInventoryToolServices(c),
+    bookings: {
+      listBookings: (query) => bookingsService.listBookings(c.var.db, query),
+      getBookingById: (id) => bookingsService.getBookingById(c.var.db, id),
+    },
+    finance: {
+      listInvoices: (query) => financeService.listInvoices(c.var.db, query),
+      getInvoiceById: (id) => financeService.getInvoiceById(c.var.db, id),
+    },
+    quotes: {
+      listQuotes: (query) => quotesService.listQuotes(c.var.db, query),
+      getQuoteById: (id) => quotesService.getQuoteById(c.var.db, id),
+    },
+    relationships: {
+      listPeople: (query) => relationshipsService.listPeople(c.var.db, query),
+      getPersonById: (id) => relationshipsService.getPersonById(c.var.db, id),
+      listOrganizations: (query) => relationshipsService.listOrganizations(c.var.db, query),
+      getOrganizationById: (id) => relationshipsService.getOrganizationById(c.var.db, id),
+    },
   }
 }
 


### PR DESCRIPTION
Part of #2800 and #2792. Extends the module-owned-tools pattern to four more domains.

Each domain exports a `./tools` array over its existing service (list + get):
- `@voyant-travel/bookings` — `list_bookings` + `get_booking` (non-PII, `bookings:read`)
- `@voyant-travel/finance` — `list_invoices` + `get_invoice` (`finance:read`)
- `@voyant-travel/quotes` — `list_quotes` + `get_quote` (`quotes:read`)
- `@voyant-travel/relationships` — `list_people` / `get_person` / `list_organizations` /
  `get_organization` (`crm:read`)

The operator registers all of them, so `/v1/admin/mcp` now serves **trips, products,
bookings, finance, quotes, and CRM** tools — each gated per-tool by scope + audience.

**N/A:** `availability` is schema-only (no service surface); `pricing` has no standalone
package (it lives inside catalog/products/charters/cruises).

## Verify
Per package: typecheck + `tests/tools.test.ts` (3 each; relationships covers people +
orgs) + lint. operator typecheck. Changeset included (four minors).