### PR TITLE
Purge obsolete catalog market collections

### DIFF
--- a/starters/operator/scripts/lib/reindex-stale-documents.test.ts
+++ b/starters/operator/scripts/lib/reindex-stale-documents.test.ts
@@ -2,8 +2,11 @@ import type { IndexerSlice } from "@voyant-travel/catalog"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
+  createTypesenseCollectionAdmin,
   createTypesenseDocumentSearch,
+  listObsoleteCatalogCollections,
   listStaleDocuments,
+  TypesenseCollectionAdminError,
   TypesenseDocumentSearchError,
 } from "./reindex-stale-documents"
 
@@ -85,5 +88,86 @@ describe("listStaleDocuments", () => {
       collection: "products__en-GB__customer__default",
       status: 401,
     })
+  })
+})
+
+describe("listObsoleteCatalogCollections", () => {
+  const activeMarketSlice: IndexerSlice = {
+    vertical: "cruises",
+    locale: "en-GB",
+    audience: "customer",
+    market: "mkt_current",
+  }
+
+  it("returns old market collections that no longer match active slices", () => {
+    const obsolete = listObsoleteCatalogCollections(
+      [customerProductsSlice, activeMarketSlice],
+      [
+        "products__en-GB__customer__default",
+        "cruises__en-GB__customer__mkt_current",
+        "cruises__en-GB__customer__mkt_old",
+        "cruises__en-GB__staff__mkt_old",
+      ],
+      { verticals: new Set(["products", "cruises"]) },
+    )
+
+    expect(obsolete).toEqual([
+      "cruises__en-GB__customer__mkt_old",
+      "cruises__en-GB__staff__mkt_old",
+    ])
+  })
+
+  it("ignores unrelated and differently-prefixed Typesense collections", () => {
+    const obsolete = listObsoleteCatalogCollections(
+      [customerProductsSlice],
+      [
+        "analytics_events",
+        "custom__products__en-GB__customer__mkt_old",
+        "products__en-GB__partner__mkt_old",
+        "unknown__en-GB__customer__mkt_old",
+      ],
+      {
+        verticals: new Set(["products"]),
+        audiences: new Set(["staff", "customer"]),
+      },
+    )
+
+    expect(obsolete).toEqual([])
+  })
+})
+
+describe("createTypesenseCollectionAdmin", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("lists collection names through the Typesense REST API", async () => {
+    const fetchMock = vi.fn(async () =>
+      Response.json([{ name: "products__en-GB__customer__default" }]),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const admin = createTypesenseCollectionAdmin("http://typesense.test", "xyz")
+    await expect(admin.list()).resolves.toEqual(["products__en-GB__customer__default"])
+    expect(fetchMock).toHaveBeenCalledWith(new URL("http://typesense.test/collections"), {
+      headers: { "X-TYPESENSE-API-KEY": "xyz" },
+    })
+  })
+
+  it("treats missing collection deletes as already removed", async () => {
+    const fetchMock = vi.fn(async () => new Response("missing", { status: 404 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const admin = createTypesenseCollectionAdmin("http://typesense.test", "xyz")
+    await expect(admin.delete("products__en-GB__customer__old")).resolves.toBe(false)
+  })
+
+  it("throws on collection admin failures", async () => {
+    const fetchMock = vi.fn(async () => new Response("bad key", { status: 401 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const admin = createTypesenseCollectionAdmin("http://typesense.test", "bad")
+    await expect(admin.list()).rejects.toBeInstanceOf(TypesenseCollectionAdminError)
+    await expect(admin.list()).rejects.toMatchObject({ operation: "list", status: 401 })
   })
 })

--- a/starters/operator/scripts/lib/reindex-stale-documents.ts
+++ b/starters/operator/scripts/lib/reindex-stale-documents.ts
@@ -1,5 +1,9 @@
 import { collectionName, type IndexerSlice } from "@voyant-travel/catalog"
 
+interface TypesenseCollectionSummary {
+  name?: string
+}
+
 interface TypesenseSearchHit {
   document?: {
     id?: string
@@ -15,6 +19,11 @@ export type TypesenseDocumentSearch = (
   params: URLSearchParams,
 ) => Promise<TypesenseSearchPage | null>
 
+export interface TypesenseCollectionAdmin {
+  list(): Promise<string[]>
+  delete(collection: string): Promise<boolean>
+}
+
 export class TypesenseDocumentSearchError extends Error {
   constructor(
     readonly collection: string,
@@ -23,6 +32,17 @@ export class TypesenseDocumentSearchError extends Error {
   ) {
     super(message)
     this.name = "TypesenseDocumentSearchError"
+  }
+}
+
+export class TypesenseCollectionAdminError extends Error {
+  constructor(
+    readonly operation: "list" | "delete",
+    readonly status: number,
+    message: string,
+  ) {
+    super(message)
+    this.name = "TypesenseCollectionAdminError"
   }
 }
 
@@ -45,6 +65,43 @@ export function createTypesenseDocumentSearch(
       )
     }
     return (await res.json()) as TypesenseSearchPage
+  }
+}
+
+export function createTypesenseCollectionAdmin(
+  typesenseHost: string,
+  typesenseApiKey: string,
+): TypesenseCollectionAdmin {
+  const headers = { "X-TYPESENSE-API-KEY": typesenseApiKey }
+  return {
+    async list() {
+      const url = new URL(`${typesenseHost}/collections`)
+      const res = await fetch(url, { headers })
+      if (!res.ok) {
+        const body = await res.text().catch(() => "")
+        throw new TypesenseCollectionAdminError(
+          "list",
+          res.status,
+          body || `Typesense collection list failed with HTTP ${res.status}`,
+        )
+      }
+      const data = (await res.json()) as TypesenseCollectionSummary[]
+      return data.map((collection) => collection.name).filter((name): name is string => !!name)
+    },
+    async delete(collection) {
+      const url = new URL(`${typesenseHost}/collections/${collection}`)
+      const res = await fetch(url, { method: "DELETE", headers })
+      if (res.status === 404) return false
+      if (!res.ok) {
+        const body = await res.text().catch(() => "")
+        throw new TypesenseCollectionAdminError(
+          "delete",
+          res.status,
+          body || `Typesense collection delete failed for ${collection} with HTTP ${res.status}`,
+        )
+      }
+      return true
+    },
   }
 }
 
@@ -80,4 +137,39 @@ export async function listStaleDocuments(
   }
 
   return staleIds
+}
+
+export function listObsoleteCatalogCollections(
+  activeSlices: ReadonlyArray<IndexerSlice>,
+  collectionNames: ReadonlyArray<string>,
+  options: {
+    verticals: ReadonlySet<string>
+    audiences?: ReadonlySet<IndexerSlice["audience"]>
+  },
+): string[] {
+  const activeCollections = new Set(activeSlices.map((slice) => collectionName(slice)))
+  const audiences = options.audiences ?? new Set<IndexerSlice["audience"]>(["staff", "customer"])
+  const obsolete: string[] = []
+
+  for (const name of collectionNames) {
+    if (activeCollections.has(name)) continue
+    const slice = parseCatalogCollectionName(name)
+    if (!slice) continue
+    if (!options.verticals.has(slice.vertical)) continue
+    if (!audiences.has(slice.audience)) continue
+    obsolete.push(name)
+  }
+
+  return obsolete.sort()
+}
+
+function parseCatalogCollectionName(name: string): IndexerSlice | null {
+  const [vertical, locale, audience, market, ...rest] = name.split("__")
+  if (!vertical || !locale || !audience || !market || rest.length > 0) return null
+  if (!isIndexerAudience(audience)) return null
+  return { vertical, locale, audience, market }
+}
+
+function isIndexerAudience(value: string): value is IndexerSlice["audience"] {
+  return value === "staff" || value === "customer" || value === "partner" || value === "supplier"
 }

--- a/starters/operator/scripts/reindex.ts
+++ b/starters/operator/scripts/reindex.ts
@@ -57,7 +57,12 @@ import {
   getFieldPolicyRegistries,
   loadCatalogSlices,
 } from "../src/api/lib/catalog-runtime.js"
-import { createTypesenseDocumentSearch, listStaleDocuments } from "./lib/reindex-stale-documents.js"
+import {
+  createTypesenseCollectionAdmin,
+  createTypesenseDocumentSearch,
+  listObsoleteCatalogCollections,
+  listStaleDocuments,
+} from "./lib/reindex-stale-documents.js"
 import { asTypesenseClient } from "./lib/typesense-sdk-client.js"
 
 config({ path: ".env" })
@@ -122,6 +127,7 @@ const indexer = createTypesenseIndexer({
   importFailureMode: bestEffort ? "best-effort" : "throw",
 })
 const searchDocuments = createTypesenseDocumentSearch(typesenseHost, typesenseKey)
+const collectionAdmin = createTypesenseCollectionAdmin(typesenseHost, typesenseKey)
 
 if (bestEffort) {
   console.info("[reindex] best-effort mode — row import failures will be logged, not fatal")
@@ -142,9 +148,6 @@ const service = createIndexerService({
   slices: activeSlices,
   registries,
 })
-
-console.info(`[reindex] ensuring collections for ${activeSlices.length} slice(s)`)
-await service.ensureCollections()
 
 interface VerticalConfig {
   vertical: (typeof VERTICALS)[number]
@@ -187,6 +190,23 @@ const VERTICAL_CONFIGS: VerticalConfig[] = [
     builder: createRoomTypeDocumentBuilder(db, { sellerOperatorId }),
   },
 ]
+
+console.info(`[reindex] ensuring collections for ${activeSlices.length} slice(s)`)
+await service.ensureCollections()
+
+const reindexedVerticals: ReadonlySet<string> = new Set(
+  VERTICAL_CONFIGS.filter((cfg) => !requestedVertical || requestedVertical === cfg.vertical).map(
+    (cfg) => cfg.vertical,
+  ),
+)
+const existingCollections = await collectionAdmin.list()
+const obsoleteCollections = listObsoleteCatalogCollections(activeSlices, existingCollections, {
+  verticals: reindexedVerticals,
+})
+for (const collection of obsoleteCollections) {
+  const deleted = await collectionAdmin.delete(collection)
+  if (deleted) console.info(`[reindex] deleted obsolete catalog collection ${collection}`)
+}
 
 for (const cfg of VERTICAL_CONFIGS) {
   if (requestedVertical && requestedVertical !== cfg.vertical) continue


### PR DESCRIPTION
## Summary

Fixes #2880.

Full reindex now removes obsolete Typesense catalog collections whose slice names no longer match the active `loadCatalogSlices` set for the reindexed verticals. This covers stale market-specific customer/staff collections left behind after local DB resets or reseeds, while preserving active default and market slices and ignoring unrelated Typesense collections.

## Validation

- `pnpm exec biome check starters/operator/scripts/reindex.ts starters/operator/scripts/lib/reindex-stale-documents.ts starters/operator/scripts/lib/reindex-stale-documents.test.ts`
- `pnpm --filter operator test -- scripts/lib/reindex-stale-documents.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm --filter @voyant-travel/auth test`
- pre-commit affected lane: 186 tasks passed
- pre-push test lane: 98 tasks passed

## Notes

The issue comments were checked. The remaining reopened case was obsolete market collections from prior local seed/reset runs causing duplicated storefront cards even after document-level stale purging.