### PR TITLE
Fix supplier nested parent id enforcement

### DIFF
--- a/.changeset/supplier-nested-parent-ids.md
+++ b/.changeset/supplier-nested-parent-ids.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/distribution": patch
+---
+
+Enforce supplier parent IDs for nested supplier service, rate, and contract mutations.

--- a/packages/distribution/src/suppliers/routes.ts
+++ b/packages/distribution/src/suppliers/routes.ts
@@ -895,15 +895,18 @@ const serviceRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook 
     return row ? c.json({ data: row }, 201) : c.json({ error: "Supplier not found" }, 404)
   })
   .openapi(updateServiceRoute, async (c) => {
+    const params = c.req.valid("param")
     const row = await suppliersService.updateService(
       c.get("db"),
-      c.req.valid("param").serviceId,
+      params.id,
+      params.serviceId,
       c.req.valid("json"),
     )
     return row ? c.json({ data: row }, 200) : c.json({ error: "Service not found" }, 404)
   })
   .openapi(deleteServiceRoute, async (c) => {
-    const row = await suppliersService.deleteService(c.get("db"), c.req.valid("param").serviceId)
+    const params = c.req.valid("param")
+    const row = await suppliersService.deleteService(c.get("db"), params.id, params.serviceId)
     return row ? c.json({ success: true }, 200) : c.json({ error: "Service not found" }, 404)
   })
 
@@ -986,30 +989,42 @@ const deleteRateRoute = createRoute({
 })
 
 const rateRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
-  .openapi(listRatesRoute, async (c) =>
-    c.json(
-      { data: await suppliersService.listRates(c.get("db"), c.req.valid("param").serviceId) },
+  .openapi(listRatesRoute, async (c) => {
+    const params = c.req.valid("param")
+    return c.json(
+      { data: await suppliersService.listRates(c.get("db"), params.id, params.serviceId) },
       200,
-    ),
-  )
+    )
+  })
   .openapi(createRateRoute, async (c) => {
+    const params = c.req.valid("param")
     const row = await suppliersService.createRate(
       c.get("db"),
-      c.req.valid("param").serviceId,
+      params.id,
+      params.serviceId,
       c.req.valid("json"),
     )
     return row ? c.json({ data: row }, 201) : c.json({ error: "Service not found" }, 404)
   })
   .openapi(updateRateRoute, async (c) => {
+    const params = c.req.valid("param")
     const row = await suppliersService.updateRate(
       c.get("db"),
-      c.req.valid("param").rateId,
+      params.id,
+      params.serviceId,
+      params.rateId,
       c.req.valid("json"),
     )
     return row ? c.json({ data: row }, 200) : c.json({ error: "Rate not found" }, 404)
   })
   .openapi(deleteRateRoute, async (c) => {
-    const row = await suppliersService.deleteRate(c.get("db"), c.req.valid("param").rateId)
+    const params = c.req.valid("param")
+    const row = await suppliersService.deleteRate(
+      c.get("db"),
+      params.id,
+      params.serviceId,
+      params.rateId,
+    )
     return row ? c.json({ success: true }, 200) : c.json({ error: "Rate not found" }, 404)
   })
 
@@ -1235,15 +1250,18 @@ const contractRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook
     return row ? c.json({ data: row }, 201) : c.json({ error: "Supplier not found" }, 404)
   })
   .openapi(updateContractRoute, async (c) => {
+    const params = c.req.valid("param")
     const row = await suppliersService.updateContract(
       c.get("db"),
-      c.req.valid("param").contractId,
+      params.id,
+      params.contractId,
       c.req.valid("json"),
     )
     return row ? c.json({ data: row }, 200) : c.json({ error: "Contract not found" }, 404)
   })
   .openapi(deleteContractRoute, async (c) => {
-    const row = await suppliersService.deleteContract(c.get("db"), c.req.valid("param").contractId)
+    const params = c.req.valid("param")
+    const row = await suppliersService.deleteContract(c.get("db"), params.id, params.contractId)
     return row ? c.json({ success: true }, 200) : c.json({ error: "Contract not found" }, 404)
   })
 

--- a/packages/distribution/src/suppliers/service-operations.ts
+++ b/packages/distribution/src/suppliers/service-operations.ts
@@ -48,22 +48,62 @@ export async function createService(
 
 export async function updateService(
   db: PostgresJsDatabase,
+  serviceId: string,
+  data: UpdateServiceInput,
+): Promise<typeof supplierServices.$inferSelect | null>
+export async function updateService(
+  db: PostgresJsDatabase,
   supplierId: string,
   serviceId: string,
   data: UpdateServiceInput,
+): Promise<typeof supplierServices.$inferSelect | null>
+export async function updateService(
+  db: PostgresJsDatabase,
+  supplierOrServiceId: string,
+  serviceOrData: string | UpdateServiceInput,
+  maybeData?: UpdateServiceInput,
 ) {
+  const supplierId = typeof serviceOrData === "string" ? supplierOrServiceId : null
+  const serviceId = typeof serviceOrData === "string" ? serviceOrData : supplierOrServiceId
+  const data = typeof serviceOrData === "string" ? maybeData : serviceOrData
+  if (!data) throw new Error("updateService requires update data")
+
   const [row] = await db
     .update(supplierServices)
     .set({ ...data, updatedAt: new Date() })
-    .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId)))
+    .where(
+      supplierId
+        ? and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId))
+        : eq(supplierServices.id, serviceId),
+    )
     .returning()
   return row ?? null
 }
 
-export async function deleteService(db: PostgresJsDatabase, supplierId: string, serviceId: string) {
+export async function deleteService(
+  db: PostgresJsDatabase,
+  serviceId: string,
+): Promise<{ id: string } | null>
+export async function deleteService(
+  db: PostgresJsDatabase,
+  supplierId: string,
+  serviceId: string,
+): Promise<{ id: string } | null>
+export async function deleteService(
+  db: PostgresJsDatabase,
+  supplierOrServiceId: string,
+  maybeServiceId?: string,
+) {
+  const supplierId = maybeServiceId ? supplierOrServiceId : null
+  const serviceId = maybeServiceId ?? supplierOrServiceId
+
   const [row] = await db
     .delete(supplierServices)
-    .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId)))
+    .where(
+      supplierId
+        ? and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId))
+        : eq(supplierServices.id, serviceId),
+    )
     .returning({ id: supplierServices.id })
   return row ?? null
 }
@@ -77,29 +117,58 @@ function serviceBelongsToSupplier(db: PostgresJsDatabase, supplierId: string, se
   )
 }
 
-export function listRates(db: PostgresJsDatabase, supplierId: string, serviceId: string) {
+export function listRates(
+  db: PostgresJsDatabase,
+  supplierOrServiceId: string,
+  maybeServiceId?: string,
+) {
+  const supplierId = maybeServiceId ? supplierOrServiceId : null
+  const serviceId = maybeServiceId ?? supplierOrServiceId
+
   return db
     .select()
     .from(supplierRates)
     .where(
-      and(
-        eq(supplierRates.serviceId, serviceId),
-        serviceBelongsToSupplier(db, supplierId, serviceId),
-      ),
+      supplierId
+        ? and(
+            eq(supplierRates.serviceId, serviceId),
+            serviceBelongsToSupplier(db, supplierId, serviceId),
+          )
+        : eq(supplierRates.serviceId, serviceId),
     )
     .orderBy(supplierRates.createdAt)
 }
 
 export async function createRate(
   db: PostgresJsDatabase,
+  serviceId: string,
+  data: CreateRateInput,
+): Promise<typeof supplierRates.$inferSelect | null>
+export async function createRate(
+  db: PostgresJsDatabase,
   supplierId: string,
   serviceId: string,
   data: CreateRateInput,
+): Promise<typeof supplierRates.$inferSelect | null>
+export async function createRate(
+  db: PostgresJsDatabase,
+  supplierOrServiceId: string,
+  serviceOrData: string | CreateRateInput,
+  maybeData?: CreateRateInput,
 ) {
+  const supplierId = typeof serviceOrData === "string" ? supplierOrServiceId : null
+  const serviceId = typeof serviceOrData === "string" ? serviceOrData : supplierOrServiceId
+  const data = typeof serviceOrData === "string" ? maybeData : serviceOrData
+  if (!data) throw new Error("createRate requires create data")
+
   const [service] = await db
     .select({ id: supplierServices.id })
     .from(supplierServices)
-    .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId)))
+    .where(
+      supplierId
+        ? and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId))
+        : eq(supplierServices.id, serviceId),
+    )
     .limit(1)
   if (!service) {
     return null
@@ -114,20 +183,40 @@ export async function createRate(
 
 export async function updateRate(
   db: PostgresJsDatabase,
+  rateId: string,
+  data: UpdateRateInput,
+): Promise<typeof supplierRates.$inferSelect | null>
+export async function updateRate(
+  db: PostgresJsDatabase,
   supplierId: string,
   serviceId: string,
   rateId: string,
   data: UpdateRateInput,
+): Promise<typeof supplierRates.$inferSelect | null>
+export async function updateRate(
+  db: PostgresJsDatabase,
+  supplierOrRateId: string,
+  serviceOrData: string | UpdateRateInput,
+  rateId?: string,
+  maybeData?: UpdateRateInput,
 ) {
+  const supplierId = typeof serviceOrData === "string" ? supplierOrRateId : null
+  const serviceId = typeof serviceOrData === "string" ? serviceOrData : null
+  const resolvedRateId = typeof serviceOrData === "string" ? rateId : supplierOrRateId
+  const data = typeof serviceOrData === "string" ? maybeData : serviceOrData
+  if (!resolvedRateId || !data) throw new Error("updateRate requires rate id and update data")
+
   const [row] = await db
     .update(supplierRates)
     .set(data)
     .where(
-      and(
-        eq(supplierRates.id, rateId),
-        eq(supplierRates.serviceId, serviceId),
-        serviceBelongsToSupplier(db, supplierId, serviceId),
-      ),
+      supplierId && serviceId
+        ? and(
+            eq(supplierRates.id, resolvedRateId),
+            eq(supplierRates.serviceId, serviceId),
+            serviceBelongsToSupplier(db, supplierId, serviceId),
+          )
+        : eq(supplierRates.id, resolvedRateId),
     )
     .returning()
   return row ?? null
@@ -135,18 +224,34 @@ export async function updateRate(
 
 export async function deleteRate(
   db: PostgresJsDatabase,
+  rateId: string,
+): Promise<{ id: string } | null>
+export async function deleteRate(
+  db: PostgresJsDatabase,
   supplierId: string,
   serviceId: string,
   rateId: string,
+): Promise<{ id: string } | null>
+export async function deleteRate(
+  db: PostgresJsDatabase,
+  supplierOrRateId: string,
+  maybeServiceId?: string,
+  maybeRateId?: string,
 ) {
+  const supplierId = maybeRateId ? supplierOrRateId : null
+  const serviceId = maybeRateId ? maybeServiceId : null
+  const rateId = maybeRateId ?? supplierOrRateId
+
   const [row] = await db
     .delete(supplierRates)
     .where(
-      and(
-        eq(supplierRates.id, rateId),
-        eq(supplierRates.serviceId, serviceId),
-        serviceBelongsToSupplier(db, supplierId, serviceId),
-      ),
+      supplierId && serviceId
+        ? and(
+            eq(supplierRates.id, rateId),
+            eq(supplierRates.serviceId, serviceId),
+            serviceBelongsToSupplier(db, supplierId, serviceId),
+          )
+        : eq(supplierRates.id, rateId),
     )
     .returning({ id: supplierRates.id })
   return row ?? null
@@ -253,26 +358,62 @@ export async function createContract(
 
 export async function updateContract(
   db: PostgresJsDatabase,
+  contractId: string,
+  data: UpdateContractInput,
+): Promise<typeof supplierContracts.$inferSelect | null>
+export async function updateContract(
+  db: PostgresJsDatabase,
   supplierId: string,
   contractId: string,
   data: UpdateContractInput,
+): Promise<typeof supplierContracts.$inferSelect | null>
+export async function updateContract(
+  db: PostgresJsDatabase,
+  supplierOrContractId: string,
+  contractOrData: string | UpdateContractInput,
+  maybeData?: UpdateContractInput,
 ) {
+  const supplierId = typeof contractOrData === "string" ? supplierOrContractId : null
+  const contractId = typeof contractOrData === "string" ? contractOrData : supplierOrContractId
+  const data = typeof contractOrData === "string" ? maybeData : contractOrData
+  if (!data) throw new Error("updateContract requires update data")
+
   const [row] = await db
     .update(supplierContracts)
     .set({ ...data, updatedAt: new Date() })
-    .where(and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId)))
+    .where(
+      supplierId
+        ? and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId))
+        : eq(supplierContracts.id, contractId),
+    )
     .returning()
   return row ?? null
 }
 
 export async function deleteContract(
   db: PostgresJsDatabase,
+  contractId: string,
+): Promise<{ id: string } | null>
+export async function deleteContract(
+  db: PostgresJsDatabase,
   supplierId: string,
   contractId: string,
+): Promise<{ id: string } | null>
+export async function deleteContract(
+  db: PostgresJsDatabase,
+  supplierOrContractId: string,
+  maybeContractId?: string,
 ) {
+  const supplierId = maybeContractId ? supplierOrContractId : null
+  const contractId = maybeContractId ?? supplierOrContractId
+
   const [row] = await db
     .delete(supplierContracts)
-    .where(and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId)))
+    .where(
+      supplierId
+        ? and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId))
+        : eq(supplierContracts.id, contractId),
+    )
     .returning({ id: supplierContracts.id })
   return row ?? null
 }

--- a/packages/distribution/src/suppliers/service-operations.ts
+++ b/packages/distribution/src/suppliers/service-operations.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, lte } from "drizzle-orm"
+import { and, asc, desc, eq, exists, gte, lte, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -48,38 +48,58 @@ export async function createService(
 
 export async function updateService(
   db: PostgresJsDatabase,
+  supplierId: string,
   serviceId: string,
   data: UpdateServiceInput,
 ) {
   const [row] = await db
     .update(supplierServices)
     .set({ ...data, updatedAt: new Date() })
-    .where(eq(supplierServices.id, serviceId))
+    .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId)))
     .returning()
   return row ?? null
 }
 
-export async function deleteService(db: PostgresJsDatabase, serviceId: string) {
+export async function deleteService(db: PostgresJsDatabase, supplierId: string, serviceId: string) {
   const [row] = await db
     .delete(supplierServices)
-    .where(eq(supplierServices.id, serviceId))
+    .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId)))
     .returning({ id: supplierServices.id })
   return row ?? null
 }
 
-export function listRates(db: PostgresJsDatabase, serviceId: string) {
+function serviceBelongsToSupplier(db: PostgresJsDatabase, supplierId: string, serviceId: string) {
+  return exists(
+    db
+      .select({ one: sql`1` })
+      .from(supplierServices)
+      .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId))),
+  )
+}
+
+export function listRates(db: PostgresJsDatabase, supplierId: string, serviceId: string) {
   return db
     .select()
     .from(supplierRates)
-    .where(eq(supplierRates.serviceId, serviceId))
+    .where(
+      and(
+        eq(supplierRates.serviceId, serviceId),
+        serviceBelongsToSupplier(db, supplierId, serviceId),
+      ),
+    )
     .orderBy(supplierRates.createdAt)
 }
 
-export async function createRate(db: PostgresJsDatabase, serviceId: string, data: CreateRateInput) {
+export async function createRate(
+  db: PostgresJsDatabase,
+  supplierId: string,
+  serviceId: string,
+  data: CreateRateInput,
+) {
   const [service] = await db
     .select({ id: supplierServices.id })
     .from(supplierServices)
-    .where(eq(supplierServices.id, serviceId))
+    .where(and(eq(supplierServices.id, serviceId), eq(supplierServices.supplierId, supplierId)))
     .limit(1)
   if (!service) {
     return null
@@ -92,19 +112,42 @@ export async function createRate(db: PostgresJsDatabase, serviceId: string, data
   return row ?? null
 }
 
-export async function updateRate(db: PostgresJsDatabase, rateId: string, data: UpdateRateInput) {
+export async function updateRate(
+  db: PostgresJsDatabase,
+  supplierId: string,
+  serviceId: string,
+  rateId: string,
+  data: UpdateRateInput,
+) {
   const [row] = await db
     .update(supplierRates)
     .set(data)
-    .where(eq(supplierRates.id, rateId))
+    .where(
+      and(
+        eq(supplierRates.id, rateId),
+        eq(supplierRates.serviceId, serviceId),
+        serviceBelongsToSupplier(db, supplierId, serviceId),
+      ),
+    )
     .returning()
   return row ?? null
 }
 
-export async function deleteRate(db: PostgresJsDatabase, rateId: string) {
+export async function deleteRate(
+  db: PostgresJsDatabase,
+  supplierId: string,
+  serviceId: string,
+  rateId: string,
+) {
   const [row] = await db
     .delete(supplierRates)
-    .where(eq(supplierRates.id, rateId))
+    .where(
+      and(
+        eq(supplierRates.id, rateId),
+        eq(supplierRates.serviceId, serviceId),
+        serviceBelongsToSupplier(db, supplierId, serviceId),
+      ),
+    )
     .returning({ id: supplierRates.id })
   return row ?? null
 }
@@ -210,21 +253,26 @@ export async function createContract(
 
 export async function updateContract(
   db: PostgresJsDatabase,
+  supplierId: string,
   contractId: string,
   data: UpdateContractInput,
 ) {
   const [row] = await db
     .update(supplierContracts)
     .set({ ...data, updatedAt: new Date() })
-    .where(eq(supplierContracts.id, contractId))
+    .where(and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId)))
     .returning()
   return row ?? null
 }
 
-export async function deleteContract(db: PostgresJsDatabase, contractId: string) {
+export async function deleteContract(
+  db: PostgresJsDatabase,
+  supplierId: string,
+  contractId: string,
+) {
   const [row] = await db
     .delete(supplierContracts)
-    .where(eq(supplierContracts.id, contractId))
+    .where(and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId)))
     .returning({ id: supplierContracts.id })
   return row ?? null
 }

--- a/packages/distribution/tests/suppliers/integration/routes.test.ts
+++ b/packages/distribution/tests/suppliers/integration/routes.test.ts
@@ -1,4 +1,11 @@
-import { supplierRoutes } from "@voyant-travel/distribution"
+import {
+  supplierContracts,
+  supplierRates,
+  supplierServices,
+  suppliersHonoModule,
+} from "@voyant-travel/distribution"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -6,10 +13,11 @@ const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
 
 describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
   let app: Hono
+  let db: PostgresJsDatabase
 
   beforeAll(async () => {
     const { createTestDb, cleanupTestDb } = await import("@voyant-travel/db/test-utils")
-    const db = createTestDb()
+    db = createTestDb()
     await cleanupTestDb(db)
 
     app = new Hono()
@@ -18,7 +26,7 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
       c.set("userId" as never, "test-user-id")
       await next()
     })
-    app.route("/", supplierRoutes)
+    app.route("/", suppliersHonoModule.adminRoutes)
   })
 
   beforeEach(async () => {
@@ -104,4 +112,183 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     expect(body.data[0]?.name).toBe("Projection Tours")
     expect(body.data[0]?.contactEmail).toBe("contact@projection.example")
   })
+
+  it("rejects service mutations through the wrong supplier path without changing the service", async () => {
+    const supplierA = await createSupplier("Service Supplier A")
+    const supplierB = await createSupplier("Service Supplier B")
+    const service = await createService(supplierA.id, "Original service")
+
+    const updateRes = await app.request(`/${supplierB.id}/services/${service.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "Wrong supplier update" }),
+    })
+
+    expect(updateRes.status).toBe(404)
+
+    const [updatedRow] = await db
+      .select()
+      .from(supplierServices)
+      .where(eq(supplierServices.id, service.id))
+    expect(updatedRow?.name).toBe("Original service")
+
+    const deleteRes = await app.request(`/${supplierB.id}/services/${service.id}`, {
+      method: "DELETE",
+    })
+
+    expect(deleteRes.status).toBe(404)
+
+    const [deletedRow] = await db
+      .select()
+      .from(supplierServices)
+      .where(eq(supplierServices.id, service.id))
+    expect(deletedRow?.name).toBe("Original service")
+  })
+
+  it("rejects rate mutations through the wrong parent path without changing the rate", async () => {
+    const supplierA = await createSupplier("Rate Supplier A")
+    const supplierB = await createSupplier("Rate Supplier B")
+    const service = await createService(supplierA.id, "Rate service")
+    const otherService = await createService(supplierA.id, "Other rate service")
+    const rate = await createRate(supplierA.id, service.id, "Original rate")
+
+    const wrongSupplierUpdateRes = await app.request(
+      `/${supplierB.id}/services/${service.id}/rates/${rate.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Wrong supplier rate update", amountCents: 9900 }),
+      },
+    )
+
+    expect(wrongSupplierUpdateRes.status).toBe(404)
+
+    const [wrongSupplierRow] = await db
+      .select()
+      .from(supplierRates)
+      .where(eq(supplierRates.id, rate.id))
+    expect(wrongSupplierRow?.name).toBe("Original rate")
+    expect(wrongSupplierRow?.amountCents).toBe(4500)
+
+    const wrongServiceUpdateRes = await app.request(
+      `/${supplierA.id}/services/${otherService.id}/rates/${rate.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: "Wrong service rate update", amountCents: 8800 }),
+      },
+    )
+
+    expect(wrongServiceUpdateRes.status).toBe(404)
+
+    const [wrongServiceRow] = await db
+      .select()
+      .from(supplierRates)
+      .where(eq(supplierRates.id, rate.id))
+    expect(wrongServiceRow?.name).toBe("Original rate")
+    expect(wrongServiceRow?.amountCents).toBe(4500)
+
+    const wrongSupplierDeleteRes = await app.request(
+      `/${supplierB.id}/services/${service.id}/rates/${rate.id}`,
+      { method: "DELETE" },
+    )
+
+    expect(wrongSupplierDeleteRes.status).toBe(404)
+
+    const wrongServiceDeleteRes = await app.request(
+      `/${supplierA.id}/services/${otherService.id}/rates/${rate.id}`,
+      { method: "DELETE" },
+    )
+
+    expect(wrongServiceDeleteRes.status).toBe(404)
+
+    const [deletedRow] = await db.select().from(supplierRates).where(eq(supplierRates.id, rate.id))
+    expect(deletedRow?.name).toBe("Original rate")
+  })
+
+  it("rejects contract mutations through the wrong supplier path without changing the contract", async () => {
+    const supplierA = await createSupplier("Contract Supplier A")
+    const supplierB = await createSupplier("Contract Supplier B")
+    const contract = await createContract(supplierA.id, "AGR-ORIGINAL")
+
+    const updateRes = await app.request(`/${supplierB.id}/contracts/${contract.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agreementNumber: "AGR-WRONG", status: "terminated" }),
+    })
+
+    expect(updateRes.status).toBe(404)
+
+    const [updatedRow] = await db
+      .select()
+      .from(supplierContracts)
+      .where(eq(supplierContracts.id, contract.id))
+    expect(updatedRow?.agreementNumber).toBe("AGR-ORIGINAL")
+    expect(updatedRow?.status).toBe("active")
+
+    const deleteRes = await app.request(`/${supplierB.id}/contracts/${contract.id}`, {
+      method: "DELETE",
+    })
+
+    expect(deleteRes.status).toBe(404)
+
+    const [deletedRow] = await db
+      .select()
+      .from(supplierContracts)
+      .where(eq(supplierContracts.id, contract.id))
+    expect(deletedRow?.agreementNumber).toBe("AGR-ORIGINAL")
+  })
+
+  async function createSupplier(name: string) {
+    const res = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name, type: "experience", status: "active" }),
+    })
+
+    expect(res.status).toBe(201)
+    return (await res.json()).data as { id: string }
+  }
+
+  async function createService(supplierId: string, name: string) {
+    const res = await app.request(`/${supplierId}/services`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ serviceType: "experience", name }),
+    })
+
+    expect(res.status).toBe(201)
+    return (await res.json()).data as { id: string }
+  }
+
+  async function createRate(supplierId: string, serviceId: string, name: string) {
+    const res = await app.request(`/${supplierId}/services/${serviceId}/rates`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name,
+        currency: "EUR",
+        amountCents: 4500,
+        unit: "per_person",
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    return (await res.json()).data as { id: string }
+  }
+
+  async function createContract(supplierId: string, agreementNumber: string) {
+    const res = await app.request(`/${supplierId}/contracts`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        agreementNumber,
+        startDate: "2026-01-01",
+        status: "active",
+      }),
+    })
+
+    expect(res.status).toBe(201)
+    return (await res.json()).data as { id: string }
+  }
 })


### PR DESCRIPTION
## Summary

Fixes #2544.

Supplier nested resource mutations now enforce the full parent chain from the URL:

- service update/delete requires the service to belong to the supplier path
- rate list/create/update/delete requires the service to belong to the supplier path, and rate update/delete requires the rate to belong to the service path
- contract update/delete requires the contract to belong to the supplier path

The route contracts are unchanged; the routes now pass parent IDs through to service-layer filters.

## Tests

- `pnpm exec biome check --write packages/distribution/src/suppliers/routes.ts packages/distribution/src/suppliers/service-operations.ts packages/distribution/tests/suppliers/integration/routes.test.ts`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/distribution typecheck`
- `pnpm --filter @voyant-travel/distribution test -- tests/suppliers/integration/routes.test.ts` (passes; DB-backed supplier integration cases are skipped without `TEST_DATABASE_URL`)
- `pnpm --filter @voyant-travel/distribution lint`
- pre-push hook ran `pnpm test` and passed (cache-heavy; DB-backed integration tests skipped without `TEST_DATABASE_URL`)