### PR TITLE
Add catalog MCP tools

### DIFF
--- a/.changeset/catalog-agent-search-tools.md
+++ b/.changeset/catalog-agent-search-tools.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Add catalog MCP tools for search and resolved entry reads.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -273,6 +273,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -268,6 +268,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -9,6 +9,7 @@
     "./schema-sourced-entries": "./src/schema-sourced-entries.ts",
     "./contract": "./src/contract.ts",
     "./provenance": "./src/provenance.ts",
+    "./tools": "./src/tools.ts",
     "./overlay/schema": "./src/overlay/schema.ts",
     "./overlay/resolver": "./src/overlay/resolver.ts",
     "./snapshot/schema": "./src/snapshot/schema.ts",
@@ -85,6 +86,11 @@
         "types": "./dist/provenance.d.ts",
         "import": "./dist/provenance.js",
         "default": "./dist/provenance.js"
+      },
+      "./tools": {
+        "types": "./dist/tools.d.ts",
+        "import": "./dist/tools.js",
+        "default": "./dist/tools.js"
       },
       "./overlay/schema": {
         "types": "./dist/overlay/schema.d.ts",
@@ -236,6 +242,7 @@
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
+    "@voyant-travel/tools": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
     "zod": "catalog:"

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -336,3 +336,15 @@ export {
   readPricingBasis,
   type SelectBookingCatalogSnapshot,
 } from "./snapshot/schema.js"
+export {
+  type CatalogEntryResult,
+  type CatalogEntryServiceInput,
+  type CatalogSearchArgs,
+  type CatalogSearchServiceInput,
+  type CatalogToolContext,
+  type CatalogToolServices,
+  catalogTools,
+  type GetCatalogEntryArgs,
+  getCatalogEntryTool,
+  searchCatalogTool,
+} from "./tools.js"

--- a/packages/catalog/src/tools.ts
+++ b/packages/catalog/src/tools.ts
@@ -1,0 +1,199 @@
+/**
+ * Catalog agent tools on the framework tool contract.
+ *
+ * Thin wrappers over deployment-injected catalog search/read services. The
+ * catalog package owns the tool contract and audience checks; operator wiring
+ * supplies the indexer and resolved-entity runtime.
+ */
+import {
+  defineTool,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  ToolError,
+  type Visibility,
+} from "@voyant-travel/tools"
+import { z } from "zod"
+
+import type {
+  IndexerSlice,
+  SearchFilter,
+  SearchRequest,
+  SearchResults,
+} from "./indexer/contract.js"
+
+const visibilitySchema = z.enum(["staff", "customer", "partner", "supplier"])
+const searchModeSchema = z.enum(["keyword", "semantic", "hybrid"])
+const searchSortSchema = z.enum(["relevance", "price-asc", "price-desc", "departure-asc", "newest"])
+
+const searchFilterSchema: z.ZodType<SearchFilter> = z.lazy(() =>
+  z.union([
+    z.object({
+      kind: z.literal("eq"),
+      field: z.string().min(1),
+      value: z.union([z.string(), z.number(), z.boolean()]),
+    }),
+    z.object({
+      kind: z.literal("in"),
+      field: z.string().min(1),
+      values: z.array(z.union([z.string(), z.number()])),
+    }),
+    z.object({
+      kind: z.literal("range"),
+      field: z.string().min(1),
+      gte: z.number().optional(),
+      lte: z.number().optional(),
+    }),
+    z.object({ kind: z.literal("and"), clauses: z.array(searchFilterSchema) }),
+    z.object({ kind: z.literal("or"), clauses: z.array(searchFilterSchema) }),
+  ]),
+)
+
+const catalogSearchArgs = z.object({
+  vertical: z.string().min(1),
+  query: z.string().optional(),
+  mode: searchModeSchema.default("keyword"),
+  sort: searchSortSchema.optional(),
+  filters: z.array(searchFilterSchema).optional(),
+  facets: z
+    .array(z.object({ field: z.string().min(1), limit: z.number().int().positive().optional() }))
+    .optional(),
+  pagination: z
+    .object({
+      limit: z.number().int().positive().optional(),
+      cursor: z.string().optional(),
+    })
+    .optional(),
+  locale: z.string().min(1).optional(),
+  market: z.string().min(1).optional(),
+  audience: visibilitySchema.optional(),
+  alpha: z.number().min(0).max(1).optional(),
+  distance_threshold: z.number().optional(),
+  query_embedding: z.array(z.number()).optional(),
+})
+
+const getCatalogEntryArgs = z.object({
+  vertical: z.string().min(1),
+  id: z.string().min(1),
+  locale: z.string().min(1).optional(),
+  market: z.string().min(1).optional(),
+  audience: visibilitySchema.optional(),
+})
+
+export type CatalogSearchArgs = z.infer<typeof catalogSearchArgs>
+export type GetCatalogEntryArgs = z.infer<typeof getCatalogEntryArgs>
+
+export interface CatalogSearchServiceInput {
+  slice: IndexerSlice
+  request: SearchRequest
+}
+
+export interface CatalogEntryResult {
+  vertical: string
+  id: string
+  fields: Record<string, unknown>
+  provenance?: Record<string, { locale: string; audience: string; market: string } | null>
+}
+
+export interface CatalogEntryServiceInput {
+  vertical: string
+  id: string
+  scope: {
+    locale: string
+    audience: Visibility
+    market: string
+    actor: Visibility
+  }
+}
+
+/** The catalog read surface a deployment binds into the tool context. */
+export interface CatalogToolServices {
+  search(input: CatalogSearchServiceInput): Promise<SearchResults>
+  getEntry(input: CatalogEntryServiceInput): Promise<CatalogEntryResult | null>
+}
+
+/** Tool context with the catalog service injected. */
+export type CatalogToolContext = ToolContext & { catalog?: CatalogToolServices }
+
+function catalog(ctx: CatalogToolContext): CatalogToolServices {
+  return requireService(ctx.catalog, "catalog")
+}
+
+function resolveAudience(ctx: CatalogToolContext, requested?: Visibility): Visibility {
+  const audience = requested ?? ctx.audience
+  if (ctx.actor === "staff" || audience === ctx.audience) return audience
+  throw new ToolError(
+    `Actor "${ctx.actor}" is not authorized to query audience "${audience}". Non-staff tools may only use their grant audience.`,
+    "AUTHORIZATION_DENIED",
+    { actor: ctx.actor, grantAudience: ctx.audience, requestedAudience: audience },
+  )
+}
+
+function searchRequest(args: CatalogSearchArgs): SearchRequest {
+  return {
+    query: args.query ?? "",
+    mode: args.mode,
+    sort: args.sort,
+    filters: args.filters,
+    facets: args.facets,
+    pagination: args.pagination,
+    alpha: args.alpha,
+    distance_threshold: args.distance_threshold,
+    query_embedding: args.query_embedding,
+  }
+}
+
+export const searchCatalogTool = defineTool<CatalogSearchArgs, SearchResults, CatalogToolContext>({
+  name: "search_catalog",
+  description:
+    "Search a catalog vertical in one locale/audience/market slice. Returns raw index hits, total, cursor, and facets. Read-only.",
+  inputSchema: catalogSearchArgs,
+  outputSchema: z.custom<SearchResults>(),
+  requiredScopes: ["catalog:search"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(args, ctx) {
+    const audience = resolveAudience(ctx, args.audience)
+    return catalog(ctx).search({
+      slice: {
+        vertical: args.vertical,
+        locale: args.locale ?? ctx.resolverScope.locale,
+        audience,
+        market: args.market ?? ctx.resolverScope.market,
+      },
+      request: searchRequest(args),
+    })
+  },
+})
+
+export const getCatalogEntryTool = defineTool<
+  GetCatalogEntryArgs,
+  { entry: CatalogEntryResult | null },
+  CatalogToolContext
+>({
+  name: "get_catalog_entry",
+  description:
+    "Read one resolved catalog entry by vertical and id. Returns null when not found. Read-only.",
+  inputSchema: getCatalogEntryArgs,
+  outputSchema: z.object({ entry: z.custom<CatalogEntryResult>().nullable() }),
+  requiredScopes: ["catalog:read"],
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(args, ctx) {
+    const audience = resolveAudience(ctx, args.audience)
+    const entry = await catalog(ctx).getEntry({
+      vertical: args.vertical,
+      id: args.id,
+      scope: {
+        locale: args.locale ?? ctx.resolverScope.locale,
+        audience,
+        market: args.market ?? ctx.resolverScope.market,
+        actor: ctx.actor,
+      },
+    })
+    return { entry: entry ?? null }
+  },
+})
+
+/** All catalog agent tools, ready to register on a `ToolRegistry`. */
+export const catalogTools = [searchCatalogTool, getCatalogEntryTool] as const

--- a/packages/catalog/tests/tools.test.ts
+++ b/packages/catalog/tests/tools.test.ts
@@ -1,0 +1,145 @@
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import { type CatalogToolServices, catalogTools } from "../src/tools.js"
+
+function ctxWith(
+  services?: Partial<CatalogToolServices>,
+  overrides: Partial<ToolContext> = {},
+): ToolContext & { catalog?: CatalogToolServices } {
+  const actor = overrides.actor ?? "customer"
+  const audience = overrides.audience ?? actor
+  return {
+    db: {},
+    actor,
+    audience,
+    tenantId: "default",
+    resolverScope: {
+      locale: "en-GB",
+      audience,
+      market: "default",
+      actor,
+      ...overrides.resolverScope,
+    },
+    ...overrides,
+    catalog: services as CatalogToolServices | undefined,
+  }
+}
+
+function makeRegistry() {
+  const registry = createToolRegistry()
+  registry.registerAll(catalogTools)
+  return registry
+}
+
+describe("catalog tools", () => {
+  it("registers read-only catalog tools with read/search scopes", () => {
+    const manifest = makeRegistry().list()
+    expect(manifest.map((tool) => tool.name).sort()).toEqual([
+      "get_catalog_entry",
+      "search_catalog",
+    ])
+    for (const tool of manifest) {
+      expect(tool.tier).toBe("read")
+      expect(tool.riskPolicy.destructive).toBe(false)
+    }
+    expect(manifest.find((tool) => tool.name === "search_catalog")?.requiredScopes).toEqual([
+      "catalog:search",
+    ])
+    expect(manifest.find((tool) => tool.name === "get_catalog_entry")?.requiredScopes).toEqual([
+      "catalog:read",
+    ])
+  })
+
+  it("searches the caller audience slice through the injected service", async () => {
+    const registry = makeRegistry()
+    let forwarded: unknown
+    const result = await registry.dispatch<{ total: number }>(
+      "search_catalog",
+      { vertical: "products", query: "beach", pagination: { limit: 5 } },
+      ctxWith({
+        async search(input) {
+          forwarded = input
+          return { hits: [], total: 0 }
+        },
+        async getEntry() {
+          return null
+        },
+      }),
+    )
+
+    expect(result.total).toBe(0)
+    expect(forwarded).toMatchObject({
+      slice: { vertical: "products", locale: "en-GB", audience: "customer", market: "default" },
+      request: { query: "beach", mode: "keyword", pagination: { limit: 5 } },
+    })
+  })
+
+  it("allows staff to search a requested audience", async () => {
+    const registry = makeRegistry()
+    let forwarded: unknown
+    await registry.dispatch(
+      "search_catalog",
+      { vertical: "products", audience: "customer" },
+      ctxWith(
+        {
+          async search(input) {
+            forwarded = input
+            return { hits: [], total: 0 }
+          },
+          async getEntry() {
+            return null
+          },
+        },
+        { actor: "staff", audience: "staff" },
+      ),
+    )
+    expect(forwarded).toMatchObject({
+      slice: { audience: "customer" },
+      request: { query: "", mode: "keyword" },
+    })
+  })
+
+  it("rejects non-staff searches for a different audience", async () => {
+    const registry = makeRegistry()
+    await expect(
+      registry.dispatch(
+        "search_catalog",
+        { vertical: "products", audience: "partner" },
+        ctxWith({
+          async search() {
+            throw new Error("not used")
+          },
+          async getEntry() {
+            return null
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "AUTHORIZATION_DENIED" })
+  })
+
+  it("reads a resolved catalog entry and normalizes not-found to null", async () => {
+    const registry = makeRegistry()
+    const result = await registry.dispatch<{ entry: { id: string } | null }>(
+      "get_catalog_entry",
+      { vertical: "products", id: "prod_1" },
+      ctxWith({
+        async search() {
+          return { hits: [], total: 0 }
+        },
+        async getEntry(input) {
+          return { vertical: input.vertical, id: input.id, fields: { title: "Beach" } }
+        },
+      }),
+    )
+
+    expect(result.entry).toEqual({ vertical: "products", id: "prod_1", fields: { title: "Beach" } })
+  })
+
+  it("throws MISSING_SERVICE when catalog is not wired", async () => {
+    const registry = makeRegistry()
+    await expect(
+      registry.dispatch("search_catalog", { vertical: "products" }, ctxWith(undefined)),
+    ).rejects.toMatchObject({ code: "MISSING_SERVICE" })
+  })
+})

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -344,6 +344,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -343,6 +343,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -338,6 +338,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -338,6 +338,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -344,6 +344,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -338,6 +338,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -344,6 +344,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -338,6 +338,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -344,6 +344,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -337,6 +337,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -338,6 +338,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -339,6 +339,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/tools": ["../catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -928,6 +928,9 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
+      '@voyant-travel/tools':
+        specifier: workspace:^
+        version: link:../tools
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260628.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)

--- a/starters/operator/src/api/lib/catalog-context.ts
+++ b/starters/operator/src/api/lib/catalog-context.ts
@@ -69,10 +69,14 @@ export function buildCatalogContext(c: Context): OperatorCatalogContext {
     catalog: {
       embeddings,
       indexer,
-      async resolveEntity(vertical, entityId): Promise<OperatorCatalogResolvedEntity | null> {
+      async resolveEntity(
+        vertical,
+        entityId,
+        scope,
+      ): Promise<OperatorCatalogResolvedEntity | null> {
         const ctx = {
           sellerOperatorId,
-          scope: { locale, audience, market: "default", actor },
+          scope,
         }
         let view: Awaited<ReturnType<typeof getResolvedProductById>> | null = null
         if (vertical === "products") view = await getResolvedProductById(db, entityId, ctx)

--- a/starters/operator/src/api/runtime/mcp-runtime.ts
+++ b/starters/operator/src/api/runtime/mcp-runtime.ts
@@ -10,18 +10,25 @@
  * The route mounts at `/v1/admin/mcp` via the `"operator/mcp"` composition entry.
  */
 
+import {
+  type CatalogToolServices,
+  catalogTools,
+  executeSemanticSearch,
+} from "@voyant-travel/catalog"
 import { productsService } from "@voyant-travel/inventory"
 import { type InventoryToolServices, inventoryTools } from "@voyant-travel/inventory/tools"
 import { createMcpHonoApp } from "@voyant-travel/mcp"
-import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import { createToolRegistry, type ToolContext, ToolError } from "@voyant-travel/tools"
 import { type TripsToolServices, tripsService, tripsTools } from "@voyant-travel/trips"
 import type { Context, Hono } from "hono"
 
+import { buildCatalogContext } from "../lib/catalog-context"
 import { DEFAULT_SLICES } from "../lib/catalog-runtime"
 import { createOperatorTripsRoutesOptions } from "./trips-runtime"
 
 /** The per-request tool context shape this deployment builds (base + injected services). */
 type OperatorToolContext = ToolContext & {
+  catalog: CatalogToolServices
   trips: TripsToolServices
   inventory: InventoryToolServices
 }
@@ -29,6 +36,7 @@ type OperatorToolContext = ToolContext & {
 /** Build the MCP admin routes wired with this deployment's tools + context. */
 export function buildMcpAdminRoutes(): Hono {
   const registry = createToolRegistry()
+  registry.registerAll(catalogTools)
   registry.registerAll(tripsTools)
   registry.registerAll(inventoryTools)
   return createMcpHonoApp({ registry, buildContext: buildToolContext })
@@ -45,8 +53,47 @@ function buildToolContext(c: Context): OperatorToolContext {
     audience,
     tenantId: env.TENANT_ID ?? "default",
     resolverScope: { locale, audience, market: "default", actor },
+    catalog: createCatalogToolServices(c),
     trips: createTripsToolServices(c),
     inventory: createInventoryToolServices(c),
+  }
+}
+
+function createCatalogToolServices(c: Context): CatalogToolServices {
+  const catalogContext = buildCatalogContext(c)
+  return {
+    async search({ slice, request }) {
+      const indexer = catalogContext.catalog.indexer
+      if (!indexer) {
+        throw new ToolError(
+          "Catalog search indexer is not configured for this deployment.",
+          "PROVIDER_ERROR",
+        )
+      }
+      if (request.mode === "keyword") return indexer.search(slice, request)
+
+      try {
+        return await executeSemanticSearch({
+          adapter: indexer,
+          embeddings: catalogContext.catalog.embeddings,
+          slice,
+          request,
+        })
+      } catch {
+        const keywordRequest = { ...request, mode: "keyword" as const, query_embedding: undefined }
+        return indexer.search(slice, keywordRequest)
+      }
+    },
+    async getEntry({ vertical, id, scope }) {
+      const entry = await catalogContext.catalog.resolveEntity?.(vertical, id, scope)
+      if (!entry) return null
+      return {
+        vertical: entry.vertical,
+        id: entry.entityId,
+        fields: entry.fields,
+        provenance: entry.provenance,
+      }
+    },
   }
 }
 

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -448,6 +448,7 @@
       "@voyant-travel/catalog/snapshot/schema": [
         "../../packages/catalog/dist/snapshot/schema.d.ts"
       ],
+      "@voyant-travel/catalog/tools": ["../../packages/catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../../packages/charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../../packages/charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -448,6 +448,7 @@
       "@voyant-travel/catalog/snapshot/schema": [
         "../../packages/catalog/dist/snapshot/schema.d.ts"
       ],
+      "@voyant-travel/catalog/tools": ["../../packages/catalog/dist/tools.d.ts"],
       "@voyant-travel/charters": ["../../packages/charters/dist/index.d.ts"],
       "@voyant-travel/charters-contracts": ["../../packages/charters-contracts/dist/index.d.ts"],
       "@voyant-travel/charters-contracts/content-shape": [


### PR DESCRIPTION
Part of #2800.

## Summary
- add catalog MCP tools for read-only catalog search and resolved entry reads
- enforce audience boundaries in the catalog tool contract
- wire catalog tools into the operator MCP runtime with keyword search, semantic fallback, and resolved entity lookup
- add package exports, generated config updates, and a changeset

## Validation
- `pnpm exec biome check starters/operator/src/api/lib/catalog-context.ts starters/operator/src/api/runtime/mcp-runtime.ts packages/catalog/src/tools.ts packages/catalog/tests/tools.test.ts packages/catalog/src/index.ts packages/catalog/package.json`
- `pnpm --filter @voyant-travel/catalog test -- tests/tools.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/catalog typecheck`
- `pnpm --filter @voyant-travel/catalog build`
- `pnpm verify:dep-paths && pnpm verify:dist-configs`

Note: `pnpm --filter operator typecheck` was started but interrupted after several minutes in server compilation with no compiler output, to avoid tying up memory while working sequentially.
