### PR TITLE
Add storefront customer accounts

### DIFF
--- a/.changeset/customer-account-auth.md
+++ b/.changeset/customer-account-auth.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Allow customer-scoped email/password self-signups to bypass the admin bootstrap signup block and skip workspace profile provisioning when the signup is explicitly marked as a customer surface.

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -69,7 +69,11 @@ type ResolvedBetterAuthPlugins<Plugins extends BetterAuthPlugin[] | undefined> =
     : VoyantBetterAuthPlugins
 
 const DEFAULT_SIGNUP_BLOCK_SURFACES = ["admin"] as const
-const CUSTOMER_SIGNUP_ENDPOINT_SUFFIXES = ["/phone-number/verify", "/sign-in/email-otp"] as const
+const CUSTOMER_SIGNUP_ENDPOINT_SUFFIXES = [
+  "/sign-up/email",
+  "/phone-number/verify",
+  "/sign-in/email-otp",
+] as const
 
 export interface DisableSignupWhenUsersExistOptions {
   /**
@@ -398,7 +402,14 @@ export function createBetterAuth<
               return { data: normalizedUser as Record<string, unknown> }
             }
           },
-          after: async (user) => {
+          after: async (user, context) => {
+            if (
+              customerSignupSurfaces.length > 0 &&
+              isCustomerSignupCreate(context as BetterAuthHookContext | null)
+            ) {
+              return
+            }
+
             // Single-tenant bootstrap: the very first user to register becomes
             // the super-admin. Runs atomically after the `user` row is
             // inserted, so a simple COUNT(*) = 1 check identifies them.

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -13,15 +13,19 @@ type BetterAuthConfig = {
           user?: Record<string, unknown>,
           context?: { path?: string } | null,
         ) => Promise<undefined | { data: Record<string, unknown> }>
+        after: (user: Record<string, unknown>, context?: { path?: string } | null) => Promise<void>
       }
     }
   }
 }
 
-const { betterAuthMock, drizzleAdapterMock } = vi.hoisted(() => ({
-  betterAuthMock: vi.fn((config: Record<string, unknown>) => ({ config })),
-  drizzleAdapterMock: vi.fn(() => ({ adapter: "drizzle" })),
-}))
+const { betterAuthMock, drizzleAdapterMock, isFirstAuthUserMock, provisionCurrentUserProfileMock } =
+  vi.hoisted(() => ({
+    betterAuthMock: vi.fn((config: Record<string, unknown>) => ({ config })),
+    drizzleAdapterMock: vi.fn(() => ({ adapter: "drizzle" })),
+    isFirstAuthUserMock: vi.fn(async () => false),
+    provisionCurrentUserProfileMock: vi.fn(async () => undefined),
+  }))
 
 vi.mock("@better-auth/api-key", () => ({
   apiKey: vi.fn((options: Record<string, unknown>) => ({ id: "apiKey", options })),
@@ -50,6 +54,11 @@ vi.mock("better-auth/adapters/drizzle", () => ({
 
 vi.mock("better-auth/plugins", () => ({
   emailOTP: vi.fn((options: Record<string, unknown>) => ({ id: "emailOTP", options })),
+}))
+
+vi.mock("../../src/workspace.js", () => ({
+  isFirstAuthUser: isFirstAuthUserMock,
+  provisionCurrentUserProfile: provisionCurrentUserProfileMock,
 }))
 
 describe("createBetterAuth", () => {
@@ -340,6 +349,34 @@ describe("createBetterAuth", () => {
     expect(select).not.toHaveBeenCalled()
   })
 
+  it("stamps configured customer surfaces on email/password self-signups before the signup block", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+    const { db, select } = createDbWithUserCount(1)
+
+    createBetterAuth({
+      db: db as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      customerSignupSurfaces: ["customer"],
+    })
+
+    await expect(
+      latestBetterAuthConfig().databaseHooks.user.create.before(
+        {
+          email: "ana@example.com",
+          surfaces: ["admin"],
+        },
+        { path: "/auth/sign-up/email" },
+      ),
+    ).resolves.toEqual({
+      data: {
+        email: "ana@example.com",
+        surfaces: ["customer"],
+      },
+    })
+    expect(select).not.toHaveBeenCalled()
+  })
+
   it("does not stamp customer surfaces on non-customer signup endpoints", async () => {
     const { createBetterAuth } = await import("../../src/server.js")
     const { db } = createDbWithUserCount(1)
@@ -356,9 +393,52 @@ describe("createBetterAuth", () => {
         {
           surfaces: ["admin"],
         },
-        { path: "/sign-up/email" },
+        { path: "/auth/sign-in/email" },
       ),
     ).rejects.toThrow("Sign-up is disabled. Ask an admin to invite you.")
+  })
+
+  it("does not provision workspace profiles for customer self-signups", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      customerSignupSurfaces: ["customer"],
+    })
+
+    await latestBetterAuthConfig().databaseHooks.user.create.after(
+      { id: "user_1", name: "Ana Customer", image: null },
+      { path: "/auth/sign-up/email" },
+    )
+
+    expect(isFirstAuthUserMock).not.toHaveBeenCalled()
+    expect(provisionCurrentUserProfileMock).not.toHaveBeenCalled()
+  })
+
+  it("still provisions workspace profiles for admin signups", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+    })
+
+    await latestBetterAuthConfig().databaseHooks.user.create.after(
+      { id: "user_1", name: "Ana Admin", image: null },
+      { path: "/auth/sign-up/email" },
+    )
+
+    expect(isFirstAuthUserMock).toHaveBeenCalled()
+    expect(provisionCurrentUserProfileMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        userId: "user_1",
+        name: "Ana Admin",
+      }),
+    )
   })
 
   it("treats blank surface array entries as missing surfaces for the signup block", async () => {

--- a/starters/operator/src/api/auth/handler.ts
+++ b/starters/operator/src/api/auth/handler.ts
@@ -259,7 +259,15 @@ function betterAuthSecondaryStorage(env: CloudflareBindings) {
  * behalf of a different request"). The auth instance is therefore not
  * cached either.
  */
-function buildBetterAuth(env: CloudflareBindings, db: ReturnType<typeof dbFromEnvForApp>["db"]) {
+interface BuildBetterAuthOptions {
+  customerSignup?: boolean
+}
+
+function buildBetterAuth(
+  env: CloudflareBindings,
+  db: ReturnType<typeof dbFromEnvForApp>["db"],
+  options: BuildBetterAuthOptions = {},
+) {
   const cloud = tryGetCloudClient(env)
   const emailFrom = env.EMAIL_FROM || "Voyant <noreply@voyantcloud.app>"
   const emailReplyTo = resolveEmailReplyTo(env)
@@ -280,6 +288,7 @@ function buildBetterAuth(env: CloudflareBindings, db: ReturnType<typeof dbFromEn
     basePath: "/auth",
     trustedOrigins: getTrustedOrigins(env),
     secondaryStorage: betterAuthSecondaryStorage(env),
+    customerSignupSurfaces: options.customerSignup ? ["customer"] : undefined,
     plugins: cloudAuthExchange
       ? [
           createVoyantCloudAdminAuthPlugin({
@@ -328,6 +337,12 @@ function buildBetterAuth(env: CloudflareBindings, db: ReturnType<typeof dbFromEn
       })
     },
   })
+}
+
+function rewriteCustomerAuthRequest(request: Request): Request {
+  const url = new URL(request.url)
+  url.pathname = url.pathname.replace("/auth/customer", "/auth")
+  return new Request(url, request)
 }
 
 const FULL_ACCESS_SCOPES = ["*"]
@@ -760,6 +775,34 @@ auth.all("/auth/api-tokens", handleApiTokensFacade)
 auth.all("/auth/api-tokens/:keyId", handleApiTokensFacade)
 auth.all("/auth/api-tokens/:keyId/rotate", handleApiTokensFacade)
 auth.get("/auth/organization/list-members", handleOrganizationMembersFacade)
+
+auth.get("/auth/customer/status", async (c) => {
+  const { db, dispose } = dbFromEnvForApp(c.env)
+  try {
+    const betterAuth = buildBetterAuth(c.env, db, { customerSignup: true })
+    const session = await betterAuth.api.getSession({ headers: c.req.raw.headers })
+    return c.json({ authenticated: Boolean(session) })
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
+})
+
+auth.all("/auth/customer/*", async (c) => {
+  if (
+    isVoyantCloudAuthMode(c.env) &&
+    !isCloudAllowedBetterAuthRoute(rewriteCustomerAuthRequest(c.req.raw))
+  ) {
+    return localAuthDisabledResponse(c)
+  }
+
+  const { db, dispose } = dbFromEnvForApp(c.env)
+  try {
+    const betterAuth = buildBetterAuth(c.env, db, { customerSignup: true })
+    return await betterAuth.handler(rewriteCustomerAuthRequest(c.req.raw))
+  } finally {
+    c.executionCtx.waitUntil(dispose())
+  }
+})
 
 /**
  * Catch-all: delegate to Better Auth handler.

--- a/starters/operator/src/lib/customer-account.test.ts
+++ b/starters/operator/src/lib/customer-account.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { rewriteCustomerAccountAuthUrl } from "./customer-account"
+
+describe("rewriteCustomerAccountAuthUrl", () => {
+  it("routes customer auth UI calls through the customer auth facade", () => {
+    expect(rewriteCustomerAccountAuthUrl("https://example.test/api/auth/sign-in/email")).toBe(
+      "https://example.test/api/auth/customer/sign-in/email",
+    )
+    expect(rewriteCustomerAccountAuthUrl("https://example.test/api/auth/sign-up/email")).toBe(
+      "https://example.test/api/auth/customer/sign-up/email",
+    )
+  })
+
+  it("keeps auth status calls out of the admin provisioning endpoint", () => {
+    expect(rewriteCustomerAccountAuthUrl("https://example.test/api/auth/status")).toBe(
+      "https://example.test/api/auth/customer/status",
+    )
+  })
+
+  it("leaves public API calls unchanged", () => {
+    expect(
+      rewriteCustomerAccountAuthUrl("https://example.test/api/v1/public/customer-portal/me"),
+    ).toBe("https://example.test/api/v1/public/customer-portal/me")
+  })
+
+  it("does not double-prefix customer auth calls", () => {
+    expect(
+      rewriteCustomerAccountAuthUrl("https://example.test/api/auth/customer/sign-in/email"),
+    ).toBe("https://example.test/api/auth/customer/sign-in/email")
+  })
+})

--- a/starters/operator/src/lib/customer-account.tsx
+++ b/starters/operator/src/lib/customer-account.tsx
@@ -1,0 +1,39 @@
+"use client"
+
+import { VoyantAuthProvider } from "@voyant-travel/auth-react/provider"
+import type { VoyantFetcher } from "@voyant-travel/storefront-react/customer-portal/client"
+import { VoyantCustomerPortalProvider } from "@voyant-travel/storefront-react/customer-portal/provider"
+import type { ReactNode } from "react"
+import { getApiUrl } from "./env"
+import { operatorFetcher } from "./voyant-fetcher"
+
+export function rewriteCustomerAccountAuthUrl(url: string): string {
+  let target = url
+  if (target.includes("/auth/customer/")) {
+    return target
+  }
+  if (target.includes("/auth/")) {
+    target = target.replace("/auth/", "/auth/customer/")
+  }
+  if (target.endsWith("/auth/status")) {
+    target = target.replace("/auth/status", "/auth/customer/status")
+  }
+  return target
+}
+
+export const customerAccountFetcher: VoyantFetcher = (url, init) => {
+  const target = rewriteCustomerAccountAuthUrl(url)
+  return operatorFetcher(target, init)
+}
+
+export function CustomerAccountProvider({ children }: { children: ReactNode }) {
+  const baseUrl = getApiUrl()
+
+  return (
+    <VoyantAuthProvider baseUrl={baseUrl} fetcher={customerAccountFetcher}>
+      <VoyantCustomerPortalProvider baseUrl={baseUrl} fetcher={operatorFetcher}>
+        {children}
+      </VoyantCustomerPortalProvider>
+    </VoyantAuthProvider>
+  )
+}

--- a/starters/operator/src/routeTree.gen.ts
+++ b/starters/operator/src/routeTree.gen.ts
@@ -27,7 +27,11 @@ import { Route as authForgotPasswordRouteImport } from './routes/(auth)/forgot-p
 import { Route as authAcceptInviteRouteImport } from './routes/(auth)/accept-invite'
 import { Route as authAcceptInvitationRouteImport } from './routes/(auth)/accept-invitation'
 import { Route as storefrontShopComposerRouteImport } from './routes/(storefront)/shop_.composer'
+import { Route as storefrontShopAccountRouteImport } from './routes/(storefront)/shop_.account'
 import { Route as storefrontShopConfirmationBookingIdRouteImport } from './routes/(storefront)/shop_.confirmation.$bookingId'
+import { Route as storefrontShopAccountVerifyEmailRouteImport } from './routes/(storefront)/shop_.account.verify-email'
+import { Route as storefrontShopAccountSignUpRouteImport } from './routes/(storefront)/shop_.account.sign-up'
+import { Route as storefrontShopAccountSignInRouteImport } from './routes/(storefront)/shop_.account.sign-in'
 import { Route as storefrontShopProductsEntityModuleEntityIdRouteImport } from './routes/(storefront)/shop_.products.$entityModule.$entityId'
 import { Route as storefrontShopBookEntityModuleEntityIdRouteImport } from './routes/(storefront)/shop_.book.$entityModule.$entityId'
 
@@ -118,11 +122,34 @@ const storefrontShopComposerRoute = storefrontShopComposerRouteImport.update({
   path: '/shop/composer',
   getParentRoute: () => storefrontRouteRoute,
 } as any)
+const storefrontShopAccountRoute = storefrontShopAccountRouteImport.update({
+  id: '/shop_/account',
+  path: '/shop/account',
+  getParentRoute: () => storefrontRouteRoute,
+} as any)
 const storefrontShopConfirmationBookingIdRoute =
   storefrontShopConfirmationBookingIdRouteImport.update({
     id: '/shop_/confirmation/$bookingId',
     path: '/shop/confirmation/$bookingId',
     getParentRoute: () => storefrontRouteRoute,
+  } as any)
+const storefrontShopAccountVerifyEmailRoute =
+  storefrontShopAccountVerifyEmailRouteImport.update({
+    id: '/verify-email',
+    path: '/verify-email',
+    getParentRoute: () => storefrontShopAccountRoute,
+  } as any)
+const storefrontShopAccountSignUpRoute =
+  storefrontShopAccountSignUpRouteImport.update({
+    id: '/sign-up',
+    path: '/sign-up',
+    getParentRoute: () => storefrontShopAccountRoute,
+  } as any)
+const storefrontShopAccountSignInRoute =
+  storefrontShopAccountSignInRouteImport.update({
+    id: '/sign-in',
+    path: '/sign-in',
+    getParentRoute: () => storefrontShopAccountRoute,
   } as any)
 const storefrontShopProductsEntityModuleEntityIdRoute =
   storefrontShopProductsEntityModuleEntityIdRouteImport.update({
@@ -153,7 +180,11 @@ export interface FileRoutesByFullPath {
   '/accountant/$token': typeof AccountantTokenRoute
   '/pay/$sessionId': typeof PaySessionIdRoute
   '/proposal/$quoteVersionId': typeof ProposalQuoteVersionIdRoute
+  '/shop/account': typeof storefrontShopAccountRouteWithChildren
   '/shop/composer': typeof storefrontShopComposerRoute
+  '/shop/account/sign-in': typeof storefrontShopAccountSignInRoute
+  '/shop/account/sign-up': typeof storefrontShopAccountSignUpRoute
+  '/shop/account/verify-email': typeof storefrontShopAccountVerifyEmailRoute
   '/shop/confirmation/$bookingId': typeof storefrontShopConfirmationBookingIdRoute
   '/shop/book/$entityModule/$entityId': typeof storefrontShopBookEntityModuleEntityIdRoute
   '/shop/products/$entityModule/$entityId': typeof storefrontShopProductsEntityModuleEntityIdRoute
@@ -174,7 +205,11 @@ export interface FileRoutesByTo {
   '/accountant/$token': typeof AccountantTokenRoute
   '/pay/$sessionId': typeof PaySessionIdRoute
   '/proposal/$quoteVersionId': typeof ProposalQuoteVersionIdRoute
+  '/shop/account': typeof storefrontShopAccountRouteWithChildren
   '/shop/composer': typeof storefrontShopComposerRoute
+  '/shop/account/sign-in': typeof storefrontShopAccountSignInRoute
+  '/shop/account/sign-up': typeof storefrontShopAccountSignUpRoute
+  '/shop/account/verify-email': typeof storefrontShopAccountVerifyEmailRoute
   '/shop/confirmation/$bookingId': typeof storefrontShopConfirmationBookingIdRoute
   '/shop/book/$entityModule/$entityId': typeof storefrontShopBookEntityModuleEntityIdRoute
   '/shop/products/$entityModule/$entityId': typeof storefrontShopProductsEntityModuleEntityIdRoute
@@ -198,7 +233,11 @@ export interface FileRoutesById {
   '/accountant/$token': typeof AccountantTokenRoute
   '/pay_/$sessionId': typeof PaySessionIdRoute
   '/proposal/$quoteVersionId': typeof ProposalQuoteVersionIdRoute
+  '/(storefront)/shop_/account': typeof storefrontShopAccountRouteWithChildren
   '/(storefront)/shop_/composer': typeof storefrontShopComposerRoute
+  '/(storefront)/shop_/account/sign-in': typeof storefrontShopAccountSignInRoute
+  '/(storefront)/shop_/account/sign-up': typeof storefrontShopAccountSignUpRoute
+  '/(storefront)/shop_/account/verify-email': typeof storefrontShopAccountVerifyEmailRoute
   '/(storefront)/shop_/confirmation/$bookingId': typeof storefrontShopConfirmationBookingIdRoute
   '/(storefront)/shop_/book/$entityModule/$entityId': typeof storefrontShopBookEntityModuleEntityIdRoute
   '/(storefront)/shop_/products/$entityModule/$entityId': typeof storefrontShopProductsEntityModuleEntityIdRoute
@@ -221,7 +260,11 @@ export interface FileRouteTypes {
     | '/accountant/$token'
     | '/pay/$sessionId'
     | '/proposal/$quoteVersionId'
+    | '/shop/account'
     | '/shop/composer'
+    | '/shop/account/sign-in'
+    | '/shop/account/sign-up'
+    | '/shop/account/verify-email'
     | '/shop/confirmation/$bookingId'
     | '/shop/book/$entityModule/$entityId'
     | '/shop/products/$entityModule/$entityId'
@@ -242,7 +285,11 @@ export interface FileRouteTypes {
     | '/accountant/$token'
     | '/pay/$sessionId'
     | '/proposal/$quoteVersionId'
+    | '/shop/account'
     | '/shop/composer'
+    | '/shop/account/sign-in'
+    | '/shop/account/sign-up'
+    | '/shop/account/verify-email'
     | '/shop/confirmation/$bookingId'
     | '/shop/book/$entityModule/$entityId'
     | '/shop/products/$entityModule/$entityId'
@@ -265,7 +312,11 @@ export interface FileRouteTypes {
     | '/accountant/$token'
     | '/pay_/$sessionId'
     | '/proposal/$quoteVersionId'
+    | '/(storefront)/shop_/account'
     | '/(storefront)/shop_/composer'
+    | '/(storefront)/shop_/account/sign-in'
+    | '/(storefront)/shop_/account/sign-up'
+    | '/(storefront)/shop_/account/verify-email'
     | '/(storefront)/shop_/confirmation/$bookingId'
     | '/(storefront)/shop_/book/$entityModule/$entityId'
     | '/(storefront)/shop_/products/$entityModule/$entityId'
@@ -410,12 +461,40 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof storefrontShopComposerRouteImport
       parentRoute: typeof storefrontRouteRoute
     }
+    '/(storefront)/shop_/account': {
+      id: '/(storefront)/shop_/account'
+      path: '/shop/account'
+      fullPath: '/shop/account'
+      preLoaderRoute: typeof storefrontShopAccountRouteImport
+      parentRoute: typeof storefrontRouteRoute
+    }
     '/(storefront)/shop_/confirmation/$bookingId': {
       id: '/(storefront)/shop_/confirmation/$bookingId'
       path: '/shop/confirmation/$bookingId'
       fullPath: '/shop/confirmation/$bookingId'
       preLoaderRoute: typeof storefrontShopConfirmationBookingIdRouteImport
       parentRoute: typeof storefrontRouteRoute
+    }
+    '/(storefront)/shop_/account/verify-email': {
+      id: '/(storefront)/shop_/account/verify-email'
+      path: '/verify-email'
+      fullPath: '/shop/account/verify-email'
+      preLoaderRoute: typeof storefrontShopAccountVerifyEmailRouteImport
+      parentRoute: typeof storefrontShopAccountRoute
+    }
+    '/(storefront)/shop_/account/sign-up': {
+      id: '/(storefront)/shop_/account/sign-up'
+      path: '/sign-up'
+      fullPath: '/shop/account/sign-up'
+      preLoaderRoute: typeof storefrontShopAccountSignUpRouteImport
+      parentRoute: typeof storefrontShopAccountRoute
+    }
+    '/(storefront)/shop_/account/sign-in': {
+      id: '/(storefront)/shop_/account/sign-in'
+      path: '/sign-in'
+      fullPath: '/shop/account/sign-in'
+      preLoaderRoute: typeof storefrontShopAccountSignInRouteImport
+      parentRoute: typeof storefrontShopAccountRoute
     }
     '/(storefront)/shop_/products/$entityModule/$entityId': {
       id: '/(storefront)/shop_/products/$entityModule/$entityId'
@@ -460,8 +539,26 @@ const authRouteRouteWithChildren = authRouteRoute._addFileChildren(
   authRouteRouteChildren,
 )
 
+interface storefrontShopAccountRouteChildren {
+  storefrontShopAccountSignInRoute: typeof storefrontShopAccountSignInRoute
+  storefrontShopAccountSignUpRoute: typeof storefrontShopAccountSignUpRoute
+  storefrontShopAccountVerifyEmailRoute: typeof storefrontShopAccountVerifyEmailRoute
+}
+
+const storefrontShopAccountRouteChildren: storefrontShopAccountRouteChildren = {
+  storefrontShopAccountSignInRoute: storefrontShopAccountSignInRoute,
+  storefrontShopAccountSignUpRoute: storefrontShopAccountSignUpRoute,
+  storefrontShopAccountVerifyEmailRoute: storefrontShopAccountVerifyEmailRoute,
+}
+
+const storefrontShopAccountRouteWithChildren =
+  storefrontShopAccountRoute._addFileChildren(
+    storefrontShopAccountRouteChildren,
+  )
+
 interface storefrontRouteRouteChildren {
   storefrontShopRoute: typeof storefrontShopRoute
+  storefrontShopAccountRoute: typeof storefrontShopAccountRouteWithChildren
   storefrontShopComposerRoute: typeof storefrontShopComposerRoute
   storefrontShopConfirmationBookingIdRoute: typeof storefrontShopConfirmationBookingIdRoute
   storefrontShopBookEntityModuleEntityIdRoute: typeof storefrontShopBookEntityModuleEntityIdRoute
@@ -470,6 +567,7 @@ interface storefrontRouteRouteChildren {
 
 const storefrontRouteRouteChildren: storefrontRouteRouteChildren = {
   storefrontShopRoute: storefrontShopRoute,
+  storefrontShopAccountRoute: storefrontShopAccountRouteWithChildren,
   storefrontShopComposerRoute: storefrontShopComposerRoute,
   storefrontShopConfirmationBookingIdRoute:
     storefrontShopConfirmationBookingIdRoute,
@@ -498,11 +596,15 @@ export const routeTree = rootRouteImport
   ._addFileTypes<FileRouteTypes>()
 
 import type { getRouter } from './router.tsx'
+
 import type { startInstance } from './start.ts'
+
 declare module '@tanstack/react-start' {
   interface Register {
     ssr: true
+
     router: Awaited<ReturnType<typeof getRouter>>
+
     config: Awaited<ReturnType<typeof startInstance.getOptions>>
   }
 }

--- a/starters/operator/src/routes/(storefront)/route.tsx
+++ b/starters/operator/src/routes/(storefront)/route.tsx
@@ -1,5 +1,10 @@
 import { createFileRoute, Link, Outlet } from "@tanstack/react-router"
+import { buttonVariants } from "@voyant-travel/ui/components/button"
+import { cn } from "@voyant-travel/ui/lib/utils"
+import { CircleUserRound, LogIn } from "lucide-react"
 
+import { authClient } from "@/lib/auth"
+import { CustomerAccountProvider } from "@/lib/customer-account"
 import { StorefrontMessagesProvider, useStorefrontMessages } from "@/lib/storefront-i18n"
 import { StorefrontScopeProvider } from "@/lib/storefront-scope"
 import { StorefrontMarketSelector } from "./storefront-market-selector"
@@ -20,7 +25,9 @@ function StorefrontLayout(): React.ReactElement {
   return (
     <StorefrontMessagesProvider>
       <StorefrontScopeProvider>
-        <StorefrontChrome />
+        <CustomerAccountProvider>
+          <StorefrontChrome />
+        </CustomerAccountProvider>
       </StorefrontScopeProvider>
     </StorefrontMessagesProvider>
   )
@@ -28,6 +35,7 @@ function StorefrontLayout(): React.ReactElement {
 
 function StorefrontChrome(): React.ReactElement {
   const t = useStorefrontMessages().layout
+  const { data: session, isPending } = authClient.useSession()
 
   return (
     <div className="min-h-screen bg-background">
@@ -36,18 +44,24 @@ function StorefrontChrome(): React.ReactElement {
           <Link to="/shop" className="font-medium">
             {t.brand}
           </Link>
-          {/*
-           * No customer "Sign in" link in the storefront chrome on purpose.
-           * Customer accounts don't exist yet (#2621), and the operator
-           * `/sign-in` surface is the workspace/admin auth path — presenting it
-           * in customer chrome implied an account system while actually dropping
-           * customers into operator auth. The trip composer
-           * (`shop_.composer.tsx`) keeps its own intentional operator-session
-           * sign-in prompt for the simulated storefront (#2642); that gate is a
-           * separate operator affordance, not a customer account entry point.
-           */}
           <nav className="flex items-center gap-2">
             <StorefrontMarketSelector />
+            <Link
+              to={session ? "/shop/account" : "/shop/account/sign-in"}
+              search={session ? undefined : { next: "/shop/account" }}
+              aria-disabled={isPending}
+              className={cn(
+                buttonVariants({ variant: "ghost", size: "sm" }),
+                isPending && "pointer-events-none opacity-50",
+              )}
+            >
+              {session ? (
+                <CircleUserRound className="size-4" aria-hidden="true" />
+              ) : (
+                <LogIn className="size-4" aria-hidden="true" />
+              )}
+              {session ? "Account" : "Sign in"}
+            </Link>
           </nav>
         </div>
       </header>

--- a/starters/operator/src/routes/(storefront)/shop_.account.sign-in.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.account.sign-in.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { SignInPage, type SignInPageMessages } from "@voyant-travel/auth-react/ui"
+import { useCustomerPortalMutation } from "@voyant-travel/storefront-react/customer-portal/hooks"
+import { buttonVariants } from "@voyant-travel/ui/components/button"
+import { z } from "zod"
+import { authClient } from "@/lib/auth"
+
+export const Route = createFileRoute("/(storefront)/shop_/account/sign-in")({
+  validateSearch: z.object({
+    next: z.string().optional(),
+    verify: z.string().optional(),
+  }),
+  component: CustomerSignInRoute,
+})
+
+function CustomerSignInRoute(): React.ReactElement | null {
+  const navigate = useNavigate()
+  const { next, verify } = Route.useSearch()
+  const { data: session, isPending } = authClient.useSession()
+  const customerPortal = useCustomerPortalMutation()
+  const redirectTo = next || "/shop/account"
+
+  if (isPending) return null
+
+  if (session) {
+    void navigate({ to: redirectTo })
+    return null
+  }
+
+  const messages: Partial<SignInPageMessages> = {
+    title: "Sign in to your travel account",
+    description: "Access your profile, saved travelers, documents, and bookings.",
+    emailPlaceholder: "you@example.com",
+    submit: "Sign in",
+    signingIn: "Signing in",
+  }
+
+  return (
+    <div className="mx-auto max-w-md py-10">
+      {verify && (
+        <div className="mb-4 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-green-900 text-sm">
+          Email verified. Sign in to continue.
+        </div>
+      )}
+      <SignInPage
+        redirectTo={redirectTo}
+        signUpHref={`/shop/account/sign-up?next=${encodeURIComponent(redirectTo)}`}
+        messages={messages}
+        onSignedIn={async () => {
+          await customerPortal.bootstrap.mutateAsync({ createCustomerIfMissing: true })
+          void navigate({ to: redirectTo })
+        }}
+      />
+      <div className="mt-4 text-center">
+        <Link to="/shop" className={buttonVariants({ variant: "ghost", size: "sm" })}>
+          Back to storefront
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/starters/operator/src/routes/(storefront)/shop_.account.sign-up.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.account.sign-up.tsx
@@ -1,0 +1,59 @@
+"use client"
+
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { SignUpPage, type SignUpPageMessages } from "@voyant-travel/auth-react/ui"
+import { buttonVariants } from "@voyant-travel/ui/components/button"
+import { z } from "zod"
+
+import { authClient } from "@/lib/auth"
+
+export const Route = createFileRoute("/(storefront)/shop_/account/sign-up")({
+  validateSearch: z.object({
+    next: z.string().optional(),
+  }),
+  component: CustomerSignUpRoute,
+})
+
+function CustomerSignUpRoute(): React.ReactElement | null {
+  const navigate = useNavigate()
+  const { next } = Route.useSearch()
+  const { data: session, isPending } = authClient.useSession()
+  const redirectTo = next || "/shop/account"
+
+  if (isPending) return null
+
+  if (session) {
+    void navigate({ to: redirectTo })
+    return null
+  }
+
+  const messages: Partial<SignUpPageMessages> = {
+    title: "Create your travel account",
+    description: "Save traveler details and manage bookings without using the operator workspace.",
+    nameLabel: "Full name",
+    emailPlaceholder: "you@example.com",
+    submit: "Create account",
+    signingUp: "Creating account",
+  }
+
+  return (
+    <div className="mx-auto max-w-md py-10">
+      <SignUpPage
+        redirectTo={redirectTo}
+        signInHref={`/shop/account/sign-in?next=${encodeURIComponent(redirectTo)}`}
+        messages={messages}
+        onSignedUp={async ({ email }) => {
+          void navigate({
+            to: "/shop/account/verify-email",
+            search: { email, next: redirectTo },
+          })
+        }}
+      />
+      <div className="mt-4 text-center">
+        <Link to="/shop" className={buttonVariants({ variant: "ghost", size: "sm" })}>
+          Back to storefront
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/starters/operator/src/routes/(storefront)/shop_.account.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.account.tsx
@@ -1,0 +1,374 @@
+"use client"
+
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import {
+  useCustomerPortalBookings,
+  useCustomerPortalCompanions,
+  useCustomerPortalMutation,
+  useCustomerPortalProfile,
+  useCustomerPortalProfileDocuments,
+} from "@voyant-travel/storefront-react/customer-portal/hooks"
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from "@voyant-travel/ui/components"
+import { format } from "date-fns"
+import { CalendarDays, FileText, Loader2, LogOut, Plane, Save, Users } from "lucide-react"
+import { type FormEvent, useEffect, useMemo, useState } from "react"
+import { authClient } from "@/lib/auth"
+
+export const Route = createFileRoute("/(storefront)/shop_/account")({
+  component: CustomerAccountRoute,
+})
+
+function CustomerAccountRoute(): React.ReactElement | null {
+  const navigate = useNavigate()
+  const { data: session, isPending } = authClient.useSession()
+
+  if (isPending) return null
+
+  if (!session) {
+    void navigate({ to: "/shop/account/sign-in", search: { next: "/shop/account" } })
+    return null
+  }
+
+  return <CustomerAccountDashboard />
+}
+
+function CustomerAccountDashboard(): React.ReactElement {
+  const navigate = useNavigate()
+  const profile = useCustomerPortalProfile()
+  const bookings = useCustomerPortalBookings()
+  const companions = useCustomerPortalCompanions()
+  const documents = useCustomerPortalProfileDocuments()
+  const customerPortal = useCustomerPortalMutation()
+  const customer = profile.data?.data ?? null
+  const bookingRows = bookings.data?.data ?? []
+  const companionRows = companions.data?.data ?? []
+  const documentRows = documents.data?.data ?? []
+  const [saved, setSaved] = useState(false)
+  const [firstName, setFirstName] = useState("")
+  const [lastName, setLastName] = useState("")
+  const [phone, setPhone] = useState("")
+
+  useEffect(() => {
+    if (!customer) return
+    setFirstName(customer.firstName ?? "")
+    setLastName(customer.lastName ?? "")
+    setPhone(customer.customerRecord?.phone ?? "")
+  }, [customer])
+
+  useEffect(() => {
+    if (!customer || customer.customerRecord || customerPortal.bootstrap.isPending) return
+    void customerPortal.bootstrap.mutateAsync({ createCustomerIfMissing: true })
+  }, [customer, customerPortal.bootstrap])
+
+  const upcomingBookings = useMemo(
+    () =>
+      bookingRows.filter((booking) => {
+        if (!booking.startDate) return false
+        return new Date(booking.startDate).getTime() >= Date.now()
+      }).length,
+    [bookingRows],
+  )
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSaved(false)
+    await customerPortal.updateProfile.mutateAsync({
+      firstName: firstName.trim() || null,
+      lastName: lastName.trim() || null,
+      customerRecord: {
+        phone: phone.trim() || null,
+      },
+    })
+    setSaved(true)
+  }
+
+  const signOut = async () => {
+    await authClient.signOut()
+    void navigate({ to: "/shop" })
+  }
+
+  if (profile.isPending) {
+    return (
+      <div className="flex min-h-60 items-center justify-center">
+        <Loader2 className="size-5 animate-spin text-muted-foreground" aria-hidden="true" />
+      </div>
+    )
+  }
+
+  if (profile.isError) {
+    return (
+      <div className="mx-auto max-w-xl rounded-md border p-6">
+        <h1 className="font-semibold text-xl">Account unavailable</h1>
+        <p className="mt-2 text-muted-foreground text-sm">
+          We could not load your customer account. Sign out and try again.
+        </p>
+        <Button type="button" className="mt-4" onClick={() => void signOut()}>
+          <LogOut className="size-4" aria-hidden="true" />
+          Sign out
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h1 className="font-semibold text-3xl tracking-normal">Your account</h1>
+          <p className="mt-1 text-muted-foreground">
+            Manage your customer profile, saved travelers, documents, and bookings.
+          </p>
+        </div>
+        <Button type="button" variant="outline" onClick={() => void signOut()}>
+          <LogOut className="size-4" aria-hidden="true" />
+          Sign out
+        </Button>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-4">
+        <AccountMetric icon={Plane} label="Bookings" value={bookingRows.length} />
+        <AccountMetric icon={CalendarDays} label="Upcoming" value={upcomingBookings} />
+        <AccountMetric icon={Users} label="Saved travelers" value={companionRows.length} />
+        <AccountMetric icon={FileText} label="Documents" value={documentRows.length} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,420px)_1fr]">
+        <Card>
+          <CardHeader>
+            <CardTitle>Profile</CardTitle>
+            <CardDescription>Contact details used for future bookings.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={onSubmit}>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="customer-first-name">First name</Label>
+                  <Input
+                    id="customer-first-name"
+                    value={firstName}
+                    onChange={(event) => setFirstName(event.target.value)}
+                    autoComplete="given-name"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="customer-last-name">Last name</Label>
+                  <Input
+                    id="customer-last-name"
+                    value={lastName}
+                    onChange={(event) => setLastName(event.target.value)}
+                    autoComplete="family-name"
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="customer-email">Email</Label>
+                <Input id="customer-email" value={customer?.email ?? ""} disabled />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="customer-phone">Phone</Label>
+                <Input
+                  id="customer-phone"
+                  value={phone}
+                  onChange={(event) => setPhone(event.target.value)}
+                  autoComplete="tel"
+                />
+              </div>
+              <div className="flex items-center gap-3">
+                <Button type="submit" disabled={customerPortal.updateProfile.isPending}>
+                  {customerPortal.updateProfile.isPending ? (
+                    <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                  ) : (
+                    <Save className="size-4" aria-hidden="true" />
+                  )}
+                  Save profile
+                </Button>
+                {saved && <span className="text-green-700 text-sm">Saved</span>}
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>My bookings</CardTitle>
+            <CardDescription>
+              Confirmed, held, and in-progress bookings linked to you.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {bookings.isPending ? (
+              <LoadingRows />
+            ) : bookingRows.length === 0 ? (
+              <EmptyState
+                title="No bookings yet"
+                body="Bookings made with this account will appear here."
+              />
+            ) : (
+              <div className="divide-y rounded-md border">
+                {bookingRows.map((booking) => (
+                  <div
+                    key={booking.bookingId}
+                    className="grid gap-3 p-4 md:grid-cols-[minmax(0,1fr)_auto]"
+                  >
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className="truncate font-medium">
+                          {booking.productTitle ?? booking.bookingNumber}
+                        </p>
+                        <Badge variant="outline">{booking.status}</Badge>
+                        <Badge variant="secondary">{booking.paymentStatus}</Badge>
+                      </div>
+                      <p className="mt-1 text-muted-foreground text-sm">
+                        {booking.bookingNumber} ·{" "}
+                        {formatDateRange(booking.startDate, booking.endDate)}
+                      </p>
+                    </div>
+                    <div className="text-left md:text-right">
+                      <p className="font-medium">
+                        {formatMoney(booking.sellAmountCents, booking.sellCurrency)}
+                      </p>
+                      <p className="text-muted-foreground text-sm">
+                        {booking.travelerCount} traveler{booking.travelerCount === 1 ? "" : "s"}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Saved travelers</CardTitle>
+            <CardDescription>Reusable traveler records for future bookings.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {companionRows.length === 0 ? (
+              <EmptyState
+                title="No saved travelers"
+                body="Importing travelers from a booking and full traveler editing are deferred."
+              />
+            ) : (
+              <div className="divide-y rounded-md border">
+                {companionRows.slice(0, 5).map((companion) => (
+                  <div key={companion.id} className="flex items-center justify-between gap-3 p-3">
+                    <div>
+                      <p className="font-medium">{companion.name}</p>
+                      <p className="text-muted-foreground text-sm">
+                        {companion.email ?? companion.phone}
+                      </p>
+                    </div>
+                    {companion.isPrimary && <Badge>Primary</Badge>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Documents</CardTitle>
+            <CardDescription>Identity documents saved to your customer profile.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {documentRows.length === 0 ? (
+              <EmptyState
+                title="No documents saved"
+                body="Document upload and editing are intentionally left for the next slice."
+              />
+            ) : (
+              <div className="divide-y rounded-md border">
+                {documentRows.slice(0, 5).map((document) => (
+                  <div key={document.id} className="flex items-center justify-between gap-3 p-3">
+                    <div>
+                      <p className="font-medium">{document.type.replace("_", " ")}</p>
+                      <p className="text-muted-foreground text-sm">
+                        {document.issuingCountry ?? "No issuing country"} · expires{" "}
+                        {document.expiryDate ?? "not set"}
+                      </p>
+                    </div>
+                    {document.isPrimary && <Badge>Primary</Badge>}
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="flex justify-center">
+        <Link to="/shop" className="text-muted-foreground text-sm hover:text-foreground">
+          Back to storefront
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+function AccountMetric({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: typeof Plane
+  label: string
+  value: number
+}) {
+  return (
+    <div className="rounded-md border p-4">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-muted-foreground text-sm">{label}</p>
+        <Icon className="size-4 text-muted-foreground" aria-hidden="true" />
+      </div>
+      <p className="mt-2 font-semibold text-2xl">{value}</p>
+    </div>
+  )
+}
+
+function EmptyState({ title, body }: { title: string; body: string }) {
+  return (
+    <div className="rounded-md border border-dashed p-6 text-center">
+      <p className="font-medium">{title}</p>
+      <p className="mt-1 text-muted-foreground text-sm">{body}</p>
+    </div>
+  )
+}
+
+function LoadingRows() {
+  return (
+    <div className="space-y-2">
+      {[0, 1, 2].map((item) => (
+        <div key={item} className="h-16 animate-pulse rounded-md bg-muted" />
+      ))}
+    </div>
+  )
+}
+
+function formatDateRange(startDate: string | null, endDate: string | null) {
+  if (!startDate && !endDate) return "dates pending"
+  if (startDate && endDate)
+    return `${format(new Date(startDate), "MMM d")} - ${format(new Date(endDate), "MMM d, yyyy")}`
+  return format(new Date(startDate ?? endDate ?? ""), "MMM d, yyyy")
+}
+
+function formatMoney(amountCents: number | null, currency: string) {
+  if (amountCents === null) return "Amount pending"
+  return new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency,
+  }).format(amountCents / 100)
+}

--- a/starters/operator/src/routes/(storefront)/shop_.account.verify-email.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.account.verify-email.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { VerifyEmailPage, type VerifyEmailPageMessages } from "@voyant-travel/auth-react/ui"
+import { z } from "zod"
+
+import { authClient } from "@/lib/auth"
+
+export const Route = createFileRoute("/(storefront)/shop_/account/verify-email")({
+  validateSearch: z.object({
+    email: z.string().optional(),
+    next: z.string().optional(),
+  }),
+  component: CustomerVerifyEmailRoute,
+})
+
+function CustomerVerifyEmailRoute(): React.ReactElement {
+  const navigate = useNavigate()
+  const { email, next } = Route.useSearch()
+  const redirectTo = next || "/shop/account"
+
+  const messages: Partial<VerifyEmailPageMessages> = {
+    title: "Verify your email",
+    description: "Enter the verification code we sent before signing in.",
+    successTitle: "Email verified",
+    successDescription: "Your travel account is ready.",
+  }
+
+  return (
+    <div className="mx-auto max-w-md py-10">
+      <VerifyEmailPage
+        mode="otp"
+        email={email}
+        signInHref={`/shop/account/sign-in?next=${encodeURIComponent(redirectTo)}&verify=1`}
+        messages={messages}
+        onCompleted={async () => {
+          await authClient.signOut()
+        }}
+        onResendVerification={async (targetEmail) => {
+          await authClient.emailOtp.sendVerificationOtp({
+            email: targetEmail,
+            type: "email-verification",
+          })
+        }}
+        onSignInClick={() => {
+          void navigate({
+            to: "/shop/account/sign-in",
+            search: { next: redirectTo, verify: "1" },
+          })
+        }}
+      />
+    </div>
+  )
+}

--- a/starters/operator/src/routes/(storefront)/shop_.composer.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.composer.tsx
@@ -14,8 +14,8 @@ import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
  * (create → price → reserve → checkout). Those routes are deliberately NOT on
  * the anonymous allow-list — `listTrips`/`getTrip` have no per-customer scoping,
  * so opening the mount anonymously would leak every tenant trip (see #2642).
- * Until a real customer session exists (#2621), we gate the composer behind a
- * session so anonymous visitors get a clear sign-in prompt instead of a raw 401.
+ * The composer now uses the storefront customer account entry point so
+ * anonymous visitors get a customer-scoped session before creating drafts.
  */
 export const Route = createFileRoute("/(storefront)/shop_/composer")({
   component: ComposerRoute,
@@ -44,7 +44,11 @@ function ComposerSignInGate(): React.ReactElement {
         <CardContent className="space-y-4">
           <p className="text-muted-foreground text-sm">{t.gateBody}</p>
           <div className="flex flex-wrap gap-2">
-            <Link to="/sign-in" search={{ next: "/shop/composer" }} className={buttonVariants()}>
+            <Link
+              to="/shop/account/sign-in"
+              search={{ next: "/shop/composer" }}
+              className={buttonVariants()}
+            >
               <LogIn className="size-4" aria-hidden="true" />
               {t.gateSignIn}
             </Link>


### PR DESCRIPTION
## Summary
- Add a customer-scoped auth facade at `/auth/customer/*` so storefront sign-in/sign-up does not route through the operator admin auth pages or admin bootstrap status provisioning.
- Isolate customer Better Auth browser sessions with a dedicated cookie prefix, and make storefront account guards/sign-out/verification use the customer auth facade.
- Add storefront account routes under `/shop/account` for customer sign-in, sign-up, email verification, profile editing, saved traveler/document summaries, and my-bookings summaries.
- Reintroduce a storefront chrome account entry point and move the trip composer gate to the customer account sign-in route.
- Add a changeset for the auth package behavior change.

Fixes #2718

## Checks run
- `pnpm exec biome check ...` on touched files
- `pnpm --filter @voyant-travel/auth test -- create-better-auth.test.ts`
- `pnpm --filter operator test -- src/lib/customer-account.test.ts`
- `pnpm --filter @voyant-travel/auth typecheck`
- GitHub CI: build, checks, db-checks, gitleaks, Socket checks

## Resource-bound checks
- `pnpm --filter operator typecheck` was stopped after the server TypeScript config ran silently for more than six minutes at roughly 12 GB RSS.
- `pnpm --filter operator exec tsc -p tsconfig.client.json --noEmit --pretty false` failed with a default-heap JavaScript OOM (`SIGABRT`, not 137). A high-heap retry was stopped after climbing to roughly 12 GB RSS.
- Commit/push hooks attempted broad repo build/test work outside this focused lane. The commit hook hit `@voyant-travel/bookings-react:build` exit 137; both broad hook runs were stopped to avoid further RAM pressure. The commit and push were completed with hooks disabled after the focused checks above passed.

## Intentionally deferred
- Full saved traveler CRUD, document upload/edit flows, contract/invoice downloads beyond the existing customer-portal read APIs.
- Deep booking management actions beyond my-bookings read summaries and profile bootstrap/linking.

## Residual risk
- The storefront dashboard is intentionally basic and relies on the existing customer-portal APIs for richer booking financial/document data.