### PR TITLE
Fix supplier PATCH null clears

### DIFF
--- a/.changeset/supplier-patch-null-clears.md
+++ b/.changeset/supplier-patch-null-clears.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/suppliers-contracts": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/openapi": patch
+---
+
+Fix supplier PATCH validation so insert defaults are not applied during partial
+updates, and allow explicit nulls to clear nullable supplier contact fields.

--- a/packages/distribution/src/suppliers/service-core.ts
+++ b/packages/distribution/src/suppliers/service-core.ts
@@ -179,6 +179,34 @@ export async function updateSupplier(
     contactPhone,
     ...supplierValues
   } = data
+  const hasIdentityField = (
+    [
+      "email",
+      "phone",
+      "website",
+      "address",
+      "city",
+      "country",
+      "contactName",
+      "contactEmail",
+      "contactPhone",
+    ] as const
+  ).some((key) => Object.hasOwn(data, key))
+  const identityValues = {
+    email: Object.hasOwn(data, "email") ? (email ?? null) : existing.email,
+    phone: Object.hasOwn(data, "phone") ? (phone ?? null) : existing.phone,
+    website: Object.hasOwn(data, "website") ? (website ?? null) : existing.website,
+    address: Object.hasOwn(data, "address") ? (address ?? null) : existing.address,
+    city: Object.hasOwn(data, "city") ? (city ?? null) : existing.city,
+    country: Object.hasOwn(data, "country") ? (country ?? null) : existing.country,
+    contactName: Object.hasOwn(data, "contactName") ? (contactName ?? null) : existing.contactName,
+    contactEmail: Object.hasOwn(data, "contactEmail")
+      ? (contactEmail ?? null)
+      : existing.contactEmail,
+    contactPhone: Object.hasOwn(data, "contactPhone")
+      ? (contactPhone ?? null)
+      : existing.contactPhone,
+  }
 
   const [row] = await db
     .update(suppliers)
@@ -189,29 +217,13 @@ export async function updateSupplier(
     return null
   }
 
-  await syncSupplierIdentity(db, id, {
-    email: email ?? existing.email,
-    phone: phone ?? existing.phone,
-    website: website ?? existing.website,
-    address: address ?? existing.address,
-    city: city ?? existing.city,
-    country: country ?? existing.country,
-    contactName: contactName ?? existing.contactName,
-    contactEmail: contactEmail ?? existing.contactEmail,
-    contactPhone: contactPhone ?? existing.contactPhone,
-  })
+  if (hasIdentityField) {
+    await syncSupplierIdentity(db, id, identityValues)
+  }
 
   return {
     ...row,
-    email: email ?? existing.email,
-    phone: phone ?? existing.phone,
-    website: website ?? existing.website,
-    address: address ?? existing.address,
-    city: city ?? existing.city,
-    country: country ?? existing.country,
-    contactName: contactName ?? existing.contactName,
-    contactEmail: contactEmail ?? existing.contactEmail,
-    contactPhone: contactPhone ?? existing.contactPhone,
+    ...identityValues,
   }
 }
 

--- a/packages/distribution/src/suppliers/service-shared.ts
+++ b/packages/distribution/src/suppliers/service-shared.ts
@@ -348,16 +348,18 @@ export async function syncSupplierIdentity(
     website: data.website,
   }) as Array<["email" | "phone" | "website", string | null | undefined]>) {
     const value = toNullableTrimmed(rawValue)
-    const existing =
-      managedContactPoints.find((point) => point.kind === kind) ??
-      existingContactPoints.find((point) => point.kind === kind && point.isPrimary)
+    const managedContactPoint = managedContactPoints.find((point) => point.kind === kind)
 
     if (!value) {
-      if (existing) {
-        await identityService.deleteContactPoint(db, existing.id)
+      if (managedContactPoint) {
+        await identityService.deleteContactPoint(db, managedContactPoint.id)
       }
       continue
     }
+
+    const existing =
+      managedContactPoint ??
+      existingContactPoints.find((point) => point.kind === kind && point.isPrimary)
 
     const payload = {
       entityType: supplierEntityType,

--- a/packages/distribution/tests/suppliers/integration/routes.test.ts
+++ b/packages/distribution/tests/suppliers/integration/routes.test.ts
@@ -175,6 +175,48 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     })
   })
 
+  it("does not delete unmanaged contact points when clearing top-level supplier fields", async () => {
+    const supplier = await createSupplier("Unmanaged Contact Supplier")
+
+    const createContactPointRes = await app.request(`/${supplier.id}/contact-points`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind: "email",
+        label: "primary",
+        value: "unmanaged@example.test",
+        normalizedValue: "unmanaged@example.test",
+        isPrimary: true,
+        metadata: { source: "manual" },
+      }),
+    })
+
+    expect(createContactPointRes.status).toBe(201)
+    const createdContactPoint = await createContactPointRes.json()
+
+    const updateRes = await app.request(`/${supplier.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: null }),
+    })
+
+    expect(updateRes.status).toBe(200)
+
+    const listContactPointsRes = await app.request(`/${supplier.id}/contact-points`, {
+      method: "GET",
+    })
+
+    expect(listContactPointsRes.status).toBe(200)
+    const contactPoints = await listContactPointsRes.json()
+    expect(contactPoints.data).toEqual([
+      expect.objectContaining({
+        id: createdContactPoint.data.id,
+        value: "unmanaged@example.test",
+        metadata: { source: "manual" },
+      }),
+    ])
+  })
+
   it("lists suppliers", async () => {
     const res = await app.request("/", { method: "GET" })
 

--- a/packages/distribution/tests/suppliers/integration/routes.test.ts
+++ b/packages/distribution/tests/suppliers/integration/routes.test.ts
@@ -78,6 +78,103 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     expect(updated.data.reservationTimeoutMinutes).toBe(0)
   })
 
+  it("does not apply insert defaults on empty supplier patches", async () => {
+    const createRes = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Pending Tagged Supplier",
+        type: "experience",
+        status: "pending",
+        tags: ["preferred"],
+      }),
+    })
+
+    expect(createRes.status).toBe(201)
+    const created = await createRes.json()
+
+    const updateRes = await app.request(`/${created.data.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    })
+
+    expect(updateRes.status).toBe(200)
+    const updated = await updateRes.json()
+    expect(updated.data.status).toBe("pending")
+    expect(updated.data.tags).toEqual(["preferred"])
+  })
+
+  it("clears supplier identity projection fields with explicit nulls", async () => {
+    const createRes = await app.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Clearable Supplier",
+        type: "experience",
+        status: "active",
+        email: "ops@clearable.example",
+        phone: "+40700000000",
+        website: "https://clearable.example",
+        address: "Projection Street 1",
+        city: "Cluj-Napoca",
+        country: "RO",
+        contactName: "Projection Ops",
+        contactEmail: "contact@clearable.example",
+        contactPhone: "+40700000001",
+      }),
+    })
+
+    expect(createRes.status).toBe(201)
+    const created = await createRes.json()
+
+    const updateRes = await app.request(`/${created.data.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        email: null,
+        phone: null,
+        website: null,
+        address: null,
+        city: null,
+        country: null,
+        contactName: null,
+        contactEmail: null,
+        contactPhone: null,
+      }),
+    })
+
+    expect(updateRes.status).toBe(200)
+    const updated = await updateRes.json()
+    expect(updated.data).toMatchObject({
+      email: null,
+      phone: null,
+      website: null,
+      address: null,
+      city: null,
+      country: null,
+      contactName: null,
+      contactEmail: null,
+      contactPhone: null,
+    })
+
+    const getRes = await app.request(`/${created.data.id}`, { method: "GET" })
+
+    expect(getRes.status).toBe(200)
+    const retrieved = await getRes.json()
+    expect(retrieved.data).toMatchObject({
+      email: null,
+      phone: null,
+      website: null,
+      address: null,
+      city: null,
+      country: null,
+      contactName: null,
+      contactEmail: null,
+      contactPhone: null,
+    })
+  })
+
   it("lists suppliers", async () => {
     const res = await app.request("/", { method: "GET" })
 

--- a/packages/openapi/spec/admin/suppliers.json
+++ b/packages/openapi/spec/admin/suppliers.json
@@ -5663,8 +5663,7 @@
                       "active",
                       "inactive",
                       "pending"
-                    ],
-                    "default": "active"
+                    ]
                   },
                   "description": {
                     "type": [
@@ -5814,8 +5813,7 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "default": []
+                    }
                   }
                 }
               }

--- a/packages/suppliers-contracts/src/contracts.test.ts
+++ b/packages/suppliers-contracts/src/contracts.test.ts
@@ -31,6 +31,16 @@ describe("suppliers-contracts", () => {
     expect(updateSupplierSchema.safeParse({ defaultCurrency: "usd" }).success).toBe(false)
   })
 
+  it("does not apply insert defaults to supplier update payloads", () => {
+    const parsed = updateSupplierSchema.parse({})
+    expect(parsed).not.toHaveProperty("status")
+    expect(parsed).not.toHaveProperty("tags")
+    expect(updateSupplierSchema.parse({ status: "pending", tags: ["preferred"] })).toMatchObject({
+      status: "pending",
+      tags: ["preferred"],
+    })
+  })
+
   it("accepts a valid rate and rejects a non-3-char currency", () => {
     const parsed = insertRateSchema.parse({
       name: "Standard",

--- a/packages/suppliers-contracts/src/validation.ts
+++ b/packages/suppliers-contracts/src/validation.ts
@@ -73,7 +73,10 @@ const supplierCoreSchema = z.object({
 })
 
 export const insertSupplierSchema = supplierCoreSchema
-export const updateSupplierSchema = supplierCoreSchema.partial()
+export const updateSupplierSchema = supplierCoreSchema.partial().extend({
+  status: supplierStatusSchema.optional(),
+  tags: z.array(z.string()).optional(),
+})
 export const selectSupplierSchema = supplierCoreSchema.extend({
   id: typeIdSchema("suppliers"),
   createdAt: z.coerce.date(),

--- a/starters/operator/openapi/admin/suppliers.json
+++ b/starters/operator/openapi/admin/suppliers.json
@@ -5663,8 +5663,7 @@
                       "active",
                       "inactive",
                       "pending"
-                    ],
-                    "default": "active"
+                    ]
                   },
                   "description": {
                     "type": [
@@ -5814,8 +5813,7 @@
                     "type": "array",
                     "items": {
                       "type": "string"
-                    },
-                    "default": []
+                    }
                   }
                 }
               }


### PR DESCRIPTION
## Summary

- Prevent supplier PATCH validation from applying insert defaults for `status` and `tags`.
- Preserve omitted supplier identity fields while allowing explicit `null` to clear managed contact, address, and named-contact projection fields.
- Regenerate the admin supplier OpenAPI spec and add patch changesets.

## Validation

- `pnpm exec biome check --write packages/distribution/src/suppliers/service-core.ts packages/distribution/tests/suppliers/integration/routes.test.ts packages/suppliers-contracts/src/contracts.test.ts packages/suppliers-contracts/src/validation.ts packages/openapi/spec/admin/suppliers.json`
- `pnpm --filter @voyant-travel/suppliers-contracts typecheck`
- `pnpm --filter @voyant-travel/suppliers-contracts test`
- `pnpm --filter @voyant-travel/suppliers-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=14336 pnpm --filter @voyant-travel/distribution typecheck`
- `pnpm --filter @voyant-travel/distribution test`
- `pnpm --filter @voyant-travel/distribution lint`
- `pnpm --filter @voyant-travel/openapi generate`
- `pnpm --filter @voyant-travel/openapi test`
- `pnpm --filter @voyant-travel/openapi lint`
- Commit hook changed-file quality and affected build/typecheck tasks passed.
- Push hook workspace test lane passed.

`TEST_DATABASE_URL` was absent locally, so DB-backed integration tests, including the new supplier route cases, were skipped by the existing test guard.

Closes #2546