### PR TITLE
Fix supplier default currency validation

### DIFF
--- a/.changeset/supplier-default-currency-validation.md
+++ b/.changeset/supplier-default-currency-validation.md
@@ -2,6 +2,7 @@
 "@voyant-travel/suppliers-contracts": patch
 "@voyant-travel/distribution": patch
 "@voyant-travel/distribution-react": patch
+"@voyant-travel/openapi": patch
 ---
 
 Reject supplier default currency values unless they are exactly three uppercase letters.

--- a/.changeset/supplier-default-currency-validation.md
+++ b/.changeset/supplier-default-currency-validation.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/suppliers-contracts": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/distribution-react": patch
+---
+
+Reject supplier default currency values unless they are exactly three uppercase letters.

--- a/packages/distribution-react/src/suppliers/components/supplier-dialog.tsx
+++ b/packages/distribution-react/src/suppliers/components/supplier-dialog.tsx
@@ -30,6 +30,10 @@ import { SUPPLIER_STATUSES, SUPPLIER_TYPES, type Supplier, useSupplierMutation }
 
 function getSupplierSchema(messages: ReturnType<typeof useSuppliersUiMessagesOrDefault>) {
   const dialog = messages.dialogs.supplier
+  const currencyCodeSchema = z
+    .string()
+    .length(3, dialog.validationIsoCurrency)
+    .regex(/^[A-Z]{3}$/, dialog.validationIsoCurrency)
   return z.object({
     name: z.string().min(1, dialog.validationNameRequired),
     type: z.enum(["hotel", "transfer", "guide", "experience", "airline", "restaurant", "other"]),
@@ -41,7 +45,10 @@ function getSupplierSchema(messages: ReturnType<typeof useSuppliersUiMessagesOrD
     address: z.string().optional().nullable(),
     city: z.string().optional().nullable(),
     country: z.string().optional().nullable(),
-    defaultCurrency: z.string().max(3, dialog.validationIsoCurrency).optional().nullable(),
+    defaultCurrency: z
+      .union([z.literal(""), currencyCodeSchema])
+      .optional()
+      .nullable(),
     reservationTimeoutMinutes: z
       .union([z.literal(""), z.coerce.number().int().min(0, dialog.validationReservationTimeout)])
       .optional()
@@ -121,7 +128,7 @@ export function SupplierDialog({ open, onOpenChange, supplier, onSuccess }: Supp
       address: values.address || null,
       city: values.city || null,
       country: values.country || null,
-      defaultCurrency: values.defaultCurrency || null,
+      defaultCurrency: values.defaultCurrency ? values.defaultCurrency.toUpperCase() : null,
       reservationTimeoutMinutes:
         values.reservationTimeoutMinutes === "" ||
         values.reservationTimeoutMinutes === null ||

--- a/packages/openapi/spec/admin/suppliers.json
+++ b/packages/openapi/spec/admin/suppliers.json
@@ -5102,7 +5102,9 @@
                       "string",
                       "null"
                     ],
-                    "maxLength": 3
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "primaryFacilityId": {
                     "type": [
@@ -5711,7 +5713,9 @@
                       "string",
                       "null"
                     ],
-                    "maxLength": 3
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "primaryFacilityId": {
                     "type": [

--- a/packages/suppliers-contracts/src/contracts.test.ts
+++ b/packages/suppliers-contracts/src/contracts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { insertRateSchema, insertSupplierSchema } from "./index.js"
+import { insertRateSchema, insertSupplierSchema, updateSupplierSchema } from "./index.js"
 
 describe("suppliers-contracts", () => {
   it("accepts a valid supplier and rejects an unknown type", () => {
@@ -8,6 +8,27 @@ describe("suppliers-contracts", () => {
     expect(insertSupplierSchema.safeParse({ name: "Acme Tours", type: "spaceship" }).success).toBe(
       false,
     )
+  })
+
+  it("accepts uppercase 3-letter supplier defaultCurrency", () => {
+    const parsed = insertSupplierSchema.parse({
+      name: "Acme Tours",
+      type: "guide",
+      defaultCurrency: "EUR",
+    })
+    expect(parsed.defaultCurrency).toBe("EUR")
+  })
+
+  it("rejects short and lowercase supplier defaultCurrency values", () => {
+    expect(
+      insertSupplierSchema.safeParse({ name: "Acme Tours", type: "guide", defaultCurrency: "X" })
+        .success,
+    ).toBe(false)
+    expect(
+      insertSupplierSchema.safeParse({ name: "Acme Tours", type: "guide", defaultCurrency: "" })
+        .success,
+    ).toBe(false)
+    expect(updateSupplierSchema.safeParse({ defaultCurrency: "usd" }).success).toBe(false)
   })
 
   it("accepts a valid rate and rejects a non-3-char currency", () => {

--- a/packages/suppliers-contracts/src/validation.ts
+++ b/packages/suppliers-contracts/src/validation.ts
@@ -24,6 +24,11 @@ const serviceTypeSchema = z.enum([
 
 const rateUnitSchema = z.enum(["per_person", "per_group", "per_night", "per_vehicle", "flat"])
 
+const currencyCodeSchema = z
+  .string()
+  .length(3)
+  .regex(/^[A-Z]{3}$/, "Expected ISO 4217 code")
+
 // ---------- suppliers ----------
 
 const depositRuleSchema = z.object({
@@ -50,7 +55,7 @@ const supplierCoreSchema = z.object({
   address: z.string().optional().nullable(),
   city: z.string().optional().nullable(),
   country: z.string().optional().nullable(),
-  defaultCurrency: z.string().max(3).optional().nullable(),
+  defaultCurrency: currencyCodeSchema.optional().nullable(),
   primaryFacilityId: z.string().optional().nullable(),
   contactName: z.string().optional().nullable(),
   contactEmail: z.string().email().optional().nullable(),

--- a/starters/operator/openapi/admin/suppliers.json
+++ b/starters/operator/openapi/admin/suppliers.json
@@ -5102,7 +5102,9 @@
                       "string",
                       "null"
                     ],
-                    "maxLength": 3
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "primaryFacilityId": {
                     "type": [
@@ -5711,7 +5713,9 @@
                       "string",
                       "null"
                     ],
-                    "maxLength": 3
+                    "minLength": 3,
+                    "maxLength": 3,
+                    "pattern": "^[A-Z]{3}$"
                   },
                   "primaryFacilityId": {
                     "type": [


### PR DESCRIPTION
## Summary

Fixes #2543.

- tighten supplier `defaultCurrency` validation in the shared suppliers contract to require exactly three uppercase letters
- mirror the same validation in the supplier React dialog
- add contract tests for valid uppercase values and invalid short/lowercase values
- add patch changesets for the affected packages

## Checks

- `pnpm --filter @voyant-travel/suppliers-contracts test`
- `pnpm --filter @voyant-travel/suppliers-contracts typecheck`
- `pnpm --filter @voyant-travel/suppliers-contracts lint`
- `pnpm --filter @voyant-travel/distribution test`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm --filter @voyant-travel/distribution typecheck`
- `pnpm --filter @voyant-travel/distribution lint`
- `pnpm --filter @voyant-travel/distribution-react test`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/distribution-react typecheck`
- `pnpm --filter @voyant-travel/distribution-react lint`
- commit hook changed-file/affected checks
- pre-push `pnpm test`
