### PR TITLE
Use KMS subpath in bookings

### DIFF
--- a/.changeset/bookings-kms-subpath.md
+++ b/.changeset/bookings-kms-subpath.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Import booking PII KMS helpers through the explicit utils KMS subpath so release builds do not depend on the utils root barrel declaration cache.

--- a/packages/bookings/src/pii.ts
+++ b/packages/bookings/src/pii.ts
@@ -1,5 +1,5 @@
-import type { KeyRef, KmsProvider } from "@voyant-travel/utils"
-import { decryptOptionalJsonEnvelope, encryptOptionalJsonEnvelope } from "@voyant-travel/utils"
+import type { KeyRef, KmsProvider } from "@voyant-travel/utils/kms"
+import { decryptOptionalJsonEnvelope, encryptOptionalJsonEnvelope } from "@voyant-travel/utils/kms"
 import { eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -1,5 +1,5 @@
 import type { CustomFieldRegistryResolver } from "@voyant-travel/core/custom-fields"
-import { createKmsProviderFromEnv, type KmsProvider } from "@voyant-travel/utils"
+import { createKmsProviderFromEnv, type KmsProvider } from "@voyant-travel/utils/kms"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import type { BookingTravelerSnapshot } from "./pii.js"


### PR DESCRIPTION
## Summary
- change bookings PII/runtime KMS imports to use `@voyant-travel/utils/kms` directly
- add a bookings patch changeset so the emitted declarations are released with the explicit KMS subpath

## Why
Release CI failed while building `@voyant-travel/bookings-react` because emitted bookings declarations pulled KMS types/helpers from the `@voyant-travel/utils` root barrel, but that root declaration surface did not include the KMS exports in the release build context. The KMS subpath is already a package export and has a direct dist declaration mapping.

## Validation
- pnpm install
- pnpm --filter @voyant-travel/utils build
- pnpm --filter @voyant-travel/bookings build
- pnpm --filter @voyant-travel/catalog-contracts build
- pnpm --filter @voyant-travel/i18n build
- pnpm --filter @voyant-travel/bookings-react build
- pnpm --filter @voyant-travel/bookings typecheck
- pnpm verify:package-exports
- pnpm verify:agent-quality:changed

Note: `pnpm --filter @voyant-travel/bookings-react typecheck` is currently blocked on unrelated finance declaration/source errors on `origin/main`; the release-failing `bookings-react build` path passes after this change.
