### PR TITLE
Allow manifest-only workflow metadata

### DIFF
--- a/.changeset/manifest-workflow-metadata.md
+++ b/.changeset/manifest-workflow-metadata.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/commerce": patch
+"@voyant-travel/core": patch
+"@voyant-travel/framework": patch
+"@voyant-travel/hono": patch
+"@voyant-travel/workflows": patch
+---
+
+Allow modules to register workflow and event-filter manifest metadata without importing run-bearing workflow definitions into request-serving apps.

--- a/docs/architecture/workflows-runtime-architecture.md
+++ b/docs/architecture/workflows-runtime-architecture.md
@@ -138,6 +138,14 @@ Self-host Node deployments do this in-process against Postgres. Managed Cloud
 deployments forward the same logical calls to the Cloud control plane, which
 then schedules execution on Node runners.
 
+Request-serving apps should keep module workflow metadata manifest-only when
+workflow bodies execute in a detached bundle. `Module.workflows` accepts
+`{ id, config }` descriptors, and `Module.eventFilters` accepts entries carrying
+`{ id, eventType, manifest }`, so the API app can register workflow ids,
+schedules, concurrency, and event routing without statically importing
+run-bearing workflow modules. Workflow bundle entrypoints still import the full
+`workflow({ id, run })` definitions so the Node runner can execute them.
+
 ## Migration Rules
 
 - Do not add new `edge` runtime types, options, docs, or tests.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -415,6 +415,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -410,6 +410,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -386,6 +386,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -381,6 +381,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -9,6 +9,7 @@
     "./checkout": "./src/checkout/index.ts",
     "./markets/validation": "./src/markets/validation.ts",
     "./promotions/validation": "./src/promotions/validation.ts",
+    "./promotions/workflow-bulk-reindex-manifest": "./src/promotions/workflow-bulk-reindex-manifest.ts",
     "./promotions/workflow-bulk-reindex": "./src/promotions/workflow-bulk-reindex.ts",
     "./sellability/validation": "./src/sellability/validation.ts"
   },
@@ -91,6 +92,11 @@
         "types": "./dist/promotions/validation.d.ts",
         "import": "./dist/promotions/validation.js",
         "default": "./dist/promotions/validation.js"
+      },
+      "./promotions/workflow-bulk-reindex-manifest": {
+        "types": "./dist/promotions/workflow-bulk-reindex-manifest.d.ts",
+        "import": "./dist/promotions/workflow-bulk-reindex-manifest.js",
+        "default": "./dist/promotions/workflow-bulk-reindex-manifest.js"
       },
       "./promotions/workflow-bulk-reindex": {
         "types": "./dist/promotions/workflow-bulk-reindex.d.ts",

--- a/packages/commerce/src/promotions/index.ts
+++ b/packages/commerce/src/promotions/index.ts
@@ -67,6 +67,7 @@ export {
   type BulkReindexProductsInput,
   type BulkReindexProductsOutput,
   bulkReindexProductsWorkflow,
+  bulkReindexProductsWorkflowManifest,
   promotionAffectedAllFilter,
 } from "./workflow-bulk-reindex.js"
 export {

--- a/packages/commerce/src/promotions/module-metadata.ts
+++ b/packages/commerce/src/promotions/module-metadata.ts
@@ -1,9 +1,12 @@
 import type { Module } from "@voyant-travel/core"
 
-import { bulkReindexProductsWorkflow, promotionAffectedAllFilter } from "./workflow-bulk-reindex.js"
+import {
+  bulkReindexProductsWorkflowManifest,
+  promotionAffectedAllFilter,
+} from "./workflow-bulk-reindex-manifest.js"
 
 export const promotionsModule: Module = {
   name: "promotions",
-  workflows: [bulkReindexProductsWorkflow],
+  workflows: [bulkReindexProductsWorkflowManifest],
   eventFilters: [promotionAffectedAllFilter],
 }

--- a/packages/commerce/src/promotions/workflow-bulk-reindex-manifest.ts
+++ b/packages/commerce/src/promotions/workflow-bulk-reindex-manifest.ts
@@ -1,0 +1,40 @@
+import type { WorkflowDescriptor } from "@voyant-travel/core"
+import { trigger } from "@voyant-travel/workflows"
+
+import { PROMOTION_CHANGED_EVENT, type PromotionChangedSource } from "./events.js"
+
+export interface BulkReindexProductsInput {
+  /** The offer that triggered the reindex (for logging / correlation). */
+  offerId: string
+  source: PromotionChangedSource
+}
+
+export interface BulkReindexProductsOutput {
+  reindexed: number
+}
+
+export const bulkReindexProductsWorkflowManifest = {
+  id: "promotions.reindex-all-products",
+  config: {
+    defaultRuntime: "node" as const,
+  },
+} satisfies WorkflowDescriptor
+
+/**
+ * Routes `promotion.changed` envelopes whose `affected.kind === "all"` into
+ * the workflow above. Other shapes (`{ kind: "products", productIds }`) fall
+ * through to the in-process catalog-bridge subscriber.
+ */
+export const promotionAffectedAllFilter = trigger.on<BulkReindexProductsInput>(
+  PROMOTION_CHANGED_EVENT,
+  {
+    target: { id: bulkReindexProductsWorkflowManifest.id },
+    where: { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
+    input: {
+      object: {
+        offerId: { path: "data.offerId" },
+        source: { path: "data.source" },
+      },
+    },
+  },
+)

--- a/packages/commerce/src/promotions/workflow-bulk-reindex.ts
+++ b/packages/commerce/src/promotions/workflow-bulk-reindex.ts
@@ -18,20 +18,15 @@
  * the codebase for cross-module behavior (workflow → ctx.services.resolve).
  */
 
-import { trigger, workflow } from "@voyant-travel/workflows"
+import { workflow } from "@voyant-travel/workflows"
 
-import { PROMOTION_CHANGED_EVENT, type PromotionChangedSource } from "./events.js"
+import {
+  type BulkReindexProductsInput,
+  type BulkReindexProductsOutput,
+  bulkReindexProductsWorkflowManifest,
+  promotionAffectedAllFilter,
+} from "./workflow-bulk-reindex-manifest.js"
 import { BULK_REINDEX_SERVICE_KEY, type BulkReindexProductsService } from "./workflow-runtime.js"
-
-export interface BulkReindexProductsInput {
-  /** The offer that triggered the reindex (for logging / correlation). */
-  offerId: string
-  source: PromotionChangedSource
-}
-
-export interface BulkReindexProductsOutput {
-  reindexed: number
-}
 
 /** Cap on concurrent per-product reindex steps to avoid hammering the index. */
 const REINDEX_CONCURRENCY = 8
@@ -40,8 +35,8 @@ export const bulkReindexProductsWorkflow = workflow<
   BulkReindexProductsInput,
   BulkReindexProductsOutput
 >({
-  id: "promotions.reindex-all-products",
-  defaultRuntime: "node",
+  ...bulkReindexProductsWorkflowManifest.config,
+  id: bulkReindexProductsWorkflowManifest.id,
   async run(_input, ctx) {
     const svc = ctx.services.resolve<BulkReindexProductsService>(BULK_REINDEX_SERVICE_KEY)
 
@@ -61,21 +56,9 @@ export const bulkReindexProductsWorkflow = workflow<
   },
 })
 
-/**
- * Routes `promotion.changed` envelopes whose `affected.kind === "all"` into
- * the workflow above. Other shapes (`{ kind: "products", productIds }`) fall
- * through to the in-process catalog-bridge subscriber.
- */
-export const promotionAffectedAllFilter = trigger.on<BulkReindexProductsInput>(
-  PROMOTION_CHANGED_EVENT,
-  {
-    target: bulkReindexProductsWorkflow,
-    where: { eq: [{ path: "data.affected.kind" }, { lit: "all" }] },
-    input: {
-      object: {
-        offerId: { path: "data.offerId" },
-        source: { path: "data.source" },
-      },
-    },
-  },
-)
+export {
+  type BulkReindexProductsInput,
+  type BulkReindexProductsOutput,
+  bulkReindexProductsWorkflowManifest,
+  promotionAffectedAllFilter,
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -78,9 +78,13 @@ export type {
   BootstrapContext,
   BootstrapHandler,
   EventFilterDescriptor,
+  EventFilterManifestDescriptor,
   Extension,
   Module,
+  WorkflowConcurrencyDescriptor,
   WorkflowDescriptor,
+  WorkflowManifestConfigDescriptor,
+  WorkflowScheduleDescriptor,
 } from "./module.js"
 export type { JobOptions, JobRunner } from "./orchestration.js"
 export type {

--- a/packages/core/src/module.ts
+++ b/packages/core/src/module.ts
@@ -16,9 +16,54 @@ import type { LinkableDefinition } from "./links.js"
  * Same pattern Voyant uses for {@link LinkableDefinition} — the structural
  * contract lives in core, concrete types live in their owning packages.
  */
+export type WorkflowScheduleDescriptor = (
+  | { readonly cron: string }
+  | { readonly every: string | number }
+  | { readonly at: string | Date }
+) & {
+  readonly timezone?: string
+  readonly input?: unknown | (() => unknown | Promise<unknown>)
+  readonly enabled?: boolean
+  readonly overlap?: "skip" | "queue" | "allow"
+  readonly environments?: readonly ("production" | "preview" | "development")[]
+  readonly name?: string
+}
+
+export interface WorkflowConcurrencyDescriptor {
+  readonly key?: string | ((input: unknown) => string)
+  readonly limit?: number
+  readonly strategy?: "queue" | "cancel-in-progress" | "cancel-newest" | "round-robin"
+}
+
+export interface WorkflowManifestConfigDescriptor {
+  readonly description?: string
+  readonly input?: unknown
+  readonly output?: unknown
+  readonly defaultRuntime?: "node"
+  readonly concurrency?: WorkflowConcurrencyDescriptor
+  readonly retry?: unknown
+  readonly timeout?: unknown
+  readonly schedule?: WorkflowScheduleDescriptor | readonly WorkflowScheduleDescriptor[]
+}
+
 export interface WorkflowDescriptor {
   /** Stable workflow identifier (e.g. `"promotions.bulk-reindex-products"`). */
   readonly id: string
+  /**
+   * Optional manifest-only workflow metadata. Full workflow definitions from
+   * `@voyant-travel/workflows` also carry this field, with an additional
+   * non-serializable `run` function that the app manifest path ignores.
+   */
+  readonly config?: WorkflowManifestConfigDescriptor
+}
+
+export interface EventFilterManifestDescriptor {
+  readonly id: string
+  readonly eventType: string
+  readonly where?: unknown
+  readonly input?: unknown
+  readonly payloadHash: string
+  readonly targetWorkflowId: string
 }
 
 /**
@@ -34,6 +79,12 @@ export interface EventFilterDescriptor {
   readonly id: string
   /** Event name the filter targets (matches `EventEnvelope.name`). */
   readonly eventType: string
+  /**
+   * Optional manifest-only filter metadata. Runtime entries returned from
+   * `trigger.on(...)` carry this field; module metadata may also provide it
+   * directly when the request app must not import workflow handler bodies.
+   */
+  readonly manifest?: EventFilterManifestDescriptor
 }
 
 export interface BootstrapContext<TBindings = unknown> {
@@ -94,9 +145,12 @@ export interface Module {
    * Workflows owned by this module. Collected at `createApp()` boot and
    * registered with the configured workflow driver.
    *
-   * Concrete entries are produced by `workflow({ id, run })` in
-   * `@voyant-travel/workflows`; the field type here is the structural
-   * {@link WorkflowDescriptor} so core stays workflow-agnostic.
+   * Prefer manifest-only descriptors (`{ id, config }`) in request apps so
+   * module metadata stays importable without pulling workflow handler bodies
+   * into the HTTP Worker bundle. Full entries produced by
+   * `workflow({ id, run })` remain compatible for self-hosted runtimes and
+   * workflow bundle entrypoints. The field type here is structural so core
+   * stays workflow-agnostic.
    */
   workflows?: readonly WorkflowDescriptor[]
 
@@ -106,9 +160,9 @@ export interface Module {
    * `driver.ingestEvent(...)` time.
    *
    * Concrete entries are produced by `trigger.on(eventName, { ... })` in
-   * `@voyant-travel/workflows`; the field type here is the structural
-   * {@link EventFilterDescriptor} for the same cycle-avoidance reason as
-   * {@link workflows} above.
+   * `@voyant-travel/workflows`. Request apps may also provide manifest-only
+   * entries carrying `{ id, eventType, manifest }` so event routing can be
+   * registered without importing workflow handler bodies.
    */
   eventFilters?: readonly EventFilterDescriptor[]
 

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -485,6 +485,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -480,6 +480,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -480,6 +480,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -486,6 +486,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -9,9 +9,9 @@ import type {
 } from "@voyant-travel/bookings"
 import type { CatalogSearchRoutesOptions } from "@voyant-travel/catalog"
 import {
-  bulkReindexProductsWorkflow,
+  bulkReindexProductsWorkflowManifest,
   promotionAffectedAllFilter,
-} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex"
+} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
 import type { BootstrapHandler } from "@voyant-travel/core"
 import type {
   CheckoutNotificationDelivery,
@@ -379,7 +379,7 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
         sellability: { name: "sellability" },
         promotions: {
           name: "promotions",
-          workflows: [bulkReindexProductsWorkflow],
+          workflows: [bulkReindexProductsWorkflowManifest],
           eventFilters: [promotionAffectedAllFilter],
         },
       } satisfies Record<string, HonoModule["module"]>

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -480,6 +480,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/hono/src/app-workflows.ts
+++ b/packages/hono/src/app-workflows.ts
@@ -1,20 +1,24 @@
 import type {
   EventEnvelope,
   EventFilterDescriptor,
+  EventFilterManifestDescriptor,
   Module,
   ModuleContainer,
   WorkflowDescriptor,
 } from "@voyant-travel/core"
 import type { WorkflowDriver } from "@voyant-travel/workflows/driver"
-import {
-  type BuildManifestArgs,
-  buildManifest,
-  type EventFilterRuntimeEntry,
-} from "@voyant-travel/workflows/events"
+import { type BuildManifestArgs, buildManifest } from "@voyant-travel/workflows/events"
 
 import type { VoyantAppConfig } from "./types.js"
 
 type ManifestWorkflowDescriptor = BuildManifestArgs["workflows"][number]
+type ManifestEventFilterEntry = {
+  readonly id: string
+  readonly eventType: string
+  readonly manifest: EventFilterManifestDescriptor
+  readonly declaration: { readonly target: { readonly id: string } }
+  readonly targetWorkflowId: string
+}
 
 function toManifestWorkflowDescriptor(wf: WorkflowDescriptor): ManifestWorkflowDescriptor {
   const candidate = wf as WorkflowDescriptor & Partial<Pick<ManifestWorkflowDescriptor, "config">>
@@ -43,9 +47,9 @@ export async function wireWorkflowRuntime(args: WireWorkflowRuntimeArgs): Promis
   // the manifest builder needs the runtime shape with `.manifest` populated.
   // Validate before casting so a contract-violating plugin fails loudly here
   // instead of crashing on `entry.manifest.id` deep inside the sort.
-  const filterEntries: EventFilterRuntimeEntry[] = []
+  const filterEntries: ManifestEventFilterEntry[] = []
   for (const entry of args.collectedFilters) {
-    const candidate = entry as Partial<EventFilterRuntimeEntry>
+    const candidate = entry as EventFilterDescriptor
     if (!candidate.manifest || typeof candidate.manifest.id !== "string") {
       throw new Error(
         `[voyant] event filter "${entry.id}" (event "${entry.eventType}") is missing the runtime ` +
@@ -54,7 +58,13 @@ export async function wireWorkflowRuntime(args: WireWorkflowRuntimeArgs): Promis
           `createApp() needs the manifest payload to register with the driver.`,
       )
     }
-    filterEntries.push(candidate as EventFilterRuntimeEntry)
+    filterEntries.push({
+      id: candidate.manifest.id,
+      eventType: candidate.manifest.eventType,
+      manifest: candidate.manifest,
+      declaration: { target: { id: candidate.manifest.targetWorkflowId } },
+      targetWorkflowId: candidate.manifest.targetWorkflowId,
+    })
   }
 
   const manifest = await buildManifest({
@@ -72,7 +82,7 @@ export async function wireWorkflowRuntime(args: WireWorkflowRuntimeArgs): Promis
   // Install one EventBus subscriber per unique eventType. Each subscriber
   // forwards the envelope through `driver.ingestEvent(...)`, which routes
   // through the same predicate/mapper machinery the HTTP ingest path uses.
-  const eventTypes = new Set(filterEntries.map((f) => f.eventType))
+  const eventTypes = new Set(filterEntries.map((f) => f.manifest.eventType))
   for (const eventType of eventTypes) {
     args.eventBus.subscribe(eventType, async (envelope: EventEnvelope) => {
       const stamped = ensureMetadataEventId(envelope)

--- a/packages/hono/tests/unit/app-workflows.test.ts
+++ b/packages/hono/tests/unit/app-workflows.test.ts
@@ -160,6 +160,112 @@ describe("mountApp workflows wiring", () => {
     ])
   })
 
+  test("registers manifest-only workflow config without a run-bearing definition", async () => {
+    const moduleSpec: Module = {
+      name: "manifest-only-workflows",
+      workflows: [
+        {
+          id: "test-manifest-only-scheduled-report",
+          config: {
+            description: "Manifest-only scheduled report",
+            defaultRuntime: "node",
+            schedule: {
+              every: "15m",
+              timezone: "UTC",
+              input: { source: "manifest-only" },
+              overlap: "skip",
+              environments: ["production"],
+              name: "every-fifteen-minutes",
+            },
+          },
+        } satisfies WorkflowDescriptor,
+      ],
+    }
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = mountApp({
+      db: () => null as never,
+      modules: [{ module: moduleSpec }],
+      workflows: {
+        driver: () => (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+
+    const manifest = await driverHandle?.getManifest({ environment: "production" })
+    expect(manifest?.workflows).toEqual([
+      expect.objectContaining({
+        id: "test-manifest-only-scheduled-report",
+        description: "Manifest-only scheduled report",
+        schedules: [
+          {
+            every: "15m",
+            timezone: "UTC",
+            input: { source: "manifest-only" },
+            overlap: "skip",
+            environments: ["production"],
+            name: "every-fifteen-minutes",
+          },
+        ],
+      }),
+    ])
+  })
+
+  test("registers manifest-only event filters without runtime declarations", async () => {
+    const moduleSpec: Module = {
+      name: "manifest-only-filters",
+      workflows: [{ id: "test-filter-target" } satisfies WorkflowDescriptor],
+      eventFilters: [
+        {
+          id: "ef_manifest_only",
+          eventType: "test.manifest-only",
+          manifest: {
+            id: "ef_manifest_only",
+            eventType: "test.manifest-only",
+            payloadHash: "manifest_only",
+            targetWorkflowId: "test-filter-target",
+            where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+            input: { object: { kind: { path: "data.kind" } } },
+          },
+        } satisfies EventFilterDescriptor,
+      ],
+    }
+    const factory = createInMemoryDriver()
+    let driverHandle: ReturnType<typeof factory> | undefined
+
+    const app = mountApp({
+      db: () => null as never,
+      modules: [{ module: moduleSpec }],
+      workflows: {
+        driver: () => (deps) => {
+          driverHandle = factory(deps)
+          return driverHandle
+        },
+        environment: "production",
+      },
+    })
+
+    await app.ready()
+
+    const manifest = await driverHandle?.getManifest({ environment: "production" })
+    expect(manifest?.eventFilters).toEqual([
+      {
+        id: "ef_manifest_only",
+        eventType: "test.manifest-only",
+        payloadHash: "manifest_only",
+        targetWorkflowId: "test-filter-target",
+        where: { eq: [{ path: "data.kind" }, { lit: "all" }] },
+        input: { object: { kind: { path: "data.kind" } } },
+      },
+    ])
+  })
+
   test("registers workflow concurrency config in the runtime manifest", async () => {
     const queued = workflow<{ tenantId: string }, { ok: true }>({
       id: "test-queued-workflow",

--- a/packages/hono/tests/unit/plugin.test.ts
+++ b/packages/hono/tests/unit/plugin.test.ts
@@ -130,11 +130,10 @@ describe("mountApp with plugins", () => {
 
   function buildUnauthenticated(plugins: ReturnType<typeof defineHonoPlugin>[]) {
     return mountApp({
-      // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db.
-      db: () => ({}) as any,
+      db: () => ({}) as never,
       plugins,
       // Simulate the processor's credential-less POST: no actor resolved.
-      auth: { resolve: () => ({ userId: "", actor: undefined as unknown as Actor }) },
+      auth: { resolve: () => null },
     })
   }
 
@@ -229,7 +228,7 @@ describe("mountApp with plugins", () => {
     const res = await app.request("/v1/admin/events/emit", { method: "POST" }, TEST_ENV, TEST_CTX)
     expect(res.status).toBe(200)
     expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(
+    expect(handler.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         name: "booking.created",
         data: { bookingId: "b_123" },
@@ -372,7 +371,7 @@ describe("mountApp with plugins", () => {
     const res = await app.request("/v1/admin/bus/emit", { method: "POST" }, TEST_ENV, TEST_CTX)
     expect(res.status).toBe(200)
     expect(handler).toHaveBeenCalledTimes(1)
-    expect(handler).toHaveBeenCalledWith(
+    expect(handler.mock.calls[0]?.[0]).toEqual(
       expect.objectContaining({
         name: "booking.updated",
         data: { bookingId: "b_234" },

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -486,6 +486,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -480,6 +480,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -486,6 +486,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -479,6 +479,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/workflows/src/events/manifest-builder.ts
+++ b/packages/workflows/src/events/manifest-builder.ts
@@ -20,7 +20,6 @@ import type {
 } from "../protocol/index.js"
 import type { ConcurrencyPolicy, ScheduleDeclaration } from "../workflow.js"
 import { canonicalJson, shortHash } from "./payload-hash.js"
-import type { EventFilterRuntimeEntry } from "./registry.js"
 
 export interface BuildManifestArgs {
   /** Project / tenant identifier. Single-tenant runtimes pass `"default"`. */
@@ -38,11 +37,11 @@ export interface BuildManifestArgs {
       concurrency?: ConcurrencyPolicy<unknown>
       retry?: unknown
       timeout?: unknown
-      schedule?: ScheduleDeclaration | ScheduleDeclaration[]
+      schedule?: ScheduleDeclaration | readonly ScheduleDeclaration[]
     }
   }>
-  /** Event-filter entries from `getEventFilterRegistry()`. */
-  eventFilters: ReadonlyArray<EventFilterRuntimeEntry>
+  /** Event-filter entries from `trigger.on(...)` or manifest-only module metadata. */
+  eventFilters: ReadonlyArray<{ readonly manifest: EventFilterManifestEntry }>
   /** Wall-clock build time, ms-since-epoch. Defaults to `Date.now()`. */
   builtAt?: number
   /** Source-code version of the manifest builder. */
@@ -347,7 +346,7 @@ function serializeConcurrency(
 }
 
 function serializeSchedules(
-  schedule: ScheduleDeclaration | ScheduleDeclaration[] | undefined,
+  schedule: ScheduleDeclaration | readonly ScheduleDeclaration[] | undefined,
 ): ManifestSchedule[] {
   if (!schedule) return []
   const schedules = Array.isArray(schedule) ? schedule : [schedule]

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -480,6 +480,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -481,6 +481,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../commerce/dist/sellability/validation.d.ts"

--- a/scripts/check-v1-package-cleanup.ts
+++ b/scripts/check-v1-package-cleanup.ts
@@ -107,7 +107,8 @@ const temporaryOwnerExports = new Map<string, string[]>([
       ./promotions/service-catalog-evaluator ./promotions/service-catalog-plane-promotions
       ./promotions/service-evaluator ./promotions/service-storefront ./promotions/service
       ./promotions/validation ./promotions/workflow-bulk-reindex
-      ./promotions/workflow-runtime ./sellability ./sellability/routes ./sellability/schema
+      ./promotions/workflow-bulk-reindex-manifest ./promotions/workflow-runtime
+      ./sellability ./sellability/routes ./sellability/schema
       ./sellability/service-records ./sellability/service-resolve ./sellability/service-shared
       ./sellability/service-snapshots ./sellability/service ./sellability/validation
       ./pricing/public-routes ./pricing/public-validation

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -616,6 +616,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../../packages/commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../../packages/commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../../packages/commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../../packages/commerce/dist/sellability/validation.d.ts"

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -616,6 +616,9 @@
       "@voyant-travel/commerce/promotions/workflow-bulk-reindex": [
         "../../packages/commerce/dist/promotions/workflow-bulk-reindex.d.ts"
       ],
+      "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest": [
+        "../../packages/commerce/dist/promotions/workflow-bulk-reindex-manifest.d.ts"
+      ],
       "@voyant-travel/commerce/schema": ["../../packages/commerce/dist/schema.d.ts"],
       "@voyant-travel/commerce/sellability/validation": [
         "../../packages/commerce/dist/sellability/validation.d.ts"


### PR DESCRIPTION
Fixes #2925.

## Summary
- allow modules to provide manifest-only workflow and event-filter metadata without importing run-bearing workflow definitions
- split Commerce bulk reindex workflow metadata into a lightweight manifest subpath and use it from framework composition
- update Hono/workflows manifest wiring, docs, generated package configs, and regression tests

## Verification
- pnpm verify:fast

Note: local migration replay parity skipped because TEST_DATABASE_URL is not set.