### PR TITLE
Use GitHub API mode for Changesets release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,11 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           createGithubReleases: false
+          # Avoid GitHub's intermittent server-side `commit_refs` failures when
+          # the action force-pushes `changeset-release/main` via the Git CLI.
+          # The API mode creates the same version commit/PR through GitHub's
+          # refs API instead of `git push origin HEAD:changeset-release/main`.
+          commitMode: github-api
           version: pnpm version-packages
           commit: "chore: release packages"
           title: "chore: release packages"


### PR DESCRIPTION
## Summary

Fixes the release workflow failure where `changesets/action` successfully creates the release commit locally, then GitHub rejects the Git CLI force-push to `changeset-release/main` with:

```text
remote: fatal error in commit_refs
! [remote rejected] HEAD -> changeset-release/main (failure)
```

## Root Cause

The pinned `changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d` supports two commit modes. Its default is `git-cli`, which updates the release PR branch with `git push origin HEAD:changeset-release/main --force`. That is the exact operation failing in the release log.

## Change

Set `commitMode: github-api` for the Changesets step. The action source at the pinned SHA supports this input and wires Octokit into its commit path, avoiding the failing Git CLI push path while preserving the same version command, commit message, PR title, and release PR behavior.

## Validation

- Confirmed the pinned action exposes `commitMode` in `action.yml`.
- Confirmed the pinned action source accepts `github-api` and passes Octokit to its Git helper.
- `pnpm verify:release-config`
- `python3` YAML parse of `.github/workflows/release.yml`
- `git diff --check`
- pre-commit hook passed: changed-file agent quality and Turbo lint/typecheck/build

Note: direct Git push for this fix branch also hit GitHub `fatal error in commit_refs`, so I created the branch through the GitHub refs API. That matches the workflow fix path.
