### PR TITLE
Fix settings route mounts

### DIFF
--- a/.changeset/settings-routes-reachable.md
+++ b/.changeset/settings-routes-reachable.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/framework": patch
+---
+
+Expose booking tax settings through the finance admin route mount so local starters can reach `/v1/admin/finance/tax-settings` without the bookings detail route capturing the request.

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -3,6 +3,7 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import type { Module } from "@voyant-travel/core"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
+import { type BookingTaxRouteOptions, createBookingTaxRoutes } from "./booking-tax.js"
 import {
   buildFinanceCheckoutRouteRuntime,
   type CheckoutRoutesOptions,
@@ -134,7 +135,8 @@ export const financeModule: Module = {
 export interface FinanceHonoModuleOptions
   extends FinanceRuntimeOptions,
     PublicFinanceRouteOptions,
-    CheckoutRoutesOptions {}
+    CheckoutRoutesOptions,
+    BookingTaxRouteOptions {}
 
 export function createFinanceHonoModule(options: FinanceHonoModuleOptions = {}): HonoModule {
   const adminRoutes = new OpenAPIHono()
@@ -145,6 +147,7 @@ export function createFinanceHonoModule(options: FinanceHonoModuleOptions = {}):
     .route("/", createInvoiceFxRoutes(options))
     .route("/", createFinanceAdminDocumentRoutes(options))
     .route("/", createFinanceAdminSettlementRoutes(options))
+    .route("/", createBookingTaxRoutes(options))
 
   const module: Module = {
     ...financeModule,

--- a/packages/finance/tests/unit/booking-tax.test.ts
+++ b/packages/finance/tests/unit/booking-tax.test.ts
@@ -7,6 +7,7 @@ import {
   createBookingTaxRoutes,
   matchesTaxPolicyCondition,
 } from "../../src/booking-tax.js"
+import { createFinanceHonoModule } from "../../src/index.js"
 
 describe("booking tax helpers", () => {
   it("computes exclusive tax lines", () => {
@@ -193,6 +194,33 @@ describe("booking tax helpers", () => {
     await expect(patchResponse.json()).resolves.toEqual({
       data: {
         taxPriceMode: "exclusive",
+        taxPolicyProfileId: "profile_1",
+      },
+    })
+  })
+
+  it("serves booking tax settings through the finance admin mount without hitting booking detail", async () => {
+    const db = {} as PostgresJsDatabase
+    const finance = createFinanceHonoModule({
+      resolveBookingTaxSettings: () => ({
+        taxPriceMode: "inclusive",
+        taxPolicyProfileId: "profile_1",
+      }),
+    })
+    const app = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db", db)
+        await next()
+      })
+      .get("/v1/admin/bookings/:id", (c) => c.json({ error: "Booking not found" }, 404))
+      .route("/v1/admin/finance", finance.adminRoutes!)
+
+    const response = await app.request("/v1/admin/finance/tax-settings")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        taxPriceMode: "inclusive",
         taxPolicyProfileId: "profile_1",
       },
     })

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -516,6 +516,8 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
           policy: capabilities.financeCheckoutPolicy,
           paymentScheduleLineDescriptionFormat:
             capabilities.financePaymentScheduleLineDescriptionFormat,
+          resolveBookingTaxSettings,
+          updateBookingTaxSettings,
           resolveBankTransferDetails: capabilities.resolveBankTransferDetails,
           resolvePublicCheckoutBaseUrl: capabilities.resolvePublicCheckoutBaseUrl,
           listBookingReminderRuns: async (db, bookingId, query) => {

--- a/starters/operator/src/api/app.ts
+++ b/starters/operator/src/api/app.ts
@@ -15,6 +15,7 @@ import {
 } from "./composition"
 import { createBulkReindexProductsService } from "./lib/bulk-reindex-service"
 import { dbFromEnvForApp, httpDbFromEnvForApp } from "./lib/db"
+import { OPERATOR_PUBLIC_PATHS } from "./public-paths"
 import { bookingScheduleBundle } from "./routes/booking-schedule"
 import { channelPushBundle } from "./routes/channel-push"
 import {
@@ -93,16 +94,9 @@ export const app = createVoyantApp<CloudflareBindings, ReturnType<typeof buildOp
   //     declaration.
   //   - products / accommodations: storefront detail surfaces whose owning
   //     module isn't yet annotated.
-  //   - operator-profile / payment-policy: sanitized storefront-preview reads;
+  //   - operator-profile / settings/operator / payment-policy: sanitized storefront-preview reads;
   //     owning module not yet annotated.
-  publicPaths: [
-    "/v1/public/payment-link-config",
-    "/v1/public/payment-link",
-    "/v1/public/products",
-    "/v1/public/accommodations",
-    "/v1/public/operator-profile",
-    "/v1/public/payment-policy",
-  ],
+  publicPaths: [...OPERATOR_PUBLIC_PATHS],
   plugins: [
     {
       name: "operator-promotions-runtime",

--- a/starters/operator/src/api/operator-route-mounting.test.ts
+++ b/starters/operator/src/api/operator-route-mounting.test.ts
@@ -22,6 +22,7 @@ import {
   OPERATOR_RUNTIME_MANIFEST,
   operatorComposition,
 } from "./composition"
+import { OPERATOR_PUBLIC_PATHS } from "./public-paths"
 
 const TEST_ENV = { DATABASE_URL: "postgres://test" } as never
 const TEST_CTX = { waitUntil: () => {}, passThroughOnException: () => {} } as never
@@ -72,6 +73,7 @@ function buildWithLiveFrontDoor() {
     providers: buildOperatorProviders(),
     modules: deploymentLocalModules,
     extensions: deploymentLocalExtensions,
+    publicPaths: [...OPERATOR_PUBLIC_PATHS],
     // biome-ignore lint/suspicious/noExplicitAny: stub db for mount smoke test -- owner: operator API tests.
     db: () => ({}) as any,
     auth: {
@@ -149,7 +151,9 @@ describe("operator composed route mounting (smoke)", () => {
   it("mounts multi-prefix lazyRoutes families (catalog-booking, media, settings, payment-link)", async () => {
     expect(await status("/v1/admin/catalog/orders")).not.toBe(404)
     expect(await status("/v1/admin/media/anything")).not.toBe(404)
+    expect(await liveFrontDoorStatus("/v1/admin/finance/tax-settings")).not.toBe(404)
     expect(await status("/v1/public/operator-profile")).not.toBe(404)
+    expect(await status("/v1/public/settings/operator")).not.toBe(404)
     expect(await status("/v1/public/payment-link-config")).not.toBe(404)
   })
 
@@ -201,5 +205,13 @@ describe("operator composed route mounting (smoke)", () => {
     expect(redeem).not.toBe(401)
     expect(redeem).not.toBe(403)
     expect(redeem).not.toBe(404)
+  })
+
+  it("lets public operator settings pass the starter public actor gate", async () => {
+    const settings = await liveFrontDoorStatus("/v1/public/settings/operator")
+
+    expect(settings).not.toBe(401)
+    expect(settings).not.toBe(403)
+    expect(settings).not.toBe(404)
   })
 })

--- a/starters/operator/src/api/public-paths.ts
+++ b/starters/operator/src/api/public-paths.ts
@@ -1,0 +1,9 @@
+export const OPERATOR_PUBLIC_PATHS = [
+  "/v1/public/payment-link-config",
+  "/v1/public/payment-link",
+  "/v1/public/products",
+  "/v1/public/accommodations",
+  "/v1/public/operator-profile",
+  "/v1/public/settings/operator",
+  "/v1/public/payment-policy",
+] as const


### PR DESCRIPTION
## Summary
- Exposes booking tax settings through the finance admin mount at `/v1/admin/finance/tax-settings` so the settings route is not captured by `/v1/admin/bookings/:id`.
- Passes the operator-settings-backed booking tax callbacks into the finance module composition.
- Adds `/v1/public/settings/operator` to the operator starter public allow-list and reuses that allow-list in route smoke tests.

Fixes #2609

## Checks
- `pnpm exec vitest run tests/unit/booking-tax.test.ts` in `packages/finance`
- `pnpm exec vitest run src/api/operator-route-mounting.test.ts` in `starters/operator`
- `pnpm exec vitest run src/anonymous-surface.test.ts` in `packages/framework`
- `pnpm exec biome check packages/finance/src/index.ts packages/finance/tests/unit/booking-tax.test.ts packages/framework/src/composition.ts starters/operator/src/api/app.ts starters/operator/src/api/operator-route-mounting.test.ts starters/operator/src/api/public-paths.ts`
- Commit hook: affected lint/build/typecheck graph completed successfully
- Push hook: workspace `pnpm test` completed successfully

## Residual Risk
- `pnpm --filter @voyant-travel/finance typecheck` was attempted before the commit hook and hit a V8 heap OOM at the package script's 4 GB limit, exit 134. The later commit hook completed the affected graph including finance build/typecheck successfully.
