### PR TITLE
fix(mice): validate program date ranges

### DIFF
--- a/.changeset/mice-program-date-range-validation.md
+++ b/.changeset/mice-program-date-range-validation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mice": patch
+---
+
+Reject MICE program create and update payloads whose end date is before the start date.

--- a/packages/mice/src/service.ts
+++ b/packages/mice/src/service.ts
@@ -1,13 +1,30 @@
+import { RequestValidationError } from "@voyant-travel/hono"
 import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { type Program, programs } from "./schema.js"
 import type { CreateProgramBody, ProgramListQuery, UpdateProgramBody } from "./validation.js"
 
+const PROGRAM_DATE_RANGE_ERROR_MESSAGE = "endDate must be on or after startDate"
+
+type ProgramDateRangeShape = {
+  startDate?: string | null
+  endDate?: string | null
+}
+
+function assertProgramDateRange(program: ProgramDateRangeShape) {
+  if (!program.startDate || !program.endDate || program.endDate >= program.startDate) return
+
+  throw new RequestValidationError(PROGRAM_DATE_RANGE_ERROR_MESSAGE, {
+    issues: [{ path: ["endDate"], message: PROGRAM_DATE_RANGE_ERROR_MESSAGE }],
+  })
+}
+
 export async function createProgram(
   db: PostgresJsDatabase,
   input: CreateProgramBody,
 ): Promise<Program> {
+  assertProgramDateRange(input)
   const [program] = await db.insert(programs).values(input).returning()
   if (!program) throw new Error("createProgram: insert returned no rows")
   return program
@@ -43,6 +60,11 @@ export async function updateProgram(
   id: string,
   input: UpdateProgramBody,
 ): Promise<Program | null> {
+  const [current] = await db.select().from(programs).where(eq(programs.id, id)).limit(1)
+  if (!current) return null
+
+  assertProgramDateRange({ ...current, ...input })
+
   const [program] = await db
     .update(programs)
     .set({ ...input, updatedAt: new Date() })

--- a/packages/mice/src/validation.ts
+++ b/packages/mice/src/validation.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "expected YYYY-MM-DD")
+const PROGRAM_DATE_RANGE_ERROR_MESSAGE = "endDate must be on or after startDate"
 
 export const programTypeSchema = z.enum([
   "meeting",
@@ -19,7 +20,26 @@ export const programStatusSchema = z.enum([
   "cancelled",
 ])
 
-const programMutationSchema = z.object({
+type ProgramDateRangeInput = {
+  startDate?: string | null
+  endDate?: string | null
+}
+
+function isProgramDateRangeValid(value: ProgramDateRangeInput): boolean {
+  return !(value.startDate && value.endDate && value.endDate < value.startDate)
+}
+
+function validateProgramDateRange(value: ProgramDateRangeInput, ctx: z.RefinementCtx) {
+  if (isProgramDateRangeValid(value)) return
+
+  ctx.addIssue({
+    code: "custom",
+    path: ["endDate"],
+    message: PROGRAM_DATE_RANGE_ERROR_MESSAGE,
+  })
+}
+
+const programMutationFields = {
   name: z.string().min(1),
   organizationId: z.string().min(1).optional(),
   primaryContactPersonId: z.string().min(1).optional(),
@@ -34,30 +54,37 @@ const programMutationSchema = z.object({
   confirmedPax: z.number().int().min(0).optional(),
   currency: z.string().optional(),
   budgetAmountCents: z.number().int().min(0).optional(),
-})
+} satisfies z.ZodRawShape
 
-export const createProgramSchema = programMutationSchema.extend({
-  type: programTypeSchema.default("conference"),
-  status: programStatusSchema.default("lead"),
-})
+export const createProgramSchema = z
+  .object({
+    ...programMutationFields,
+    type: programTypeSchema.default("conference"),
+    status: programStatusSchema.default("lead"),
+  })
+  .superRefine(validateProgramDateRange)
 
 // Update accepts `null` on the optional fields so a PATCH can CLEAR them (the
 // columns are nullable and `updateProgram` spreads the body into `.set()`).
 // `.partial()` alone only allows omitting a key, which leaves the prior value
 // in place — operators could set an optional field but never clear it.
-export const updateProgramSchema = programMutationSchema.partial().extend({
-  organizationId: z.string().min(1).nullish(),
-  primaryContactPersonId: z.string().min(1).nullish(),
-  accountManagerId: z.string().min(1).nullish(),
-  code: z.string().nullish(),
-  destination: z.string().nullish(),
-  startDate: isoDate.nullish(),
-  endDate: isoDate.nullish(),
-  estimatedPax: z.number().int().min(0).nullish(),
-  confirmedPax: z.number().int().min(0).nullish(),
-  currency: z.string().nullish(),
-  budgetAmountCents: z.number().int().min(0).nullish(),
-})
+export const updateProgramSchema = z
+  .object(programMutationFields)
+  .partial()
+  .extend({
+    organizationId: z.string().min(1).nullish(),
+    primaryContactPersonId: z.string().min(1).nullish(),
+    accountManagerId: z.string().min(1).nullish(),
+    code: z.string().nullish(),
+    destination: z.string().nullish(),
+    startDate: isoDate.nullish(),
+    endDate: isoDate.nullish(),
+    estimatedPax: z.number().int().min(0).nullish(),
+    confirmedPax: z.number().int().min(0).nullish(),
+    currency: z.string().nullish(),
+    budgetAmountCents: z.number().int().min(0).nullish(),
+  })
+  .superRefine(validateProgramDateRange)
 
 export const programListQuerySchema = z.object({
   status: programStatusSchema.optional(),

--- a/packages/mice/tests/unit/routes-validation.test.ts
+++ b/packages/mice/tests/unit/routes-validation.test.ts
@@ -1,0 +1,99 @@
+import { handleApiError } from "@voyant-travel/hono"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+
+import { miceAdminRoutes } from "../../src/routes.js"
+
+function fakeProgramDb(selectRows: unknown[][] = []) {
+  return {
+    select: vi.fn(() => {
+      const rows = selectRows.shift() ?? []
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => Promise.resolve(rows)),
+      }
+      return builder
+    }),
+    insert: vi.fn(() => {
+      throw new Error("insert should not be reached")
+    }),
+    update: vi.fn(() => {
+      throw new Error("update should not be reached")
+    }),
+  }
+}
+
+function makeApp(db: ReturnType<typeof fakeProgramDb>) {
+  const app = new Hono()
+  app.onError((err, c) => handleApiError(err, c))
+  app.use("*", async (c, next) => {
+    c.set("db", db)
+    await next()
+  })
+  app.route("/", miceAdminRoutes)
+  return app
+}
+
+describe("mice program route validation", () => {
+  it("rejects program create when endDate is before startDate", async () => {
+    const db = fakeProgramDb()
+    const response = await makeApp(db).request("/programs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Acme Kickoff",
+        type: "meeting",
+        startDate: "2026-12-10",
+        endDate: "2026-12-01",
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      code: "invalid_request",
+      details: {
+        issues: [
+          expect.objectContaining({
+            path: ["endDate"],
+            message: "endDate must be on or after startDate",
+          }),
+        ],
+      },
+    })
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects program patch when the stored date range would become reversed", async () => {
+    const db = fakeProgramDb([
+      [
+        {
+          id: "mice_programs_1",
+          name: "Acme Kickoff",
+          startDate: "2026-12-10",
+          endDate: "2026-12-20",
+        },
+      ],
+    ])
+
+    const response = await makeApp(db).request("/programs/mice_programs_1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ endDate: "2026-12-01" }),
+    })
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      code: "invalid_request",
+      details: {
+        issues: [
+          expect.objectContaining({
+            path: ["endDate"],
+            message: "endDate must be on or after startDate",
+          }),
+        ],
+      },
+    })
+    expect(db.update).not.toHaveBeenCalled()
+  })
+})

--- a/packages/mice/tests/unit/service-validation.test.ts
+++ b/packages/mice/tests/unit/service-validation.test.ts
@@ -1,0 +1,119 @@
+import { RequestValidationError } from "@voyant-travel/hono"
+import { describe, expect, it, vi } from "vitest"
+
+import { createProgram, updateProgram } from "../../src/service.js"
+
+function fakeProgramDb({
+  selectRows = [],
+  updateRows = [],
+}: {
+  selectRows?: unknown[][]
+  updateRows?: unknown[]
+}) {
+  return {
+    select: vi.fn(() => {
+      const rows = selectRows.shift() ?? []
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        limit: vi.fn(() => Promise.resolve(rows)),
+      }
+      return builder
+    }),
+    insert: vi.fn(() => {
+      throw new Error("insert should not be reached")
+    }),
+    update: vi.fn(() => {
+      const builder = {
+        set: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        returning: vi.fn(() => Promise.resolve(updateRows)),
+      }
+      return builder
+    }),
+  }
+}
+
+function expectInvalidProgramDateRange(error: unknown) {
+  expect(error).toBeInstanceOf(RequestValidationError)
+  expect(error).toMatchObject({
+    details: {
+      issues: [
+        expect.objectContaining({
+          path: ["endDate"],
+          message: "endDate must be on or after startDate",
+        }),
+      ],
+    },
+  })
+}
+
+async function expectRejectsInvalidProgramDateRange(action: () => Promise<unknown>) {
+  try {
+    await action()
+  } catch (error) {
+    expectInvalidProgramDateRange(error)
+    return
+  }
+
+  throw new Error("Expected RequestValidationError")
+}
+
+describe("mice program service validation", () => {
+  it("rejects program create when endDate is before startDate", async () => {
+    const db = fakeProgramDb({})
+
+    await expectRejectsInvalidProgramDateRange(() =>
+      createProgram(db as never, {
+        name: "Backward dates",
+        type: "meeting",
+        startDate: "2026-12-10",
+        endDate: "2026-12-01",
+      }),
+    )
+
+    expect(db.insert).not.toHaveBeenCalled()
+  })
+
+  it("rejects program update when the merged date range is inverted", async () => {
+    const db = fakeProgramDb({
+      selectRows: [
+        [
+          {
+            id: "mice_programs_1",
+            name: "Acme Kickoff",
+            startDate: "2026-12-10",
+            endDate: "2026-12-20",
+          },
+        ],
+      ],
+    })
+
+    await expectRejectsInvalidProgramDateRange(() =>
+      updateProgram(db as never, "mice_programs_1", { endDate: "2026-12-01" }),
+    )
+
+    expect(db.update).not.toHaveBeenCalled()
+  })
+
+  it("allows omitted-date patch payloads when the stored range is valid", async () => {
+    const current = {
+      id: "mice_programs_1",
+      name: "Acme Kickoff",
+      startDate: "2026-12-10",
+      endDate: "2026-12-20",
+    }
+    const db = fakeProgramDb({
+      selectRows: [[current]],
+      updateRows: [{ ...current, status: "planning" }],
+    })
+
+    await expect(
+      updateProgram(db as never, "mice_programs_1", { status: "planning" }),
+    ).resolves.toMatchObject({
+      id: "mice_programs_1",
+      status: "planning",
+    })
+    expect(db.update).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/mice/tests/unit/validation.test.ts
+++ b/packages/mice/tests/unit/validation.test.ts
@@ -29,6 +29,58 @@ describe("mice validation", () => {
     expect(result.success).toBe(false)
   })
 
+  it("accepts a valid program date range", () => {
+    const parsed = createProgramSchema.parse({
+      name: "Acme Kickoff",
+      startDate: "2026-12-01",
+      endDate: "2026-12-10",
+    })
+    expect(parsed.startDate).toBe("2026-12-01")
+    expect(parsed.endDate).toBe("2026-12-10")
+  })
+
+  it("rejects program create when endDate is before startDate", () => {
+    const result = createProgramSchema.safeParse({
+      name: "Acme Kickoff",
+      type: "meeting",
+      startDate: "2026-12-10",
+      endDate: "2026-12-01",
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["endDate"],
+          message: "endDate must be on or after startDate",
+        }),
+      ])
+    }
+  })
+
+  it("rejects program patch when both provided dates are reversed", () => {
+    const result = updateProgramSchema.safeParse({
+      startDate: "2026-12-10",
+      endDate: "2026-12-01",
+    })
+
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues).toEqual([
+        expect.objectContaining({
+          path: ["endDate"],
+          message: "endDate must be on or after startDate",
+        }),
+      ])
+    }
+  })
+
+  it("allows program patch payloads that omit one or both dates", () => {
+    expect(updateProgramSchema.safeParse({}).success).toBe(true)
+    expect(updateProgramSchema.safeParse({ startDate: "2026-12-10" }).success).toBe(true)
+    expect(updateProgramSchema.safeParse({ endDate: "2026-12-01" }).success).toBe(true)
+  })
+
   it("coerces + defaults list pagination", () => {
     const parsed = programListQuerySchema.parse({ limit: "25" })
     expect(parsed.limit).toBe(25)


### PR DESCRIPTION
Fixes #2535

## Root cause
MICE program create and update validation checked date string shape but did not enforce the relationship between `startDate` and `endDate`, so reversed ranges could be accepted and persisted.

## Changes
- Added create/PATCH schema refinement that rejects `endDate` before `startDate` when both dates are provided.
- Added service-level range validation for creates and merged updates so partial PATCH payloads cannot make a stored program range invalid.
- Preserved omitted-date PATCH behavior and null clearing semantics.
- Added focused validation, service, and route tests for invalid create, invalid merged PATCH, valid ranges, and omitted-date PATCH payloads.
- Added a patch changeset for `@voyant-travel/mice`.

## Checks
- `pnpm --filter @voyant-travel/mice test -- validation.test.ts service-validation.test.ts routes-validation.test.ts routes-contract.test.ts`
- `pnpm --filter @voyant-travel/mice lint`
- `pnpm exec biome check packages/mice/tests/unit/service-validation.test.ts packages/mice/tests/unit/routes-validation.test.ts packages/mice/tests/unit/validation.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/mice typecheck`
- Commit hook affected checks passed
- Pre-push `pnpm test` hook passed