### PR TITLE
Record paid booking cancellation settlement

### DIFF
--- a/.changeset/paid-cancellation-settlement.md
+++ b/.changeset/paid-cancellation-settlement.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/framework": patch
+---
+
+Expose a booking cancellation settlement runtime hook and persist cancellation reasons plus settlement metadata on booking activity entries.

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -135,6 +135,7 @@ export type {
   BookingRouteRuntime,
   BookingRouteRuntimeOptions,
   ClosePaymentSchedulesForBooking,
+  RecordCancellationFinancialSettlement,
   ResolveBookingBillingOrganizationById,
   ResolveBookingBillingPerson,
   ResolveBookingBillingPersonById,

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -80,6 +80,24 @@ export type ClosePaymentSchedulesForBooking = (
   status: Extract<BookingStatus, "cancelled" | "expired">,
 ) => Promise<void> | void
 
+export type RecordCancellationFinancialSettlement = (
+  db: PostgresJsDatabase,
+  input: {
+    bookingId: string
+    bookingNumber: string
+    previousStatus: Extract<
+      BookingStatus,
+      "draft" | "on_hold" | "awaiting_payment" | "confirmed" | "in_progress"
+    >
+    reason: string | null
+    actorId: string
+  },
+) =>
+  | Promise<Record<string, unknown> | null | undefined>
+  | Record<string, unknown>
+  | null
+  | undefined
+
 export interface BookingRouteRuntime {
   getKmsProvider(): Promise<KmsProvider>
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
@@ -88,6 +106,7 @@ export interface BookingRouteRuntime {
   resolveBillingPersonById?: ResolveBookingBillingPersonById
   resolveBillingOrganizationById?: ResolveBookingBillingOrganizationById
   closePaymentSchedulesForBooking?: ClosePaymentSchedulesForBooking
+  recordCancellationFinancialSettlement?: RecordCancellationFinancialSettlement
   /** Deployment custom-field registry — validates `customFields` on write. */
   customFields?: CustomFieldRegistryResolver
 }
@@ -111,6 +130,7 @@ export interface BookingRouteRuntimeOptions {
   resolveBillingPersonById?: ResolveBookingBillingPersonById
   resolveBillingOrganizationById?: ResolveBookingBillingOrganizationById
   closePaymentSchedulesForBooking?: ClosePaymentSchedulesForBooking
+  recordCancellationFinancialSettlement?: RecordCancellationFinancialSettlement
   customFields?: CustomFieldRegistryResolver
 }
 
@@ -147,6 +167,7 @@ export function buildBookingRouteRuntime(
     resolveBillingPersonById: options.resolveBillingPersonById,
     resolveBillingOrganizationById: options.resolveBillingOrganizationById,
     closePaymentSchedulesForBooking: options.closePaymentSchedulesForBooking,
+    recordCancellationFinancialSettlement: options.recordCancellationFinancialSettlement,
     customFields: options.customFields,
   }
 }

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -917,6 +917,7 @@ function bookingStatusMutationRuntime(
   return {
     eventBus: c.get("eventBus"),
     closePaymentSchedulesForBooking: getRouteRuntime(c).closePaymentSchedulesForBooking,
+    recordCancellationFinancialSettlement: getRouteRuntime(c).recordCancellationFinancialSettlement,
     actionLedgerContext: getActionLedgerRequestContext(c),
     actionLedgerAuthorizationSource: auth.access.authorizationSource,
     actionLedgerCausationActionId: approvedExecution?.causationActionId ?? null,

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -341,6 +341,20 @@ export interface BookingServiceRuntime {
     bookingId: string,
     status: Extract<BookingStatus, "cancelled" | "expired">,
   ) => Promise<void> | void
+  recordCancellationFinancialSettlement?: (
+    db: PostgresJsDatabase,
+    input: {
+      bookingId: string
+      bookingNumber: string
+      previousStatus: BookingCancelledEvent["previousStatus"]
+      reason: string | null
+      actorId: string
+    },
+  ) =>
+    | Promise<Record<string, unknown> | null | undefined>
+    | Record<string, unknown>
+    | null
+    | undefined
 }
 
 type BookingStatusActionName =
@@ -461,7 +475,8 @@ export interface BookingConfirmedEvent {
 export interface BookingCancelledEvent {
   bookingId: string
   bookingNumber: string
-  previousStatus: "draft" | "on_hold" | "confirmed" | "in_progress"
+  previousStatus: "draft" | "on_hold" | "awaiting_payment" | "confirmed" | "in_progress"
+  reason?: string | null
   actorId: string | null
 }
 
@@ -3654,12 +3669,14 @@ export const bookingsService = {
     try {
       const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
-          sql`SELECT id, status
+          sql`SELECT id, status, booking_number
               FROM ${bookings}
               WHERE ${bookings.id} = ${id}
               FOR UPDATE`,
         )
-        const booking = toRows<{ id: string; status: BookingStatus }>(rows)[0]
+        const booking = toRows<{ id: string; status: BookingStatus; booking_number: string }>(
+          rows,
+        )[0]
 
         if (!booking) {
           throw new BookingServiceError("not_found")
@@ -3670,6 +3687,7 @@ export const bookingsService = {
 
         const patch = transitionBooking(booking.status, "cancelled")
         const previousStatus = booking.status as BookingCancelledEvent["previousStatus"]
+        const cancellationReason = data.note?.trim() || null
 
         const allocations = await tx
           .select()
@@ -3727,20 +3745,45 @@ export const bookingsService = {
           .returning()
 
         await runtime.closePaymentSchedulesForBooking?.(tx as PostgresJsDatabase, id, "cancelled")
+        const financialSettlement = await runtime.recordCancellationFinancialSettlement?.(
+          tx as PostgresJsDatabase,
+          {
+            bookingId: id,
+            bookingNumber: booking.booking_number,
+            previousStatus,
+            reason: cancellationReason,
+            actorId: userId ?? "system",
+          },
+        )
+        const financialSettlementMessage =
+          typeof financialSettlement?.message === "string" ? financialSettlement.message : null
+        const cancellationDescription = [
+          cancellationReason
+            ? `Booking cancelled from ${booking.status}: ${cancellationReason}`
+            : `Booking cancelled from ${booking.status}`,
+          financialSettlementMessage,
+        ]
+          .filter(Boolean)
+          .join(" ")
 
         await tx.insert(bookingActivityLog).values({
           bookingId: id,
           actorId: userId ?? "system",
           activityType: "status_change",
-          description: `Booking cancelled from ${booking.status}`,
-          metadata: { oldStatus: booking.status, newStatus: "cancelled" },
+          description: cancellationDescription,
+          metadata: {
+            oldStatus: booking.status,
+            newStatus: "cancelled",
+            reason: cancellationReason,
+            ...(financialSettlement ? { financialSettlement } : {}),
+          },
         })
 
-        if (data.note) {
+        if (cancellationReason) {
           await tx.insert(bookingNotes).values({
             bookingId: id,
             authorId: userId ?? "system",
-            content: data.note,
+            content: cancellationReason,
           })
         }
 
@@ -3767,6 +3810,7 @@ export const bookingsService = {
             bookingId: result.booking.id,
             bookingNumber: result.booking.bookingNumber,
             previousStatus: result.previousStatus,
+            reason: data.note?.trim() || null,
             actorId: userId ?? null,
           } satisfies BookingCancelledEvent,
           { category: "domain", source: "service" },

--- a/packages/bookings/tests/integration/routes.integration-suite.ts
+++ b/packages/bookings/tests/integration/routes.integration-suite.ts
@@ -23,9 +23,14 @@ import {
   productsRef,
   productTicketSettingsRef,
 } from "../../src/products-ref.js"
+import {
+  BOOKING_ROUTE_RUNTIME_CONTAINER_KEY,
+  buildBookingRouteRuntime,
+} from "../../src/route-runtime.js"
 import { bookingRoutes } from "../../src/routes.js"
 import { bookingTravelerTravelDetails } from "../../src/schema/travel-details.js"
 import {
+  bookingActivityLog,
   bookingAllocations,
   bookingDocuments,
   bookingFulfillments,
@@ -2232,6 +2237,85 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
         .from(availabilitySlotsRef)
         .where(eq(availabilitySlotsRef.id, slot.id))
       expect(updatedSlot?.remainingPax).toBe(3)
+    })
+
+    it("records cancellation reason and financial settlement metadata", async () => {
+      const slot = await seedSlot({ initialPax: 3, remainingPax: 3 })
+      const reserveRes = await app.request("/reserve", {
+        method: "POST",
+        ...json({
+          bookingNumber: nextBookingNumber(),
+          sellCurrency: "USD",
+          items: [{ title: "Adult ticket", availabilitySlotId: slot.id, quantity: 1 }],
+        }),
+      })
+      const { data: booking } = await reserveRes.json()
+      await app.request(`/${booking.id}/confirm`, { method: "POST", ...json({}) })
+
+      const settlementCalls: Array<Record<string, unknown>> = []
+      const runtime = buildBookingRouteRuntime(
+        {},
+        {
+          recordCancellationFinancialSettlement: async (_db, input) => {
+            settlementCalls.push(input)
+            return {
+              status: "action_required",
+              invoiceNumbers: ["INV-PAID-1"],
+              message: "Paid booking cancelled; review settlement.",
+            }
+          },
+        },
+      )
+
+      const scopedApp = new Hono()
+      scopedApp.use("*", async (c, next) => {
+        c.set("db" as never, db)
+        c.set("eventBus" as never, eventBus)
+        c.set("userId" as never, "test-user-id")
+        c.set("actor" as never, "staff")
+        c.set("container" as never, {
+          resolve(key: string) {
+            if (key === BOOKING_ROUTE_RUNTIME_CONTAINER_KEY) return runtime
+            return undefined
+          },
+        })
+        await next()
+      })
+      scopedApp.route("/", bookingRoutes)
+
+      const cancelRes = await scopedApp.request(`/${booking.id}/cancel`, {
+        method: "POST",
+        ...json({ note: "Client requested" }),
+      })
+
+      expect(cancelRes.status).toBe(200)
+      expect(settlementCalls).toEqual([
+        expect.objectContaining({
+          bookingId: booking.id,
+          bookingNumber: booking.bookingNumber,
+          previousStatus: "confirmed",
+          reason: "Client requested",
+          actorId: "test-user-id",
+        }),
+      ])
+
+      const rows = await db
+        .select()
+        .from(bookingActivityLog)
+        .where(eq(bookingActivityLog.bookingId, booking.id))
+      const statusChange = rows.find((row) => row.activityType === "status_change")
+      expect(statusChange?.description).toBe(
+        "Booking cancelled from confirmed: Client requested Paid booking cancelled; review settlement.",
+      )
+      expect(statusChange?.metadata).toMatchObject({
+        oldStatus: "confirmed",
+        newStatus: "cancelled",
+        reason: "Client requested",
+        financialSettlement: {
+          status: "action_required",
+          invoiceNumbers: ["INV-PAID-1"],
+        },
+      })
     })
 
     it("emits booking.cancelled with previousStatus after cancel", async () => {

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -288,6 +288,8 @@ export interface FrameworkProviders {
   closePaymentSchedulesForBooking: NonNullable<
     BookingsHonoModuleOptions["closePaymentSchedulesForBooking"]
   >
+  /** Records cancellation settlement guidance for paid bookings. */
+  recordCancellationFinancialSettlement?: BookingsHonoModuleOptions["recordCancellationFinancialSettlement"]
   /**
    * Deployment custom-field registry (see `@voyant-travel/core/custom-fields`),
    * injected into entities that validate `customFields` on write. Optional — a
@@ -573,6 +575,7 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
             (await capabilities.relationshipsService.getOrganizationById(db, organizationId)) !=
             null,
           closePaymentSchedulesForBooking: capabilities.closePaymentSchedulesForBooking,
+          recordCancellationFinancialSettlement: capabilities.recordCancellationFinancialSettlement,
           customFields: capabilities.customFields,
         }),
         true,

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -66,6 +66,7 @@ import {
 } from "./runtime/payment-config"
 import { createRelationshipsStorefrontIntakePersistence } from "./runtime/storefront-intake-runtime"
 import { createOperatorTripsRoutesOptions } from "./runtime/trips-runtime"
+import { recordPaidBookingCancellationSettlement } from "./subscribers/booking-cancellation-settlement"
 import { closeTerminalBookingPaymentSchedules } from "./subscribers/booking-payment-cleanup"
 
 /**
@@ -91,6 +92,7 @@ export interface OperatorCapabilities extends FrameworkProviders {
   resolveBankTransferDetails: typeof resolveBankTransferDetails
   relationshipsService: typeof relationshipsService
   closePaymentSchedulesForBooking: typeof closeTerminalBookingPaymentSchedules
+  recordCancellationFinancialSettlement: typeof recordPaidBookingCancellationSettlement
   createTripsRoutesOptions: typeof createOperatorTripsRoutesOptions
   resolveBookingRequirementsProductSnapshot: typeof resolveBookingRequirementsProductSnapshot
 }
@@ -116,6 +118,7 @@ export function buildOperatorProviders(): OperatorCapabilities {
     resolveBankTransferDetails,
     relationshipsService,
     closePaymentSchedulesForBooking: closeTerminalBookingPaymentSchedules,
+    recordCancellationFinancialSettlement: recordPaidBookingCancellationSettlement,
     // Adapt the deployment's catalog context into the package's search runtime
     // shape (the framework catalog factory consumes this directly).
     resolveCatalogRuntime: (c) => {

--- a/starters/operator/src/api/subscribers/booking-cancellation-settlement.test.ts
+++ b/starters/operator/src/api/subscribers/booking-cancellation-settlement.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildPaidBookingCancellationSettlementNote,
+  recordPaidBookingCancellationSettlement,
+} from "./booking-cancellation-settlement"
+
+describe("recordPaidBookingCancellationSettlement", () => {
+  it("creates finance notes for paid invoices and returns settlement metadata", async () => {
+    const db = createFakeDb([
+      {
+        id: "inv_1",
+        invoiceNumber: "INV-1",
+        currency: "GBP",
+        paidCents: 12000,
+        status: "paid",
+      },
+      {
+        id: "inv_2",
+        invoiceNumber: "INV-2",
+        currency: "GBP",
+        paidCents: 3000,
+        status: "partially_paid",
+      },
+    ])
+
+    const settlement = await recordPaidBookingCancellationSettlement(db as never, {
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+      previousStatus: "confirmed",
+      reason: "Client requested",
+      actorId: "user_1",
+    })
+
+    expect(settlement).toMatchObject({
+      status: "action_required",
+      kind: "paid_booking_cancellation",
+      invoiceIds: ["inv_1", "inv_2"],
+      invoiceNumbers: ["INV-1", "INV-2"],
+      paidByCurrency: { GBP: 15000 },
+    })
+    expect(db.insertedNotes).toHaveLength(2)
+    expect(db.insertedNotes[0]).toMatchObject({
+      invoiceId: "inv_1",
+      authorId: "user_1",
+    })
+    expect(db.insertedNotes[0]?.content).toContain("Booking BK-1 was cancelled from confirmed.")
+    expect(db.insertedNotes[0]?.content).toContain("Cancellation reason: Client requested")
+    expect(db.insertedNotes[0]?.content).toContain("Invoice paid amount: 12000 GBP cents.")
+  })
+
+  it("does not create notes when the booking has no paid invoices", async () => {
+    const db = createFakeDb([])
+
+    const settlement = await recordPaidBookingCancellationSettlement(db as never, {
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+      previousStatus: "confirmed",
+      reason: null,
+      actorId: "user_1",
+    })
+
+    expect(settlement).toBeNull()
+    expect(db.insertedNotes).toEqual([])
+  })
+
+  it("builds a no-reason settlement note", () => {
+    expect(
+      buildPaidBookingCancellationSettlementNote({
+        bookingId: "book_1",
+        bookingNumber: "BK-1",
+        previousStatus: "confirmed",
+        reason: null,
+        actorId: "user_1",
+      }),
+    ).not.toContain("Cancellation reason")
+  })
+
+  it("builds settlement notes for awaiting-payment cancellations", () => {
+    expect(
+      buildPaidBookingCancellationSettlementNote({
+        bookingId: "book_1",
+        bookingNumber: "BK-1",
+        previousStatus: "awaiting_payment",
+        reason: "Card capture failed",
+        actorId: "user_1",
+      }),
+    ).toContain("Booking BK-1 was cancelled from awaiting_payment.")
+  })
+})
+
+interface FakePaidInvoice {
+  id: string
+  invoiceNumber: string
+  currency: string
+  paidCents: number
+  status: string
+}
+
+function createFakeDb(paidInvoices: FakePaidInvoice[]) {
+  const insertedNotes: Array<Record<string, unknown>> = []
+
+  return {
+    insertedNotes,
+    select() {
+      return {
+        from() {
+          return {
+            where: async () => paidInvoices,
+          }
+        },
+      }
+    },
+    insert() {
+      return {
+        values(row: Record<string, unknown>) {
+          insertedNotes.push(row)
+          return {
+            returning: async () => [{ id: `fnote_${insertedNotes.length}` }],
+          }
+        },
+      }
+    },
+  }
+}

--- a/starters/operator/src/api/subscribers/booking-cancellation-settlement.ts
+++ b/starters/operator/src/api/subscribers/booking-cancellation-settlement.ts
@@ -1,0 +1,90 @@
+import { financeNotes, invoices } from "@voyant-travel/finance/schema"
+import { and, eq, gt, ne } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+export interface BookingCancellationSettlementInput {
+  bookingId: string
+  bookingNumber: string
+  previousStatus: "draft" | "on_hold" | "awaiting_payment" | "confirmed" | "in_progress"
+  reason: string | null
+  actorId: string
+}
+
+interface PaidInvoice {
+  id: string
+  invoiceNumber: string
+  currency: string
+  paidCents: number
+  status: string
+}
+
+export async function recordPaidBookingCancellationSettlement(
+  db: PostgresJsDatabase,
+  input: BookingCancellationSettlementInput,
+): Promise<Record<string, unknown> | null> {
+  const paidInvoices = (await db
+    .select({
+      id: invoices.id,
+      invoiceNumber: invoices.invoiceNumber,
+      currency: invoices.currency,
+      paidCents: invoices.paidCents,
+      status: invoices.status,
+    })
+    .from(invoices)
+    .where(
+      and(
+        eq(invoices.bookingId, input.bookingId),
+        gt(invoices.paidCents, 0),
+        ne(invoices.status, "void"),
+      ),
+    )) as PaidInvoice[]
+
+  if (paidInvoices.length === 0) return null
+
+  const noteIds: string[] = []
+  const content = buildPaidBookingCancellationSettlementNote(input)
+  for (const invoice of paidInvoices) {
+    const [note] = await db
+      .insert(financeNotes)
+      .values({
+        invoiceId: invoice.id,
+        authorId: input.actorId,
+        content: `${content}\n\nInvoice paid amount: ${invoice.paidCents} ${invoice.currency} cents.`,
+      })
+      .returning({ id: financeNotes.id })
+    if (note?.id) noteIds.push(note.id)
+  }
+
+  return {
+    status: "action_required",
+    kind: "paid_booking_cancellation",
+    invoiceIds: paidInvoices.map((invoice) => invoice.id),
+    invoiceNumbers: paidInvoices.map((invoice) => invoice.invoiceNumber),
+    financeNoteIds: noteIds,
+    paidByCurrency: summarizePaidByCurrency(paidInvoices),
+    message: "Paid booking cancelled; review refund, credit-note, or no-refund settlement.",
+  }
+}
+
+export function buildPaidBookingCancellationSettlementNote(
+  input: BookingCancellationSettlementInput,
+): string {
+  const parts = [
+    `Booking ${input.bookingNumber} was cancelled from ${input.previousStatus}.`,
+    "The customer-facing invoice remains paid until an operator records a refund, credit note, or no-refund decision.",
+  ]
+
+  if (input.reason) {
+    parts.push(`Cancellation reason: ${input.reason}`)
+  }
+
+  return parts.join("\n")
+}
+
+function summarizePaidByCurrency(invoicesToSummarize: PaidInvoice[]): Record<string, number> {
+  const totals: Record<string, number> = {}
+  for (const invoice of invoicesToSummarize) {
+    totals[invoice.currency] = (totals[invoice.currency] ?? 0) + invoice.paidCents
+  }
+  return totals
+}


### PR DESCRIPTION
## Summary
- add a bookings cancellation settlement hook and expose cancellation reasons in cancellation activity metadata
- wire the framework/operator runtime so paid booking cancellations create finance notes for paid invoices
- record a visible operator next step to review refund, credit-note, or no-refund settlement

Closes #2881

## Validation
- pnpm --filter @voyant-travel/bookings typecheck
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter operator typecheck
- pnpm --filter operator test -- src/api/subscribers/booking-cancellation-settlement.test.ts
- pnpm exec vitest run packages/bookings/tests/unit/validation-operations.test.ts packages/bookings/tests/unit/status-transitions.test.ts
- pnpm exec vitest run packages/bookings/tests/tools.test.ts packages/finance/tests/tools.test.ts
- pnpm verify:fast
