### PR TITLE
Fix operator OpenAPI API prefix

### DIFF
--- a/starters/operator/src/routes/docs.test.ts
+++ b/starters/operator/src/routes/docs.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+import { withOperatorApiServer } from "./docs"
+
+describe("operator API docs", () => {
+  it("points OpenAPI try-it-out requests at the starter API mount", () => {
+    const spec = {
+      openapi: "3.1.0",
+      servers: [{ url: "/", description: "This deployment (same origin)" }],
+      paths: {
+        "/v1/public/catalog/search": {
+          post: { summary: "POST /v1/public/catalog/search" },
+        },
+      },
+    }
+
+    const normalized = withOperatorApiServer(spec, "http://localhost:3300/api/")
+
+    expect(normalized).toEqual({
+      ...spec,
+      servers: [
+        {
+          url: "http://localhost:3300/api",
+          description: "Operator API via this starter's /api mount",
+        },
+      ],
+    })
+    expect(spec.servers).toEqual([{ url: "/", description: "This deployment (same origin)" }])
+  })
+})

--- a/starters/operator/src/routes/docs.tsx
+++ b/starters/operator/src/routes/docs.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { lazy, Suspense, useEffect, useMemo, useState } from "react"
+import { getApiUrl } from "../lib/env"
 
 // Scalar is a browser-only widget — lazy-load it (+ its CSS) so the module is
 // never evaluated during SSR, and so each visit code-splits it out of the main
@@ -39,6 +40,21 @@ interface SpecEntry {
   load: () => Promise<{ default: Record<string, unknown> }>
 }
 
+export function withOperatorApiServer(
+  spec: Record<string, unknown>,
+  apiUrl = getApiUrl(),
+): Record<string, unknown> {
+  return {
+    ...spec,
+    servers: [
+      {
+        url: apiUrl.replace(/\/+$/, ""),
+        description: "Operator API via this starter's /api mount",
+      },
+    ],
+  }
+}
+
 function buildEntries(): SpecEntry[] {
   const entries: SpecEntry[] = []
   for (const [path, load] of Object.entries(specLoaders)) {
@@ -75,7 +91,7 @@ function ApiDocsPage(): React.ReactElement {
     if (!entry) return
     let cancelled = false
     entry.load().then((mod) => {
-      if (!cancelled) setSpec(mod.default)
+      if (!cancelled) setSpec(withOperatorApiServer(mod.default))
     })
     return () => {
       cancelled = true


### PR DESCRIPTION
## Summary

- Point the operator docs OpenAPI `servers` entry at the starter API mount (`/api`) before Scalar renders the spec.
- Preserve generated `/v1/...` package paths while making try-it-out requests target `/api/v1/...` in the local starter.
- Add a regression test for the docs spec normalization.

Closes #2914.

## Validation

- `pnpm --filter operator test -- src/routes/docs.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator lint`
- commit hook: repo lint + typecheck passed
- pre-push hook: repo test lane passed