### PR TITLE
Fix sourced package booking path

### DIFF
--- a/.changeset/sourced-package-booking.md
+++ b/.changeset/sourced-package-booking.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Thread sourced package booking drafts into Connect package quote/book parameters, including route, contact, and traveler details.

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -201,6 +201,7 @@ export {
   type CatalogBookingHoldPlaceBody,
   type CatalogBookingHoldReleaseBody,
   type CatalogBookingHoldTtlInput,
+  type CatalogBookingPrepareBookParametersInput,
   type CatalogBookingProvenance,
   type CatalogBookingProvenanceInput,
   type CatalogBookingQuoteBody,

--- a/packages/catalog/src/booking-engine/routes-contracts.ts
+++ b/packages/catalog/src/booking-engine/routes-contracts.ts
@@ -8,6 +8,7 @@ import type { BookEntityResult } from "./book.js"
 import type { OwnedBookingHandlerRegistry } from "./owned-handler.js"
 import type { QuoteEntityDeps, QuoteEntityResult } from "./quote.js"
 import type { SourceAdapterRegistry } from "./registry.js"
+import type { SelectCatalogQuote } from "./schema.js"
 import type { SnapshotContentCapturer } from "./snapshot-content.js"
 
 const recordSchema = z.record(z.string(), z.unknown())
@@ -139,6 +140,17 @@ export interface CatalogBookingBookTransformInput {
   result: BookEntityResult
 }
 
+export interface CatalogBookingPrepareBookParametersInput {
+  c: Context
+  db: AnyDrizzleDb
+  request: CatalogBookingBookBody
+  quoteId: string
+  quote?: SelectCatalogQuote
+  draftPayload?: Record<string, unknown>
+  provenance: CatalogBookingProvenance
+  parameters: Record<string, unknown>
+}
+
 export interface CatalogBookingDraftConsumedError {
   c: Context
   db: AnyDrizzleDb
@@ -184,6 +196,9 @@ export interface CatalogBookingRoutesOptions {
     db: AnyDrizzleDb
   }): QuoteEntityDeps["evaluatePromotions"]
   captureSnapshotContent?: SnapshotContentCapturer
+  prepareBookParameters?(
+    input: CatalogBookingPrepareBookParametersInput,
+  ): Promise<Record<string, unknown>> | Record<string, unknown>
   transformQuoteResult?(input: CatalogBookingQuoteTransformInput): Promise<QuoteEntityResult>
   transformBookResult?(input: CatalogBookingBookTransformInput): Promise<BookEntityResult>
   onDraftConsumedError?(event: CatalogBookingDraftConsumedError): void

--- a/packages/catalog/src/booking-engine/routes.test.ts
+++ b/packages/catalog/src/booking-engine/routes.test.ts
@@ -298,8 +298,12 @@ describe("createCatalogBookingRoutes", () => {
   it("books draft-first, forwards draft parameters, and reports draft consume races", async () => {
     vi.mocked(getBookingDraft).mockResolvedValue({
       id: "draft_1",
+      source_kind: "demo",
+      source_connection_id: "conn_demo",
+      source_ref: "upstream_1",
       current_quote_id: "quote_1",
       draft_payload: {
+        entity: { module: "products", id: "prod_1" },
         configure: {
           departureSlotId: "slot_1",
           pax: { adult: 2 },
@@ -353,7 +357,7 @@ describe("createCatalogBookingRoutes", () => {
           ratePlanId: "HOTEL:DZL1:BB",
           board: "BB",
         }),
-        adapterContext: { connection_id: "engine", correlation_id: "req_2" },
+        adapterContext: { connection_id: "conn_demo", correlation_id: "req_2" },
       }),
     )
     expect(onDraftConsumedError).toHaveBeenCalledWith(
@@ -411,6 +415,106 @@ describe("createCatalogBookingRoutes", () => {
     expect(releaseHold).toHaveBeenCalledWith(
       { db, adapterContext: { connection_id: "engine", correlation_id: "req_3" } },
       "hold_1",
+    )
+  })
+
+  it("maps sourced Connect package drafts to package confirm parameters", async () => {
+    vi.mocked(getBookingDraft).mockResolvedValue({
+      id: "draft_pkg",
+      source_kind: "voyant-connect",
+      source_connection_id: "conn_tui",
+      source_ref: "pkg_1",
+      current_quote_id: "quote_pkg",
+      draft_payload: {
+        entity: { module: "products", id: "pkg_1" },
+        configure: {
+          pax: { adult: 2 },
+          roomTypeId: "LCA20072:DZL1",
+          ratePlanId: "LCA20072:DZL1:AI",
+          board: "AI",
+        },
+        billing: {
+          contact: {
+            firstName: "Ada",
+            lastName: "Lovelace",
+            email: "ada@example.com",
+            phone: "+40 700 000 000",
+          },
+        },
+        travelers: [
+          {
+            firstName: "Ada",
+            lastName: "Lovelace",
+            band: "adult",
+            dateOfBirth: "1980-01-02",
+            email: "ada@example.com",
+            documents: { sex: "female", nationality: "RO" },
+            isPrimary: true,
+          },
+          {
+            firstName: "Grace",
+            lastName: "Hopper",
+            band: "adult",
+            dateOfBirth: "1981-03-04",
+            documents: { gender: "f" },
+          },
+        ],
+      },
+    } as never)
+    vi.mocked(bookEntity).mockResolvedValue({
+      bookingId: "booking_pkg",
+      orderRef: "package:book_1",
+      status: "held",
+      snapshotId: "snap_pkg",
+      pricing,
+    })
+    const { app } = createTestApp({ resolveCorrelationId: () => "req_pkg" })
+
+    const response = await app.request("/v1/public/catalog/book", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ draftId: "draft_pkg", idempotencyKey: "idem_package_1" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(bookEntity).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ registry }),
+      expect.objectContaining({
+        quoteId: "quote_pkg",
+        adapterContext: { connection_id: "conn_tui", correlation_id: "req_pkg" },
+        parameters: expect.objectContaining({
+          connectRoute: "packages",
+          roomTypeId: "LCA20072:DZL1",
+          ratePlanId: "LCA20072:DZL1:AI",
+          board: "AI",
+          contact: {
+            email: "ada@example.com",
+            phone: "+40 700 000 000",
+          },
+          leadTraveler: expect.objectContaining({
+            firstName: "Ada",
+            lastName: "Lovelace",
+            category: "adult",
+            dateOfBirth: "1980-01-02",
+            sex: "female",
+            nationality: "RO",
+            isPrimary: true,
+          }),
+          travelers: [
+            expect.objectContaining({
+              firstName: "Ada",
+              lastName: "Lovelace",
+              sex: "female",
+            }),
+            expect.objectContaining({
+              firstName: "Grace",
+              lastName: "Hopper",
+              sex: "female",
+            }),
+          ],
+        }),
+      }),
     )
   })
 })

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -20,6 +20,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { handleApiError, openApiValidationHook, RequestValidationError } from "@voyant-travel/hono"
 import type { HonoModule } from "@voyant-travel/hono/module"
+import { eq } from "drizzle-orm"
 import type { Context } from "hono"
 
 import type { SourceAdapterContext } from "../adapter/contract.js"
@@ -70,6 +71,7 @@ import {
   holdReleaseBodySchema,
   quoteBodySchema,
 } from "./routes-contracts.js"
+import { catalogQuotesTable, type SelectCatalogQuote } from "./schema.js"
 
 const DEFAULT_HOLD_TTL_MS = 30 * 60 * 1000
 
@@ -339,6 +341,7 @@ export type {
   CatalogBookingHoldPlaceBody,
   CatalogBookingHoldReleaseBody,
   CatalogBookingHoldTtlInput,
+  CatalogBookingPrepareBookParametersInput,
   CatalogBookingProvenance,
   CatalogBookingProvenanceInput,
   CatalogBookingQuoteBody,
@@ -438,7 +441,11 @@ async function handleQuote(
           market: body.scope?.market ?? "default",
           currency: body.scope?.currency,
         },
-        parameters: engineParametersFromDraft(body.parameters, body.draft),
+        parameters: engineParametersFromDraft(body.parameters, body.draft, {
+          entityModule: body.entityModule,
+          sourceKind: provenance.sourceKind,
+          sourceProvider: provenance.sourceProvider,
+        }),
         ttlMs: body.ttlMs,
         adapterContext,
       },
@@ -461,6 +468,7 @@ async function handleBook(
 
   let quoteId = body.quoteId
   let draftPayload: Record<string, unknown> | undefined
+  let draftProvenance: CatalogBookingProvenance | undefined
   // Load the draft whenever a draftId is present — even when the caller pins an
   // explicit `quoteId` — so its payload (selected departure/room/pax/travelers)
   // still feeds `engineParametersFromDraft`. An explicit `quoteId` only overrides
@@ -470,6 +478,11 @@ async function handleBook(
     const draft = await getBookingDraft(db, body.draftId)
     if (draft) {
       draftPayload = draft.draft_payload
+      draftProvenance = {
+        sourceKind: draft.source_kind,
+        sourceConnectionId: draft.source_connection_id ?? undefined,
+        sourceRef: draft.source_ref ?? undefined,
+      }
       if (!quoteId) {
         if (!draft.current_quote_id) {
           return c.json({ error: "draft has no current quote - call /quote first" }, 409)
@@ -486,10 +499,17 @@ async function handleBook(
   }
 
   try {
+    const quoteForBook =
+      options.prepareBookParameters || !draftProvenance
+        ? await loadQuoteForBook(db, quoteId)
+        : undefined
+    const provenance = draftProvenance ??
+      quoteToBookProvenance(quoteForBook) ?? { sourceKind: "engine" }
     const adapterContext = resolveAdapterContext(c, options, {
       db,
       operation: "book",
-      sourceKind: "engine",
+      sourceKind: provenance.sourceKind,
+      sourceConnectionId: provenance.sourceConnectionId,
       correlationId,
     })
     const result = await bookEntity(
@@ -504,10 +524,14 @@ async function handleBook(
         bookingId: body.bookingId,
         party: body.party,
         paymentIntent: body.paymentIntent,
-        parameters: engineParametersFromDraft(
-          body.parameters,
-          draftPayload ?? body.parameters?.draft,
-        ),
+        parameters: await prepareBookParameters(c, options, {
+          db,
+          body,
+          quoteId,
+          quote: quoteForBook,
+          draftPayload,
+          provenance,
+        }),
         idempotencyKey: body.idempotencyKey,
         adapterContext,
         contentScope: options.resolveContentScope?.({ c, db, body, draftPayload }),
@@ -534,6 +558,70 @@ async function handleBook(
     return c.json(serializeBookResult(transformed))
   } catch (err) {
     return bookingEngineErrorResponse(c, err)
+  }
+}
+
+async function prepareBookParameters(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+  input: {
+    db: AnyDrizzleDb
+    body: CatalogBookingBookBody
+    quoteId: string
+    quote?: SelectCatalogQuote
+    draftPayload?: Record<string, unknown>
+    provenance: CatalogBookingProvenance
+  },
+): Promise<Record<string, unknown>> {
+  const parameters = engineParametersFromDraft(
+    input.body.parameters,
+    input.draftPayload ?? input.body.parameters?.draft,
+    {
+      entityModule: input.draftPayload
+        ? (stringValue(asRecord(input.draftPayload)?.entity_module) ??
+          stringValue(asRecord(asRecord(input.draftPayload)?.entity)?.module) ??
+          undefined)
+        : undefined,
+      sourceKind: input.provenance.sourceKind,
+      sourceProvider: input.provenance.sourceProvider,
+    },
+  )
+
+  return (
+    (await options.prepareBookParameters?.({
+      c,
+      db: input.db,
+      request: input.body,
+      quoteId: input.quoteId,
+      quote: input.quote,
+      draftPayload: input.draftPayload,
+      provenance: input.provenance,
+      parameters,
+    })) ?? parameters
+  )
+}
+
+async function loadQuoteForBook(
+  db: AnyDrizzleDb,
+  quoteId: string,
+): Promise<SelectCatalogQuote | undefined> {
+  const rows = (await db
+    .select()
+    .from(catalogQuotesTable)
+    .where(eq(catalogQuotesTable.id, quoteId))
+    .limit(1)) as SelectCatalogQuote[]
+  return rows[0]
+}
+
+function quoteToBookProvenance(
+  quote: SelectCatalogQuote | undefined,
+): CatalogBookingProvenance | undefined {
+  if (!quote) return undefined
+  return {
+    sourceKind: quote.source_kind,
+    sourceProvider: quote.source_provider ?? undefined,
+    sourceConnectionId: quote.source_connection_id ?? undefined,
+    sourceRef: quote.source_ref ?? undefined,
   }
 }
 
@@ -729,6 +817,11 @@ function defaultAudienceForPath(c: Context): "staff" | "customer" {
 function engineParametersFromDraft(
   parameters: Record<string, unknown> | undefined,
   draftPayload: unknown,
+  context: {
+    entityModule?: string
+    sourceKind?: string
+    sourceProvider?: string
+  } = {},
 ): Record<string, unknown> {
   const draft = asRecord(draftPayload)
   const configure = asRecord(draft?.configure)
@@ -759,8 +852,130 @@ function engineParametersFromDraft(
   if (promotionCode && next.promotionCode == null) {
     next.promotionCode = promotionCode
   }
+  applyConnectPackageConfirmParameters(next, draft, context)
 
   return next
+}
+
+function applyConnectPackageConfirmParameters(
+  parameters: Record<string, unknown>,
+  draft: Record<string, unknown> | undefined,
+  context: { entityModule?: string; sourceKind?: string },
+): void {
+  if (!draft || !isConnectPackageCandidate(parameters, draft, context)) return
+
+  if (parameters.connectRoute == null) parameters.connectRoute = "packages"
+
+  const billing = asRecord(draft.billing)
+  const contact = asRecord(billing?.contact)
+  const mappedContact = mapPackageContact(contact)
+  if (mappedContact && parameters.contact == null) parameters.contact = mappedContact
+
+  const travelers = mapPackageTravelers(draft.travelers, contact)
+  if (travelers.length === 0) return
+  if (parameters.travelers == null) parameters.travelers = travelers
+  if (parameters.leadTraveler == null) {
+    parameters.leadTraveler =
+      travelers.find((traveler) => traveler.isPrimary === true) ?? travelers[0]
+  }
+}
+
+function isConnectPackageCandidate(
+  parameters: Record<string, unknown>,
+  draft: Record<string, unknown>,
+  context: { entityModule?: string; sourceKind?: string },
+): boolean {
+  if (parameters.connectRoute === "packages") return true
+  if (context.sourceKind !== "voyant-connect") return false
+  const entityModule = context.entityModule ?? stringValue(asRecord(draft.entity)?.module)
+  if (entityModule !== "products") return false
+  const configure = asRecord(draft.configure)
+  return Boolean(
+    stringValue(configure?.roomTypeId) ||
+      stringValue(configure?.ratePlanId) ||
+      stringValue(configure?.board),
+  )
+}
+
+function mapPackageContact(
+  contact: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const email = stringValue(contact?.email)
+  const phone = stringValue(contact?.phone)
+  if (!email && !phone) return undefined
+  return {
+    ...(email ? { email } : {}),
+    ...(phone ? { phone } : {}),
+  }
+}
+
+function mapPackageTravelers(
+  travelersValue: unknown,
+  fallbackContact: Record<string, unknown> | undefined,
+): Array<Record<string, unknown>> {
+  const travelers = Array.isArray(travelersValue) ? travelersValue : []
+  const mapped = travelers
+    .map((value, index) => mapPackageTraveler(asRecord(value), index))
+    .filter((value): value is Record<string, unknown> => value !== undefined)
+  if (mapped.length > 0) return mapped
+
+  const firstName = stringValue(fallbackContact?.firstName)
+  const lastName = stringValue(fallbackContact?.lastName)
+  if (!firstName || !lastName) return []
+  return [
+    {
+      category: "adult",
+      firstName,
+      lastName,
+      ...(stringValue(fallbackContact?.email)
+        ? { email: stringValue(fallbackContact?.email) }
+        : {}),
+      ...(stringValue(fallbackContact?.phone)
+        ? { phone: stringValue(fallbackContact?.phone) }
+        : {}),
+      isPrimary: true,
+    },
+  ]
+}
+
+function mapPackageTraveler(
+  traveler: Record<string, unknown> | undefined,
+  index: number,
+): Record<string, unknown> | undefined {
+  const firstName = stringValue(traveler?.firstName)
+  const lastName = stringValue(traveler?.lastName)
+  if (!firstName || !lastName) return undefined
+  const documents = asRecord(traveler?.documents)
+  return {
+    category: packageTravelerCategory(stringValue(traveler?.band)),
+    firstName,
+    lastName,
+    ...(stringValue(traveler?.dateOfBirth)
+      ? { dateOfBirth: stringValue(traveler?.dateOfBirth) }
+      : {}),
+    ...(packageTravelerSex(stringValue(documents?.sex) ?? stringValue(documents?.gender))
+      ? { sex: packageTravelerSex(stringValue(documents?.sex) ?? stringValue(documents?.gender)) }
+      : {}),
+    ...(stringValue(documents?.title) ? { title: stringValue(documents?.title) } : {}),
+    ...(stringValue(documents?.nationality)
+      ? { nationality: stringValue(documents?.nationality) }
+      : {}),
+    ...(stringValue(traveler?.email) ? { email: stringValue(traveler?.email) } : {}),
+    ...(stringValue(traveler?.phone) ? { phone: stringValue(traveler?.phone) } : {}),
+    isPrimary: traveler?.isPrimary === true || index === 0,
+  }
+}
+
+function packageTravelerCategory(value: string | null): "adult" | "child" | "infant" | "senior" {
+  if (value === "child" || value === "infant" || value === "senior") return value
+  return "adult"
+}
+
+function packageTravelerSex(value: string | null): "male" | "female" | "unspecified" | undefined {
+  if (value === "male" || value === "female" || value === "unspecified") return value
+  if (value === "m") return "male"
+  if (value === "f") return "female"
+  return undefined
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {

--- a/starters/operator/src/api/runtime/catalog-booking-runtime.package-hold.test.ts
+++ b/starters/operator/src/api/runtime/catalog-booking-runtime.package-hold.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  capturedOptions: { current: undefined as unknown },
+  lockPackage: vi.fn(async () => ({ id: "hold_pkg_1" })),
+}))
+
+vi.mock("@voyant-travel/catalog/booking-engine", async () => {
+  const actual = await vi.importActual<typeof import("@voyant-travel/catalog/booking-engine")>(
+    "@voyant-travel/catalog/booking-engine",
+  )
+  return {
+    ...actual,
+    mountCatalogBookingRoutes: vi.fn((_hono, options) => {
+      mocks.capturedOptions.current = options
+    }),
+  }
+})
+
+vi.mock("@voyant-travel/connect-sdk", () => ({
+  createVoyantConnectClient: vi.fn(() => ({
+    packages: {
+      lock: mocks.lockPackage,
+    },
+  })),
+}))
+
+vi.mock("@voyant-travel/plugin-voyant-connect", async () => {
+  const actual = await vi.importActual<typeof import("@voyant-travel/plugin-voyant-connect")>(
+    "@voyant-travel/plugin-voyant-connect",
+  )
+  return {
+    ...actual,
+    resolveVoyantConnectEnv: vi.fn(() => ({
+      apiKey: ["connect", "key"].join("_"),
+      operatorId: "operator_1",
+      baseUrl: "https://connect.test",
+    })),
+  }
+})
+
+import { mountCatalogBookingRoutes } from "./catalog-booking-runtime"
+
+describe("operator Connect package hold preparation", () => {
+  it("locks stored package offers that do not include hold status", async () => {
+    mountCatalogBookingRoutes({} as never)
+    const options = mocks.capturedOptions.current as {
+      booking: {
+        prepareBookParameters: (input: unknown) => Promise<Record<string, unknown>>
+      }
+    }
+    const offer = {
+      id: "offer_pkg_1",
+      connectionId: "conn_1",
+      supplierId: "supplier_1",
+      productRef: { id: "product_1" },
+      stay: { checkIn: "2026-08-01", checkOut: "2026-08-08" },
+      flights: [],
+      pricing: { currency: "EUR", total: 120000 },
+      cancellationPolicy: { refundable: false },
+      expiresAt: "2026-07-03T12:00:00.000Z",
+    }
+
+    const next = await options.booking.prepareBookParameters({
+      c: { env: {} },
+      parameters: { connectRoute: "packages" },
+      provenance: {
+        sourceKind: "voyant-connect",
+        sourceConnectionId: "conn_1",
+      },
+      quote: {
+        upstream_payload: { offer },
+      },
+    })
+
+    expect(mocks.lockPackage).toHaveBeenCalledWith("conn_1", offer)
+    expect(next.holdId).toBe("hold_pkg_1")
+  })
+})

--- a/starters/operator/src/api/runtime/catalog-booking-runtime.ts
+++ b/starters/operator/src/api/runtime/catalog-booking-runtime.ts
@@ -4,6 +4,7 @@ import {
   type CatalogBookingBookBody,
   type CatalogBookingCommittedEvent,
   type CatalogBookingMountTarget,
+  type CatalogBookingPrepareBookParametersInput,
   type CatalogBookingRouteModuleOptions,
   type CatalogBookingRoutesOptions,
   catalogQuotesTable,
@@ -14,6 +15,7 @@ import {
   type SlotRow,
 } from "@voyant-travel/catalog/booking-engine"
 import { createCatalogPromotionEvaluator } from "@voyant-travel/commerce"
+import { createVoyantConnectClient, type PackageOffer } from "@voyant-travel/connect-sdk"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { newId } from "@voyant-travel/db/lib/typeid"
 import { suppliers } from "@voyant-travel/distribution"
@@ -22,6 +24,7 @@ import { products, productsService } from "@voyant-travel/inventory"
 import { getProductContent } from "@voyant-travel/inventory/service-content"
 import { availabilitySlots } from "@voyant-travel/operations"
 import { resolveBookingTaxSettings } from "@voyant-travel/operator-settings"
+import { resolveVoyantConnectEnv } from "@voyant-travel/plugin-voyant-connect"
 import { and, asc, eq, gte } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -71,6 +74,7 @@ function createOperatorCatalogBookingRoutesOptions(): CatalogBookingRoutesOption
         },
       })
     },
+    prepareBookParameters: prepareConnectPackageBookParameters,
     onCommitted: materializeSourcedBookingForCatalogCommit,
     onDraftConsumedError: ({ error }) => {
       console.warn("[catalog-booking] markDraftConsumed failed:", error)
@@ -205,6 +209,66 @@ export function buildSourcedBookingRows({
       },
     },
   }
+}
+
+async function prepareConnectPackageBookParameters({
+  c,
+  parameters,
+  provenance,
+  quote,
+}: CatalogBookingPrepareBookParametersInput): Promise<Record<string, unknown>> {
+  if (parameters.connectRoute !== "packages") return parameters
+  if (stringValue(parameters.holdId)) return parameters
+  if (provenance.sourceKind !== "voyant-connect" || !provenance.sourceConnectionId) {
+    return parameters
+  }
+
+  const offer = readPackageOffer(quote?.upstream_payload)
+  if (!offer) return parameters
+
+  const config = resolveVoyantConnectEnv(c.env as Record<string, string | undefined>, {
+    warn: (message) => console.warn(`[catalog-booking] ${message}`),
+  })
+  if (!config) return parameters
+
+  const client = createVoyantConnectClient({
+    apiKey: config.apiKey,
+    operatorId: config.operatorId,
+    baseUrl: config.baseUrl,
+  })
+  const hold = await client.packages.lock(provenance.sourceConnectionId, offer)
+  return {
+    ...parameters,
+    holdId: hold.id,
+  }
+}
+
+function readPackageOffer(value: unknown): PackageOffer | undefined {
+  const payload = asRecord(value)
+  const offer = asRecord(payload?.offer) ?? payload
+  return isPackageOffer(offer) ? offer : undefined
+}
+
+function isPackageOffer(value: unknown): value is PackageOffer {
+  const offer = asRecord(value)
+  if (!offer) return false
+  if (
+    !stringValue(offer.id) ||
+    !stringValue(offer.connectionId) ||
+    !stringValue(offer.supplierId)
+  ) {
+    return false
+  }
+  if (!asRecord(offer.productRef) || !asRecord(offer.stay) || !Array.isArray(offer.flights)) {
+    return false
+  }
+  if (!asRecord(offer.pricing) || !asRecord(offer.cancellationPolicy)) {
+    return false
+  }
+  if (!stringValue(offer.expiresAt)) {
+    return false
+  }
+  return true
 }
 
 function bookingStatusForSourcedResult(

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { buildStorefrontCommitParty } from "./storefront-booking-journey"
+
+describe("buildStorefrontCommitParty", () => {
+  it("keeps billing contact and traveler details for sourced reserve", () => {
+    const party = buildStorefrontCommitParty({
+      entity: { module: "products", id: "pkg_1", sourceKind: "" },
+      configure: { pax: { adult: 1 } },
+      billing: {
+        buyerType: "B2C",
+        contact: {
+          firstName: "Ada",
+          lastName: "Lovelace",
+          email: "ada@example.com",
+          phone: "+40 700 000 000",
+          personId: "person_1",
+        },
+        address: {},
+      },
+      travelers: [
+        {
+          firstName: "Ada",
+          lastName: "Lovelace",
+          band: "adult",
+          dateOfBirth: "1980-01-02",
+          documents: { sex: "female" },
+          isPrimary: true,
+        },
+      ],
+      addons: [],
+      payment: { intent: "hold" },
+    })
+
+    expect(party).toMatchObject({
+      personId: "person_1",
+      billing: {
+        personId: "person_1",
+        contact: {
+          firstName: "Ada",
+          lastName: "Lovelace",
+          email: "ada@example.com",
+          phone: "+40 700 000 000",
+        },
+      },
+      travelerParty: {
+        travelers: [
+          {
+            firstName: "Ada",
+            lastName: "Lovelace",
+            dateOfBirth: "1980-01-02",
+            band: "adult",
+            documents: { sex: "female" },
+            isPrimary: true,
+          },
+        ],
+      },
+    })
+  })
+})

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -22,6 +22,7 @@ import {
   type BookingJourneyCheckoutContext,
   type BookingJourneyProps,
   type ContractAcceptanceEvent,
+  type Draft,
 } from "@voyant-travel/bookings-react/journey"
 import {
   computePaymentSchedule,
@@ -190,6 +191,7 @@ export function StorefrontBookingJourney({
         body: JSON.stringify({
           draftId,
           quoteId: context.quoteId,
+          party: buildStorefrontCommitParty(context.draft),
           paymentIntent: { type: "hold" },
           idempotencyKey,
         }),
@@ -419,6 +421,40 @@ function checkoutIntentFromDraft(
 ): "card" | "bank_transfer" | "hold" | "inquiry" {
   if (intent === "card" || intent === "bank_transfer" || intent === "inquiry") return intent
   return "hold"
+}
+
+export function buildStorefrontCommitParty(draft: Draft): Record<string, unknown> {
+  const contact = draft.billing.contact
+  const personId = draft.billing.buyerType === "B2C" ? contact.personId : undefined
+  const organizationId =
+    draft.billing.buyerType === "B2B" ? draft.billing.organizationId : undefined
+  return {
+    personId,
+    organizationId,
+    billing: {
+      personId,
+      organizationId,
+      contact: {
+        firstName: contact.firstName,
+        lastName: contact.lastName,
+        email: contact.email,
+        phone: contact.phone,
+      },
+    },
+    travelerParty: {
+      travelers: draft.travelers.map((traveler) => ({
+        personId: traveler.personId,
+        firstName: traveler.firstName,
+        lastName: traveler.lastName,
+        email: traveler.email,
+        phone: traveler.phone,
+        dateOfBirth: traveler.dateOfBirth,
+        band: traveler.band,
+        documents: traveler.documents,
+        isPrimary: traveler.isPrimary,
+      })),
+    },
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes #2847.

## Summary
- Preserve sourced Connect provenance through quote/book adapter context.
- Map sourced package checkout data into Connect package confirm parameters, including travelers, lead traveler, contact, and `connectRoute: "packages"`.
- Add an operator prepare hook that creates a Connect package lock from the quoted offer before booking.
- Send storefront checkout party details to public catalog booking.

## Coordination
- Depends on connect#101 shipping with this change; the published Connect adapter does not yet route `connectRoute: "packages"` reserves to the package confirmation path.
- ProTravel does not consume this starter runtime. After package publish, ProTravel needs a follow-up to add the equivalent `prepareBookParameters` hook in its catalog booking composition and bump the `@voyant-travel/catalog` / `@voyant-travel/connect-adapter` overrides.

## Verification
- `pnpm exec biome check ...` on touched files
- `pnpm --filter @voyant-travel/catalog typecheck`
- `pnpm --filter @voyant-travel/catalog build`
- `pnpm --filter @voyant-travel/catalog test -- routes.test.ts`
- `pnpm --filter operator test -- src/api/runtime/catalog-booking-runtime.package-hold.test.ts`
- `pnpm --filter operator test -- src/api/runtime/catalog-booking-runtime.package-hold.test.ts src/api/runtime/catalog-booking-runtime.test.ts`
- `pnpm --filter operator test -- src/components/voyant/booking-journey/storefront-booking-journey.test.ts src/api/runtime/catalog-booking-runtime.test.ts`
- `pnpm exec tsc -p tsconfig.server.json && pnpm exec tsc -p tsconfig.client.json` in `starters/operator`
- `pnpm verify:agent-quality:changed`
- Commit hook: 186/186 tasks successful
- Push hook: 98/98 tasks successful