### PR TITLE
fix(mice): expose rooming and booking links

### DIFF
--- a/.changeset/mice-rooming-booking-ui.md
+++ b/.changeset/mice-rooming-booking-ui.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mice-react": patch
+---
+
+Expose MICE rooming assignment and booking linkage workflows on the program detail UI.

--- a/packages/mice-react/src/components/program-delegates-section.tsx
+++ b/packages/mice-react/src/components/program-delegates-section.tsx
@@ -10,6 +10,7 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Input,
   Label,
   Select,
   SelectContent,
@@ -23,9 +24,10 @@ import {
   TableHeader,
   TableRow,
 } from "@voyant-travel/ui/components"
-import { Loader2, Plus, UserPlus } from "lucide-react"
-import { useState } from "react"
+import { Link2, Loader2, Plus, UserPlus } from "lucide-react"
+import { useEffect, useState } from "react"
 
+import { useBookingLinkMutation } from "../hooks/use-booking-link-mutation.js"
 import { useDelegateMutation } from "../hooks/use-delegate-mutation.js"
 import { useProgramDelegates, useProgramSessions } from "../hooks/use-mice-lists.js"
 import type { DelegateRecord } from "../schemas.js"
@@ -92,6 +94,7 @@ export function ProgramDelegatesSection({ programId }: ProgramDelegatesSectionPr
   const capped = delegates.length === DELEGATES_PAGE_LIMIT
   const [showCreate, setShowCreate] = useState(false)
   const [enrollTarget, setEnrollTarget] = useState<DelegateRecord | null>(null)
+  const [bookingTarget, setBookingTarget] = useState<DelegateRecord | null>(null)
 
   return (
     <section className="space-y-3">
@@ -110,13 +113,14 @@ export function ProgramDelegatesSection({ programId }: ProgramDelegatesSectionPr
               <TableHead>Delegate</TableHead>
               <TableHead>Role</TableHead>
               <TableHead>Status</TableHead>
+              <TableHead>Booking</TableHead>
               <TableHead> </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {!isLoading && delegates.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={4} className="text-center text-muted-foreground">
+                <TableCell colSpan={5} className="text-center text-muted-foreground">
                   No delegates yet.
                 </TableCell>
               </TableRow>
@@ -130,11 +134,20 @@ export function ProgramDelegatesSection({ programId }: ProgramDelegatesSectionPr
                       {statusLabel(d.status)}
                     </Badge>
                   </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {d.bookingId ?? "—"}
+                  </TableCell>
                   <TableCell className="text-right">
-                    <Button variant="ghost" size="sm" onClick={() => setEnrollTarget(d)}>
-                      <UserPlus className="size-4" aria-hidden="true" />
-                      Enroll
-                    </Button>
+                    <div className="flex justify-end gap-1">
+                      <Button variant="ghost" size="sm" onClick={() => setEnrollTarget(d)}>
+                        <UserPlus className="size-4" aria-hidden="true" />
+                        Enroll
+                      </Button>
+                      <Button variant="ghost" size="sm" onClick={() => setBookingTarget(d)}>
+                        <Link2 className="size-4" aria-hidden="true" />
+                        Booking
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))
@@ -155,6 +168,13 @@ export function ProgramDelegatesSection({ programId }: ProgramDelegatesSectionPr
         delegate={enrollTarget}
         onOpenChange={(open) => {
           if (!open) setEnrollTarget(null)
+        }}
+      />
+      <LinkBookingDialog
+        programId={programId}
+        delegate={bookingTarget}
+        onOpenChange={(open) => {
+          if (!open) setBookingTarget(null)
         }}
       />
     </section>
@@ -352,6 +372,86 @@ function EnrollDelegateDialog({ programId, delegate, onOpenChange }: EnrollDeleg
               <Loader2 className="size-4 animate-spin" aria-hidden="true" />
             ) : null}
             Enroll
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface LinkBookingDialogProps {
+  programId: string
+  delegate: DelegateRecord | null
+  onOpenChange: (open: boolean) => void
+}
+
+function LinkBookingDialog({ programId, delegate, onOpenChange }: LinkBookingDialogProps) {
+  const open = delegate !== null
+  const { linkDelegateBooking } = useBookingLinkMutation()
+  const [bookingId, setBookingId] = useState("")
+
+  useEffect(() => {
+    if (!open) return
+    setBookingId(delegate?.bookingId ?? "")
+  }, [delegate, open])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setBookingId("")
+    onOpenChange(next)
+  }
+
+  const submit = async () => {
+    const trimmed = bookingId.trim()
+    if (!delegate || !trimmed) return
+    await linkDelegateBooking.mutateAsync({
+      programId,
+      delegateId: delegate.id,
+      bookingId: trimmed,
+      previousBookingId: delegate.bookingId,
+    })
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Link delegate booking</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="delegate-booking-id">Booking ID</Label>
+            <Input
+              id="delegate-booking-id"
+              value={bookingId}
+              onChange={(e) => setBookingId(e.target.value)}
+              placeholder="book_..."
+            />
+          </div>
+          {delegate ? (
+            <p className="text-muted-foreground text-xs">
+              Delegate {delegate.personId ?? delegate.id}
+            </p>
+          ) : null}
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={linkDelegateBooking.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={() => void submit()}
+            disabled={!bookingId.trim() || linkDelegateBooking.isPending}
+          >
+            {linkDelegateBooking.isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Link2 className="size-4" aria-hidden="true" />
+            )}
+            Link booking
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/packages/mice-react/src/components/program-detail-page.tsx
+++ b/packages/mice-react/src/components/program-detail-page.tsx
@@ -10,6 +10,7 @@ import { ProgramCostSheetPanel } from "./program-cost-sheet-panel.js"
 import { ProgramDelegatesSection } from "./program-delegates-section.js"
 import { ProgramFormDialog } from "./program-form-dialog.js"
 import { ProgramRfpsSection } from "./program-rfps-section.js"
+import { ProgramRoomingSection } from "./program-rooming-section.js"
 import { ProgramSessionsSection } from "./program-sessions-section.js"
 
 export interface ProgramDetailPageProps {
@@ -83,6 +84,8 @@ export function ProgramDetailPage({ programId }: ProgramDetailPageProps) {
       <ProgramSessionsSection programId={programId} />
 
       <ProgramDelegatesSection programId={programId} />
+
+      <ProgramRoomingSection programId={programId} />
 
       <ProgramRfpsSection programId={programId} />
     </div>

--- a/packages/mice-react/src/components/program-rooming-section.tsx
+++ b/packages/mice-react/src/components/program-rooming-section.tsx
@@ -1,0 +1,481 @@
+"use client"
+
+import {
+  Badge,
+  Button,
+  Checkbox,
+  DatePicker,
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Label,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Textarea,
+} from "@voyant-travel/ui/components"
+import { BedDouble, Loader2, Plus, Users } from "lucide-react"
+import { useEffect, useState } from "react"
+
+import {
+  useProgramDelegates,
+  useProgramRooming,
+  useRoomingAssignment,
+} from "../hooks/use-mice-lists.js"
+import { useRoomingMutation } from "../hooks/use-rooming-mutation.js"
+import type { DelegateRecord, RoomingAssignmentDelegateRecord } from "../schemas.js"
+
+const ROOMING_PAGE_LIMIT = 500
+const DELEGATES_PAGE_LIMIT = 500
+
+export interface ProgramRoomingSectionProps {
+  programId: string
+}
+
+function assignmentLabel(value: string | null | undefined): string {
+  return value?.trim() || "-"
+}
+
+function delegateLabel(delegate: DelegateRecord): string {
+  return delegate.personId ?? delegate.bookingId ?? delegate.id
+}
+
+/**
+ * Rooming assignments for a program. The list stays intentionally compact; the
+ * occupant workflow opens per assignment and replaces the full room delegate set.
+ */
+export function ProgramRoomingSection({ programId }: ProgramRoomingSectionProps) {
+  const { data, isLoading } = useProgramRooming(programId)
+  const assignments = data?.data ?? []
+  const capped = assignments.length === ROOMING_PAGE_LIMIT
+  const [showCreate, setShowCreate] = useState(false)
+  const [manageAssignmentId, setManageAssignmentId] = useState<string | null>(null)
+
+  return (
+    <section className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h2 className="font-semibold text-lg tracking-tight">Rooming</h2>
+        <Button size="sm" onClick={() => setShowCreate(true)}>
+          <Plus className="size-4" aria-hidden="true" />
+          New assignment
+        </Button>
+      </div>
+
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Room block</TableHead>
+              <TableHead>Room type</TableHead>
+              <TableHead>Stay</TableHead>
+              <TableHead>Bed</TableHead>
+              <TableHead>Sharing group</TableHead>
+              <TableHead> </TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {!isLoading && assignments.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={6} className="text-center text-muted-foreground">
+                  No rooming assignments yet.
+                </TableCell>
+              </TableRow>
+            ) : (
+              assignments.map((assignment) => (
+                <TableRow key={assignment.id}>
+                  <TableCell className="font-medium">
+                    {assignmentLabel(assignment.roomBlockId)}
+                  </TableCell>
+                  <TableCell>{assignmentLabel(assignment.roomTypeId)}</TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {assignment.checkIn || assignment.checkOut
+                      ? `${assignment.checkIn ?? "?"} to ${assignment.checkOut ?? "?"}`
+                      : "-"}
+                  </TableCell>
+                  <TableCell>
+                    {assignment.bedConfig ? (
+                      <Badge variant="outline">{assignment.bedConfig}</Badge>
+                    ) : (
+                      "-"
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {assignmentLabel(assignment.sharingGroupId)}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setManageAssignmentId(assignment.id)}
+                    >
+                      <Users className="size-4" aria-hidden="true" />
+                      Occupants
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {capped ? (
+        <p className="text-muted-foreground text-xs">
+          Showing the first {ROOMING_PAGE_LIMIT} assignments.
+        </p>
+      ) : null}
+
+      <CreateRoomingAssignmentDialog
+        programId={programId}
+        open={showCreate}
+        onOpenChange={setShowCreate}
+      />
+      <ManageRoomingOccupantsDialog
+        programId={programId}
+        assignmentId={manageAssignmentId}
+        onOpenChange={(open) => {
+          if (!open) setManageAssignmentId(null)
+        }}
+      />
+    </section>
+  )
+}
+
+interface CreateRoomingAssignmentDialogProps {
+  programId: string
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function CreateRoomingAssignmentDialog({
+  programId,
+  open,
+  onOpenChange,
+}: CreateRoomingAssignmentDialogProps) {
+  const { create } = useRoomingMutation()
+  const [roomBlockId, setRoomBlockId] = useState("")
+  const [roomTypeId, setRoomTypeId] = useState("")
+  const [bedConfig, setBedConfig] = useState("")
+  const [sharingGroupId, setSharingGroupId] = useState("")
+  const [checkIn, setCheckIn] = useState("")
+  const [checkOut, setCheckOut] = useState("")
+  const [specialRequests, setSpecialRequests] = useState("")
+
+  const reset = () => {
+    setRoomBlockId("")
+    setRoomTypeId("")
+    setBedConfig("")
+    setSharingGroupId("")
+    setCheckIn("")
+    setCheckOut("")
+    setSpecialRequests("")
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  const submit = async () => {
+    await create.mutateAsync({
+      programId,
+      roomBlockId: roomBlockId.trim() || undefined,
+      roomTypeId: roomTypeId.trim() || undefined,
+      bedConfig: bedConfig.trim() || undefined,
+      sharingGroupId: sharingGroupId.trim() || undefined,
+      checkIn: checkIn || undefined,
+      checkOut: checkOut || undefined,
+      specialRequests: specialRequests.trim() || undefined,
+    })
+    handleOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>New rooming assignment</DialogTitle>
+        </DialogHeader>
+        <DialogBody className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="rooming-room-block">Room block</Label>
+              <Input
+                id="rooming-room-block"
+                value={roomBlockId}
+                onChange={(e) => setRoomBlockId(e.target.value)}
+                placeholder="rb_..."
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rooming-room-type">Room type</Label>
+              <Input
+                id="rooming-room-type"
+                value={roomTypeId}
+                onChange={(e) => setRoomTypeId(e.target.value)}
+                placeholder="rt_..."
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="rooming-check-in">Check-in</Label>
+              <DatePicker
+                value={checkIn || null}
+                onChange={(value) => setCheckIn(value ?? "")}
+                placeholder="Check-in"
+                className="w-full"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rooming-check-out">Check-out</Label>
+              <DatePicker
+                value={checkOut || null}
+                onChange={(value) => setCheckOut(value ?? "")}
+                placeholder="Check-out"
+                className="w-full"
+              />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="rooming-bed-config">Bed configuration</Label>
+              <Input
+                id="rooming-bed-config"
+                value={bedConfig}
+                onChange={(e) => setBedConfig(e.target.value)}
+                placeholder="Twin"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="rooming-sharing-group">Sharing group</Label>
+              <Input
+                id="rooming-sharing-group"
+                value={sharingGroupId}
+                onChange={(e) => setSharingGroupId(e.target.value)}
+                placeholder="group-a"
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="rooming-special-requests">Special requests</Label>
+            <Textarea
+              id="rooming-special-requests"
+              value={specialRequests}
+              onChange={(e) => setSpecialRequests(e.target.value)}
+              placeholder="Accessible room, late arrival, dietary notes"
+            />
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={create.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={create.isPending}>
+            {create.isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <BedDouble className="size-4" aria-hidden="true" />
+            )}
+            Create assignment
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+interface ManageRoomingOccupantsDialogProps {
+  programId: string
+  assignmentId: string | null
+  onOpenChange: (open: boolean) => void
+}
+
+type OccupantDraft = Record<string, { isPrimary: boolean; bedLabel: string }>
+
+function draftFromRows(rows: RoomingAssignmentDelegateRecord[]): OccupantDraft {
+  return Object.fromEntries(
+    rows.map((row) => [row.delegateId, { isPrimary: row.isPrimary, bedLabel: row.bedLabel ?? "" }]),
+  )
+}
+
+function ManageRoomingOccupantsDialog({
+  programId,
+  assignmentId,
+  onOpenChange,
+}: ManageRoomingOccupantsDialogProps) {
+  const open = assignmentId !== null
+  const { setDelegates } = useRoomingMutation()
+  const { data: assignmentData, isLoading: assignmentLoading } = useRoomingAssignment(
+    assignmentId ?? undefined,
+    { enabled: open },
+  )
+  const { data: delegatesData, isLoading: delegatesLoading } = useProgramDelegates(
+    { programId, limit: DELEGATES_PAGE_LIMIT },
+    { enabled: open },
+  )
+  const delegates = delegatesData?.data ?? []
+  const assignment = assignmentData?.data
+  const [draft, setDraft] = useState<OccupantDraft>({})
+
+  useEffect(() => {
+    if (!open || !assignment) return
+    setDraft(draftFromRows(assignment.delegates))
+  }, [assignment, open])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) setDraft({})
+    onOpenChange(next)
+  }
+
+  const toggleDelegate = (delegateId: string, checked: boolean) => {
+    setDraft((current) => {
+      const next = { ...current }
+      if (checked) {
+        next[delegateId] = next[delegateId] ?? { isPrimary: false, bedLabel: "" }
+      } else {
+        delete next[delegateId]
+      }
+      return next
+    })
+  }
+
+  const setPrimary = (delegateId: string, checked: boolean) => {
+    setDraft((current) =>
+      Object.fromEntries(
+        Object.entries(current).map(([id, value]) => [
+          id,
+          { ...value, isPrimary: checked && id === delegateId },
+        ]),
+      ),
+    )
+  }
+
+  const setBedLabel = (delegateId: string, bedLabel: string) => {
+    setDraft((current) => ({
+      ...current,
+      [delegateId]: { ...(current[delegateId] ?? { isPrimary: false }), bedLabel },
+    }))
+  }
+
+  const submit = async () => {
+    if (!assignmentId) return
+    await setDelegates.mutateAsync({
+      assignmentId,
+      delegates: Object.entries(draft).map(([delegateId, value]) => ({
+        delegateId,
+        isPrimary: value.isPrimary,
+        bedLabel: value.bedLabel.trim() || undefined,
+      })),
+    })
+    handleOpenChange(false)
+  }
+
+  const loading = assignmentLoading || delegatesLoading
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Assign room occupants</DialogTitle>
+        </DialogHeader>
+        <DialogBody>
+          {loading && !assignment ? (
+            <div className="py-6 text-center text-muted-foreground text-sm">Loading...</div>
+          ) : (
+            <div className="space-y-3">
+              <div className="rounded-md border">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-12"> </TableHead>
+                      <TableHead>Delegate</TableHead>
+                      <TableHead className="w-24">Primary</TableHead>
+                      <TableHead className="w-40">Bed label</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {delegates.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4} className="text-center text-muted-foreground">
+                          No delegates yet.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      delegates.map((delegate) => {
+                        const selected = draft[delegate.id]
+                        return (
+                          <TableRow key={delegate.id}>
+                            <TableCell>
+                              <Checkbox
+                                checked={selected !== undefined}
+                                onCheckedChange={(checked) =>
+                                  toggleDelegate(delegate.id, checked === true)
+                                }
+                                aria-label={`Assign ${delegateLabel(delegate)}`}
+                              />
+                            </TableCell>
+                            <TableCell className="font-medium">{delegateLabel(delegate)}</TableCell>
+                            <TableCell>
+                              <Checkbox
+                                checked={selected?.isPrimary ?? false}
+                                onCheckedChange={(checked) =>
+                                  setPrimary(delegate.id, checked === true)
+                                }
+                                disabled={!selected}
+                                aria-label={`Mark ${delegateLabel(delegate)} as primary`}
+                              />
+                            </TableCell>
+                            <TableCell>
+                              <Input
+                                value={selected?.bedLabel ?? ""}
+                                onChange={(e) => setBedLabel(delegate.id, e.target.value)}
+                                placeholder="A"
+                                disabled={!selected}
+                              />
+                            </TableCell>
+                          </TableRow>
+                        )
+                      })
+                    )}
+                  </TableBody>
+                </Table>
+              </div>
+              {delegates.length === DELEGATES_PAGE_LIMIT ? (
+                <p className="text-muted-foreground text-xs">
+                  Showing the first {DELEGATES_PAGE_LIMIT} delegates.
+                </p>
+              ) : null}
+            </div>
+          )}
+        </DialogBody>
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={setDelegates.isPending}
+          >
+            Cancel
+          </Button>
+          <Button onClick={() => void submit()} disabled={!assignmentId || setDelegates.isPending}>
+            {setDelegates.isPending ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : null}
+            Save occupants
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/packages/mice-react/src/hooks/index.ts
+++ b/packages/mice-react/src/hooks/index.ts
@@ -1,10 +1,16 @@
+export {
+  type LinkDelegateBookingInput,
+  useBookingLinkMutation,
+} from "./use-booking-link-mutation.js"
 export { useDelegateMutation } from "./use-delegate-mutation.js"
 export {
+  useBookingMiceDetails,
   useProgramDelegates,
   useProgramRfps,
   useProgramRooming,
   useProgramSessions,
   useRfp,
+  useRoomingAssignment,
 } from "./use-mice-lists.js"
 export { useProgramMutation } from "./use-program-mutation.js"
 export {
@@ -14,4 +20,5 @@ export {
   usePrograms,
 } from "./use-programs.js"
 export { useRfpMutation } from "./use-rfp-mutation.js"
+export { useRoomingMutation } from "./use-rooming-mutation.js"
 export { useSessionMutation } from "./use-session-mutation.js"

--- a/packages/mice-react/src/hooks/use-booking-link-mutation.ts
+++ b/packages/mice-react/src/hooks/use-booking-link-mutation.ts
@@ -1,0 +1,80 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import { z } from "zod"
+
+import { fetchWithValidation, VoyantApiError } from "../client.js"
+import { useVoyantContext } from "../provider.js"
+import { miceQueryKeys } from "../query-keys.js"
+import { bookingMiceDetailResponse, delegateSingleResponse } from "../schemas.js"
+
+const miceBasePath = "/v1/admin/mice"
+const successResponse = z.object({ success: z.literal(true) })
+
+export interface LinkDelegateBookingInput {
+  programId: string
+  delegateId: string
+  bookingId: string
+  previousBookingId?: string | null | undefined
+}
+
+/**
+ * Links a MICE delegate to a booking in both places the backend exposes:
+ * the delegate row (`bookingId`) and the booking sidecar (`mice-details`).
+ */
+export function useBookingLinkMutation() {
+  const { baseUrl, fetcher } = useVoyantContext()
+  const queryClient = useQueryClient()
+  const client = { baseUrl, fetcher }
+
+  const invalidate = (input: LinkDelegateBookingInput) => {
+    void queryClient.invalidateQueries({ queryKey: miceQueryKeys.delegates() })
+    void queryClient.invalidateQueries({
+      queryKey: miceQueryKeys.bookingMiceDetails(input.bookingId),
+    })
+    if (input.previousBookingId && input.previousBookingId !== input.bookingId) {
+      void queryClient.invalidateQueries({
+        queryKey: miceQueryKeys.bookingMiceDetails(input.previousBookingId),
+      })
+    }
+  }
+
+  const linkDelegateBooking = useMutation({
+    mutationFn: async (input: LinkDelegateBookingInput) => {
+      const bookingPath = `/v1/admin/bookings/${encodeURIComponent(input.bookingId)}/mice-details`
+      const { data: bookingDetails } = await fetchWithValidation(
+        bookingPath,
+        bookingMiceDetailResponse,
+        client,
+        {
+          method: "PUT",
+          body: JSON.stringify({ programId: input.programId, delegateId: input.delegateId }),
+        },
+      )
+      const { data: delegate } = await fetchWithValidation(
+        `${miceBasePath}/delegates/${input.delegateId}`,
+        delegateSingleResponse,
+        client,
+        { method: "PATCH", body: JSON.stringify({ bookingId: input.bookingId }) },
+      )
+
+      if (input.previousBookingId && input.previousBookingId !== input.bookingId) {
+        try {
+          await fetchWithValidation(
+            `/v1/admin/bookings/${encodeURIComponent(input.previousBookingId)}/mice-details`,
+            successResponse,
+            client,
+            { method: "DELETE" },
+          )
+        } catch (error) {
+          if (!(error instanceof VoyantApiError) || error.status !== 404) throw error
+        }
+      }
+
+      return { bookingDetails, delegate }
+    },
+    onSuccess: (_result, input) => invalidate(input),
+  })
+
+  return { linkDelegateBooking }
+}

--- a/packages/mice-react/src/hooks/use-mice-lists.ts
+++ b/packages/mice-react/src/hooks/use-mice-lists.ts
@@ -5,9 +5,11 @@ import { useQuery } from "@tanstack/react-query"
 import { useVoyantContext } from "../provider.js"
 import type { DelegateListFilters, RfpListFilters } from "../query-keys.js"
 import {
+  getBookingMiceDetailsQueryOptions,
   getDelegatesQueryOptions,
   getRfpQueryOptions,
   getRfpsQueryOptions,
+  getRoomingAssignmentQueryOptions,
   getRoomingQueryOptions,
   getSessionsQueryOptions,
 } from "../query-options.js"
@@ -42,6 +44,28 @@ export function useProgramRooming(
   return useQuery({
     ...getRoomingQueryOptions({ baseUrl, fetcher }, programId ?? ""),
     enabled: (options.enabled ?? true) && !!programId,
+  })
+}
+
+export function useRoomingAssignment(
+  assignmentId: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const { baseUrl, fetcher } = useVoyantContext()
+  return useQuery({
+    ...getRoomingAssignmentQueryOptions({ baseUrl, fetcher }, assignmentId ?? ""),
+    enabled: (options.enabled ?? true) && !!assignmentId,
+  })
+}
+
+export function useBookingMiceDetails(
+  bookingId: string | undefined,
+  options: { enabled?: boolean } = {},
+) {
+  const { baseUrl, fetcher } = useVoyantContext()
+  return useQuery({
+    ...getBookingMiceDetailsQueryOptions({ baseUrl, fetcher }, bookingId ?? ""),
+    enabled: (options.enabled ?? true) && !!bookingId,
   })
 }
 

--- a/packages/mice-react/src/hooks/use-rooming-mutation.ts
+++ b/packages/mice-react/src/hooks/use-rooming-mutation.ts
@@ -1,0 +1,85 @@
+"use client"
+
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+import type {
+  CreateRoomingAssignmentBody,
+  RoomingDelegateInput,
+  UpdateRoomingAssignmentBody,
+} from "@voyant-travel/mice"
+
+import { fetchWithValidation } from "../client.js"
+import { useVoyantContext } from "../provider.js"
+import { miceQueryKeys } from "../query-keys.js"
+import { roomingDelegatesResponse, roomingSingleResponse } from "../schemas.js"
+
+const basePath = "/v1/admin/mice"
+
+/**
+ * Mutations for a program's rooming assignments. Occupant assignment is a full
+ * replace on the backend, so the mutation accepts the complete delegate set for
+ * the rooming assignment.
+ */
+export function useRoomingMutation() {
+  const { baseUrl, fetcher } = useVoyantContext()
+  const queryClient = useQueryClient()
+  const client = { baseUrl, fetcher }
+
+  const invalidateRooming = (programId?: string, assignmentId?: string) => {
+    void queryClient.invalidateQueries({ queryKey: miceQueryKeys.rooming() })
+    if (programId) {
+      void queryClient.invalidateQueries({ queryKey: miceQueryKeys.roomingList(programId) })
+    }
+    if (assignmentId) {
+      void queryClient.invalidateQueries({
+        queryKey: miceQueryKeys.roomingAssignment(assignmentId),
+      })
+    }
+  }
+
+  const create = useMutation({
+    mutationFn: async (input: CreateRoomingAssignmentBody) => {
+      const { data } = await fetchWithValidation(
+        `${basePath}/rooming-assignments`,
+        roomingSingleResponse,
+        client,
+        { method: "POST", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: (assignment) => invalidateRooming(assignment.programId, assignment.id),
+  })
+
+  const update = useMutation({
+    mutationFn: async ({ id, ...input }: UpdateRoomingAssignmentBody & { id: string }) => {
+      const { data } = await fetchWithValidation(
+        `${basePath}/rooming-assignments/${id}`,
+        roomingSingleResponse,
+        client,
+        { method: "PATCH", body: JSON.stringify(input) },
+      )
+      return data
+    },
+    onSuccess: (assignment) => invalidateRooming(assignment.programId, assignment.id),
+  })
+
+  const setDelegates = useMutation({
+    mutationFn: async ({
+      assignmentId,
+      delegates,
+    }: {
+      assignmentId: string
+      delegates: RoomingDelegateInput[]
+    }) => {
+      const { data } = await fetchWithValidation(
+        `${basePath}/rooming-assignments/${assignmentId}/delegates`,
+        roomingDelegatesResponse,
+        client,
+        { method: "PUT", body: JSON.stringify({ delegates }) },
+      )
+      return { assignmentId, delegates: data }
+    },
+    onSuccess: ({ assignmentId }) => invalidateRooming(undefined, assignmentId),
+  })
+
+  return { create, update, setDelegates }
+}

--- a/packages/mice-react/src/query-keys.ts
+++ b/packages/mice-react/src/query-keys.ts
@@ -43,6 +43,9 @@ export const miceQueryKeys = {
   roomingList: (programId: string) => [...miceQueryKeys.rooming(), "list", programId] as const,
   roomingAssignment: (id: string) => [...miceQueryKeys.rooming(), "detail", id] as const,
 
+  bookingMiceDetails: (bookingId: string) =>
+    [...miceQueryKeys.all, "booking-mice-details", bookingId] as const,
+
   rfps: () => [...miceQueryKeys.all, "rfps"] as const,
   rfpsList: (filters: RfpListFilters) => [...miceQueryKeys.rfps(), "list", filters] as const,
   rfp: (id: string) => [...miceQueryKeys.rfps(), "detail", id] as const,

--- a/packages/mice-react/src/query-options.ts
+++ b/packages/mice-react/src/query-options.ts
@@ -10,12 +10,14 @@ import {
   type RfpListFilters,
 } from "./query-keys.js"
 import {
+  bookingMiceDetailResponse,
   delegateListResponse,
   programCostSheetResponse,
   programListResponse,
   programSingleResponse,
   rfpDetailResponse,
   rfpListResponse,
+  roomingDetailResponse,
   roomingListResponse,
   sessionListResponse,
 } from "./schemas.js"
@@ -106,13 +108,49 @@ export function getDelegatesQueryOptions(
   })
 }
 
-export function getRoomingQueryOptions(client: FetchWithValidationOptions, programId: string) {
+const ROOMING_PAGE_LIMIT = 500
+
+export function getRoomingQueryOptions(
+  client: FetchWithValidationOptions,
+  programId: string,
+  limit: number = ROOMING_PAGE_LIMIT,
+) {
   return queryOptions({
     queryKey: miceQueryKeys.roomingList(programId),
     queryFn: () =>
       fetchWithValidation(
-        `${basePath}/rooming-assignments${qs({ programId })}`,
+        `${basePath}/rooming-assignments${qs({ programId, limit })}`,
         roomingListResponse,
+        client,
+      ),
+  })
+}
+
+export function getRoomingAssignmentQueryOptions(
+  client: FetchWithValidationOptions,
+  assignmentId: string,
+) {
+  return queryOptions({
+    queryKey: miceQueryKeys.roomingAssignment(assignmentId),
+    queryFn: () =>
+      fetchWithValidation(
+        `${basePath}/rooming-assignments/${assignmentId}`,
+        roomingDetailResponse,
+        client,
+      ),
+  })
+}
+
+export function getBookingMiceDetailsQueryOptions(
+  client: FetchWithValidationOptions,
+  bookingId: string,
+) {
+  return queryOptions({
+    queryKey: miceQueryKeys.bookingMiceDetails(bookingId),
+    queryFn: () =>
+      fetchWithValidation(
+        `/v1/admin/bookings/${encodeURIComponent(bookingId)}/mice-details`,
+        bookingMiceDetailResponse,
         client,
       ),
   })

--- a/packages/mice-react/src/schemas.ts
+++ b/packages/mice-react/src/schemas.ts
@@ -92,6 +92,32 @@ export const roomingAssignmentRecordSchema = z.object({
 })
 export type RoomingAssignmentRecord = z.infer<typeof roomingAssignmentRecordSchema>
 export const roomingListResponse = listEnvelope(roomingAssignmentRecordSchema)
+export const roomingAssignmentDelegateRecordSchema = z.object({
+  id: z.string(),
+  roomingAssignmentId: z.string(),
+  delegateId: z.string(),
+  isPrimary: z.boolean(),
+  bedLabel: nullableString,
+})
+export type RoomingAssignmentDelegateRecord = z.infer<typeof roomingAssignmentDelegateRecordSchema>
+export const roomingAssignmentDetailSchema = roomingAssignmentRecordSchema.extend({
+  delegates: z.array(roomingAssignmentDelegateRecordSchema),
+})
+export type RoomingAssignmentDetail = z.infer<typeof roomingAssignmentDetailSchema>
+export const roomingSingleResponse = singleEnvelope(roomingAssignmentRecordSchema)
+export const roomingDetailResponse = singleEnvelope(roomingAssignmentDetailSchema)
+export const roomingDelegatesResponse = singleEnvelope(
+  z.array(roomingAssignmentDelegateRecordSchema),
+)
+
+// ── Booking sidecar linkage ──
+export const bookingMiceDetailRecordSchema = z.object({
+  bookingId: z.string(),
+  programId: nullableString,
+  delegateId: nullableString,
+})
+export type BookingMiceDetailRecord = z.infer<typeof bookingMiceDetailRecordSchema>
+export const bookingMiceDetailResponse = singleEnvelope(bookingMiceDetailRecordSchema.nullable())
 
 // ── RFP + Bid ──
 export const rfpRecordSchema = z.object({

--- a/packages/mice-react/src/ui.ts
+++ b/packages/mice-react/src/ui.ts
@@ -16,6 +16,10 @@ export {
   type ProgramRfpsSectionProps,
 } from "./components/program-rfps-section.js"
 export {
+  ProgramRoomingSection,
+  type ProgramRoomingSectionProps,
+} from "./components/program-rooming-section.js"
+export {
   ProgramSessionsSection,
   type ProgramSessionsSectionProps,
 } from "./components/program-sessions-section.js"


### PR DESCRIPTION
Fixes #2537

## Root cause
The MICE admin program detail UI only rendered cost sheet, agenda, delegates, and sourcing sections even though the package already exposed rooming assignment APIs and the booking MICE sidecar extension. Operators had no visible way to create rooming assignments, assign occupants, or link delegates to bookings.

## Changes
- Added a Rooming section to the MICE program detail page with assignment listing, basic assignment creation, and occupant replacement using the existing rooming APIs.
- Added rooming detail/query schemas and React Query hooks/mutations for assignment detail, create/update, and occupant assignment.
- Added a booking-link action to the delegate roster that writes both the booking sidecar (`/v1/admin/bookings/:bookingId/mice-details`) and the delegate `bookingId`.
- Added the booking sidecar schema/query key/mutation support in `@voyant-travel/mice-react`.
- Added a patch changeset for `@voyant-travel/mice-react`.

## Checks run
- `pnpm --filter @voyant-travel/mice-react lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/mice-react typecheck`
- `pnpm --filter @voyant-travel/mice-react test`
- Commit hook: changed-file quality checks plus affected Turbo lint/typecheck/build lane
- Pre-push hook: repository test lane

## Scope tradeoff
This adds pragmatic operator workflows on top of the existing APIs rather than building a full hotel room-block planning subsystem. Room block and room type fields remain ID-based inputs until a broader accommodation picker surface exists.