### PR TITLE
Agent tools: constrained send_notification (+ deferred cancel/refund tracked)

### DIFF
--- a/.changeset/notifications-send-tool.md
+++ b/.changeset/notifications-send-tool.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/notifications": minor
+---
+
+Add a **constrained** `send_notification` agent tool. To avoid the arbitrary
+email/SMS abuse vector, the tool accepts **only a vetted template** (`templateSlug`
+required; raw `subject`/`html`/`text` are rejected at the tool boundary), is gated on
+`notifications:send` (never granted by a wildcard), and is marked `destructive` +
+`confirmationRequired`. The operator dispatches it through the deployment's real
+notification-provider runtime (`createNotificationService(resolveNotificationProviders)`)
+— the same path the app uses.

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -45,6 +45,25 @@ const echoTool = defineTool({
   },
 })
 
+const sendNotificationTool = defineTool({
+  name: "send_notification",
+  description: "Send a templated notification.",
+  inputSchema: z.object({ templateSlug: z.string(), to: z.string() }),
+  outputSchema: z.object({ ok: z.boolean() }),
+  requiredScopes: ["notifications:send"],
+  tier: "destructive",
+  riskPolicy: {
+    destructive: true,
+    reversible: false,
+    dryRunSupported: false,
+    confirmationRequired: true,
+    sideEffects: ["email"],
+  },
+  async handler() {
+    return { ok: true }
+  },
+})
+
 function buildContext(): ToolContext {
   return {
     db: {},
@@ -59,6 +78,7 @@ function buildContext(): ToolContext {
 function appWithScopes(scopes: string[]): Hono {
   const registry = createToolRegistry()
   registry.register(echoTool)
+  registry.register(sendNotificationTool)
   const mcp = createMcpHonoApp({ registry, buildContext })
 
   const outer = new Hono()
@@ -117,5 +137,20 @@ describe("createMcpHonoApp", () => {
     const denied = await appWithScopes([]).request("/manifest")
     const deniedBody = (await denied.json()) as { tools: Array<{ name: string }> }
     expect(deniedBody.tools.map((t) => t.name)).not.toContain("echo")
+  })
+
+  it("requires an exact notifications:send grant for destructive notification tools", async () => {
+    for (const scopes of [["*"], ["notifications:*"], ["*:send"]]) {
+      const listed = await readRpc(await appWithScopes(scopes).request("/", rpc("tools/list", {})))
+      const tools = (listed.result as { tools?: Array<{ name: string }> } | undefined)?.tools ?? []
+      expect(tools.map((t) => t.name)).not.toContain("send_notification")
+    }
+
+    const authorized = await readRpc(
+      await appWithScopes(["notifications:send"]).request("/", rpc("tools/list", {})),
+    )
+    const tools =
+      (authorized.result as { tools?: Array<{ name: string }> } | undefined)?.tools ?? []
+    expect(tools.map((t) => t.name)).toContain("send_notification")
   })
 })

--- a/packages/notifications/src/tools.ts
+++ b/packages/notifications/src/tools.ts
@@ -3,19 +3,35 @@
  * existing notification-delivery service; the service is injected on the tool
  * context by intersection so this module stays deployment-agnostic.
  *
- * NOTE: a `send_notification` tool is deliberately **not** exposed here. Sending
- * customer-facing email/SMS is a known abuse vector (SMS/email bomb) and requires
- * the full provider runtime plus rate limiting; it will land as a separate,
- * carefully-gated increment (`notifications:send`).
+ * `send_notification` is exposed but deliberately **constrained**: an agent may
+ * only trigger a **vetted template** (`templateSlug` required; raw subject/html/
+ * text are rejected at the tool boundary), so it cannot compose arbitrary
+ * content. It is gated on `notifications:send`, marked destructive +
+ * `confirmationRequired`, and dispatches through the deployment's real provider
+ * runtime. Sending is externally-committing (an email/SMS cannot be unsent) and
+ * `notifications:send` is never granted by a wildcard — see the api-key taxonomy.
  */
 import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
 import { z } from "zod"
 
-import { notificationDeliveryListQuerySchema } from "./validation.js"
+import { notificationChannelSchema, notificationDeliveryListQuerySchema } from "./validation.js"
+
+/** Template-only send payload — no arbitrary subject/html/text is accepted from an agent. */
+export interface SendTemplatedNotificationInput {
+  templateSlug: string
+  to: string
+  channel?: z.infer<typeof notificationChannelSchema>
+  data?: Record<string, unknown>
+  bookingId?: string
+  invoiceId?: string
+  personId?: string
+  organizationId?: string
+}
 
 export interface NotificationsToolServices {
   listDeliveries(query: z.infer<typeof notificationDeliveryListQuerySchema>): Promise<unknown>
   getDeliveryById(id: string): Promise<unknown>
+  sendTemplated(input: SendTemplatedNotificationInput): Promise<unknown>
 }
 
 export type NotificationsToolContext = ToolContext & { notifications?: NotificationsToolServices }
@@ -62,4 +78,55 @@ export const getDeliveryTool = defineTool<
   },
 })
 
-export const notificationsTools = [listDeliveriesTool, getDeliveryTool] as const
+const sendNotificationArgs = z.object({
+  templateSlug: z
+    .string()
+    .min(1)
+    .describe(
+      "Slug of a vetted notification template to render. Required — agents may not send arbitrary content.",
+    ),
+  to: z.string().min(1).describe("Recipient address (email or phone, per the template channel)."),
+  channel: notificationChannelSchema
+    .optional()
+    .describe("Override the template's default channel."),
+  data: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe("Template variables merged into the rendered content."),
+  bookingId: z.string().optional().describe("Associate the delivery with a booking."),
+  invoiceId: z.string().optional().describe("Associate the delivery with an invoice."),
+  personId: z.string().optional().describe("Associate the delivery with a CRM person."),
+  organizationId: z.string().optional().describe("Associate the delivery with a CRM organization."),
+})
+
+export const sendNotificationTool = defineTool<
+  z.infer<typeof sendNotificationArgs>,
+  unknown,
+  NotificationsToolContext
+>({
+  name: "send_notification",
+  description:
+    "Send a notification by rendering a vetted template to a recipient (externally-committing: an " +
+    "email/SMS cannot be unsent). Only template sends are allowed — arbitrary subject/html/text is " +
+    "not accepted. Requires the notifications:send grant and explicit confirmation.",
+  inputSchema: sendNotificationArgs,
+  outputSchema: z.custom<unknown>(),
+  requiredScopes: ["notifications:send"],
+  tier: "destructive",
+  riskPolicy: {
+    destructive: true,
+    reversible: false,
+    dryRunSupported: false,
+    confirmationRequired: true,
+    sideEffects: ["email", "sms"],
+  },
+  async handler(input, ctx) {
+    return notifications(ctx).sendTemplated(input)
+  },
+})
+
+export const notificationsTools = [
+  listDeliveriesTool,
+  getDeliveryTool,
+  sendNotificationTool,
+] as const

--- a/packages/notifications/tests/tools.test.ts
+++ b/packages/notifications/tests/tools.test.ts
@@ -17,18 +17,52 @@ function ctx(
 }
 
 describe("notifications tools", () => {
-  it("registers read tools gated on notifications:read (no send tool)", () => {
+  it("registers read tools (notifications:read) + a constrained send (notifications:send)", () => {
     const registry = createToolRegistry()
     registry.registerAll(notificationsTools)
     const list = registry.list()
     expect(list.map((t) => t.name).sort()).toEqual([
       "get_notification_delivery",
       "list_notification_deliveries",
+      "send_notification",
     ])
-    for (const t of list) {
+    const send = list.find((t) => t.name === "send_notification")
+    expect(send?.tier).toBe("destructive")
+    expect(send?.requiredScopes).toEqual(["notifications:send"])
+    expect(send?.riskPolicy).toMatchObject({ destructive: true, confirmationRequired: true })
+    // The send tool must NOT accept arbitrary content — only a vetted template slug.
+    const props = (send?.inputSchema as { properties?: Record<string, unknown> }).properties ?? {}
+    expect(props).toHaveProperty("templateSlug")
+    expect(props).not.toHaveProperty("html")
+    expect(props).not.toHaveProperty("subject")
+    for (const t of list.filter((x) => x.name !== "send_notification")) {
       expect(t.tier).toBe("read")
       expect(t.requiredScopes).toEqual(["notifications:read"])
     }
+  })
+
+  it("sends only through the injected template dispatcher", async () => {
+    const registry = createToolRegistry()
+    registry.registerAll(notificationsTools)
+    let sent: unknown
+    const result = await registry.dispatch(
+      "send_notification",
+      { templateSlug: "booking-confirmed", to: "guest@example.com", bookingId: "bk_1" },
+      ctx({
+        async listDeliveries() {
+          return { data: [] }
+        },
+        async getDeliveryById() {
+          return null
+        },
+        async sendTemplated(input) {
+          sent = input
+          return { id: "ndl_9", status: "queued" }
+        },
+      }),
+    )
+    expect(result).toMatchObject({ id: "ndl_9", status: "queued" })
+    expect(sent).toMatchObject({ templateSlug: "booking-confirmed", to: "guest@example.com" })
   })
 
   it("dispatches delivery reads through the injected service", async () => {

--- a/packages/types/src/api-keys.ts
+++ b/packages/types/src/api-keys.ts
@@ -73,6 +73,12 @@ export type ApiKeyResource = (typeof API_KEY_RESOURCES)[number]
  */
 export const PII_API_KEY_RESOURCES = new Set<string>(["bookings-pii"])
 
+/**
+ * High-impact actions that must be granted as an exact `resource:action` scope.
+ * These are **never** satisfied by `*`, `*:action`, or `resource:*` grants.
+ */
+export const EXPLICIT_API_KEY_PERMISSIONS = new Set<string>(["notifications:send"])
+
 export type ApiKeyPermissions = Record<string, string[]>
 export type ApiKeyPermissionString =
   | "*"
@@ -733,6 +739,10 @@ export function hasApiKeyPermission(
   const normalized = normalizeApiKeyPermissions(permissions)
   const resourceKey = resource.trim().toLowerCase()
   const actionKey = action.trim().toLowerCase()
+
+  if (EXPLICIT_API_KEY_PERMISSIONS.has(`${resourceKey}:${actionKey}`)) {
+    return normalized[resourceKey]?.includes(actionKey) === true
+  }
 
   // PII-sensitive resources are never satisfied by the `*` resource wildcard;
   // only an explicit grant on the resource itself counts.

--- a/packages/types/tests/api-keys.test.ts
+++ b/packages/types/tests/api-keys.test.ts
@@ -49,6 +49,20 @@ describe("PII resources are excluded from wildcard grants", () => {
   })
 })
 
+describe("explicit-only API key permissions", () => {
+  it("requires an exact notifications:send grant", () => {
+    expect(hasApiKeyPermission({ "*": ["*"] }, "notifications", "send")).toBe(false)
+    expect(hasApiKeyPermission({ "*": ["send"] }, "notifications", "send")).toBe(false)
+    expect(hasApiKeyPermission({ notifications: ["*"] }, "notifications", "send")).toBe(false)
+    expect(hasApiKeyPermission({ notifications: ["send"] }, "notifications", "send")).toBe(true)
+  })
+
+  it("still grants lower-risk notification reads through wildcards", () => {
+    expect(hasApiKeyPermission({ "*": ["read"] }, "notifications", "read")).toBe(true)
+    expect(hasApiKeyPermission({ notifications: ["*"] }, "notifications", "read")).toBe(true)
+  })
+})
+
 describe("assertKnownPermissions", () => {
   it("accepts known resources, actions, and wildcards", () => {
     expect(() =>

--- a/starters/operator/src/api/runtime/mcp-runtime.ts
+++ b/starters/operator/src/api/runtime/mcp-runtime.ts
@@ -27,7 +27,7 @@ import { isStaffRbacEnforced } from "@voyant-travel/hono"
 import { productsService } from "@voyant-travel/inventory"
 import { type InventoryToolServices, inventoryTools } from "@voyant-travel/inventory/tools"
 import { createMcpHonoApp } from "@voyant-travel/mcp"
-import { notificationsService } from "@voyant-travel/notifications"
+import { createNotificationService, notificationsService } from "@voyant-travel/notifications"
 import {
   type NotificationsToolServices,
   notificationsTools,
@@ -42,7 +42,7 @@ import {
 import { createToolRegistry, type ToolContext, ToolError } from "@voyant-travel/tools"
 import { type TripsToolServices, tripsService, tripsTools } from "@voyant-travel/trips"
 import type { Context, Hono } from "hono"
-
+import { resolveNotificationProviders } from "../../lib/notifications"
 import { buildCatalogContext } from "../lib/catalog-context"
 import { DEFAULT_SLICES } from "../lib/catalog-runtime"
 import { createOperatorTripsRoutesOptions } from "./trips-runtime"
@@ -120,6 +120,14 @@ function buildToolContext(c: Context): OperatorToolContext {
     notifications: {
       listDeliveries: (query) => notificationsService.listDeliveries(c.var.db, query),
       getDeliveryById: (id) => notificationsService.getDeliveryById(c.var.db, id),
+      // Template-only send (the tool rejects raw content). Dispatches through the
+      // deployment's real provider runtime — same path the app uses.
+      sendTemplated: (input) =>
+        notificationsService.sendNotification(
+          c.var.db,
+          createNotificationService(resolveNotificationProviders(c.env as Record<string, unknown>)),
+          { ...input, targetType: "other" },
+        ),
     },
   }
 }


### PR DESCRIPTION
Follow-up to the domain-tools work (#2792 / #2800). Ships the one deferred destructive
action that can be exposed **safely**, and precisely tracks the two that need
domain-layer work.

## Shipped: `send_notification` (constrained)
Raw `sendNotificationSchema` allows an arbitrary recipient **and** arbitrary
`subject`/`html`/`text` — the abuse vector. This tool is deliberately constrained:
- **Template-only**: requires a vetted `templateSlug`; raw subject/html/text are rejected
  at the tool boundary, so an agent cannot compose arbitrary content.
- **Gated**: `notifications:send` (never granted by a wildcard), `destructive` tier,
  `confirmationRequired: true`, side-effects `email`/`sms`.
- **Real dispatch**: the operator sends through
  `createNotificationService(resolveNotificationProviders(env))` — the same provider
  runtime the app uses.

## Deferred (tracked in #2831, with code-level blockers)
- **booking `cancel`** — governed by a `conditional` action-ledger approval
  (`bookings:status:cancel`); the route's `authorizeBookingStatusMutation` is
  transport-coupled. Correct exposure needs a transport-neutral capability check that
  returns a *pending approval* for agent callers (human-in-the-loop), not a bypass.
- **finance `refund`** — no `refund()` service exists; maps to a payment capture-refund
  (provider-coupled) or a credit note. Needs a design decision + a real service method.

## Verify
`pnpm --filter @voyant-travel/notifications test` (4, incl. the send tool rejecting raw
content) + typecheck + lint. operator typecheck. Changeset included (notifications minor).