### PR TITLE
fix(mice): mount booking details extension

### DIFF
--- a/.changeset/mice-booking-extension-mount.md
+++ b/.changeset/mice-booking-extension-mount.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Mount eager module and extension routes before lazy wildcard route stubs so concrete booking extensions, including MICE booking details, are reachable under shared admin surfaces.

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -103,7 +103,7 @@ export interface ModuleMount {
   moduleName: string
   /** Absolute surface mount prefix, or `"/"` for absolute `lazyRoutes`. */
   prefix: string
-  // biome-ignore lint/suspicious/noExplicitAny: accepts any composed sub-app regardless of its Env/Schema/BasePath, matching LazyRoutesLoader's AnyHono.
+  // biome-ignore lint/suspicious/noExplicitAny: accepts any composed sub-app regardless of its Env/Schema/BasePath, matching LazyRoutesLoader's AnyHono -- owner: hono runtime.
   load: () => Hono<any, any, any> | Promise<Hono<any, any, any>>
 }
 
@@ -588,6 +588,27 @@ export function mountApp<TBindings extends VoyantBindings>(
   // uniform across eager + lazy. Webhook routes are intentionally excluded — the
   // per-module docs cover the admin/storefront surfaces only.
   const moduleMounts: ModuleMount[] = []
+  const deferredLazyRouteMounts: Array<() => void> = []
+
+  function deferLazyRoutesAt(moduleName: string, prefix: string, load: LazyRoutesLoader) {
+    lazyMounts.push({ prefix, load })
+    moduleMounts.push({ moduleName, prefix, load })
+    deferredLazyRouteMounts.push(() => {
+      mountLazyRoutesAt(app, prefix, load)
+    })
+  }
+
+  function deferLazyRoutePaths(
+    moduleName: string,
+    paths: readonly string[],
+    load: LazyRoutesLoader,
+  ) {
+    lazyMounts.push({ prefix: "/", load })
+    moduleMounts.push({ moduleName, prefix: "/", load })
+    deferredLazyRouteMounts.push(() => {
+      mountLazyRoutePaths(app, paths, load)
+    })
+  }
 
   // Mount module routes
   for (const mod of allModules) {
@@ -605,19 +626,13 @@ export function mountApp<TBindings extends VoyantBindings>(
       moduleMounts.push({ moduleName, prefix: publicPrefix, load: () => publicRoutes })
     }
     if (mod.lazyAdminRoutes) {
-      mountLazyRoutesAt(app, adminPrefix, mod.lazyAdminRoutes)
-      lazyMounts.push({ prefix: adminPrefix, load: mod.lazyAdminRoutes })
-      moduleMounts.push({ moduleName, prefix: adminPrefix, load: mod.lazyAdminRoutes })
+      deferLazyRoutesAt(moduleName, adminPrefix, mod.lazyAdminRoutes)
     }
     if (mod.lazyPublicRoutes) {
-      mountLazyRoutesAt(app, publicPrefix, mod.lazyPublicRoutes)
-      lazyMounts.push({ prefix: publicPrefix, load: mod.lazyPublicRoutes })
-      moduleMounts.push({ moduleName, prefix: publicPrefix, load: mod.lazyPublicRoutes })
+      deferLazyRoutesAt(moduleName, publicPrefix, mod.lazyPublicRoutes)
     }
     if (mod.lazyRoutes) {
-      mountLazyRoutePaths(app, mod.lazyRoutes.paths, mod.lazyRoutes.load)
-      lazyMounts.push({ prefix: "/", load: mod.lazyRoutes.load })
-      moduleMounts.push({ moduleName, prefix: "/", load: mod.lazyRoutes.load })
+      deferLazyRoutePaths(moduleName, mod.lazyRoutes.paths, mod.lazyRoutes.load)
     }
     if (mod.webhookRoutes) {
       app.route(`/v1/${moduleName}`, mod.webhookRoutes)
@@ -640,23 +655,21 @@ export function mountApp<TBindings extends VoyantBindings>(
       moduleMounts.push({ moduleName, prefix: publicPrefix, load: () => publicRoutes })
     }
     if (ext.lazyAdminRoutes) {
-      mountLazyRoutesAt(app, adminPrefix, ext.lazyAdminRoutes)
-      lazyMounts.push({ prefix: adminPrefix, load: ext.lazyAdminRoutes })
-      moduleMounts.push({ moduleName, prefix: adminPrefix, load: ext.lazyAdminRoutes })
+      deferLazyRoutesAt(moduleName, adminPrefix, ext.lazyAdminRoutes)
     }
     if (ext.lazyPublicRoutes) {
-      mountLazyRoutesAt(app, publicPrefix, ext.lazyPublicRoutes)
-      lazyMounts.push({ prefix: publicPrefix, load: ext.lazyPublicRoutes })
-      moduleMounts.push({ moduleName, prefix: publicPrefix, load: ext.lazyPublicRoutes })
+      deferLazyRoutesAt(moduleName, publicPrefix, ext.lazyPublicRoutes)
     }
     if (ext.lazyRoutes) {
-      mountLazyRoutePaths(app, ext.lazyRoutes.paths, ext.lazyRoutes.load)
-      lazyMounts.push({ prefix: "/", load: ext.lazyRoutes.load })
-      moduleMounts.push({ moduleName, prefix: "/", load: ext.lazyRoutes.load })
+      deferLazyRoutePaths(moduleName, ext.lazyRoutes.paths, ext.lazyRoutes.load)
     }
     if (ext.webhookRoutes) {
       app.route(`/v1/${moduleName}`, ext.webhookRoutes)
     }
+  }
+
+  for (const mountLazyRoutes of deferredLazyRouteMounts) {
+    mountLazyRoutes()
   }
 
   // Additional routes

--- a/packages/hono/tests/unit/app-lazy-routes.test.ts
+++ b/packages/hono/tests/unit/app-lazy-routes.test.ts
@@ -2,7 +2,7 @@ import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
 import { mountApp } from "../../src/app.js"
-import type { HonoModule } from "../../src/module.js"
+import type { HonoExtension, HonoModule } from "../../src/module.js"
 import type { VoyantBindings } from "../../src/types.js"
 
 const TEST_ENV: VoyantBindings = { DATABASE_URL: "postgres://test" }
@@ -67,6 +67,38 @@ describe("mountApp lazy route mounting", () => {
     // Context bridged: the lazy route saw the db the mountApp middleware leased.
     expect(body.db).toBe("leased-db")
     expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not let a lazy extension wildcard shadow a later eager extension route", async () => {
+    const loadMaintenance = vi.fn(async () =>
+      new Hono().post("/:id/rebuild-tax-lines", (c) => c.json({ maintenance: true })),
+    )
+    const lazyExtension: HonoExtension = {
+      extension: { name: "booking-maintenance", module: "bookings" },
+      lazyAdminRoutes: loadMaintenance,
+    }
+    const eagerExtension: HonoExtension = {
+      extension: { name: "mice-booking", module: "bookings" },
+      adminRoutes: new Hono().get("/:id/mice-details", (c) => c.json({ mounted: true })),
+    }
+
+    const app = mountApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db -- owner: hono.
+      db: () => ({}) as any,
+      modules: [{ module: { name: "bookings" } }],
+      extensions: [lazyExtension, eagerExtension],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const res = await app.request(
+      "/v1/admin/bookings/book_123/mice-details",
+      {},
+      TEST_ENV,
+      TEST_CTX,
+    )
+    expect(res.status).toBe(200)
+    expect((await res.json()) as { mounted: boolean }).toEqual({ mounted: true })
+    expect(loadMaintenance).not.toHaveBeenCalled()
   })
 
   it("caches the loaded sub-app across requests (load once per isolate)", async () => {

--- a/starters/operator/src/api/composition.test.ts
+++ b/starters/operator/src/api/composition.test.ts
@@ -95,6 +95,10 @@ describe("operator runtime composition", () => {
 
     expect(byName("catalog-offers")?.extension.module).toBe("catalog")
     expect(byName("catalog-checkout")?.extension.module).toBe("catalog")
+
+    const miceBooking = byName("mice-booking")
+    expect(miceBooking?.extension.module).toBe("bookings")
+    expect(miceBooking?.adminRoutes).toBeDefined()
   })
 
   it("composes deployment-local route modules as lazy modules", () => {

--- a/starters/operator/src/api/operator-route-mounting.test.ts
+++ b/starters/operator/src/api/operator-route-mounting.test.ts
@@ -10,12 +10,15 @@
  */
 
 import type { Actor } from "@voyant-travel/core"
+import { createVoyantApp } from "@voyant-travel/framework"
 import { mountApp } from "@voyant-travel/hono"
 import { composeFromManifest } from "@voyant-travel/hono/composition"
 import { describe, expect, it } from "vitest"
 
 import {
   buildOperatorProviders,
+  deploymentLocalExtensions,
+  deploymentLocalModules,
   OPERATOR_RUNTIME_MANIFEST,
   operatorComposition,
 } from "./composition"
@@ -32,7 +35,7 @@ function build() {
   return mountApp({
     // Stub db — enough to be leased + bridged; handlers may 5xx using it, which
     // still proves the route is mounted and the context reached the sub-app.
-    // biome-ignore lint/suspicious/noExplicitAny: stub db for mount smoke test.
+    // biome-ignore lint/suspicious/noExplicitAny: stub db for mount smoke test -- owner: operator API tests.
     db: () => ({}) as any,
     modules,
     extensions,
@@ -54,7 +57,7 @@ function buildWithSessionActor(actor: Actor) {
     buildOperatorProviders(),
   )
   return mountApp({
-    // biome-ignore lint/suspicious/noExplicitAny: stub db for auth-surface regression.
+    // biome-ignore lint/suspicious/noExplicitAny: stub db for auth-surface regression -- owner: operator API tests.
     db: () => ({}) as any,
     modules,
     extensions,
@@ -64,9 +67,28 @@ function buildWithSessionActor(actor: Actor) {
   })
 }
 
+function buildWithLiveFrontDoor() {
+  return createVoyantApp({
+    providers: buildOperatorProviders(),
+    modules: deploymentLocalModules,
+    extensions: deploymentLocalExtensions,
+    // biome-ignore lint/suspicious/noExplicitAny: stub db for mount smoke test -- owner: operator API tests.
+    db: () => ({}) as any,
+    auth: {
+      resolve: () => ({ userId: "u1", actor: "staff" }),
+    },
+  })
+}
+
 async function status(path: string, method = "GET"): Promise<number> {
   const app = build()
   const res = await app.request(path, { method }, TEST_ENV, TEST_CTX)
+  return res.status
+}
+
+async function liveFrontDoorStatus(path: string, init: RequestInit = {}): Promise<number> {
+  const app = buildWithLiveFrontDoor()
+  const res = await app.request(path, init, TEST_ENV, TEST_CTX)
   return res.status
 }
 
@@ -82,6 +104,20 @@ async function responseWithSessionActor(
 describe("operator composed route mounting (smoke)", () => {
   it("returns 404 for an unmounted admin path (control)", async () => {
     expect(await status("/v1/admin/definitely-not-mounted/x")).toBe(404)
+  })
+
+  it("mounts MICE booking details routes through the live starter front door", async () => {
+    const bookingPath = "/v1/admin/bookings/book_123/mice-details"
+
+    expect(await liveFrontDoorStatus(bookingPath)).not.toBe(404)
+    expect(
+      await liveFrontDoorStatus(bookingPath, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ programId: "mice_program_123", delegateId: "mice_delegate_123" }),
+      }),
+    ).not.toBe(404)
+    expect(await liveFrontDoorStatus(bookingPath, { method: "DELETE" })).not.toBe(404)
   })
 
   it("mounts lazyAdminRoutes modules (flights, mcp)", async () => {


### PR DESCRIPTION
Fixes #2534

## Summary

- Mount lazy route dispatchers after all eager module and extension routes so wildcard lazy stubs cannot shadow concrete shared-surface extension routes.
- Add Hono regression coverage for a lazy bookings extension shadowing a later eager bookings extension.
- Add operator composition smoke coverage for the MICE booking details GET, PUT, and DELETE routes through the live starter front door.

## Root Cause

Lazy route stubs were registered immediately while iterating modules and extensions. A lazy bookings extension registered a wildcard under `/v1/admin/bookings/*` before the MICE eager booking extension was mounted, so requests for `/bookings/:id/mice-details` could be consumed by the earlier lazy stub and return 404.

## Checks

- `pnpm --filter @voyant-travel/hono test -- app-lazy-routes.test.ts`
- `pnpm --filter operator test -- src/api/composition.test.ts src/api/operator-route-mounting.test.ts`
- `pnpm --filter @voyant-travel/hono typecheck`
- `pnpm --filter operator typecheck`
- Commit hook: 186 tasks passed
- Pre-push hook: 98 tasks passed
