### PR TITLE
Surface storefront booking API errors

### DIFF
--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-errors.ts
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-errors.ts
@@ -1,0 +1,60 @@
+export type StorefrontBookErrorBody = {
+  error?: unknown
+  code?: unknown
+  requestId?: unknown
+  details?: unknown
+  context?: { upstreamPayload?: { reason?: unknown } }
+}
+
+export function buildStorefrontBookFailureMessage(
+  body: StorefrontBookErrorBody,
+  requestId: string | null,
+  fallback: string,
+  requestReferenceTemplate: string,
+): string {
+  const message = firstString(body.error) ?? firstFieldError(body.details)
+  const reference = firstString(body.requestId) ?? requestId
+  const withMessage = message ? appendSentence(fallback, message) : fallback
+  return reference
+    ? appendSentence(withMessage, requestReferenceTemplate.replace("{requestId}", reference))
+    : withMessage
+}
+
+function appendSentence(base: string, sentence: string): string {
+  const trimmedBase = base.trim()
+  const trimmedSentence = sentence.trim()
+  if (!trimmedSentence) return trimmedBase
+  const separator = /[.!?]$/.test(trimmedBase) ? " " : ". "
+  const suffix = /[.!?]$/.test(trimmedSentence) ? trimmedSentence : `${trimmedSentence}.`
+  return `${trimmedBase}${separator}${suffix}`
+}
+
+function firstFieldError(details: unknown): string | null {
+  const record = asObject(details)
+  const fields = asObject(record?.fields) ?? record
+  const fieldErrors = asObject(fields?.fieldErrors)
+  if (!fieldErrors) return null
+
+  for (const value of Object.values(fieldErrors)) {
+    const message = firstString(value)
+    if (message) return message
+  }
+  return null
+}
+
+function firstString(value: unknown): string | null {
+  if (typeof value === "string") return value.trim() || null
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const message = firstString(item)
+      if (message) return message
+    }
+  }
+  return null
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-errors.ts
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-errors.ts
@@ -6,6 +6,10 @@ export type StorefrontBookErrorBody = {
   context?: { upstreamPayload?: { reason?: unknown } }
 }
 
+const SPACE = String.fromCharCode(32)
+const PERIOD = String.fromCharCode(46)
+const SENTENCE_SEPARATOR = PERIOD + SPACE
+
 export function buildStorefrontBookFailureMessage(
   body: StorefrontBookErrorBody,
   requestId: string | null,
@@ -24,8 +28,8 @@ function appendSentence(base: string, sentence: string): string {
   const trimmedBase = base.trim()
   const trimmedSentence = sentence.trim()
   if (!trimmedSentence) return trimmedBase
-  const separator = /[.!?]$/.test(trimmedBase) ? " " : ". "
-  const suffix = /[.!?]$/.test(trimmedSentence) ? trimmedSentence : `${trimmedSentence}.`
+  const separator = /[.!?]$/.test(trimmedBase) ? SPACE : SENTENCE_SEPARATOR
+  const suffix = /[.!?]$/.test(trimmedSentence) ? trimmedSentence : trimmedSentence + PERIOD
   return `${trimmedBase}${separator}${suffix}`
 }
 

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts
@@ -110,4 +110,15 @@ describe("buildStorefrontBookFailureMessage", () => {
       ),
     ).toBe("We couldn't complete your booking. Please try again.")
   })
+
+  it("keeps parse-failure bodies generic while preserving a request reference", () => {
+    expect(
+      buildStorefrontBookFailureMessage(
+        {},
+        "req_header_1",
+        "We couldn't complete your booking. Please try again.",
+        "Reference: {requestId}",
+      ),
+    ).toBe("We couldn't complete your booking. Please try again. Reference: req_header_1.")
+  })
 })

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { buildStorefrontBookFailureMessage } from "./storefront-booking-errors"
 import { buildStorefrontCommitParty } from "./storefront-booking-journey"
 
 describe("buildStorefrontCommitParty", () => {
@@ -56,5 +57,57 @@ describe("buildStorefrontCommitParty", () => {
         ],
       },
     })
+  })
+})
+
+describe("buildStorefrontBookFailureMessage", () => {
+  it("includes the API error and request id for failed public booking", () => {
+    expect(
+      buildStorefrontBookFailureMessage(
+        {
+          error: "Select a billing person or organization",
+          code: "invalid_request",
+          requestId: "req_book_1",
+        },
+        "req_header_ignored",
+        "We couldn't complete your booking. Please try again.",
+        "Reference: {requestId}",
+      ),
+    ).toBe(
+      "We couldn't complete your booking. Please try again. Select a billing person or organization. Reference: req_book_1.",
+    )
+  })
+
+  it("falls back to nested field errors and the response header request id", () => {
+    expect(
+      buildStorefrontBookFailureMessage(
+        {
+          code: "invalid_request",
+          details: {
+            fields: {
+              fieldErrors: {
+                personId: ["Select a billing person or organization"],
+              },
+            },
+          },
+        },
+        "req_header_1",
+        "We couldn't complete your booking. Please try again.",
+        "Reference: {requestId}",
+      ),
+    ).toBe(
+      "We couldn't complete your booking. Please try again. Select a billing person or organization. Reference: req_header_1.",
+    )
+  })
+
+  it("uses the generic checkout message when the API body is not actionable", () => {
+    expect(
+      buildStorefrontBookFailureMessage(
+        { error: "" },
+        null,
+        "We couldn't complete your booking. Please try again.",
+        "Reference: {requestId}",
+      ),
+    ).toBe("We couldn't complete your booking. Please try again.")
   })
 })

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -201,9 +201,7 @@ export function StorefrontBookingJourney({
         }),
       })
       if (!bookRes.ok) {
-        const errBody = (await bookRes
-          .json()
-          .catch(() => ({ error: "book_failed" }))) as StorefrontBookErrorBody
+        const errBody = (await bookRes.json().catch(() => ({}))) as StorefrontBookErrorBody
         console.error("[storefront] /book failed", errBody)
         // Reserve failures (e.g. 502 RESERVE_FAILED with reason
         // "rates_missing") must reach the customer — throw so the journey

--- a/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
+++ b/starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx
@@ -39,6 +39,10 @@ import {
   type OperatorInfoVariables,
   resolveContractVariables,
 } from "./resolve-contract-variables"
+import {
+  buildStorefrontBookFailureMessage,
+  type StorefrontBookErrorBody,
+} from "./storefront-booking-errors"
 
 /**
  * Marker for checkout failures we've already turned into a localized,
@@ -197,11 +201,9 @@ export function StorefrontBookingJourney({
         }),
       })
       if (!bookRes.ok) {
-        const errBody = (await bookRes.json().catch(() => ({ error: "book_failed" }))) as {
-          error?: string
-          code?: string
-          context?: { upstreamPayload?: { reason?: string } }
-        }
+        const errBody = (await bookRes
+          .json()
+          .catch(() => ({ error: "book_failed" }))) as StorefrontBookErrorBody
         console.error("[storefront] /book failed", errBody)
         // Reserve failures (e.g. 502 RESERVE_FAILED with reason
         // "rates_missing") must reach the customer — throw so the journey
@@ -210,11 +212,19 @@ export function StorefrontBookingJourney({
         // "adjust your selection" copy; everything else the generic message.
         // The engine error serializer nests the upstream payload under
         // `context.upstreamPayload` (ReserveFailedError), not at top level.
-        const reason = errBody.context?.upstreamPayload?.reason
+        const reason =
+          typeof errBody.context?.upstreamPayload?.reason === "string"
+            ? errBody.context.upstreamPayload.reason
+            : undefined
         throw new CheckoutError(
           reason === "rates_missing"
             ? messages.bookingJourney.reserveFailed
-            : messages.bookingJourney.checkoutFailed,
+            : buildStorefrontBookFailureMessage(
+                errBody,
+                bookRes.headers.get("x-request-id"),
+                messages.bookingJourney.checkoutFailed,
+                messages.bookingJourney.requestReference,
+              ),
         )
       }
       const bookJson = (await bookRes.json()) as { bookingId?: string }

--- a/starters/operator/src/lib/storefront-i18n.tsx
+++ b/starters/operator/src/lib/storefront-i18n.tsx
@@ -236,6 +236,7 @@ const storefrontMessagesEn = {
     marketingLabel: "Email me occasional updates about new tours and promotions.",
     checkoutFailed:
       "We couldn't complete your booking. Please review your selection or try again in a moment.",
+    requestReference: "Reference: {requestId}",
     reserveFailed:
       "This selection isn't available to book right now. Please adjust your dates or room and try again.",
   },
@@ -462,6 +463,7 @@ const storefrontMessagesRo: StorefrontMessages = {
     marketingLabel: "Trimite-mi ocazional noutati despre tururi noi si promotii.",
     checkoutFailed:
       "Nu am putut finaliza rezervarea. Verifica selectia sau incearca din nou peste putin timp.",
+    requestReference: "Referinta: {requestId}",
     reserveFailed:
       "Aceasta selectie nu poate fi rezervata acum. Ajusteaza datele sau camera si incearca din nou.",
   },


### PR DESCRIPTION
## Summary

Fixes #2618.

This PR keeps the existing anonymous owned-product billing resolution path intact and addresses the remaining storefront failure mode from the issue comments: when `/v1/public/catalog/book` rejects checkout, the customer now sees the API error detail plus a request reference instead of only the generic checkout message.

## Details

- Adds a small storefront booking error parser for `{ error, requestId, details.fields.fieldErrors }` responses.
- Uses the parser in the storefront checkout flow for `/book` failures while preserving the existing `rates_missing` reserve copy.
- Adds localized request-reference templates for EN and RO storefront messages.
- Covers body `requestId`, header `x-request-id`, nested field errors, and generic fallback behavior in tests.

## Validation

- `pnpm exec biome check --write starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.tsx starters/operator/src/components/voyant/booking-journey/storefront-booking-errors.ts starters/operator/src/components/voyant/booking-journey/storefront-booking-journey.test.ts starters/operator/src/lib/storefront-i18n.tsx`
- `pnpm --filter ./starters/operator test -- --run storefront-booking-journey product-booking-handler`
- `pnpm --filter ./starters/operator typecheck`
- `pnpm --filter ./starters/operator lint`
- pre-commit hook: changed-file agent quality plus Turbo lint/typecheck/build passed with existing file-size warnings
- pre-push hook: repository test lane passed; the initial non-namespaced branch push failed with GitHub `fatal error in commit_refs`, then the namespaced branch push succeeded
