### PR TITLE
Warm inventory product read model

### DIFF
--- a/.changeset/inventory-read-model-warm.md
+++ b/.changeset/inventory-read-model-warm.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Export product read-model helpers and the public product read service, and add a write-time warm path for product read-model recomputation after inventory mutations.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -834,6 +834,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -851,6 +852,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -829,6 +829,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -846,6 +847,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -805,6 +805,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -822,6 +823,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -800,6 +800,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -817,6 +818,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -889,6 +889,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -906,6 +907,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -885,6 +885,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -902,6 +903,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -870,6 +870,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -887,6 +888,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -871,6 +871,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -888,6 +889,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -886,6 +886,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -903,6 +904,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -887,6 +887,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -904,6 +905,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -889,6 +889,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -906,6 +907,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -884,6 +884,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -901,6 +902,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -899,6 +899,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -916,6 +917,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -900,6 +900,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -917,6 +918,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -890,6 +890,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -907,6 +908,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -885,6 +885,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -902,6 +903,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -9,6 +9,7 @@
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
     "./tools": "./src/tools.ts",
+    "./read-model": "./src/read-model.ts",
     "./routes": "./src/routes.ts",
     "./routes-brochure": "./src/routes-brochure.ts",
     "./action-ledger-drift": "./src/action-ledger-drift.ts",
@@ -25,6 +26,7 @@
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
     "./service-catalog-plane-destinations": "./src/service-catalog-plane-destinations.ts",
     "./service-catalog-plane-taxonomy": "./src/service-catalog-plane-taxonomy.ts",
+    "./service-public": "./src/service-public.ts",
     "./content-shape": "./src/content-shape.ts",
     "./service-content": "./src/service-content.ts",
     "./service-content-synthesizer": "./src/service-content-synthesizer.ts",
@@ -108,6 +110,11 @@
         "import": "./dist/tools.js",
         "default": "./dist/tools.js"
       },
+      "./read-model": {
+        "types": "./dist/read-model.d.ts",
+        "import": "./dist/read-model.js",
+        "default": "./dist/read-model.js"
+      },
       "./routes": {
         "types": "./dist/routes.d.ts",
         "import": "./dist/routes.js",
@@ -187,6 +194,11 @@
         "types": "./dist/service-catalog-plane-taxonomy.d.ts",
         "import": "./dist/service-catalog-plane-taxonomy.js",
         "default": "./dist/service-catalog-plane-taxonomy.js"
+      },
+      "./service-public": {
+        "types": "./dist/service-public.d.ts",
+        "import": "./dist/service-public.js",
+        "default": "./dist/service-public.js"
       },
       "./content-shape": {
         "types": "./dist/content-shape.d.ts",

--- a/packages/inventory/src/index.ts
+++ b/packages/inventory/src/index.ts
@@ -16,6 +16,23 @@ export {
   type ProductContentChangedEvent,
 } from "./events.js"
 export { productLinkable } from "./linkables.js"
+export {
+  buildProductReadModelDoc,
+  invalidateProductReadModel,
+  type ProductReadModelQuery,
+  type ProductReadModelVariant,
+  type ProductReadModelVariantInput,
+  type ProductSlugResolution,
+  productDocKey,
+  productDocQueryFromVariant,
+  productDocVariant,
+  productSlugMapKey,
+  readThroughProductDoc,
+  readThroughSlugMapping,
+  type WarmProductReadModelInput,
+  type WarmProductReadModelResult,
+  warmProductReadModel,
+} from "./read-model.js"
 export type { ProductRoutes } from "./routes.js"
 export type { PublicProductRoutes } from "./routes-public.js"
 export { publicProductRoutes } from "./routes-public.js"

--- a/packages/inventory/src/read-model.ts
+++ b/packages/inventory/src/read-model.ts
@@ -1,4 +1,7 @@
 import type { KVStore } from "@voyant-travel/utils/cache"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import { publicProductsService } from "./service-public.js"
 
 /**
  * KV-backed read model for the public product detail surface (RFC
@@ -8,9 +11,9 @@ import type { KVStore } from "@voyant-travel/utils/cache"
  * Model: read-through with exact invalidation. The first read of a
  * (product, variant) materializes the render-ready document into KV;
  * repeat reads cost one KV get and ZERO Postgres queries. Admin
- * mutations to a product delete its documents (see
- * `productsReadModelInvalidation` in routes.ts), and a generous TTL
- * bounds staleness for anything invalidation misses.
+ * mutations to a product recompute or delete its documents (see
+ * `readModelInvalidation` in routes.ts), and a generous TTL bounds
+ * staleness for anything invalidation misses.
  *
  * Slug lookups resolve through a short-lived slug→product+locale mapping
  * so the id-keyed document is shared between `/:id` and `/slug/:slug`. The
@@ -25,6 +28,29 @@ const PRODUCT_DOC_TTL_SECONDS = 24 * 60 * 60
 /** Slug→id mappings are refill-cheap; the TTL bounds rename staleness. */
 const SLUG_MAP_TTL_SECONDS = 5 * 60
 
+export interface ProductReadModelQuery {
+  languageTag?: string | null
+}
+
+export interface ProductReadModelVariant {
+  variant: string
+  query?: ProductReadModelQuery
+}
+
+export type ProductReadModelVariantInput = string | ProductReadModelVariant
+
+export interface WarmProductReadModelInput {
+  db: PostgresJsDatabase
+  kv: KVStore
+  productId: string
+  variants?: ProductReadModelVariantInput[]
+}
+
+export interface WarmProductReadModelResult {
+  warmed: string[]
+  missing: string[]
+}
+
 export function productDocKey(productId: string, variant: string): string {
   return `${RM_PREFIX}:${productId}:${variant}`
 }
@@ -36,6 +62,18 @@ export function productSlugMapKey(slug: string, variant: string): string {
 /** Stable variant id from the detail query (currently just the locale). */
 export function productDocVariant(query: { languageTag?: string | null }): string {
   return query.languageTag ? `lang=${query.languageTag}` : "default"
+}
+
+export function productDocQueryFromVariant(variant: string): ProductReadModelQuery {
+  return variant.startsWith("lang=") ? { languageTag: variant.slice("lang=".length) } : {}
+}
+
+export async function buildProductReadModelDoc(
+  db: PostgresJsDatabase,
+  productId: string,
+  query: ProductReadModelQuery = {},
+) {
+  return publicProductsService.getCatalogProductById(db, productId, query)
 }
 
 export interface ProductSlugResolution {
@@ -64,7 +102,7 @@ export async function readThroughProductDoc<T>(
   const data = await compute()
   if (data !== null && kv) {
     try {
-      await kv.put(key, JSON.stringify(data), { expirationTtl: PRODUCT_DOC_TTL_SECONDS })
+      await putProductDoc(kv, key, data)
     } catch {
       // best-effort materialization
     }
@@ -105,11 +143,90 @@ export async function readThroughSlugMapping(
  * it, where the TTL becomes the only freshness bound).
  */
 export async function invalidateProductReadModel(kv: KVStore, productId: string): Promise<void> {
-  if (!kv.list) return
+  const keys = await listProductDocKeys(kv, productId)
+  if (!keys) return
+  await deleteProductDocKeys(kv, keys)
+}
+
+export async function warmProductReadModel(
+  input: WarmProductReadModelInput,
+): Promise<WarmProductReadModelResult> {
+  const explicitVariants = input.variants?.map(normalizeVariantInput)
+  const existingVariants = explicitVariants
+    ? null
+    : await listProductDocVariants(input.kv, input.productId)
+  const variants =
+    explicitVariants && explicitVariants.length > 0
+      ? explicitVariants
+      : existingVariants && existingVariants.length > 0
+        ? existingVariants.map((variant) => ({
+            variant,
+            query: productDocQueryFromVariant(variant),
+          }))
+        : [{ variant: "default", query: {} }]
+
+  const warmed: string[] = []
+  const missing: string[] = []
+
+  for (const { variant, query } of variants) {
+    const key = productDocKey(input.productId, variant)
+    await safeDeleteProductDoc(input.kv, key)
+    const data = await buildProductReadModelDoc(input.db, input.productId, query)
+    if (data === null) {
+      missing.push(variant)
+      continue
+    }
+    try {
+      await putProductDoc(input.kv, key, data)
+      warmed.push(variant)
+    } catch {
+      // best-effort materialization; the next read can still recompute
+    }
+  }
+
+  return { warmed, missing }
+}
+
+async function putProductDoc<T>(kv: KVStore, key: string, data: T) {
+  await kv.put(key, JSON.stringify(data), { expirationTtl: PRODUCT_DOC_TTL_SECONDS })
+}
+
+async function listProductDocKeys(kv: KVStore, productId: string): Promise<string[] | null> {
+  if (!kv.list) return null
   try {
     const { keys } = await kv.list({ prefix: `${RM_PREFIX}:${productId}:` })
-    await Promise.all(keys.map((key) => kv.delete(key.name)))
+    return keys.map((key) => key.name)
+  } catch {
+    // best-effort — the document TTL bounds staleness if this fails
+    return null
+  }
+}
+
+async function listProductDocVariants(kv: KVStore, productId: string): Promise<string[] | null> {
+  const keys = await listProductDocKeys(kv, productId)
+  if (!keys) return null
+  const prefix = `${RM_PREFIX}:${productId}:`
+  return keys.map((key) => key.slice(prefix.length)).filter(Boolean)
+}
+
+async function deleteProductDocKeys(kv: KVStore, keys: string[]) {
+  await Promise.all(keys.map((key) => safeDeleteProductDoc(kv, key)))
+}
+
+async function safeDeleteProductDoc(kv: KVStore, key: string) {
+  try {
+    await kv.delete(key)
   } catch {
     // best-effort — the document TTL bounds staleness if this fails
   }
+}
+
+function normalizeVariantInput(input: ProductReadModelVariantInput): {
+  variant: string
+  query: ProductReadModelQuery
+} {
+  if (typeof input === "string") {
+    return { variant: input, query: productDocQueryFromVariant(input) }
+  }
+  return { variant: input.variant, query: input.query ?? productDocQueryFromVariant(input.variant) }
 }

--- a/packages/inventory/src/routes-public.ts
+++ b/packages/inventory/src/routes-public.ts
@@ -6,6 +6,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 import {
+  buildProductReadModelDoc,
   productDocKey,
   productDocVariant,
   readThroughProductDoc,
@@ -390,8 +391,7 @@ export const publicProductRoutes = new OpenAPIHono<Env>({ defaultHook: openApiVa
     const { data } = await readThroughProductDoc(
       kv,
       productDocKey(resolution.productId, productDocVariant(detailQuery)),
-      () =>
-        publicProductsService.getCatalogProductById(c.get("db"), resolution.productId, detailQuery),
+      () => buildProductReadModelDoc(c.get("db"), resolution.productId, detailQuery),
     )
     if (!data) {
       return c.json({ error: "Catalog product not found" }, 404)
@@ -406,7 +406,7 @@ export const publicProductRoutes = new OpenAPIHono<Env>({ defaultHook: openApiVa
     const { data } = await readThroughProductDoc(
       readModelKv(c),
       productDocKey(productId, productDocVariant(query)),
-      () => publicProductsService.getCatalogProductById(c.get("db"), productId, query),
+      () => buildProductReadModelDoc(c.get("db"), productId, query),
     )
 
     if (!data) {

--- a/packages/inventory/src/routes.ts
+++ b/packages/inventory/src/routes.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { KVStore } from "@voyant-travel/utils/cache"
 
-import { invalidateProductReadModel } from "./read-model.js"
+import { invalidateProductReadModel, warmProductReadModel } from "./read-model.js"
 import type { Env } from "./route-env.js"
 import { productAssociationRoutes } from "./routes-associations.js"
 import { productCatalogRoutes } from "./routes-catalog.js"
@@ -21,22 +21,27 @@ export type { Env } from "./route-env.js"
 /** Matches the product TypeID anywhere in an admin mutation path. */
 const PRODUCT_ID_IN_PATH = /(prod_[a-z0-9]+)/
 
+export interface ReadModelInvalidationOptions {
+  mode?: "delete" | "recompute"
+}
+
 /**
  * Exact read-model invalidation for the public product-detail documents
  * (see read-model.ts): after any successful admin mutation whose path
- * names a product, that product's cached KV documents are dropped —
- * regardless of which route group (core, media, translations, options,
- * itinerary, …) performed the write. Runs after the response via
+ * names a product, that product's cached KV documents are dropped or
+ * recomputed — regardless of which route group (core, media, translations,
+ * options, itinerary, …) performed the write. Runs after the response via
  * `waitUntil` when available; deployments without the CACHE binding (or
  * outside Workers) skip it and rely on the document TTL.
  */
-export function readModelInvalidation() {
+export function readModelInvalidation(options: ReadModelInvalidationOptions = {}) {
   return async (
     c: {
       req: { method: string; path: string }
       res?: Response
       env?: { CACHE?: KVStore }
       executionCtx?: unknown
+      get?: (key: "db") => Env["Variables"]["db"]
     },
     next: () => Promise<void>,
   ) => {
@@ -47,7 +52,7 @@ export function readModelInvalidation() {
     if (!kv) return
     const match = PRODUCT_ID_IN_PATH.exec(c.req.path)
     if (!match?.[1]) return
-    const pending = invalidateProductReadModel(kv, match[1])
+    const pending = buildReadModelInvalidationTask(c, kv, match[1], options.mode ?? "delete")
     try {
       const ctx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined
       if (ctx && typeof ctx.waitUntil === "function") {
@@ -61,6 +66,24 @@ export function readModelInvalidation() {
   }
 }
 
+function buildReadModelInvalidationTask(
+  c: { get?: (key: "db") => Env["Variables"]["db"] },
+  kv: KVStore,
+  productId: string,
+  mode: "delete" | "recompute",
+) {
+  if (mode === "recompute" && typeof c.get === "function") {
+    try {
+      return warmProductReadModel({ db: c.get("db"), kv, productId }).catch(() =>
+        invalidateProductReadModel(kv, productId),
+      )
+    } catch {
+      // fall through to delete-only invalidation
+    }
+  }
+  return invalidateProductReadModel(kv, productId)
+}
+
 // Product route groups stay split by domain area; mount at root to preserve
 // public paths. The parent is an `OpenAPIHono` so the converted children's
 // `.openapi()` operations propagate up into the generated spec (voyant#2114 —
@@ -68,7 +91,7 @@ export function readModelInvalidation() {
 // are converted in later batches.
 export const productRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
   // biome-ignore lint/suspicious/noExplicitAny: the structural middleware shape doesn't need the full Env generics -- owner: inventory; existing suppression is intentional pending typed cleanup.
-  .use("*", readModelInvalidation() as any)
+  .use("*", readModelInvalidation({ mode: "recompute" }) as any)
   .route("/", productConfigurationRoutes)
   .route("/", productMerchandisingRoutes)
   .route("/", productOptionRoutes)

--- a/packages/inventory/tests/unit/read-model.test.ts
+++ b/packages/inventory/tests/unit/read-model.test.ts
@@ -20,6 +20,7 @@ import {
   productDocVariant,
   readThroughProductDoc,
   readThroughSlugMapping,
+  warmProductReadModel,
 } from "../../src/read-model.js"
 import { productRoutes, readModelInvalidation } from "../../src/routes.js"
 import { publicProductRoutes } from "../../src/routes-public.js"
@@ -111,6 +112,48 @@ describe("read-model primitives", () => {
     expect(first).toEqual({ productId: "prod_1", languageTag: "ro" })
     expect(second).toEqual({ productId: "prod_1", languageTag: "ro" })
     expect(resolve).toHaveBeenCalledOnce()
+  })
+
+  it("warmProductReadModel writes the default product document", async () => {
+    const kv = fakeKv()
+
+    const result = await warmProductReadModel({
+      db: {} as never,
+      kv,
+      productId: PRODUCT.id,
+    })
+
+    expect(result).toEqual({ warmed: ["default"], missing: [] })
+    expect(JSON.parse(kv.store.get(productDocKey(PRODUCT.id, "default")) ?? "null")).toEqual(
+      PRODUCT,
+    )
+    expect(mockedService.getCatalogProductById).toHaveBeenCalledWith({}, PRODUCT.id, {})
+  })
+
+  it("warmProductReadModel recomputes existing locale variants", async () => {
+    const kv = fakeKv()
+    kv.store.set(productDocKey(PRODUCT.id, "default"), JSON.stringify({ stale: true }))
+    kv.store.set(productDocKey(PRODUCT.id, "lang=de"), JSON.stringify({ stale: true }))
+    mockedService.getCatalogProductById.mockImplementation(async (_db, _productId, query) => ({
+      ...PRODUCT,
+      contentLanguageTag: query.languageTag ?? null,
+    }))
+
+    const result = await warmProductReadModel({
+      db: {} as never,
+      kv,
+      productId: PRODUCT.id,
+    })
+
+    expect(result.warmed).toEqual(["default", "lang=de"])
+    expect(JSON.parse(kv.store.get(productDocKey(PRODUCT.id, "default")) ?? "null")).toEqual({
+      ...PRODUCT,
+      contentLanguageTag: null,
+    })
+    expect(JSON.parse(kv.store.get(productDocKey(PRODUCT.id, "lang=de")) ?? "null")).toEqual({
+      ...PRODUCT,
+      contentLanguageTag: "de",
+    })
   })
 })
 
@@ -245,5 +288,21 @@ describe("admin mutation invalidation middleware", () => {
 
     expect(miss.status).toBe(404)
     expect(kv.store.has(productDocKey(PRODUCT.id, "default"))).toBe(true)
+  })
+
+  it("can recompute cached documents after a successful mutation", async () => {
+    const kv = fakeKv()
+    kv.store.set(productDocKey(PRODUCT.id, "default"), JSON.stringify({ stale: true }))
+    const app = new Hono()
+    // biome-ignore lint/suspicious/noExplicitAny: structural middleware shape (same cast as production mounting) -- owner: products; existing suppression is intentional pending typed cleanup.
+    app.use("*", readModelInvalidation({ mode: "recompute" }) as any)
+    app.patch("/:id", (c) => c.json({ ok: true }))
+
+    const res = await app.request(`/${PRODUCT.id}`, { method: "PATCH" }, { CACHE: kv })
+
+    expect(res.status).toBe(200)
+    expect(JSON.parse(kv.store.get(productDocKey(PRODUCT.id, "default")) ?? "null")).toEqual(
+      PRODUCT,
+    )
   })
 })

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -899,6 +899,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -916,6 +917,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -900,6 +900,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -917,6 +918,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -900,6 +900,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -917,6 +918,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -905,6 +905,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -922,6 +923,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -900,6 +900,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -917,6 +918,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -898,6 +898,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -915,6 +916,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -899,6 +899,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -916,6 +917,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -900,6 +900,7 @@
       "@voyant-travel/inventory/linkables": ["../inventory/dist/linkables.d.ts"],
       "@voyant-travel/inventory/public-routes": ["../inventory/dist/public-routes.d.ts"],
       "@voyant-travel/inventory/public-validation": ["../inventory/dist/public-validation.d.ts"],
+      "@voyant-travel/inventory/read-model": ["../inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": ["../inventory/dist/routes-brochure.d.ts"],
       "@voyant-travel/inventory/routes-content": ["../inventory/dist/routes-content.d.ts"],
@@ -917,6 +918,7 @@
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../inventory/dist/service-content-synthesizer.d.ts"
       ],
+      "@voyant-travel/inventory/service-public": ["../inventory/dist/service-public.d.ts"],
       "@voyant-travel/inventory/tasks": ["../inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1157,6 +1157,7 @@
       "@voyant-travel/inventory/public-validation": [
         "../../packages/inventory/dist/public-validation.d.ts"
       ],
+      "@voyant-travel/inventory/read-model": ["../../packages/inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../../packages/inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": [
         "../../packages/inventory/dist/routes-brochure.d.ts"
@@ -1179,6 +1180,9 @@
       ],
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../../packages/inventory/dist/service-content-synthesizer.d.ts"
+      ],
+      "@voyant-travel/inventory/service-public": [
+        "../../packages/inventory/dist/service-public.d.ts"
       ],
       "@voyant-travel/inventory/tasks": ["../../packages/inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../../packages/inventory/dist/tools.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1157,6 +1157,7 @@
       "@voyant-travel/inventory/public-validation": [
         "../../packages/inventory/dist/public-validation.d.ts"
       ],
+      "@voyant-travel/inventory/read-model": ["../../packages/inventory/dist/read-model.d.ts"],
       "@voyant-travel/inventory/routes": ["../../packages/inventory/dist/routes.d.ts"],
       "@voyant-travel/inventory/routes-brochure": [
         "../../packages/inventory/dist/routes-brochure.d.ts"
@@ -1179,6 +1180,9 @@
       ],
       "@voyant-travel/inventory/service-content-synthesizer": [
         "../../packages/inventory/dist/service-content-synthesizer.d.ts"
+      ],
+      "@voyant-travel/inventory/service-public": [
+        "../../packages/inventory/dist/service-public.d.ts"
       ],
       "@voyant-travel/inventory/tasks": ["../../packages/inventory/dist/tasks.d.ts"],
       "@voyant-travel/inventory/tools": ["../../packages/inventory/dist/tools.d.ts"],


### PR DESCRIPTION
## Summary
- export the inventory product read-model surface through `./read-model` and the public product doc builder through `./service-public`
- add `buildProductReadModelDoc(...)` and `warmProductReadModel(...)` for in-process build/write warming of `rm:v1:product:*` docs
- add `readModelInvalidation({ mode: "recompute" })` and wire first-party inventory admin mutations to recompute cached product docs via the existing `waitUntil` path
- regenerate composition type path maps for the new inventory subpath exports

Closes #2895
Closes #2896

## Validation
- `pnpm --filter @voyant-travel/inventory test -- tests/unit/read-model.test.ts tests/unit/routes-public.test.ts`
- `pnpm --filter @voyant-travel/inventory lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/inventory typecheck`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm --filter @voyant-travel/inventory build`
- `pnpm verify:package-exports`
- `pnpm verify:agent-quality:changed`
- `node scripts/check-composition-dep-paths.mjs`

Note: the first local inventory typecheck/build attempt hit Node's default heap limit when run in parallel; rerunning sequentially with an 8GB heap passed. A stale local `@voyant-travel/catalog` dist declaration also required `pnpm --filter @voyant-travel/catalog build` before the inventory checks.
