### PR TITLE
Validate supplier rate and contract ranges

### DIFF
--- a/.changeset/supplier-range-validation.md
+++ b/.changeset/supplier-range-validation.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/suppliers-contracts": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/distribution-react": patch
+---
+
+Reject reversed supplier rate and contract ranges. Rate date and pax bounds must be ordered, contract end dates must not precede start dates, and renewal dates must stay within bounded contract terms.
+
+Supplier UI forms now block those invalid ranges and persisted invalid rate rows are flagged in the rate table.

--- a/packages/distribution-react/src/suppliers/components/rate-dialog.tsx
+++ b/packages/distribution-react/src/suppliers/components/rate-dialog.tsx
@@ -23,24 +23,10 @@ import { zodResolver } from "@voyant-travel/ui/lib/zod-resolver"
 import { Loader2 } from "lucide-react"
 import * as React from "react"
 import { useForm } from "react-hook-form"
-import { z } from "zod/v4"
+import type { z } from "zod/v4"
 import { useSuppliersUiMessagesOrDefault } from "../i18n/index.js"
 import { RATE_UNITS, type SupplierRate, useSupplierRateMutation } from "../index.js"
-
-function getRateSchema(messages: ReturnType<typeof useSuppliersUiMessagesOrDefault>) {
-  const dialog = messages.dialogs.rate
-  return z.object({
-    name: z.string().min(1, dialog.validationNameRequired),
-    currency: z.string().min(3, dialog.validationIsoCurrency).max(3, dialog.validationIsoCurrency),
-    amount: z.coerce.number().min(0, dialog.validationNonNegative),
-    unit: z.enum(["per_person", "per_group", "per_night", "per_vehicle", "flat"]),
-    validFrom: z.string().optional().nullable(),
-    validTo: z.string().optional().nullable(),
-    minPax: z.coerce.number().int().positive().optional().or(z.literal("")).nullable(),
-    maxPax: z.coerce.number().int().positive().optional().or(z.literal("")).nullable(),
-    notes: z.string().optional().nullable(),
-  })
-}
+import { getRateSchema } from "./supplier-form-validation.js"
 
 export type RateDialogProps = {
   open: boolean
@@ -173,7 +159,7 @@ export function RateDialog({
               </div>
             </div>
             <div className="grid gap-4 sm:grid-cols-2">
-              <Field label={dialog.validFromLabel}>
+              <Field label={dialog.validFromLabel} error={form.formState.errors.validFrom?.message}>
                 <DatePicker
                   value={form.watch("validFrom") || null}
                   onChange={(nextValue) =>
@@ -184,7 +170,7 @@ export function RateDialog({
                   }
                 />
               </Field>
-              <Field label={dialog.validToLabel}>
+              <Field label={dialog.validToLabel} error={form.formState.errors.validTo?.message}>
                 <DatePicker
                   value={form.watch("validTo") || null}
                   onChange={(nextValue) =>
@@ -197,7 +183,7 @@ export function RateDialog({
               </Field>
             </div>
             <div className="grid gap-4 sm:grid-cols-2">
-              <Field label={dialog.minPaxLabel}>
+              <Field label={dialog.minPaxLabel} error={form.formState.errors.minPax?.message}>
                 <Input
                   {...form.register("minPax")}
                   type="number"
@@ -205,7 +191,7 @@ export function RateDialog({
                   placeholder={dialog.minPaxPlaceholder}
                 />
               </Field>
-              <Field label={dialog.maxPaxLabel}>
+              <Field label={dialog.maxPaxLabel} error={form.formState.errors.maxPax?.message}>
                 <Input
                   {...form.register("maxPax")}
                   type="number"

--- a/packages/distribution-react/src/suppliers/components/supplier-form-validation.ts
+++ b/packages/distribution-react/src/suppliers/components/supplier-form-validation.ts
@@ -1,0 +1,76 @@
+import { z } from "zod/v4"
+import type { SuppliersUiMessages } from "../i18n/messages.js"
+
+export function getRateSchema(messages: SuppliersUiMessages) {
+  const dialog = messages.dialogs.rate
+  return z
+    .object({
+      name: z.string().min(1, dialog.validationNameRequired),
+      currency: z
+        .string()
+        .min(3, dialog.validationIsoCurrency)
+        .max(3, dialog.validationIsoCurrency),
+      amount: z.coerce.number().min(0, dialog.validationNonNegative),
+      unit: z.enum(["per_person", "per_group", "per_night", "per_vehicle", "flat"]),
+      validFrom: z.string().optional().nullable(),
+      validTo: z.string().optional().nullable(),
+      minPax: z.coerce.number().int().positive().optional().or(z.literal("")).nullable(),
+      maxPax: z.coerce.number().int().positive().optional().or(z.literal("")).nullable(),
+      notes: z.string().optional().nullable(),
+    })
+    .superRefine((values, ctx) => {
+      if (values.validFrom && values.validTo && values.validFrom > values.validTo) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["validTo"],
+          message: dialog.validationDateRange,
+        })
+      }
+
+      if (
+        typeof values.minPax === "number" &&
+        typeof values.maxPax === "number" &&
+        values.minPax > values.maxPax
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["maxPax"],
+          message: dialog.validationPaxRange,
+        })
+      }
+    })
+}
+
+export function getContractSchema(messages: SuppliersUiMessages) {
+  const dialog = messages.dialogs.contract
+  return z
+    .object({
+      agreementNumber: z.string().optional().nullable(),
+      startDate: z.string().min(1, dialog.validationStartDateRequired),
+      endDate: z.string().optional().nullable(),
+      renewalDate: z.string().optional().nullable(),
+      status: z.enum(["active", "expired", "pending", "terminated"]),
+      terms: z.string().optional().nullable(),
+    })
+    .superRefine((values, ctx) => {
+      if (values.startDate && values.endDate && values.startDate > values.endDate) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["endDate"],
+          message: dialog.validationEndDateRange,
+        })
+      }
+
+      if (
+        values.renewalDate &&
+        ((values.startDate && values.renewalDate < values.startDate) ||
+          (values.endDate && values.renewalDate > values.endDate))
+      ) {
+        ctx.addIssue({
+          code: "custom",
+          path: ["renewalDate"],
+          message: dialog.validationRenewalDateRange,
+        })
+      }
+    })
+}

--- a/packages/distribution-react/src/suppliers/components/supplier-operations-resource-dialogs.tsx
+++ b/packages/distribution-react/src/suppliers/components/supplier-operations-resource-dialogs.tsx
@@ -20,6 +20,7 @@ import {
   useSupplierAvailabilityMutation,
   useSupplierContractMutation,
 } from "../index.js"
+import { getContractSchema } from "./supplier-form-validation.js"
 import {
   DialogActions,
   Field,
@@ -119,18 +120,7 @@ export function ContractDialog({
   const messages = useSuppliersUiMessagesOrDefault()
   const dialog = messages.dialogs.contract
   const mutation = useSupplierContractMutation(supplierId)
-  const schema = React.useMemo(
-    () =>
-      z.object({
-        agreementNumber: z.string().optional().nullable(),
-        startDate: z.string().min(1, dialog.validationStartDateRequired),
-        endDate: z.string().optional().nullable(),
-        renewalDate: z.string().optional().nullable(),
-        status: z.enum(["active", "expired", "pending", "terminated"]),
-        terms: z.string().optional().nullable(),
-      }),
-    [dialog.validationStartDateRequired],
-  )
+  const schema = React.useMemo(() => getContractSchema(messages), [messages])
   const isEditing = !!contract
   const form = useForm<z.input<typeof schema>, unknown, z.output<typeof schema>>({
     resolver: zodResolver(schema),
@@ -194,10 +184,13 @@ export function ContractDialog({
               <Field label={dialog.startDateLabel} error={form.formState.errors.startDate?.message}>
                 <Input {...form.register("startDate")} type="date" />
               </Field>
-              <Field label={dialog.endDateLabel}>
+              <Field label={dialog.endDateLabel} error={form.formState.errors.endDate?.message}>
                 <Input {...form.register("endDate")} type="date" />
               </Field>
-              <Field label={dialog.renewalDateLabel}>
+              <Field
+                label={dialog.renewalDateLabel}
+                error={form.formState.errors.renewalDate?.message}
+              >
                 <Input {...form.register("renewalDate")} type="date" />
               </Field>
             </div>

--- a/packages/distribution-react/src/suppliers/components/supplier-service-row.tsx
+++ b/packages/distribution-react/src/suppliers/components/supplier-service-row.tsx
@@ -1,6 +1,7 @@
 import { Badge, Button } from "@voyant-travel/ui/components"
-import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react"
+import { AlertTriangle, ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react"
 import { useSuppliersUiI18nOrDefault } from "../i18n/index.js"
+import type { SuppliersUiMessages } from "../i18n/messages.js"
 import { type SupplierRate, type SupplierService, useSupplierServiceRates } from "../index.js"
 
 export function SupplierServiceRow({
@@ -135,49 +136,14 @@ export function SupplierServiceRow({
                 </thead>
                 <tbody>
                   {resolvedRates.map((rate) => (
-                    <tr key={rate.id} className="border-b last:border-b-0">
-                      <td className="p-2">{rate.name}</td>
-                      <td className="p-2 font-mono">
-                        {i18n.formatCurrency(rate.amountCents / 100, rate.currency)}
-                      </td>
-                      <td className="p-2">{messages.common.rateUnitLabels[rate.unit]}</td>
-                      <td className="p-2">
-                        {rate.validFrom || rate.validTo
-                          ? `${rate.validFrom ?? messages.supplierServiceRow.validFallback} — ${
-                              rate.validTo ?? messages.supplierServiceRow.validFallback
-                            }`
-                          : messages.common.none}
-                      </td>
-                      <td className="p-2">
-                        {rate.minPax || rate.maxPax
-                          ? `${rate.minPax ?? messages.common.unknown}-${
-                              rate.maxPax ?? messages.common.unknown
-                            }`
-                          : messages.common.none}
-                      </td>
-                      <td className="p-2">
-                        <div className="flex items-center gap-1">
-                          <button
-                            type="button"
-                            onClick={() => onEditRate(rate)}
-                            aria-label={messages.common.edit}
-                            title={messages.common.edit}
-                            className="text-muted-foreground hover:text-foreground"
-                          >
-                            <Pencil className="h-3 w-3" />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => onDeleteRate(rate.id)}
-                            aria-label={messages.common.delete}
-                            title={messages.common.delete}
-                            className="text-muted-foreground hover:text-destructive"
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </button>
-                        </div>
-                      </td>
-                    </tr>
+                    <RateRow
+                      key={rate.id}
+                      rate={rate}
+                      messages={messages}
+                      formatCurrency={i18n.formatCurrency}
+                      onEditRate={onEditRate}
+                      onDeleteRate={onDeleteRate}
+                    />
                   ))}
                 </tbody>
               </table>
@@ -186,5 +152,81 @@ export function SupplierServiceRow({
         </div>
       ) : null}
     </div>
+  )
+}
+
+function RateRow({
+  rate,
+  messages,
+  formatCurrency,
+  onEditRate,
+  onDeleteRate,
+}: {
+  rate: SupplierRate
+  messages: SuppliersUiMessages
+  formatCurrency: (amount: number, currency: string) => string
+  onEditRate: (rate: SupplierRate) => void
+  onDeleteRate: (rateId: string) => void
+}) {
+  const invalidDateRange = Boolean(rate.validFrom && rate.validTo && rate.validFrom > rate.validTo)
+  const invalidPaxRange = Boolean(
+    rate.minPax != null && rate.maxPax != null && rate.minPax > rate.maxPax,
+  )
+
+  return (
+    <tr className="border-b last:border-b-0">
+      <td className="p-2">{rate.name}</td>
+      <td className="p-2 font-mono">{formatCurrency(rate.amountCents / 100, rate.currency)}</td>
+      <td className="p-2">{messages.common.rateUnitLabels[rate.unit]}</td>
+      <td className="p-2">
+        {rate.validFrom || rate.validTo
+          ? `${rate.validFrom ?? messages.supplierServiceRow.validFallback} - ${
+              rate.validTo ?? messages.supplierServiceRow.validFallback
+            }`
+          : messages.common.none}
+        {invalidDateRange ? (
+          <InvalidRangeMessage>{messages.supplierServiceRow.invalidDateRange}</InvalidRangeMessage>
+        ) : null}
+      </td>
+      <td className="p-2">
+        {rate.minPax || rate.maxPax
+          ? `${rate.minPax ?? messages.common.unknown}-${rate.maxPax ?? messages.common.unknown}`
+          : messages.common.none}
+        {invalidPaxRange ? (
+          <InvalidRangeMessage>{messages.supplierServiceRow.invalidPaxRange}</InvalidRangeMessage>
+        ) : null}
+      </td>
+      <td className="p-2">
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onEditRate(rate)}
+            aria-label={messages.common.edit}
+            title={messages.common.edit}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            <Pencil className="h-3 w-3" />
+          </button>
+          <button
+            type="button"
+            onClick={() => onDeleteRate(rate.id)}
+            aria-label={messages.common.delete}
+            title={messages.common.delete}
+            className="text-muted-foreground hover:text-destructive"
+          >
+            <Trash2 className="h-3 w-3" />
+          </button>
+        </div>
+      </td>
+    </tr>
+  )
+}
+
+function InvalidRangeMessage({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="mt-1 flex items-center gap-1 text-[11px] text-destructive">
+      <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+      {children}
+    </span>
   )
 }

--- a/packages/distribution-react/src/suppliers/i18n.test.tsx
+++ b/packages/distribution-react/src/suppliers/i18n.test.tsx
@@ -13,9 +13,11 @@ function withProviders(children: ReactNode) {
   )
 }
 
+import { getContractSchema, getRateSchema } from "./components/supplier-form-validation.js"
 import { SupplierNestedResources } from "./components/supplier-nested-resources.js"
 import { SupplierServiceRow } from "./components/supplier-service-row.js"
 import { SuppliersPage } from "./components/suppliers-page.js"
+import { suppliersUiEn } from "./i18n/en.js"
 import {
   getSuppliersUiI18n,
   resolveSuppliersUiMessages,
@@ -49,6 +51,23 @@ const rates: SupplierRate[] = [
     validTo: "2026-09-30",
     minPax: 1,
     maxPax: 8,
+    notes: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+  },
+]
+
+const invalidRates: SupplierRate[] = [
+  {
+    id: "rate-invalid",
+    serviceId: "service-1",
+    name: "Invalid",
+    currency: "EUR",
+    amountCents: 12500,
+    unit: "per_person",
+    validFrom: "2026-09-10",
+    validTo: "2026-09-01",
+    minPax: 8,
+    maxPax: 2,
     notes: null,
     createdAt: "2026-01-01T00:00:00.000Z",
   },
@@ -114,6 +133,56 @@ describe("suppliers-ui i18n", () => {
     expect(html).toContain("Contracts")
     expect(html).toContain("Guide")
     expect(html).toContain("Per person")
+  })
+
+  it("flags invalid persisted rate ranges", () => {
+    const html = renderToStaticMarkup(
+      withProviders(
+        <SupplierServiceRow
+          service={service}
+          rates={invalidRates}
+          expanded
+          onToggle={() => {}}
+          onEdit={() => {}}
+          onDelete={() => {}}
+          onAddRate={() => {}}
+          onEditRate={() => {}}
+          onDeleteRate={() => {}}
+        />,
+      ),
+    )
+
+    expect(html).toContain("Invalid date range")
+    expect(html).toContain("Invalid pax range")
+  })
+
+  it("rejects invalid supplier rate and contract form ranges", () => {
+    const rateSchema = getRateSchema(suppliersUiEn)
+    expect(
+      rateSchema.safeParse({
+        name: "Bad range",
+        currency: "EUR",
+        amount: 100,
+        unit: "per_group",
+        validFrom: "2026-09-10",
+        validTo: "2026-09-01",
+        minPax: 8,
+        maxPax: 2,
+        notes: "",
+      }).success,
+    ).toBe(false)
+
+    const contractSchema = getContractSchema(suppliersUiEn)
+    expect(
+      contractSchema.safeParse({
+        agreementNumber: "AGR-BAD",
+        startDate: "2026-07-01",
+        endDate: "2026-12-31",
+        renewalDate: "2027-01-01",
+        status: "active",
+        terms: "",
+      }).success,
+    ).toBe(false)
   })
 
   it("renders Romanian copy with the package provider", () => {

--- a/packages/distribution-react/src/suppliers/i18n/en.ts
+++ b/packages/distribution-react/src/suppliers/i18n/en.ts
@@ -263,6 +263,8 @@ export const suppliersUiEn = {
       validationNameRequired: "Rate name is required.",
       validationIsoCurrency: "Use a 3-letter currency code.",
       validationNonNegative: "Amount must be zero or greater.",
+      validationDateRange: "Valid to must be on or after valid from.",
+      validationPaxRange: "Maximum pax must be greater than or equal to minimum pax.",
     },
     contactPoint: {
       newTitle: "New contact point",
@@ -341,6 +343,8 @@ export const suppliersUiEn = {
       termsLabel: "Terms",
       termsPlaceholder: "Contract terms and operating notes",
       validationStartDateRequired: "Start date is required.",
+      validationEndDateRange: "End date must be on or after start date.",
+      validationRenewalDateRange: "Renewal date must fall within the contract term.",
     },
   },
   supplierServiceRow: {
@@ -355,5 +359,7 @@ export const suppliersUiEn = {
       pax: "Pax",
     },
     validFallback: "...",
+    invalidDateRange: "Invalid date range",
+    invalidPaxRange: "Invalid pax range",
   },
 } satisfies SuppliersUiMessages

--- a/packages/distribution-react/src/suppliers/i18n/messages.ts
+++ b/packages/distribution-react/src/suppliers/i18n/messages.ts
@@ -170,6 +170,8 @@ export type SuppliersUiMessages = {
       pax: string
     }
     validFallback: string
+    invalidDateRange: string
+    invalidPaxRange: string
   }
 }
 
@@ -254,6 +256,8 @@ export type ContractFormMessages = {
   termsLabel: string
   termsPlaceholder: string
   validationStartDateRequired: string
+  validationEndDateRange: string
+  validationRenewalDateRange: string
 }
 
 export type SupplierFormMessages = {
@@ -329,4 +333,6 @@ export type RateFormMessages = {
   validationNameRequired: string
   validationIsoCurrency: string
   validationNonNegative: string
+  validationDateRange: string
+  validationPaxRange: string
 }

--- a/packages/distribution-react/src/suppliers/i18n/ro.ts
+++ b/packages/distribution-react/src/suppliers/i18n/ro.ts
@@ -263,6 +263,8 @@ export const suppliersUiRo = {
       validationNameRequired: "Numele tarifului este obligatoriu.",
       validationIsoCurrency: "Foloseste un cod monetar de 3 litere.",
       validationNonNegative: "Suma trebuie sa fie zero sau mai mare.",
+      validationDateRange: "Data de final trebuie sa fie dupa sau in aceeasi zi cu data de start.",
+      validationPaxRange: "Pax maxim trebuie sa fie mai mare sau egal cu pax minim.",
     },
     contactPoint: {
       newTitle: "Punct de contact nou",
@@ -341,6 +343,9 @@ export const suppliersUiRo = {
       termsLabel: "Termeni",
       termsPlaceholder: "Termeni contractuali si note operationale",
       validationStartDateRequired: "Data de start este obligatorie.",
+      validationEndDateRange:
+        "Data de sfarsit trebuie sa fie dupa sau in aceeasi zi cu data de start.",
+      validationRenewalDateRange: "Data de reinnoire trebuie sa fie in intervalul contractului.",
     },
   },
   supplierServiceRow: {
@@ -355,5 +360,7 @@ export const suppliersUiRo = {
       pax: "Pax",
     },
     validFallback: "...",
+    invalidDateRange: "Interval de date invalid",
+    invalidPaxRange: "Interval pax invalid",
   },
 } satisfies SuppliersUiMessages

--- a/packages/distribution/src/suppliers/service-operations.ts
+++ b/packages/distribution/src/suppliers/service-operations.ts
@@ -1,3 +1,4 @@
+import { RequestValidationError } from "@voyant-travel/hono"
 import { and, asc, desc, eq, exists, gte, lte, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
@@ -20,6 +21,49 @@ import type {
   UpdateServiceInput,
 } from "./service-shared.js"
 import { ensureSupplierExists } from "./service-shared.js"
+
+function assertRateRange(data: {
+  validFrom?: string | null
+  validTo?: string | null
+  minPax?: number | null
+  maxPax?: number | null
+}) {
+  if (data.validFrom && data.validTo && data.validFrom > data.validTo) {
+    throw new RequestValidationError("validTo must be on or after validFrom", {
+      field: "validTo",
+    })
+  }
+
+  if (data.minPax != null && data.maxPax != null && data.minPax > data.maxPax) {
+    throw new RequestValidationError("maxPax must be greater than or equal to minPax", {
+      field: "maxPax",
+    })
+  }
+}
+
+function assertContractTerm(data: {
+  startDate?: string | null
+  endDate?: string | null
+  renewalDate?: string | null
+}) {
+  if (data.startDate && data.endDate && data.startDate > data.endDate) {
+    throw new RequestValidationError("endDate must be on or after startDate", {
+      field: "endDate",
+    })
+  }
+
+  if (data.renewalDate && data.startDate && data.renewalDate < data.startDate) {
+    throw new RequestValidationError("renewalDate must be on or after startDate", {
+      field: "renewalDate",
+    })
+  }
+
+  if (data.renewalDate && data.endDate && data.renewalDate > data.endDate) {
+    throw new RequestValidationError("renewalDate must be on or before endDate", {
+      field: "renewalDate",
+    })
+  }
+}
 
 export function listServices(db: PostgresJsDatabase, supplierId: string) {
   return db
@@ -174,6 +218,8 @@ export async function createRate(
     return null
   }
 
+  assertRateRange(data)
+
   const [row] = await db
     .insert(supplierRates)
     .values({ ...data, serviceId })
@@ -206,19 +252,22 @@ export async function updateRate(
   const data = typeof serviceOrData === "string" ? maybeData : serviceOrData
   if (!resolvedRateId || !data) throw new Error("updateRate requires rate id and update data")
 
-  const [row] = await db
-    .update(supplierRates)
-    .set(data)
-    .where(
-      supplierId && serviceId
-        ? and(
-            eq(supplierRates.id, resolvedRateId),
-            eq(supplierRates.serviceId, serviceId),
-            serviceBelongsToSupplier(db, supplierId, serviceId),
-          )
-        : eq(supplierRates.id, resolvedRateId),
-    )
-    .returning()
+  const where =
+    supplierId && serviceId
+      ? and(
+          eq(supplierRates.id, resolvedRateId),
+          eq(supplierRates.serviceId, serviceId),
+          serviceBelongsToSupplier(db, supplierId, serviceId),
+        )
+      : eq(supplierRates.id, resolvedRateId)
+  const [existing] = await db.select().from(supplierRates).where(where).limit(1)
+  if (!existing) {
+    return null
+  }
+
+  assertRateRange({ ...existing, ...data })
+
+  const [row] = await db.update(supplierRates).set(data).where(where).returning()
   return row ?? null
 }
 
@@ -365,6 +414,8 @@ export async function createContract(
     return null
   }
 
+  assertContractTerm(data)
+
   const [row] = await db
     .insert(supplierContracts)
     .values({ ...data, supplierId })
@@ -394,14 +445,20 @@ export async function updateContract(
   const data = typeof contractOrData === "string" ? maybeData : contractOrData
   if (!data) throw new Error("updateContract requires update data")
 
+  const where = supplierId
+    ? and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId))
+    : eq(supplierContracts.id, contractId)
+  const [existing] = await db.select().from(supplierContracts).where(where).limit(1)
+  if (!existing) {
+    return null
+  }
+
+  assertContractTerm({ ...existing, ...data })
+
   const [row] = await db
     .update(supplierContracts)
     .set({ ...data, updatedAt: new Date() })
-    .where(
-      supplierId
-        ? and(eq(supplierContracts.id, contractId), eq(supplierContracts.supplierId, supplierId))
-        : eq(supplierContracts.id, contractId),
-    )
+    .where(where)
     .returning()
   return row ?? null
 }

--- a/packages/distribution/tests/suppliers/integration/routes.test.ts
+++ b/packages/distribution/tests/suppliers/integration/routes.test.ts
@@ -5,6 +5,7 @@ import {
   supplierServices,
   suppliersHonoModule,
 } from "@voyant-travel/distribution"
+import { handleApiError } from "@voyant-travel/hono"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
@@ -22,6 +23,7 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     await cleanupTestDb(db)
 
     app = new Hono()
+    app.onError(handleApiError)
     app.use("*", async (c, next) => {
       c.set("db" as never, db)
       c.set("userId" as never, "test-user-id")
@@ -329,6 +331,82 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     expect(body.data[0]?.contactEmail).toBe("contact@projection.example")
   })
 
+  it("rejects partial rate updates that would reverse existing ranges", async () => {
+    const supplier = await createSupplier("Partial Rate Range Supplier")
+    const service = await createService(supplier.id, "Partial rate service")
+    const rate = await createRate(supplier.id, service.id, "Partial range rate", {
+      validFrom: "2026-09-01",
+      validTo: "2026-09-10",
+      minPax: 2,
+      maxPax: 8,
+    })
+
+    const invalidDateRes = await app.request(
+      `/${supplier.id}/services/${service.id}/rates/${rate.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ validTo: "2026-08-31" }),
+      },
+    )
+
+    expect(invalidDateRes.status).toBe(400)
+
+    const invalidPaxRes = await app.request(
+      `/${supplier.id}/services/${service.id}/rates/${rate.id}`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ minPax: 9 }),
+      },
+    )
+
+    expect(invalidPaxRes.status).toBe(400)
+
+    const [row] = await db.select().from(supplierRates).where(eq(supplierRates.id, rate.id))
+    expect(row).toMatchObject({
+      validFrom: "2026-09-01",
+      validTo: "2026-09-10",
+      minPax: 2,
+      maxPax: 8,
+    })
+  })
+
+  it("rejects partial contract updates that would reverse existing terms", async () => {
+    const supplier = await createSupplier("Partial Contract Range Supplier")
+    const contract = await createContract(supplier.id, "AGR-PARTIAL", {
+      startDate: "2026-07-01",
+      endDate: "2026-12-31",
+      renewalDate: "2026-10-01",
+    })
+
+    const invalidEndRes = await app.request(`/${supplier.id}/contracts/${contract.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ endDate: "2026-06-30" }),
+    })
+
+    expect(invalidEndRes.status).toBe(400)
+
+    const invalidRenewalRes = await app.request(`/${supplier.id}/contracts/${contract.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ renewalDate: "2027-01-01" }),
+    })
+
+    expect(invalidRenewalRes.status).toBe(400)
+
+    const [row] = await db
+      .select()
+      .from(supplierContracts)
+      .where(eq(supplierContracts.id, contract.id))
+    expect(row).toMatchObject({
+      startDate: "2026-07-01",
+      endDate: "2026-12-31",
+      renewalDate: "2026-10-01",
+    })
+  })
+
   it("rejects service mutations through the wrong supplier path without changing the service", async () => {
     const supplierA = await createSupplier("Service Supplier A")
     const supplierB = await createSupplier("Service Supplier B")
@@ -477,7 +555,12 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     return (await res.json()).data as { id: string }
   }
 
-  async function createRate(supplierId: string, serviceId: string, name: string) {
+  async function createRate(
+    supplierId: string,
+    serviceId: string,
+    name: string,
+    overrides: Record<string, unknown> = {},
+  ) {
     const res = await app.request(`/${supplierId}/services/${serviceId}/rates`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -486,6 +569,7 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
         currency: "EUR",
         amountCents: 4500,
         unit: "per_person",
+        ...overrides,
       }),
     })
 
@@ -493,7 +577,11 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
     return (await res.json()).data as { id: string }
   }
 
-  async function createContract(supplierId: string, agreementNumber: string) {
+  async function createContract(
+    supplierId: string,
+    agreementNumber: string,
+    overrides: Record<string, unknown> = {},
+  ) {
     const res = await app.request(`/${supplierId}/contracts`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -501,6 +589,7 @@ describe.skipIf(!DB_AVAILABLE)("Supplier routes", () => {
         agreementNumber,
         startDate: "2026-01-01",
         status: "active",
+        ...overrides,
       }),
     })
 

--- a/packages/distribution/tests/suppliers/unit/routes-validation.test.ts
+++ b/packages/distribution/tests/suppliers/unit/routes-validation.test.ts
@@ -1,0 +1,78 @@
+import { suppliersHonoModule } from "@voyant-travel/distribution"
+import { handleApiError } from "@voyant-travel/hono"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+
+function makeApp() {
+  const app = new Hono()
+  app.onError(handleApiError)
+  app.route("/", suppliersHonoModule.adminRoutes)
+  return app
+}
+
+describe("Supplier route validation", () => {
+  it("rejects reversed supplier rate ranges before handlers run", async () => {
+    const app = makeApp()
+
+    const createRes = await app.request("/supplier_1/services/service_1/rates", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Invalid rate",
+        currency: "EUR",
+        amountCents: 5000,
+        unit: "per_group",
+        validFrom: "2026-09-10",
+        validTo: "2026-09-01",
+        minPax: 8,
+        maxPax: 2,
+      }),
+    })
+
+    expect(createRes.status).toBe(400)
+
+    const updateRes = await app.request("/supplier_1/services/service_1/rates/rate_1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        validFrom: "2026-09-10",
+        validTo: "2026-09-01",
+        minPax: 8,
+        maxPax: 2,
+      }),
+    })
+
+    expect(updateRes.status).toBe(400)
+  })
+
+  it("rejects reversed supplier contract terms and renewals outside the term", async () => {
+    const app = makeApp()
+
+    const createRes = await app.request("/supplier_1/contracts", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        agreementNumber: "QA-BAD",
+        startDate: "2027-06-30",
+        endDate: "2026-07-01",
+        renewalDate: "2028-01-01",
+        terms: "Bad range",
+        status: "active",
+      }),
+    })
+
+    expect(createRes.status).toBe(400)
+
+    const updateRes = await app.request("/supplier_1/contracts/contract_1", {
+      method: "PATCH",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        startDate: "2026-07-01",
+        endDate: "2026-12-31",
+        renewalDate: "2027-01-01",
+      }),
+    })
+
+    expect(updateRes.status).toBe(400)
+  })
+})

--- a/packages/suppliers-contracts/src/contracts.test.ts
+++ b/packages/suppliers-contracts/src/contracts.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { insertRateSchema, insertSupplierSchema, updateSupplierSchema } from "./index.js"
+import {
+  insertContractSchema,
+  insertRateSchema,
+  insertSupplierSchema,
+  updateContractSchema,
+  updateRateSchema,
+  updateSupplierSchema,
+} from "./index.js"
 
 describe("suppliers-contracts", () => {
   it("accepts a valid supplier and rejects an unknown type", () => {
@@ -55,6 +62,61 @@ describe("suppliers-contracts", () => {
         currency: "EURO",
         amountCents: 1000,
         unit: "per_person",
+      }).success,
+    ).toBe(false)
+  })
+
+  it("rejects reversed supplier rate date and pax ranges", () => {
+    const baseRate = {
+      name: "Standard",
+      currency: "EUR",
+      amountCents: 1000,
+      unit: "per_person",
+    } as const
+
+    expect(
+      insertRateSchema.safeParse({
+        ...baseRate,
+        validFrom: "2026-09-10",
+        validTo: "2026-09-01",
+      }).success,
+    ).toBe(false)
+    expect(
+      updateRateSchema.safeParse({ validFrom: "2026-09-10", validTo: "2026-09-01" }).success,
+    ).toBe(false)
+    expect(
+      insertRateSchema.safeParse({
+        ...baseRate,
+        minPax: 8,
+        maxPax: 2,
+      }).success,
+    ).toBe(false)
+    expect(updateRateSchema.safeParse({ minPax: 8, maxPax: 2 }).success).toBe(false)
+  })
+
+  it("rejects supplier contract term ranges and renewal dates outside the term", () => {
+    expect(
+      insertContractSchema.safeParse({
+        startDate: "2027-06-30",
+        endDate: "2026-07-01",
+      }).success,
+    ).toBe(false)
+    expect(
+      updateContractSchema.safeParse({ startDate: "2027-06-30", endDate: "2026-07-01" }),
+    ).toMatchObject({ success: false })
+
+    expect(
+      insertContractSchema.safeParse({
+        startDate: "2026-07-01",
+        endDate: "2026-12-31",
+        renewalDate: "2027-01-01",
+      }).success,
+    ).toBe(false)
+    expect(
+      insertContractSchema.safeParse({
+        startDate: "2026-07-01",
+        endDate: "2026-12-31",
+        renewalDate: "2026-06-30",
       }).success,
     ).toBe(false)
   })

--- a/packages/suppliers-contracts/src/validation.ts
+++ b/packages/suppliers-contracts/src/validation.ts
@@ -148,8 +148,34 @@ const rateCoreSchema = z.object({
   notes: z.string().optional().nullable(),
 })
 
-export const insertRateSchema = rateCoreSchema
-export const updateRateSchema = rateCoreSchema.partial()
+function validateRateRange(
+  data: {
+    validFrom?: string | null
+    validTo?: string | null
+    minPax?: number | null
+    maxPax?: number | null
+  },
+  ctx: z.RefinementCtx,
+) {
+  if (data.validFrom && data.validTo && data.validFrom > data.validTo) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["validTo"],
+      message: "validTo must be on or after validFrom",
+    })
+  }
+
+  if (data.minPax != null && data.maxPax != null && data.minPax > data.maxPax) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["maxPax"],
+      message: "maxPax must be greater than or equal to minPax",
+    })
+  }
+}
+
+export const insertRateSchema = rateCoreSchema.superRefine(validateRateRange)
+export const updateRateSchema = rateCoreSchema.partial().superRefine(validateRateRange)
 
 export type InsertRate = z.infer<typeof insertRateSchema>
 export type UpdateRate = z.infer<typeof updateRateSchema>
@@ -188,5 +214,38 @@ const contractCoreSchema = z.object({
   status: supplierContractStatusSchema.default("active"),
 })
 
-export const insertContractSchema = contractCoreSchema
-export const updateContractSchema = contractCoreSchema.partial()
+function validateContractTerm(
+  data: {
+    startDate?: string
+    endDate?: string | null
+    renewalDate?: string | null
+  },
+  ctx: z.RefinementCtx,
+) {
+  if (data.endDate && data.startDate && data.startDate > data.endDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["endDate"],
+      message: "endDate must be on or after startDate",
+    })
+  }
+
+  if (data.renewalDate && data.startDate && data.renewalDate < data.startDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["renewalDate"],
+      message: "renewalDate must be on or after startDate",
+    })
+  }
+
+  if (data.renewalDate && data.endDate && data.renewalDate > data.endDate) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["renewalDate"],
+      message: "renewalDate must be on or before endDate",
+    })
+  }
+}
+
+export const insertContractSchema = contractCoreSchema.superRefine(validateContractTerm)
+export const updateContractSchema = contractCoreSchema.partial().superRefine(validateContractTerm)


### PR DESCRIPTION
## Summary

- Reject supplier rate payloads where `validFrom` is after `validTo` or `minPax` is greater than `maxPax`.
- Reject supplier contract payloads where `startDate` is after `endDate`, and constrain renewal dates to the bounded contract term.
- Add supplier UI form validation and flag persisted invalid rate ranges in the supplier rate table.

Closes #2547.

## Validation

- `pnpm exec biome check --write ...changed files...`
- `pnpm --filter @voyant-travel/suppliers-contracts test -- src/contracts.test.ts`
- `pnpm --filter @voyant-travel/distribution test -- tests/suppliers/unit/routes-validation.test.ts`
- `pnpm --filter @voyant-travel/distribution-react test -- src/suppliers/i18n.test.tsx`
- `pnpm --filter @voyant-travel/suppliers-contracts typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/distribution typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/distribution-react typecheck`
- `pnpm --filter @voyant-travel/suppliers-contracts lint`
- `pnpm --filter @voyant-travel/distribution lint`
- `pnpm --filter @voyant-travel/distribution-react lint`
- `pnpm --filter @voyant-travel/openapi generate`
- `pnpm -C starters/operator generate:openapi`
- Commit hook: 186 affected lint/typecheck/build tasks passed
- Push hook: 98 test tasks passed

## Notes

- OpenAPI generators produced no spec diffs because the request shapes did not change; the new ordering rules are runtime refinements.
- DB integration tests remained gated/skipped when `TEST_DATABASE_URL` was not set; the new route validation tests run without a database.