### PR TITLE
Fix storefront realtime token calls

### DIFF
--- a/starters/operator/src/components/providers.test.tsx
+++ b/starters/operator/src/components/providers.test.tsx
@@ -1,0 +1,86 @@
+import { QueryClient } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  capturedProviders: [] as unknown[],
+}))
+
+vi.mock("@voyant-travel/admin/providers/operator-admin-shell", async () => {
+  const React = await import("react")
+  return {
+    OperatorAdminShellProvider: ({
+      children,
+      providers,
+    }: {
+      children: ReactNode
+      providers?: readonly unknown[]
+    }) => {
+      mocks.capturedProviders = [...(providers ?? [])]
+      return React.createElement("div", null, children)
+    },
+  }
+})
+
+vi.mock("@voyant-travel/operations-react/availability/provider", async () => {
+  const React = await import("react")
+  return {
+    VoyantAvailabilityProvider: ({ children }: { children: ReactNode }) =>
+      React.createElement(React.Fragment, null, children),
+  }
+})
+
+vi.mock("@voyant-travel/ui/components/tooltip", async () => {
+  const React = await import("react")
+  function TooltipProvider({ children }: { children: ReactNode }) {
+    return React.createElement(React.Fragment, null, children)
+  }
+  return { TooltipProvider }
+})
+
+vi.mock("@/lib/env", () => ({
+  getApiUrl: () => "https://operator.test/api",
+}))
+
+vi.mock("@/lib/voyant-fetcher", () => ({
+  operatorFetcher: vi.fn(),
+}))
+
+import { Providers } from "./providers"
+
+describe("Providers", () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    host = document.createElement("div")
+    document.body.appendChild(host)
+    root = createRoot(host)
+    mocks.capturedProviders = []
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it("keeps admin realtime out of the root provider stack shared with storefront routes", async () => {
+    await act(async () => {
+      root.render(
+        <Providers queryClient={new QueryClient()}>
+          <span>content</span>
+        </Providers>,
+      )
+    })
+
+    expect(host.textContent).toContain("content")
+    const providerNames = mocks.capturedProviders.map(
+      (provider) => (provider as { name?: string }).name,
+    )
+    expect(providerNames).toContain("TooltipProvider")
+    expect(providerNames).toContain("AvailabilityProvider")
+    expect(providerNames).not.toContain("RealtimeLiveProvider")
+  })
+})

--- a/starters/operator/src/components/providers.tsx
+++ b/starters/operator/src/components/providers.tsx
@@ -12,7 +12,6 @@ import { TooltipProvider } from "@voyant-travel/ui/components/tooltip"
 import type * as React from "react"
 import { getApiUrl } from "@/lib/env"
 import { operatorFetcher } from "@/lib/voyant-fetcher"
-import { RealtimeLiveProvider } from "./realtime-live"
 
 // VoyantAvailabilityProvider needs a baseUrl prop — wrap it once so it
 // fits the child-only AdminChildProvider shape used by the admin shell.
@@ -22,11 +21,7 @@ const AvailabilityProvider: AdminChildProvider = ({ children }) => (
   </VoyantAvailabilityProvider>
 )
 
-const appProviders = [
-  TooltipProvider,
-  AvailabilityProvider,
-  RealtimeLiveProvider,
-] satisfies readonly AdminChildProvider[]
+const appProviders = [TooltipProvider, AvailabilityProvider] satisfies readonly AdminChildProvider[]
 
 export function Providers({
   children,

--- a/starters/operator/src/components/realtime-live.test.tsx
+++ b/starters/operator/src/components/realtime-live.test.tsx
@@ -1,0 +1,97 @@
+import type { ReactNode } from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  useLiveQueries: vi.fn(),
+  useSession: vi.fn(),
+}))
+
+vi.mock("@voyant-travel/cloud-sdk", () => ({
+  RealtimeChannel: class {},
+}))
+
+vi.mock("@voyant-travel/realtime-react", () => ({
+  createRealtimeChannelConnector: vi.fn(() => ({ subscribe: vi.fn() })),
+  RealtimeReactProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useLiveQueries: mocks.useLiveQueries,
+}))
+
+vi.mock("@/lib/auth", () => ({
+  authClient: {
+    useSession: mocks.useSession,
+  },
+}))
+
+vi.mock("@/lib/env", () => ({
+  getApiUrl: () => "/api",
+}))
+
+vi.mock("@/lib/voyant-fetcher", () => ({
+  operatorFetcher: vi.fn(),
+}))
+
+import { hasAdminRealtimeSession, RealtimeLiveProvider } from "./realtime-live"
+
+describe("hasAdminRealtimeSession", () => {
+  it("rejects anonymous truthy session wrappers", () => {
+    expect(hasAdminRealtimeSession({ user: null, session: null })).toBe(false)
+    expect(hasAdminRealtimeSession({})).toBe(false)
+  })
+
+  it("accepts authenticated session shapes", () => {
+    expect(hasAdminRealtimeSession({ user: { id: "usr_1" }, session: null })).toBe(true)
+    expect(hasAdminRealtimeSession({ user: null, session: { userId: "usr_1" } })).toBe(true)
+  })
+})
+
+describe("RealtimeLiveProvider", () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    host = document.createElement("div")
+    document.body.appendChild(host)
+    root = createRoot(host)
+    mocks.useLiveQueries.mockReset()
+    mocks.useSession.mockReset()
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it("does not enable admin realtime for anonymous storefront session wrappers", async () => {
+    mocks.useSession.mockReturnValue({ data: { user: null, session: null } })
+
+    await act(async () => {
+      root.render(
+        <RealtimeLiveProvider>
+          <div>Storefront</div>
+        </RealtimeLiveProvider>,
+      )
+    })
+
+    expect(mocks.useLiveQueries).toHaveBeenCalledWith(["admin"], expect.any(Function), {
+      enabled: false,
+    })
+  })
+
+  it("enables admin realtime when a signed-in user is present", async () => {
+    mocks.useSession.mockReturnValue({ data: { user: { id: "usr_1" }, session: null } })
+
+    await act(async () => {
+      root.render(
+        <RealtimeLiveProvider>
+          <div>Admin</div>
+        </RealtimeLiveProvider>,
+      )
+    })
+
+    expect(mocks.useLiveQueries).toHaveBeenCalledWith(["admin"], expect.any(Function), {
+      enabled: true,
+    })
+  })
+})

--- a/starters/operator/src/components/realtime-live.tsx
+++ b/starters/operator/src/components/realtime-live.tsx
@@ -58,14 +58,24 @@ function mapHintToKeys(hint: RealtimeInvalidationHint): ReadonlyArray<QueryKey> 
   return ENTITY_INVALIDATIONS[hint.entity] ?? []
 }
 
+export function hasAdminRealtimeSession(session: unknown): boolean {
+  if (!session || typeof session !== "object") return false
+  const record = session as {
+    user?: { id?: unknown } | null
+    session?: { userId?: unknown } | null
+  }
+  return Boolean(
+    (typeof record.user?.id === "string" && record.user.id.trim()) ||
+      (typeof record.session?.userId === "string" && record.session.userId.trim()),
+  )
+}
+
 function AdminLiveRegion() {
-  // Only staff surfaces have an admin session; anonymous storefront pages share
-  // this root provider but must not mint an admin realtime token (the
-  // `/v1/admin/realtime/token` route 401s without a session, spamming the
-  // console). Gate the subscription on a live session so no token is fetched
-  // until someone is signed in.
+  // Only staff surfaces should mint an admin realtime token. Keep the
+  // subscription gated on a concrete session shape so a truthy anonymous wrapper
+  // cannot POST `/v1/admin/realtime/token`.
   const { data: session } = authClient.useSession()
-  useLiveQueries(ADMIN_CHANNELS, mapHintToKeys, { enabled: Boolean(session) })
+  useLiveQueries(ADMIN_CHANNELS, mapHintToKeys, { enabled: hasAdminRealtimeSession(session) })
   return null
 }
 

--- a/starters/operator/src/routes/_workspace/route.test.tsx
+++ b/starters/operator/src/routes/_workspace/route.test.tsx
@@ -1,0 +1,110 @@
+import type { ReactNode } from "react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  user: {
+    id: "usr_1",
+    email: "staff@example.test",
+    firstName: "Staff",
+    lastName: "User",
+    locale: "en",
+    timezone: null,
+    uiPrefs: null,
+    isSuperAdmin: true,
+    isSupportUser: false,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    profilePictureUrl: null,
+  },
+  signOut: vi.fn(),
+}))
+
+vi.mock("@tanstack/react-router", async () => {
+  const React = await import("react")
+  return {
+    createFileRoute: () => (config: Record<string, unknown>) => ({
+      ...config,
+      useLoaderData: () => ({ user: mocks.user }),
+    }),
+    Outlet: () => React.createElement("div", { "data-testid": "workspace-outlet" }),
+  }
+})
+
+vi.mock("@voyant-travel/admin", () => ({
+  defaultOperatorNavIcons: {},
+}))
+
+vi.mock("@voyant-travel/admin/app/workspace", async () => {
+  const React = await import("react")
+  return {
+    AdminWorkspacePendingFallback: () =>
+      React.createElement("div", { "data-testid": "workspace-pending" }),
+    AdminWorkspaceShell: ({ children }: { children: ReactNode }) =>
+      React.createElement("div", { "data-testid": "workspace-shell" }, children),
+    createAdminWorkspaceBeforeLoad: () => vi.fn(),
+  }
+})
+
+vi.mock("@/components/providers/user-provider", async () => {
+  const React = await import("react")
+  return {
+    UserProvider: ({ children }: { children: ReactNode }) =>
+      React.createElement("div", { "data-testid": "user-provider" }, children),
+    useUser: () => ({ user: mocks.user, isLoading: false }),
+  }
+})
+
+vi.mock("@/components/realtime-live", async () => {
+  const React = await import("react")
+  return {
+    RealtimeLiveProvider: ({ children }: { children: ReactNode }) =>
+      React.createElement("div", { "data-testid": "realtime-live" }, children),
+  }
+})
+
+vi.mock("@/lib/admin-destinations", () => ({
+  operatorAdminDestinations: {},
+}))
+
+vi.mock("@/lib/admin-extensions", () => ({
+  createOperatorAdminExtensions: () => [],
+}))
+
+vi.mock("@/lib/auth", () => ({
+  useSignOut: () => mocks.signOut,
+}))
+
+vi.mock("@/lib/current-user", () => ({
+  getCurrentUser: vi.fn(),
+}))
+
+import { WorkspaceLayout } from "./route"
+
+describe("_workspace route", () => {
+  let host: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    host = document.createElement("div")
+    document.body.appendChild(host)
+    root = createRoot(host)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+  })
+
+  it("mounts admin realtime only inside the authenticated workspace layout", async () => {
+    await act(async () => {
+      root.render(<WorkspaceLayout />)
+    })
+
+    expect(host.querySelector("[data-testid='user-provider']")).not.toBeNull()
+    expect(
+      host.querySelector("[data-testid='realtime-live'] [data-testid='workspace-shell']"),
+    ).not.toBeNull()
+    expect(host.querySelector("[data-testid='workspace-outlet']")).not.toBeNull()
+  })
+})

--- a/starters/operator/src/routes/_workspace/route.tsx
+++ b/starters/operator/src/routes/_workspace/route.tsx
@@ -6,6 +6,7 @@ import {
   createAdminWorkspaceBeforeLoad,
 } from "@voyant-travel/admin/app/workspace"
 import { UserProvider, useUser } from "@/components/providers/user-provider"
+import { RealtimeLiveProvider } from "@/components/realtime-live"
 import { operatorAdminDestinations } from "@/lib/admin-destinations"
 import { createOperatorAdminExtensions } from "@/lib/admin-extensions"
 import { useSignOut } from "@/lib/auth"
@@ -31,12 +32,14 @@ export const Route = createFileRoute("/_workspace")({
   component: WorkspaceLayout,
 })
 
-function WorkspaceLayout() {
+export function WorkspaceLayout() {
   const { user } = Route.useLoaderData()
 
   return (
     <UserProvider initialUser={user}>
-      <WorkspaceContent />
+      <RealtimeLiveProvider>
+        <WorkspaceContent />
+      </RealtimeLiveProvider>
     </UserProvider>
   )
 }


### PR DESCRIPTION
## Summary
- remove `RealtimeLiveProvider` from the root provider stack shared by storefront routes
- mount admin realtime only inside the authenticated workspace layout
- keep a defensive session-shape gate so truthy anonymous auth wrappers cannot mint admin realtime tokens
- add tests for the root provider stack, workspace realtime mount, and anonymous session wrapper behavior

Closes #2641

## Validation
- `pnpm --dir starters/operator test -- providers.test.tsx route.test.tsx realtime-live.test.tsx`
- `pnpm exec biome check starters/operator/src/components/providers.tsx starters/operator/src/components/providers.test.tsx starters/operator/src/components/realtime-live.tsx starters/operator/src/components/realtime-live.test.tsx starters/operator/src/routes/_workspace/route.tsx starters/operator/src/routes/_workspace/route.test.tsx`
- `pnpm --dir starters/operator typecheck`
- pre-push `pnpm test` hook: 98 successful tasks
