### PR TITLE
Fix stale Typesense documents after reindex

### DIFF
--- a/starters/operator/scripts/lib/reindex-stale-documents.test.ts
+++ b/starters/operator/scripts/lib/reindex-stale-documents.test.ts
@@ -1,0 +1,57 @@
+import type { IndexerSlice } from "@voyant-travel/catalog"
+import { describe, expect, it, vi } from "vitest"
+
+import { listStaleDocuments } from "./reindex-stale-documents"
+
+const customerProductsSlice: IndexerSlice = {
+  vertical: "products",
+  locale: "en-GB",
+  audience: "customer",
+  market: "default",
+}
+
+describe("listStaleDocuments", () => {
+  it("keeps live owned and sourced documents while pruning stale customer docs", async () => {
+    const search = vi.fn().mockResolvedValueOnce({
+      hits: [
+        { document: { id: "prod_live_owned" } },
+        { document: { id: "cdmi_live_sourced" } },
+        { document: { id: "cdmi_stale_sourced" } },
+      ],
+    })
+
+    const stale = await listStaleDocuments(
+      customerProductsSlice,
+      new Set(["prod_live_owned", "cdmi_live_sourced"]),
+      search,
+    )
+
+    expect(stale).toEqual(["cdmi_stale_sourced"])
+    expect(search).toHaveBeenCalledOnce()
+    expect(search.mock.calls[0]?.[0]).toBe("products__en-GB__customer__default")
+
+    const params = search.mock.calls[0]?.[1] as URLSearchParams
+    expect(params.get("filter_by")).toBeNull()
+    expect(params.get("include_fields")).toBe("id")
+  })
+
+  it("pages through the collection until Typesense returns a short page", async () => {
+    const search = vi
+      .fn()
+      .mockResolvedValueOnce({
+        hits: [{ document: { id: "stale_1" } }, { document: { id: "live_1" } }],
+      })
+      .mockResolvedValueOnce({
+        hits: [{ document: { id: "stale_2" } }],
+      })
+
+    const stale = await listStaleDocuments(customerProductsSlice, new Set(["live_1"]), search, {
+      perPage: 2,
+    })
+
+    expect(stale).toEqual(["stale_1", "stale_2"])
+    expect(search).toHaveBeenCalledTimes(2)
+    expect((search.mock.calls[0]?.[1] as URLSearchParams).get("page")).toBe("1")
+    expect((search.mock.calls[1]?.[1] as URLSearchParams).get("page")).toBe("2")
+  })
+})

--- a/starters/operator/scripts/lib/reindex-stale-documents.ts
+++ b/starters/operator/scripts/lib/reindex-stale-documents.ts
@@ -1,0 +1,64 @@
+import { collectionName, type IndexerSlice } from "@voyant-travel/catalog"
+
+interface TypesenseSearchHit {
+  document?: {
+    id?: string
+  }
+}
+
+export interface TypesenseSearchPage {
+  hits?: TypesenseSearchHit[]
+}
+
+export type TypesenseDocumentSearch = (
+  collection: string,
+  params: URLSearchParams,
+) => Promise<TypesenseSearchPage | null>
+
+export function createTypesenseDocumentSearch(
+  typesenseHost: string,
+  typesenseApiKey: string,
+): TypesenseDocumentSearch {
+  return async (collection, params) => {
+    const url = new URL(`${typesenseHost}/collections/${collection}/documents/search`)
+    url.search = params.toString()
+
+    const res = await fetch(url, { headers: { "X-TYPESENSE-API-KEY": typesenseApiKey } })
+    if (!res.ok) return null
+    return (await res.json()) as TypesenseSearchPage
+  }
+}
+
+export async function listStaleDocuments(
+  slice: IndexerSlice,
+  liveIds: ReadonlySet<string>,
+  search: TypesenseDocumentSearch,
+  options: { perPage?: number } = {},
+): Promise<string[]> {
+  const staleIds: string[] = []
+  const perPage = options.perPage ?? 250
+  let page = 1
+
+  while (true) {
+    const params = new URLSearchParams()
+    params.set("q", "*")
+    params.set("query_by", "name")
+    params.set("include_fields", "id")
+    params.set("per_page", String(perPage))
+    params.set("page", String(page))
+
+    const data = await search(collectionName(slice), params)
+    if (!data) break
+
+    const hits = data.hits ?? []
+    for (const hit of hits) {
+      const id = hit.document?.id
+      if (id && !liveIds.has(id)) staleIds.push(id)
+    }
+
+    if (hits.length < perPage) break
+    page += 1
+  }
+
+  return staleIds
+}

--- a/starters/operator/scripts/reindex.ts
+++ b/starters/operator/scripts/reindex.ts
@@ -31,13 +31,13 @@
 import { roomTypes } from "@voyant-travel/accommodations/schema"
 import { createRoomTypeDocumentBuilder } from "@voyant-travel/accommodations/service-catalog-plane"
 import {
+  catalogSourcedEntriesTable,
   createGeminiEmbeddingProvider,
   createIndexerService,
   createTypesenseIndexer,
   type DocumentBuilder,
   type EmbeddingProvider,
   type IndexerDocument,
-  type IndexerSlice,
 } from "@voyant-travel/catalog"
 import { charterProducts } from "@voyant-travel/charters/schema"
 import { createCharterDocumentBuilder } from "@voyant-travel/charters/service-catalog-plane"
@@ -46,6 +46,7 @@ import { createDbClient } from "@voyant-travel/db"
 import { createExtraDocumentBuilder, productExtras } from "@voyant-travel/inventory/extras"
 import { products } from "@voyant-travel/inventory/schema"
 import { config } from "dotenv"
+import { eq } from "drizzle-orm"
 import type { PgTable } from "drizzle-orm/pg-core"
 import { Client as TypesenseSdkClient } from "typesense"
 
@@ -56,6 +57,7 @@ import {
   getFieldPolicyRegistries,
   loadCatalogSlices,
 } from "../src/api/lib/catalog-runtime.js"
+import { createTypesenseDocumentSearch, listStaleDocuments } from "./lib/reindex-stale-documents.js"
 import { asTypesenseClient } from "./lib/typesense-sdk-client.js"
 
 config({ path: ".env" })
@@ -119,6 +121,7 @@ const indexer = createTypesenseIndexer({
   vectorDimensions: embeddings?.capabilities.dimensions,
   importFailureMode: bestEffort ? "best-effort" : "throw",
 })
+const searchDocuments = createTypesenseDocumentSearch(typesenseHost, typesenseKey)
 
 if (bestEffort) {
   console.info("[reindex] best-effort mode — row import failures will be logged, not fatal")
@@ -222,61 +225,23 @@ for (const cfg of VERTICAL_CONFIGS) {
   const sliceCount = activeSlices.filter((s) => s.vertical === cfg.vertical).length
   console.info(`[reindex] ${cfg.vertical}: done (${done} entities × ${sliceCount} slices)`)
 
-  // Purge stale owned docs whose entity is no longer in Postgres. Without
-  // this, every `pnpm seed` cycle (which re-creates products with fresh
-  // TypeIDs) leaves the previous generation's docs behind and the catalog
-  // UI shows duplicates. Sourced docs are owned by their adapter and are
-  // intentionally NOT purged here — the discovery sync handles them.
-  const liveIds = new Set(rows.map((r) => r.id))
+  // Purge stale docs whose entity is no longer represented in local Postgres.
+  // Owned rows come from the vertical table; sourced rows come from the durable
+  // catalog_sourced_entries store. This keeps local DB/source resets from
+  // leaving old customer-facing Typesense docs behind.
+  const sourcedRows = await db
+    .select({ id: catalogSourcedEntriesTable.entity_id })
+    .from(catalogSourcedEntriesTable)
+    .where(eq(catalogSourcedEntriesTable.entity_module, cfg.vertical))
+  const liveIds = new Set([...rows.map((r) => r.id), ...sourcedRows.map((r) => r.id)])
   for (const slice of activeSlices.filter((s) => s.vertical === cfg.vertical)) {
-    const toDelete = await listOwnedOrphans(slice, liveIds)
+    const toDelete = await listStaleDocuments(slice, liveIds, searchDocuments)
     if (toDelete.length === 0) continue
     console.info(
-      `[reindex] ${cfg.vertical}/${slice.audience}: purging ${toDelete.length} stale owned doc(s)`,
+      `[reindex] ${cfg.vertical}/${slice.audience}: purging ${toDelete.length} stale doc(s)`,
     )
     await indexer.delete(slice, toDelete)
   }
-}
-
-interface OrphanProbeDoc {
-  id: string
-  "source.kind"?: string
-}
-
-async function listOwnedOrphans(
-  slice: IndexerSlice,
-  liveIds: ReadonlySet<string>,
-): Promise<string[]> {
-  // Page through everything in the slice that came from owned source.
-  // Filter by `source.kind:owned` so a future sourced-projection drift
-  // can't accidentally delete a still-live sourced row.
-  const orphans: string[] = []
-  const collection = `${slice.vertical}__${slice.locale}__${slice.audience}__${slice.market}`
-  const perPage = 250
-  let page = 1
-  while (true) {
-    const url = new URL(`${typesenseHost}/collections/${collection}/documents/search`)
-    url.searchParams.set("q", "*")
-    url.searchParams.set("query_by", "name")
-    url.searchParams.set("filter_by", "source.kind:=owned")
-    url.searchParams.set("include_fields", "id,source.kind")
-    url.searchParams.set("per_page", String(perPage))
-    url.searchParams.set("page", String(page))
-    const res = await fetch(url, { headers: { "X-TYPESENSE-API-KEY": typesenseKey ?? "" } })
-    if (!res.ok) break
-    const data = (await res.json()) as {
-      hits?: Array<{ document: OrphanProbeDoc }>
-      found?: number
-    }
-    const hits = data.hits ?? []
-    for (const h of hits) {
-      const id = h.document.id
-      if (id && !liveIds.has(id)) orphans.push(id)
-    }
-    if (hits.length < perPage) break
-    page += 1
-  }
-  return orphans
 }
 
 console.info("[reindex] complete")


### PR DESCRIPTION
## Summary
- make local reindex stale-doc pruning compare Typesense documents against both owned vertical rows and durable sourced-entry rows
- remove the customer-incompatible `source.kind` Typesense filter from the stale scan
- add script-level tests for preserving live owned/sourced ids while pruning stale customer docs

## Root cause
The reindex CLI only looked for stale `source.kind=owned` documents. Customer storefront collections do not expose that staff-only field, and stale sourced documents left behind by a DB/source reset were never considered for deletion.

## Validation
- pnpm --filter operator test -- scripts/lib/reindex-stale-documents.test.ts
- pnpm --filter operator typecheck
- pnpm verify:fast

Closes #2880