### PR TITLE
inventory: fold the product's default itinerary into the product read-model doc

### DIFF
--- a/.changeset/fold-default-itinerary-into-product-read-model.md
+++ b/.changeset/fold-default-itinerary-into-product-read-model.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/products-contracts": minor
+"@voyant-travel/inventory": minor
+---
+
+Fold the product's default itinerary into the catalog product read-model document.
+
+`getCatalogProductById` (and the `/v1/public/products/:id` + `/slug/:slug`
+read-through documents) can now include the product's default day-by-day
+itinerary — days and day-services with `product_day_translations` /
+`product_day_service_translations` resolved by the document's locale, plus a
+per-day thumbnail. It is opt-in via `?include=itinerary`, encoded in the
+read-model variant so itinerary and non-itinerary documents cache — and warm on
+mutation — independently. Only the product default itinerary is folded;
+departure-specific overrides stay on the departure itinerary endpoint.
+
+The itinerary update/delete/duplicate admin routes (keyed on the itinerary id,
+not the product id) now trigger read-model recompute so the folded itinerary
+stays fresh.

--- a/packages/inventory/src/read-model.ts
+++ b/packages/inventory/src/read-model.ts
@@ -30,7 +30,17 @@ const SLUG_MAP_TTL_SECONDS = 5 * 60
 
 export interface ProductReadModelQuery {
   languageTag?: string | null
+  /**
+   * Fold the product's default itinerary (days + day-services, localized)
+   * into the document. Opt-in so callers that don't render the day-by-day
+   * plan don't pay the join (issue voyant#2910). Encoded in the variant so
+   * itinerary and non-itinerary documents cache — and warm — independently.
+   */
+  includeItinerary?: boolean
 }
+
+/** Variant suffix marking a document that carries the folded itinerary. */
+const ITINERARY_VARIANT_SUFFIX = "+itinerary"
 
 export interface ProductReadModelVariant {
   variant: string
@@ -59,13 +69,22 @@ export function productSlugMapKey(slug: string, variant: string): string {
   return `rm:v1:product-slug:${variant}:${slug}`
 }
 
-/** Stable variant id from the detail query (currently just the locale). */
-export function productDocVariant(query: { languageTag?: string | null }): string {
-  return query.languageTag ? `lang=${query.languageTag}` : "default"
+/** Stable variant id from the detail query (locale + itinerary inclusion). */
+export function productDocVariant(query: ProductReadModelQuery): string {
+  const base = query.languageTag ? `lang=${query.languageTag}` : "default"
+  return query.includeItinerary ? `${base}${ITINERARY_VARIANT_SUFFIX}` : base
 }
 
 export function productDocQueryFromVariant(variant: string): ProductReadModelQuery {
-  return variant.startsWith("lang=") ? { languageTag: variant.slice("lang=".length) } : {}
+  const includeItinerary = variant.endsWith(ITINERARY_VARIANT_SUFFIX)
+  const rest = includeItinerary
+    ? variant.slice(0, variant.length - ITINERARY_VARIANT_SUFFIX.length)
+    : variant
+  const query: ProductReadModelQuery = rest.startsWith("lang=")
+    ? { languageTag: rest.slice("lang=".length) }
+    : {}
+  if (includeItinerary) query.includeItinerary = true
+  return query
 }
 
 export async function buildProductReadModelDoc(
@@ -185,6 +204,66 @@ export async function warmProductReadModel(
   }
 
   return { warmed, missing }
+}
+
+/**
+ * The slice of a request context read-model invalidation needs: the KV
+ * binding, the (optional) Workers `executionCtx` for background scheduling,
+ * and `db` for the recompute path.
+ */
+export interface ReadModelInvalidationContext {
+  // `unknown` so a Hono `Context` whose `Bindings` don't declare `CACHE` (the
+  // admin route groups) is still assignable; the binding is narrowed at use.
+  env?: unknown
+  executionCtx?: unknown
+  get?: (key: "db") => PostgresJsDatabase
+}
+
+function buildReadModelInvalidationTask(
+  c: Pick<ReadModelInvalidationContext, "get">,
+  kv: KVStore,
+  productId: string,
+  mode: "delete" | "recompute",
+): Promise<unknown> {
+  if (mode === "recompute" && typeof c.get === "function") {
+    try {
+      return warmProductReadModel({ db: c.get("db"), kv, productId }).catch(() =>
+        invalidateProductReadModel(kv, productId),
+      )
+    } catch {
+      // fall through to delete-only invalidation
+    }
+  }
+  return invalidateProductReadModel(kv, productId)
+}
+
+/**
+ * Schedule read-model invalidation/recompute for a product whose id the caller
+ * already knows. Used both by the path-matching admin middleware and directly
+ * by write routes whose path is keyed on a child resource id (e.g. an itinerary
+ * id) rather than the product id, so the middleware's path regex can't see the
+ * product (issue voyant#2910). Runs in the background via `waitUntil` when
+ * available; otherwise returns the pending promise for the caller to await. A
+ * no-op (returns `undefined`) when the CACHE binding is absent.
+ */
+export function scheduleReadModelInvalidation(
+  c: ReadModelInvalidationContext,
+  productId: string,
+  mode: "delete" | "recompute" = "recompute",
+): Promise<unknown> | undefined {
+  const kv = (c.env as { CACHE?: KVStore } | undefined)?.CACHE
+  if (!kv) return undefined
+  const pending = buildReadModelInvalidationTask(c, kv, productId, mode)
+  try {
+    const ctx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined
+    if (ctx && typeof ctx.waitUntil === "function") {
+      ctx.waitUntil(pending)
+      return undefined
+    }
+  } catch {
+    // Hono throws on executionCtx access outside Workers
+  }
+  return pending
 }
 
 async function putProductDoc<T>(kv: KVStore, key: string, data: T) {

--- a/packages/inventory/src/routes-itinerary.ts
+++ b/packages/inventory/src/routes-itinerary.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: inventory; the itinerary admin route groups (itineraries, days, day-services, translations, versions, notes) stay co-located until a dedicated split preserves the OpenAPI operation chain and tests.
 /**
  * Admin product itinerary routes — itineraries, itinerary days, product days,
  * day services, day translations, version snapshots, and notes. Mounted by the
@@ -34,6 +35,7 @@ import { listResponseSchema } from "@voyant-travel/types"
 
 import { appendProductMutationLedgerEntry, changedMutationFields } from "./action-ledger.js"
 import { emitProductContentChanged } from "./events.js"
+import { scheduleReadModelInvalidation } from "./read-model.js"
 import type { Env } from "./route-env.js"
 import { productsService } from "./service.js"
 import * as validation from "./validation.js"
@@ -297,6 +299,10 @@ const itineraryRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
       routeOrToolName: "products.itinerary.update",
     })
     await emitProductContentChanged(c.get("eventBus"), { id: row.productId, axis: "itinerary" })
+    // This path is keyed on the itinerary id, so the product-id path regex in
+    // the read-model middleware can't see the product — recompute explicitly so
+    // the folded default itinerary stays fresh (issue voyant#2910).
+    await scheduleReadModelInvalidation(c, row.productId)
     return c.json({ data: row }, 200)
   })
   .openapi(deleteItineraryRoute, async (c) => {
@@ -321,6 +327,8 @@ const itineraryRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
       routeOrToolName: "products.itinerary.delete",
     })
     await emitProductContentChanged(c.get("eventBus"), { id: before.productId, axis: "itinerary" })
+    // Itinerary-id-keyed path — recompute explicitly (issue voyant#2910).
+    await scheduleReadModelInvalidation(c, before.productId)
     return c.json({ success: true }, 200)
   })
   .openapi(duplicateItineraryRoute, async (c) => {
@@ -349,6 +357,8 @@ const itineraryRoutes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHoo
       id: source.productId,
       axis: "itinerary",
     })
+    // Itinerary-id-keyed path — recompute explicitly (issue voyant#2910).
+    await scheduleReadModelInvalidation(c, source.productId)
     return c.json({ data: row }, 201)
   })
 

--- a/packages/inventory/src/routes-public.ts
+++ b/packages/inventory/src/routes-public.ts
@@ -16,6 +16,7 @@ import { publicProductsService } from "./service-public.js"
 import {
   publicCatalogCategoryListQuerySchema,
   publicCatalogDestinationListQuerySchema,
+  publicCatalogItinerarySchema,
   publicCatalogProductListQuerySchema,
   publicCatalogProductLookupBySlugQuerySchema,
   publicCatalogTagListQuerySchema,
@@ -36,6 +37,24 @@ type Env = {
 /** The KV binding is optional — deployments without it serve live. */
 function readModelKv(c: Context<Env>): KVStore | undefined {
   return c.env?.CACHE
+}
+
+/**
+ * Parse the `?include=itinerary` opt-in (comma-separated, forward-compatible)
+ * into the read-model query flag that folds the default itinerary into the
+ * document (issue voyant#2910).
+ */
+function readModelQuery(query: { languageTag?: string | null; include?: string | null }) {
+  const includeItinerary = (query.include ?? "")
+    .split(",")
+    .map((token) => token.trim())
+    .includes("itinerary")
+  // Only carry the flag when opted in, so the default document query keeps its
+  // existing `{ languageTag }` shape (and variant key) unchanged.
+  return {
+    languageTag: query.languageTag ?? undefined,
+    ...(includeItinerary ? { includeItinerary: true } : {}),
+  }
 }
 
 /**
@@ -254,6 +273,8 @@ export const publicCatalogProductSchema = z.object({
   brochure: publicCatalogMediaSchema.nullable().optional(),
   features: z.array(publicCatalogFeatureSchema).optional(),
   faqs: z.array(publicCatalogFaqSchema).optional(),
+  // Present only when requested via `?include=itinerary` (voyant#2910).
+  itinerary: publicCatalogItinerarySchema.nullable().optional(),
 })
 
 const errorResponseSchema = z.object({ error: z.string() })
@@ -364,10 +385,12 @@ export const publicProductRoutes = new OpenAPIHono<Env>({ defaultHook: openApiVa
     const query = c.req.valid("query")
     const kv = readModelKv(c)
     const slug = c.req.valid("param").slug
+    const docQuery = readModelQuery(query)
 
-    // Resolve slug → id through the short-lived KV mapping so both detail
-    // routes share one id-keyed document per variant.
-    const requestedVariant = productDocVariant(query)
+    // Resolve slug → id through the short-lived KV mapping. The mapping only
+    // depends on the locale (not itinerary inclusion), so key it by the
+    // locale-only variant and let both `?include` variants share it.
+    const requestedVariant = productDocVariant({ languageTag: docQuery.languageTag })
     const resolution = await readThroughSlugMapping(kv, slug, requestedVariant, async () => {
       const row = await publicProductsService.getCatalogProductBySlug(c.get("db"), slug, query)
       const productId = row ? ((row as { id?: string }).id ?? null) : null
@@ -384,9 +407,10 @@ export const publicProductRoutes = new OpenAPIHono<Env>({ defaultHook: openApiVa
       return c.json({ error: "Catalog product not found" }, 404)
     }
 
-    const detailQuery = resolution.languageTag
-      ? { ...query, languageTag: resolution.languageTag }
-      : query
+    const detailQuery = {
+      ...docQuery,
+      languageTag: resolution.languageTag ?? docQuery.languageTag,
+    }
 
     const { data } = await readThroughProductDoc(
       kv,
@@ -401,12 +425,12 @@ export const publicProductRoutes = new OpenAPIHono<Env>({ defaultHook: openApiVa
     return c.json({ data }, 200)
   })
   .openapi(productByIdRoute, async (c) => {
-    const query = c.req.valid("query")
+    const docQuery = readModelQuery(c.req.valid("query"))
     const productId = c.req.valid("param").id
     const { data } = await readThroughProductDoc(
       readModelKv(c),
-      productDocKey(productId, productDocVariant(query)),
-      () => buildProductReadModelDoc(c.get("db"), productId, query),
+      productDocKey(productId, productDocVariant(docQuery)),
+      () => buildProductReadModelDoc(c.get("db"), productId, docQuery),
     )
 
     if (!data) {

--- a/packages/inventory/src/routes.ts
+++ b/packages/inventory/src/routes.ts
@@ -2,7 +2,7 @@ import { OpenAPIHono } from "@hono/zod-openapi"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { KVStore } from "@voyant-travel/utils/cache"
 
-import { invalidateProductReadModel, warmProductReadModel } from "./read-model.js"
+import { scheduleReadModelInvalidation } from "./read-model.js"
 import type { Env } from "./route-env.js"
 import { productAssociationRoutes } from "./routes-associations.js"
 import { productCatalogRoutes } from "./routes-catalog.js"
@@ -48,40 +48,12 @@ export function readModelInvalidation(options: ReadModelInvalidationOptions = {}
     await next()
     if (c.req.method === "GET" || c.req.method === "HEAD" || c.req.method === "OPTIONS") return
     if (!c.res || c.res.status >= 400) return
-    const kv = c.env?.CACHE
-    if (!kv) return
+    if (!c.env?.CACHE) return
     const match = PRODUCT_ID_IN_PATH.exec(c.req.path)
     if (!match?.[1]) return
-    const pending = buildReadModelInvalidationTask(c, kv, match[1], options.mode ?? "delete")
-    try {
-      const ctx = c.executionCtx as { waitUntil?: (p: Promise<unknown>) => void } | undefined
-      if (ctx && typeof ctx.waitUntil === "function") {
-        ctx.waitUntil(pending)
-        return
-      }
-    } catch {
-      // Hono throws on executionCtx access outside Workers
-    }
-    await pending
+    const pending = scheduleReadModelInvalidation(c, match[1], options.mode ?? "delete")
+    if (pending) await pending
   }
-}
-
-function buildReadModelInvalidationTask(
-  c: { get?: (key: "db") => Env["Variables"]["db"] },
-  kv: KVStore,
-  productId: string,
-  mode: "delete" | "recompute",
-) {
-  if (mode === "recompute" && typeof c.get === "function") {
-    try {
-      return warmProductReadModel({ db: c.get("db"), kv, productId }).catch(() =>
-        invalidateProductReadModel(kv, productId),
-      )
-    } catch {
-      // fall through to delete-only invalidation
-    }
-  }
-  return invalidateProductReadModel(kv, productId)
 }
 
 // Product route groups stay split by domain area; mount at root to preserve

--- a/packages/inventory/src/service-catalog.ts
+++ b/packages/inventory/src/service-catalog.ts
@@ -8,9 +8,15 @@ import {
   productCapabilities,
   productCategories,
   productCategoryProducts,
+  productDayServices,
+  productDayServiceTranslations,
+  productDays,
+  productDayTranslations,
   productDestinations,
   productFaqs,
   productFeatures,
+  productItineraries,
+  productItineraryTranslations,
   productLocations,
   productMedia,
   products,
@@ -30,8 +36,46 @@ type CatalogProductRow = typeof products.$inferSelect
 
 type HydrateCatalogProductOptions = {
   includeContent?: boolean
+  /**
+   * Fold each product's default itinerary (days + day-services, localized)
+   * into the detail payload. Opt-in — the day/service joins only run for
+   * callers that render the day-by-day plan (issue voyant#2910). Implies
+   * `includeContent` semantics: the itinerary only rides the detail shape.
+   */
+  includeItinerary?: boolean
   languageTag?: string | null
   fallbackLanguageTags?: string[]
+}
+
+/** Localized day-service line within a folded itinerary. */
+export type CatalogItineraryDayService = {
+  id: string
+  serviceType: string
+  name: string
+  description: string | null
+  sortOrder: number | null
+}
+
+/** Localized day within a folded itinerary. */
+export type CatalogItineraryDay = {
+  id: string
+  dayNumber: number
+  title: string | null
+  description: string | null
+  location: string | null
+  thumbnailUrl: string | null
+  services: CatalogItineraryDayService[]
+}
+
+/**
+ * The product's default itinerary, folded into the read-model document.
+ * Departure-specific overrides stay on `getStorefrontDepartureItinerary`;
+ * this is the product-level default only (issue voyant#2910).
+ */
+export type CatalogItinerary = {
+  id: string
+  name: string
+  days: CatalogItineraryDay[]
 }
 
 export const DEFAULT_CATALOG_SEARCH_FALLBACK_LANGUAGE_TAGS = ["en", "ro"] as const
@@ -86,6 +130,236 @@ function normalizeLanguageTagList(values: Array<string | null | undefined>) {
 function resolveFallbackLanguageTags(languageTag?: string | null, fallbackLanguageTags?: string[]) {
   const normalizedPrimary = normalizeLanguageTag(languageTag)
   return normalizeLanguageTagList([normalizedPrimary, ...(fallbackLanguageTags ?? [])])
+}
+
+/**
+ * Pick the first translation row matching the ordered fallback language
+ * tags, mirroring the product-level selection in `loadCatalogHydrationData`.
+ * Returns `null` when no candidate locales are configured (so callers fall
+ * back to the base row's own columns).
+ */
+function pickTranslationByFallback<T extends { languageTag: string }>(
+  rows: T[],
+  fallbackLanguageTags: string[],
+): T | null {
+  if (fallbackLanguageTags.length === 0) return null
+  return (
+    fallbackLanguageTags
+      .map((languageTag) =>
+        rows.find((row) => normalizeLanguageTag(row.languageTag) === languageTag),
+      )
+      .find(Boolean) ?? null
+  )
+}
+
+function groupBy<T, K>(rows: T[], keyOf: (row: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>()
+  for (const row of rows) {
+    const key = keyOf(row)
+    const existing = map.get(key) ?? []
+    existing.push(row)
+    map.set(key, existing)
+  }
+  return map
+}
+
+/**
+ * Load each product's default itinerary — days + day-services with their
+ * `product_day_translations` / `product_day_service_translations` resolved
+ * by the same fallback-locale chain the rest of the document uses — and the
+ * first per-day media as a thumbnail. All inventory-owned tables. Only the
+ * product default (`is_default = true`) is folded here; departure overrides
+ * stay on `getStorefrontDepartureItinerary` (issue voyant#2910).
+ */
+async function loadDefaultItineraries(
+  db: PostgresJsDatabase,
+  productIds: string[],
+  fallbackLanguageTags: string[],
+): Promise<Map<string, CatalogItinerary>> {
+  const byProduct = new Map<string, CatalogItinerary>()
+  if (productIds.length === 0) return byProduct
+
+  const itineraryRows = await db
+    .select({
+      id: productItineraries.id,
+      productId: productItineraries.productId,
+      name: productItineraries.name,
+    })
+    .from(productItineraries)
+    .where(
+      and(
+        inArray(productItineraries.productId, productIds),
+        eq(productItineraries.isDefault, true),
+      ),
+    )
+    .orderBy(asc(productItineraries.sortOrder), asc(productItineraries.createdAt))
+
+  // One default per product (the partial unique index enforces this, but keep
+  // the first deterministically in case older data drifted).
+  const itineraryByProduct = new Map<string, (typeof itineraryRows)[number]>()
+  for (const row of itineraryRows) {
+    if (!itineraryByProduct.has(row.productId)) itineraryByProduct.set(row.productId, row)
+  }
+  const itineraryIds = [...itineraryByProduct.values()].map((row) => row.id)
+  if (itineraryIds.length === 0) return byProduct
+
+  const [itineraryTranslationRows, dayRows] = await Promise.all([
+    fallbackLanguageTags.length > 0
+      ? db
+          .select({
+            itineraryId: productItineraryTranslations.itineraryId,
+            languageTag: productItineraryTranslations.languageTag,
+            name: productItineraryTranslations.name,
+          })
+          .from(productItineraryTranslations)
+          .where(
+            and(
+              inArray(productItineraryTranslations.itineraryId, itineraryIds),
+              inArray(productItineraryTranslations.languageTag, fallbackLanguageTags),
+            ),
+          )
+      : Promise.resolve([]),
+    db
+      .select({
+        id: productDays.id,
+        itineraryId: productDays.itineraryId,
+        dayNumber: productDays.dayNumber,
+        title: productDays.title,
+        description: productDays.description,
+        location: productDays.location,
+      })
+      .from(productDays)
+      .where(inArray(productDays.itineraryId, itineraryIds))
+      .orderBy(asc(productDays.dayNumber)),
+  ])
+
+  const dayIds = dayRows.map((row) => row.id)
+
+  const [dayTranslationRows, serviceRows, dayMediaRows] =
+    dayIds.length > 0
+      ? await Promise.all([
+          fallbackLanguageTags.length > 0
+            ? db
+                .select({
+                  dayId: productDayTranslations.dayId,
+                  languageTag: productDayTranslations.languageTag,
+                  title: productDayTranslations.title,
+                  description: productDayTranslations.description,
+                  location: productDayTranslations.location,
+                })
+                .from(productDayTranslations)
+                .where(
+                  and(
+                    inArray(productDayTranslations.dayId, dayIds),
+                    inArray(productDayTranslations.languageTag, fallbackLanguageTags),
+                  ),
+                )
+            : Promise.resolve([]),
+          db
+            .select({
+              id: productDayServices.id,
+              dayId: productDayServices.dayId,
+              serviceType: productDayServices.serviceType,
+              name: productDayServices.name,
+              description: productDayServices.description,
+              sortOrder: productDayServices.sortOrder,
+            })
+            .from(productDayServices)
+            .where(inArray(productDayServices.dayId, dayIds))
+            .orderBy(asc(productDayServices.sortOrder), asc(productDayServices.createdAt)),
+          db
+            .select({
+              dayId: productMedia.dayId,
+              url: productMedia.url,
+              isCover: productMedia.isCover,
+              sortOrder: productMedia.sortOrder,
+            })
+            .from(productMedia)
+            .where(
+              and(inArray(productMedia.productId, productIds), inArray(productMedia.dayId, dayIds)),
+            )
+            .orderBy(
+              desc(productMedia.isCover),
+              asc(productMedia.sortOrder),
+              asc(productMedia.createdAt),
+            ),
+        ])
+      : [[], [], []]
+
+  const serviceIds = serviceRows.map((row) => row.id)
+  const serviceTranslationRows =
+    serviceIds.length > 0 && fallbackLanguageTags.length > 0
+      ? await db
+          .select({
+            serviceId: productDayServiceTranslations.serviceId,
+            languageTag: productDayServiceTranslations.languageTag,
+            name: productDayServiceTranslations.name,
+            description: productDayServiceTranslations.description,
+          })
+          .from(productDayServiceTranslations)
+          .where(
+            and(
+              inArray(productDayServiceTranslations.serviceId, serviceIds),
+              inArray(productDayServiceTranslations.languageTag, fallbackLanguageTags),
+            ),
+          )
+      : []
+
+  const itineraryTranslationsById = groupBy(itineraryTranslationRows, (row) => row.itineraryId)
+  const daysByItinerary = groupBy(dayRows, (row) => row.itineraryId)
+  const dayTranslationsByDay = groupBy(dayTranslationRows, (row) => row.dayId)
+  const servicesByDay = groupBy(serviceRows, (row) => row.dayId)
+  const serviceTranslationsByService = groupBy(serviceTranslationRows, (row) => row.serviceId)
+
+  const thumbnailByDay = new Map<string, string>()
+  for (const row of dayMediaRows) {
+    if (row.dayId && !thumbnailByDay.has(row.dayId)) thumbnailByDay.set(row.dayId, row.url)
+  }
+
+  for (const [productId, itinerary] of itineraryByProduct) {
+    const nameTranslation = pickTranslationByFallback(
+      itineraryTranslationsById.get(itinerary.id) ?? [],
+      fallbackLanguageTags,
+    )
+    const days = (daysByItinerary.get(itinerary.id) ?? []).map<CatalogItineraryDay>((day) => {
+      const dayTranslation = pickTranslationByFallback(
+        dayTranslationsByDay.get(day.id) ?? [],
+        fallbackLanguageTags,
+      )
+      const services = (servicesByDay.get(day.id) ?? []).map<CatalogItineraryDayService>(
+        (service) => {
+          const serviceTranslation = pickTranslationByFallback(
+            serviceTranslationsByService.get(service.id) ?? [],
+            fallbackLanguageTags,
+          )
+          return {
+            id: service.id,
+            serviceType: service.serviceType,
+            name: serviceTranslation?.name ?? service.name,
+            description: serviceTranslation?.description ?? service.description ?? null,
+            sortOrder: service.sortOrder ?? null,
+          }
+        },
+      )
+      return {
+        id: day.id,
+        dayNumber: day.dayNumber,
+        title: dayTranslation?.title ?? day.title ?? null,
+        description: dayTranslation?.description ?? day.description ?? null,
+        location: dayTranslation?.location ?? day.location ?? null,
+        thumbnailUrl: thumbnailByDay.get(day.id) ?? null,
+        services,
+      }
+    })
+
+    byProduct.set(productId, {
+      id: itinerary.id,
+      name: nameTranslation?.name ?? itinerary.name,
+      days,
+    })
+  }
+
+  return byProduct
 }
 
 async function loadCatalogHydrationData(
@@ -432,6 +706,12 @@ async function loadCatalogHydrationData(
   const typeById = new Map(typeRows.map((row) => [row.id, row] as const))
   const featuredIds = new Set(featuredRows.map((row) => row.productId))
 
+  // Itinerary folding is opt-in (detail-only) — the day/service joins run
+  // only when a caller asks for the day-by-day plan (issue voyant#2910).
+  const itineraryByProduct = options.includeItinerary
+    ? await loadDefaultItineraries(db, productIds, fallbackLanguageTags)
+    : new Map<string, CatalogItinerary>()
+
   const translationByProduct = new Map<string, (typeof translationRows)[number] | null>()
   for (const productId of productIds) {
     const rows = translationsByProduct.get(productId) ?? []
@@ -458,6 +738,7 @@ async function loadCatalogHydrationData(
     locationsByProduct,
     typeById,
     featuredIds,
+    itineraryByProduct,
   }
 }
 
@@ -590,6 +871,11 @@ export const catalogProductsService = {
           answer: row.answer,
           sortOrder: row.sortOrder,
         })),
+        // Only present the key when itinerary folding was requested, so the
+        // default (non-itinerary) document shape is unchanged (voyant#2910).
+        ...(options.includeItinerary
+          ? { itinerary: hydrationData.itineraryByProduct.get(product.id) ?? null }
+          : {}),
       }
     })
   },

--- a/packages/inventory/src/service-public.ts
+++ b/packages/inventory/src/service-public.ts
@@ -139,10 +139,11 @@ async function listProductIdsForLocationType(
 async function hydrateCatalogProducts(
   db: PostgresJsDatabase,
   productRows: PublicCatalogProductRow[],
-  options?: { includeContent?: boolean; languageTag?: string | null },
+  options?: { includeContent?: boolean; includeItinerary?: boolean; languageTag?: string | null },
 ) {
   return catalogProductsService.hydrateProducts(db, productRows, {
     includeContent: options?.includeContent,
+    includeItinerary: options?.includeItinerary,
     languageTag: options?.languageTag,
     fallbackLanguageTags: options?.languageTag ? [options.languageTag] : [],
   })
@@ -293,7 +294,7 @@ export const publicProductsService = {
   async getCatalogProductById(
     db: PostgresJsDatabase,
     id: string,
-    query: { languageTag?: string | null } = {},
+    query: { languageTag?: string | null; includeItinerary?: boolean } = {},
   ) {
     const [row] = await db
       .select()
@@ -314,6 +315,7 @@ export const publicProductsService = {
 
     const [product] = await hydrateCatalogProducts(db, [row], {
       includeContent: true,
+      includeItinerary: query.includeItinerary === true,
       languageTag: normalizeLanguageTag(query.languageTag),
     })
     return product ?? null

--- a/packages/inventory/tests/unit/read-model.test.ts
+++ b/packages/inventory/tests/unit/read-model.test.ts
@@ -17,6 +17,7 @@ import { Hono } from "hono"
 import {
   invalidateProductReadModel,
   productDocKey,
+  productDocQueryFromVariant,
   productDocVariant,
   readThroughProductDoc,
   readThroughSlugMapping,
@@ -100,6 +101,40 @@ describe("read-model primitives", () => {
   it("variant key incorporates the locale", () => {
     expect(productDocVariant({})).toBe("default")
     expect(productDocVariant({ languageTag: "de-DE" })).toBe("lang=de-DE")
+  })
+
+  it("variant key encodes the itinerary opt-in and round-trips", () => {
+    expect(productDocVariant({ includeItinerary: true })).toBe("default+itinerary")
+    expect(productDocVariant({ languageTag: "de-DE", includeItinerary: true })).toBe(
+      "lang=de-DE+itinerary",
+    )
+
+    expect(productDocQueryFromVariant("default")).toEqual({})
+    expect(productDocQueryFromVariant("lang=de-DE")).toEqual({ languageTag: "de-DE" })
+    expect(productDocQueryFromVariant("default+itinerary")).toEqual({ includeItinerary: true })
+    expect(productDocQueryFromVariant("lang=de-DE+itinerary")).toEqual({
+      languageTag: "de-DE",
+      includeItinerary: true,
+    })
+  })
+
+  it("warmProductReadModel recomputes an itinerary variant with the folded flag", async () => {
+    const kv = fakeKv()
+    kv.store.set(productDocKey(PRODUCT.id, "default+itinerary"), JSON.stringify({ stale: true }))
+    mockedService.getCatalogProductById.mockImplementation(async (_db, _id, query) => ({
+      ...PRODUCT,
+      includeItinerary: query.includeItinerary ?? false,
+    }))
+
+    const result = await warmProductReadModel({ db: {} as never, kv, productId: PRODUCT.id })
+
+    expect(result.warmed).toEqual(["default+itinerary"])
+    expect(
+      JSON.parse(kv.store.get(productDocKey(PRODUCT.id, "default+itinerary")) ?? "null"),
+    ).toEqual({ ...PRODUCT, includeItinerary: true })
+    expect(mockedService.getCatalogProductById).toHaveBeenCalledWith({}, PRODUCT.id, {
+      includeItinerary: true,
+    })
   })
 
   it("readThroughSlugMapping caches the matched product and locale", async () => {
@@ -214,6 +249,36 @@ describe("public detail routes — KV document plane", () => {
     await publicProductRoutes.request(`/${PRODUCT.id}?languageTag=de-DE`, {}, env)
 
     expect(mockedService.getCatalogProductById).toHaveBeenCalledTimes(2)
+  })
+
+  it("GET /:id?include=itinerary folds the itinerary and caches its own variant", async () => {
+    const kv = fakeKv()
+    const env = { CACHE: kv }
+    mockedService.getCatalogProductById.mockImplementation(async (_db, _id, query) => ({
+      ...PRODUCT,
+      ...(query.includeItinerary ? { itinerary: { id: "piti_1", name: "Default", days: [] } } : {}),
+    }))
+
+    const withItinerary = await publicProductRoutes.request(
+      `/${PRODUCT.id}?include=itinerary`,
+      {},
+      env,
+    )
+    const body = (await withItinerary.json()) as { data: { itinerary?: unknown } }
+
+    expect(withItinerary.status).toBe(200)
+    expect(body.data.itinerary).toEqual({ id: "piti_1", name: "Default", days: [] })
+    // The itinerary variant is keyed separately from the plain document.
+    expect(kv.store.has(productDocKey(PRODUCT.id, "default+itinerary"))).toBe(true)
+    expect(kv.store.has(productDocKey(PRODUCT.id, "default"))).toBe(false)
+    expect(mockedService.getCatalogProductById).toHaveBeenCalledWith(undefined, PRODUCT.id, {
+      languageTag: undefined,
+      includeItinerary: true,
+    })
+
+    // Second read is served from the itinerary variant without recomputing.
+    await publicProductRoutes.request(`/${PRODUCT.id}?include=itinerary`, {}, env)
+    expect(mockedService.getCatalogProductById).toHaveBeenCalledOnce()
   })
 
   it("works without a CACHE binding (live path)", async () => {

--- a/packages/products-contracts/src/validation-public.ts
+++ b/packages/products-contracts/src/validation-public.ts
@@ -60,6 +60,13 @@ export const publicCatalogDestinationListQuerySchema = z.object({
 
 export const publicCatalogProductLookupBySlugQuerySchema = z.object({
   languageTag: languageTagSchema.optional(),
+  /**
+   * Comma-separated list of extra sections to fold into the detail document.
+   * Currently only `itinerary` — the product's default day-by-day plan
+   * (issue voyant#2910). Opt-in so callers that don't render it don't pay the
+   * join; itinerary and non-itinerary documents cache independently.
+   */
+  include: z.string().optional(),
 })
 
 export const publicCatalogProductCategorySchema = z.object({
@@ -170,11 +177,41 @@ export const publicCatalogProductSummarySchema = z.object({
   isFeatured: z.boolean(),
 })
 
+export const publicCatalogItineraryDayServiceSchema = z.object({
+  id: z.string(),
+  serviceType: z.string(),
+  name: z.string(),
+  description: z.string().nullable(),
+  sortOrder: z.number().int().nullable(),
+})
+
+export const publicCatalogItineraryDaySchema = z.object({
+  id: z.string(),
+  dayNumber: z.number().int(),
+  title: z.string().nullable(),
+  description: z.string().nullable(),
+  location: z.string().nullable(),
+  thumbnailUrl: z.string().nullable(),
+  services: z.array(publicCatalogItineraryDayServiceSchema),
+})
+
+/**
+ * The product's folded default itinerary (issue voyant#2910). Present on the
+ * detail document only when requested via `?include=itinerary`; departure
+ * overrides stay on the departure itinerary endpoint.
+ */
+export const publicCatalogItinerarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  days: z.array(publicCatalogItineraryDaySchema),
+})
+
 export const publicCatalogProductDetailSchema = publicCatalogProductSummarySchema.extend({
   brochure: publicCatalogProductMediaSchema.nullable(),
   media: z.array(publicCatalogProductMediaSchema),
   features: z.array(publicCatalogProductFeatureSchema),
   faqs: z.array(publicCatalogProductFaqSchema),
+  itinerary: publicCatalogItinerarySchema.nullable().optional(),
 })
 
 export const publicCatalogProductListResponseSchema = z.object({


### PR DESCRIPTION
## Summary

Folds the product's **default** localized itinerary into the catalog product read-model document built by `getCatalogProductById` (`@voyant-travel/inventory`), so storefronts get the day-by-day plan the same way they get the description: one KV read, admin-warmed on mutation — instead of a separate, uncached, departure-scoped endpoint.

Closes #2910.

## What changed

- **Fold the default itinerary into the doc.** `hydrateProducts` gains an opt-in `includeItinerary` path that bulk-loads the product's default itinerary (`is_default = true`) — days + day-services with `product_day_translations` / `product_day_service_translations` resolved by the document's fallback-locale chain (same selection the rest of the doc uses), plus the first per-day media as a thumbnail. Attached to the detail payload as an `itinerary` field.
- **Opt-in via `?include=itinerary`.** Callers that don't render the plan don't pay the join. The flag is encoded in the read-model variant (`…+itinerary`), so itinerary and non-itinerary documents cache — and warm-on-write — independently. `productDocVariant` / `productDocQueryFromVariant` round-trip it, so `warmProductReadModel` rebuilds each cached variant (including the folded itinerary) on mutation.
- **Freshness for itinerary writes.** The itinerary update/delete/duplicate admin routes are keyed on the itinerary id (`piti_…`), which the read-model middleware's product-id path regex can't see, so they previously skipped invalidation. Extracted `scheduleReadModelInvalidation` and call it explicitly from those three handlers with the resolved product id. (Day / day-service / translation write routes are already product-id-keyed and covered.)

## Scope / non-goals

- **Only the product default itinerary** is folded. Departure-specific overrides (`availability_slots.itinerary_id ≠ product default`) stay on `getStorefrontDepartureItinerary`; storefronts still hit the departure endpoint when a departure overrides.

## Testing

- New unit tests: variant encode/decode round-trip for the itinerary flag; `warmProductReadModel` recomputes an itinerary variant with the folded flag; `GET /:id?include=itinerary` folds the itinerary, caches its own variant separately from the plain document, and serves the second read from KV.
- Full pre-commit affected verify (typecheck + tests, 186 tasks) passed; `@voyant-travel/inventory` src typecheck and `@voyant-travel/products-contracts` typecheck/tests green.
