### PR TITLE
Declare storefront offers anonymous

### DIFF
--- a/.changeset/storefront-public-offers-anonymous.md
+++ b/.changeset/storefront-public-offers-anonymous.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/storefront": patch
+"@voyant-travel/framework": patch
+---
+
+Declare storefront public offer detail, apply, and redeem routes as anonymous surfaces so standard hosts admit them without hand-maintained `publicPaths` entries.

--- a/packages/framework/src/anonymous-surface.test.ts
+++ b/packages/framework/src/anonymous-surface.test.ts
@@ -55,6 +55,7 @@ describe("standard anonymous surface (ADR-0008)", () => {
       "/v1/public/legal",
       "/v1/public/markets",
       "/v1/public/newsletter",
+      "/v1/public/offers",
       "/v1/public/proposals",
       "/v1/public/storefront-verification",
     ])

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -462,20 +462,16 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
         true,
       ),
     "@voyant-travel/storefront": ({ capabilities }) =>
-      // Storefront mounts at the public root (`publicPath: "/"`); its anonymous
-      // CRM-intake routes (lead capture + newsletter signup) are reached before
-      // any session.
-      withAnonymous(
-        createStorefrontHonoModule({
-          offers: createCommerceStorefrontOfferResolvers(),
-          // Async booking-bootstrap intents (queued write pipeline, RFC
-          // voyant#1687 §3.2) — the handler runs on the app bus with
-          // outbox-grade retries; the */2min cron sweeps stale intents.
-          bookingIntents: { resolveDb: capabilities.resolveDb },
-          intake: { persistence: capabilities.storefrontIntakePersistence },
-        }),
-        ["/leads", "/newsletter"],
-      ),
+      // Storefront mounts at the public root (`publicPath: "/"`) and declares
+      // its own anonymous public paths next to the routes it owns.
+      createStorefrontHonoModule({
+        offers: createCommerceStorefrontOfferResolvers(),
+        // Async booking-bootstrap intents (queued write pipeline, RFC
+        // voyant#1687 §3.2) — the handler runs on the app bus with outbox-grade
+        // retries; the */2min cron sweeps stale intents.
+        bookingIntents: { resolveDb: capabilities.resolveDb },
+        intake: { persistence: capabilities.storefrontIntakePersistence },
+      }),
     "@voyant-travel/finance": ({ capabilities }) =>
       // The emailed-link finance pages (payment-session landing, collections,
       // accountant share portal, booking summary) are reached without a session

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -241,6 +241,55 @@ describe("mountApp surface mounting", () => {
     expect(((await res.json()) as { surface: string }).surface).toBe("public")
   })
 
+  it("treats module-declared public offers paths as anonymous while protecting other surfaces", async () => {
+    const publicRoutes = new Hono()
+      .get("/offers/:slug", (c) => c.json({ route: "detail", actor: c.get("actor") }))
+      .post("/offers/:slug/apply", (c) => c.json({ route: "apply", actor: c.get("actor") }))
+      .post("/offers/redeem", (c) => c.json({ route: "redeem", actor: c.get("actor") }))
+      .get("/account", (c) => c.json({ route: "account", actor: c.get("actor") }))
+    const adminRoutes = new Hono().get("/offers", (c) =>
+      c.json({ route: "admin-offers", actor: c.get("actor") }),
+    )
+    const app = mountApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db -- owner: hono; existing suppression is intentional pending typed cleanup.
+      db: () => ({}) as any,
+      modules: [
+        {
+          module: { name: "storefront" },
+          adminRoutes,
+          publicPath: "/",
+          publicRoutes,
+          anonymous: ["/offers"],
+        },
+      ],
+    })
+
+    const detail = await app.request("/v1/public/offers/summer-sale", {}, TEST_ENV, TEST_CTX)
+    const apply = await app.request(
+      "/v1/public/offers/summer-sale/apply",
+      { method: "POST" },
+      TEST_ENV,
+      TEST_CTX,
+    )
+    const redeem = await app.request(
+      "/v1/public/offers/redeem",
+      { method: "POST" },
+      TEST_ENV,
+      TEST_CTX,
+    )
+    const privatePublic = await app.request("/v1/public/account", {}, TEST_ENV, TEST_CTX)
+    const admin = await app.request("/v1/admin/storefront/offers", {}, TEST_ENV, TEST_CTX)
+
+    expect(detail.status).toBe(200)
+    expect(await detail.json()).toEqual({ route: "detail", actor: "customer" })
+    expect(apply.status).toBe(200)
+    expect(await apply.json()).toEqual({ route: "apply", actor: "customer" })
+    expect(redeem.status).toBe(200)
+    expect(await redeem.json()).toEqual({ route: "redeem", actor: "customer" })
+    expect(privatePublic.status).toBe(401)
+    expect(admin.status).toBe(401)
+  })
+
   it("exposes /health publicly without auth", async () => {
     const app = mountApp({
       // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db -- owner: hono; existing suppression is intentional pending typed cleanup.

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -201,6 +201,8 @@ export const storefrontModule: Module = {
   name: "storefront",
 }
 
+export const storefrontAnonymousPublicPaths = ["/leads", "/newsletter", "/offers"] as const
+
 export function createStorefrontHonoModule(
   options?: Parameters<typeof createStorefrontPublicRoutes>[0],
 ): HonoModule {
@@ -229,6 +231,7 @@ export function createStorefrontHonoModule(
     adminRoutes: createStorefrontAdminRoutes(options),
     publicPath: "/",
     publicRoutes: createStorefrontPublicRoutes(options),
+    anonymous: storefrontAnonymousPublicPaths,
   }
 }
 export {

--- a/packages/storefront/tests/unit/hono-module.test.ts
+++ b/packages/storefront/tests/unit/hono-module.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+
+import { createStorefrontHonoModule, storefrontAnonymousPublicPaths } from "../../src/index.js"
+
+describe("createStorefrontHonoModule", () => {
+  it("declares anonymous storefront offer paths next to the owned public routes", () => {
+    const module = createStorefrontHonoModule()
+
+    expect(module.publicPath).toBe("/")
+    expect(module.anonymous).toBe(storefrontAnonymousPublicPaths)
+    expect(module.anonymous).toContain("/offers")
+  })
+})

--- a/starters/operator/src/api/operator-route-mounting.test.ts
+++ b/starters/operator/src/api/operator-route-mounting.test.ts
@@ -171,4 +171,35 @@ describe("operator composed route mounting (smoke)", () => {
     expect(res.status).not.toBe(403)
     expect(res.status).not.toBe(404)
   })
+
+  it("lets storefront offer detail, apply, and redeem pass the public actor gate", async () => {
+    const offerPayload = {
+      productId: "prod_123",
+      pax: 2,
+      basePriceCents: 100_00,
+      currency: "EUR",
+    }
+
+    const detail = await liveFrontDoorStatus("/v1/public/offers/summer-sale")
+    const apply = await liveFrontDoorStatus("/v1/public/offers/summer-sale/apply", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(offerPayload),
+    })
+    const redeem = await liveFrontDoorStatus("/v1/public/offers/redeem", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ...offerPayload, code: "SAVE10" }),
+    })
+
+    expect(detail).not.toBe(401)
+    expect(detail).not.toBe(403)
+    expect(detail).not.toBe(404)
+    expect(apply).not.toBe(401)
+    expect(apply).not.toBe(403)
+    expect(apply).not.toBe(404)
+    expect(redeem).not.toBe(401)
+    expect(redeem).not.toBe(403)
+    expect(redeem).not.toBe(404)
+  })
 })


### PR DESCRIPTION
## Summary

- Declares the storefront `/offers` public surface as anonymous next to the storefront routes that own it.
- Lets standard framework/operator composition inherit the storefront-owned anonymous declaration instead of overriding it with only lead/newsletter paths.
- Adds regression coverage for public offer detail, apply, and redeem paths passing the actor gate while unrelated surfaces stay protected.

Closes #2602.

## Verification

- `pnpm --filter @voyant-travel/hono test -- tests/unit/app-surfaces.test.ts`
- `pnpm --filter @voyant-travel/framework test -- src/anonymous-surface.test.ts`
- `pnpm --filter @voyant-travel/storefront test -- tests/unit/hono-module.test.ts`
- `pnpm --filter operator test -- src/api/operator-route-mounting.test.ts`
- `pnpm --filter @voyant-travel/storefront lint`
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm --filter @voyant-travel/hono lint`
- `pnpm --filter operator lint`
- `pnpm exec biome check packages/hono/tests/unit/app-surfaces.test.ts packages/storefront/tests/unit/hono-module.test.ts packages/framework/src/anonymous-surface.test.ts packages/framework/src/composition.ts packages/storefront/src/index.ts .changeset/storefront-public-offers-anonymous.md`
- `pnpm exec biome check starters/operator/src/api/operator-route-mounting.test.ts`
- `NODE_OPTIONS=--max-old-space-size=14336 pnpm --filter @voyant-travel/storefront typecheck`
- `pnpm --filter @voyant-travel/hono typecheck`
- commit hook affected verification: 186 tasks successful
- push hook test run: 98 tasks successful

Note: `pnpm --filter @voyant-travel/framework typecheck` was attempted directly and was killed by the OS with exit 137 after a long CPU-bound run; the commit hook later ran framework build/typecheck as part of affected verification and completed successfully.