### PR TITLE
Replace native date inputs with shared pickers

### DIFF
--- a/.changeset/shared-date-pickers-release.md
+++ b/.changeset/shared-date-pickers-release.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/distribution-react": patch
+"@voyant-travel/relationships-react": patch
+---
+
+Replace native date inputs with shared date picker components in supplier and relationship UI.

--- a/packages/distribution-react/src/suppliers/components/supplier-operations-resource-dialogs.tsx
+++ b/packages/distribution-react/src/suppliers/components/supplier-operations-resource-dialogs.tsx
@@ -9,6 +9,7 @@ import {
   Input,
   Textarea,
 } from "@voyant-travel/ui/components"
+import { DatePicker } from "@voyant-travel/ui/components/date-picker"
 import { zodResolver } from "@voyant-travel/ui/lib/zod-resolver"
 import * as React from "react"
 import { useForm } from "react-hook-form"
@@ -82,7 +83,15 @@ export function AvailabilityDialog({
         >
           <DialogBody className="grid gap-4">
             <Field label={dialog.dateLabel} error={form.formState.errors.date?.message}>
-              <Input {...form.register("date")} type="date" />
+              <DatePicker
+                value={form.watch("date") || null}
+                onChange={(nextValue) =>
+                  form.setValue("date", nextValue ?? "", {
+                    shouldDirty: true,
+                    shouldValidate: true,
+                  })
+                }
+              />
             </Field>
             <SwitchField
               label={dialog.availableLabel}
@@ -182,16 +191,40 @@ export function ContractDialog({
             </Field>
             <div className="grid gap-4 sm:grid-cols-3">
               <Field label={dialog.startDateLabel} error={form.formState.errors.startDate?.message}>
-                <Input {...form.register("startDate")} type="date" />
+                <DatePicker
+                  value={form.watch("startDate") || null}
+                  onChange={(nextValue) =>
+                    form.setValue("startDate", nextValue ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
+                />
               </Field>
               <Field label={dialog.endDateLabel} error={form.formState.errors.endDate?.message}>
-                <Input {...form.register("endDate")} type="date" />
+                <DatePicker
+                  value={form.watch("endDate") || null}
+                  onChange={(nextValue) =>
+                    form.setValue("endDate", nextValue ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
+                />
               </Field>
               <Field
                 label={dialog.renewalDateLabel}
                 error={form.formState.errors.renewalDate?.message}
               >
-                <Input {...form.register("renewalDate")} type="date" />
+                <DatePicker
+                  value={form.watch("renewalDate") || null}
+                  onChange={(nextValue) =>
+                    form.setValue("renewalDate", nextValue ?? "", {
+                      shouldDirty: true,
+                      shouldValidate: true,
+                    })
+                  }
+                />
               </Field>
             </div>
             <SelectField

--- a/packages/relationships-react/src/components/person-detail-panels.tsx
+++ b/packages/relationships-react/src/components/person-detail-panels.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+// agent-quality: file-size exception -- owner: relationships-react; existing detail panels stay co-located pending a dedicated split because this release fix only replaces a native datetime input.
 import { Badge, Button, Card, CardContent, ConfirmActionButton } from "@voyant-travel/ui/components"
+import { DateTimePicker } from "@voyant-travel/ui/components/date-time-picker"
 import { Input } from "@voyant-travel/ui/components/input"
 import { Label } from "@voyant-travel/ui/components/label"
 import {
@@ -639,11 +641,9 @@ export function PersonCommunicationsPanel({
           </div>
           <div className="flex flex-col gap-1.5">
             <Label htmlFor="communication-sent-at">{labels.fields.sentAt}</Label>
-            <Input
-              id="communication-sent-at"
-              type="datetime-local"
+            <DateTimePicker
               value={form.sentAt}
-              onChange={(event) => set("sentAt", event.target.value)}
+              onChange={(nextValue) => set("sentAt", nextValue ?? "")}
             />
           </div>
           <div className="flex flex-col gap-1.5 sm:col-span-2">


### PR DESCRIPTION
## Summary
- Replace supplier availability/contract native date inputs with `DatePicker`.
- Replace relationship communication `datetime-local` input with `DateTimePicker`.
- Add patch changeset for `@voyant-travel/distribution-react` and `@voyant-travel/relationships-react`.

## Verification
- `pnpm verify:native-date-inputs`
- `pnpm lint:changed && pnpm verify:agent-quality:changed && pnpm verify:date-picker-single-source && pnpm verify:ui-components-barrel && pnpm verify:ui-orientation-selectors && pnpm verify:native-date-inputs && pnpm verify:raw-minor-unit-labels`
- `pnpm --filter @voyant-travel/distribution-react typecheck`
- `pnpm --filter @voyant-travel/relationships-react typecheck`
- Commit hook: 186/186 tasks successful
- Push hook: 98/98 tasks successful