### PR TITLE
Fix bank-transfer checkout lifecycle audit

### DIFF
--- a/.changeset/bank-transfer-checkout-lifecycle.md
+++ b/.changeset/bank-transfer-checkout-lifecycle.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/commerce": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Snapshot accepted bank-transfer checkout payment terms into booking activity and show pre-payment checkout lifecycle rows in the admin activity timeline.

--- a/packages/bookings-react/src/components/booking-activity-timeline.tsx
+++ b/packages/bookings-react/src/components/booking-activity-timeline.tsx
@@ -81,6 +81,7 @@ const activityIcons: Record<string, LucideIcon> = {
   supplier_update: RefreshCw,
   traveler_update: UserPlus,
   note_added: Pencil,
+  system_action: Clock,
 }
 
 const sourceVariant: Record<TimelineSource, "default" | "secondary" | "outline"> = {

--- a/packages/bookings-react/tests/unit/booking-activity-timeline.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-activity-timeline.test.tsx
@@ -93,4 +93,22 @@ describe("BookingActivityTimeline", () => {
 
     expect(html).toContain("Note updated")
   })
+
+  it("uses system-action descriptions as visible lifecycle text", () => {
+    bookingHooks.activity = [
+      {
+        id: "act_bank_transfer",
+        bookingId: "book_123",
+        actorId: "system",
+        activityType: "system_action",
+        description: "Proforma/payment instructions issued; awaiting bank transfer",
+        metadata: { kind: "storefront_bank_transfer_awaiting_payment" },
+        createdAt: "2026-07-03T12:00:00.000Z",
+      },
+    ]
+
+    const html = renderToStaticMarkup(<BookingActivityTimeline bookingId="book_123" />)
+
+    expect(html).toContain("Proforma/payment instructions issued; awaiting bank transfer")
+  })
 })

--- a/packages/commerce/src/checkout/index.ts
+++ b/packages/commerce/src/checkout/index.ts
@@ -43,6 +43,7 @@ export {
 } from "./materialization-support.js"
 export { materializeBookingItemTaxLine } from "./materialization-tax.js"
 export type {
+  CheckoutAcceptedPaymentPolicy,
   CheckoutBankTransferInstructions,
   CheckoutModuleOptions,
   CheckoutStartOptions,

--- a/packages/commerce/src/checkout/options.ts
+++ b/packages/commerce/src/checkout/options.ts
@@ -19,7 +19,7 @@
  *     payment-instruction rows for the bank-transfer checkout path.
  */
 
-import type { BookingTaxSettings } from "@voyant-travel/finance"
+import type { BookingTaxSettings, PaymentPolicy, PaymentPolicySource } from "@voyant-travel/finance"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 /**
@@ -31,6 +31,11 @@ export interface CheckoutBankTransferInstructions {
   beneficiary: string
   iban: string
   bankName: string
+}
+
+export interface CheckoutAcceptedPaymentPolicy {
+  policy: PaymentPolicy
+  source: PaymentPolicySource
 }
 
 /**
@@ -72,6 +77,22 @@ export interface CheckoutStartOptions extends CheckoutModuleOptions {
     db: PostgresJsDatabase,
     env: Record<string, string | undefined>,
   ): Promise<CheckoutBankTransferInstructions>
+  /**
+   * Resolve the payment terms the customer accepted during checkout. The
+   * checkout service snapshots the resolved policy + computed schedule into
+   * the activity log for audit, without creating official
+   * `booking_payment_schedules` rows before payment confirmation.
+   */
+  resolveAcceptedPaymentPolicy?(params: {
+    db: PostgresJsDatabase
+    booking: {
+      id: string
+      sellAmountCents: number | null
+      sellCurrency: string
+      startDate: string | null
+      customerPaymentPolicy: PaymentPolicy | null
+    }
+  }): Promise<CheckoutAcceptedPaymentPolicy | null>
   /**
    * Start the card-payment provider session for the `card` checkout intent.
    * INJECTED so commerce never imports a specific payment provider (which

--- a/packages/commerce/src/checkout/start-service.test.ts
+++ b/packages/commerce/src/checkout/start-service.test.ts
@@ -1,7 +1,8 @@
+import * as financeModule from "@voyant-travel/finance"
 import { handleApiError } from "@voyant-travel/hono"
 import { Hono } from "hono"
-import { describe, expect, it, vi } from "vitest"
-import type { CheckoutStartOptions } from "./options.js"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { CheckoutAcceptedPaymentPolicy, CheckoutStartOptions } from "./options.js"
 import { createCatalogCheckoutRoutes } from "./routes.js"
 import { CatalogCheckoutStartError, startCatalogCheckout } from "./start-service.js"
 
@@ -71,6 +72,10 @@ function queuedDb(selectRows: unknown[][]) {
 }
 
 describe("startCatalogCheckout", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("places a hold for an existing booking", async () => {
     const booking = { id: "bk_1", status: "on_hold", holdExpiresAt: null }
     const result = await startCatalogCheckout(
@@ -128,6 +133,155 @@ describe("startCatalogCheckout", () => {
       status: 422,
     })
     expect(calls.updates).toBe(0)
+  })
+
+  it("records bank-transfer checkout activity with accepted payment terms before confirmation", async () => {
+    vi.spyOn(financeModule.financeService, "resolveDefaultInvoiceNumberSeries").mockResolvedValue({
+      id: "series_proforma",
+    } as never)
+    vi.spyOn(financeModule.financeService, "createPaymentSession").mockResolvedValue({
+      id: "ps_bank_transfer",
+    } as never)
+    vi.spyOn(financeModule, "issueProformaFromBooking").mockResolvedValue({
+      id: "inv_proforma",
+      invoiceNumber: "PF-1001",
+    } as never)
+
+    const booking = {
+      id: "bk_bank",
+      bookingNumber: "BK-1001",
+      status: "on_hold",
+      holdExpiresAt: null,
+      personId: null,
+      organizationId: null,
+      sellAmountCents: 100000,
+      sellCurrency: "EUR",
+      baseCurrency: null,
+      baseSellAmountCents: null,
+      startDate: "2026-09-01",
+    }
+    const inserts: Array<{ table: unknown; values: Record<string, unknown> }> = []
+    const updates: Record<string, unknown>[] = []
+    const selectRows = [[booking], [], []]
+    const nextRows = () => selectRows.shift() ?? []
+    let selectCalls = 0
+    type SelectChain = {
+      from: () => SelectChain
+      where: () => SelectChain
+      limit: () => Promise<unknown[]>
+    }
+    const selectChain: SelectChain = {
+      from: () => selectChain,
+      where: () => selectChain,
+      limit: async () => nextRows(),
+    }
+    const db = {
+      select: () => {
+        selectCalls += 1
+        if (selectCalls === 3) {
+          return {
+            from: () => ({
+              where: async () => nextRows(),
+            }),
+          }
+        }
+        return selectChain
+      },
+      insert: (table: unknown) => ({
+        values: (values: Record<string, unknown>) => {
+          inserts.push({ table, values })
+          return {
+            onConflictDoNothing: () => ({ returning: async () => [] }),
+            returning: async () => [],
+          }
+        },
+      }),
+      update: () => ({
+        set: (values: Record<string, unknown>) => {
+          updates.push(values)
+          return { where: async () => undefined }
+        },
+      }),
+    } as never
+    const acceptedPaymentPolicy = {
+      source: "operator_default",
+      policy: {
+        deposit: { kind: "percent", percent: 30 },
+        minDaysBeforeDepartureForDeposit: 0,
+        balanceDueDaysBeforeDeparture: 21,
+        balanceDueMinDaysFromNow: 7,
+      },
+    } satisfies CheckoutAcceptedPaymentPolicy
+
+    const result = await startCatalogCheckout(
+      {
+        db,
+        env: {},
+        options: stubOptions({
+          resolveAcceptedPaymentPolicy: vi.fn(async () => acceptedPaymentPolicy),
+        }),
+        requestMeta: {
+          clientIp: "203.0.113.10",
+          userAgent: "Test Browser",
+        },
+      },
+      {
+        bookingId: "bk_bank",
+        paymentIntent: "bank_transfer",
+        payerEmail: "ada@example.com",
+        contractAcceptance: {
+          templateId: "tmpl_1",
+          templateSlug: "terms",
+          acceptedTerms: true,
+          acceptedMarketing: false,
+          acceptedAt: "2026-07-03T12:00:00.000Z",
+          renderedHtml: "<p>Accepted terms</p>",
+        },
+      },
+    )
+
+    expect(result).toMatchObject({
+      kind: "bank_transfer_instructions",
+      bookingId: "bk_bank",
+      proformaId: "inv_proforma",
+      proformaNumber: "PF-1001",
+      paymentSessionId: "ps_bank_transfer",
+    })
+    expect(updates).toHaveLength(1)
+    const activityRows = inserts.map((insert) => insert.values)
+    expect(activityRows).toHaveLength(3)
+    expect(activityRows.map((row) => row.description)).toEqual([
+      "Storefront bank-transfer checkout started",
+      "Draft storefront terms accepted before payment",
+      "Proforma/payment instructions issued; awaiting bank transfer",
+    ])
+    expect(activityRows.every((row) => row.activityType === "system_action")).toBe(true)
+    expect(activityRows[1]?.metadata).toMatchObject({
+      kind: "storefront_draft_terms_accepted",
+      officialContractNumber: null,
+      acceptance: {
+        templateId: "tmpl_1",
+        templateSlug: "terms",
+        acceptedAt: "2026-07-03T12:00:00.000Z",
+      },
+      paymentTerms: {
+        kind: "accepted_payment_terms",
+        policySource: "operator_default",
+        totalCents: 100000,
+        currency: "EUR",
+        entries: [
+          { scheduleType: "deposit", amountCents: 30000, currency: "EUR" },
+          { scheduleType: "balance", amountCents: 70000, currency: "EUR" },
+        ],
+      },
+    })
+    expect(activityRows[2]?.metadata).toMatchObject({
+      kind: "storefront_bank_transfer_awaiting_payment",
+      proformaId: "inv_proforma",
+      proformaNumber: "PF-1001",
+      paymentSessionId: "ps_bank_transfer",
+      reference: "BOOK-BK-1001",
+    })
   })
 })
 

--- a/packages/commerce/src/checkout/start-service.ts
+++ b/packages/commerce/src/checkout/start-service.ts
@@ -2,13 +2,16 @@
 // service (card / bank-transfer / inquiry / hold intents) is one cohesive
 // entry point; splitting it would scatter a single request lifecycle.
 import { bookingsService, canTransitionBooking, transitionBooking } from "@voyant-travel/bookings"
-import { bookings } from "@voyant-travel/bookings/schema"
+import { bookingActivityLog, bookings } from "@voyant-travel/bookings/schema"
 import type { EventBus } from "@voyant-travel/core"
 import {
   type CreateInvoiceFromBookingInput,
+  computePaymentSchedule,
   financeService,
   InvoiceNumberAllocationError,
   issueProformaFromBooking,
+  type PaymentPolicy,
+  type PaymentPolicySource,
 } from "@voyant-travel/finance"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -106,6 +109,17 @@ interface CheckoutAcceptanceMetadata {
   renderedHtmlLength: number
 }
 
+interface AcceptedPaymentTermsSnapshot {
+  kind: "accepted_payment_terms"
+  policySource: PaymentPolicySource
+  policy: PaymentPolicy
+  entries: ReturnType<typeof computePaymentSchedule>
+  totalCents: number
+  currency: string
+  departureDate: string | null
+  resolvedAt: string
+}
+
 export async function startCatalogCheckout(
   context: CatalogCheckoutStartContext,
   body: CheckoutStartInput,
@@ -178,7 +192,7 @@ export async function startCatalogCheckout(
     case "card":
       return startCardCheckout(context, booking, body)
     case "bank_transfer":
-      return startBankTransferCheckout(context, booking)
+      return startBankTransferCheckout(context, booking, body)
     case "inquiry":
       return startInquiryCheckout(context, booking)
     case "hold":
@@ -399,9 +413,34 @@ async function startCardCheckout(
 async function startBankTransferCheckout(
   context: CatalogCheckoutStartContext,
   booking: typeof bookings.$inferSelect,
+  body: CheckoutStartInput,
 ): Promise<CatalogCheckoutStartResult> {
   const db = context.db
   await ensureBankTransferProformaPrerequisites(db)
+  const paymentTerms = await snapshotAcceptedPaymentTerms(context, booking)
+
+  await recordCheckoutActivity(db, booking.id, "Storefront bank-transfer checkout started", {
+    kind: "storefront_bank_transfer_checkout_started",
+    paymentIntent: "bank_transfer",
+    paymentTerms,
+  })
+
+  if (body.contractAcceptance) {
+    await recordCheckoutActivity(db, booking.id, "Draft storefront terms accepted before payment", {
+      kind: "storefront_draft_terms_accepted",
+      acceptance: {
+        templateId: body.contractAcceptance.templateId,
+        templateSlug: body.contractAcceptance.templateSlug,
+        acceptedAt: body.contractAcceptance.acceptedAt,
+        acceptedMarketing: body.contractAcceptance.acceptedMarketing,
+        renderedHtmlLength: body.contractAcceptance.renderedHtml.length,
+        clientIp: context.requestMeta?.clientIp ?? "",
+        userAgent: context.requestMeta?.userAgent ?? "",
+      },
+      officialContractNumber: null,
+      paymentTerms,
+    })
+  }
 
   // Issue a proforma synchronously so the customer leaves with a
   // document reference. SmartBill (subscribing to
@@ -482,6 +521,22 @@ async function startBankTransferCheckout(
   } as never)
 
   const bankTransfer = await context.options.resolveBankTransferInstructions(db, context.env)
+  await recordCheckoutActivity(
+    db,
+    booking.id,
+    "Proforma/payment instructions issued; awaiting bank transfer",
+    {
+      kind: "storefront_bank_transfer_awaiting_payment",
+      proformaId: proforma?.id ?? null,
+      proformaNumber: proforma?.invoiceNumber ?? null,
+      paymentSessionId: paymentSession?.id ?? null,
+      amountCents: booking.sellAmountCents ?? 0,
+      currency: booking.sellCurrency ?? "EUR",
+      dueAt: dueDate,
+      reference: `BOOK-${booking.bookingNumber}`,
+      paymentTerms,
+    },
+  )
   return {
     kind: "bank_transfer_instructions",
     bookingId: booking.id,
@@ -498,6 +553,61 @@ async function startBankTransferCheckout(
       dueAt: dueDate,
     },
   }
+}
+
+async function snapshotAcceptedPaymentTerms(
+  context: CatalogCheckoutStartContext,
+  booking: typeof bookings.$inferSelect,
+): Promise<AcceptedPaymentTermsSnapshot | null> {
+  const resolved = await context.options.resolveAcceptedPaymentPolicy?.({
+    db: context.db,
+    booking: {
+      id: booking.id,
+      sellAmountCents: booking.sellAmountCents,
+      sellCurrency: booking.sellCurrency,
+      startDate: booking.startDate,
+      customerPaymentPolicy:
+        (booking.customerPaymentPolicy as PaymentPolicy | null | undefined) ?? null,
+    },
+  })
+  if (!resolved) return null
+
+  const resolvedAt = new Date().toISOString()
+  const totalCents = booking.sellAmountCents ?? 0
+  const currency = booking.sellCurrency ?? "EUR"
+  return {
+    kind: "accepted_payment_terms",
+    policySource: resolved.source,
+    policy: resolved.policy,
+    entries: computePaymentSchedule(
+      {
+        totalCents,
+        currency,
+        departureDate: booking.startDate,
+        today: new Date(resolvedAt),
+      },
+      resolved.policy,
+    ),
+    totalCents,
+    currency,
+    departureDate: booking.startDate ?? null,
+    resolvedAt,
+  }
+}
+
+async function recordCheckoutActivity(
+  db: PostgresJsDatabase,
+  bookingId: string,
+  description: string,
+  metadata: Record<string, unknown>,
+): Promise<void> {
+  await db.insert(bookingActivityLog).values({
+    bookingId,
+    actorId: "system",
+    activityType: "system_action",
+    description,
+    metadata,
+  })
 }
 
 async function ensureBankTransferProformaPrerequisites(db: PostgresJsDatabase): Promise<void> {

--- a/starters/operator/src/api/runtime/catalog-checkout-options.ts
+++ b/starters/operator/src/api/runtime/catalog-checkout-options.ts
@@ -13,15 +13,26 @@
  *   - `resolveBankTransferInstructions` — operator profile / payment-instruction
  *     rows + env fallbacks for the bank-transfer checkout path.
  */
-import type { CheckoutModuleOptions, CheckoutStartOptions } from "@voyant-travel/commerce/checkout"
+import type {
+  CheckoutAcceptedPaymentPolicy,
+  CheckoutModuleOptions,
+  CheckoutStartOptions,
+} from "@voyant-travel/commerce/checkout"
+import { noDepositPolicy, resolveEffectivePaymentPolicy } from "@voyant-travel/finance"
 import { productsService } from "@voyant-travel/inventory"
 import {
   getOperatorPaymentInstructions,
   getOperatorProfile,
   resolveBookingTaxSettings,
+  resolveOperatorDefaultPaymentPolicy,
 } from "@voyant-travel/operator-settings"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
+import {
+  resolveCategoryPolicy,
+  resolveListingPolicy,
+  resolveSupplierPolicy,
+} from "./booking-payment-policy-runtime"
 import { cardPaymentStarter } from "./card-payment"
 
 /** Resolve an owned product's display name (cycle-avoiding inventory read). */
@@ -99,6 +110,25 @@ function createStartCardPayment(c: Context): CheckoutStartOptions["startCardPaym
     })
 }
 
+const resolveAcceptedPaymentPolicy: NonNullable<
+  CheckoutStartOptions["resolveAcceptedPaymentPolicy"]
+> = async ({ db, booking }): Promise<CheckoutAcceptedPaymentPolicy | null> => {
+  const [operatorDefault, supplierPolicy, categoryPolicy, listingPolicy] = await Promise.all([
+    resolveOperatorDefaultPaymentPolicy(db),
+    resolveSupplierPolicy(db, booking.id),
+    resolveCategoryPolicy(db, booking.id),
+    resolveListingPolicy(db, booking.id),
+  ])
+
+  return resolveEffectivePaymentPolicy({
+    bookingPolicy: booking.customerPaymentPolicy,
+    listingPolicy,
+    categoryPolicy,
+    supplierPolicy,
+    operatorDefault: operatorDefault ?? noDepositPolicy,
+  })
+}
+
 /**
  * Checkout-start options — module options + bank-transfer reader + card-payment
  * starter. Pass the request `Context` to wire the Netopia card-payment start
@@ -109,6 +139,7 @@ export function createOperatorCheckoutStartOptions(c?: Context): CheckoutStartOp
   return {
     ...createOperatorCheckoutModuleOptions(),
     resolveBankTransferInstructions,
+    resolveAcceptedPaymentPolicy,
     startCardPayment: c ? createStartCardPayment(c) : undefined,
   }
 }


### PR DESCRIPTION
## Summary

- Snapshot the bank-transfer checkout payment terms the customer accepted into `booking_activity_log.metadata` without creating final `booking_payment_schedules` early.
- Emit pre-payment bank-transfer lifecycle activity rows for checkout start, draft terms acceptance, and proforma/payment instructions issued while awaiting transfer.
- Reuse the operator payment-policy cascade for the accepted-terms snapshot and keep final schedule/contract generation post-payment.
- Show checkout lifecycle system-action rows clearly in the admin activity timeline.

## Validation

- `pnpm lint:changed`
- `pnpm --filter @voyant-travel/commerce test -- src/checkout/start-service.test.ts`
- `pnpm --filter @voyant-travel/bookings-react test -- tests/unit/booking-activity-timeline.test.tsx`
- `git diff --check`

Typecheck notes:

- `pnpm --filter @voyant-travel/commerce typecheck` and `pnpm --filter @voyant-travel/bookings-react typecheck` OOMed with exit 134 when run in parallel at default heap.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/commerce typecheck` also OOMed with exit 134.
- `pnpm -C starters/operator typecheck` was started with the starter's configured larger heap, produced no diagnostics for several minutes, and was interrupted to avoid tying up the sequential queue.

## Residual Risk

- Local typecheck did not complete because of OOM/long-running checks; CI remains the broad typecheck gate.
- This intentionally does not mint official contract numbers or persist final `booking_payment_schedules` at checkout. Those remain post-payment/post-confirmation.

Fixes #2723
