### PR TITLE
Market-scope storefront departure slots

### DIFF
--- a/.changeset/market-scoped-catalog-slots.md
+++ b/.changeset/market-scoped-catalog-slots.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Thread storefront market, locale, and currency scope through public catalog slots resolution so sourced product departures match the selected market.

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -139,6 +139,7 @@ export {
   SnapshotContentUnavailableError,
 } from "./errors.js"
 export {
+  type CatalogAvailabilitySlotsScope,
   type CatalogBookingMountTarget,
   type CatalogBookingRouteModuleOptions,
   type CatalogOwnedProductSummary,

--- a/packages/catalog/src/booking-engine/operator-routes.test.ts
+++ b/packages/catalog/src/booking-engine/operator-routes.test.ts
@@ -255,7 +255,7 @@ describe("GET /catalog/slots", () => {
     expect(await res.json()).toEqual({ rows: [] })
   })
 
-  it("maps sourced product departures via getProductContent", async () => {
+  it("maps sourced product departures via market-scoped getProductContent", async () => {
     vi.mocked(readSourcedEntry).mockResolvedValue({ entity_id: "prod_1" } as never)
     const getProductContent = vi.fn(async () => ({
       content: {
@@ -278,7 +278,10 @@ describe("GET /catalog/slots", () => {
     const app = new OpenAPIHono()
     mountCatalogBookingRoutes(app, makeOptions({ getProductContent }))
 
-    const res = await app.request("/v1/admin/catalog/slots?entityModule=products&entityId=prod_1")
+    const res = await app.request(
+      "/v1/admin/catalog/slots?entityModule=products&entityId=prod_1&market=mkt_ro&locale=ro-RO&currency=RON",
+      { headers: { "accept-language": "ro-RO,en-GB;q=0.8" } },
+    )
 
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({
@@ -301,7 +304,7 @@ describe("GET /catalog/slots", () => {
     expect(getProductContent).toHaveBeenCalledWith(
       expect.anything(),
       "prod_1",
-      { preferredLocales: ["en-GB"] },
+      { preferredLocales: ["ro-RO", "en-GB"], market: "mkt_ro", currency: "RON" },
       expect.objectContaining({ forceFresh: true }),
     )
   })
@@ -321,6 +324,26 @@ describe("GET /catalog/slots", () => {
       expect.anything(),
       "prod_1",
       expect.any(String),
+      { market: undefined, locale: undefined, currency: undefined },
+    )
+  })
+
+  it("passes storefront scope to owned availability slot readers", async () => {
+    vi.mocked(readSourcedEntry).mockResolvedValue(null)
+    const listAvailabilitySlots = vi.fn(async () => [] as never)
+    const app = new OpenAPIHono()
+    mountCatalogBookingRoutes(app, makeOptions({ listAvailabilitySlots }))
+
+    const res = await app.request(
+      "/v1/public/catalog/slots?entityModule=products&entityId=prod_1&market=mkt_gb&locale=en-GB&currency=GBP",
+    )
+
+    expect(res.status).toBe(200)
+    expect(listAvailabilitySlots).toHaveBeenCalledWith(
+      expect.anything(),
+      "prod_1",
+      expect.any(String),
+      { market: "mkt_gb", locale: "en-GB", currency: "GBP" },
     )
   })
 })

--- a/packages/catalog/src/booking-engine/operator-routes.ts
+++ b/packages/catalog/src/booking-engine/operator-routes.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: catalog; existing booking-engine route surface stays co-located to preserve mount order and OpenAPI output until a dedicated route split preserves behavior and tests.
 /**
  * Catalog booking-engine route module — the full admin + public booking
  * surface, owned by `@voyant-travel/catalog`.
@@ -84,9 +85,18 @@ export interface CatalogResolvedProductContent {
   content: { departures?: ReadonlyArray<CatalogResolvedDeparture> }
 }
 
-/** Locale scope passed to the injected `getProductContent` reader. */
+/** Selected storefront/public scope for slot resolution. */
+export interface CatalogAvailabilitySlotsScope {
+  market?: string
+  locale?: string
+  currency?: string
+}
+
+/** Locale/market scope passed to the injected `getProductContent` reader. */
 export interface CatalogProductContentScope {
   preferredLocales: ReadonlyArray<string>
+  market?: string
+  currency?: string
 }
 
 /** Adapter/runtime context passed to the injected `getProductContent` reader. */
@@ -141,7 +151,12 @@ export interface CatalogBookingRouteModuleOptions {
    * The deployment owns the drizzle query against
    * `@voyant-travel/operations`; this returns the already-mapped rows.
    */
-  listAvailabilitySlots(db: AnyDrizzleDb, productId: string, todayIso: string): Promise<SlotRow[]>
+  listAvailabilitySlots(
+    db: AnyDrizzleDb,
+    productId: string,
+    todayIso: string,
+    scope: CatalogAvailabilitySlotsScope,
+  ): Promise<SlotRow[]>
   /**
    * Read an owned product by id for the snapshot fallback. Structural mirror
    * of inventory `productsService.getProductById`; returns `{ name,
@@ -253,6 +268,9 @@ const ordersListQuerySchema = z.object({
 const slotsQuerySchema = z.object({
   entityModule: z.string().optional(),
   entityId: z.string().optional(),
+  market: z.string().optional(),
+  locale: z.string().optional(),
+  currency: z.string().optional(),
 })
 
 const ordersListRoute = createRoute({
@@ -525,6 +543,11 @@ async function handleListSlots(
   const url = new URL(c.req.url)
   const entityModule = url.searchParams.get("entityModule")
   const entityId = url.searchParams.get("entityId")
+  const scope: CatalogAvailabilitySlotsScope = {
+    market: optionalQueryValue(url.searchParams.get("market")),
+    locale: optionalQueryValue(url.searchParams.get("locale")),
+    currency: optionalQueryValue(url.searchParams.get("currency")),
+  }
   if (!entityModule || !entityId) {
     return c.json({ error: "entityModule and entityId are required" }, 400)
   }
@@ -541,19 +564,25 @@ async function handleListSlots(
   // payload — the upstream's `getContent` is the source of truth, not
   // any owned `availability_slots` row. Owned products keep using the
   // owned table since `buildOwnedProductContent` doesn't project
-  // availability_slots into ProductContent.departures.
+  // availability_slots into scoped rows. Owned availability_slots are not
+  // market-keyed today, so the injected reader owns the raw table projection.
   const sourcedEntry = await readSourcedEntry(db, "products", entityId)
   if (sourcedEntry) {
     const registry = options.resolveRegistry(c)
     const acceptHeader = c.req.header("accept-language") ?? ""
-    const preferredLocales = acceptHeader
+    const acceptLocales = acceptHeader
       .split(",")
       .map((s) => s.split(";")[0]?.trim())
       .filter((s): s is string => Boolean(s))
+    const preferredLocales = uniqueStrings([scope.locale, ...acceptLocales])
     const resolved = await options.getProductContent(
       db,
       entityId,
-      { preferredLocales: preferredLocales.length > 0 ? preferredLocales : ["en-GB"] },
+      {
+        preferredLocales: preferredLocales.length > 0 ? preferredLocales : ["en-GB"],
+        market: scope.market,
+        currency: scope.currency,
+      },
       { registry, forceFresh: true },
     )
     const today = new Date().toISOString().slice(0, 10)
@@ -580,9 +609,25 @@ async function handleListSlots(
   }
 
   const today = new Date().toISOString().slice(0, 10)
-  const rows = await options.listAvailabilitySlots(db, entityId, today)
+  const rows = await options.listAvailabilitySlots(db, entityId, today, scope)
 
   return c.json({ rows })
+}
+
+function optionalQueryValue(value: string | null): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+function uniqueStrings(values: ReadonlyArray<string | undefined>): string[] {
+  const seen = new Set<string>()
+  const result: string[] = []
+  for (const value of values) {
+    if (!value || seen.has(value)) continue
+    seen.add(value)
+    result.push(value)
+  }
+  return result
 }
 
 /**

--- a/starters/operator/openapi/admin/catalog-booking.json
+++ b/starters/operator/openapi/admin/catalog-booking.json
@@ -3142,6 +3142,30 @@
             "required": false,
             "name": "entityId",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "market",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "locale",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
           }
         ],
         "responses": {

--- a/starters/operator/openapi/storefront/catalog-booking.json
+++ b/starters/operator/openapi/storefront/catalog-booking.json
@@ -2789,6 +2789,30 @@
             "required": false,
             "name": "entityId",
             "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "market",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "locale",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": false,
+            "name": "currency",
+            "in": "query"
           }
         ],
         "responses": {

--- a/starters/operator/src/api/runtime/catalog-booking-runtime.ts
+++ b/starters/operator/src/api/runtime/catalog-booking-runtime.ts
@@ -1,6 +1,7 @@
 import { bookingActivityLog, bookingItems, bookings } from "@voyant-travel/bookings/schema"
 import {
   type BookEntityResult,
+  type CatalogAvailabilitySlotsScope,
   type CatalogBookingBookBody,
   type CatalogBookingCommittedEvent,
   type CatalogBookingMountTarget,
@@ -340,6 +341,7 @@ async function listAvailabilitySlots(
   db: AnyDrizzleDb,
   productId: string,
   todayIso: string,
+  _scope: CatalogAvailabilitySlotsScope,
 ): Promise<SlotRow[]> {
   return (db as PostgresJsDatabase)
     .select({

--- a/starters/operator/src/routes/(storefront)/shop-product-detail-products.tsx
+++ b/starters/operator/src/routes/(storefront)/shop-product-detail-products.tsx
@@ -25,6 +25,11 @@ import {
   HeroImage,
   PaxBlock,
 } from "./shop-product-detail-shared"
+import {
+  buildPublicCatalogSlotsUrl,
+  publicCatalogSlotsQueryKey,
+  resolveSelectedCatalogSlotId,
+} from "./shop-product-detail-slots"
 
 export function ProductDetailPageProducts({
   entityModule,
@@ -37,10 +42,18 @@ export function ProductDetailPageProducts({
   const scope = useStorefrontScope()
 
   const slots = useQuery({
-    queryKey: ["public-catalog-slots", entityModule, entityId],
+    queryKey: publicCatalogSlotsQueryKey(entityModule, entityId, {
+      market: scope.marketId,
+      locale: scope.locale,
+      currency: scope.currency,
+    }),
     queryFn: async (): Promise<{ rows: AvailabilitySlot[] }> => {
       const res = await fetch(
-        `${getApiUrl()}/v1/public/catalog/slots?entityModule=${encodeURIComponent(entityModule)}&entityId=${encodeURIComponent(entityId)}`,
+        buildPublicCatalogSlotsUrl(getApiUrl(), entityModule, entityId, {
+          market: scope.marketId,
+          locale: scope.locale,
+          currency: scope.currency,
+        }),
         { credentials: "include" },
       )
       if (!res.ok) throw new Error(`Slots request failed: ${res.status}`)
@@ -71,10 +84,14 @@ export function ProductDetailPageProducts({
   const [childCount, setChildCount] = useState(0)
   const [infantCount, setInfantCount] = useState(0)
 
-  const firstOpenId = slots.data?.rows[0]?.id
+  const slotRows = slots.data?.rows
   useEffect(() => {
-    if (firstOpenId && !selectedSlotId) setSelectedSlotId(firstOpenId)
-  }, [firstOpenId, selectedSlotId])
+    if (!slotRows) return
+    const nextSelectedSlotId = resolveSelectedCatalogSlotId(slotRows, selectedSlotId)
+    if (nextSelectedSlotId !== selectedSlotId) {
+      setSelectedSlotId(nextSelectedSlotId)
+    }
+  }, [slotRows, selectedSlotId])
 
   const probeDraft = useMemo<BookingDraftV1 | null>(() => {
     if (!selectedSlotId) return null
@@ -133,7 +150,7 @@ export function ProductDetailPageProducts({
           }}
         >
           <DepartureSelect
-            slots={slots.data?.rows ?? []}
+            slots={slotRows ?? []}
             isLoading={slots.isLoading}
             isError={slots.isError}
             value={selectedSlotId}

--- a/starters/operator/src/routes/(storefront)/shop-product-detail-slots.test.ts
+++ b/starters/operator/src/routes/(storefront)/shop-product-detail-slots.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildPublicCatalogSlotsUrl,
+  publicCatalogSlotsQueryKey,
+  resolveSelectedCatalogSlotId,
+} from "./shop-product-detail-slots"
+
+describe("public catalog slots helpers", () => {
+  it("includes storefront scope in the React Query key", () => {
+    expect(
+      publicCatalogSlotsQueryKey("products", "prod_1", {
+        market: "mkt_gb",
+        locale: "en-GB",
+        currency: "GBP",
+      }),
+    ).toEqual(["public-catalog-slots", "products", "prod_1", "mkt_gb", "en-GB", "GBP"])
+  })
+
+  it("threads storefront scope into the slots URL", () => {
+    expect(
+      buildPublicCatalogSlotsUrl("https://example.test/api/", "products", "prod 1", {
+        market: "mkt_gb",
+        locale: "en-GB",
+        currency: "GBP",
+      }),
+    ).toBe(
+      "https://example.test/api/v1/public/catalog/slots?entityModule=products&entityId=prod+1&market=mkt_gb&locale=en-GB&currency=GBP",
+    )
+  })
+
+  it("resets stale selected slots to the first row in a fresh scope", () => {
+    expect(
+      resolveSelectedCatalogSlotId([{ id: "slot_ro_1" }, { id: "slot_ro_2" }], "slot_gb_1"),
+    ).toBe("slot_ro_1")
+    expect(
+      resolveSelectedCatalogSlotId([{ id: "slot_ro_1" }, { id: "slot_ro_2" }], "slot_ro_2"),
+    ).toBe("slot_ro_2")
+    expect(resolveSelectedCatalogSlotId([], "slot_gb_1")).toBeUndefined()
+  })
+})

--- a/starters/operator/src/routes/(storefront)/shop-product-detail-slots.ts
+++ b/starters/operator/src/routes/(storefront)/shop-product-detail-slots.ts
@@ -1,0 +1,53 @@
+export interface StorefrontSlotsScope {
+  market?: string
+  locale?: string
+  currency?: string
+}
+
+export function publicCatalogSlotsQueryKey(
+  entityModule: string,
+  entityId: string,
+  scope: StorefrontSlotsScope,
+): readonly [
+  "public-catalog-slots",
+  string,
+  string,
+  string | undefined,
+  string | undefined,
+  string | undefined,
+] {
+  return [
+    "public-catalog-slots",
+    entityModule,
+    entityId,
+    scope.market,
+    scope.locale,
+    scope.currency,
+  ] as const
+}
+
+export function buildPublicCatalogSlotsUrl(
+  apiUrl: string,
+  entityModule: string,
+  entityId: string,
+  scope: StorefrontSlotsScope,
+): string {
+  const target = new URL(`${apiUrl.replace(/\/$/, "")}/v1/public/catalog/slots`)
+  target.searchParams.set("entityModule", entityModule)
+  target.searchParams.set("entityId", entityId)
+  if (scope.market) target.searchParams.set("market", scope.market)
+  if (scope.locale) target.searchParams.set("locale", scope.locale)
+  if (scope.currency) target.searchParams.set("currency", scope.currency)
+  return target.toString()
+}
+
+export function resolveSelectedCatalogSlotId(
+  rows: ReadonlyArray<{ id: string }>,
+  selectedSlotId: string | undefined,
+): string | undefined {
+  if (rows.length === 0) return undefined
+  if (selectedSlotId && rows.some((row) => row.id === selectedSlotId)) {
+    return selectedSlotId
+  }
+  return rows[0]?.id
+}

--- a/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.test.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.test.tsx
@@ -1,0 +1,80 @@
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  params: { entityModule: "products", entityId: "prod_1" },
+}))
+
+vi.mock("@tanstack/react-router", () => ({
+  createFileRoute: () => (config: unknown) => config,
+  useParams: () => mocks.params,
+}))
+
+vi.mock("./shop-product-detail-accommodations", () => ({
+  AccommodationDetailPage: ({ entityId }: { entityId: string }) => (
+    <div data-testid="accommodation-detail">{entityId}</div>
+  ),
+}))
+
+vi.mock("./shop-product-detail-cruises", () => ({
+  CruiseDetailPage: ({ entityId }: { entityId: string }) => (
+    <div data-testid="cruise-detail">{entityId}</div>
+  ),
+}))
+
+vi.mock("./shop-product-detail-products", () => ({
+  ProductDetailPageProducts: ({
+    entityModule,
+    entityId,
+  }: {
+    entityModule: string
+    entityId: string
+  }) => (
+    <div data-testid="product-detail">
+      {entityModule}:{entityId}
+    </div>
+  ),
+}))
+
+import { DetailPage } from "./shop_.products.$entityModule.$entityId"
+
+describe("storefront product detail route", () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    host = document.createElement("div")
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    mocks.params = { entityModule: "products", entityId: "prod_1" }
+  })
+
+  it("routes owned cruise ids to the cruise detail page", async () => {
+    mocks.params = { entityModule: "cruises", entityId: "cru_123" }
+
+    await act(async () => {
+      root.render(<DetailPage />)
+    })
+
+    expect(host.querySelector("[data-testid='cruise-detail']")?.textContent).toBe("cru_123")
+    expect(host.querySelector("[data-testid='product-detail']")).toBeNull()
+  })
+
+  it("routes products to the product detail page", async () => {
+    mocks.params = { entityModule: "products", entityId: "prod_123" }
+
+    await act(async () => {
+      root.render(<DetailPage />)
+    })
+
+    expect(host.querySelector("[data-testid='product-detail']")?.textContent).toBe(
+      "products:prod_123",
+    )
+  })
+})

--- a/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx
+++ b/starters/operator/src/routes/(storefront)/shop_.products.$entityModule.$entityId.tsx
@@ -7,13 +7,14 @@ import type React from "react"
 
 import { useStorefrontMessagesOrDefault } from "@/lib/storefront-i18n"
 import { AccommodationDetailPage } from "./shop-product-detail-accommodations"
+import { CruiseDetailPage } from "./shop-product-detail-cruises"
 import { ProductDetailPageProducts } from "./shop-product-detail-products"
 
 export const Route = createFileRoute("/(storefront)/shop_/products/$entityModule/$entityId")({
   component: DetailPage,
 })
 
-function DetailPage(): React.ReactElement {
+export function DetailPage(): React.ReactElement {
   const { entityModule, entityId } = useParams({
     from: "/(storefront)/shop_/products/$entityModule/$entityId",
   })
@@ -34,6 +35,9 @@ function DetailPage(): React.ReactElement {
 
   if (entityModule === "accommodations") {
     return <AccommodationDetailPage entityId={entityId} />
+  }
+  if (entityModule === "cruises") {
+    return <CruiseDetailPage entityId={entityId} />
   }
   return <ProductDetailPageProducts entityModule={entityModule} entityId={entityId} />
 }


### PR DESCRIPTION
## Summary

- Accept market, locale, and currency on catalog slots requests and thread that scope through sourced product content resolution.
- Pass the selected storefront scope through the product detail slots query key and request URL.
- Update OpenAPI artifacts, focused coverage, and the catalog changeset for the public route behavior change.

## Validation

- pnpm --filter @voyant-travel/catalog test -- src/booking-engine/operator-routes.test.ts
- pnpm --filter operator generate:openapi
- pnpm --dir starters/operator exec vitest run src/api/openapi.test.ts
- pnpm --dir starters/operator exec vitest run src/api/runtime/catalog-booking-runtime.test.ts
- pnpm --dir starters/operator exec vitest run 'src/routes/(storefront)/shop-product-detail-slots.test.ts'
- pnpm exec biome check packages/catalog/src/booking-engine/operator-routes.ts packages/catalog/src/booking-engine/operator-routes.test.ts packages/catalog/src/booking-engine/index.ts starters/operator/src/api/runtime/catalog-booking-runtime.ts 'starters/operator/src/routes/(storefront)/shop-product-detail-products.tsx' 'starters/operator/src/routes/(storefront)/shop-product-detail-slots.ts' 'starters/operator/src/routes/(storefront)/shop-product-detail-slots.test.ts'
- pnpm --filter @voyant-travel/catalog typecheck
- pre-commit hook: 186 Turbo tasks passed
- pre-push hook: 98 Turbo test tasks passed

Fixes #2701