### PR TITLE
fix(mice): preserve omitted fields on patch

### DIFF
--- a/.changeset/mice-empty-patch-defaults.md
+++ b/.changeset/mice-empty-patch-defaults.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mice": patch
+---
+
+Preserve omitted enum fields on MICE update payloads instead of applying create-time defaults.

--- a/packages/mice/src/validation-delegates.ts
+++ b/packages/mice/src/validation-delegates.ts
@@ -21,18 +21,23 @@ export const delegateStatusSchema = z.enum([
 
 export const enrollmentStatusSchema = z.enum(["registered", "waitlisted", "attended", "cancelled"])
 
-export const createDelegateSchema = z.object({
+const delegateMutationSchema = z.object({
   programId: z.string().min(1),
   personId: z.string().min(1).optional(),
   bookingId: z.string().min(1).optional(),
-  role: delegateRoleSchema.default("attendee"),
-  status: delegateStatusSchema.default("invited"),
+  role: delegateRoleSchema,
+  status: delegateStatusSchema,
   arrivalAt: z.string().datetime().optional(),
   departureAt: z.string().datetime().optional(),
   notes: z.string().optional(),
 })
 
-export const updateDelegateSchema = createDelegateSchema.partial().omit({ programId: true })
+export const createDelegateSchema = delegateMutationSchema.extend({
+  role: delegateRoleSchema.default("attendee"),
+  status: delegateStatusSchema.default("invited"),
+})
+
+export const updateDelegateSchema = delegateMutationSchema.partial().omit({ programId: true })
 
 export const delegateListQuerySchema = z.object({
   programId: z.string().min(1),

--- a/packages/mice/src/validation-rfp.ts
+++ b/packages/mice/src/validation-rfp.ts
@@ -14,17 +14,21 @@ export const bidStatusSchema = z.enum([
 const rfpEditableStatusSchema = z.enum(["draft", "issued", "closed", "cancelled"])
 const bidEditableStatusSchema = z.enum(["draft", "submitted", "under_review"])
 
-export const createRfpSchema = z.object({
+const rfpMutationSchema = z.object({
   programId: z.string().min(1),
   title: z.string().min(1),
   requirements: z.record(z.string(), z.unknown()).optional(),
-  status: rfpEditableStatusSchema.default("draft"),
+  status: rfpEditableStatusSchema,
   issuedAt: z.string().datetime().optional(),
   dueAt: z.string().datetime().optional(),
   notes: z.string().optional(),
 })
 
-export const updateRfpSchema = createRfpSchema.partial().omit({ programId: true })
+export const createRfpSchema = rfpMutationSchema.extend({
+  status: rfpEditableStatusSchema.default("draft"),
+})
+
+export const updateRfpSchema = rfpMutationSchema.partial().omit({ programId: true })
 
 export const rfpListQuerySchema = z.object({
   programId: z.string().min(1),
@@ -37,9 +41,9 @@ export const inviteSupplierSchema = z.object({
   supplierId: z.string().min(1),
 })
 
-export const createBidSchema = z.object({
+const bidMutationSchema = z.object({
   supplierId: z.string().min(1),
-  status: bidEditableStatusSchema.default("draft"),
+  status: bidEditableStatusSchema,
   totalCents: z.number().int().min(0).optional(),
   currency: z.string().optional(),
   proposalDoc: z.string().optional(),
@@ -47,7 +51,11 @@ export const createBidSchema = z.object({
   notes: z.string().optional(),
 })
 
-export const updateBidSchema = createBidSchema.partial().omit({ supplierId: true })
+export const createBidSchema = bidMutationSchema.extend({
+  status: bidEditableStatusSchema.default("draft"),
+})
+
+export const updateBidSchema = bidMutationSchema.partial().omit({ supplierId: true })
 
 export const setBidLinesSchema = z.object({
   lines: z.array(

--- a/packages/mice/src/validation-sessions.ts
+++ b/packages/mice/src/validation-sessions.ts
@@ -14,10 +14,10 @@ export const sessionTypeSchema = z.enum([
 
 export const sessionInclusionKindSchema = z.enum(["fnb", "av", "materials", "signage", "other"])
 
-export const createSessionSchema = z.object({
+const sessionMutationSchema = z.object({
   programId: z.string().min(1),
   title: z.string().min(1),
-  sessionType: sessionTypeSchema.default("breakout"),
+  sessionType: sessionTypeSchema,
   functionSpaceId: z.string().min(1).optional(),
   dayDate: isoDate.optional(),
   startsAt: z.string().datetime().optional(),
@@ -28,7 +28,11 @@ export const createSessionSchema = z.object({
   notes: z.string().optional(),
 })
 
-export const updateSessionSchema = createSessionSchema.partial().omit({ programId: true })
+export const createSessionSchema = sessionMutationSchema.extend({
+  sessionType: sessionTypeSchema.default("breakout"),
+})
+
+export const updateSessionSchema = sessionMutationSchema.partial().omit({ programId: true })
 
 export const sessionListQuerySchema = z.object({
   programId: z.string().min(1),

--- a/packages/mice/src/validation.ts
+++ b/packages/mice/src/validation.ts
@@ -19,14 +19,14 @@ export const programStatusSchema = z.enum([
   "cancelled",
 ])
 
-export const createProgramSchema = z.object({
+const programMutationSchema = z.object({
   name: z.string().min(1),
   organizationId: z.string().min(1).optional(),
   primaryContactPersonId: z.string().min(1).optional(),
   accountManagerId: z.string().min(1).optional(),
   code: z.string().optional(),
-  type: programTypeSchema.default("conference"),
-  status: programStatusSchema.default("lead"),
+  type: programTypeSchema,
+  status: programStatusSchema,
   destination: z.string().optional(),
   startDate: isoDate.optional(),
   endDate: isoDate.optional(),
@@ -36,11 +36,16 @@ export const createProgramSchema = z.object({
   budgetAmountCents: z.number().int().min(0).optional(),
 })
 
+export const createProgramSchema = programMutationSchema.extend({
+  type: programTypeSchema.default("conference"),
+  status: programStatusSchema.default("lead"),
+})
+
 // Update accepts `null` on the optional fields so a PATCH can CLEAR them (the
 // columns are nullable and `updateProgram` spreads the body into `.set()`).
 // `.partial()` alone only allows omitting a key, which leaves the prior value
 // in place — operators could set an optional field but never clear it.
-export const updateProgramSchema = createProgramSchema.partial().extend({
+export const updateProgramSchema = programMutationSchema.partial().extend({
   organizationId: z.string().min(1).nullish(),
   primaryContactPersonId: z.string().min(1).nullish(),
   accountManagerId: z.string().min(1).nullish(),

--- a/packages/mice/tests/unit/validation.test.ts
+++ b/packages/mice/tests/unit/validation.test.ts
@@ -1,7 +1,21 @@
 import { describe, expect, it } from "vitest"
-
-import { createProgramSchema, programListQuerySchema } from "../../src/validation.js"
-import { createSessionSchema, sessionListQuerySchema } from "../../src/validation-sessions.js"
+import {
+  createProgramSchema,
+  programListQuerySchema,
+  updateProgramSchema,
+} from "../../src/validation.js"
+import { createDelegateSchema, updateDelegateSchema } from "../../src/validation-delegates.js"
+import {
+  createBidSchema,
+  createRfpSchema,
+  updateBidSchema,
+  updateRfpSchema,
+} from "../../src/validation-rfp.js"
+import {
+  createSessionSchema,
+  sessionListQuerySchema,
+  updateSessionSchema,
+} from "../../src/validation-sessions.js"
 
 describe("mice validation", () => {
   it("applies defaults on create", () => {
@@ -25,6 +39,38 @@ describe("mice validation", () => {
     const parsed = createSessionSchema.parse({ programId: "prog_1", title: "Keynote" })
     expect(parsed.sessionType).toBe("breakout")
     expect(parsed.requiresRegistration).toBeUndefined()
+  })
+
+  it("applies defaults on related resource create schemas", () => {
+    expect(createDelegateSchema.parse({ programId: "prog_1", personId: "person_1" })).toMatchObject(
+      {
+        role: "attendee",
+        status: "invited",
+      },
+    )
+    expect(createRfpSchema.parse({ programId: "prog_1", title: "Venue RFP" }).status).toBe("draft")
+    expect(createBidSchema.parse({ supplierId: "sup_1" }).status).toBe("draft")
+  })
+
+  it("does not apply create-time enum defaults to empty patch payloads", () => {
+    expect(updateProgramSchema.parse({})).not.toHaveProperty("status")
+    expect(updateProgramSchema.parse({})).not.toHaveProperty("type")
+    expect(updateSessionSchema.parse({})).not.toHaveProperty("sessionType")
+    expect(updateDelegateSchema.parse({})).not.toHaveProperty("role")
+    expect(updateDelegateSchema.parse({})).not.toHaveProperty("status")
+    expect(updateRfpSchema.parse({})).not.toHaveProperty("status")
+    expect(updateBidSchema.parse({})).not.toHaveProperty("status")
+  })
+
+  it("still accepts explicit lifecycle enum changes on patch", () => {
+    expect(updateProgramSchema.parse({ status: "operating" }).status).toBe("operating")
+    expect(updateSessionSchema.parse({ sessionType: "gala" }).sessionType).toBe("gala")
+    expect(updateDelegateSchema.parse({ role: "vip", status: "confirmed" })).toMatchObject({
+      role: "vip",
+      status: "confirmed",
+    })
+    expect(updateRfpSchema.parse({ status: "issued" }).status).toBe("issued")
+    expect(updateBidSchema.parse({ status: "under_review" }).status).toBe("under_review")
   })
 
   it("requires programId on session list", () => {

--- a/starters/operator/openapi/admin/mice.json
+++ b/starters/operator/openapi/admin/mice.json
@@ -1040,8 +1040,7 @@
                       "conference",
                       "exhibition",
                       "other"
-                    ],
-                    "default": "conference"
+                    ]
                   },
                   "status": {
                     "type": "string",
@@ -1052,8 +1051,7 @@
                       "operating",
                       "completed",
                       "cancelled"
-                    ],
-                    "default": "lead"
+                    ]
                   },
                   "destination": {
                     "type": [
@@ -1972,8 +1970,7 @@
                       "gala",
                       "excursion",
                       "free"
-                    ],
-                    "default": "breakout"
+                    ]
                   },
                   "functionSpaceId": {
                     "type": "string",
@@ -3056,8 +3053,7 @@
                       "staff",
                       "exhibitor",
                       "organizer"
-                    ],
-                    "default": "attendee"
+                    ]
                   },
                   "status": {
                     "type": "string",
@@ -3068,8 +3064,7 @@
                       "checked_in",
                       "no_show",
                       "cancelled"
-                    ],
-                    "default": "invited"
+                    ]
                   },
                   "arrivalAt": {
                     "type": "string",
@@ -5587,8 +5582,7 @@
                       "issued",
                       "closed",
                       "cancelled"
-                    ],
-                    "default": "draft"
+                    ]
                   },
                   "issuedAt": {
                     "type": "string",
@@ -6325,8 +6319,7 @@
                       "draft",
                       "submitted",
                       "under_review"
-                    ],
-                    "default": "draft"
+                    ]
                   },
                   "totalCents": {
                     "type": "integer",


### PR DESCRIPTION
Fixes #2533.

## Summary
- split MICE create defaults from update schemas so omitted PATCH enum fields are not defaulted
- preserve create-time defaults for programs, sessions, delegates, RFPs, and bids
- update MICE validation regression coverage and the generated operator OpenAPI artifact

## Verification
- pnpm --filter @voyant-travel/mice test
- pnpm --filter @voyant-travel/mice typecheck
- pnpm --filter operator test -- src/api/openapi.test.ts
- pre-push hook: 98 successful test tasks