### PR TITLE
fix(mice): emit RFP award event

### DIFF
--- a/.changeset/mice-rfp-award-event.md
+++ b/.changeset/mice-rfp-award-event.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/mice": patch
+---
+
+Emit a `mice.rfp.awarded` domain event after a MICE RFP award succeeds, and clarify that downstream booking, room-block, and contract artifact creation belongs to deployment-level subscribers.

--- a/packages/mice/src/routes.ts
+++ b/packages/mice/src/routes.ts
@@ -27,6 +27,7 @@
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { EventBus } from "@voyant-travel/core"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -103,6 +104,7 @@ import {
 type Env = {
   Variables: {
     db: PostgresJsDatabase
+    eventBus?: EventBus
     userId?: string
   }
 }
@@ -1004,7 +1006,10 @@ const rfpRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   })
   .openapi(awardRfpRoute, async (c) => {
     const { bidId } = c.req.valid("json")
-    const outcome = await rfpService.awardRfp(c.get("db"), c.req.valid("param").id, bidId)
+    const outcome = await rfpService.awardRfp(c.get("db"), c.req.valid("param").id, bidId, {
+      eventBus: c.get("eventBus"),
+      actorId: c.get("userId") ?? null,
+    })
     switch (outcome.status) {
       case "ok":
         return c.json({ data: { rfp: outcome.rfp, bid: outcome.bid } }, 200)

--- a/packages/mice/src/schema-rfp.ts
+++ b/packages/mice/src/schema-rfp.ts
@@ -17,8 +17,9 @@ import { programs } from "./schema.js"
  * opportunity/quote model single-deal closure, not multi-supplier bid
  * solicitation/comparison/scoring; this is the gap. See RFC voyant#1489 §3/§5
  * (Phase 4). Award atomically accepts the winning bid, rejects the rest, and
- * moves the RFP to `awarded` (downstream contract/block/booking spawn is a
- * workflow subscriber on `mice.rfp.awarded`).
+ * moves the RFP to `awarded`; the service emits `mice.rfp.awarded` so
+ * deployment-level workflows can create/link downstream contract, room-block,
+ * or booking artifacts.
  */
 export const rfpStatusEnum = pgEnum("mice_rfp_status", [
   "draft",

--- a/packages/mice/src/service-rfp.ts
+++ b/packages/mice/src/service-rfp.ts
@@ -1,3 +1,4 @@
+import type { EventBus } from "@voyant-travel/core"
 import { and, asc, eq, ne } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -226,18 +227,36 @@ export type AwardRfpOutcome =
   | { status: "bid_not_found" }
   | { status: "already_awarded" }
 
+export const MICE_RFP_AWARDED_EVENT = "mice.rfp.awarded" as const
+
+export interface MiceRfpAwardedEventPayload {
+  rfpId: string
+  programId: string
+  bidId: string
+  supplierId: string
+  actorId: string | null
+  awardedAt: string
+}
+
+export interface AwardRfpRuntime {
+  eventBus?: EventBus
+  actorId?: string | null
+}
+
 /**
  * Award an RFP to a bid: accept the winner, reject every other bid, and move
- * the RFP to `awarded` — all in one transaction. The downstream auto-spawn
- * (legal contract + provisional room block + booking) is a workflow subscriber
- * on the `mice.rfp.awarded` domain event, mounted operator-side (§9-Q6).
+ * the RFP to `awarded` — all in one transaction. On success, emit
+ * `mice.rfp.awarded` so deployment-level workflows can create/link downstream
+ * booking, room-block, and contract artifacts without coupling this package to
+ * those package services.
  */
 export async function awardRfp(
   db: PostgresJsDatabase,
   rfpId: string,
   bidId: string,
+  runtime: AwardRfpRuntime = {},
 ): Promise<AwardRfpOutcome> {
-  return db.transaction(async (tx) => {
+  const outcome = await db.transaction(async (tx) => {
     const [rfp] = await tx.select().from(rfps).where(eq(rfps.id, rfpId)).for("update").limit(1)
     if (!rfp) return { status: "rfp_not_found" as const }
     if (rfp.status === "awarded") return { status: "already_awarded" as const }
@@ -268,6 +287,23 @@ export async function awardRfp(
     if (!acceptedBid || !awardedRfp) throw new Error("awardRfp: update returned no rows")
     return { status: "ok" as const, bid: acceptedBid, rfp: awardedRfp }
   })
+
+  if (outcome.status === "ok") {
+    await runtime.eventBus?.emit<MiceRfpAwardedEventPayload>(
+      MICE_RFP_AWARDED_EVENT,
+      {
+        rfpId: outcome.rfp.id,
+        programId: outcome.rfp.programId,
+        bidId: outcome.bid.id,
+        supplierId: outcome.bid.supplierId,
+        actorId: runtime.actorId ?? null,
+        awardedAt: new Date().toISOString(),
+      },
+      { category: "domain", source: "service" },
+    )
+  }
+
+  return outcome
 }
 
 export const rfpService = {

--- a/packages/mice/tests/unit/routes-validation.test.ts
+++ b/packages/mice/tests/unit/routes-validation.test.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
 import { createMiceAdminRoutes, miceAdminRoutes } from "../../src/routes.js"
+import { MICE_RFP_AWARDED_EVENT } from "../../src/service-rfp.js"
 
 function delegateRow(patch: Record<string, unknown> = {}) {
   return {
@@ -74,17 +75,94 @@ function fakeProgramDb(options: FakeProgramDbOptions | unknown[][] = {}) {
 }
 
 function makeApp(
-  db: ReturnType<typeof fakeProgramDb>,
+  db: unknown,
   routes: ReturnType<typeof createMiceAdminRoutes> = miceAdminRoutes,
+  options: { eventBus?: unknown; userId?: string } = {},
 ) {
   const app = new Hono()
   app.onError((err, c) => handleApiError(err, c))
   app.use("*", async (c, next) => {
-    c.set("db", db)
+    c.set("db", db as never)
+    if (options.eventBus) c.set("eventBus" as never, options.eventBus as never)
+    if (options.userId) c.set("userId" as never, options.userId as never)
     await next()
   })
   app.route("/", routes)
   return app
+}
+
+function fakeAwardRfpDb() {
+  const rfp = {
+    id: "mice_rfps_1",
+    programId: "mice_programs_1",
+    title: "Venue RFP",
+    requirements: null,
+    status: "issued",
+    issuedAt: null,
+    dueAt: null,
+    notes: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  }
+  const winner = {
+    id: "mice_bids_winner",
+    rfpId: rfp.id,
+    supplierId: "suppliers_1",
+    status: "submitted",
+    totalCents: 90_000,
+    currency: "EUR",
+    proposalDoc: null,
+    validUntil: null,
+    notes: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  }
+  const acceptedBid = {
+    ...winner,
+    status: "accepted",
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+  }
+  const awardedRfp = {
+    ...rfp,
+    status: "awarded",
+    updatedAt: new Date("2026-01-02T00:00:00.000Z"),
+  }
+  const selectRows = [[rfp], [winner]]
+  const updateReturningRows = [[acceptedBid], [awardedRfp]]
+  let updateCalls = 0
+
+  const tx = {
+    select: vi.fn(() => {
+      const rows = selectRows.shift() ?? []
+      const builder = {
+        from: vi.fn(() => builder),
+        where: vi.fn(() => builder),
+        for: vi.fn(() => builder),
+        limit: vi.fn(() => Promise.resolve(rows)),
+      }
+      return builder
+    }),
+    update: vi.fn(() => {
+      const updateCall = updateCalls
+      updateCalls += 1
+      const builder = {
+        set: vi.fn(() => builder),
+        where: vi.fn(() => (updateCall === 0 ? Promise.resolve([]) : builder)),
+        returning: vi.fn(() => Promise.resolve(updateReturningRows.shift() ?? [])),
+      }
+      return builder
+    }),
+  }
+
+  return {
+    db: {
+      transaction: vi.fn((callback: (transactionDb: typeof tx) => unknown) => callback(tx)),
+    },
+    rfp,
+    winner,
+    acceptedBid,
+    awardedRfp,
+  }
 }
 
 describe("mice program route validation", () => {
@@ -249,5 +327,39 @@ describe("mice program route validation", () => {
 
     expect(response.status).toBe(200)
     expect(updatedValues).toEqual([expect.objectContaining({ personId: null })])
+  })
+
+  it("emits a domain event when awarding an RFP", async () => {
+    const { db, rfp, winner } = fakeAwardRfpDb()
+    const eventBus = { emit: vi.fn(async () => undefined) }
+
+    const response = await makeApp(db, miceAdminRoutes, {
+      eventBus,
+      userId: "user_1",
+    }).request(`/rfps/${rfp.id}/award`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ bidId: winner.id }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      data: {
+        rfp: { id: rfp.id, status: "awarded" },
+        bid: { id: winner.id, status: "accepted" },
+      },
+    })
+    expect(eventBus.emit).toHaveBeenCalledWith(
+      MICE_RFP_AWARDED_EVENT,
+      expect.objectContaining({
+        rfpId: rfp.id,
+        programId: rfp.programId,
+        bidId: winner.id,
+        supplierId: winner.supplierId,
+        actorId: "user_1",
+        awardedAt: expect.any(String),
+      }),
+      { category: "domain", source: "service" },
+    )
   })
 })


### PR DESCRIPTION
## Summary

- emit a `mice.rfp.awarded` domain event after a successful MICE RFP award
- pass the request event bus and actor id from the award route into the RFP service
- clarify the package comment so downstream booking, room-block, and contract artifacts are described as deployment-level subscriber work
- add a focused route test covering the award event payload

Closes #2539

## Checks

- `pnpm --filter @voyant-travel/mice test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/mice typecheck`
- `pnpm --filter @voyant-travel/mice lint`
- `pnpm exec biome check packages/mice/tests/unit/routes-validation.test.ts`
- commit hook: changed-file lint/secretlint/agent-quality plus affected lint/typecheck/build checks
- push hook: `pnpm test`