### PR TITLE
Cover bookable starter seed packaging

### DIFF
--- a/scripts/tests/package-starters.test.mjs
+++ b/scripts/tests/package-starters.test.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..")
 
-test("operator starter archive includes standalone flights demo API package", () => {
+test("operator starter archive includes bookable catalog seed inventory and standalone flights demo API package", () => {
   const tempDir = mkdtempSync(join(tmpdir(), "voyant-package-starters-test-"))
   const outDir = join(tempDir, "out")
   const extractDir = join(tempDir, "extract")
@@ -33,7 +33,23 @@ test("operator starter archive includes standalone flights demo API package", ()
       existsSync(join(extractDir, "apps", "flights-demo-api", "docker-compose.yml")),
       true,
     )
+    assert.equal(existsSync(join(extractDir, "scripts", "seed-catalog-verticals.ts")), true)
     assert.equal(existsSync(join(extractDir, "pnpm-workspace.yaml")), false)
+
+    const seedScript = readFileSync(join(extractDir, "scripts", "seed.ts"), "utf8")
+    assert.match(seedScript, /seedCruises/)
+    assert.match(seedScript, /seedAccommodationRooms/)
+
+    const verticalSeedScript = readFileSync(
+      join(extractDir, "scripts", "seed-catalog-verticals.ts"),
+      "utf8",
+    )
+    assert.match(verticalSeedScript, /cruiseSailings/)
+    assert.match(verticalSeedScript, /cruiseCabinCategories/)
+    assert.match(verticalSeedScript, /cruisePrices/)
+    assert.match(verticalSeedScript, /ratePlans/)
+    assert.match(verticalSeedScript, /ratePlanDailyRates/)
+    assert.match(verticalSeedScript, /roomTypeDailyInventory/)
 
     const demoPackage = JSON.parse(
       readFileSync(join(extractDir, "apps", "flights-demo-api", "package.json"), "utf8"),


### PR DESCRIPTION
Fixes #2878

## Summary
- asserts the packaged operator starter archive includes the catalog vertical seed helper
- checks the archived seed path still wires `seedCruises` and `seedAccommodationRooms`
- checks the archive contains the cruise sailing/cabin/price and accommodation rate/inventory seed code required for bookable storefront demo cards

## Root cause
`main` already contains the source fix from #2888, but the latest GitHub starter release asset `v0.104.1` predates that fix. I verified that `voyant-starter-operator-0.104.1.tar.gz` contains `scripts/seed-catalog-verticals.ts` but not the inventory seeding symbols, which matches the reopened fresh-starter reproduction. This regression test covers the packaged artifact users actually consume.

## Validation
- `node --test scripts/tests/package-starters.test.mjs`
- `pnpm --filter operator test -- scripts/seed-catalog-verticals.test.ts`
- pre-push hook: `pnpm test` (cached)
