### PR TITLE
Fix people nested identity routes

### DIFF
--- a/.changeset/people-nested-identity-routes.md
+++ b/.changeset/people-nested-identity-routes.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/relationships": patch
+---
+
+Allow People nested contact method and address creates to derive identity ownership from the route path, and reject creates for missing people.

--- a/packages/openapi/spec/admin/relationships.json
+++ b/packages/openapi/spec/admin/relationships.json
@@ -4669,16 +4669,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "kind": {
                     "type": "string",
                     "enum": [
@@ -4731,8 +4721,6 @@
                   }
                 },
                 "required": [
-                  "entityType",
-                  "entityId",
                   "kind",
                   "value"
                 ]
@@ -4826,6 +4814,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Person not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5030,16 +5036,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "label": {
                     "type": "string",
                     "enum": [
@@ -5132,11 +5128,7 @@
                     ],
                     "additionalProperties": {}
                   }
-                },
-                "required": [
-                  "entityType",
-                  "entityId"
-                ]
+                }
               }
             }
           }
@@ -5279,6 +5271,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Person not found",
             "content": {
               "application/json": {
                 "schema": {

--- a/packages/relationships/src/routes/accounts.ts
+++ b/packages/relationships/src/routes/accounts.ts
@@ -1,4 +1,6 @@
 /**
+ * agent-quality: file-size exception -- owner: relationships; existing accounts route surface stays co-located until route groups are split without changing mount order or OpenAPI output.
+ *
  * Relationships "accounts" admin routes — organizations, people, their notes,
  * contact methods, addresses, payment methods, communications, segments, and
  * the people CSV import/export. Migrated to `@hono/zod-openapi` for the OpenAPI
@@ -34,9 +36,7 @@ import {
 } from "@voyant-travel/hono"
 import {
   insertAddressForEntitySchema,
-  insertAddressSchema,
   insertContactPointForEntitySchema,
-  insertContactPointSchema,
   updateAddressSchema,
   updateContactPointSchema,
 } from "@voyant-travel/identity/validation"
@@ -99,9 +99,6 @@ type Env = {
 const organizationEntity = "organization" as const
 const personEntity = "person" as const
 
-/** The hydrated person read surface (base row + identity email/phone/website). */
-type HydratedPerson = z.infer<typeof personSchema>
-
 const jsonContent = <T extends z.ZodTypeAny>(schema: T) => ({
   content: { "application/json": { schema } },
 })
@@ -115,6 +112,11 @@ function mergeErrorResponse(c: Context<Env>, error: unknown) {
     return c.json({ error: error.message }, error.status)
   }
   throw error
+}
+
+function optionalHydratedPersonField(row: object, field: "email" | "phone" | "website") {
+  const value = Reflect.get(row, field)
+  return typeof value === "string" ? value : null
 }
 
 /**
@@ -586,13 +588,14 @@ const listPersonContactMethodsRoute = createRoute({
 const createPersonContactMethodRoute = createRoute({
   method: "post",
   path: "/people/{id}/contact-methods",
-  request: { params: idParamSchema, ...requiredJsonBody(insertContactPointSchema) },
+  request: { params: idParamSchema, ...requiredJsonBody(insertContactPointForEntitySchema) },
   responses: {
     201: {
       description: "The created contact method",
       ...jsonContent(z.object({ data: contactMethodSchema })),
     },
     400: { description: "invalid_request", ...jsonContent(errorResponseSchema) },
+    404: { description: "Person not found", ...jsonContent(errorResponseSchema) },
   },
 })
 
@@ -611,13 +614,14 @@ const listPersonAddressesRoute = createRoute({
 const createPersonAddressRoute = createRoute({
   method: "post",
   path: "/people/{id}/addresses",
-  request: { params: idParamSchema, ...requiredJsonBody(insertAddressSchema) },
+  request: { params: idParamSchema, ...requiredJsonBody(insertAddressForEntitySchema) },
   responses: {
     201: {
       description: "The created address",
       ...jsonContent(z.object({ data: addressSchema })),
     },
     400: { description: "invalid_request", ...jsonContent(errorResponseSchema) },
+    404: { description: "Person not found", ...jsonContent(errorResponseSchema) },
   },
 })
 
@@ -788,7 +792,13 @@ peopleRoutes
       )
       // The service always returns the hydrated survivor (email/phone/website);
       // the `?? row` fallback in the service only widens the static type.
-      return c.json({ data: row as unknown as HydratedPerson }, 200)
+      const data = {
+        ...row,
+        email: optionalHydratedPersonField(row, "email"),
+        phone: optionalHydratedPersonField(row, "phone"),
+        website: optionalHydratedPersonField(row, "website"),
+      }
+      return c.json({ data }, 200)
     } catch (error) {
       return mergeErrorResponse(c, error)
     }
@@ -819,7 +829,7 @@ peopleRoutes
       c.req.valid("param").id,
       c.req.valid("json"),
     )
-    return c.json({ data: row! }, 201)
+    return row ? c.json({ data: row }, 201) : c.json({ error: "Person not found" }, 404)
   })
   .openapi(listPersonAddressesRoute, async (c) =>
     c.json(
@@ -840,7 +850,7 @@ peopleRoutes
       c.req.valid("param").id,
       c.req.valid("json"),
     )
-    return c.json({ data: row! }, 201)
+    return row ? c.json({ data: row }, 201) : c.json({ error: "Person not found" }, 404)
   })
   .openapi(listPersonNotesRoute, async (c) =>
     c.json(

--- a/packages/relationships/src/service/accounts-people.ts
+++ b/packages/relationships/src/service/accounts-people.ts
@@ -88,6 +88,15 @@ async function organizationExists(db: PostgresJsDatabase, organizationId: string
   return Boolean(row)
 }
 
+async function personExists(db: PostgresJsDatabase, personId: string) {
+  const [row] = await db
+    .select({ id: people.id })
+    .from(people)
+    .where(eq(people.id, personId))
+    .limit(1)
+  return Boolean(row)
+}
+
 function buildPersonSearchCondition(
   db: PostgresJsDatabase,
   search: string,
@@ -295,6 +304,9 @@ export const peopleAccountsService = {
     if (entityType === "organization" && !(await organizationExists(db, entityId))) {
       return null
     }
+    if (entityType === "person" && !(await personExists(db, entityId))) {
+      return null
+    }
 
     return identityService.createContactPoint(db, {
       ...data,
@@ -326,6 +338,9 @@ export const peopleAccountsService = {
     data: CreateAddressInput | CreateAddressForEntityInput,
   ) {
     if (entityType === "organization" && !(await organizationExists(db, entityId))) {
+      return null
+    }
+    if (entityType === "person" && !(await personExists(db, entityId))) {
       return null
     }
 

--- a/packages/relationships/tests/integration/accounts-people.suite.ts
+++ b/packages/relationships/tests/integration/accounts-people.suite.ts
@@ -532,8 +532,6 @@ describe.skipIf(!DB_AVAILABLE)("People account routes", () => {
       const res = await getApp().request(`/people/${created.id}/contact-methods`, {
         method: "POST",
         ...json({
-          entityType: "organization",
-          entityId: "crm_org_wrong_000000000000000000",
           kind: "email",
           value: "nested.person@example.com",
           isPrimary: true,
@@ -547,6 +545,33 @@ describe.skipIf(!DB_AVAILABLE)("People account routes", () => {
         entityId: created.id,
         kind: "email",
         value: "nested.person@example.com",
+      })
+    })
+
+    it("derives nested contact method ownership from the person path", async () => {
+      const createRes = await getApp().request("/people", {
+        method: "POST",
+        ...json({ firstName: "Nested", lastName: "Owner" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/people/${created.id}/contact-methods`, {
+        method: "POST",
+        ...json({
+          entityType: "organization",
+          entityId: "crm_org_wrong_000000000000000000",
+          kind: "email",
+          value: "nested.owner@example.com",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        entityType: "person",
+        entityId: created.id,
+        kind: "email",
+        value: "nested.owner@example.com",
       })
     })
 

--- a/packages/relationships/tests/integration/accounts-people.suite.ts
+++ b/packages/relationships/tests/integration/accounts-people.suite.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: relationships; existing people route coverage stays co-located until account route suites are split by child resource.
 import { sql } from "drizzle-orm"
 import { describe, expect, it } from "vitest"
 
@@ -519,6 +520,94 @@ describe.skipIf(!DB_AVAILABLE)("People account routes", () => {
         method: "GET",
       })
       expect(res.status).toBe(404)
+    })
+
+    it("creates nested contact methods from the person path", async () => {
+      const createRes = await getApp().request("/people", {
+        method: "POST",
+        ...json({ firstName: "Nested", lastName: "Contact" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/people/${created.id}/contact-methods`, {
+        method: "POST",
+        ...json({
+          entityType: "organization",
+          entityId: "crm_org_wrong_000000000000000000",
+          kind: "email",
+          value: "nested.person@example.com",
+          isPrimary: true,
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        entityType: "person",
+        entityId: created.id,
+        kind: "email",
+        value: "nested.person@example.com",
+      })
+    })
+
+    it("creates nested addresses from natural person payloads", async () => {
+      const createRes = await getApp().request("/people", {
+        method: "POST",
+        ...json({ firstName: "Nested", lastName: "Address" }),
+      })
+      const { data: created } = await createRes.json()
+
+      const res = await getApp().request(`/people/${created.id}/addresses`, {
+        method: "POST",
+        ...json({
+          label: "billing",
+          line1: "20 Main Street",
+          city: "Cluj-Napoca",
+          country: "RO",
+        }),
+      })
+
+      expect(res.status).toBe(201)
+      const body = await res.json()
+      expect(body.data).toMatchObject({
+        entityType: "person",
+        entityId: created.id,
+        label: "billing",
+        line1: "20 Main Street",
+      })
+    })
+
+    it("rejects nested identity rows for missing people", async () => {
+      const { createTestDb } = await import("@voyant-travel/db/test-utils")
+      const db = createTestDb()
+      const missingPersonId = "pers_missing_nested_identity_0001"
+
+      const contactRes = await getApp().request(`/people/${missingPersonId}/contact-methods`, {
+        method: "POST",
+        ...json({ kind: "email", value: "missing.person@example.com" }),
+      })
+      const addressRes = await getApp().request(`/people/${missingPersonId}/addresses`, {
+        method: "POST",
+        ...json({ label: "billing", line1: "Missing Person Street" }),
+      })
+
+      expect(contactRes.status).toBe(404)
+      expect(addressRes.status).toBe(404)
+
+      const contactRows = await db.execute<{ count: number }>(sql`
+          SELECT count(*)::int
+          FROM identity_contact_points
+          WHERE entity_type = 'person'
+            AND entity_id = ${missingPersonId}
+        `)
+      const addressRows = await db.execute<{ count: number }>(sql`
+          SELECT count(*)::int
+          FROM identity_addresses
+          WHERE entity_type = 'person'
+            AND entity_id = ${missingPersonId}
+        `)
+      expect(contactRows[0]?.count).toBe(0)
+      expect(addressRows[0]?.count).toBe(0)
     })
 
     it("creates a person note", async () => {

--- a/starters/operator/openapi/admin/relationships.json
+++ b/starters/operator/openapi/admin/relationships.json
@@ -4669,16 +4669,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "kind": {
                     "type": "string",
                     "enum": [
@@ -4731,8 +4721,6 @@
                   }
                 },
                 "required": [
-                  "entityType",
-                  "entityId",
                   "kind",
                   "value"
                 ]
@@ -4826,6 +4814,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Person not found",
             "content": {
               "application/json": {
                 "schema": {
@@ -5030,16 +5036,6 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "entityType": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
-                  "entityId": {
-                    "type": "string",
-                    "minLength": 1,
-                    "maxLength": 100
-                  },
                   "label": {
                     "type": "string",
                     "enum": [
@@ -5132,11 +5128,7 @@
                     ],
                     "additionalProperties": {}
                   }
-                },
-                "required": [
-                  "entityType",
-                  "entityId"
-                ]
+                }
               }
             }
           }
@@ -5279,6 +5271,24 @@
           },
           "400": {
             "description": "invalid_request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Person not found",
             "content": {
               "application/json": {
                 "schema": {


### PR DESCRIPTION
## Summary

Fixes #2550.

- Derive People nested contact method/address ownership from the path instead of requiring `entityType` and `entityId` in the body.
- Reject nested People contact method/address creates when the path person does not exist, avoiding dangling identity rows.
- Add focused People route coverage for natural payloads, disagreeing body entity fields, and missing-person creates.
- Add a patch changeset for `@voyant-travel/relationships`.

## Checks

- `pnpm --filter @voyant-travel/relationships test -- tests/integration/accounts-people.suite.ts`
- `pnpm --filter @voyant-travel/relationships typecheck`
- `pnpm --filter @voyant-travel/relationships lint`
- `pnpm exec biome check packages/relationships/src/routes/accounts.ts packages/relationships/tests/integration/accounts-people.suite.ts .changeset/people-nested-identity-routes.md`
- `pnpm verify:agent-quality:changed`
- Commit hook affected checks: 186 successful tasks
- Push hook test lane: 98 successful tasks