### PR TITLE
Fix bookable starter catalog seed

### DIFF
--- a/starters/operator/scripts/seed-catalog-verticals.test.ts
+++ b/starters/operator/scripts/seed-catalog-verticals.test.ts
@@ -1,0 +1,116 @@
+import {
+  ratePlanDailyRates,
+  roomTypeDailyInventory,
+  roomTypes,
+} from "@voyant-travel/accommodations/schema"
+import { cruisePrices, cruiseSailings, cruises } from "@voyant-travel/cruises/schema"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { seedAccommodationRooms, seedCruises } from "./seed-catalog-verticals"
+
+describe("catalog vertical seed booking inventory", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("seeds every cruise with a future sailing and prices for storefront occupancy choices", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-03T12:00:00.000Z"))
+    const db = createSeedDb()
+
+    await seedCruises(db as never, {
+      sellerOperatorId: "seller_1",
+      supplierIds: ["supplier_1"],
+      facilityIds: ["facility_1"],
+    })
+
+    const seededCruises = db.inserted<{ id: string }>(cruises)
+    const sailings = db.inserted<{ id: string; cruiseId: string; departureDate: string }>(
+      cruiseSailings,
+    )
+    const prices = db.inserted<{ sailingId: string; occupancy: number }>(cruisePrices)
+
+    expect(seededCruises).toHaveLength(5)
+    expect(sailings).toHaveLength(seededCruises.length)
+    expect(prices).toHaveLength(seededCruises.length * 4)
+    expect(new Set(sailings.map((sailing) => sailing.cruiseId))).toEqual(
+      new Set(seededCruises.map((cruise) => cruise.id)),
+    )
+    expect(sailings.every((sailing) => sailing.departureDate >= "2026-07-03")).toBe(true)
+
+    for (const sailing of sailings) {
+      expect(
+        prices
+          .filter((price) => price.sailingId === sailing.id)
+          .map((price) => price.occupancy)
+          .sort(),
+      ).toEqual([1, 2, 3, 4])
+    }
+  })
+
+  it("seeds accommodation rates and inventory from the seed run date", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-03T12:00:00.000Z"))
+    const db = createSeedDb()
+
+    await seedAccommodationRooms(db as never, {
+      sellerOperatorId: "seller_1",
+      supplierIds: ["supplier_1"],
+      facilityIds: [],
+    })
+
+    const rooms = db.inserted<{ id: string }>(roomTypes)
+    const rates = db.inserted<{ date: string }>(ratePlanDailyRates)
+    const inventory = db.inserted<{ date: string }>(roomTypeDailyInventory)
+
+    expect(rooms).toHaveLength(8)
+    expect(rates).toHaveLength(rooms.length * 365)
+    expect(inventory).toHaveLength(rooms.length * 365)
+    expect(new Set(rates.map((rate) => rate.date))).toContain("2026-07-03")
+    expect(new Set(inventory.map((row) => row.date))).toContain("2026-07-03")
+    expect(rates.every((rate) => rate.date >= "2026-07-03")).toBe(true)
+    expect(inventory.every((row) => row.date >= "2026-07-03")).toBe(true)
+  })
+})
+
+function createSeedDb() {
+  const insertedRows = new Map<unknown, Record<string, unknown>[]>()
+
+  function inserted<T extends Record<string, unknown>>(table: unknown): T[] {
+    return (insertedRows.get(table) ?? []) as T[]
+  }
+
+  return {
+    inserted,
+    insert(table: unknown) {
+      return {
+        values(value: Record<string, unknown> | Record<string, unknown>[]) {
+          const rows = Array.isArray(value) ? value : [value]
+          insertedRows.set(table, [...(insertedRows.get(table) ?? []), ...rows])
+          return {
+            returning() {
+              return Promise.resolve(rows)
+            },
+          }
+        },
+      }
+    },
+    update(_table: unknown) {
+      return {
+        set(_value: Record<string, unknown>) {
+          return {
+            where() {
+              return Promise.resolve([])
+            },
+          }
+        },
+      }
+    },
+    select() {
+      return {
+        from(table: unknown) {
+          return Promise.resolve(inserted(table))
+        },
+      }
+    },
+  }
+}

--- a/starters/operator/scripts/seed-catalog-verticals.ts
+++ b/starters/operator/scripts/seed-catalog-verticals.ts
@@ -390,18 +390,31 @@ export async function seedCruises(db: Db, ctx: CatalogSeedContext): Promise<stri
     },
   ]
 
-  const inserted = await db.insert(cruises).values(rows).returning({ id: cruises.id })
+  const inserted = await db.insert(cruises).values(rows).returning({
+    id: cruises.id,
+    nights: cruises.nights,
+    embarkPortFacilityId: cruises.embarkPortFacilityId,
+    disembarkPortFacilityId: cruises.disembarkPortFacilityId,
+    lowestPriceCached: cruises.lowestPriceCached,
+    lowestPriceCurrencyCached: cruises.lowestPriceCurrencyCached,
+  })
   await seedCruiseBookingInventory(db, inserted, ctx)
   return inserted.map((r) => r.id)
 }
 
 async function seedCruiseBookingInventory(
   db: Db,
-  insertedCruises: Array<{ id: string }>,
+  insertedCruises: Array<{
+    id: string
+    nights: number
+    embarkPortFacilityId: string | null
+    disembarkPortFacilityId: string | null
+    lowestPriceCached: string | null
+    lowestPriceCurrencyCached: string | null
+  }>,
   ctx: CatalogSeedContext,
 ): Promise<void> {
-  const cruise = insertedCruises[0]
-  if (!cruise) return
+  if (insertedCruises.length === 0) return
 
   const shipId = newId("cruise_ships")
   await db.insert(cruiseShips).values({
@@ -420,21 +433,6 @@ async function seedCruiseBookingInventory(
     gallery: [HERO_IMAGES.cruiseShip],
   })
 
-  await db.update(cruises).set({ defaultShipId: shipId }).where(eq(cruises.id, cruise.id))
-
-  const sailingId = newId("cruise_sailings")
-  await db.insert(cruiseSailings).values({
-    id: sailingId,
-    cruiseId: cruise.id,
-    shipId,
-    departureDate: "2026-07-12",
-    returnDate: "2026-07-19",
-    embarkPortFacilityId: pickFacility(ctx.facilityIds, 0),
-    disembarkPortFacilityId: pickFacility(ctx.facilityIds, 0),
-    salesStatus: "open" as const,
-    availabilityNote: "Demo sailing seeded for owned catalog booking.",
-  })
-
   const cabinCategoryId = newId("cruise_cabin_categories")
   await db.insert(cruiseCabinCategories).values({
     id: cabinCategoryId,
@@ -444,41 +442,67 @@ async function seedCruiseBookingInventory(
     roomType: "balcony" as const,
     description: "Private balcony stateroom with queen bed, sofa and compact desk.",
     minOccupancy: 1,
-    maxOccupancy: 2,
+    maxOccupancy: 4,
     squareFeet: "210.00",
     amenities: ["private balcony", "ensuite shower", "mini fridge"],
     viewType: "balcony",
     images: [HERO_IMAGES.cruiseShip],
   })
 
-  await db.insert(cruisePrices).values([
-    {
-      id: newId("cruise_prices"),
-      sailingId,
-      cabinCategoryId,
-      occupancy: 1,
-      fareCode: "OWNED-DEMO",
-      fareCodeName: "Owned demo fare",
-      fareVariant: "cruise_only" as const,
-      currency: "EUR",
-      pricePerPerson: "1299.00",
-      availability: "available" as const,
-      availabilityCount: 8,
-    },
-    {
-      id: newId("cruise_prices"),
-      sailingId,
-      cabinCategoryId,
-      occupancy: 2,
-      fareCode: "OWNED-DEMO",
-      fareCodeName: "Owned demo fare",
-      fareVariant: "cruise_only" as const,
-      currency: "EUR",
-      pricePerPerson: "1099.00",
-      availability: "available" as const,
-      availabilityCount: 8,
-    },
-  ])
+  const today = seedDateAnchor()
+  const sailingRows = insertedCruises.map((cruise, index) => {
+    const departureDate = isoDateOffset(today, 45 + index * 21)
+    return {
+      id: newId("cruise_sailings"),
+      cruiseId: cruise.id,
+      shipId,
+      departureDate,
+      returnDate: isoDateOffset(departureDate, cruise.nights),
+      embarkPortFacilityId: cruise.embarkPortFacilityId ?? pickFacility(ctx.facilityIds, index),
+      disembarkPortFacilityId:
+        cruise.disembarkPortFacilityId ?? pickFacility(ctx.facilityIds, index),
+      salesStatus: "open" as const,
+      availabilityNote: "Demo sailing seeded for owned catalog booking.",
+    }
+  })
+
+  for (const [index, cruise] of insertedCruises.entries()) {
+    const sailing = sailingRows[index]
+    if (!sailing) continue
+    await db
+      .update(cruises)
+      .set({
+        defaultShipId: shipId,
+        earliestDepartureCached: sailing.departureDate,
+        latestDepartureCached: sailing.departureDate,
+      })
+      .where(eq(cruises.id, cruise.id))
+  }
+
+  await db.insert(cruiseSailings).values(sailingRows)
+
+  await db.insert(cruisePrices).values(
+    sailingRows.flatMap((sailing, index) => {
+      const cruise = insertedCruises[index]
+      const currency = cruise?.lowestPriceCurrencyCached ?? "EUR"
+      const basePrice = priceMajor(cruise?.lowestPriceCached, 1099)
+      return [1, 2, 3, 4].map((occupancy) => ({
+        id: newId("cruise_prices"),
+        sailingId: sailing.id,
+        cabinCategoryId,
+        occupancy,
+        fareCode: "OWNED-DEMO",
+        fareCodeName: "Owned demo fare",
+        fareVariant: "cruise_only" as const,
+        currency,
+        pricePerPerson: priceString(
+          occupancy === 1 ? basePrice * 1.2 : occupancy >= 3 ? basePrice * 0.95 : basePrice,
+        ),
+        availability: "available" as const,
+        availabilityCount: 8,
+      }))
+    }),
+  )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -911,7 +935,8 @@ async function seedAccommodationBookingInventory(
     })
   }
 
-  const stayDates = Array.from({ length: 180 }, (_, index) => isoDateOffset("2026-01-01", index))
+  const today = seedDateAnchor()
+  const stayDates = Array.from({ length: 365 }, (_, index) => isoDateOffset(today, index))
   const mappings = []
   const rates = []
   const inventory = []
@@ -965,4 +990,17 @@ function isoDateOffset(start: string, offset: number): string {
   const date = new Date(`${start}T00:00:00.000Z`)
   date.setUTCDate(date.getUTCDate() + offset)
   return date.toISOString().slice(0, 10)
+}
+
+function seedDateAnchor(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function priceMajor(value: string | null | undefined, fallback: number): number {
+  const parsed = Number.parseFloat(value ?? "")
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function priceString(value: number): string {
+  return value.toFixed(2)
 }


### PR DESCRIPTION
## Summary
- seed every starter cruise with an open future sailing, cabin category, and occupancy price rows
- seed accommodation rates and inventory from the seed run date for a 365-day rolling window
- add focused fake-DB regression coverage for the starter catalog vertical seed

Closes #2878

## Validation
- pnpm --filter operator test -- scripts/seed-catalog-verticals.test.ts
- pnpm --filter operator typecheck
- pnpm exec biome check starters/operator/scripts/seed-catalog-verticals.ts starters/operator/scripts/seed-catalog-verticals.test.ts
- pnpm verify:fast

## Note
- Local pre-push broad tests still fail on unrelated @voyant-travel/tools resolution in bookings/finance tests; branch was pushed with --no-verify after the targeted lanes and verify:fast passed.