### PR TITLE
Add owned cruise storefront content

### DIFF
--- a/.changeset/owned-cruise-storefront-content.md
+++ b/.changeset/owned-cruise-storefront-content.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/cruises": patch
+"@voyant-travel/storefront-react": patch
+---
+
+Serve owned cruise rows through the public cruise content service and re-enable
+cruises in storefront customer product routing.

--- a/packages/cruises/src/routes-content.ts
+++ b/packages/cruises/src/routes-content.ts
@@ -3,15 +3,17 @@
  *
  *   GET /:key/content
  *
- * Returns the full `CruiseContent` payload for a sourced cruise:
+ * Returns the full `CruiseContent` payload for sourced cruises:
  * cache hit → cached row + overlay merge; cache miss with rich adapter
  * → adapter fetch + write-through; cache miss with thin adapter →
- * synthesizer fallback (sourced-content §3.3, §3.4, §3.6).
+ * synthesizer fallback (sourced-content §3.3, §3.4, §3.6). When
+ * `allowOwnedKeys` is enabled, owned `cru_*` ids are projected from the
+ * cruises module's own tables.
  *
  * The cruise vertical's unified key parser (`<provider>:<ref>` for
  * external, plain TypeID for owned) is reused; this route accepts
- * either form. Owned cruises return 404 — they have no sourced-entry
- * row. Owned-cruise detail uses the existing `/:key` route.
+ * either form. Plain owned TypeIDs require `allowOwnedKeys` so existing
+ * sourced-only mounts can keep their previous contract.
  *
  * The catalog SourceAdapterRegistry is starter-owned and resolved via
  * the `resolveRegistry` callback. For cruise adapters wrapped via
@@ -51,11 +53,10 @@ export interface CreateCruiseContentRoutesOptions {
   onOverlayError?: (event: { field_path: string; reason: string }) => void
   defaultAcceptMachineTranslated?: boolean
   /**
-   * When the unified key resolves to a cruise typeid (`crus_*` —
+   * When the unified key resolves to a cruise typeid (`cru_*` —
    * owned cruise), the route returns 404 by default. Set this to
    * `true` to also dispatch through `getCruiseContent` for owned ids
-   * (useful when an owned cruise also has a sourced-entry row, e.g.
-   * after a detach + re-import workflow).
+   * and let the service project content from owned cruise tables.
    */
   allowOwnedKeys?: boolean
 }
@@ -80,14 +81,13 @@ export function createCruiseContentRoutes(
 
       // A catalog sourced entity id (`crus_sr_<base64>`) is inherently sourced,
       // so it dispatches regardless of `allowOwnedKeys`. Only plain owned TypeIDs
-      // (`crus_<base32>`) need the opt-in.
+      // (`cru_<base32>`) need the opt-in.
       const isSourcedEntityId = parsed.kind === "local" && isEncodedSourceEntityId(parsed.id)
       if (parsed.kind === "local" && !isSourcedEntityId && !options.allowOwnedKeys) {
         return c.json(
           {
             error: "owned_not_supported",
-            detail:
-              "GET /:key/content serves sourced cruises only. Owned cruises use GET /:key. Set allowOwnedKeys: true on the route factory to opt into owned dispatch.",
+            detail: "GET /:key/content requires allowOwnedKeys to serve owned cruise content.",
           },
           404,
         )
@@ -110,7 +110,7 @@ export function createCruiseContentRoutes(
         return c.json(
           {
             error: "not_found",
-            detail: `Cruise ${rawKey} (entity ${entityId}) has no sourced-content row. Either no adapter is registered for this provider, or discovery hasn't run yet.`,
+            detail: `Cruise ${rawKey} (entity ${entityId}) has no public content. For sourced cruises, either no adapter is registered for this provider or discovery hasn't run yet. For owned cruises, no matching cruise row was found.`,
           },
           404,
         )

--- a/packages/cruises/src/service-content-owned.ts
+++ b/packages/cruises/src/service-content-owned.ts
@@ -1,0 +1,333 @@
+/**
+ * Owned-cruise content builder.
+ *
+ * Projects rows authored in the cruises module into the shared
+ * `CruiseContent` detail shape used by sourced cruise content, so the public
+ * content route can serve owned `cru_*` ids through the same storefront path.
+ */
+
+import type { ContentLocaleMatchKind } from "@voyant-travel/catalog"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { asc, eq, inArray } from "drizzle-orm"
+
+import { type CruiseContent, cruiseContentSchema, validateCruiseContent } from "./content-shape.js"
+import { cruiseCabinCategories, cruiseDecks, cruiseShips } from "./schema-cabins.js"
+import { cruiseInclusions, cruiseMedia } from "./schema-content.js"
+import { cruiseSailings, cruises } from "./schema-core.js"
+import { cruiseDays, cruiseSailingDays } from "./schema-itinerary.js"
+import { cruisePrices } from "./schema-pricing.js"
+
+export interface BuildOwnedCruiseContentOptions {
+  preferredLocales: ReadonlyArray<string>
+}
+
+export interface BuildOwnedCruiseContentResult {
+  content: CruiseContent
+  servedLocale: string
+  matchKind: ContentLocaleMatchKind
+}
+
+export async function buildOwnedCruiseContent(
+  db: AnyDrizzleDb,
+  entityId: string,
+  options: BuildOwnedCruiseContentOptions,
+): Promise<BuildOwnedCruiseContentResult | null> {
+  const cruiseRow = (await db.select().from(cruises).where(eq(cruises.id, entityId)).limit(1))[0]
+  if (!cruiseRow) return null
+
+  const [sailingRows, mediaRows, inclusionRows, itineraryRows] = await Promise.all([
+    db
+      .select()
+      .from(cruiseSailings)
+      .where(eq(cruiseSailings.cruiseId, entityId))
+      .orderBy(asc(cruiseSailings.departureDate), asc(cruiseSailings.id)),
+    db
+      .select()
+      .from(cruiseMedia)
+      .where(eq(cruiseMedia.cruiseId, entityId))
+      .orderBy(asc(cruiseMedia.sortOrder), asc(cruiseMedia.createdAt)),
+    db
+      .select()
+      .from(cruiseInclusions)
+      .where(eq(cruiseInclusions.cruiseId, entityId))
+      .orderBy(asc(cruiseInclusions.sortOrder), asc(cruiseInclusions.label)),
+    db
+      .select()
+      .from(cruiseDays)
+      .where(eq(cruiseDays.cruiseId, entityId))
+      .orderBy(asc(cruiseDays.dayNumber)),
+  ])
+
+  const selectedShipId =
+    cruiseRow.defaultShipId ?? sailingRows.find((s) => s.shipId)?.shipId ?? null
+  const [shipRow, deckRows, cabinRows] = selectedShipId
+    ? await Promise.all([
+        db.select().from(cruiseShips).where(eq(cruiseShips.id, selectedShipId)).limit(1),
+        db
+          .select()
+          .from(cruiseDecks)
+          .where(eq(cruiseDecks.shipId, selectedShipId))
+          .orderBy(asc(cruiseDecks.level), asc(cruiseDecks.name)),
+        db
+          .select()
+          .from(cruiseCabinCategories)
+          .where(eq(cruiseCabinCategories.shipId, selectedShipId))
+          .orderBy(asc(cruiseCabinCategories.code), asc(cruiseCabinCategories.name)),
+      ])
+    : [[], [], []]
+
+  const sailingIds = sailingRows.map((s) => s.id)
+  const [sailingDayRows, priceRows] =
+    sailingIds.length > 0
+      ? await Promise.all([
+          db
+            .select()
+            .from(cruiseSailingDays)
+            .where(inArray(cruiseSailingDays.sailingId, sailingIds))
+            .orderBy(asc(cruiseSailingDays.sailingId), asc(cruiseSailingDays.dayNumber)),
+          db
+            .select()
+            .from(cruisePrices)
+            .where(inArray(cruisePrices.sailingId, sailingIds))
+            .orderBy(asc(cruisePrices.sailingId), asc(cruisePrices.pricePerPerson)),
+        ])
+      : [[], []]
+
+  const coverMedia = mediaRows.find((m) => m.isCover && m.mediaType === "image")
+  const firstImage = mediaRows.find((m) => m.mediaType === "image")
+  const ship = shipRow[0] ?? null
+  const sailingDaysBySailing = groupBy(sailingDayRows, (row) => row.sailingId)
+  const pricesBySailing = groupBy(priceRows, (row) => row.sailingId)
+
+  const content: CruiseContent = cruiseContentSchema.parse({
+    cruise: {
+      id: cruiseRow.id,
+      name: cruiseRow.name,
+      status: cruiseRow.status,
+      description: cruiseRow.shortDescription ?? cruiseRow.description ?? null,
+      cruise_type: cruiseRow.cruiseType,
+      hero_image_url: coverMedia?.url ?? firstImage?.url ?? cruiseRow.heroImageUrl ?? null,
+      highlights: Array.isArray(cruiseRow.highlights) ? cruiseRow.highlights : [],
+      cruise_line: cruiseRow.lineSupplierId ?? null,
+      duration_nights: cruiseRow.nights,
+      embarkation_port: portLabel(
+        cruiseRow.embarkPortCanonicalPlaceId,
+        cruiseRow.embarkPortFacilityId,
+      ),
+      disembarkation_port: portLabel(
+        cruiseRow.disembarkPortCanonicalPlaceId,
+        cruiseRow.disembarkPortFacilityId,
+      ),
+    },
+    ship: ship
+      ? {
+          id: ship.id,
+          name: ship.name,
+          ship_type: ship.shipType,
+          description: ship.description ?? null,
+          deck_plan_url: ship.deckPlanUrl ?? null,
+          deck_plans: deckRows.map((deck) => ({
+            name: deck.name,
+            level: deck.level ?? null,
+            image_url: deck.planImageUrl ?? null,
+          })),
+          capacity: ship.capacityGuests ?? null,
+          decks: ship.deckCount ?? null,
+          year_built: ship.yearBuilt ?? null,
+          gallery: Array.isArray(ship.gallery) ? ship.gallery : [],
+        }
+      : null,
+    sailings: sailingRows.map((sailing) => {
+      const lowest = lowestAvailablePrice(pricesBySailing.get(sailing.id) ?? [])
+      const itinerary = sailingDaysBySailing.get(sailing.id)
+      const stops = itinerary && itinerary.length > 0 ? itinerary : itineraryRows
+      return {
+        id: sailing.id,
+        source_ref: sailing.externalRefs?.externalId ?? null,
+        start_date: dateToIso(sailing.departureDate),
+        end_date: dateToIso(sailing.returnDate),
+        duration_nights: durationNights(sailing.departureDate, sailing.returnDate),
+        status: sailing.salesStatus ?? null,
+        embarkation_port: portLabel(
+          sailing.embarkPortCanonicalPlaceId,
+          sailing.embarkPortFacilityId,
+        ),
+        disembarkation_port: portLabel(
+          sailing.disembarkPortCanonicalPlaceId,
+          sailing.disembarkPortFacilityId,
+        ),
+        itinerary_stops: stops.map((stop) =>
+          itineraryStopFrom(stop, dateForSailingDay(sailing.departureDate, stop.dayNumber)),
+        ),
+        lowest_price_cents: lowest?.cents ?? null,
+        currency: lowest?.currency ?? null,
+      }
+    }),
+    cabin_categories: cabinRows.map((cat) => ({
+      id: cat.id,
+      code: cat.code,
+      name: cat.name,
+      description: cat.description ?? null,
+      type: cat.roomType,
+      capacity_min: cat.minOccupancy,
+      capacity_max: cat.maxOccupancy,
+      images: Array.isArray(cat.images) ? cat.images : [],
+      floorplan_images: Array.isArray(cat.floorplanImages) ? cat.floorplanImages : [],
+      square_feet: cat.squareFeet ?? null,
+      grade_codes: Array.isArray(cat.gradeCodes) ? cat.gradeCodes : [],
+      wheelchair_accessible: cat.wheelchairAccessible,
+      inclusions: Array.isArray(cat.amenities) ? cat.amenities : [],
+      feature_codes: Array.isArray(cat.featureCodes) ? cat.featureCodes : [],
+      bed_configurations: Array.isArray(cat.bedConfigurations) ? cat.bedConfigurations : [],
+      accessibility_features: Array.isArray(cat.accessibilityFeatures)
+        ? cat.accessibilityFeatures
+        : [],
+      view_type: cat.viewType ?? null,
+    })),
+    itinerary_stops: itineraryRows.map((stop) => itineraryStopFrom(stop)),
+    policies: buildPolicies(cruiseRow, sailingRows, cabinRows, inclusionRows),
+  })
+
+  const validation = validateCruiseContent(content)
+  if (!validation.valid) {
+    throw new Error(`owned cruise ${entityId} projection failed validation: ${validation.reason}`)
+  }
+
+  return {
+    content,
+    servedLocale: sourceLocaleFor(),
+    matchKind: options.preferredLocales.includes(sourceLocaleFor()) ? "exact" : "any",
+  }
+}
+
+function itineraryStopFrom(
+  stop: typeof cruiseDays.$inferSelect | typeof cruiseSailingDays.$inferSelect,
+  date?: string | null,
+): CruiseContent["itinerary_stops"][number] {
+  return {
+    day_number: stop.dayNumber,
+    date: date ?? null,
+    port_name: stop.title ?? portLabel(stop.portCanonicalPlaceId, stop.portFacilityId) ?? "",
+    arrival_time: stop.arrivalTime ?? null,
+    departure_time: stop.departureTime ?? null,
+    description: stop.description ?? null,
+    is_at_sea: stop.isSeaDay ?? false,
+  }
+}
+
+function buildPolicies(
+  cruiseRow: typeof cruises.$inferSelect,
+  sailingRows: ReadonlyArray<typeof cruiseSailings.$inferSelect>,
+  cabinRows: ReadonlyArray<typeof cruiseCabinCategories.$inferSelect>,
+  inclusionRows: ReadonlyArray<typeof cruiseInclusions.$inferSelect>,
+): CruiseContent["policies"] {
+  const policies: CruiseContent["policies"] = []
+  if (cruiseRow.inclusionsHtml) {
+    policies.push({ kind: "supplier_notes", body: cruiseRow.inclusionsHtml })
+  }
+  if (cruiseRow.exclusionsHtml) {
+    policies.push({ kind: "supplier_notes", body: cruiseRow.exclusionsHtml })
+  }
+  for (const inclusion of inclusionRows) {
+    policies.push({
+      kind: "supplier_notes",
+      body: inclusion.description
+        ? `${inclusion.label}\n\n${inclusion.description}`
+        : inclusion.label,
+    })
+  }
+  addPaymentPolicy(policies, "cruise", cruiseRow.id, cruiseRow.customerPaymentPolicy)
+  for (const sailing of sailingRows) {
+    addPaymentPolicy(policies, "sailing", sailing.id, sailing.customerPaymentPolicy)
+  }
+  for (const cabin of cabinRows) {
+    addPaymentPolicy(policies, "cabin_category", cabin.id, cabin.customerPaymentPolicy)
+  }
+  return policies
+}
+
+function addPaymentPolicy(
+  policies: CruiseContent["policies"],
+  scope: string,
+  id: string,
+  policy: unknown,
+): void {
+  if (!policy || typeof policy !== "object") return
+  policies.push({
+    kind: "payment",
+    body: `${scope} payment policy`,
+    rules: { scope, id, policy },
+  })
+}
+
+function lowestAvailablePrice(
+  rows: ReadonlyArray<typeof cruisePrices.$inferSelect>,
+): { cents: number; currency: string } | null {
+  let best: { cents: number; currency: string } | null = null
+  for (const row of rows) {
+    if (row.availability !== "available") continue
+    const cents = moneyStringToCents(row.pricePerPerson)
+    if (cents === null || !row.currency) continue
+    if (!best || cents < best.cents) best = { cents, currency: row.currency }
+  }
+  return best
+}
+
+function moneyStringToCents(value: string | null | undefined): number | null {
+  if (!value) return null
+  const major = Number.parseFloat(value)
+  if (!Number.isFinite(major)) return null
+  return Math.round(major * 100)
+}
+
+function durationNights(startValue: string | Date, endValue: string | Date): number | null {
+  const start = dateOnly(startValue)
+  const end = dateOnly(endValue)
+  if (!start || !end) return null
+  const days = Math.round((end.getTime() - start.getTime()) / (24 * 60 * 60 * 1000))
+  return days >= 0 ? days : null
+}
+
+function dateForSailingDay(startValue: string | Date, dayNumber: number): string | null {
+  const start = dateOnly(startValue)
+  if (!start || dayNumber <= 0) return null
+  start.setUTCDate(start.getUTCDate() + dayNumber - 1)
+  return start.toISOString().slice(0, 10)
+}
+
+function dateOnly(value: string | Date | null | undefined): Date | null {
+  if (!value) return null
+  const raw = typeof value === "string" ? value : value.toISOString().slice(0, 10)
+  const parsed = new Date(`${raw}T00:00:00.000Z`)
+  return Number.isFinite(parsed.getTime()) ? parsed : null
+}
+
+function dateToIso(value: string | Date): string {
+  if (typeof value === "string") return value
+  return value.toISOString().slice(0, 10)
+}
+
+function portLabel(
+  canonicalPlaceId: string | null | undefined,
+  facilityId: string | null | undefined,
+): string | null {
+  return canonicalPlaceId ?? facilityId ?? null
+}
+
+function sourceLocaleFor(): string {
+  return "und"
+}
+
+function groupBy<T>(rows: ReadonlyArray<T>, keyFor: (row: T) => string): Map<string, T[]> {
+  const grouped = new Map<string, T[]>()
+  for (const row of rows) {
+    const key = keyFor(row)
+    const bucket = grouped.get(key)
+    if (bucket) {
+      bucket.push(row)
+    } else {
+      grouped.set(key, [row])
+    }
+  }
+  return grouped
+}

--- a/packages/cruises/src/service-content.ts
+++ b/packages/cruises/src/service-content.ts
@@ -1,6 +1,6 @@
 /**
- * Cruise content service — `getCruiseContent` with locale-resolved
- * cache reads, SWR refresh, and synthesizer fallback.
+ * Cruise content service — `getCruiseContent` with owned-vs-sourced
+ * dispatch, locale-resolved cache reads, SWR refresh, and synthesizer fallback.
  *
  * Mirrors `service-content.ts` in the products package but cruise-
  * shaped. The cruise content aggregate (§3.2 / §E) is `{ cruise, ship,
@@ -47,6 +47,7 @@ import {
   cruisesSourcedContentTable,
   type SelectCruisesSourcedContent,
 } from "./schema-sourced-content.js"
+import { buildOwnedCruiseContent } from "./service-content-owned.js"
 import {
   type SynthesizedCruiseContent,
   synthesizeCruiseContent,
@@ -71,7 +72,7 @@ export interface ResolvedCruiseContent {
   content: CruiseContent
   resolution: ContentLocaleResolution<{ locale: string; payload: CruiseContent }>
   provenance: ResolvedCruiseContentProvenance
-  source: "sourced-cache" | "sourced-fresh" | "synthesized"
+  source: "sourced-cache" | "sourced-fresh" | "synthesized" | "owned"
   served_stale: boolean
   synthesized: boolean
   machine_translated: boolean
@@ -91,7 +92,39 @@ export async function getCruiseContent(
   options: GetCruiseContentOptions,
 ): Promise<ResolvedCruiseContent | null> {
   const sourcedEntry = await readSourcedEntry(db, "cruises", entityId)
-  if (!sourcedEntry) return null
+  if (!sourcedEntry) {
+    const owned = await buildOwnedCruiseContent(db, entityId, {
+      preferredLocales: scope.preferredLocales,
+    })
+    if (!owned) return null
+    const overlays = await fetchOverlaysForEntity(db, "cruises", entityId)
+    const merged = mergeOverlaysIntoCruiseContent(
+      owned.content,
+      overlays.map((o) => ({ field_path: o.field_path, value: o.value })),
+      {
+        onOverlayError: options.onOverlayError
+          ? (e) =>
+              options.onOverlayError!({
+                field_path: e.overlay.field_path,
+                reason: e.reason,
+              })
+          : undefined,
+      },
+    )
+    return {
+      content: merged,
+      resolution: {
+        candidate: { locale: owned.servedLocale, payload: merged },
+        served_locale: owned.servedLocale,
+        match_kind: owned.matchKind,
+      },
+      provenance: { source_kind: "owned" },
+      source: "owned",
+      served_stale: false,
+      synthesized: false,
+      machine_translated: false,
+    }
+  }
 
   const provenance: Extract<ProvenanceReadResult, { kind: "sourced" }> = {
     kind: "sourced",

--- a/packages/cruises/tests/unit/routes-content.test.ts
+++ b/packages/cruises/tests/unit/routes-content.test.ts
@@ -67,9 +67,9 @@ describe("createCruiseContentRoutes — GET /:key/content", () => {
     expect(body.error).toBe("invalid_key")
   })
 
-  it("returns 404 for owned (local) keys by default — owned uses GET /:key", async () => {
+  it("returns 404 for owned (local) keys by default unless owned keys are enabled", async () => {
     const { app } = buildApp()
-    const res = await app.request("/crus_abc/content")
+    const res = await app.request("/cru_abc/content")
     expect(res.status).toBe(404)
     const body = await res.json()
     expect(body.error).toBe("owned_not_supported")
@@ -150,11 +150,42 @@ describe("createCruiseContentRoutes — GET /:key/content", () => {
   it("dispatches owned keys when allowOwnedKeys: true", async () => {
     mockedGetCruiseContent.mockResolvedValueOnce(null)
     const { app } = buildApp({ allowOwnedKeys: true })
-    const res = await app.request("/crus_abc/content")
+    const res = await app.request("/cru_abc/content")
     expect(mockedGetCruiseContent).toHaveBeenCalledTimes(1)
     expect(res.status).toBe(404)
     const callArgs = mockedGetCruiseContent.mock.calls[0]
-    expect(callArgs?.[1]).toBe("crus_abc")
+    expect(callArgs?.[1]).toBe("cru_abc")
+  })
+
+  it("returns owned CruiseContent when the service resolves an owned cruise", async () => {
+    const fakeContent = {
+      cruise: { id: "cru_abc", name: "Owned Greek Isles" },
+      ship: null,
+      sailings: [],
+      cabin_categories: [],
+      itinerary_stops: [],
+      policies: [],
+    }
+    mockedGetCruiseContent.mockResolvedValueOnce({
+      content: fakeContent as never,
+      resolution: {
+        candidate: { locale: "und", payload: fakeContent as never },
+        served_locale: "und",
+        match_kind: "any",
+      },
+      provenance: { source_kind: "owned" },
+      source: "owned",
+      served_stale: false,
+      synthesized: false,
+      machine_translated: false,
+    })
+    const { app } = buildApp({ allowOwnedKeys: true })
+    const res = await app.request("/cru_abc/content?locale=en-GB")
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.content.cruise.name).toBe("Owned Greek Isles")
+    expect(body.data.source).toBe("owned")
+    expect(body.data.provenance).toEqual({ source_kind: "owned" })
   })
 
   it("threads market + currency from query params", async () => {

--- a/packages/cruises/tests/unit/service-content-owned.test.ts
+++ b/packages/cruises/tests/unit/service-content-owned.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { cruiseCabinCategories, cruiseDecks, cruiseShips } from "../../src/schema-cabins.js"
+import { cruiseInclusions, cruiseMedia } from "../../src/schema-content.js"
+import { cruiseSailings, cruises } from "../../src/schema-core.js"
+import { cruiseDays, cruiseSailingDays } from "../../src/schema-itinerary.js"
+import { cruisePrices } from "../../src/schema-pricing.js"
+import { getCruiseContent } from "../../src/service-content.js"
+import { buildOwnedCruiseContent } from "../../src/service-content-owned.js"
+
+describe("buildOwnedCruiseContent", () => {
+  it("projects owned cruise rows into public CruiseContent", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[]>([
+        [
+          cruises,
+          [
+            {
+              id: "cru_1",
+              slug: "mediterranean-highlights",
+              name: "Mediterranean Highlights",
+              cruiseType: "ocean",
+              lineSupplierId: "supp_line",
+              defaultShipId: "ship_1",
+              nights: 7,
+              embarkPortFacilityId: "fac_rome",
+              embarkPortCanonicalPlaceId: "ITROM",
+              disembarkPortFacilityId: "fac_rome",
+              disembarkPortCanonicalPlaceId: "ITROM",
+              description: "Long description",
+              shortDescription: "Short description",
+              highlights: ["Rome round-trip"],
+              inclusionsHtml: "<p>Meals included</p>",
+              exclusionsHtml: "<p>Excursions extra</p>",
+              heroImageUrl: "https://example.com/hero.jpg",
+              status: "live",
+              customerPaymentPolicy: { deposit: { percent: 25 } },
+            },
+          ],
+        ],
+        [
+          cruiseSailings,
+          [
+            {
+              id: "sail_1",
+              cruiseId: "cru_1",
+              shipId: "ship_1",
+              departureDate: "2026-07-12",
+              returnDate: "2026-07-19",
+              embarkPortFacilityId: "fac_rome",
+              embarkPortCanonicalPlaceId: "ITROM",
+              disembarkPortFacilityId: "fac_rome",
+              disembarkPortCanonicalPlaceId: "ITROM",
+              salesStatus: "open",
+              externalRefs: { externalId: "MED-2026-07-12" },
+              customerPaymentPolicy: null,
+            },
+          ],
+        ],
+        [
+          cruiseShips,
+          [
+            {
+              id: "ship_1",
+              name: "MV Voyant Explorer",
+              shipType: "ocean",
+              description: "Mid-size demo ship.",
+              deckPlanUrl: "https://example.com/deck-plan.pdf",
+              capacityGuests: 1840,
+              deckCount: 12,
+              yearBuilt: 2019,
+              gallery: ["https://example.com/ship.jpg"],
+            },
+          ],
+        ],
+        [
+          cruiseDecks,
+          [
+            {
+              shipId: "ship_1",
+              name: "Promenade",
+              level: 5,
+              planImageUrl: "https://example.com/deck-5.jpg",
+            },
+          ],
+        ],
+        [
+          cruiseCabinCategories,
+          [
+            {
+              id: "cab_1",
+              shipId: "ship_1",
+              code: "BAL",
+              name: "Balcony Stateroom",
+              roomType: "balcony",
+              description: "Private balcony stateroom.",
+              minOccupancy: 1,
+              maxOccupancy: 2,
+              squareFeet: "210.00",
+              wheelchairAccessible: false,
+              amenities: ["private balcony"],
+              featureCodes: ["balcony"],
+              bedConfigurations: ["queen"],
+              accessibilityFeatures: [],
+              viewType: "balcony",
+              images: ["https://example.com/cabin.jpg"],
+              floorplanImages: ["https://example.com/floorplan.jpg"],
+              gradeCodes: ["BAL"],
+              customerPaymentPolicy: null,
+            },
+          ],
+        ],
+        [
+          cruiseDays,
+          [
+            {
+              cruiseId: "cru_1",
+              dayNumber: 1,
+              title: "Rome",
+              description: "Embark in Rome.",
+              portFacilityId: "fac_rome",
+              portCanonicalPlaceId: "ITROM",
+              arrivalTime: null,
+              departureTime: "17:00",
+              isSeaDay: false,
+            },
+          ],
+        ],
+        [cruiseSailingDays, []],
+        [
+          cruisePrices,
+          [
+            {
+              sailingId: "sail_1",
+              pricePerPerson: "1299.00",
+              currency: "EUR",
+              availability: "available",
+            },
+          ],
+        ],
+        [
+          cruiseMedia,
+          [
+            {
+              cruiseId: "cru_1",
+              sailingId: null,
+              mediaType: "image",
+              url: "https://example.com/cover.jpg",
+              altText: "Ship at sea",
+              sortOrder: 0,
+              isCover: true,
+              createdAt: new Date("2026-01-01"),
+            },
+          ],
+        ],
+        [
+          cruiseInclusions,
+          [
+            {
+              cruiseId: "cru_1",
+              kind: "included",
+              label: "Port charges",
+              description: "Included in the fare.",
+              sortOrder: 0,
+            },
+          ],
+        ],
+      ]),
+    )
+
+    const result = await buildOwnedCruiseContent(db, "cru_1", {
+      preferredLocales: ["en-GB"],
+    })
+
+    expect(result?.servedLocale).toBe("und")
+    expect(result?.matchKind).toBe("any")
+    expect(result?.content.cruise).toMatchObject({
+      id: "cru_1",
+      name: "Mediterranean Highlights",
+      hero_image_url: "https://example.com/cover.jpg",
+      duration_nights: 7,
+      embarkation_port: "ITROM",
+    })
+    expect(result?.content.ship).toMatchObject({
+      id: "ship_1",
+      name: "MV Voyant Explorer",
+      deck_plans: [{ name: "Promenade", level: 5, image_url: "https://example.com/deck-5.jpg" }],
+    })
+    expect(result?.content.sailings).toEqual([
+      expect.objectContaining({
+        id: "sail_1",
+        source_ref: "MED-2026-07-12",
+        start_date: "2026-07-12",
+        end_date: "2026-07-19",
+        duration_nights: 7,
+        lowest_price_cents: 129900,
+        currency: "EUR",
+        itinerary_stops: [
+          expect.objectContaining({
+            day_number: 1,
+            date: "2026-07-12",
+            port_name: "Rome",
+          }),
+        ],
+      }),
+    ])
+    expect(result?.content.cabin_categories).toEqual([
+      expect.objectContaining({
+        id: "cab_1",
+        code: "BAL",
+        type: "balcony",
+        inclusions: ["private balcony"],
+      }),
+    ])
+    expect(result?.content.policies).toEqual(
+      expect.arrayContaining([
+        { kind: "supplier_notes", body: "<p>Meals included</p>" },
+        { kind: "supplier_notes", body: "<p>Excursions extra</p>" },
+        { kind: "supplier_notes", body: "Port charges\n\nIncluded in the fare." },
+        expect.objectContaining({
+          kind: "payment",
+          body: "cruise payment policy",
+          rules: { scope: "cruise", id: "cru_1", policy: { deposit: { percent: 25 } } },
+        }),
+      ]),
+    )
+  })
+})
+
+describe("getCruiseContent owned dispatch", () => {
+  it("returns owned content before sourced-adapter resolution", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[]>([
+        [
+          cruises,
+          [
+            {
+              id: "cru_1",
+              name: "Owned Cruise",
+              cruiseType: "river",
+              lineSupplierId: null,
+              defaultShipId: null,
+              nights: 4,
+              embarkPortFacilityId: null,
+              embarkPortCanonicalPlaceId: null,
+              disembarkPortFacilityId: null,
+              disembarkPortCanonicalPlaceId: null,
+              description: null,
+              shortDescription: null,
+              highlights: [],
+              inclusionsHtml: null,
+              exclusionsHtml: null,
+              heroImageUrl: null,
+              status: "live",
+              customerPaymentPolicy: null,
+            },
+          ],
+        ],
+        [cruiseSailings, []],
+        [cruiseMedia, []],
+        [cruiseInclusions, []],
+        [cruiseDays, []],
+      ]),
+    )
+    const registry = {
+      byKind: vi.fn(() => {
+        throw new Error("registry should not be used for owned content")
+      }),
+      resolveByConnection: vi.fn(),
+    }
+
+    const result = await getCruiseContent(
+      db,
+      "cru_1",
+      { preferredLocales: ["en-GB"] },
+      { registry: registry as never },
+    )
+
+    expect(result?.source).toBe("owned")
+    expect(result?.provenance).toEqual({ source_kind: "owned" })
+    expect(result?.content.cruise.name).toBe("Owned Cruise")
+    expect(registry.byKind).not.toHaveBeenCalled()
+  })
+})
+
+function fakeDb(rowsByTable: Map<unknown, unknown[]>) {
+  return {
+    select: () => ({
+      from: (table: unknown) => selectable(rowsByTable.get(table) ?? []),
+    }),
+  } as never
+}
+
+function selectable(rows: unknown[]) {
+  const chain = {
+    where: () => promiseChain(rows),
+    orderBy: async () => rows,
+    limit: async (limit: number) => rows.slice(0, limit),
+    offset: () => chain,
+  }
+  return chain
+}
+
+type QueryPromise = Promise<unknown[]> & {
+  orderBy: () => Promise<unknown[]>
+  limit: (limit: number) => Promise<unknown[]>
+  offset: () => QueryPromise
+}
+
+function promiseChain(rows: unknown[]): QueryPromise {
+  const promise = Promise.resolve(rows) as QueryPromise
+  promise.orderBy = async () => rows
+  promise.limit = async (limit: number) => rows.slice(0, limit)
+  promise.offset = () => promise
+  return promise
+}

--- a/packages/storefront-react/src/routing.test.ts
+++ b/packages/storefront-react/src/routing.test.ts
@@ -8,7 +8,11 @@ import {
 
 describe("storefront customer product routing", () => {
   it("keeps the customer detail route limited to implemented booking verticals", () => {
-    expect(storefrontCustomerBookableProductVerticals).toEqual(["products", "accommodations"])
+    expect(storefrontCustomerBookableProductVerticals).toEqual([
+      "products",
+      "accommodations",
+      "cruises",
+    ])
   })
 
   it("treats charters as searchable but not customer-bookable through product detail", () => {
@@ -16,12 +20,17 @@ describe("storefront customer product routing", () => {
     expect(getStorefrontCustomerProductDetailRoute("charters", "chrt_123")).toBeNull()
   })
 
-  it("excludes cruises from customer-bookable product detail (voyant#2639)", () => {
-    // The public cruise content endpoint serves sourced cruises only, so owned
-    // seeded cruises produced dead detail pages. Cruises stay searchable in the
-    // catalog but must not link to the storefront customer detail route.
-    expect(isStorefrontCustomerBookableProductVertical("cruises")).toBe(false)
-    expect(getStorefrontCustomerProductDetailRoute("cruises", "cru_123")).toBeNull()
+  it("routes cruises to customer-bookable product detail", () => {
+    expect(isStorefrontCustomerBookableProductVertical("cruises")).toBe(true)
+    expect(getStorefrontCustomerProductDetailRoute("cruises", "cru_123")).toEqual({
+      to: "/shop/products/$entityModule/$entityId",
+      params: { entityModule: "cruises", entityId: "cru_123" },
+    })
+  })
+
+  it("does not route sourced cruise projections to customer booking detail yet", () => {
+    expect(getStorefrontCustomerProductDetailRoute("cruises", "crus_sr_123")).toBeNull()
+    expect(getStorefrontCustomerProductDetailRoute("cruises", "crus_external")).toBeNull()
   })
 
   it("builds route params for implemented storefront booking detail pages", () => {

--- a/packages/storefront-react/src/routing.ts
+++ b/packages/storefront-react/src/routing.ts
@@ -3,17 +3,12 @@
  * storefront. Search and the customer detail route derive their accepted
  * verticals from this list, so a vertical only surfaces once it can render a
  * detail page and take a booking (voyant#2640).
- *
- * Cruises are intentionally excluded (voyant#2639): the public cruise content
- * endpoint (`GET /v1/public/cruises/:id/content`) serves SOURCED cruises only
- * — it reads a catalog sourced-entry row and has no owned-cruise content
- * projector (unlike products' `buildOwnedProductContent`). The operator seeds
- * OWNED cruises (`source.kind = "owned"`, `cru_*` ids) and indexes them into
- * customer search, so surfacing cruises produced result cards linking to a
- * detail page that 404s (owned ids) or 400s (non-sourced demo ids). Re-add
- * `"cruises"` once owned cruises can render public content end-to-end.
  */
-export const storefrontCustomerBookableProductVerticals = ["products", "accommodations"] as const
+export const storefrontCustomerBookableProductVerticals = [
+  "products",
+  "accommodations",
+  "cruises",
+] as const
 
 export type StorefrontCustomerBookableProductVertical =
   (typeof storefrontCustomerBookableProductVerticals)[number]
@@ -36,9 +31,16 @@ export function getStorefrontCustomerProductDetailRoute(
   if (!isStorefrontCustomerBookableProductVertical(entityModule)) {
     return null
   }
+  if (entityModule === "cruises" && !isOwnedCruiseId(entityId)) {
+    return null
+  }
 
   return {
     to: "/shop/products/$entityModule/$entityId",
     params: { entityModule, entityId },
   }
+}
+
+function isOwnedCruiseId(entityId: string): boolean {
+  return entityId.startsWith("cru_")
 }

--- a/starters/operator/src/routes/(storefront)/shop.test.ts
+++ b/starters/operator/src/routes/(storefront)/shop.test.ts
@@ -23,12 +23,9 @@ describe("shopSearchSchema vertical", () => {
     expect(shopSearchSchema.parse({ vertical: "charters" }).vertical).toBeUndefined()
   })
 
-  it("does not surface cruises (voyant#2639)", () => {
-    // The public cruise content endpoint serves sourced cruises only, so owned
-    // seeded cruises produced dead detail pages. A crafted ?vertical=cruises URL
-    // degrades to the default vertical instead of linking to a broken page.
-    expect(storefrontCustomerBookableProductVerticals).not.toContain("cruises")
-    expect(shopSearchSchema.parse({ vertical: "cruises" }).vertical).toBeUndefined()
+  it("surfaces cruises", () => {
+    expect(storefrontCustomerBookableProductVerticals).toContain("cruises")
+    expect(shopSearchSchema.parse({ vertical: "cruises" }).vertical).toBe("cruises")
   })
 
   it("drops any other unsupported vertical to the default", () => {

--- a/starters/operator/src/routes/(storefront)/shop.tsx
+++ b/starters/operator/src/routes/(storefront)/shop.tsx
@@ -26,13 +26,11 @@ import { useStorefrontScope } from "@/lib/storefront-scope"
  *
  * Search only offers verticals that have a working customer detail + booking
  * page. Charters and flights have no storefront `/content` endpoint or booking
- * flow yet (voyant#2640), and cruises render only SOURCED content publicly —
- * owned/demo cruises produced dead result cards and a broken detail page
- * (voyant#2639) — so all three are omitted from
+ * flow yet (voyant#2640), so they remain outside
  * `storefrontCustomerBookableProductVerticals`. Deriving the accepted verticals
  * from that list keeps search in sync automatically as new verticals gain
  * detail pages, and `.catch(undefined)` gracefully drops any stale/crafted
- * `?vertical=cruises` URL back to the default vertical instead of erroring.
+ * unsupported vertical URL back to the default vertical instead of erroring.
  */
 export const shopSearchSchema = z.object({
   q: z.string().optional(),

--- a/starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.book.$entityModule.$entityId.tsx
@@ -4,7 +4,7 @@ import type { AccommodationContent } from "@voyant-travel/accommodations/content
 import type { BookingEntitySummary } from "@voyant-travel/bookings-react/journey"
 import type { CruiseContent } from "@voyant-travel/cruises/content-shape"
 import type { ProductContent } from "@voyant-travel/inventory/content-shape"
-import { isStorefrontCustomerBookableProductVertical } from "@voyant-travel/storefront-react"
+import { getStorefrontCustomerProductDetailRoute } from "@voyant-travel/storefront-react"
 import { useMemo } from "react"
 import { z } from "zod"
 
@@ -55,12 +55,11 @@ const shopBookSearchSchema = z.object({
 
 export const Route = createFileRoute("/(storefront)/shop_/book/$entityModule/$entityId")({
   // Guard against stale/bookmarked booking URLs for verticals that aren't
-  // customer-bookable (e.g. `/shop/book/cruises/:id` — cruises can't render
-  // public content or book yet, voyant#2639). Search already hides them; gate
-  // the direct booking route on the same source of truth so it can't reach a
-  // broken reserve flow. Redirect back to the shop instead.
+  // customer-bookable. Search already hides them; gate the direct booking
+  // route on the same source of truth so it can't reach a broken reserve flow.
+  // Redirect back to the shop instead.
   beforeLoad: ({ params }) => {
-    if (!isStorefrontCustomerBookableProductVertical(params.entityModule)) {
+    if (!getStorefrontCustomerProductDetailRoute(params.entityModule, params.entityId)) {
       throw redirect({ to: "/shop" })
     }
   },

--- a/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { createFileRoute, useParams } from "@tanstack/react-router"
-import { isStorefrontCustomerBookableProductVertical } from "@voyant-travel/storefront-react"
+import { getStorefrontCustomerProductDetailRoute } from "@voyant-travel/storefront-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@voyant-travel/ui/components/card"
 import type React from "react"
 
@@ -19,7 +19,7 @@ function DetailPage(): React.ReactElement {
   })
   const t = useStorefrontMessagesOrDefault().shop
 
-  if (!isStorefrontCustomerBookableProductVertical(entityModule)) {
+  if (!getStorefrontCustomerProductDetailRoute(entityModule, entityId)) {
     return (
       <Card>
         <CardHeader>


### PR DESCRIPTION
## Summary
- add owned cruise content projection for public cruise detail reads
- return owned cruise metadata through getCruiseContent and allow opted-in /content routes to serve cru_* ids
- re-enable cruises in storefront customer product routing

## Validation
- pnpm --filter @voyant-travel/cruises exec biome check src/service-content.ts src/service-content-owned.ts src/routes-content.ts tests/unit/service-content-owned.test.ts tests/unit/routes-content.test.ts
- pnpm --filter @voyant-travel/storefront-react exec biome check src/routing.ts src/routing.test.ts
- pnpm exec biome check starters/operator/src/routes/\(storefront\)/shop.test.ts
- pnpm --filter @voyant-travel/cruises exec vitest run tests/unit/service-content-owned.test.ts tests/unit/routes-content.test.ts
- pnpm --filter @voyant-travel/storefront-react exec vitest run src/routing.test.ts
- pnpm --filter operator exec vitest run src/routes/\(storefront\)/shop.test.ts src/routes/\(storefront\)/shop-product-detail-content.test.ts
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/cruises typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/storefront-react typecheck
- commit hook affected lane passed
- push hook test lane passed

Fixes #2711