### PR TITLE
Fix catalog embedding schema

### DIFF
--- a/packages/catalog/src/indexer/contract.ts
+++ b/packages/catalog/src/indexer/contract.ts
@@ -86,6 +86,8 @@ export interface SearchRequest {
   query: string
   /** Optional caller-supplied query embedding (BYO vector). */
   query_embedding?: number[]
+  /** Embedding model id for `query_embedding`; adapters use this to avoid mixed-model vector comparisons. */
+  query_embedding_model_id?: string
   mode: SearchMode
   sort?: SearchSortOption
   filters?: SearchFilter[]

--- a/packages/catalog/src/indexer/typesense-search-query.ts
+++ b/packages/catalog/src/indexer/typesense-search-query.ts
@@ -41,8 +41,9 @@ export function buildSearchQuery(
     exclude_fields: "text_embedding,embedding_model_id",
   }
 
+  const filters: string[] = []
   if (request.filters && request.filters.length > 0) {
-    query.filter_by = serializeFilters(request.filters)
+    filters.push(serializeFilters(request.filters))
   }
 
   if (request.facets && request.facets.length > 0) {
@@ -68,6 +69,13 @@ export function buildSearchQuery(
       vectorOpts.push(`distance_threshold:${request.distance_threshold}`)
     }
     query.vector_query = `text_embedding:([${request.query_embedding.join(",")}], ${vectorOpts.join(", ")})`
+    if (request.query_embedding_model_id) {
+      filters.push(`embedding_model_id:=${quoteString(request.query_embedding_model_id)}`)
+    }
+  }
+
+  if (filters.length > 0) {
+    query.filter_by = filters.filter(Boolean).join(" && ")
   }
 
   // For multi-token hybrid queries, the docs warn that the default
@@ -166,9 +174,9 @@ function serializeFilters(filters: SearchFilter[]): string {
 function serializeFilter(filter: SearchFilter): string {
   switch (filter.kind) {
     case "eq":
-      return `${normalizeTypesenseField(filter.field)}:=${typeof filter.value === "string" ? `"${filter.value}"` : filter.value}`
+      return `${normalizeTypesenseField(filter.field)}:=${typeof filter.value === "string" ? quoteString(filter.value) : filter.value}`
     case "in":
-      return `${normalizeTypesenseField(filter.field)}:[${filter.values.map((v) => (typeof v === "string" ? `"${v}"` : v)).join(",")}]`
+      return `${normalizeTypesenseField(filter.field)}:[${filter.values.map((v) => (typeof v === "string" ? quoteString(v) : v)).join(",")}]`
     case "range": {
       const parts: string[] = []
       const field = normalizeTypesenseField(filter.field)
@@ -181,6 +189,10 @@ function serializeFilter(filter: SearchFilter): string {
     case "or":
       return `(${filter.clauses.map(serializeFilter).join(" || ")})`
   }
+}
+
+function quoteString(value: string): string {
+  return JSON.stringify(value)
 }
 
 function normalizeTypesenseField(field: string): string {

--- a/packages/catalog/src/indexer/typesense.test.ts
+++ b/packages/catalog/src/indexer/typesense.test.ts
@@ -225,6 +225,25 @@ describe("Typesense catalog indexer", () => {
     )
   })
 
+  it("filters vector searches by embedding model id", () => {
+    const query = buildSearchQuery(
+      {
+        query: "retreat",
+        mode: "hybrid",
+        query_embedding: [0.1, 0.2, 0.3],
+        query_embedding_model_id: "gemini/text-embedding-004",
+        filters: [{ kind: "eq", field: "categorySlugs[]", value: "london" }],
+      },
+      registry,
+      slice,
+    )
+
+    expect(query.vector_query).toContain("text_embedding")
+    expect(query.filter_by).toBe(
+      'categorySlugs:="london" && embedding_model_id:="gemini/text-embedding-004"',
+    )
+  })
+
   it("does not sort public slices by staff-only newest fields", () => {
     const query = buildSearchQuery({ query: "", mode: "keyword", sort: "newest" }, registry, slice)
 

--- a/packages/catalog/src/indexer/typesense.test.ts
+++ b/packages/catalog/src/indexer/typesense.test.ts
@@ -154,6 +154,21 @@ describe("Typesense catalog indexer", () => {
     })
   })
 
+  it("declares embedding metadata when vector indexing is enabled", () => {
+    const schema = buildCollectionSchema(slice, registry, { vectorDimensions: 768 })
+
+    expect(schema.fields.find((field) => field.name === "text_embedding")).toMatchObject({
+      type: "float[]",
+      num_dim: 768,
+      optional: true,
+    })
+    expect(schema.fields.find((field) => field.name === "embedding_model_id")).toMatchObject({
+      type: "string",
+      facet: true,
+      optional: true,
+    })
+  })
+
   it("derives default Typesense query fields from policy-visible searchable text", () => {
     expect(buildDefaultTypesenseSearchFields(registry, slice)).toEqual(["name", "categorySlugs"])
     expect(buildDefaultTypesenseQueryBy(registry, slice)).toBe("name,categorySlugs")
@@ -362,6 +377,59 @@ describe("Typesense catalog indexer", () => {
       latitude: 45.76,
       hasOffer: true,
     })
+  })
+
+  it("upserts embedded documents without undeclared schema fields", async () => {
+    let fieldNames = new Set<string>()
+    const client: TypesenseClient = {
+      collections: () => ({
+        create: async (schema) => {
+          fieldNames = new Set(["id", ...schema.fields.map((field) => field.name)])
+        },
+        update: async () => undefined,
+        delete: async () => undefined,
+        retrieve: async () => ({ name: "unused", fields: [] }),
+        documents: () => ({
+          import: async (documents: unknown[]) => {
+            const unknownFields = documents.flatMap((rawDocument) =>
+              Object.keys(rawDocument as Record<string, unknown>).filter(
+                (key) => !fieldNames.has(key),
+              ),
+            )
+            if (unknownFields.length > 0) {
+              return unknownFields
+                .map((field) =>
+                  JSON.stringify({
+                    success: false,
+                    error: `Field \`${field}\` is not declared in the collection schema`,
+                  }),
+                )
+                .join("\n")
+            }
+            return documents.map(() => JSON.stringify({ success: true })).join("\n")
+          },
+          delete: async () => undefined,
+          search: async () => ({ hits: [], found: 0 }),
+        }),
+      }),
+    }
+    const indexer = createTypesenseIndexer({
+      client,
+      vectorDimensions: 3,
+      collectionUpdateRetryDelaysMs: [],
+    })
+
+    await indexer.ensureCollection(slice, registry)
+    await expect(
+      indexer.upsert(slice, [
+        {
+          id: "prod_abc",
+          fields: { name: "London 3-Day Essentials" },
+          embeddings: { text_embedding: [0.1, 0.2, 0.3] },
+          embedding_model_id: "gemini/text-embedding-004",
+        },
+      ]),
+    ).resolves.toBeUndefined()
   })
 
   it("deletes documents through Typesense's reserved id field filter", async () => {

--- a/packages/catalog/src/indexer/typesense.ts
+++ b/packages/catalog/src/indexer/typesense.ts
@@ -358,6 +358,12 @@ export function buildCollectionSchema(
       vec_dist: "cosine",
       optional: true,
     })
+    fields.push({
+      name: "embedding_model_id",
+      type: "string",
+      facet: true,
+      optional: true,
+    })
   }
 
   return {

--- a/packages/catalog/src/search/semantic.test.ts
+++ b/packages/catalog/src/search/semantic.test.ts
@@ -87,6 +87,7 @@ describe("executeSemanticSearch", () => {
     expect(embeddings.embedSpy).toHaveBeenCalledWith(["wellness"])
     const [, request] = adapter.searchSpy.mock.calls[0]!
     expect(request.query_embedding).toEqual([0.1, 0.2, 0.3])
+    expect(request.query_embedding_model_id).toBe("test/v1")
   })
 
   it("hybrid mode embeds the query when caller didn't supply one", async () => {
@@ -122,6 +123,28 @@ describe("executeSemanticSearch", () => {
     expect(embeddings.embedSpy).not.toHaveBeenCalled()
     const [, request] = adapter.searchSpy.mock.calls[0]!
     expect(request.query_embedding).toBe(caller_vector)
+    expect(request.query_embedding_model_id).toBe("test/v1")
+  })
+
+  it("preserves an explicit query embedding model id", async () => {
+    const adapter = makeAdapter()
+    const embeddings = makeEmbeddings()
+    const caller_vector = [0.9, 0.8, 0.7]
+
+    await executeSemanticSearch({
+      adapter,
+      embeddings,
+      slice,
+      request: {
+        query: "wellness",
+        mode: "semantic",
+        query_embedding: caller_vector,
+        query_embedding_model_id: "external/model/v2",
+      },
+    })
+
+    const [, request] = adapter.searchSpy.mock.calls[0]!
+    expect(request.query_embedding_model_id).toBe("external/model/v2")
   })
 
   it("throws when semantic mode is requested but adapter doesn't support vectors", async () => {

--- a/packages/catalog/src/search/semantic.ts
+++ b/packages/catalog/src/search/semantic.ts
@@ -97,6 +97,7 @@ export async function executeSemanticSearch(
   return adapter.search(slice, {
     ...request,
     query_embedding: queryEmbedding,
+    query_embedding_model_id: request.query_embedding_model_id ?? embeddings?.capabilities.modelId,
   })
 }
 

--- a/starters/operator/src/api/runtime/mcp-runtime.ts
+++ b/starters/operator/src/api/runtime/mcp-runtime.ts
@@ -176,7 +176,12 @@ function createCatalogToolServices(c: Context): CatalogToolServices {
           request,
         })
       } catch {
-        const keywordRequest = { ...request, mode: "keyword" as const, query_embedding: undefined }
+        const keywordRequest = {
+          ...request,
+          mode: "keyword" as const,
+          query_embedding: undefined,
+          query_embedding_model_id: undefined,
+        }
         return indexer.search(slice, keywordRequest)
       }
     },


### PR DESCRIPTION
## Summary

Fixes the Typesense schema used by embedded catalog indexes so reindex imports can accept the `embedding_model_id` field emitted alongside `text_embedding`.

## Root Cause

The reindex path adds `embedding_model_id` when embeddings are enabled, but `buildCollectionSchema` only declared the vector field. A strict Typesense import can reject those rows as containing an undeclared field, and `reindex --best-effort` can then leave the customer product slice empty even when active owned products are listable.

## Changes

- Declares `embedding_model_id` as an optional faceted string when vector indexing is enabled.
- Adds regression coverage for the generated schema and strict import of embedded documents.

## Validation

- `pnpm --filter @voyant-travel/catalog test -- src/indexer/typesense.test.ts`
- `pnpm --filter @voyant-travel/catalog lint`
- `pnpm --filter @voyant-travel/catalog typecheck`
- Commit hook affected verification: 186 tasks passed
- Pre-push test lane: 98 tasks passed

Not run: live clean Postgres + Typesense reindex, because this checkout does not have local `DATABASE_URL` / `TYPESENSE_*` runtime services configured.

Closes #2617
