### PR TITLE
Fix legacy payment policy normalization

### DIFF
--- a/.changeset/legacy-payment-policy-normalization.md
+++ b/.changeset/legacy-payment-policy-normalization.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/finance-react": patch
+---
+
+Normalize legacy customer payment policy JSON so operator settings and payment policy forms do not crash on existing rows.

--- a/packages/finance-react/src/components/payment-policy-form.test.tsx
+++ b/packages/finance-react/src/components/payment-policy-form.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import type { PaymentPolicy } from "@voyant-travel/finance/payment-policy"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { PaymentPolicyForm } from "./payment-policy-form.js"
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+describe("PaymentPolicyForm", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("renders a legacy deposit policy without throwing", async () => {
+    const legacyPolicy: Partial<PaymentPolicy> & {
+      type: "deposit"
+      depositPercent: number
+      balanceDueDays: number
+    } = {
+      type: "deposit",
+      depositPercent: 30,
+      balanceDueDays: 30,
+    }
+
+    await act(async () => {
+      root.render(
+        <PaymentPolicyForm
+          value={legacyPolicy as PaymentPolicy}
+          onChange={() => {}}
+          inheritable={false}
+        />,
+      )
+    })
+
+    expect(container.textContent).toContain("Deposit kind")
+    expect(container.textContent).toContain("Deposit percent")
+    expect(container.textContent).toContain("Balance due")
+  })
+
+  it("keeps non-inheritable malformed policies editable", async () => {
+    await act(async () => {
+      root.render(
+        <PaymentPolicyForm value={{} as PaymentPolicy} onChange={() => {}} inheritable={false} />,
+      )
+    })
+
+    expect(container.querySelector("fieldset")?.disabled).toBe(false)
+  })
+})

--- a/packages/finance-react/src/components/payment-policy-form.tsx
+++ b/packages/finance-react/src/components/payment-policy-form.tsx
@@ -4,6 +4,7 @@ import {
   type ComputedScheduleEntry,
   computePaymentSchedule,
   noDepositPolicy,
+  normalizePaymentPolicy,
   type PaymentPolicy,
 } from "@voyant-travel/finance/payment-policy"
 import { formatMessage } from "@voyant-travel/i18n"
@@ -80,11 +81,12 @@ export function PaymentPolicyForm({
   className,
 }: PaymentPolicyFormProps): React.ReactElement {
   const messages = useFinanceUiI18nOrDefault().messages.paymentPolicy.form
-  const isInheriting = value === null
-  const policy = value ?? noDepositPolicy
+  const normalizedValue = React.useMemo(() => normalizePaymentPolicy(value), [value])
+  const isInheriting = inheritable && normalizedValue === null
+  const policy = normalizedValue ?? noDepositPolicy
 
   const setPolicyField = <K extends keyof PaymentPolicy>(key: K, next: PaymentPolicy[K]) => {
-    onChange({ ...(value ?? DEFAULT_POLICY), [key]: next })
+    onChange({ ...(normalizedValue ?? DEFAULT_POLICY), [key]: next })
   }
   const setDepositKind = (kind: DepositKind) => {
     if (kind === "none") {
@@ -122,7 +124,9 @@ export function PaymentPolicyForm({
             <Switch
               id="payment-policy-inherit"
               checked={isInheriting}
-              onCheckedChange={(checked) => onChange(checked ? null : (value ?? DEFAULT_POLICY))}
+              onCheckedChange={(checked) =>
+                onChange(checked ? null : (normalizedValue ?? DEFAULT_POLICY))
+              }
               disabled={disabled}
             />
           </div>

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -253,6 +253,7 @@ export {
   computePaymentSchedule,
   isPaymentPolicyEmpty,
   noDepositPolicy,
+  normalizePaymentPolicy,
   policyShouldRequireFullPayment,
   resolveEffectivePaymentPolicy,
 } from "./payment-policy.js"

--- a/packages/finance/src/payment-policy.ts
+++ b/packages/finance/src/payment-policy.ts
@@ -59,6 +59,41 @@ export const noDepositPolicy: PaymentPolicy = {
   balanceDueMinDaysFromNow: 0,
 }
 
+export function normalizePaymentPolicy(value: unknown): PaymentPolicy | null {
+  if (value == null) return null
+  if (isPaymentPolicy(value)) return value
+  if (!value || typeof value !== "object") return null
+
+  const legacy = value as {
+    type?: unknown
+    depositPercent?: unknown
+    balanceDueDays?: unknown
+    balanceDueDaysBeforeDeparture?: unknown
+    minDaysBeforeDepartureForDeposit?: unknown
+    balanceDueMinDaysFromNow?: unknown
+  }
+
+  if (legacy.type === "full" || legacy.type === "none") {
+    return noDepositPolicy
+  }
+
+  if (legacy.type !== "deposit") return null
+
+  const percent = readPercent(legacy.depositPercent)
+  if (percent === null) return null
+
+  return {
+    deposit: { kind: "percent", percent },
+    minDaysBeforeDepartureForDeposit:
+      readNonNegativeInteger(legacy.minDaysBeforeDepartureForDeposit) ?? 0,
+    balanceDueDaysBeforeDeparture:
+      readNonNegativeInteger(legacy.balanceDueDaysBeforeDeparture) ??
+      readNonNegativeInteger(legacy.balanceDueDays) ??
+      0,
+    balanceDueMinDaysFromNow: readNonNegativeInteger(legacy.balanceDueMinDaysFromNow) ?? 0,
+  }
+}
+
 export function isPaymentPolicy(value: unknown): value is PaymentPolicy {
   if (!value || typeof value !== "object") return false
   const policy = value as Partial<PaymentPolicy>
@@ -85,6 +120,14 @@ function isDepositRule(value: unknown): value is DepositRule {
 
 function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0
+}
+
+function readNonNegativeInteger(value: unknown): number | null {
+  return isNonNegativeInteger(value) ? value : null
+}
+
+function readPercent(value: unknown): number | null {
+  return typeof value === "number" && value >= 0 && value <= 100 ? value : null
 }
 
 export type PaymentScheduleEntryType = "deposit" | "balance" | "full"
@@ -117,7 +160,7 @@ export function computePaymentSchedule(
   input: ComputeScheduleInput,
   policy: PaymentPolicy,
 ): ComputedScheduleEntry[] {
-  const effectivePolicy = isPaymentPolicy(policy) ? policy : noDepositPolicy
+  const effectivePolicy = normalizePaymentPolicy(policy) ?? noDepositPolicy
   const total = Math.max(0, Math.round(input.totalCents))
   const today = input.today ?? new Date()
   const todayIso = isoDate(today)
@@ -194,17 +237,18 @@ function computeDepositCents(total: number, rule: DepositRule): number {
 
 /** True when this policy is empty / "inherit from parent". */
 export function isPaymentPolicyEmpty(policy: PaymentPolicy | null | undefined): boolean {
-  if (!isPaymentPolicy(policy)) return true
-  if (policy.deposit.kind === "none") return true
+  const effectivePolicy = normalizePaymentPolicy(policy)
+  if (!effectivePolicy) return true
+  if (effectivePolicy.deposit.kind === "none") return true
   if (
-    policy.deposit.kind === "percent" &&
-    (policy.deposit.percent === undefined || policy.deposit.percent === 0)
+    effectivePolicy.deposit.kind === "percent" &&
+    (effectivePolicy.deposit.percent === undefined || effectivePolicy.deposit.percent === 0)
   ) {
     return true
   }
   if (
-    policy.deposit.kind === "fixed_cents" &&
-    (policy.deposit.amountCents === undefined || policy.deposit.amountCents === 0)
+    effectivePolicy.deposit.kind === "fixed_cents" &&
+    (effectivePolicy.deposit.amountCents === undefined || effectivePolicy.deposit.amountCents === 0)
   ) {
     return true
   }
@@ -250,18 +294,16 @@ export interface ResolvedPaymentPolicy {
 export function resolveEffectivePaymentPolicy(
   layers: PaymentPolicyCascadeLayers,
 ): ResolvedPaymentPolicy {
-  if (isPaymentPolicy(layers.bookingPolicy))
-    return { policy: layers.bookingPolicy, source: "booking" }
-  if (isPaymentPolicy(layers.listingPolicy))
-    return { policy: layers.listingPolicy, source: "listing" }
-  if (isPaymentPolicy(layers.categoryPolicy)) {
-    return { policy: layers.categoryPolicy, source: "category" }
-  }
-  if (isPaymentPolicy(layers.supplierPolicy)) {
-    return { policy: layers.supplierPolicy, source: "supplier" }
-  }
+  const bookingPolicy = normalizePaymentPolicy(layers.bookingPolicy)
+  if (bookingPolicy) return { policy: bookingPolicy, source: "booking" }
+  const listingPolicy = normalizePaymentPolicy(layers.listingPolicy)
+  if (listingPolicy) return { policy: listingPolicy, source: "listing" }
+  const categoryPolicy = normalizePaymentPolicy(layers.categoryPolicy)
+  if (categoryPolicy) return { policy: categoryPolicy, source: "category" }
+  const supplierPolicy = normalizePaymentPolicy(layers.supplierPolicy)
+  if (supplierPolicy) return { policy: supplierPolicy, source: "supplier" }
   return {
-    policy: isPaymentPolicy(layers.operatorDefault) ? layers.operatorDefault : noDepositPolicy,
+    policy: normalizePaymentPolicy(layers.operatorDefault) ?? noDepositPolicy,
     source: "operator_default",
   }
 }
@@ -276,7 +318,7 @@ export function policyShouldRequireFullPayment(
   departureDate: string | null | undefined,
   today: Date = new Date(),
 ): boolean {
-  const effectivePolicy = isPaymentPolicy(policy) ? policy : noDepositPolicy
+  const effectivePolicy = normalizePaymentPolicy(policy) ?? noDepositPolicy
   if (effectivePolicy.deposit.kind === "none") return true
   const departure = parseIsoDate(departureDate)
   if (!departure) return true

--- a/packages/finance/tests/unit/payment-policy.test.ts
+++ b/packages/finance/tests/unit/payment-policy.test.ts
@@ -4,6 +4,7 @@ import {
   computePaymentSchedule,
   isPaymentPolicyEmpty,
   noDepositPolicy,
+  normalizePaymentPolicy,
   type PaymentPolicy,
   policyShouldRequireFullPayment,
   resolveEffectivePaymentPolicy,
@@ -17,6 +18,32 @@ const fiftyFifty: PaymentPolicy = {
   balanceDueDaysBeforeDeparture: 30,
   balanceDueMinDaysFromNow: 7,
 }
+
+const legacyDepositPolicy = {
+  type: "deposit",
+  depositPercent: 30,
+  balanceDueDays: 30,
+}
+
+describe("normalizePaymentPolicy", () => {
+  it("maps the legacy operator default shape to the current payment policy shape", () => {
+    expect(normalizePaymentPolicy(legacyDepositPolicy)).toEqual({
+      deposit: { kind: "percent", percent: 30 },
+      minDaysBeforeDepartureForDeposit: 0,
+      balanceDueDaysBeforeDeparture: 30,
+      balanceDueMinDaysFromNow: 0,
+    })
+  })
+
+  it("preserves current payment policy objects", () => {
+    expect(normalizePaymentPolicy(fiftyFifty)).toBe(fiftyFifty)
+  })
+
+  it("returns null for malformed values", () => {
+    expect(normalizePaymentPolicy({ type: "deposit", depositPercent: 120 })).toBeNull()
+    expect(normalizePaymentPolicy({})).toBeNull()
+  })
+})
 
 describe("computePaymentSchedule", () => {
   it("emits a single full-payment row for a no-deposit policy", () => {
@@ -154,6 +181,23 @@ describe("computePaymentSchedule", () => {
       { scheduleType: "full", amountCents: 100_000, currency: "EUR", dueDate: "2026-01-01" },
     ])
   })
+
+  it("computes schedules from the legacy operator default shape", () => {
+    const rows = computePaymentSchedule(
+      { totalCents: 100_000, currency: "EUR", departureDate: "2026-06-15", today: fixedToday },
+      legacyDepositPolicy as PaymentPolicy,
+    )
+
+    expect(rows[0]).toMatchObject({
+      scheduleType: "deposit",
+      amountCents: 30_000,
+    })
+    expect(rows[1]).toMatchObject({
+      scheduleType: "balance",
+      amountCents: 70_000,
+      dueDate: "2026-05-16",
+    })
+  })
 })
 
 describe("resolveEffectivePaymentPolicy", () => {
@@ -221,6 +265,20 @@ describe("resolveEffectivePaymentPolicy", () => {
     })
     expect(result.source).toBe("operator_default")
     expect(result.policy).toEqual(noDepositPolicy)
+  })
+
+  it("normalizes a legacy operator default policy", () => {
+    const result = resolveEffectivePaymentPolicy({
+      operatorDefault: legacyDepositPolicy as PaymentPolicy,
+    })
+
+    expect(result.source).toBe("operator_default")
+    expect(result.policy).toEqual({
+      deposit: { kind: "percent", percent: 30 },
+      minDaysBeforeDepartureForDeposit: 0,
+      balanceDueDaysBeforeDeparture: 30,
+      balanceDueMinDaysFromNow: 0,
+    })
   })
 })
 

--- a/starters/operator/src/components/voyant/settings/operator-settings-page.tsx
+++ b/starters/operator/src/components/voyant/settings/operator-settings-page.tsx
@@ -9,7 +9,11 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { noDepositPolicy, type PaymentPolicy } from "@voyant-travel/finance/payment-policy"
+import {
+  noDepositPolicy,
+  normalizePaymentPolicy,
+  type PaymentPolicy,
+} from "@voyant-travel/finance/payment-policy"
 import { PaymentPolicyForm, PaymentPolicyPreview } from "@voyant-travel/finance-react/ui"
 import {
   Button,
@@ -60,7 +64,9 @@ type OperatorPaymentInstructionsRecord = Pick<
   OperatorProfileForm,
   "bankTransferBeneficiary" | "iban" | "bank" | "notes"
 >
-type OperatorPaymentDefaultsRecord = Pick<OperatorProfileForm, "customerPaymentPolicy">
+interface OperatorPaymentDefaultsRecord {
+  customerPaymentPolicy?: unknown
+}
 type OperatorCheckoutLinksRecord = Pick<
   OperatorProfileForm,
   "bookingCheckoutUrlTemplate" | "invoicePayUrlTemplate"
@@ -124,7 +130,8 @@ function OperatorProfilePage() {
         ...EMPTY_FORM,
         ...(profileJson.data ?? {}),
         ...(instructionsJson.data ?? {}),
-        customerPaymentPolicy: defaultsJson.data?.customerPaymentPolicy ?? null,
+        customerPaymentPolicy:
+          normalizePaymentPolicy(defaultsJson.data?.customerPaymentPolicy) ?? noDepositPolicy,
         bookingCheckoutUrlTemplate: defaultsJson.data?.bookingCheckoutUrlTemplate ?? "",
         invoicePayUrlTemplate: defaultsJson.data?.invoicePayUrlTemplate ?? "",
       }


### PR DESCRIPTION
## Summary
- Normalize legacy customer payment policy JSON into the current payment policy shape.
- Use normalization when loading Operator Profile payment defaults so saving writes the current shape.
- Make the shared payment policy form tolerant of legacy runtime values and add regression coverage.

Fixes #2610

## Checks
- pnpm --filter @voyant-travel/finance test -- tests/unit/payment-policy.test.ts
- pnpm --filter @voyant-travel/finance-react test -- src/components/payment-policy-form.test.tsx
- pnpm --filter @voyant-travel/finance lint
- pnpm --filter @voyant-travel/finance-react lint
- pnpm --filter operator lint
- pnpm run verify:agent-quality:changed
- pre-commit affected lint/typecheck/build hook passed
- pre-push test hook passed

## Notes
- Direct package typecheck attempts for @voyant-travel/finance and @voyant-travel/finance-react hit Node heap OOM (exit 134) before the later pre-commit affected hook completed successfully.
- An operator typecheck attempt was interrupted after several minutes with no output to avoid tying up the local queue; the later pre-commit affected hook completed operator typecheck successfully.