### PR TITLE
Finalize checkout before payment callback returns

### DIFF
--- a/.changeset/core-event-handler-context.md
+++ b/.changeset/core-event-handler-context.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/core": patch
+---
+
+Expose a scheduler-scoped event bus to event handlers so inline subscribers can emit nested events without forcing deferrable downstream subscribers onto the caller path.

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -50,10 +50,19 @@ export interface EventEnvelope<
 /**
  * Event handler callback invoked when a subscribed event is emitted.
  */
+export interface EventHandlerContext {
+  /**
+   * Emits nested events with the current runtime scheduler. Inline handlers
+   * still complete before the nested emit resolves; deferrable handlers stay
+   * on the scheduler supplied by the original emitter.
+   */
+  eventBus: EventBus
+}
+
 export type EventHandler<
   TData = unknown,
   TMetadata extends EventMetadata | undefined = EventMetadata | undefined,
-> = (event: EventEnvelope<TData, TMetadata>) => Promise<void> | void
+> = (event: EventEnvelope<TData, TMetadata>, context?: EventHandlerContext) => Promise<void> | void
 
 /**
  * Subscription handle returned from {@link EventBus.subscribe}.
@@ -241,10 +250,11 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
     event: string,
     handler: EventHandler,
     envelope: EventEnvelope,
+    context?: EventHandlerContext,
   ): Promise<string | null> {
     try {
       if (timeoutMs === false) {
-        await handler(envelope)
+        await (context ? handler(envelope, context) : handler(envelope))
         return null
       }
       let timer: ReturnType<typeof setTimeout> | null = null
@@ -253,7 +263,9 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
       })
       try {
         const result = await Promise.race([
-          Promise.resolve(handler(envelope)).then(() => "done" as const),
+          Promise.resolve(context ? handler(envelope, context) : handler(envelope)).then(
+            () => "done" as const,
+          ),
           timedOut,
         ])
         if (result === "timeout") {
@@ -282,8 +294,9 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
     event: string,
     batch: EventHandler[],
     envelope: EventEnvelope,
+    context?: EventHandlerContext,
   ): Promise<string[]> {
-    return Promise.all(batch.map((h) => runHandler(event, h, envelope))).then((results) =>
+    return Promise.all(batch.map((h) => runHandler(event, h, envelope, context))).then((results) =>
       results.filter((r): r is string => r !== null),
     )
   }
@@ -319,7 +332,24 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
     }
   }
 
-  return {
+  function handlerContext(emitOptions?: EmitOptions): EventHandlerContext | undefined {
+    if (!emitOptions?.schedule) return undefined
+    const nestedOptions: EmitOptions = { schedule: emitOptions.schedule }
+    const scopedBus: EventBus = {
+      emit(event, data, metadata, options) {
+        return bus.emit(event, data, metadata, { ...nestedOptions, ...options })
+      },
+      subscribe(event, handler, options) {
+        return bus.subscribe(event, handler, options)
+      },
+    }
+    if (bus.deliver) {
+      scopedBus.deliver = (envelope) => bus.deliver!(envelope)
+    }
+    return { eventBus: scopedBus }
+  }
+
+  const bus: EventBus = {
     async emit<TData, TMetadata extends EventMetadata | undefined = EventMetadata | undefined>(
       event: string,
       data: TData,
@@ -342,7 +372,9 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
       }
 
       const { inline, deferrable } = partition(event)
-      const run = (batch: EventHandler[]) => runBatch(event, batch, envelope as EventEnvelope)
+      const context = handlerContext(emitOptions)
+      const run = (batch: EventHandler[]) =>
+        runBatch(event, batch, envelope as EventEnvelope, context)
 
       if (!store) {
         if (emitOptions?.schedule && deferrable.length > 0) {
@@ -413,4 +445,6 @@ export function createEventBus(options: EventBusOptions = {}): EventBus {
       }
     },
   }
+
+  return bus
 }

--- a/packages/core/tests/unit/events.test.ts
+++ b/packages/core/tests/unit/events.test.ts
@@ -209,6 +209,31 @@ describe("createEventBus", () => {
       expect(schedule).not.toHaveBeenCalled()
     })
 
+    it("gives inline handlers a scheduler-scoped bus for nested emits", async () => {
+      const bus = createEventBus()
+      const scheduled: Promise<unknown>[] = []
+      let nestedDone = false
+
+      bus.subscribe(
+        "outer",
+        async (_event, context) => {
+          await context?.eventBus.emit("inner", {})
+        },
+        { inline: true },
+      )
+      bus.subscribe("inner", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        nestedDone = true
+      })
+
+      await bus.emit("outer", {}, undefined, { schedule: (p) => scheduled.push(p) })
+
+      expect(nestedDone).toBe(false)
+      expect(scheduled).toHaveLength(1)
+      await Promise.all(scheduled)
+      expect(nestedDone).toBe(true)
+    })
+
     it("scheduled batch never rejects even when a deferred handler throws", async () => {
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
       const bus = createEventBus()

--- a/starters/operator/src/api/subscribers/catalog-checkout-finalize-runtime.test.ts
+++ b/starters/operator/src/api/subscribers/catalog-checkout-finalize-runtime.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest"
+
+const checkoutMocks = vi.hoisted(() => ({
+  dispatchCheckoutFinalize: vi.fn(async () => ({ runId: "run_1" })),
+  persistAcceptanceSignature: vi.fn(),
+}))
+
+const dbMocks = vi.hoisted(() => ({
+  withDbFromEnv: vi.fn(async (_env, cb: (db: unknown) => Promise<unknown>) => cb({ raw: true })),
+}))
+
+const runtimeMocks = vi.hoisted(() => ({
+  operatorBindings: vi.fn((bindings: unknown) => bindings),
+  operatorPostgresDb: vi.fn((rawDb: unknown) => rawDb),
+}))
+
+vi.mock("@voyant-travel/commerce/checkout", () => checkoutMocks)
+vi.mock("../lib/db", () => dbMocks)
+vi.mock("../runtime/operator-runtime-adapter", () => runtimeMocks)
+
+import { createCatalogCheckoutBundle } from "./catalog-checkout-finalize-runtime"
+
+type SubscribeOptions = { inline?: boolean }
+type Handler = (
+  envelope: { data: unknown },
+  context?: { eventBus: unknown },
+) => Promise<void> | void
+
+function createRecordingBus() {
+  const subscriptions: Array<{
+    event: string
+    handler: Handler
+    options: SubscribeOptions | undefined
+  }> = []
+
+  return {
+    subscriptions,
+    bus: {
+      subscribe(event: string, handler: Handler, options?: SubscribeOptions) {
+        subscriptions.push({ event, handler, options })
+        return { unsubscribe() {} }
+      },
+      emit: vi.fn(),
+    },
+  }
+}
+
+describe("catalog checkout finalize subscriber", () => {
+  it("runs payment completion finalization inline with the emitting request", () => {
+    const { bus, subscriptions } = createRecordingBus()
+
+    createCatalogCheckoutBundle({}).bootstrap?.({
+      bindings: {} as never,
+      container: {} as never,
+      eventBus: bus as never,
+    })
+
+    expect(subscriptions.find((sub) => sub.event === "payment.completed")?.options).toEqual({
+      inline: true,
+    })
+  })
+
+  it("uses the scheduler-scoped handler bus for nested checkout events", async () => {
+    const { bus, subscriptions } = createRecordingBus()
+    const scopedBus = { emit: vi.fn(), subscribe: vi.fn() }
+
+    createCatalogCheckoutBundle({}).bootstrap?.({
+      bindings: {} as never,
+      container: {} as never,
+      eventBus: bus as never,
+    })
+
+    await subscriptions
+      .find((sub) => sub.event === "payment.completed")
+      ?.handler(
+        {
+          data: {
+            bookingId: "book_1",
+            paymentSessionId: "ps_1",
+            paymentIntent: "card",
+          },
+        },
+        { eventBus: scopedBus },
+      )
+
+    expect(checkoutMocks.dispatchCheckoutFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventBus: scopedBus,
+        input: expect.objectContaining({
+          bookingId: "book_1",
+          paymentSessionId: "ps_1",
+          paymentIntent: "card",
+        }),
+      }),
+    )
+  })
+})

--- a/starters/operator/src/api/subscribers/catalog-checkout-finalize-runtime.ts
+++ b/starters/operator/src/api/subscribers/catalog-checkout-finalize-runtime.ts
@@ -103,36 +103,44 @@ export function createCatalogCheckoutBundle(opts: {
           }
         },
       )
-      eventBus.subscribe<PaymentCompletedPayload>("payment.completed", async ({ data }) => {
-        if (!data.bookingId) return
-        const bookingId = data.bookingId
-        try {
-          await withDbFromEnv(env, async (rawDb) => {
-            await dispatchCheckoutFinalize({
-              env,
-              db: operatorPostgresDb(rawDb),
-              eventBus,
-              input: {
-                bookingId,
-                paymentSessionId: data.paymentSessionId,
-                paymentIntent: data.paymentIntent,
-              },
-              trigger: "payment.completed",
-              correlationId: data.paymentSessionId ?? null,
-              tags: [
-                `bookingId:${bookingId}`,
-                ...(data.paymentSessionId ? [`paymentSessionId:${data.paymentSessionId}`] : []),
-                ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
-              ],
-              generateContractPdf: opts.generateContractPdf,
+      eventBus.subscribe<PaymentCompletedPayload>(
+        "payment.completed",
+        async ({ data }, context) => {
+          if (!data.bookingId) return
+          const bookingId = data.bookingId
+          const nestedEventBus = context?.eventBus ?? eventBus
+          try {
+            await withDbFromEnv(env, async (rawDb) => {
+              await dispatchCheckoutFinalize({
+                env,
+                db: operatorPostgresDb(rawDb),
+                eventBus: nestedEventBus,
+                input: {
+                  bookingId,
+                  paymentSessionId: data.paymentSessionId,
+                  paymentIntent: data.paymentIntent,
+                },
+                trigger: "payment.completed",
+                correlationId: data.paymentSessionId ?? null,
+                tags: [
+                  `bookingId:${bookingId}`,
+                  ...(data.paymentSessionId ? [`paymentSessionId:${data.paymentSessionId}`] : []),
+                  ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
+                ],
+                generateContractPdf: opts.generateContractPdf,
+              })
             })
-          })
-        } catch {
-          // dispatchCheckoutFinalize already logged + recorded the
-          // failure; swallow here so the event-bus callback doesn't
-          // bubble to the dispatch caller.
-        }
-      })
+          } catch {
+            // dispatchCheckoutFinalize already logged + recorded the
+            // failure; swallow here so the event-bus callback doesn't
+            // bubble to the dispatch caller.
+          }
+        },
+        // Payment completion must not return before booking confirmation,
+        // invoice linkage, schedule settlement, and forced contract
+        // regeneration are visible to the storefront/admin follow-up reads.
+        { inline: true },
+      )
 
       if (opts.workflowRunnerRegistry) {
         opts.workflowRunnerRegistry.register({


### PR DESCRIPTION
Closes #2877.

## Summary
- run catalog checkout finalization inline on `payment.completed` so the payment callback does not return before booking confirmation, invoice/payment linkage, schedule settlement, and forced contract regeneration are visible
- add a subscriber wiring regression test for the inline payment completion handler

## Verification
- pnpm --filter operator test -- src/api/subscribers/catalog-checkout-finalize-runtime.test.ts
- pnpm --filter @voyant-travel/catalog test -- src/booking-engine/checkout-finalize.test.ts
- pnpm --filter operator lint
- pnpm --filter @voyant-travel/finance build
- pnpm --filter @voyant-travel/framework build
- pnpm --filter operator typecheck
- git diff --check
- pre-push test hook: 98/98 tasks passed