### PR TITLE
Show paid cancellation settlement notice

### DIFF
--- a/.changeset/paid-cancellation-dialog-settlement.md
+++ b/.changeset/paid-cancellation-dialog-settlement.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Show an explicit settlement-review notice when cancelling bookings that already have recorded payments.

--- a/packages/bookings-react/src/admin/booking-detail-host.tsx
+++ b/packages/bookings-react/src/admin/booking-detail-host.tsx
@@ -10,7 +10,11 @@ import {
   useLocale,
   useOperatorAdminMessages,
 } from "@voyant-travel/admin"
-import { useInvoices, usePaymentMutation } from "@voyant-travel/finance-react"
+import {
+  useAdminBookingPayments,
+  useInvoices,
+  usePaymentMutation,
+} from "@voyant-travel/finance-react"
 import { Sheet, SheetContent } from "@voyant-travel/ui/components/sheet"
 import { type ReactNode, useState } from "react"
 import {
@@ -161,6 +165,7 @@ export function BookingDetailHost({
   // Sum customer payments across this booking's non-credit-note,
   // non-draft invoices.
   const { data: invoicesData } = useInvoices({ bookingId: id, limit: 20 })
+  const { data: adminPaymentsData } = useAdminBookingPayments(id)
   const paidAmountCents = invoicesData?.data
     ? invoicesData.data
         .filter((inv) => {
@@ -169,6 +174,10 @@ export function BookingDetailHost({
         })
         .reduce((sum, inv) => sum + (inv.paidCents ?? 0), 0)
     : null
+  const hasRecordedPayment =
+    adminPaymentsData?.data.payments.some(
+      (payment) => payment.status === "completed" && payment.amountCents > 0,
+    ) ?? false
   const fullyPaidReason =
     booking &&
     booking.sellAmountCents != null &&
@@ -220,6 +229,7 @@ export function BookingDetailHost({
         recordPaymentDisabledReason={fullyPaidReason}
         addScheduleDisabledReason={fullyPaidReason}
         paidAmountCents={paidAmountCents}
+        hasRecordedPayment={hasRecordedPayment}
         onItemResourceOpen={(kind, resourceId) => {
           if (kind === "product") {
             navigateTo("product.detail", { productId: resourceId })

--- a/packages/bookings-react/src/components/booking-activity-timeline.tsx
+++ b/packages/bookings-react/src/components/booking-activity-timeline.tsx
@@ -276,6 +276,7 @@ function TimelinePagination({
       <PaginationContent>
         <PaginationItem>
           <PaginationPrevious
+            size="default"
             aria-disabled={!canPrev}
             tabIndex={canPrev ? 0 : -1}
             className={canPrev ? undefined : "pointer-events-none opacity-50"}
@@ -289,6 +290,7 @@ function TimelinePagination({
         {pages.map((idx) => (
           <PaginationItem key={idx}>
             <PaginationLink
+              size="icon"
               isActive={idx === pageIndex}
               onClick={(event) => {
                 event.preventDefault()
@@ -302,6 +304,7 @@ function TimelinePagination({
         ))}
         <PaginationItem>
           <PaginationNext
+            size="default"
             aria-disabled={!canNext}
             tabIndex={canNext ? 0 : -1}
             className={canNext ? undefined : "pointer-events-none opacity-50"}

--- a/packages/bookings-react/src/components/booking-cancellation-dialog.tsx
+++ b/packages/bookings-react/src/components/booking-cancellation-dialog.tsx
@@ -39,6 +39,14 @@ export interface BookingCancellationDialogProps {
   onOpenChange: (open: boolean) => void
   booking: BookingRecord
   /**
+   * Amount already paid against the booking, in cents of `booking.sellCurrency`.
+   * When present and greater than zero, the dialog makes the finance settlement
+   * consequence explicit before cancellation.
+   */
+  paidAmountCents?: number | null
+  /** True when the host knows this booking has at least one recorded payment. */
+  hasRecordedPayment?: boolean
+  /**
    * Product ID used to resolve the applicable cancellation policy.
    *
    * Leave unset (or pass `undefined`) to auto-resolve from the booking's items
@@ -54,6 +62,8 @@ export function BookingCancellationDialog({
   open,
   onOpenChange,
   booking,
+  paidAmountCents,
+  hasRecordedPayment,
   productId,
   onSuccess,
 }: BookingCancellationDialogProps) {
@@ -113,6 +123,7 @@ export function BookingCancellationDialog({
   }
 
   const total = booking.sellAmountCents
+  const showPaidSettlementNotice = hasRecordedPayment ?? (paidAmountCents ?? 0) > 0
   const refund = evaluation?.refundCents ?? 0
   const penalty = total != null ? Math.max(0, total - refund) : 0
   const formatAmount = React.useCallback(
@@ -248,6 +259,20 @@ export function BookingCancellationDialog({
                   {messages.bookingCancellationDialog.policy.noTotalAmount}
                 </p>
               ) : null}
+            </div>
+          )}
+
+          {showPaidSettlementNotice && (
+            <div className="rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-950">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+                <div className="space-y-1">
+                  <div className="font-medium">
+                    {messages.bookingCancellationDialog.paidSettlement.title}
+                  </div>
+                  <p>{messages.bookingCancellationDialog.paidSettlement.description}</p>
+                </div>
+              </div>
             </div>
           )}
 

--- a/packages/bookings-react/src/components/booking-detail-page.tsx
+++ b/packages/bookings-react/src/components/booking-detail-page.tsx
@@ -145,6 +145,12 @@ export interface BookingDetailPageProps {
    */
   paidAmountCents?: number | null
   /**
+   * True when the host has found at least one recorded customer payment. Kept
+   * separate from `paidAmountCents` because host invoice summaries can be
+   * paginated while the cancellation settlement path checks all paid invoices.
+   */
+  hasRecordedPayment?: boolean
+  /**
    * Open a linked resource referenced by a booking item (product or
    * availability slot) in the host app. When omitted, the item-snapshot
    * sheet renders the names as plain text.
@@ -190,6 +196,7 @@ export function BookingDetailPage({
   recordPaymentDisabledReason,
   addScheduleDisabledReason,
   paidAmountCents,
+  hasRecordedPayment,
   onItemResourceOpen,
   onPersonOpen,
   onOrganizationOpen,
@@ -604,6 +611,8 @@ export function BookingDetailPage({
         open={cancelDialogOpen}
         onOpenChange={setCancelDialogOpen}
         booking={booking}
+        paidAmountCents={paidAmountCents}
+        hasRecordedPayment={hasRecordedPayment}
       />
 
       <AlertDialog

--- a/packages/bookings-react/src/components/booking-list.tsx
+++ b/packages/bookings-react/src/components/booking-list.tsx
@@ -552,6 +552,7 @@ function BookingListPagination({
           <PaginationPrevious
             href="#"
             text={previousLabel}
+            size="default"
             aria-disabled={!canPrev}
             tabIndex={canPrev ? 0 : -1}
             className={canPrev ? undefined : "pointer-events-none opacity-50"}
@@ -573,6 +574,7 @@ function BookingListPagination({
             ) : (
               <PaginationLink
                 href="#"
+                size="icon"
                 isActive={entry === page}
                 onClick={(event) => {
                   event.preventDefault()
@@ -588,6 +590,7 @@ function BookingListPagination({
           <PaginationNext
             href="#"
             text={nextLabel}
+            size="default"
             aria-disabled={!canNext}
             tabIndex={canNext ? 0 : -1}
             className={canNext ? undefined : "pointer-events-none opacity-50"}

--- a/packages/bookings-react/src/i18n/en-operations.ts
+++ b/packages/bookings-react/src/i18n/en-operations.ts
@@ -212,9 +212,15 @@ export const bookingsUiEnOperations = {
       rule: "Rule",
       resolving: "Resolving cancellation policy...",
       missing: "No cancellation policy configured for this booking.",
-      missingHint: "Proceeding will cancel without a refund preview.",
+      missingHint:
+        "Proceeding will cancel without a refund preview. Paid bookings will be marked for settlement review.",
       calculating: "Calculating refund...",
       noTotalAmount: "Booking has no total amount. Refund cannot be calculated.",
+    },
+    paidSettlement: {
+      title: "Paid booking settlement required",
+      description:
+        "Cancelling keeps existing invoices and payments intact and records an action-required finance note to review a refund, credit note, or no-refund decision.",
     },
     refundTypeLabels: {
       cash: "Cash refund",

--- a/packages/bookings-react/src/i18n/messages-operations.ts
+++ b/packages/bookings-react/src/i18n/messages-operations.ts
@@ -210,6 +210,10 @@ export type BookingsUiOperationsMessages = {
       calculating: string
       noTotalAmount: string
     }
+    paidSettlement: {
+      title: string
+      description: string
+    }
     refundTypeLabels: Record<"cash" | "credit" | "cash_or_credit" | "none", string>
     fields: {
       reason: string

--- a/packages/bookings-react/src/i18n/ro-operations.ts
+++ b/packages/bookings-react/src/i18n/ro-operations.ts
@@ -211,9 +211,15 @@ export const bookingsUiRoOperations = {
       rule: "Regula",
       resolving: "Se rezolva politica de anulare...",
       missing: "Nu exista o politica de anulare configurata pentru aceasta rezervare.",
-      missingHint: "Continuarea va anula rezervarea fara o previzualizare a rambursarii.",
+      missingHint:
+        "Continuarea va anula rezervarea fara o previzualizare a rambursarii. Rezervarile platite vor fi marcate pentru revizuirea decontarii.",
       calculating: "Se calculeaza rambursarea...",
       noTotalAmount: "Rezervarea nu are o suma totala. Rambursarea nu poate fi calculata.",
+    },
+    paidSettlement: {
+      title: "Decontarea rezervarii platite este necesara",
+      description:
+        "Anularea pastreaza facturile si platile existente si inregistreaza o nota financiara care cere revizuirea rambursarii, notei de credit sau deciziei fara rambursare.",
     },
     refundTypeLabels: {
       cash: "Rambursare cash",

--- a/packages/bookings-react/tests/unit/booking-cancellation-dialog.test.tsx
+++ b/packages/bookings-react/tests/unit/booking-cancellation-dialog.test.tsx
@@ -1,0 +1,85 @@
+import type { ReactNode } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const legalHooks = vi.hoisted(() => ({
+  useResolvePolicy: vi.fn(),
+  useEvaluateCancellation: vi.fn(),
+}))
+
+const bookingHooks = vi.hoisted(() => ({
+  useBookingCancelMutation: vi.fn(),
+  useBookingPrimaryProduct: vi.fn(),
+}))
+
+vi.mock("@voyant-travel/legal-react", () => ({
+  useResolvePolicy: legalHooks.useResolvePolicy,
+  useEvaluateCancellation: legalHooks.useEvaluateCancellation,
+}))
+
+vi.mock("@voyant-travel/ui/components", () => ({
+  Badge: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Button: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+  Dialog: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogBody: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogContent: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children?: ReactNode }) => <footer>{children}</footer>,
+  DialogHeader: ({ children }: { children?: ReactNode }) => <header>{children}</header>,
+  DialogTitle: ({ children }: { children?: ReactNode }) => <h1>{children}</h1>,
+  Label: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  Textarea: () => <textarea />,
+}))
+
+vi.mock("../../src/index.js", () => ({
+  useBookingCancelMutation: bookingHooks.useBookingCancelMutation,
+  useBookingPrimaryProduct: bookingHooks.useBookingPrimaryProduct,
+}))
+
+import { BookingCancellationDialog } from "../../src/components/booking-cancellation-dialog.js"
+import type { BookingRecord } from "../../src/schemas.js"
+
+beforeEach(() => {
+  legalHooks.useResolvePolicy.mockReturnValue({ data: null, isLoading: false })
+  legalHooks.useEvaluateCancellation.mockReturnValue({ data: null, isFetching: false })
+  bookingHooks.useBookingPrimaryProduct.mockReturnValue({ productId: null })
+  bookingHooks.useBookingCancelMutation.mockReturnValue({
+    mutateAsync: vi.fn(),
+    isPending: false,
+    error: null,
+  })
+})
+
+describe("BookingCancellationDialog", () => {
+  it("warns operators that paid cancellations require settlement review", () => {
+    const html = renderToStaticMarkup(
+      <BookingCancellationDialog
+        open
+        onOpenChange={() => {}}
+        booking={bookingRecord}
+        paidAmountCents={0}
+        hasRecordedPayment
+      />,
+    )
+
+    expect(html).toContain("Paid booking settlement required")
+    expect(html).toContain("refund, credit note, or no-refund decision")
+  })
+})
+
+const bookingRecord: BookingRecord = {
+  id: "book_1",
+  bookingNumber: "BK-1",
+  status: "confirmed",
+  personId: null,
+  organizationId: null,
+  sellCurrency: "GBP",
+  sellAmountCents: 12000,
+  costAmountCents: null,
+  marginPercent: null,
+  startDate: null,
+  endDate: null,
+  pax: 1,
+  internalNotes: null,
+  createdAt: "2026-07-04T08:00:00.000Z",
+  updatedAt: "2026-07-04T08:00:00.000Z",
+}


### PR DESCRIPTION
Closes #2881.

## Summary
- pass the booking detail paid amount into the cancellation dialog
- show an explicit paid-cancellation settlement notice before confirmation, explaining that invoices/payments stay intact and an action-required finance note is recorded for refund, credit-note, or no-refund review
- update missing-policy copy so no-refund-preview cancellations no longer look silent for paid bookings
- add a bookings-react regression test for the paid cancellation notice

## Context
#2892 added backend reason persistence and finance-note settlement recording. This follow-up closes the remaining admin UX gap from the retest by surfacing that consequence in the cancellation flow before the operator confirms.

## Verification
- pnpm --filter operator test -- src/api/subscribers/booking-cancellation-settlement.test.ts
- pnpm --filter @voyant-travel/bookings typecheck
- pnpm --filter @voyant-travel/bookings test -- --testNamePattern "records cancellation reason and financial settlement metadata|emits booking.cancelled with previousStatus after cancel"
- pnpm --filter @voyant-travel/bookings-react test -- tests/unit/booking-cancellation-dialog.test.tsx
- pnpm --filter @voyant-travel/bookings-react typecheck
- pnpm --filter @voyant-travel/bookings-react lint
- pnpm exec biome check packages/bookings-react/src/components/booking-cancellation-dialog.tsx packages/bookings-react/src/components/booking-detail-page.tsx packages/bookings-react/src/i18n/en-operations.ts packages/bookings-react/src/i18n/ro-operations.ts packages/bookings-react/src/i18n/messages-operations.ts packages/bookings-react/tests/unit/booking-cancellation-dialog.test.tsx
- git diff --check
- pre-commit hook: 186/186 tasks passed