### PR TITLE
Validate promotion product scopes

### DIFF
--- a/.changeset/promotion-product-scope-validation.md
+++ b/.changeset/promotion-product-scope-validation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/commerce": patch
+---
+
+Validate promotion product scopes against real products before creating or updating offers, preventing dangling `promotional_offer_products` rows for unknown product ids.

--- a/packages/commerce/src/promotions/index.ts
+++ b/packages/commerce/src/promotions/index.ts
@@ -1,10 +1,10 @@
 import type { Module } from "@voyant-travel/core"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
-import { promotionsRoutes } from "./routes.js"
+import { createPromotionsRoutes, type PromotionsRoutesOptions, promotionsRoutes } from "./routes.js"
 import { bulkReindexProductsWorkflow, promotionAffectedAllFilter } from "./workflow-bulk-reindex.js"
 
-export type { PromotionsRoutes } from "./routes.js"
+export type { PromotionsRoutes, PromotionsRoutesOptions } from "./routes.js"
 
 export const promotionsModule: Module = {
   name: "promotions",
@@ -15,6 +15,13 @@ export const promotionsModule: Module = {
 export const promotionsHonoModule: HonoModule = {
   module: promotionsModule,
   adminRoutes: promotionsRoutes,
+}
+
+export function createPromotionsHonoModule(options?: PromotionsRoutesOptions): HonoModule {
+  return {
+    module: promotionsModule,
+    adminRoutes: createPromotionsRoutes(options),
+  }
 }
 
 export {
@@ -41,6 +48,7 @@ export {
   type OfferMutationRuntime,
   type PromotionsService,
   promotionsService,
+  type ResolveExistingPromotionalOfferProductIds,
   recomputeOfferLinks,
   resolveScopeProductIds,
 } from "./service.js"

--- a/packages/commerce/src/promotions/routes.ts
+++ b/packages/commerce/src/promotions/routes.ts
@@ -13,7 +13,7 @@ import { openApiValidationHook } from "@voyant-travel/hono"
 import { apiErrorSchema, listResponseSchema } from "@voyant-travel/types"
 
 import { type Env, notFound } from "./routes-shared.js"
-import { promotionsService } from "./service.js"
+import { type OfferMutationRuntime, promotionsService } from "./service.js"
 import {
   insertPromotionalOfferSchema,
   promotionalOfferListQuerySchema,
@@ -24,6 +24,12 @@ import {
 const errorResponseSchema = z.object({ error: z.string() })
 const offerResponseSchema = z.object({ data: promotionalOfferSchema })
 const idParamSchema = z.object({ id: z.string() })
+
+export type PromotionsMutationRuntimeOptions = Omit<OfferMutationRuntime, "eventBus" | "source">
+
+export interface PromotionsRoutesOptions {
+  mutationRuntime?: PromotionsMutationRuntimeOptions
+}
 
 const listPromotionsRoute = createRoute({
   method: "get",
@@ -59,6 +65,10 @@ const createPromotionRoute = createRoute({
     201: {
       description: "The created promotional offer",
       content: { "application/json": { schema: offerResponseSchema } },
+    },
+    400: {
+      description: "invalid_reference: product-scoped offer references unknown product ids",
+      content: { "application/json": { schema: apiErrorSchema } },
     },
     409: {
       description: "Active promotional offer slug or code already exists",
@@ -109,6 +119,10 @@ const updatePromotionRoute = createRoute({
       description: "Promotional offer not found",
       content: { "application/json": { schema: errorResponseSchema } },
     },
+    400: {
+      description: "invalid_reference: product-scoped offer references unknown product ids",
+      content: { "application/json": { schema: apiErrorSchema } },
+    },
     409: {
       description: "Active promotional offer slug or code already exists",
       content: { "application/json": { schema: apiErrorSchema } },
@@ -152,53 +166,62 @@ const deletePromotionRoute = createRoute({
   },
 })
 
-export const promotionsRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
-  .openapi(listPromotionsRoute, async (c) =>
-    c.json(await promotionsService.listOffers(c.get("db"), c.req.valid("query"))),
-  )
-  .openapi(createPromotionRoute, async (c) =>
-    c.json(
-      {
-        data: await promotionsService.createOffer(c.get("db"), c.req.valid("json"), {
-          eventBus: c.get("eventBus"),
-        }),
-      },
-      201,
-    ),
-  )
-  .openapi(getPromotionRoute, async (c) => {
-    const offer = await promotionsService.getOfferById(c.get("db"), c.req.valid("param").id)
-    return offer ? c.json({ data: offer }, 200) : notFound(c, "Promotional offer not found")
-  })
-  .openapi(updatePromotionRoute, async (c) => {
-    const offer = await promotionsService.updateOffer(
-      c.get("db"),
-      c.req.valid("param").id,
-      c.req.valid("json"),
-      { eventBus: c.get("eventBus") },
+export function createPromotionsRoutes(options: PromotionsRoutesOptions = {}) {
+  const mutationRuntime = options.mutationRuntime ?? {}
+
+  return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+    .openapi(listPromotionsRoute, async (c) =>
+      c.json(await promotionsService.listOffers(c.get("db"), c.req.valid("query"))),
     )
-    return offer ? c.json({ data: offer }, 200) : notFound(c, "Promotional offer not found")
-  })
-  .openapi(archivePromotionRoute, async (c) => {
-    const offer = await promotionsService.archiveOffer(c.get("db"), c.req.valid("param").id, {
-      eventBus: c.get("eventBus"),
+    .openapi(createPromotionRoute, async (c) =>
+      c.json(
+        {
+          data: await promotionsService.createOffer(c.get("db"), c.req.valid("json"), {
+            ...mutationRuntime,
+            eventBus: c.get("eventBus"),
+          }),
+        },
+        201,
+      ),
+    )
+    .openapi(getPromotionRoute, async (c) => {
+      const offer = await promotionsService.getOfferById(c.get("db"), c.req.valid("param").id)
+      return offer ? c.json({ data: offer }, 200) : notFound(c, "Promotional offer not found")
     })
-    return offer ? c.json({ data: offer }, 200) : notFound(c, "Promotional offer not found")
-  })
-  .openapi(deletePromotionRoute, async (c) => {
-    try {
-      const result = await promotionsService.deleteOffer(c.get("db"), c.req.valid("param").id, {
+    .openapi(updatePromotionRoute, async (c) => {
+      const offer = await promotionsService.updateOffer(
+        c.get("db"),
+        c.req.valid("param").id,
+        c.req.valid("json"),
+        { ...mutationRuntime, eventBus: c.get("eventBus") },
+      )
+      return offer ? c.json({ data: offer }, 200) : notFound(c, "Promotional offer not found")
+    })
+    .openapi(archivePromotionRoute, async (c) => {
+      const offer = await promotionsService.archiveOffer(c.get("db"), c.req.valid("param").id, {
+        ...mutationRuntime,
         eventBus: c.get("eventBus"),
       })
-      return result ? c.json({ data: result }, 200) : notFound(c, "Promotional offer not found")
-    } catch (err) {
-      // `deleteOffer` throws when redemptions exist (the FK RESTRICT
-      // would otherwise surface a less helpful error). Translate to 409.
-      if (err instanceof Error && err.message.includes("redemption(s) exist")) {
-        return c.json({ error: err.message }, 409)
+      return offer ? c.json({ data: offer }, 200) : notFound(c, "Promotional offer not found")
+    })
+    .openapi(deletePromotionRoute, async (c) => {
+      try {
+        const result = await promotionsService.deleteOffer(c.get("db"), c.req.valid("param").id, {
+          ...mutationRuntime,
+          eventBus: c.get("eventBus"),
+        })
+        return result ? c.json({ data: result }, 200) : notFound(c, "Promotional offer not found")
+      } catch (err) {
+        // `deleteOffer` throws when redemptions exist (the FK RESTRICT
+        // would otherwise surface a less helpful error). Translate to 409.
+        if (err instanceof Error && err.message.includes("redemption(s) exist")) {
+          return c.json({ error: err.message }, 409)
+        }
+        throw err
       }
-      throw err
-    }
-  })
+    })
+}
+
+export const promotionsRoutes = createPromotionsRoutes()
 
 export type PromotionsRoutes = typeof promotionsRoutes

--- a/packages/commerce/src/promotions/service-product-scope-validation.test.ts
+++ b/packages/commerce/src/promotions/service-product-scope-validation.test.ts
@@ -1,0 +1,175 @@
+import type { ApiHttpError } from "@voyant-travel/hono"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+
+import { type PromotionalOffer, promotionalOfferProducts, promotionalOffers } from "./schema.js"
+import { promotionsService } from "./service.js"
+import type { InsertPromotionalOffer, UpdatePromotionalOffer } from "./validation.js"
+
+const baseOffer: InsertPromotionalOffer = {
+  name: "Product sale",
+  slug: "product-sale",
+  discountType: "percentage",
+  discountPercent: 10,
+  discountAmountCents: null,
+  currency: null,
+  scope: { kind: "products", productIds: ["prod_valid"] },
+  conditions: {},
+  code: null,
+  stackable: false,
+  active: true,
+}
+
+const persistedOffer: PromotionalOffer = {
+  id: "pofr_test",
+  name: baseOffer.name,
+  slug: baseOffer.slug,
+  description: null,
+  discountType: "percentage",
+  discountPercent: "10",
+  discountAmountCents: null,
+  currency: null,
+  scope: baseOffer.scope,
+  conditions: {},
+  validFrom: null,
+  validUntil: null,
+  code: null,
+  stackable: false,
+  active: true,
+  metadata: null,
+  createdAt: new Date("2026-01-01T00:00:00.000Z"),
+  updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+}
+
+interface FakeDbCalls {
+  offerInserts: unknown[]
+  offerUpdates: unknown[]
+  linkDeletes: number
+  linkInserts: unknown[]
+}
+
+function createPromotionDb(options: {
+  existingProductIds: string[]
+  selectedOffer?: PromotionalOffer | null
+}) {
+  const calls: FakeDbCalls = {
+    offerInserts: [],
+    offerUpdates: [],
+    linkDeletes: 0,
+    linkInserts: [],
+  }
+
+  const db = Object.assign(Object.create(null) as PostgresJsDatabase, {
+    execute: async () => options.existingProductIds.map((id) => ({ id })),
+    insert: (table: unknown) => ({
+      values: (values: unknown) => {
+        if (table === promotionalOffers) {
+          calls.offerInserts.push(values)
+          return {
+            returning: async () => [
+              { ...persistedOffer, ...(values as Partial<PromotionalOffer>) },
+            ],
+          }
+        }
+        if (table === promotionalOfferProducts) {
+          calls.linkInserts.push(...(Array.isArray(values) ? values : [values]))
+        }
+        return {}
+      },
+    }),
+    delete: (table: unknown) => ({
+      where: async () => {
+        if (table === promotionalOfferProducts) calls.linkDeletes += 1
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (options.selectedOffer === undefined ? [] : [options.selectedOffer]),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: (values: unknown) => ({
+        where: () => ({
+          returning: async () => {
+            calls.offerUpdates.push(values)
+            return [{ ...persistedOffer, ...(values as Partial<PromotionalOffer>) }]
+          },
+        }),
+      }),
+    }),
+  })
+
+  return { db, calls }
+}
+
+function productOffer(productIds: string[]): InsertPromotionalOffer {
+  return {
+    ...baseOffer,
+    scope: { kind: "products", productIds },
+  }
+}
+
+describe("promotionsService product scope validation", () => {
+  it("rejects unknown product ids before inserting offers or materialized links", async () => {
+    const { db, calls } = createPromotionDb({ existingProductIds: ["prod_valid"] })
+
+    await expect(
+      promotionsService.createOffer(db, productOffer(["prod_valid", "prod_missing"])),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_reference",
+      details: {
+        field: "scope.productIds",
+        missingProductIds: ["prod_missing"],
+      },
+    } satisfies Partial<ApiHttpError>)
+
+    expect(calls.offerInserts).toHaveLength(0)
+    expect(calls.linkDeletes).toBe(0)
+    expect(calls.linkInserts).toHaveLength(0)
+  })
+
+  it("preserves valid product-scope creation and materializes deduped product links", async () => {
+    const { db, calls } = createPromotionDb({ existingProductIds: ["prod_a", "prod_b"] })
+
+    const row = await promotionsService.createOffer(
+      db,
+      productOffer(["prod_a", "prod_b", "prod_a"]),
+    )
+
+    expect(row.id).toBe("pofr_test")
+    expect(calls.offerInserts).toHaveLength(1)
+    expect(calls.linkDeletes).toBe(1)
+    expect(calls.linkInserts).toEqual([
+      { offerId: "pofr_test", productId: "prod_a" },
+      { offerId: "pofr_test", productId: "prod_b" },
+    ])
+  })
+
+  it("rejects unknown product ids on update without rematerializing links", async () => {
+    const { db, calls } = createPromotionDb({
+      existingProductIds: [],
+      selectedOffer: persistedOffer,
+    })
+    const patch: UpdatePromotionalOffer = {
+      scope: { kind: "products", productIds: ["prod_missing"] },
+      conditions: {},
+      stackable: false,
+      active: true,
+    }
+
+    await expect(promotionsService.updateOffer(db, "pofr_test", patch)).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_reference",
+      details: {
+        missingProductIds: ["prod_missing"],
+      },
+    } satisfies Partial<ApiHttpError>)
+
+    expect(calls.offerUpdates).toHaveLength(0)
+    expect(calls.linkDeletes).toBe(0)
+    expect(calls.linkInserts).toHaveLength(0)
+  })
+})

--- a/packages/commerce/src/promotions/service-product-scope-validation.test.ts
+++ b/packages/commerce/src/promotions/service-product-scope-validation.test.ts
@@ -50,6 +50,7 @@ interface FakeDbCalls {
 
 function createPromotionDb(options: {
   existingProductIds: string[]
+  executeError?: unknown
   selectedOffer?: PromotionalOffer | null
 }) {
   const calls: FakeDbCalls = {
@@ -60,7 +61,10 @@ function createPromotionDb(options: {
   }
 
   const db = Object.assign(Object.create(null) as PostgresJsDatabase, {
-    execute: async () => options.existingProductIds.map((id) => ({ id })),
+    execute: async () => {
+      if (options.executeError) throw options.executeError
+      return options.existingProductIds.map((id) => ({ id }))
+    },
     insert: (table: unknown) => ({
       values: (values: unknown) => {
         if (table === promotionalOffers) {
@@ -123,6 +127,29 @@ describe("promotionsService product scope validation", () => {
       details: {
         field: "scope.productIds",
         missingProductIds: ["prod_missing"],
+      },
+    } satisfies Partial<ApiHttpError>)
+
+    expect(calls.offerInserts).toHaveLength(0)
+    expect(calls.linkDeletes).toBe(0)
+    expect(calls.linkInserts).toHaveLength(0)
+  })
+
+  it("returns invalid_reference instead of leaking missing Inventory schema errors", async () => {
+    const { db, calls } = createPromotionDb({
+      existingProductIds: [],
+      executeError: Object.assign(new Error('relation "products" does not exist'), {
+        code: "42P01",
+      }),
+    })
+
+    await expect(
+      promotionsService.createOffer(db, productOffer(["prod_valid"])),
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "invalid_reference",
+      details: {
+        missingProductIds: ["prod_valid"],
       },
     } satisfies Partial<ApiHttpError>)
 

--- a/packages/commerce/src/promotions/service.ts
+++ b/packages/commerce/src/promotions/service.ts
@@ -18,6 +18,7 @@
  */
 
 import type { EventBus } from "@voyant-travel/core"
+import { ApiHttpError } from "@voyant-travel/hono"
 import { and, count, desc, eq, gte, ilike, isNotNull, isNull, lte, or, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { mapPromotionalOfferWriteError } from "./errors.js"
@@ -62,11 +63,25 @@ export interface OfferMutationRuntime {
    * schemas.
    */
   resolveScopeProductIds?: ResolvePromotionalOfferScopeProductIds
+  /**
+   * Optional resolver for Product-owned product id existence checks.
+   * Promotions validates explicit product scopes before writing so the
+   * denormalized `promotional_offer_products` table cannot materialize
+   * dangling product links. The default resolver uses parameter-bound raw SQL
+   * against the Product-owned `products` table to keep this package decoupled
+   * from Inventory schemas.
+   */
+  resolveExistingProductIds?: ResolveExistingPromotionalOfferProductIds
 }
 
 export type ResolvePromotionalOfferScopeProductIds = (
   db: PostgresJsDatabase,
   scope: Extract<PromotionalOfferScope, { kind: "categories" | "destinations" }>,
+) => Promise<string[]>
+
+export type ResolveExistingPromotionalOfferProductIds = (
+  db: PostgresJsDatabase,
+  productIds: string[],
 ) => Promise<string[]>
 
 /** Fields whose change does NOT affect projection or evaluation — safe to skip emit. */
@@ -125,6 +140,72 @@ function readProductIdRows(result: unknown): string[] {
   return rows
     .map((row) => (row as { product_id?: unknown }).product_id)
     .filter((productId): productId is string => typeof productId === "string")
+}
+
+function readIdRows(result: unknown): string[] {
+  const rows = Array.isArray(result)
+    ? result
+    : Array.isArray((result as { rows?: unknown[] } | null)?.rows)
+      ? (result as { rows: unknown[] }).rows
+      : []
+  return rows
+    .map((row) => (row as { id?: unknown }).id)
+    .filter((id): id is string => typeof id === "string")
+}
+
+async function loadExistingProductIds(
+  db: PostgresJsDatabase,
+  productIds: string[],
+): Promise<string[]> {
+  if (productIds.length === 0) return []
+  const dbAny = db as { execute(query: unknown): Promise<unknown> }
+  const ids = sql.join(
+    productIds.map((productId) => sql`${productId}`),
+    sql`, `,
+  )
+  const result = await dbAny.execute(
+    // agent-quality: raw-sql reviewed -- owner: promotions; Product owns this table, and ids are parameter-bound through Drizzle.
+    sql`SELECT id FROM products WHERE id IN (${ids})`,
+  )
+  return readIdRows(result)
+}
+
+async function resolveExistingProductIds(
+  db: PostgresJsDatabase,
+  productIds: string[],
+  runtime: OfferMutationRuntime,
+): Promise<string[]> {
+  const uniqueIds = [...new Set(productIds)]
+  return runtime.resolveExistingProductIds
+    ? runtime.resolveExistingProductIds(db, uniqueIds)
+    : loadExistingProductIds(db, uniqueIds)
+}
+
+async function validatePromotionalOfferScopeReferences(
+  db: PostgresJsDatabase,
+  scope: PromotionalOfferScope,
+  runtime: OfferMutationRuntime,
+): Promise<void> {
+  if (scope.kind !== "products") return
+  const productIds = [...new Set(scope.productIds)]
+  const existingIds = new Set(await resolveExistingProductIds(db, productIds, runtime))
+  const missingProductIds = productIds.filter((productId) => !existingIds.has(productId))
+  if (missingProductIds.length === 0) return
+
+  throw new ApiHttpError("Promotional offer references unknown product ids", {
+    status: 400,
+    code: "invalid_reference",
+    details: {
+      resource: "promotional_offer",
+      field: "scope.productIds",
+      missingProductIds,
+      issues: missingProductIds.map((productId) => ({
+        code: "unknown_product_id",
+        path: ["scope", "productIds"],
+        message: `Unknown product id: ${productId}`,
+      })),
+    },
+  })
 }
 
 async function loadProductIdsForCategoryScope(
@@ -355,6 +436,8 @@ async function createOffer(
   input: InsertPromotionalOffer,
   runtime: OfferMutationRuntime = {},
 ): Promise<PromotionalOffer> {
+  await validatePromotionalOfferScopeReferences(db, input.scope, runtime)
+
   let row: PromotionalOffer | undefined
   try {
     const [inserted] = await db.insert(promotionalOffers).values(toRowValues(input)).returning()
@@ -387,6 +470,9 @@ async function updateOffer(
       ? (await getOfferById(db, id))?.scope
       : null
   if (patch.scope !== undefined && previousScope === undefined) return null
+  if (patch.scope !== undefined) {
+    await validatePromotionalOfferScopeReferences(db, patch.scope, runtime)
+  }
 
   let row: PromotionalOffer | undefined
   try {
@@ -503,6 +589,7 @@ export const promotionsService = {
   deleteOffer,
   recomputeOfferLinks,
   resolveScopeProductIds,
+  validatePromotionalOfferScopeReferences,
 }
 
 export type PromotionsService = typeof promotionsService

--- a/packages/commerce/src/promotions/service.ts
+++ b/packages/commerce/src/promotions/service.ts
@@ -1,4 +1,6 @@
 /**
+ * agent-quality: file-size exception -- owner: promotions; existing promotions service keeps CRUD, link materialization, and event emission co-located until promotion services are split by responsibility.
+ *
  * Promotions service — CRUD over `promotional_offers` plus link-table
  * materialization for product-shaped scopes.
  *
@@ -153,6 +155,16 @@ function readIdRows(result: unknown): string[] {
     .filter((id): id is string => typeof id === "string")
 }
 
+function isMissingProductsTableError(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false
+  const record = error as { code?: unknown; message?: unknown }
+  return (
+    record.code === "42P01" ||
+    (typeof record.message === "string" &&
+      record.message.includes('relation "products" does not exist'))
+  )
+}
+
 async function loadExistingProductIds(
   db: PostgresJsDatabase,
   productIds: string[],
@@ -163,10 +175,16 @@ async function loadExistingProductIds(
     productIds.map((productId) => sql`${productId}`),
     sql`, `,
   )
-  const result = await dbAny.execute(
-    // agent-quality: raw-sql reviewed -- owner: promotions; Product owns this table, and ids are parameter-bound through Drizzle.
-    sql`SELECT id FROM products WHERE id IN (${ids})`,
-  )
+  let result: unknown
+  try {
+    result = await dbAny.execute(
+      // agent-quality: raw-sql reviewed -- owner: promotions; Product owns this table, and ids are parameter-bound through Drizzle.
+      sql`SELECT id FROM products WHERE id IN (${ids})`,
+    )
+  } catch (error) {
+    if (isMissingProductsTableError(error)) return []
+    throw error
+  }
   return readIdRows(result)
 }
 

--- a/packages/commerce/src/runtime.ts
+++ b/packages/commerce/src/runtime.ts
@@ -1,7 +1,11 @@
 import type { HonoModule } from "@voyant-travel/hono/module"
 import { marketsHonoModule } from "./markets/index.js"
 import { pricingHonoModule } from "./pricing/index.js"
-import { promotionsHonoModule } from "./promotions/index.js"
+import {
+  createPromotionsHonoModule,
+  type PromotionsRoutesOptions,
+  promotionsHonoModule,
+} from "./promotions/index.js"
 import { createPromotionsStorefrontResolvers } from "./promotions/service-storefront.js"
 import {
   createSellabilityHonoModule,
@@ -19,6 +23,7 @@ export const commerceRuntimeModuleNames = [
 export type CommerceRuntimeModuleName = (typeof commerceRuntimeModuleNames)[number]
 
 export interface CommerceHonoModulesOptions {
+  promotions?: PromotionsRoutesOptions
   sellability?: SellabilityRoutesOptions
 }
 
@@ -34,7 +39,7 @@ export function createCommerceHonoModules(options: CommerceHonoModulesOptions = 
     pricingHonoModule,
     marketsHonoModule,
     options.sellability ? createSellabilityHonoModule(options.sellability) : sellabilityHonoModule,
-    promotionsHonoModule,
+    options.promotions ? createPromotionsHonoModule(options.promotions) : promotionsHonoModule,
   ]
 }
 

--- a/packages/openapi/spec/admin/promotions.json
+++ b/packages/openapi/spec/admin/promotions.json
@@ -1253,6 +1253,34 @@
               }
             }
           },
+          "400": {
+            "description": "invalid_reference: product-scoped offer references unknown product ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
           "409": {
             "description": "Active promotional offer slug or code already exists",
             "content": {
@@ -2273,6 +2301,34 @@
                   },
                   "required": [
                     "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_reference: product-scoped offer references unknown product ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
                   ]
                 }
               }

--- a/starters/operator/openapi/admin/promotions.json
+++ b/starters/operator/openapi/admin/promotions.json
@@ -1253,6 +1253,34 @@
               }
             }
           },
+          "400": {
+            "description": "invalid_reference: product-scoped offer references unknown product ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
           "409": {
             "description": "Active promotional offer slug or code already exists",
             "content": {
@@ -2273,6 +2301,34 @@
                   },
                   "required": [
                     "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_reference: product-scoped offer references unknown product ids",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "requestId": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
                   ]
                 }
               }


### PR DESCRIPTION
## Summary
- Validate explicit promotion product scopes against the Product-owned `products` table before create/update writes.
- Reject unknown product ids with `invalid_reference` and keep `promotional_offer_products` untouched on failure.
- Add focused Commerce tests for rejection/no materialized links and valid product-scope materialization.

## Validation
- `pnpm --filter @voyant-travel/commerce test`
- `NODE_OPTIONS=--max-old-space-size=14336 pnpm --filter @voyant-travel/commerce typecheck`
- `pnpm --filter @voyant-travel/commerce lint` (passes with existing optional-chain warning in `accepted-quote-version-reservation-golden-flow.test.ts`)
- `pnpm verify:agent-quality:changed` (0 errors; warnings for existing service file size/raw SQL review notices)
- Commit hook affected lint/typecheck/build: 186 successful, 186 total
- Push hook test lane: 98 successful, 98 total

Closes #2601
