### PR TITLE
Fix localized storefront itinerary reads

### DIFF
--- a/.changeset/quiet-itineraries-translate.md
+++ b/.changeset/quiet-itineraries-translate.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/openapi": patch
+"@voyant-travel/storefront": patch
+"@voyant-travel/storefront-react": patch
+"@voyant-travel/storefront-sdk": patch
+---
+
+Resolve localized public departure itinerary reads by accepting `languageTag`/`lang`
+query parameters, applying day and segment translations with base-content fallback,
+and exposing the query through first-party storefront clients.

--- a/packages/openapi/spec/storefront/storefront.json
+++ b/packages/openapi/spec/storefront/storefront.json
@@ -3740,6 +3740,24 @@
             "required": true,
             "name": "departureId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+            },
+            "required": false,
+            "name": "languageTag",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+            },
+            "required": false,
+            "name": "lang",
+            "in": "query"
           }
         ],
         "responses": {

--- a/packages/storefront-react/src/hooks/use-storefront-departure-itinerary.ts
+++ b/packages/storefront-react/src/hooks/use-storefront-departure-itinerary.ts
@@ -3,10 +3,12 @@
 import { useQuery } from "@tanstack/react-query"
 
 import { useVoyantStorefrontContext } from "../provider.js"
+import type { StorefrontDepartureItineraryFilters } from "../query-keys.js"
 import { getStorefrontDepartureItineraryQueryOptions } from "../query-options.js"
 
 export interface UseStorefrontDepartureItineraryOptions {
   enabled?: boolean
+  filters?: StorefrontDepartureItineraryFilters
 }
 
 export function useStorefrontDepartureItinerary(
@@ -15,13 +17,14 @@ export function useStorefrontDepartureItinerary(
   options: UseStorefrontDepartureItineraryOptions = {},
 ) {
   const { baseUrl, fetcher } = useVoyantStorefrontContext()
-  const { enabled = true } = options
+  const { enabled = true, filters = {} } = options
 
   return useQuery({
     ...getStorefrontDepartureItineraryQueryOptions(
       { baseUrl, fetcher },
       productId ?? "",
       departureId ?? "",
+      filters,
     ),
     enabled: enabled && Boolean(productId) && Boolean(departureId),
   })

--- a/packages/storefront-react/src/operations.ts
+++ b/packages/storefront-react/src/operations.ts
@@ -2,6 +2,7 @@
 
 import { type FetchWithValidationOptions, fetchWithValidation, withQueryParams } from "./client.js"
 import {
+  type StorefrontDepartureItineraryQuery,
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
   type StorefrontOfferApplyInput,
@@ -9,6 +10,7 @@ import {
   type StorefrontProductExtensionsQuery,
   type StorefrontPromotionalOfferListQuery,
   type StorefrontSettingsPatchInput,
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItineraryResponseSchema,
   storefrontDepartureListResponseSchema,
   storefrontDeparturePricePreviewInputSchema,
@@ -112,9 +114,11 @@ export function getStorefrontDepartureItinerary(
   client: FetchWithValidationOptions,
   productId: string,
   departureId: string,
+  query?: StorefrontDepartureItineraryQuery,
 ) {
+  const parsed = query ? storefrontDepartureItineraryQuerySchema.parse(query) : undefined
   return fetchWithValidation(
-    `/v1/public/products/${productId}/departures/${departureId}/itinerary`,
+    withQueryParams(`/v1/public/products/${productId}/departures/${departureId}/itinerary`, parsed),
     storefrontDepartureItineraryResponseSchema,
     client,
   )

--- a/packages/storefront-react/src/query-keys.ts
+++ b/packages/storefront-react/src/query-keys.ts
@@ -1,10 +1,13 @@
 import type {
+  StorefrontDepartureItineraryQuery,
   StorefrontDepartureListQuery,
   StorefrontProductExtensionsQuery,
   StorefrontPromotionalOfferListQuery,
 } from "./schemas.js"
 
 export type StorefrontDepartureFilters = StorefrontDepartureListQuery
+
+export type StorefrontDepartureItineraryFilters = StorefrontDepartureItineraryQuery
 
 export type StorefrontOfferFilters = StorefrontPromotionalOfferListQuery
 
@@ -21,8 +24,11 @@ export const storefrontQueryKeys = {
     [...storefrontQueryKeys.departures(), "detail", departureId] as const,
   productDepartures: (productId: string, filters: StorefrontDepartureFilters) =>
     [...storefrontQueryKeys.departures(), "product-list", productId, filters] as const,
-  departureItinerary: (productId: string, departureId: string) =>
-    [...storefrontQueryKeys.departure(departureId), "itinerary", productId] as const,
+  departureItinerary: (
+    productId: string,
+    departureId: string,
+    filters: StorefrontDepartureItineraryFilters,
+  ) => [...storefrontQueryKeys.departure(departureId), "itinerary", productId, filters] as const,
   departurePricePreview: (departureId: string) =>
     [...storefrontQueryKeys.departure(departureId), "price-preview"] as const,
 

--- a/packages/storefront-react/src/query-options.ts
+++ b/packages/storefront-react/src/query-options.ts
@@ -16,6 +16,7 @@ import {
 } from "./operations.js"
 import {
   type StorefrontDepartureFilters,
+  type StorefrontDepartureItineraryFilters,
   type StorefrontExtensionsFilters,
   type StorefrontOfferFilters,
   storefrontQueryKeys,
@@ -70,10 +71,11 @@ export function getStorefrontDepartureItineraryQueryOptions(
   client: FetchWithValidationOptions,
   productId: string,
   departureId: string,
+  filters: StorefrontDepartureItineraryFilters = {},
 ) {
   return queryOptions({
-    queryKey: storefrontQueryKeys.departureItinerary(productId, departureId),
-    queryFn: () => getStorefrontDepartureItinerary(client, productId, departureId),
+    queryKey: storefrontQueryKeys.departureItinerary(productId, departureId, filters),
+    queryFn: () => getStorefrontDepartureItinerary(client, productId, departureId, filters),
   })
 }
 

--- a/packages/storefront-react/src/schemas.ts
+++ b/packages/storefront-react/src/schemas.ts
@@ -1,4 +1,5 @@
 import {
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -34,6 +35,7 @@ export const singleEnvelope = <T extends z.ZodTypeAny>(item: T) => z.object({ da
 export const arrayEnvelope = <T extends z.ZodTypeAny>(item: T) => z.object({ data: z.array(item) })
 
 export {
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -120,6 +122,9 @@ export type StorefrontSettingsRecord = z.infer<typeof storefrontSettingsSchema>
 export type StorefrontSettingsInput = z.input<typeof storefrontSettingsInputSchema>
 export type StorefrontSettingsPatchInput = z.input<typeof storefrontSettingsPatchSchema>
 export type StorefrontDepartureRecord = z.infer<typeof storefrontDepartureSchema>
+export type StorefrontDepartureItineraryQuery = z.input<
+  typeof storefrontDepartureItineraryQuerySchema
+>
 export type StorefrontDepartureListQuery = z.input<typeof storefrontDepartureListQuerySchema>
 export type StorefrontDeparturePricePreviewInput = z.input<
   typeof storefrontDeparturePricePreviewInputSchema

--- a/packages/storefront-sdk/src/index.ts
+++ b/packages/storefront-sdk/src/index.ts
@@ -112,8 +112,11 @@ export function createVoyantStorefrontClient(options: VoyantStorefrontClientOpti
         productId: string,
         query?: Parameters<typeof listStorefrontProductExtensions>[2],
       ) => listStorefrontProductExtensions(client, productId, query),
-      getDepartureItinerary: (productId: string, departureId: string) =>
-        getStorefrontDepartureItinerary(client, productId, departureId),
+      getDepartureItinerary: (
+        productId: string,
+        departureId: string,
+        query?: Parameters<typeof getStorefrontDepartureItinerary>[3],
+      ) => getStorefrontDepartureItinerary(client, productId, departureId, query),
       listProductOffers: (
         productId: string,
         query?: Parameters<typeof listStorefrontProductOffers>[2],

--- a/packages/storefront-sdk/src/operations.ts
+++ b/packages/storefront-sdk/src/operations.ts
@@ -33,6 +33,7 @@ import {
   publicUpdateBookingSessionSchema,
   publicUpsertBookingSessionStateSchema,
   type StorefrontBookingSessionBootstrapInput,
+  type StorefrontDepartureItineraryQuery,
   type StorefrontDepartureListQuery,
   type StorefrontDeparturePricePreviewInput,
   type StorefrontLeadIntakeInput,
@@ -41,6 +42,7 @@ import {
   type StorefrontProductExtensionsQuery,
   type StorefrontPromotionalOfferListQuery,
   storefrontBookingSessionBootstrapInputSchema,
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItineraryResponseSchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -175,11 +177,16 @@ export function getStorefrontDepartureItinerary(
   client: ResolvedClientOptions,
   productId: string,
   departureId: string,
+  query?: StorefrontDepartureItineraryQuery,
 ) {
+  const parsed = query ? storefrontDepartureItineraryQuerySchema.parse(query) : undefined
   return storefrontFetchWithValidation(
-    `/v1/public/products/${encodeURIComponent(productId)}/departures/${encodeURIComponent(
-      departureId,
-    )}/itinerary`,
+    withStorefrontQueryParams(
+      `/v1/public/products/${encodeURIComponent(productId)}/departures/${encodeURIComponent(
+        departureId,
+      )}/itinerary`,
+      parsed,
+    ),
     storefrontDepartureItineraryResponseSchema,
     client,
   ).then((response) => response.data)

--- a/packages/storefront-sdk/src/schemas.ts
+++ b/packages/storefront-sdk/src/schemas.ts
@@ -22,6 +22,7 @@ import {
 import {
   storefrontBookingSessionBootstrapInputSchema,
   storefrontBookingSessionBootstrapSchema,
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -78,6 +79,7 @@ export {
   publicUpsertBookingSessionStateSchema,
   storefrontBookingSessionBootstrapInputSchema,
   storefrontBookingSessionBootstrapSchema,
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -172,6 +174,9 @@ export type StorefrontNewsletterSubscribeRecord = z.infer<
   typeof storefrontNewsletterSubscribeResponseSchema
 >
 export type StorefrontDepartureRecord = z.infer<typeof storefrontDepartureSchema>
+export type StorefrontDepartureItineraryQuery = z.input<
+  typeof storefrontDepartureItineraryQuerySchema
+>
 export type StorefrontDepartureListQuery = z.input<typeof storefrontDepartureListQuerySchema>
 export type StorefrontDeparturePricePreviewInput = z.input<
   typeof storefrontDeparturePricePreviewInputSchema

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -10,6 +10,7 @@ import {
   idempotencyKey,
   openApiValidationHook,
   parseJsonBody,
+  parseQuery,
   type VoyantBindings,
   type VoyantVariables,
 } from "@voyant-travel/hono"
@@ -31,6 +32,7 @@ import {
   type StorefrontNewsletterSubscribeInput,
   storefrontBookingSessionBootstrapInputSchema,
   storefrontBookingSessionCompatBootstrapInputSchema,
+  storefrontDepartureItineraryQuerySchema,
   storefrontDepartureItinerarySchema,
   storefrontDepartureListQuerySchema,
   storefrontDepartureListResponseSchema,
@@ -269,6 +271,7 @@ const departureItineraryRoute = createRoute({
   path: "/products/{productId}/departures/{departureId}/itinerary",
   request: {
     params: z.object({ productId: z.string(), departureId: z.string() }),
+    query: storefrontDepartureItineraryQuerySchema,
   },
   responses: {
     200: {
@@ -637,8 +640,10 @@ export function createStorefrontPublicRoutes(options?: StorefrontServiceOptions)
     })
     .openapi(departureItineraryRoute, async (c) => {
       const { productId, departureId } = c.req.valid("param")
+      const query = parseQuery(c, storefrontDepartureItineraryQuerySchema)
       const itinerary = await storefrontService.getDepartureItinerary(c.get("db" as never), {
         departureId,
+        languageTag: query.languageTag ?? query.lang,
         productId,
       })
 

--- a/packages/storefront/src/service-boundary-sql.ts
+++ b/packages/storefront/src/service-boundary-sql.ts
@@ -495,15 +495,23 @@ export async function listOptionUnitFacts(
 export async function listItineraryDays(
   db: PostgresJsDatabase,
   itineraryId: string,
+  languageTag?: string | null,
 ): Promise<StorefrontItineraryDay[]> {
   return executeBoundaryRows<StorefrontItineraryDay>(
     db,
-    // agent-quality: raw-sql reviewed -- owner: storefront; itinerary id is parameter-bound and rows are read-only.
+    // agent-quality: raw-sql reviewed -- owner: storefront; itinerary id and optional language tag are parameter-bound and rows are read-only.
     sql`
-      SELECT id, day_number AS "dayNumber", title, description
-      FROM product_days
-      WHERE itinerary_id = ${itineraryId}
-      ORDER BY day_number ASC
+      SELECT
+        d.id,
+        d.day_number AS "dayNumber",
+        COALESCE(dt.title, d.title) AS title,
+        COALESCE(dt.description, d.description) AS description
+      FROM product_days d
+      LEFT JOIN product_day_translations dt
+        ON dt.day_id = d.id
+       AND dt.language_tag = ${languageTag ?? null}
+      WHERE d.itinerary_id = ${itineraryId}
+      ORDER BY d.day_number ASC
     `,
   )
 }
@@ -511,23 +519,27 @@ export async function listItineraryDays(
 export async function listItineraryDayServices(
   db: PostgresJsDatabase,
   dayIds: string[],
+  languageTag?: string | null,
 ): Promise<StorefrontItineraryDayService[]> {
   const uniqueIds = [...new Set(dayIds)].filter(Boolean)
   if (uniqueIds.length === 0) return []
 
   return executeBoundaryRows<StorefrontItineraryDayService>(
     db,
-    // agent-quality: raw-sql reviewed -- owner: storefront; day ids are parameter-bound and service rows are read-only.
+    // agent-quality: raw-sql reviewed -- owner: storefront; day ids and optional language tag are parameter-bound and service rows are read-only.
     sql`
       SELECT
-        id,
-        day_id AS "dayId",
-        name,
-        description,
-        sort_order AS "sortOrder"
-      FROM product_day_services
-      WHERE day_id IN (${sqlList(uniqueIds)})
-      ORDER BY sort_order ASC, created_at ASC
+        s.id,
+        s.day_id AS "dayId",
+        COALESCE(st.name, s.name) AS name,
+        COALESCE(st.description, s.description) AS description,
+        s.sort_order AS "sortOrder"
+      FROM product_day_services s
+      LEFT JOIN product_day_service_translations st
+        ON st.service_id = s.id
+       AND st.language_tag = ${languageTag ?? null}
+      WHERE s.day_id IN (${sqlList(uniqueIds)})
+      ORDER BY s.sort_order ASC, s.created_at ASC
     `,
   )
 }

--- a/packages/storefront/src/service-departures.ts
+++ b/packages/storefront/src/service-departures.ts
@@ -249,7 +249,7 @@ export async function getStorefrontProductAvailabilitySummary(
 
 export async function getStorefrontDepartureItinerary(
   db: PostgresJsDatabase,
-  input: { departureId: string; productId: string },
+  input: { departureId: string; productId: string; languageTag?: string | null },
 ) {
   const [slot] = await listSlots(db, {
     productId: input.productId,
@@ -263,7 +263,7 @@ export async function getStorefrontDepartureItinerary(
     return null
   }
 
-  const days = await listItineraryDays(db, itineraryId)
+  const days = await listItineraryDays(db, itineraryId, input.languageTag)
 
   if (days.length === 0) {
     return null
@@ -271,7 +271,7 @@ export async function getStorefrontDepartureItinerary(
 
   const dayIds = days.map((day) => day.id)
   const [services, dayMedia] = await Promise.all([
-    listItineraryDayServices(db, dayIds),
+    listItineraryDayServices(db, dayIds, input.languageTag),
     listItineraryDayMedia(db, { productId: input.productId, dayIds }),
   ])
 

--- a/packages/storefront/src/service.ts
+++ b/packages/storefront/src/service.ts
@@ -511,7 +511,7 @@ export function createStorefrontService(options?: StorefrontServiceOptions) {
     },
     getDepartureItinerary(
       db: PostgresJsDatabase,
-      input: { departureId: string; productId: string },
+      input: { departureId: string; productId: string; languageTag?: string | null },
     ) {
       return getStorefrontDepartureItinerary(db, input)
     },

--- a/packages/storefront/src/validation/departures.ts
+++ b/packages/storefront/src/validation/departures.ts
@@ -540,6 +540,11 @@ export const storefrontDepartureItinerarySegmentSchema = z.object({
   description: z.string().nullable(),
 })
 
+export const storefrontDepartureItineraryQuerySchema = z.object({
+  languageTag: languageTagSchema.optional(),
+  lang: languageTagSchema.optional(),
+})
+
 export const storefrontDepartureItineraryDaySchema = z.object({
   id: z.string(),
   title: z.string(),
@@ -559,6 +564,9 @@ export const storefrontDepartureItinerarySchema = z.object({
 })
 
 export type StorefrontDepartureListQuery = z.infer<typeof storefrontDepartureListQuerySchema>
+export type StorefrontDepartureItineraryQuery = z.infer<
+  typeof storefrontDepartureItineraryQuerySchema
+>
 export type StorefrontProductAvailabilitySummaryQuery = z.infer<
   typeof storefrontProductAvailabilitySummaryQuerySchema
 >

--- a/packages/storefront/tests/integration/public-routes.test.ts
+++ b/packages/storefront/tests/integration/public-routes.test.ts
@@ -15,7 +15,9 @@ import { productExtras } from "@voyant-travel/inventory/extras"
 import {
   optionUnits,
   productDayServices,
+  productDayServiceTranslations,
   productDays,
+  productDayTranslations,
   productItineraries,
   productLocations,
   productMedia,
@@ -1200,6 +1202,20 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
       })
       .returning()
 
+    await db.insert(productDayTranslations).values({
+      dayId: dayOne.id,
+      languageTag: "ro",
+      title: "Sosire",
+      description: "Transfer si cina de bun venit.",
+    })
+
+    await db.insert(productDayServiceTranslations).values({
+      serviceId: service.id,
+      languageTag: "ro",
+      name: "Croaziera la apus",
+      description: "Navigare prin port la ora de aur.",
+    })
+
     await db.insert(productMedia).values({
       productId: product.id,
       dayId: dayOne.id,
@@ -1301,6 +1317,34 @@ describe.skipIf(!DB_AVAILABLE)("Storefront public routes", () => {
                 id: service.id,
                 title: "Sunset cruise",
                 description: "Harbor sail at golden hour.",
+              },
+            ],
+          },
+        ],
+      },
+    })
+
+    const localizedItineraryRes = await app.request(
+      `/products/${product.id}/departures/dep_compat_123/itinerary?lang=ro`,
+    )
+    expect(localizedItineraryRes.status).toBe(200)
+    expect(await localizedItineraryRes.json()).toEqual({
+      data: {
+        id: "dep_compat_123",
+        itineraryId: defaultItinerary.id,
+        days: [
+          {
+            id: dayOne.id,
+            title: "Sosire",
+            description: "Transfer si cina de bun venit.",
+            thumbnail: {
+              url: "https://cdn.example.com/day-1.jpg",
+            },
+            segments: [
+              {
+                id: service.id,
+                title: "Croaziera la apus",
+                description: "Navigare prin port la ora de aur.",
               },
             ],
           },

--- a/starters/operator/openapi/storefront/storefront.json
+++ b/starters/operator/openapi/storefront/storefront.json
@@ -3740,6 +3740,24 @@
             "required": true,
             "name": "departureId",
             "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+            },
+            "required": false,
+            "name": "languageTag",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Za-z]{2,3}(?:-[A-Za-z0-9]{2,8})*$"
+            },
+            "required": false,
+            "name": "lang",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
## Summary

- Add `languageTag` and `lang` query support to the public departure itinerary route.
- Resolve itinerary day and day-service translations with fallback to base content.
- Thread itinerary locale filters through storefront-react and storefront-sdk clients.
- Regenerate storefront OpenAPI snapshots and add a patch changeset.

Closes #2900.

## Validation

- `pnpm --filter @voyant-travel/storefront typecheck`
- `pnpm --filter @voyant-travel/storefront-react typecheck`
- `pnpm --filter @voyant-travel/storefront-sdk typecheck`
- `pnpm --filter @voyant-travel/storefront lint` (passes with existing warnings in untouched files)
- `pnpm --filter @voyant-travel/storefront-react lint`
- `pnpm --filter @voyant-travel/storefront-sdk lint`
- `pnpm --filter @voyant-travel/storefront test`
- `pnpm --filter @voyant-travel/storefront-react test`
- `pnpm --filter @voyant-travel/storefront-sdk test`
- `pnpm --filter @voyant-travel/openapi generate`
- `pnpm --dir starters/operator generate:openapi`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (passes with file-size warnings on existing large touched files)
- Commit hook broad lint/typecheck passed.
- Pre-push test hook passed.

Note: `pnpm verify:fast` was run once and failed in `operator#test` due timeouts/assertion in `starters/operator/src/workflows-import.test.ts` and `starters/operator/src/api/lib/booking-engine-runtime.test.ts`; those same tests passed during the subsequent pre-push test hook.