### PR TITLE
Fix MICE agenda time column

### DIFF
--- a/.changeset/mice-agenda-time-column.md
+++ b/.changeset/mice-agenda-time-column.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mice-react": patch
+---
+
+Render an em dash in the MICE agenda Time column when a session has no start time instead of repeating the day date.

--- a/packages/mice-react/src/components/program-session-labels.test.ts
+++ b/packages/mice-react/src/components/program-session-labels.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { formatSessionTimeLabel } from "./program-session-labels.js"
+
+describe("formatSessionTimeLabel", () => {
+  it("renders an em dash when a session has no start time", () => {
+    expect(formatSessionTimeLabel(null)).toBe("—")
+    expect(formatSessionTimeLabel(undefined)).toBe("—")
+    expect(formatSessionTimeLabel("")).toBe("—")
+  })
+
+  it("renders the time from an ISO datetime", () => {
+    expect(formatSessionTimeLabel("2026-10-11T09:30:00.000Z")).toBe("09:30")
+    expect(formatSessionTimeLabel("2026-10-11T14:05:00+02:00")).toBe("14:05")
+  })
+
+  it("renders a time-only value", () => {
+    expect(formatSessionTimeLabel("08:15")).toBe("08:15")
+    expect(formatSessionTimeLabel("16:45:00")).toBe("16:45")
+  })
+
+  it("does not render a date-only value as a time", () => {
+    expect(formatSessionTimeLabel("2026-10-11")).toBe("—")
+  })
+})

--- a/packages/mice-react/src/components/program-session-labels.ts
+++ b/packages/mice-react/src/components/program-session-labels.ts
@@ -1,0 +1,9 @@
+const DATE_TIME_PATTERN = /[T\s](\d{2}:\d{2})(?::\d{2}(?:\.\d{1,3})?)?/
+const TIME_ONLY_PATTERN = /^(\d{2}:\d{2})(?::\d{2}(?:\.\d{1,3})?)?$/
+
+export function formatSessionTimeLabel(startsAt: string | null | undefined): string {
+  const value = startsAt?.trim()
+  if (!value) return "—"
+
+  return DATE_TIME_PATTERN.exec(value)?.[1] ?? TIME_ONLY_PATTERN.exec(value)?.[1] ?? "—"
+}

--- a/packages/mice-react/src/components/program-sessions-section.tsx
+++ b/packages/mice-react/src/components/program-sessions-section.tsx
@@ -30,7 +30,7 @@ import { useState } from "react"
 
 import { useProgramSessions } from "../hooks/use-mice-lists.js"
 import { useSessionMutation } from "../hooks/use-session-mutation.js"
-import type { SessionRecord } from "../schemas.js"
+import { formatSessionTimeLabel } from "./program-session-labels.js"
 
 /** The session types the MICE backend accepts (`createSessionSchema`). */
 const SESSION_TYPES = [
@@ -52,14 +52,6 @@ export interface ProgramSessionsSectionProps {
 // `sessionListQuerySchema` max). When an agenda hits it the section says so
 // rather than silently dropping sessions (matching the delegates/RFP surfaces).
 const SESSIONS_PAGE_LIMIT = 200
-
-function timeLabel(session: SessionRecord): string {
-  if (session.startsAt) {
-    const time = session.startsAt.slice(11, 16)
-    return time || session.startsAt
-  }
-  return session.dayDate ?? "—"
-}
 
 /**
  * Agenda sessions for a program (RFC voyant#1489 Phase 2). Lists the program's
@@ -114,7 +106,9 @@ export function ProgramSessionsSection({ programId }: ProgramSessionsSectionProp
                   <TableCell className="text-muted-foreground text-sm">
                     {s.dayDate ?? "—"}
                   </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">{timeLabel(s)}</TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {formatSessionTimeLabel(s.startsAt)}
+                  </TableCell>
                   <TableCell className="text-muted-foreground text-sm">{s.track ?? "—"}</TableCell>
                   <TableCell className="text-right tabular-nums">{s.capacity ?? "—"}</TableCell>
                 </TableRow>


### PR DESCRIPTION
## Summary

Closes #2538.

- Render the MICE agenda Time column from `startsAt` only, so sessions with only `dayDate` show an em dash instead of duplicating the Day column.
- Add a focused formatter test covering missing start times, ISO datetimes, time-only values, and date-only values.
- Add a patch changeset for `@voyant-travel/mice-react`.

## Validation

- `pnpm --filter @voyant-travel/mice-react test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/mice-react typecheck`
- `pnpm --filter @voyant-travel/mice-react lint`
- Pre-commit hook: `pnpm verify:agent-quality:changed` plus affected Turbo checks
- Pre-push hook: `pnpm test`