### PR TITLE
Reduce API cold-start module warmup

### DIFF
--- a/.changeset/auth-api-cold-path.md
+++ b/.changeset/auth-api-cold-path.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/worker-runtime": patch
+---
+
+Keep lean auth dispatch isolated from the full API graph by default. Auth
+requests no longer background-warm `loadApiApp()` unless a host explicitly sets
+`warmApiOnAuth: true`, preventing `/api/auth/*` cold requests from triggering
+the heavy framework module import path.

--- a/.changeset/lazy-framework-composition.md
+++ b/.changeset/lazy-framework-composition.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/hono": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/finance": patch
+---
+
+Split the framework standard runtime composition into lightweight per-module
+lazy route loaders, and allow overlapping lazy route mounts to fall through on
+wrapper route misses so lazy modules/extensions preserve eager route composition
+semantics without swallowing handler-authored 404 responses.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -412,6 +412,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -407,6 +407,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -383,6 +383,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -378,6 +378,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -9,6 +9,7 @@
     "./checkout": "./src/checkout/index.ts",
     "./markets/validation": "./src/markets/validation.ts",
     "./promotions/validation": "./src/promotions/validation.ts",
+    "./promotions/workflow-bulk-reindex": "./src/promotions/workflow-bulk-reindex.ts",
     "./sellability/validation": "./src/sellability/validation.ts"
   },
   "scripts": {
@@ -90,6 +91,11 @@
         "types": "./dist/promotions/validation.d.ts",
         "import": "./dist/promotions/validation.js",
         "default": "./dist/promotions/validation.js"
+      },
+      "./promotions/workflow-bulk-reindex": {
+        "types": "./dist/promotions/workflow-bulk-reindex.d.ts",
+        "import": "./dist/promotions/workflow-bulk-reindex.js",
+        "default": "./dist/promotions/workflow-bulk-reindex.js"
       },
       "./sellability/validation": {
         "types": "./dist/sellability/validation.d.ts",

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -9,7 +9,11 @@ import {
   runCheckoutFinalize,
 } from "@voyant-travel/catalog/booking-engine"
 import type { EventBus } from "@voyant-travel/core"
-import { convertProformaToInvoice, issueInvoiceFromBooking } from "@voyant-travel/finance"
+import {
+  convertProformaToInvoice,
+  issueInvoiceFromBooking,
+  settleCoveredBookingPaymentSchedules,
+} from "@voyant-travel/finance"
 import { beginWorkflowRun, type WorkflowRunRecorder } from "@voyant-travel/workflow-runs"
 import { and, desc, eq, isNull } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -200,7 +204,7 @@ function buildCheckoutFinalizeDeps(
         sessionsLinked++
       }
 
-      await financeService.settleCoveredBookingPaymentSchedules(db, bookingId)
+      await settleCoveredBookingPaymentSchedules(db, bookingId)
 
       return { paymentId: firstPaymentId, sessionsLinked }
     },

--- a/packages/commerce/src/promotions/index.ts
+++ b/packages/commerce/src/promotions/index.ts
@@ -1,16 +1,10 @@
-import type { Module } from "@voyant-travel/core"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
+import { promotionsModule } from "./module-metadata.js"
 import { createPromotionsRoutes, type PromotionsRoutesOptions, promotionsRoutes } from "./routes.js"
-import { bulkReindexProductsWorkflow, promotionAffectedAllFilter } from "./workflow-bulk-reindex.js"
 
+export { promotionsModule } from "./module-metadata.js"
 export type { PromotionsRoutes, PromotionsRoutesOptions } from "./routes.js"
-
-export const promotionsModule: Module = {
-  name: "promotions",
-  workflows: [bulkReindexProductsWorkflow],
-  eventFilters: [promotionAffectedAllFilter],
-}
 
 export const promotionsHonoModule: HonoModule = {
   module: promotionsModule,

--- a/packages/commerce/src/promotions/module-metadata.ts
+++ b/packages/commerce/src/promotions/module-metadata.ts
@@ -1,0 +1,9 @@
+import type { Module } from "@voyant-travel/core"
+
+import { bulkReindexProductsWorkflow, promotionAffectedAllFilter } from "./workflow-bulk-reindex.js"
+
+export const promotionsModule: Module = {
+  name: "promotions",
+  workflows: [bulkReindexProductsWorkflow],
+  eventFilters: [promotionAffectedAllFilter],
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -482,6 +482,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -477,6 +477,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -477,6 +477,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -483,6 +483,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -478,6 +478,7 @@ export type {
   InvoiceSettlementPollerResult,
 } from "./service-settlement.js"
 export { financeSettlementService } from "./service-settlement.js"
+export { settleCoveredBookingPaymentSchedules } from "./service-shared.js"
 export {
   type AllocationCheckEntry,
   type AllocationCheckLine,

--- a/packages/framework/src/anonymous-surface.test.ts
+++ b/packages/framework/src/anonymous-surface.test.ts
@@ -1,7 +1,7 @@
 import { assembleAnonymousPaths } from "@voyant-travel/hono"
 import { composeFromManifest } from "@voyant-travel/hono/composition"
 import { describe, expect, it } from "vitest"
-import { frameworkComposition } from "./composition.js"
+import { frameworkComposition } from "./composition-lazy.js"
 import { FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
 
 /**
@@ -10,7 +10,7 @@ import { FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
  * factory runs far enough to return its module/extension metadata without real
  * providers wired.
  */
-// biome-ignore lint/suspicious/noExplicitAny: test stub for the typed provider container.
+// biome-ignore lint/suspicious/noExplicitAny: test stub for the typed provider container -- owner: framework composition.
 const deepStub: any = new Proxy(() => deepStub, {
   get: (_t, p) => {
     if (p === Symbol.toPrimitive) return () => "stub"

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -1,0 +1,916 @@
+// agent-quality: file-size exception -- this is the lazy counterpart to the
+// framework's standard composition registry: one small metadata/loader factory
+// per standard module or extension. Keeping it together preserves manifest-order
+// reviewability while avoiding value imports of the standard module graph.
+import { OpenAPIHono } from "@hono/zod-openapi"
+import type {
+  BookingRequirementsHonoModuleOptions,
+  BookingsHonoModuleOptions,
+} from "@voyant-travel/bookings"
+import type { CatalogSearchRoutesOptions } from "@voyant-travel/catalog"
+import {
+  bulkReindexProductsWorkflow,
+  promotionAffectedAllFilter,
+} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex"
+import type { BootstrapHandler } from "@voyant-travel/core"
+import type {
+  CheckoutNotificationDelivery,
+  CheckoutPaymentStarter,
+} from "@voyant-travel/finance/checkout"
+import type { CheckoutReminderRunRecord } from "@voyant-travel/finance/checkout-validation"
+import type { LazyRoutesLoader } from "@voyant-travel/hono"
+import type { CompositionRegistry } from "@voyant-travel/hono/composition"
+import type { HonoExtension, HonoModule } from "@voyant-travel/hono/module"
+import type { CreateLegalHonoModuleOptions } from "@voyant-travel/legal"
+import type { CreateNotificationsHonoModuleOptions } from "@voyant-travel/notifications"
+import type { relationshipsService } from "@voyant-travel/relationships"
+import type { StorefrontIntakePersistence } from "@voyant-travel/storefront"
+import type { StorefrontVerificationRoutesOptions } from "@voyant-travel/storefront/verification"
+import type { TripsRoutesOptions } from "@voyant-travel/trips"
+import type { Hono } from "hono"
+
+// biome-ignore lint/suspicious/noExplicitAny: lazy sub-apps keep route-specific Hono env generics -- owner: framework composition.
+type AnyHono = Hono<any>
+
+export interface FrameworkProviders {
+  relationshipsService: typeof relationshipsService
+  closePaymentSchedulesForBooking: NonNullable<
+    BookingsHonoModuleOptions["closePaymentSchedulesForBooking"]
+  >
+  recordCancellationFinancialSettlement?: BookingsHonoModuleOptions["recordCancellationFinancialSettlement"]
+  customFields?: BookingsHonoModuleOptions["customFields"]
+  resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) => Promise<string | null>
+  resolveNotificationProviders: NonNullable<StorefrontVerificationRoutesOptions["resolveProviders"]>
+  createTripsRoutesOptions: () => TripsRoutesOptions
+  resolveDb: NonNullable<CreateLegalHonoModuleOptions["resolveDb"]>
+  createOperatorDocumentStorage: NonNullable<CreateLegalHonoModuleOptions["resolveDocumentStorage"]>
+  resolveContractDocumentGenerator: NonNullable<
+    CreateLegalHonoModuleOptions["resolveDocumentGenerator"]
+  >
+  createBookingPiiService: NonNullable<CreateLegalHonoModuleOptions["resolveBookingPiiService"]>
+  autoGenerateContractOnConfirmed: NonNullable<
+    CreateLegalHonoModuleOptions["autoGenerateContractOnConfirmed"]
+  >
+  resolvePublicCheckoutBaseUrl: NonNullable<
+    CreateNotificationsHonoModuleOptions["resolvePublicCheckoutBaseUrl"]
+  >
+  readDocumentContentBase64: (bindings: unknown, storageKey: string) => Promise<string | null>
+  resolveBookingRequirementsProductSnapshot: NonNullable<
+    NonNullable<BookingRequirementsHonoModuleOptions["publicRoutes"]>["resolveProductSnapshot"]
+  >
+  resolveCatalogRuntime: CatalogSearchRoutesOptions["resolveRuntime"]
+  storefrontIntakePersistence: StorefrontIntakePersistence
+  createInvoiceExchangeRateResolver: NonNullable<
+    import("@voyant-travel/finance").FinanceHonoModuleOptions["resolveInvoiceExchangeRateResolver"]
+  >
+  createInvoiceSettlementPollers: NonNullable<
+    import("@voyant-travel/finance").FinanceHonoModuleOptions["resolveInvoiceSettlementPollers"]
+  >
+  resolveBankTransferDetails: NonNullable<
+    import("@voyant-travel/finance").FinanceHonoModuleOptions["resolveBankTransferDetails"]
+  >
+  financeCheckoutPolicy?: import("@voyant-travel/finance").FinanceHonoModuleOptions["policy"]
+  financePaymentScheduleLineDescriptionFormat?: import("@voyant-travel/finance").FinanceHonoModuleOptions["paymentScheduleLineDescriptionFormat"]
+  netopiaCheckoutStarter: CheckoutPaymentStarter
+  notificationsAutoConfirmAndDispatch?: CreateNotificationsHonoModuleOptions["autoConfirmAndDispatch"]
+  createChannelPushExtension: () => HonoExtension
+  loadFlightAdminRoutes: LazyRoutesLoader
+  loadMcpAdminRoutes: LazyRoutesLoader
+  loadCatalogBookingRoutes: LazyRoutesLoader
+  loadCatalogContentRoutes: LazyRoutesLoader
+  loadMediaRoutes: LazyRoutesLoader
+  loadPaymentLinkRoutes: LazyRoutesLoader
+  loadContractDocumentRoutes: LazyRoutesLoader
+  loadBookingScheduleAdminRoutes: LazyRoutesLoader
+  loadPaymentPolicyPublicRoutes: LazyRoutesLoader
+  loadQuoteVersionSnapshotRoutes: LazyRoutesLoader
+  loadBookingMaintenanceRoutes: LazyRoutesLoader
+  loadActionLedgerHealthRoutes: LazyRoutesLoader
+  loadProposalAdminRoutes: LazyRoutesLoader
+  loadProposalPublicRoutes: LazyRoutesLoader
+  loadCatalogOffersRoutes: LazyRoutesLoader
+  loadCatalogCheckoutRoutes: LazyRoutesLoader
+}
+
+type LazyUnit<T> = {
+  load: () => Promise<T[]>
+  route: (select: (unit: T) => AnyHono | undefined) => LazyRoutesLoader
+  bootstrap: BootstrapHandler
+}
+
+function unitBootstrap<
+  T extends {
+    module?: { bootstrap?: BootstrapHandler }
+    extension?: { bootstrap?: BootstrapHandler }
+  },
+>(unit: T) {
+  return unit.module?.bootstrap ?? unit.extension?.bootstrap
+}
+
+function createLazyUnit<
+  T extends {
+    module?: { name?: string; bootstrap?: BootstrapHandler }
+    extension?: { name?: string; module?: string; bootstrap?: BootstrapHandler }
+  },
+>(load: () => Promise<T | T[]>): LazyUnit<T> {
+  let unitsPromise: Promise<T[]> | undefined
+  let bootstrapPromise: Promise<void> | undefined
+
+  const loadUnits = async () => {
+    unitsPromise ??= load().then((unit) => (Array.isArray(unit) ? unit : [unit]))
+    return unitsPromise
+  }
+
+  const bootstrap = async (ctx: Parameters<BootstrapHandler>[0]) => {
+    if (!bootstrapPromise) {
+      bootstrapPromise = loadUnits()
+        .then(async (units) => {
+          for (const unit of units) {
+            await unitBootstrap(unit)?.(ctx)
+          }
+        })
+        .catch((error) => {
+          bootstrapPromise = undefined
+          throw error
+        })
+    }
+    await bootstrapPromise
+  }
+
+  return {
+    load: loadUnits,
+    bootstrap,
+    route: (select) => async (): Promise<AnyHono> => {
+      const units = await loadUnits()
+      const routes = units.map(select).filter((route): route is AnyHono => Boolean(route))
+      if (routes.length === 0) return new OpenAPIHono()
+      if (routes.length === 1) return routes[0]!
+
+      const wrapped = new OpenAPIHono()
+      for (const route of routes) wrapped.route("/", route)
+      return wrapped
+    },
+  }
+}
+
+function withAnonymous(module: HonoModule, anonymous: HonoModule["anonymous"]): HonoModule {
+  return { ...module, anonymous }
+}
+
+const CATALOG_BOOKING_ROUTE_PATHS = [
+  "/v1/admin/catalog/quote",
+  "/v1/admin/catalog/book",
+  "/v1/admin/catalog/drafts/:id",
+  "/v1/admin/catalog/holds/place",
+  "/v1/admin/catalog/holds/release",
+  "/v1/admin/catalog/slots",
+  "/v1/admin/catalog/orders",
+  "/v1/admin/catalog/orders/:id",
+  "/v1/admin/catalog/orders/:id/cancel",
+  "/v1/admin/bookings/:id/catalog-snapshot",
+  "/v1/public/catalog/quote",
+  "/v1/public/catalog/book",
+  "/v1/public/catalog/drafts/:id",
+  "/v1/public/catalog/holds/place",
+  "/v1/public/catalog/holds/release",
+  "/v1/public/catalog/slots",
+] as const
+
+const CATALOG_BOOKING_TRANSACTIONAL_PATHS = [
+  "/v1/admin/catalog/quote",
+  "/v1/admin/catalog/book",
+  "/v1/admin/catalog/holds",
+  "/v1/admin/catalog/orders",
+  "/v1/public/catalog/quote",
+  "/v1/public/catalog/book",
+  "/v1/public/catalog/holds",
+] as const
+
+const CATALOG_CONTENT_ROUTE_PATHS = [
+  "/v1/admin/products/:id/content",
+  "/v1/public/products/:id/content",
+  "/v1/admin/cruises/:id/content",
+  "/v1/public/cruises/:id/content",
+  "/v1/admin/accommodations/:id/content",
+  "/v1/public/accommodations/:id/content",
+] as const
+
+const MEDIA_ROUTE_PATHS = [
+  "/v1/admin/products/:id/brochure/generate",
+  "/v1/admin/uploads",
+  "/v1/admin/uploads/video",
+  "/v1/admin/media/*",
+] as const
+
+const PAYMENT_LINK_ROUTE_PATHS = [
+  "/v1/public/payment-link-config",
+  "/v1/public/payment-link/:sessionId/retry",
+  "/v1/public/payment-link/resolve",
+  "/v1/public/payment-link/:sessionId/start-card",
+  "/v1/public/payment-link/:sessionId/trip-summary",
+  "/v1/public/payment-link/:sessionId/booking-summary",
+  "/v1/public/bookings/:bookingId/checkout-status",
+] as const
+
+type NotificationDeliveryLike = {
+  id: string
+  templateSlug: string | null
+  channel: "email" | "sms"
+  provider: string
+  status: "pending" | "sent" | "failed" | "cancelled"
+  toAddress: string
+  subject: string | null
+  sentAt: Date | string | null
+  failedAt: Date | string | null
+  errorMessage: string | null
+}
+
+function optionalDateTime(value: Date | string | null | undefined) {
+  if (!value) return null
+  return value instanceof Date ? value.toISOString() : value
+}
+
+function toCheckoutNotificationDelivery(
+  delivery: NotificationDeliveryLike | null,
+): CheckoutNotificationDelivery | null {
+  if (!delivery) return null
+  return {
+    id: delivery.id,
+    templateSlug: delivery.templateSlug,
+    channel: delivery.channel,
+    provider: delivery.provider,
+    status: delivery.status,
+    toAddress: delivery.toAddress,
+    subject: delivery.subject,
+    sentAt: optionalDateTime(delivery.sentAt),
+    failedAt: optionalDateTime(delivery.failedAt),
+    errorMessage: delivery.errorMessage,
+  }
+}
+
+function toCheckoutReminderRun(run: {
+  id: string
+  reminderRuleId: string
+  reminderRule: { slug: string; name: string; channel: "email" | "sms"; provider: string | null }
+  targetType: CheckoutReminderRunRecord["targetType"]
+  targetId: string
+  links: {
+    bookingId: string | null
+    paymentSessionId: string | null
+    notificationDeliveryId: string | null
+  }
+  status: CheckoutReminderRunRecord["status"]
+  delivery?: {
+    status: CheckoutReminderRunRecord["deliveryStatus"]
+    channel: "email" | "sms"
+    provider: string | null
+  } | null
+  recipient: string | null
+  scheduledFor: Date | string
+  processedAt: Date | string | null
+  errorMessage: string | null
+  createdAt: Date | string
+}): CheckoutReminderRunRecord {
+  return {
+    id: run.id,
+    reminderRuleId: run.reminderRuleId,
+    reminderRuleSlug: run.reminderRule.slug,
+    reminderRuleName: run.reminderRule.name,
+    targetType: run.targetType,
+    targetId: run.targetId,
+    bookingId: run.links.bookingId,
+    paymentSessionId: run.links.paymentSessionId,
+    notificationDeliveryId: run.links.notificationDeliveryId,
+    status: run.status,
+    deliveryStatus: run.delivery?.status ?? null,
+    channel: run.delivery?.channel ?? run.reminderRule.channel,
+    provider: run.delivery?.provider ?? run.reminderRule.provider ?? null,
+    recipient: run.recipient,
+    scheduledFor: optionalDateTime(run.scheduledFor) ?? "",
+    processedAt: optionalDateTime(run.processedAt) ?? "",
+    errorMessage: run.errorMessage,
+    relativeDaysFromDueDate: null,
+    createdAt: optionalDateTime(run.createdAt) ?? "",
+  }
+}
+
+export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
+  modules: {
+    "@voyant-travel/action-ledger": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/action-ledger").then((m) => m.actionLedgerHonoModule),
+      )
+      return {
+        module: { name: "action-ledger" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/relationships": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/relationships").then((m) =>
+          m.createRelationshipsHonoModule({ customFields: capabilities.customFields }),
+        ),
+      )
+      return {
+        module: { name: "relationships", requiresTransactionalDb: true },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/quotes": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/quotes").then((m) =>
+          m.createQuotesHonoModule({
+            resolveParticipantPersonById: async (db, personId) =>
+              (await capabilities.relationshipsService.getPersonById(db, personId)) != null,
+          }),
+        ),
+      )
+      return {
+        module: { name: "quotes", requiresTransactionalDb: true },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/accommodations": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/accommodations").then((m) => m.accommodationsHonoModule),
+      )
+      return {
+        module: { name: "accommodations", requiresTransactionalDb: true },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/operations": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/operations").then((m) => m.operationsHonoModule),
+      )
+      return {
+        module: { name: "operations", requiresTransactionalDb: true },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/identity": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/identity").then((m) => m.identityHonoModule),
+      )
+      return { module: { name: "identity" }, lazyAdminRoutes: unit.route((m) => m.adminRoutes) }
+    },
+    "@voyant-travel/distribution": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/distribution").then((m) => [
+          m.externalRefsHonoModule,
+          m.distributionHonoModule,
+          m.suppliersHonoModule,
+        ]),
+      )
+      return ["external-refs", "distribution", "suppliers"].map((name) => ({
+        module: { name },
+        lazyAdminRoutes: unit.route((modules) =>
+          modules.module.name === name ? modules.adminRoutes : undefined,
+        ),
+      }))
+    },
+    "@voyant-travel/commerce": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/commerce").then((m) => m.createCommerceHonoModules()),
+      )
+      const moduleMetadata = {
+        pricing: { name: "pricing" },
+        markets: { name: "markets" },
+        sellability: { name: "sellability" },
+        promotions: {
+          name: "promotions",
+          workflows: [bulkReindexProductsWorkflow],
+          eventFilters: [promotionAffectedAllFilter],
+        },
+      } satisfies Record<string, HonoModule["module"]>
+
+      return (Object.keys(moduleMetadata) as Array<keyof typeof moduleMetadata>).map((name) => {
+        const anonymous = name === "markets" ? true : undefined
+        return withAnonymous(
+          {
+            module: moduleMetadata[name],
+            lazyAdminRoutes: unit.route((modules) =>
+              modules.module.name === name ? modules.adminRoutes : undefined,
+            ),
+            lazyPublicRoutes: unit.route((modules) =>
+              modules.module.name === name ? modules.publicRoutes : undefined,
+            ),
+          },
+          anonymous,
+        )
+      })
+    },
+    "@voyant-travel/inventory": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/inventory").then((m) => m.inventoryHonoModule),
+      )
+      return {
+        module: { name: "products" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+        lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+      }
+    },
+    "@voyant-travel/inventory/extras": () => {
+      const unit = createLazyUnit(async () => {
+        const [{ OpenAPIHono }, { openApiValidationHook }, inventory, bookings] = await Promise.all(
+          [
+            import("@hono/zod-openapi"),
+            import("@voyant-travel/hono"),
+            import("@voyant-travel/inventory/extras"),
+            import("@voyant-travel/bookings/extras"),
+          ],
+        )
+        const adminRoutes = new OpenAPIHono({ defaultHook: openApiValidationHook })
+          .route("/", inventory.inventoryExtrasRoutes)
+          .route("/", bookings.bookingsExtrasRoutes)
+        return { module: { name: "extras" }, adminRoutes } satisfies HonoModule
+      })
+      return { module: { name: "extras" }, lazyAdminRoutes: unit.route((m) => m.adminRoutes) }
+    },
+    "@voyant-travel/bookings/requirements": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/bookings/requirements").then((m) =>
+          m.createBookingRequirementsHonoModule({
+            publicRoutes: {
+              resolveProductSnapshot: capabilities.resolveBookingRequirementsProductSnapshot,
+            },
+          }),
+        ),
+      )
+      return {
+        module: { name: "booking-requirements" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+        lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+      }
+    },
+    "@voyant-travel/catalog": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/catalog").then((m) =>
+          m.createCatalogSearchHonoModule({
+            resolveRuntime: capabilities.resolveCatalogRuntime,
+            executeSearch: ({ adapter, embeddings, slice, request }) =>
+              m.executeSemanticSearch({
+                adapter,
+                embeddings: embeddings as Parameters<
+                  typeof m.executeSemanticSearch
+                >[0]["embeddings"],
+                slice,
+                request,
+              }),
+          }),
+        ),
+      )
+      return withAnonymous(
+        {
+          module: { name: "catalog" },
+          lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        true,
+      )
+    },
+    "@voyant-travel/storefront": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/storefront").then(async (m) => {
+          const commerce = await import("@voyant-travel/commerce")
+          return m.createStorefrontHonoModule({
+            offers: commerce.createCommerceStorefrontOfferResolvers(),
+            bookingIntents: { resolveDb: capabilities.resolveDb },
+            intake: { persistence: capabilities.storefrontIntakePersistence },
+          })
+        }),
+      )
+      return {
+        module: { name: "storefront", bootstrap: unit.bootstrap },
+        publicPath: "/",
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+        lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        anonymous: ["/leads", "/newsletter", "/offers"],
+      }
+    },
+    "@voyant-travel/finance": ({ capabilities }) => {
+      const unit = createLazyUnit(async () => {
+        const [finance, notifications, settings] = await Promise.all([
+          import("@voyant-travel/finance"),
+          import("@voyant-travel/notifications"),
+          import("@voyant-travel/operator-settings"),
+        ])
+        return finance.createFinanceHonoModule({
+          resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) =>
+            capabilities.resolveDocumentDownloadUrl(bindings, storageKey),
+          resolveInvoiceExchangeRateResolver: capabilities.createInvoiceExchangeRateResolver,
+          resolveInvoiceSettlementPollers: capabilities.createInvoiceSettlementPollers,
+          invoiceDueDateResolver: ({ issueDate, dueDate, bookingPaymentSchedule }) =>
+            bookingPaymentSchedule && dueDate < issueDate ? issueDate : dueDate,
+          resolveNotificationDispatcher: (bindings) => {
+            const providers = capabilities.resolveNotificationProviders(bindings)
+            if (providers.length === 0) return null
+            const dispatcher = notifications.createNotificationService(providers)
+            return {
+              sendInvoiceNotification: async (db, invoiceId, input) =>
+                toCheckoutNotificationDelivery(
+                  await notifications.notificationsService.sendInvoiceNotification(
+                    db,
+                    dispatcher,
+                    invoiceId,
+                    input,
+                  ),
+                ),
+              sendPaymentSessionNotification: async (db, paymentSessionId, input) =>
+                toCheckoutNotificationDelivery(
+                  await notifications.notificationsService.sendPaymentSessionNotification(
+                    db,
+                    dispatcher,
+                    paymentSessionId,
+                    input,
+                  ),
+                ),
+            }
+          },
+          resolvePaymentStarters: (): Record<string, CheckoutPaymentStarter> => ({
+            netopia: capabilities.netopiaCheckoutStarter,
+          }),
+          policy: capabilities.financeCheckoutPolicy,
+          paymentScheduleLineDescriptionFormat:
+            capabilities.financePaymentScheduleLineDescriptionFormat,
+          resolveBookingTaxSettings: settings.resolveBookingTaxSettings,
+          updateBookingTaxSettings: settings.updateBookingTaxSettings,
+          resolveBankTransferDetails: capabilities.resolveBankTransferDetails,
+          resolvePublicCheckoutBaseUrl: capabilities.resolvePublicCheckoutBaseUrl,
+          listBookingReminderRuns: async (db, bookingId, query) => {
+            const result = await notifications.notificationsService.listReminderRuns(db, {
+              bookingId,
+              status: query.status,
+              limit: query.limit,
+              offset: query.offset,
+            })
+            return {
+              data: result.data.map(toCheckoutReminderRun),
+              total: result.total,
+              limit: result.limit,
+              offset: result.offset,
+            }
+          },
+        })
+      })
+      return withAnonymous(
+        {
+          module: { name: "finance", requiresTransactionalDb: true },
+          lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        ["/bookings", "/collections", "/payment-sessions", "/accountant", "/vouchers"],
+      )
+    },
+    "@voyant-travel/bookings": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/bookings").then((m) =>
+          m.createBookingsHonoModule({
+            resolveTravelSnapshot: (db, personId, { kms }) =>
+              capabilities.relationshipsService.loadPersonTravelSnapshot(db, personId, { kms }),
+            resolveBillingPerson: async (db, contact, ctx) =>
+              (
+                await capabilities.relationshipsService.upsertPersonFromContact(db, contact, {
+                  source: ctx.source,
+                  sourceRef: ctx.sourceRef,
+                })
+              )?.id ?? null,
+            resolveTravelerPerson: async (db, contact, ctx) =>
+              (
+                await capabilities.relationshipsService.upsertPersonFromContact(db, contact, {
+                  source: ctx.source,
+                  sourceRef: ctx.sourceRef,
+                  requireContactPoint: true,
+                })
+              )?.id ?? null,
+            resolveBillingPersonById: async (db, personId) =>
+              (await capabilities.relationshipsService.getPersonById(db, personId)) != null,
+            resolveBillingOrganizationById: async (db, organizationId) =>
+              (await capabilities.relationshipsService.getOrganizationById(db, organizationId)) !=
+              null,
+            closePaymentSchedulesForBooking: capabilities.closePaymentSchedulesForBooking,
+            recordCancellationFinancialSettlement:
+              capabilities.recordCancellationFinancialSettlement,
+            customFields: capabilities.customFields,
+          }),
+        ),
+      )
+      return withAnonymous(
+        {
+          module: { name: "bookings", requiresTransactionalDb: true },
+          lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        true,
+      )
+    },
+    "@voyant-travel/public-document-delivery": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/hono").then((m) =>
+          m.createPublicDocumentDeliveryHonoModule({
+            resolveStorage: capabilities.createOperatorDocumentStorage,
+          }),
+        ),
+      )
+      return withAnonymous(
+        {
+          module: { name: "documents" },
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        true,
+      )
+    },
+    "@voyant-travel/notifications": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/notifications").then((m) =>
+          m.createNotificationsHonoModule({
+            resolveProviders: capabilities.resolveNotificationProviders,
+            resolvePublicCheckoutBaseUrl: capabilities.resolvePublicCheckoutBaseUrl,
+            resolveDocumentAttachmentResolver: (bindings) => async (document) => {
+              if (document.storageKey) {
+                const contentBase64 = await capabilities.readDocumentContentBase64(
+                  bindings,
+                  document.storageKey,
+                )
+                if (contentBase64) {
+                  return {
+                    filename: document.name,
+                    contentBase64,
+                    contentType: document.mimeType ?? undefined,
+                  }
+                }
+                const path = await capabilities.resolveDocumentDownloadUrl(
+                  bindings,
+                  document.storageKey,
+                )
+                if (path) {
+                  return {
+                    filename: document.name,
+                    path,
+                    contentType: document.mimeType ?? undefined,
+                  }
+                }
+              }
+              return m.createDefaultBookingDocumentAttachment(document)
+            },
+            resolveDb: capabilities.resolveDb,
+            autoConfirmAndDispatch: {
+              enabled: true,
+              templateSlug: "booking-confirmation",
+              ...capabilities.notificationsAutoConfirmAndDispatch,
+            },
+          }),
+        ),
+      )
+      return {
+        module: { name: "notifications", bootstrap: unit.bootstrap },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/legal": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/legal").then((m) =>
+          m.createLegalHonoModule({
+            resolveDb: capabilities.resolveDb,
+            resolveDocumentDownloadUrl: (bindings, storageKey) =>
+              capabilities.resolveDocumentDownloadUrl(bindings, storageKey),
+            resolveDocumentStorage: capabilities.createOperatorDocumentStorage,
+            resolveDocumentGenerator: capabilities.resolveContractDocumentGenerator,
+            resolveBookingPiiService: capabilities.createBookingPiiService,
+            autoGenerateContractOnConfirmed: capabilities.autoGenerateContractOnConfirmed,
+          }),
+        ),
+      )
+      return withAnonymous(
+        {
+          module: { name: "legal", requiresTransactionalDb: true, bootstrap: unit.bootstrap },
+          lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        true,
+      )
+    },
+    "@voyant-travel/storefront/customer-portal": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/storefront/customer-portal").then((m) =>
+          m.createCustomerPortalHonoModule({
+            resolveDocumentDownloadUrl: (bindings, storageKey) =>
+              capabilities.resolveDocumentDownloadUrl(bindings, storageKey),
+          }),
+        ),
+      )
+      return withAnonymous(
+        {
+          module: { name: "customer-portal" },
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        ["/contact-exists"],
+      )
+    },
+    "@voyant-travel/storefront/verification": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/storefront/verification").then((m) =>
+          m.createStorefrontVerificationHonoModule({
+            resolveProviders: capabilities.resolveNotificationProviders,
+            email: { subject: "Your verification code" },
+          }),
+        ),
+      )
+      return withAnonymous(
+        {
+          module: { name: "storefront-verification" },
+          lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+        },
+        true,
+      )
+    },
+    "@voyant-travel/trips": ({ capabilities }) => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/trips").then((m) => {
+          const trips = m.createTripsHonoModule({
+            ...capabilities.createTripsRoutesOptions(),
+            publicRoutes: true,
+          })
+          return { ...trips, module: { ...trips.module, requiresTransactionalDb: true } }
+        }),
+      )
+      return {
+        module: { name: "trips", requiresTransactionalDb: true },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+        lazyPublicRoutes: unit.route((m) => m.publicRoutes),
+      }
+    },
+    "@voyant-travel/operator-settings": () => {
+      return {
+        module: { name: "operator-settings" },
+        lazyRoutes: {
+          paths: [
+            "/v1/admin/settings/*",
+            "/v1/public/operator-profile",
+            "/v1/public/settings/operator",
+          ],
+          load: async () => {
+            const module = await import("@voyant-travel/operator-settings/hono-module").then((m) =>
+              m.createOperatorSettingsHonoModule(),
+            )
+            if (!module.lazyRoutes) {
+              throw new Error("operator-settings module did not provide lazyRoutes")
+            }
+            return module.lazyRoutes.load()
+          },
+        },
+      }
+    },
+    "@voyant-travel/flights": ({ capabilities }) => ({
+      module: { name: "flights" },
+      lazyAdminRoutes: capabilities.loadFlightAdminRoutes,
+    }),
+    "operator/mcp": ({ capabilities }) => ({
+      module: { name: "mcp" },
+      lazyAdminRoutes: capabilities.loadMcpAdminRoutes,
+    }),
+    "operator/catalog-booking": ({ capabilities }) => ({
+      module: { name: "catalog-booking" },
+      lazyRoutes: {
+        paths: CATALOG_BOOKING_ROUTE_PATHS,
+        load: capabilities.loadCatalogBookingRoutes,
+      },
+      transactionalPaths: CATALOG_BOOKING_TRANSACTIONAL_PATHS,
+    }),
+    "operator/catalog-content": ({ capabilities }) => ({
+      module: { name: "catalog-content" },
+      lazyRoutes: {
+        paths: CATALOG_CONTENT_ROUTE_PATHS,
+        load: capabilities.loadCatalogContentRoutes,
+      },
+    }),
+    "operator/media": ({ capabilities }) => ({
+      module: { name: "media" },
+      lazyRoutes: { paths: MEDIA_ROUTE_PATHS, load: capabilities.loadMediaRoutes },
+    }),
+    "operator/payment-link": ({ capabilities }) => ({
+      module: { name: "payment-link" },
+      lazyRoutes: { paths: PAYMENT_LINK_ROUTE_PATHS, load: capabilities.loadPaymentLinkRoutes },
+    }),
+    "operator/contract-document": ({ capabilities }) => ({
+      module: { name: "contract-document" },
+      lazyRoutes: {
+        paths: ["/v1/admin/bookings/:bookingId/generate-contract", "/v1/admin/documents/files/*"],
+        load: capabilities.loadContractDocumentRoutes,
+      },
+    }),
+  },
+  extensions: {
+    "@voyant-travel/bookings/booking-supplier-extension": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/bookings").then((m) => m.bookingsSupplierExtension),
+      )
+      return {
+        extension: { name: "booking-supplier", module: "bookings" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/finance/bookings-create-extension": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/finance").then((m) => m.bookingsCreateExtension),
+      )
+      return {
+        extension: { name: "finance-bookings-create", module: "bookings" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/inventory/booking-extension": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/inventory").then((m) => m.inventoryBookingExtension),
+      )
+      return {
+        extension: { name: "products", module: "bookings" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/inventory/authoring/extension": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/inventory/authoring/extension").then(
+          (m) => m.inventoryAuthoringExtension,
+        ),
+      )
+      return {
+        extension: {
+          name: "inventory-authoring",
+          module: "products",
+          requiresTransactionalDb: true,
+        },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/quotes/booking-extension": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/quotes").then((m) => m.quotesBookingExtension),
+      )
+      return {
+        extension: { name: "quotes", module: "bookings" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/distribution": () => {
+      const unit = createLazyUnit(() =>
+        import("@voyant-travel/distribution").then((m) => m.distributionBookingExtension),
+      )
+      return {
+        extension: { name: "distribution", module: "bookings" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "@voyant-travel/distribution/channel-push-extension": ({ capabilities }) =>
+      capabilities.createChannelPushExtension(),
+    "@voyant-travel/finance/booking-tax-extension": () => {
+      const unit = createLazyUnit(async () => {
+        const [finance, settings] = await Promise.all([
+          import("@voyant-travel/finance"),
+          import("@voyant-travel/operator-settings"),
+        ])
+        return finance.createBookingTaxHonoExtension({
+          resolveBookingTaxSettings: settings.resolveBookingTaxSettings,
+          updateBookingTaxSettings: settings.updateBookingTaxSettings,
+        })
+      })
+      return {
+        extension: { name: "booking-tax", module: "bookings" },
+        lazyAdminRoutes: unit.route((m) => m.adminRoutes),
+      }
+    },
+    "operator/booking-schedule-extension": ({ capabilities }) => ({
+      extension: { name: "booking-schedule", module: "bookings" },
+      publicPath: "payment-policy",
+      lazyAdminRoutes: capabilities.loadBookingScheduleAdminRoutes,
+      lazyPublicRoutes: capabilities.loadPaymentPolicyPublicRoutes,
+    }),
+    "operator/quote-version-snapshot-extension": ({ capabilities }) => ({
+      extension: { name: "quote-version-snapshot", module: "trips" },
+      lazyAdminRoutes: capabilities.loadQuoteVersionSnapshotRoutes,
+    }),
+    "operator/booking-maintenance-extension": ({ capabilities }) => ({
+      extension: { name: "booking-maintenance", module: "bookings" },
+      lazyAdminRoutes: capabilities.loadBookingMaintenanceRoutes,
+    }),
+    "operator/action-ledger-health-extension": ({ capabilities }) => ({
+      extension: { name: "action-ledger-health", module: "action-ledger" },
+      lazyAdminRoutes: capabilities.loadActionLedgerHealthRoutes,
+    }),
+    "operator/proposal-extension": ({ capabilities }) => ({
+      extension: { name: "proposal", module: "quote-versions" },
+      publicPath: "proposals",
+      lazyAdminRoutes: capabilities.loadProposalAdminRoutes,
+      lazyPublicRoutes: capabilities.loadProposalPublicRoutes,
+      anonymous: true,
+    }),
+    "operator/catalog-offers-extension": ({ capabilities }) => ({
+      extension: { name: "catalog-offers", module: "catalog" },
+      lazyAdminRoutes: capabilities.loadCatalogOffersRoutes,
+    }),
+    "operator/catalog-checkout-extension": ({ capabilities }) => ({
+      extension: { name: "catalog-checkout", module: "catalog" },
+      lazyPublicRoutes: capabilities.loadCatalogCheckoutRoutes,
+    }),
+  },
+}

--- a/packages/framework/src/composition-policy.test.ts
+++ b/packages/framework/src/composition-policy.test.ts
@@ -1,6 +1,6 @@
 import type { CompositionContext } from "@voyant-travel/hono/composition"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { type FrameworkProviders, frameworkComposition } from "./composition.js"
+import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
 
 const mocks = vi.hoisted(() => ({
   createFinanceHonoModule: vi.fn((options: unknown) => ({
@@ -13,21 +13,20 @@ const mocks = vi.hoisted(() => ({
   })),
 }))
 
-vi.mock("@voyant-travel/finance", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return {
-    ...actual,
-    createFinanceHonoModule: mocks.createFinanceHonoModule,
-  }
-})
+vi.mock("@voyant-travel/finance", () => ({
+  createFinanceHonoModule: mocks.createFinanceHonoModule,
+}))
 
-vi.mock("@voyant-travel/notifications", async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>()
-  return {
-    ...actual,
-    createNotificationsHonoModule: mocks.createNotificationsHonoModule,
-  }
-})
+vi.mock("@voyant-travel/notifications", () => ({
+  createDefaultBookingDocumentAttachment: vi.fn(),
+  createNotificationService: vi.fn(),
+  createNotificationsHonoModule: mocks.createNotificationsHonoModule,
+  notificationsService: {
+    listReminderRuns: vi.fn(),
+    sendInvoiceNotification: vi.fn(),
+    sendPaymentSessionNotification: vi.fn(),
+  },
+}))
 
 function compositionContext(
   capabilities: Partial<FrameworkProviders> = {},
@@ -44,59 +43,69 @@ describe("frameworkComposition policy injection", () => {
     mocks.createNotificationsHonoModule.mockClear()
   })
 
-  it("passes injected finance checkout policy to the standard finance module", () => {
+  it("passes injected finance checkout policy to the standard finance module", async () => {
     const policy = { defaultCardCollectionDocumentType: "proforma" } as const
 
-    frameworkComposition.modules["@voyant-travel/finance"]?.(
+    const finance = frameworkComposition.modules["@voyant-travel/finance"]?.(
       compositionContext({ financeCheckoutPolicy: policy }),
     )
+    if (Array.isArray(finance)) throw new Error("expected a single finance module")
+    await finance?.lazyAdminRoutes?.()
 
     expect(mocks.createFinanceHonoModule).toHaveBeenCalledWith(expect.objectContaining({ policy }))
   })
 
-  it("leaves finance checkout policy unset by default", () => {
-    frameworkComposition.modules["@voyant-travel/finance"]?.(compositionContext())
+  it("leaves finance checkout policy unset by default", async () => {
+    const finance = frameworkComposition.modules["@voyant-travel/finance"]?.(compositionContext())
+    if (Array.isArray(finance)) throw new Error("expected a single finance module")
+    await finance?.lazyAdminRoutes?.()
 
     expect(mocks.createFinanceHonoModule).toHaveBeenCalledWith(
       expect.objectContaining({ policy: undefined }),
     )
   })
 
-  it("passes injected finance payment-schedule line format to the standard finance module", () => {
-    frameworkComposition.modules["@voyant-travel/finance"]?.(
+  it("passes injected finance payment-schedule line format to the standard finance module", async () => {
+    const finance = frameworkComposition.modules["@voyant-travel/finance"]?.(
       compositionContext({ financePaymentScheduleLineDescriptionFormat: "product_only" }),
     )
+    if (Array.isArray(finance)) throw new Error("expected a single finance module")
+    await finance?.lazyAdminRoutes?.()
 
     expect(mocks.createFinanceHonoModule).toHaveBeenCalledWith(
       expect.objectContaining({ paymentScheduleLineDescriptionFormat: "product_only" }),
     )
   })
 
-  it("leaves finance payment-schedule line format unset by default", () => {
-    frameworkComposition.modules["@voyant-travel/finance"]?.(compositionContext())
+  it("leaves finance payment-schedule line format unset by default", async () => {
+    const finance = frameworkComposition.modules["@voyant-travel/finance"]?.(compositionContext())
+    if (Array.isArray(finance)) throw new Error("expected a single finance module")
+    await finance?.lazyAdminRoutes?.()
 
     expect(mocks.createFinanceHonoModule).toHaveBeenCalledWith(
       expect.objectContaining({ paymentScheduleLineDescriptionFormat: undefined }),
     )
   })
 
-  it("passes injected notifications auto-dispatch policy to the standard notifications module", () => {
+  it("passes injected notifications auto-dispatch policy to the standard notifications module", async () => {
     const autoConfirmAndDispatch = {
       enabled: false,
       templateSlug: "booking-confirmation",
     } as const
 
-    frameworkComposition.modules["@voyant-travel/notifications"]?.(
+    const notifications = frameworkComposition.modules["@voyant-travel/notifications"]?.(
       compositionContext({ notificationsAutoConfirmAndDispatch: autoConfirmAndDispatch }),
     )
+    if (Array.isArray(notifications)) throw new Error("expected a single notifications module")
+    await notifications?.lazyAdminRoutes?.()
 
     expect(mocks.createNotificationsHonoModule).toHaveBeenCalledWith(
       expect.objectContaining({ autoConfirmAndDispatch }),
     )
   })
 
-  it("merges partial notifications auto-dispatch policy with the standard default", () => {
-    frameworkComposition.modules["@voyant-travel/notifications"]?.(
+  it("merges partial notifications auto-dispatch policy with the standard default", async () => {
+    const notifications = frameworkComposition.modules["@voyant-travel/notifications"]?.(
       compositionContext({
         notificationsAutoConfirmAndDispatch: {
           templateSlug: "custom-booking-confirmation",
@@ -104,6 +113,8 @@ describe("frameworkComposition policy injection", () => {
         },
       }),
     )
+    if (Array.isArray(notifications)) throw new Error("expected a single notifications module")
+    await notifications?.lazyAdminRoutes?.()
 
     expect(mocks.createNotificationsHonoModule).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -116,8 +127,12 @@ describe("frameworkComposition policy injection", () => {
     )
   })
 
-  it("keeps the standard notifications auto-dispatch default", () => {
-    frameworkComposition.modules["@voyant-travel/notifications"]?.(compositionContext())
+  it("keeps the standard notifications auto-dispatch default", async () => {
+    const notifications = frameworkComposition.modules["@voyant-travel/notifications"]?.(
+      compositionContext(),
+    )
+    if (Array.isArray(notifications)) throw new Error("expected a single notifications module")
+    await notifications?.lazyAdminRoutes?.()
 
     expect(mocks.createNotificationsHonoModule).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/packages/framework/src/create-app.ts
+++ b/packages/framework/src/create-app.ts
@@ -41,7 +41,7 @@ import {
   findCapabilityGaps,
   type ModuleFactory,
 } from "@voyant-travel/hono/composition"
-import { type FrameworkProviders, frameworkComposition } from "./composition.js"
+import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
 import { FRAMEWORK_CAPABILITY_GRAPH, FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
 
 /**

--- a/packages/framework/src/discover-modules.test.ts
+++ b/packages/framework/src/discover-modules.test.ts
@@ -1,7 +1,7 @@
 import type { CompositionContext } from "@voyant-travel/hono/composition"
 import type { HonoExtension, HonoModule } from "@voyant-travel/hono/module"
 import { describe, expect, it } from "vitest"
-import type { FrameworkProviders } from "./composition.js"
+import type { FrameworkProviders } from "./composition-lazy.js"
 import {
   defineDeploymentExtension,
   defineDeploymentModule,

--- a/packages/framework/src/discover-modules.ts
+++ b/packages/framework/src/discover-modules.ts
@@ -39,7 +39,7 @@
 
 import type { ExtensionFactory, ModuleFactory } from "@voyant-travel/hono/composition"
 import type { HonoExtension, HonoModule } from "@voyant-travel/hono/module"
-import type { FrameworkProviders } from "./composition.js"
+import type { FrameworkProviders } from "./composition-lazy.js"
 
 /** A deployment module declaration: a ready unit, or a factory that builds one. */
 export type DeploymentModuleDeclaration<TProviders> =

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -18,7 +18,7 @@
  * consolidated-deployments RFC.
  */
 
-export { type FrameworkProviders, frameworkComposition } from "./composition.js"
+export { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
 export {
   type CreateVoyantAppConfig,
   createVoyantApp,

--- a/packages/framework/src/transactional-surface.test.ts
+++ b/packages/framework/src/transactional-surface.test.ts
@@ -1,9 +1,9 @@
 import { composeFromManifest } from "@voyant-travel/hono/composition"
 import { describe, expect, it } from "vitest"
-import { frameworkComposition } from "./composition.js"
+import { frameworkComposition } from "./composition-lazy.js"
 import { FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
 
-// biome-ignore lint/suspicious/noExplicitAny: coercion-safe provider stub.
+// biome-ignore lint/suspicious/noExplicitAny: coercion-safe provider stub -- owner: framework composition.
 const deepStub: any = new Proxy(() => deepStub, {
   get: (_t, p) => {
     if (p === Symbol.toPrimitive) return () => "stub"

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -477,6 +477,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/hono/src/lazy-routes.ts
+++ b/packages/hono/src/lazy-routes.ts
@@ -52,6 +52,17 @@ export interface LazyHonoRoutes {
 
 /** Private carrier key for snapshotting `c.var` across the forward. */
 const LAZY_CONTEXT_CARRIER = Symbol.for("voyant.hono.lazyContextCarrier")
+const LAZY_ROUTE_MISS_HEADER = "x-voyant-lazy-route-miss"
+
+function withoutLazyRouteMissHeader(response: Response): Response {
+  const headers = new Headers(response.headers)
+  headers.delete(LAZY_ROUTE_MISS_HEADER)
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
 
 /**
  * Build a cached, context-preserving request handler. `mountPrefix` is where the
@@ -79,6 +90,9 @@ export function createLazyRouteHandler(mountPrefix: string, load: LazyRoutesLoad
           wrapped.onError((err) => {
             throw err
           })
+          wrapped.notFound(
+            () => new Response(null, { status: 404, headers: { [LAZY_ROUTE_MISS_HEADER]: "1" } }),
+          )
           wrapped.use("*", async (cc, next) => {
             const carried = (cc.env as Record<symbol, unknown> | undefined)?.[
               LAZY_CONTEXT_CARRIER
@@ -102,12 +116,20 @@ export function createLazyRouteHandler(mountPrefix: string, load: LazyRoutesLoad
     return cached
   }
 
-  return async (c: Context): Promise<Response> => {
+  return async (c: Context, next?: () => Promise<void>): Promise<Response> => {
     const app = await getApp()
     const snapshot = { ...c.var }
     const env = { ...(c.env as Record<string, unknown>), [LAZY_CONTEXT_CARRIER]: snapshot }
     // biome-ignore lint/suspicious/noExplicitAny: forward the host execution context when present -- owner: hono.
-    return app.fetch(c.req.raw, env, tryGetExecutionCtx(c) as any)
+    const response = await app.fetch(c.req.raw, env, tryGetExecutionCtx(c) as any)
+    const routeMiss = response.headers.get(LAZY_ROUTE_MISS_HEADER) === "1"
+    if (routeMiss && next) {
+      // Match eager `app.route(...)` composition: overlapping lazy mounts under
+      // the same prefix must let later modules/extensions try the request.
+      await next()
+      return c.res
+    }
+    return routeMiss ? withoutLazyRouteMissHeader(response) : response
   }
 }
 

--- a/packages/hono/tests/unit/app-lazy-routes.test.ts
+++ b/packages/hono/tests/unit/app-lazy-routes.test.ts
@@ -101,6 +101,51 @@ describe("mountApp lazy route mounting", () => {
     expect(loadMaintenance).not.toHaveBeenCalled()
   })
 
+  it("falls through only for lazy route misses, not handler-authored 404 responses", async () => {
+    const firstLoad = vi.fn(async () =>
+      new Hono().get("/:id/details", (c) =>
+        c.json({ error: `booking ${c.req.param("id")} not found` }, 404),
+      ),
+    )
+    const secondLoad = vi.fn(async () =>
+      new Hono()
+        .get("/:id/notes", (c) => c.json({ notes: c.req.param("id") }))
+        .get("/:id/details", (c) => c.json({ fallback: true })),
+    )
+    const firstExtension: HonoExtension = {
+      extension: { name: "first", module: "bookings" },
+      lazyAdminRoutes: firstLoad,
+    }
+    const secondExtension: HonoExtension = {
+      extension: { name: "second", module: "bookings" },
+      lazyAdminRoutes: secondLoad,
+    }
+
+    const app = mountApp({
+      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db -- owner: hono.
+      db: () => ({}) as any,
+      modules: [{ module: { name: "bookings" } }],
+      extensions: [firstExtension, secondExtension],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const resource404 = await app.request(
+      "/v1/admin/bookings/book_123/details",
+      {},
+      TEST_ENV,
+      TEST_CTX,
+    )
+    expect(resource404.status).toBe(404)
+    expect(await resource404.json()).toEqual({ error: "booking book_123 not found" })
+    expect(secondLoad).not.toHaveBeenCalled()
+
+    const routeMiss = await app.request("/v1/admin/bookings/book_123/notes", {}, TEST_ENV, TEST_CTX)
+    expect(routeMiss.status).toBe(200)
+    expect(await routeMiss.json()).toEqual({ notes: "book_123" })
+    expect(firstLoad).toHaveBeenCalledTimes(1)
+    expect(secondLoad).toHaveBeenCalledTimes(1)
+  })
+
   it("caches the loaded sub-app across requests (load once per isolate)", async () => {
     const load = vi.fn(async () => new Hono().get("/ping", (c) => c.json({ ok: true })))
     const app = mountApp({

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -483,6 +483,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -477,6 +477,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -483,6 +483,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -476,6 +476,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/worker-runtime/README.md
+++ b/packages/worker-runtime/README.md
@@ -14,10 +14,11 @@ fixes to this load-bearing code path arrive via a dependency bump.
   requests (`/api/*`) onto the app surface (`/v1/*`, `/auth/*`, `/health`),
   stripping the prefix and preserving method/headers/body/search. When
   `loadAuthApp` is set, `/api/auth/*` dispatches to the lean auth app without
-  instantiating the full API graph (the cold-start outage fix), and non-OPTIONS
-  auth traffic warms the full app in the background via `ctx.waitUntil`. Hosts
-  can pass `rewriteAppPath` for compatibility redirects that must happen after
-  prefix stripping and before the request reaches the app.
+  instantiating the full API graph (the cold-start outage fix). Hosts can opt
+  into `warmApiOnAuth: true` to warm the full app in the background on
+  non-OPTIONS auth traffic, but the default keeps auth requests isolated.
+  Hosts can pass `rewriteAppPath` for compatibility redirects that must happen
+  after prefix stripping and before the request reaches the app.
 - **`createWorkerFetch({ api, ssr })`** — the Worker `fetch` entrypoint:
   API-prefixed requests go to the dispatch, everything else to the SSR handler.
 - **`withActiveRouteSsrManifest(streamHandler)`** — restricts the TanStack

--- a/packages/worker-runtime/src/api-dispatch.ts
+++ b/packages/worker-runtime/src/api-dispatch.ts
@@ -23,8 +23,7 @@ export interface CreateApiDispatchOptions<Env, Ctx extends WaitUntilContext = Wa
    * Optional lean auth app. When set, requests under `authPrefix` dispatch to
    * it WITHOUT loading the full API graph — the fix for the cold-start outage
    * where the first `/api/auth/*` call instantiated the whole API and hung.
-   * Non-OPTIONS auth requests warm the full app in the background via
-   * `ctx.waitUntil` so the next API call is hot.
+   * Set `warmApiOnAuth` to opt into background API warm-up after auth traffic.
    */
   loadAuthApp?: AppLoader<Env, Ctx>
   /** Hosting prefix stripped before dispatch. Default `/api`. */
@@ -36,7 +35,7 @@ export interface CreateApiDispatchOptions<Env, Ctx extends WaitUntilContext = Wa
   rewriteAppPath?: (pathname: string) => string
   /** Auth sub-prefix served by the lean app. Default `${apiPrefix}/auth`. */
   authPrefix?: string
-  /** Background-warm the full app on auth traffic. Default true. */
+  /** Background-warm the full app on auth traffic. Default false. */
   warmApiOnAuth?: boolean
   /** Called when the background warm-up fails. Defaults to `console.error`. */
   onWarmError?: (error: unknown) => void
@@ -64,7 +63,7 @@ export function createApiDispatch<Env, Ctx extends WaitUntilContext = WaitUntilC
 ): ApiDispatch<Env, Ctx> {
   const apiPrefix = options.apiPrefix ?? DEFAULT_API_PREFIX
   const authPrefix = options.authPrefix ?? `${apiPrefix}/auth`
-  const warmApiOnAuth = options.warmApiOnAuth ?? true
+  const warmApiOnAuth = options.warmApiOnAuth ?? false
   const onWarmError =
     options.onWarmError ??
     ((error: unknown) => {

--- a/packages/worker-runtime/tests/api-dispatch.test.ts
+++ b/packages/worker-runtime/tests/api-dispatch.test.ts
@@ -111,7 +111,7 @@ describe("createApiDispatch", () => {
     expect(forwardedCtx).toBe(ctx)
   })
 
-  it("dispatches auth requests through the lean auth app and warms the full app", async () => {
+  it("dispatches auth requests through the lean auth app without warming the full app by default", async () => {
     const env: Env = { APP_URL: "https://example.test" }
     const ctx = makeCtx()
     const fullFetch = vi.fn(async () => Response.json({ full: true }))
@@ -129,12 +129,12 @@ describe("createApiDispatch", () => {
     await expect(response.json()).resolves.toEqual({ user: true })
     expect(loadAuthApp).toHaveBeenCalledOnce()
     expect(authFetch).toHaveBeenCalledOnce()
-    expect(loadApiApp).toHaveBeenCalledOnce()
-    expect(ctx.waitUntil).toHaveBeenCalledOnce()
+    expect(loadApiApp).not.toHaveBeenCalled()
+    expect(ctx.waitUntil).not.toHaveBeenCalled()
     expect(fullFetch).not.toHaveBeenCalled()
   })
 
-  it("does not wait for the full app warm-up before returning auth responses", async () => {
+  it("warms the full app on auth requests when enabled", async () => {
     const env: Env = { APP_URL: "https://example.test" }
     const ctx = makeCtx()
     const authFetch = vi.fn(async () => Response.json({ ok: true }))
@@ -142,6 +142,7 @@ describe("createApiDispatch", () => {
     const dispatch = createApiDispatch<Env>({
       loadApiApp,
       loadAuthApp: async () => ({ fetch: authFetch }),
+      warmApiOnAuth: true,
     })
 
     const response = await dispatch.dispatch(
@@ -166,6 +167,7 @@ describe("createApiDispatch", () => {
     const dispatch = createApiDispatch<Env>({
       loadApiApp,
       loadAuthApp: async () => ({ fetch: async () => new Response(null, { status: 204 }) }),
+      warmApiOnAuth: true,
     })
 
     const response = await dispatch.dispatch(
@@ -194,6 +196,7 @@ describe("createApiDispatch", () => {
         throw warmFailure
       },
       loadAuthApp: async () => ({ fetch: async () => Response.json({ ok: true }) }),
+      warmApiOnAuth: true,
       onWarmError,
     })
 

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -477,6 +477,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -478,6 +478,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/starters/operator/src/api/composition.test.ts
+++ b/starters/operator/src/api/composition.test.ts
@@ -68,19 +68,19 @@ describe("operator runtime composition", () => {
 
     const bookingTax = byName("booking-tax")
     expect(bookingTax?.extension.module).toBe("bookings")
-    expect(bookingTax?.adminRoutes).toBeDefined()
+    expect(bookingTax?.lazyAdminRoutes).toBeTypeOf("function")
 
     // Booking-schedule owns an admin route on bookings + a public route
     // mounted at /v1/public/payment-policy via the publicPath override.
     const bookingSchedule = byName("booking-schedule")
     expect(bookingSchedule?.extension.module).toBe("bookings")
-    expect(bookingSchedule?.adminRoutes).toBeDefined()
-    expect(bookingSchedule?.publicRoutes).toBeDefined()
+    expect(bookingSchedule?.lazyAdminRoutes).toBeTypeOf("function")
+    expect(bookingSchedule?.lazyPublicRoutes).toBeTypeOf("function")
     expect(bookingSchedule?.publicPath).toBe("payment-policy")
 
     const snapshot = byName("quote-version-snapshot")
     expect(snapshot?.extension.module).toBe("trips")
-    expect(snapshot?.adminRoutes).toBeDefined()
+    expect(snapshot?.lazyAdminRoutes).toBeTypeOf("function")
 
     // Lazy extensions (loaded on demand, context bridged by createApp).
     const actionLedgerHealth = byName("action-ledger-health")

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -46,9 +46,7 @@ import { resolveNotificationProviders } from "../lib/notifications"
 import { operatorRealtimeBridgeRoutes, resolveRealtimeProviders } from "../lib/realtime"
 import { resolveBookingRequirementsProductSnapshot } from "./lib/booking-requirements-product-snapshot"
 import { buildCatalogContext } from "./lib/catalog-context"
-import { createBookingScheduleExtension } from "./routes/booking-schedule"
 import { createChannelPushExtension } from "./routes/channel-push"
-import { createOperatorQuoteVersionSnapshotExtension } from "./routes/quote-version-snapshot-routes"
 import { AUTO_GENERATE_CONTRACT_OPTIONS } from "./runtime/contract-document-runtime"
 import {
   createOperatorBookingPiiService,
@@ -170,8 +168,18 @@ export function buildOperatorProviders(): OperatorCapabilities {
     loadContractDocumentRoutes: () =>
       import("./runtime/contract-document-runtime").then((m) => m.buildContractDocumentRoutes()),
     // Lazy `operator/*` standard extension builders/loaders.
-    createBookingScheduleExtension,
-    createQuoteVersionSnapshotExtension: createOperatorQuoteVersionSnapshotExtension,
+    loadBookingScheduleAdminRoutes: () =>
+      import("./routes/booking-schedule").then((m) =>
+        m.createBookingScheduleAdminRoutesForOperator(),
+      ),
+    loadPaymentPolicyPublicRoutes: () =>
+      import("./routes/booking-schedule").then((m) =>
+        m.createPaymentPolicyPublicRoutesForOperator(),
+      ),
+    loadQuoteVersionSnapshotRoutes: () =>
+      import("./routes/quote-version-snapshot-routes").then((m) =>
+        m.createOperatorQuoteVersionSnapshotRoutes(),
+      ),
     loadBookingMaintenanceRoutes: async () => {
       const app = new Hono<{ Variables: { db: VoyantDb } }>()
       app.post("/:bookingId/rebuild-tax-lines", async (c) => {

--- a/starters/operator/src/api/routes/booking-schedule.ts
+++ b/starters/operator/src/api/routes/booking-schedule.ts
@@ -20,30 +20,12 @@
  * docs/architecture/api-route-ownership-and-composition.md.
  */
 
-import {
-  type BookingScheduleRoutesOptions,
-  createBookingScheduleAdminRoutes,
-  createPaymentPolicyPublicRoutes,
-  financeService,
-  generatePaymentScheduleForBooking,
-} from "@voyant-travel/finance"
+import type { BookingScheduleRoutesOptions } from "@voyant-travel/finance"
+import type { LazyRoutesLoader } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import type { HonoBundle } from "@voyant-travel/hono/plugin"
-import { resolveOperatorDefaultPaymentPolicy } from "@voyant-travel/operator-settings"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
-import { withDbFromEnv } from "../lib/db"
-import {
-  readPolicySourceFromInternalNotes,
-  resolveCategoryPolicy,
-  resolveCategoryPolicyForEntity,
-  resolveListingPolicy,
-  resolveListingPolicyForEntity,
-  resolveSupplierPolicy,
-  resolveSupplierPolicyForEntity,
-  stampPolicySourceOnBooking,
-} from "../runtime/booking-payment-policy-runtime"
-import { operatorPostgresDb } from "../runtime/operator-runtime-adapter"
 
 interface BookingConfirmedPayload {
   bookingId: string
@@ -57,18 +39,22 @@ interface BookingConfirmedPayload {
  * operator default + per-request db resolver. The bookings-schema reads and
  * action-ledger appender are handled inside the package directly.
  */
-function createBookingScheduleRoutesOptions(): BookingScheduleRoutesOptions {
+async function createBookingScheduleRoutesOptions(): Promise<BookingScheduleRoutesOptions> {
+  const [settings, runtime] = await Promise.all([
+    import("@voyant-travel/operator-settings"),
+    import("../runtime/booking-payment-policy-runtime"),
+  ])
   return {
     resolveDb: (c: Context) => c.get("db") as PostgresJsDatabase,
-    resolveOperatorDefaultPaymentPolicy,
-    resolveSupplierPolicy,
-    resolveCategoryPolicy,
-    resolveListingPolicy,
-    resolveListingPolicyForEntity,
-    resolveCategoryPolicyForEntity,
-    resolveSupplierPolicyForEntity,
-    stampPolicySourceOnBooking,
-    readPolicySourceFromInternalNotes,
+    resolveOperatorDefaultPaymentPolicy: settings.resolveOperatorDefaultPaymentPolicy,
+    resolveSupplierPolicy: runtime.resolveSupplierPolicy,
+    resolveCategoryPolicy: runtime.resolveCategoryPolicy,
+    resolveListingPolicy: runtime.resolveListingPolicy,
+    resolveListingPolicyForEntity: runtime.resolveListingPolicyForEntity,
+    resolveCategoryPolicyForEntity: runtime.resolveCategoryPolicyForEntity,
+    resolveSupplierPolicyForEntity: runtime.resolveSupplierPolicyForEntity,
+    stampPolicySourceOnBooking: runtime.stampPolicySourceOnBooking,
+    readPolicySourceFromInternalNotes: runtime.readPolicySourceFromInternalNotes,
   }
 }
 
@@ -76,13 +62,23 @@ export const bookingScheduleBundle: HonoBundle = {
   name: "booking-schedule",
   bootstrap: ({ bindings, eventBus }) => {
     const env = bindings as CloudflareBindings
-    const options = createBookingScheduleRoutesOptions()
     eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
       try {
+        const [
+          { generatePaymentScheduleForBooking, settleCoveredBookingPaymentSchedules },
+          { withDbFromEnv },
+          runtime,
+          options,
+        ] = await Promise.all([
+          import("@voyant-travel/finance"),
+          import("../lib/db"),
+          import("../runtime/operator-runtime-adapter"),
+          createBookingScheduleRoutesOptions(),
+        ])
         await withDbFromEnv(env, async (rawDb) => {
-          const db = operatorPostgresDb(rawDb)
+          const db = runtime.operatorPostgresDb(rawDb)
           await generatePaymentScheduleForBooking(db, data.bookingId, options)
-          await financeService.settleCoveredBookingPaymentSchedules(db, data.bookingId)
+          await settleCoveredBookingPaymentSchedules(db, data.bookingId)
         })
       } catch (err) {
         console.error("[booking-schedule] failed to generate schedule", {
@@ -110,11 +106,26 @@ export const bookingScheduleBundle: HonoBundle = {
  * plugin — it carries no routes.
  */
 export function createBookingScheduleExtension(): HonoExtension {
-  const options = createBookingScheduleRoutesOptions()
   return {
     extension: { name: "booking-schedule", module: "bookings" },
-    adminRoutes: createBookingScheduleAdminRoutes(options),
-    publicRoutes: createPaymentPolicyPublicRoutes(options),
+    lazyAdminRoutes: createBookingScheduleAdminRoutesForOperator,
+    lazyPublicRoutes: createPaymentPolicyPublicRoutesForOperator,
     publicPath: "payment-policy",
   }
+}
+
+export const createBookingScheduleAdminRoutesForOperator: LazyRoutesLoader = async () => {
+  const [{ createBookingScheduleAdminRoutes }, options] = await Promise.all([
+    import("@voyant-travel/finance"),
+    createBookingScheduleRoutesOptions(),
+  ])
+  return createBookingScheduleAdminRoutes(options)
+}
+
+export const createPaymentPolicyPublicRoutesForOperator: LazyRoutesLoader = async () => {
+  const [{ createPaymentPolicyPublicRoutes }, options] = await Promise.all([
+    import("@voyant-travel/finance"),
+    createBookingScheduleRoutesOptions(),
+  ])
+  return createPaymentPolicyPublicRoutes(options)
 }

--- a/starters/operator/src/api/routes/quote-version-snapshot-routes.ts
+++ b/starters/operator/src/api/routes/quote-version-snapshot-routes.ts
@@ -10,8 +10,8 @@
  * See docs/architecture/api-route-ownership-and-composition.md.
  */
 
+import type { LazyRoutesLoader } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
-import { createQuoteVersionSnapshotRoutes } from "@voyant-travel/quotes"
 
 import { createQuoteProposalRoutesOptions } from "../runtime/quote-proposal-runtime"
 
@@ -19,6 +19,11 @@ import { createQuoteProposalRoutesOptions } from "../runtime/quote-proposal-runt
 export function createOperatorQuoteVersionSnapshotExtension(): HonoExtension {
   return {
     extension: { name: "quote-version-snapshot", module: "trips" },
-    adminRoutes: createQuoteVersionSnapshotRoutes(createQuoteProposalRoutesOptions()),
+    lazyAdminRoutes: createOperatorQuoteVersionSnapshotRoutes,
   }
+}
+
+export const createOperatorQuoteVersionSnapshotRoutes: LazyRoutesLoader = async () => {
+  const { createQuoteVersionSnapshotRoutes } = await import("@voyant-travel/quotes")
+  return createQuoteVersionSnapshotRoutes(createQuoteProposalRoutesOptions())
 }

--- a/starters/operator/src/hono-api-dispatch.ts
+++ b/starters/operator/src/hono-api-dispatch.ts
@@ -52,6 +52,9 @@ const loadOperatorAuthApp = lazyApp<CloudflareBindings, ExecutionContext>(async 
 export const operatorApiDispatch = createApiDispatch<CloudflareBindings, ExecutionContext>({
   loadApiApp: loadOperatorApiApp,
   loadAuthApp: loadOperatorAuthApp,
+  // Cloud isolates are frequently evicted; auth/JWKS traffic must not kick off
+  // the full framework module graph while answering the lean auth response.
+  warmApiOnAuth: false,
   rewriteAppPath: (pathname) =>
     pathname.startsWith("/v1/media/")
       ? pathname.replace("/v1/media/", "/v1/admin/media/")

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -613,6 +613,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../../packages/commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../../packages/commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../../packages/commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../../packages/commerce/dist/sellability/validation.d.ts"

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -613,6 +613,9 @@
       "@voyant-travel/commerce/promotions/validation": [
         "../../packages/commerce/dist/promotions/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
+        "../../packages/commerce/dist/promotions/workflow-bulk-reindex.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../../packages/commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../../packages/commerce/dist/sellability/validation.d.ts"


### PR DESCRIPTION
## Summary

Addresses #2883 with both cold-path fixes requested in the issue.

- Keeps lean `/api/auth/*` dispatch isolated from the full API app by default: `warmApiOnAuth` now defaults to `false`, and the operator starter opts out explicitly.
- Splits the framework standard composition into lightweight per-module lazy loaders so `createVoyantApp` can build route metadata without value-importing the full standard module graph.
- Moves operator standard extension route builders for booking schedule and quote-version snapshots behind lazy loaders.
- Lets overlapping lazy route mounts fall through only on wrapper route misses, preserving eager `app.route(...)` composition semantics without swallowing handler-authored 404 responses.
- Adds changesets for `@voyant-travel/worker-runtime`, `@voyant-travel/framework`, and `@voyant-travel/hono`.

I rechecked issue #2883 before the final push: it is still open, has no comments, and the body is unchanged.

## Validation

- `pnpm --filter @voyant-travel/worker-runtime test`
- `pnpm --filter @voyant-travel/worker-runtime typecheck`
- `pnpm --filter @voyant-travel/worker-runtime lint`
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework test -- --runInBand`
- `pnpm --filter @voyant-travel/hono typecheck`
- `pnpm --filter @voyant-travel/hono test -- tests/unit/app-lazy-routes.test.ts --runInBand`
- `pnpm --filter @voyant-travel/hono test -- --runInBand`
- `pnpm --filter @voyant-travel/hono lint` (passes with an existing unrelated warning in `src/middleware/public-cache.ts`)
- `pnpm --filter operator lint`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator test -- src/api/composition.test.ts src/api/operator-route-mounting.test.ts`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit broad lane passed: 186 tasks successful
- pre-push repo test lane passed after the 404 correction: 98 tasks successful
