### PR TITLE
Add lazy provider and plugin seams

### DIFF
--- a/.changeset/lazy-provider-plugin-seam.md
+++ b/.changeset/lazy-provider-plugin-seam.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/hono": patch
+"@voyant-travel/framework": patch
+---
+
+Add lazy provider and lazy Hono bundle helpers so deployments can keep heavy
+provider/plugin service graphs out of the eager app closure while preserving
+request-time route, bootstrap, subscriber, and anonymous webhook behavior.
+Lazy bundles can also declare eager transactional module/path metadata so the
+first request selects the transaction-capable DB before the bundle is imported.
+
+Narrow the framework relationships provider surface to the async methods the
+framework consumes, so lazy provider call sites do not proxy query-builder or
+plain-property service members.

--- a/docs/architecture/module-provider-plugin-taxonomy.md
+++ b/docs/architecture/module-provider-plugin-taxonomy.md
@@ -221,6 +221,48 @@ surface.
 
 ## Packaging Guidance
 
+### 9a. Keep provider and plugin runtime graphs lazy when they are request-owned
+
+Provider and plugin seams are also performance boundaries. If a provider or
+plugin imports a large service graph but is only used by request handlers,
+webhooks, subscribers, or bootstrap work, register it lazily instead of
+constructing the concrete value in the deployment's app module.
+
+Rules:
+
+- Provider containers may use `lazyProvider(() => import(...))` for service
+  objects or async provider functions whose first real use happens inside a
+  request/event path.
+- `lazyProvider(...)` is only valid for async functions or object surfaces whose
+  consumed members are async methods. Do not use it for plain properties,
+  sync-returning methods, query builders, or mixed service objects; narrow the
+  provider contract first.
+- Hono plugin bundles that would import heavy adapter code may use
+  `defineLazyHonoBundle(...)` with eager metadata (`name`, `anonymous`, and
+  absolute route matchers) plus a lazy `load` factory.
+- Anonymous webhook/callback paths must stay eager metadata on the lazy bundle,
+  so the first inbound unauthenticated request is admitted before the bundle is
+  imported.
+- Transactional lazy bundle surfaces must declare eager
+  `transactionalModules` or `transactionalPaths` metadata. The app selects the
+  request DB before lazy route handlers run, so transaction ownership cannot be
+  discovered from the loaded bundle on the first request.
+- Lazy bundles that must register subscribers, workflow metadata, container
+  services, or bootstrap work before a bundle-owned route is hit must opt into
+  app bootstrap loading with `loadOnBootstrap`.
+
+Rule:
+
+Do not statically import a heavy provider/plugin implementation in the
+deployment app closure when the framework can mount a lazy provider or lazy
+bundle seam with the same runtime behavior.
+
+Verification:
+
+- After building a deployment, measure the static closure of the generated API
+  app chunk with `node scripts/measure-static-import-closure.mjs <dist/server/assets/app-*.js>`.
+  The script walks static imports and stops at dynamic `import(...)` boundaries.
+
 ### 10. Prefer clear names that reveal the package role
 
 Prefer names that reveal whether the package is:

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -32,8 +32,13 @@ import type { Hono } from "hono"
 // biome-ignore lint/suspicious/noExplicitAny: lazy sub-apps keep route-specific Hono env generics -- owner: framework composition.
 type AnyHono = Hono<any>
 
+type FrameworkRelationshipsService = Pick<
+  typeof relationshipsService,
+  "getPersonById" | "getOrganizationById" | "loadPersonTravelSnapshot" | "upsertPersonFromContact"
+>
+
 export interface FrameworkProviders {
-  relationshipsService: typeof relationshipsService
+  relationshipsService: FrameworkRelationshipsService
   closePaymentSchedulesForBooking: NonNullable<
     BookingsHonoModuleOptions["closePaymentSchedulesForBooking"]
   >

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -139,6 +139,11 @@ const extrasHonoModule = {
   adminRoutes: extrasCombinedRoutes,
 } satisfies HonoModule
 
+type FrameworkRelationshipsService = Pick<
+  typeof relationshipsService,
+  "getPersonById" | "getOrganizationById" | "loadPersonTravelSnapshot" | "upsertPersonFromContact"
+>
+
 // Stable absolute route matchers for the lazy `operator/*` standard families
 // (Tier 4). The framework owns the URL contract; the deployment injects only
 // the `load` closure that wires its providers into the route bundle.
@@ -283,7 +288,7 @@ function toCheckoutReminderRun(run: NotificationReminderRunLike): CheckoutRemind
  */
 export interface FrameworkProviders {
   /** Relationships service — bookings reads person/snapshot helpers off it. */
-  relationshipsService: typeof relationshipsService
+  relationshipsService: FrameworkRelationshipsService
   /** Closes a booking's terminal payment schedules (bookings module option). */
   closePaymentSchedulesForBooking: NonNullable<
     BookingsHonoModuleOptions["closePaymentSchedulesForBooking"]

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -47,7 +47,13 @@ import { securityHeaders } from "./middleware/security-headers.js"
 import { resolveSurfaceMountPath } from "./mount-paths.js"
 import { noopReporter, safeCaptureException } from "./observability/reporter.js"
 import { getRequestId } from "./observability/request-context.js"
-import { expandHonoPlugins } from "./plugin.js"
+import {
+  type ExpandedHonoBundles,
+  expandHonoBundles,
+  type HonoBundle,
+  isLazyHonoBundle,
+  type LazyHonoBundle,
+} from "./plugin.js"
 import type { VoyantAppConfig, VoyantBindings, VoyantDb, VoyantVariables } from "./types.js"
 
 const WRITE_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"])
@@ -57,6 +63,9 @@ type MountEnv<TBindings extends VoyantBindings> = {
   Bindings: TBindings
   Variables: VoyantVariables
 }
+
+// biome-ignore lint/suspicious/noExplicitAny: route helpers accept composed sub-apps with arbitrary Hono env generics -- owner: hono runtime.
+type AnyHono = Hono<any, any, any>
 
 function resolveConfiguredRateLimitStore<TBindings extends VoyantBindings>(
   config: RateLimitConfig | undefined,
@@ -182,8 +191,22 @@ export function mountApp<TBindings extends VoyantBindings>(
   const appName = config.appName ?? "voyant"
   app.onError((err, c) => handleApiError(err, c, { reporter, appName }))
 
-  // Expand plugins into their constituent modules/extensions before mounting
-  const expanded = config.plugins ? expandHonoPlugins(config.plugins) : null
+  const pluginInputs = config.plugins ?? []
+  const eagerPlugins: HonoBundle[] = []
+  const lazyPlugins: LazyHonoBundle[] = []
+  const pluginNames = new Set<string>()
+  for (const plugin of pluginInputs) {
+    if (pluginNames.has(plugin.name)) {
+      throw new Error(`Duplicate bundle name: "${plugin.name}"`)
+    }
+    pluginNames.add(plugin.name)
+    if (isLazyHonoBundle(plugin)) lazyPlugins.push(plugin)
+    else eagerPlugins.push(plugin)
+  }
+
+  // Expand eager plugins into their constituent modules/extensions before
+  // mounting. Lazy plugins keep only their static metadata in the eager closure.
+  const expanded = eagerPlugins.length > 0 ? expandHonoBundles(eagerPlugins) : null
   const allModules = [...(config.modules ?? []), ...(expanded?.modules ?? [])]
   const allExtensions = [...(config.extensions ?? []), ...(expanded?.extensions ?? [])]
   // Anonymous-access allow-list (ADR-0008): assembled from module/extension
@@ -194,6 +217,7 @@ export function mountApp<TBindings extends VoyantBindings>(
   const anonymousPaths = assembleAnonymousPaths(allModules, allExtensions, [
     ...(config.publicPaths ?? []),
     ...(expanded?.anonymousPaths ?? []),
+    ...lazyPlugins.flatMap((plugin) => plugin.anonymous ?? []),
   ])
   // When the framework owns the bus, route subscriber-dispatch failures
   // (including the workflow forwarder) to the reporter — they're otherwise
@@ -237,18 +261,20 @@ export function mountApp<TBindings extends VoyantBindings>(
   // runtime is fail-closed).
   const collectedWorkflows: WorkflowDescriptor[] = []
   const collectedFilters: EventFilterDescriptor[] = []
-  for (const mod of allModules) {
-    if (mod.module.workflows) collectedWorkflows.push(...mod.module.workflows)
-    if (mod.module.eventFilters) collectedFilters.push(...mod.module.eventFilters)
+  function collectModuleRuntimeDescriptors(modules: readonly (typeof allModules)[number][]) {
+    for (const mod of modules) {
+      if (mod.module.workflows) collectedWorkflows.push(...mod.module.workflows)
+      if (mod.module.eventFilters) collectedFilters.push(...mod.module.eventFilters)
+    }
   }
-  for (const plugin of config.plugins ?? []) {
-    if (plugin.workflows) collectedWorkflows.push(...plugin.workflows)
-    if (plugin.eventFilters) collectedFilters.push(...plugin.eventFilters)
+  function collectPluginRuntimeDescriptors(plugins: readonly HonoBundle[]) {
+    for (const plugin of plugins) {
+      if (plugin.workflows) collectedWorkflows.push(...plugin.workflows)
+      if (plugin.eventFilters) collectedFilters.push(...plugin.eventFilters)
+    }
   }
-  // Validate duplicate workflow ids across modules + plugins. Same id from
-  // re-imports (HMR / shared bundles) is fine because identity is by id —
-  // we only flag genuinely-different definitions sharing an id.
-  if (config.workflows && collectedWorkflows.length > 0) {
+  function assertUniqueWorkflowIds() {
+    if (!config.workflows || collectedWorkflows.length === 0) return
     const seen = new Map<string, WorkflowDescriptor>()
     for (const wf of collectedWorkflows) {
       const existing = seen.get(wf.id)
@@ -263,6 +289,128 @@ export function mountApp<TBindings extends VoyantBindings>(
     }
   }
 
+  collectModuleRuntimeDescriptors(allModules)
+  collectPluginRuntimeDescriptors(eagerPlugins)
+  assertUniqueWorkflowIds()
+
+  const txModuleNames = new Set<string>()
+  const txRequiringModules: string[] = []
+  const txPrefixes: string[] = [...(config.dbTransactionalPaths ?? [])]
+
+  function addTransactionalModuleName(name: string) {
+    if (txModuleNames.has(name)) return
+    txModuleNames.add(name)
+    txRequiringModules.push(name)
+    // `/v1/public/<name>` is added unconditionally (not only when the module
+    // mounts publicRoutes): other modules mounted at the public root can serve
+    // paths under a flagged module's segment.
+    txPrefixes.push(`/v1/admin/${name}`, `/v1/${name}`, `/v1/public/${name}`)
+  }
+
+  function addTransactionalSurfaces(
+    modules: readonly (typeof allModules)[number][],
+    extensions: readonly (typeof allExtensions)[number][],
+  ) {
+    for (const mod of modules) {
+      if (mod.module.requiresTransactionalDb) addTransactionalModuleName(mod.module.name)
+    }
+    for (const ext of extensions) {
+      if (ext.extension.requiresTransactionalDb) addTransactionalModuleName(ext.extension.module)
+    }
+    for (const mod of modules) {
+      if (txModuleNames.has(mod.module.name) && mod.publicRoutes) {
+        txPrefixes.push(resolveSurfaceMountPath("/v1/public", mod.publicPath, mod.module.name))
+      }
+      if (mod.transactionalPaths) txPrefixes.push(...mod.transactionalPaths)
+    }
+    for (const ext of extensions) {
+      if (txModuleNames.has(ext.extension.module) && ext.publicRoutes) {
+        txPrefixes.push(resolveSurfaceMountPath("/v1/public", ext.publicPath, ext.extension.module))
+      }
+      if (ext.transactionalPaths) txPrefixes.push(...ext.transactionalPaths)
+    }
+  }
+
+  addTransactionalSurfaces(allModules, allExtensions)
+  for (const plugin of lazyPlugins) {
+    for (const moduleName of plugin.transactionalModules ?? []) {
+      addTransactionalModuleName(moduleName)
+    }
+    if (plugin.transactionalPaths) txPrefixes.push(...plugin.transactionalPaths)
+  }
+
+  const loadedLazyBundles = new Map<string, HonoBundle>()
+  const lazyBundlePromises = new Map<string, Promise<HonoBundle>>()
+  let lazyPluginExpansionPromise: Promise<void> | undefined
+  const expandedLazyBundleNames = new Set<string>()
+
+  function loadLazyBundle(plugin: LazyHonoBundle): Promise<HonoBundle> {
+    const cached = loadedLazyBundles.get(plugin.name)
+    if (cached) return Promise.resolve(cached)
+    const pending = lazyBundlePromises.get(plugin.name)
+    if (pending) return pending
+
+    const promise = plugin
+      .load()
+      .then((bundle) => {
+        if (bundle.name !== plugin.name) {
+          throw new Error(
+            `Lazy bundle "${plugin.name}" loaded bundle "${bundle.name}". ` +
+              "The metadata name must match the loaded bundle name.",
+          )
+        }
+        loadedLazyBundles.set(plugin.name, bundle)
+        return bundle
+      })
+      .catch((error) => {
+        lazyBundlePromises.delete(plugin.name)
+        throw error
+      })
+    lazyBundlePromises.set(plugin.name, promise)
+    return promise
+  }
+
+  function applyLazyBundleContributions(bundles: readonly HonoBundle[]) {
+    const pending = bundles.filter((bundle) => !expandedLazyBundleNames.has(bundle.name))
+    if (pending.length === 0) return
+    const lazyExpanded = expandHonoBundles(pending)
+    for (const bundle of pending) expandedLazyBundleNames.add(bundle.name)
+    allModules.push(...lazyExpanded.modules)
+    allExtensions.push(...lazyExpanded.extensions)
+    anonymousPaths.push(
+      ...assembleAnonymousPaths(lazyExpanded.modules, lazyExpanded.extensions, [
+        ...lazyExpanded.anonymousPaths,
+      ]),
+    )
+    for (const mod of lazyExpanded.modules) {
+      if (mod.module.service !== undefined) {
+        container.register(mod.module.name, mod.module.service)
+      }
+    }
+    for (const sub of lazyExpanded.subscribers) {
+      eventBus.subscribe(sub.event, sub.handler, { inline: sub.inline ?? false })
+    }
+    collectModuleRuntimeDescriptors(lazyExpanded.modules)
+    collectPluginRuntimeDescriptors(pending)
+    addTransactionalSurfaces(lazyExpanded.modules, lazyExpanded.extensions)
+  }
+
+  async function ensureBootstrapLazyPluginsExpanded() {
+    const bootstrapLazyPlugins = lazyPlugins.filter((plugin) => plugin.loadOnBootstrap)
+    if (bootstrapLazyPlugins.length === 0) return
+    if (!lazyPluginExpansionPromise) {
+      lazyPluginExpansionPromise = Promise.all(bootstrapLazyPlugins.map(loadLazyBundle))
+        .then((bundles) => {
+          applyLazyBundleContributions(bundles)
+        })
+        .catch((error) => {
+          lazyPluginExpansionPromise = undefined
+          throw error
+        })
+    }
+    await lazyPluginExpansionPromise
+  }
+
   // Workflow driver construction is **deferred** to the lazy bootstrap
   // path so callers whose driver options come from `env.*` bindings can
   // pass a function-of-bindings shape. Node / InMemory users usually
@@ -274,6 +422,8 @@ export function mountApp<TBindings extends VoyantBindings>(
     if (!bootstrapPromise) {
       bootstrapPromise = (async () => {
         const ctx = { bindings, container, eventBus }
+        await ensureBootstrapLazyPluginsExpanded()
+        assertUniqueWorkflowIds()
 
         // ---- Workflow runtime FIRST — fail-closed manifest registration
         //      and EventBus forwarder must be in place before any module
@@ -326,7 +476,12 @@ export function mountApp<TBindings extends VoyantBindings>(
           }
         }
 
-        for (const plugin of config.plugins ?? []) {
+        for (const plugin of [
+          ...eagerPlugins,
+          ...lazyPlugins
+            .filter((p) => p.loadOnBootstrap)
+            .map((p) => loadedLazyBundles.get(p.name)!),
+        ]) {
           await runIsolated(`plugin:${plugin.name}`, plugin.bootstrap)
         }
         for (const mod of allModules) {
@@ -482,48 +637,6 @@ export function mountApp<TBindings extends VoyantBindings>(
     mountAuthForwarding(app, authHandler, { reporter, appName })
   }
 
-  // Transactional surface map: a request must be served by a
-  // transaction-capable db client when its path belongs to (a) a module
-  // declaring `requiresTransactionalDb`, (b) a module targeted by an
-  // extension that declares it (extensions mount under the target
-  // module's prefix — e.g. catalog-authoring's compose routes live under
-  // /v1/admin/products), or (c) a template-supplied extra path
-  // (`dbTransactionalPaths` — for additionalRoutes / adapter-wired flows
-  // like the catalog booking engine whose transactionality depends on
-  // starter wiring).
-  const txModuleNames = new Set<string>(
-    allModules.filter((m) => m.module.requiresTransactionalDb).map((m) => m.module.name),
-  )
-  for (const ext of allExtensions) {
-    if (ext.extension.requiresTransactionalDb) txModuleNames.add(ext.extension.module)
-  }
-  const txRequiringModules = [...txModuleNames]
-  const txPrefixes: string[] = [...(config.dbTransactionalPaths ?? [])]
-  for (const name of txModuleNames) {
-    // `/v1/public/<name>` is added unconditionally (not only when the
-    // module mounts publicRoutes): other modules mounted at the public
-    // root can serve paths under a flagged module's segment — e.g.
-    // storefront (publicPath "/") handles
-    // /v1/public/bookings/sessions/bootstrap, which reaches
-    // bookings' transactional reserve flow.
-    txPrefixes.push(`/v1/admin/${name}`, `/v1/${name}`, `/v1/public/${name}`)
-  }
-  for (const mod of allModules) {
-    if (txModuleNames.has(mod.module.name) && mod.publicRoutes) {
-      txPrefixes.push(resolveSurfaceMountPath("/v1/public", mod.publicPath, mod.module.name))
-    }
-    // Absolute transactional prefixes for routes mounted outside the name-based
-    // surface (e.g. a lazy family at `/v1/admin/catalog/quote`), so the
-    // deployment doesn't hand-maintain them in `dbTransactionalPaths` (ADR-0008).
-    if (mod.transactionalPaths) txPrefixes.push(...mod.transactionalPaths)
-  }
-  for (const ext of allExtensions) {
-    if (txModuleNames.has(ext.extension.module) && ext.publicRoutes) {
-      txPrefixes.push(resolveSurfaceMountPath("/v1/public", ext.publicPath, ext.extension.module))
-    }
-    if (ext.transactionalPaths) txPrefixes.push(...ext.transactionalPaths)
-  }
-
   // With a `dbTransactional` factory, requests are routed per surface:
   // transactional prefixes get it, everything else gets the cheap
   // default (typically neon-http — no per-request connection handshake).
@@ -610,6 +723,62 @@ export function mountApp<TBindings extends VoyantBindings>(
     })
   }
 
+  function mountModuleRoutesInto(target: AnyHono, mod: (typeof allModules)[number]) {
+    const moduleName = mod.module.name
+    const adminPrefix = `/v1/admin/${moduleName}`
+    const publicPrefix = resolveSurfaceMountPath("/v1/public", mod.publicPath, moduleName)
+    if (mod.adminRoutes) {
+      target.route(adminPrefix, mod.adminRoutes)
+    }
+    if (mod.publicRoutes) {
+      target.route(publicPrefix, mod.publicRoutes)
+    }
+    if (mod.lazyAdminRoutes) {
+      mountLazyRoutesAt(target, adminPrefix, mod.lazyAdminRoutes)
+    }
+    if (mod.lazyPublicRoutes) {
+      mountLazyRoutesAt(target, publicPrefix, mod.lazyPublicRoutes)
+    }
+    if (mod.lazyRoutes) {
+      mountLazyRoutePaths(target, mod.lazyRoutes.paths, mod.lazyRoutes.load)
+    }
+    if (mod.webhookRoutes) {
+      target.route(`/v1/${moduleName}`, mod.webhookRoutes)
+    }
+  }
+
+  function mountExtensionRoutesInto(target: AnyHono, ext: (typeof allExtensions)[number]) {
+    const moduleName = ext.extension.module
+    const adminPrefix = `/v1/admin/${moduleName}`
+    const publicPrefix = resolveSurfaceMountPath("/v1/public", ext.publicPath, moduleName)
+    if (ext.adminRoutes) {
+      target.route(adminPrefix, ext.adminRoutes)
+    }
+    if (ext.publicRoutes) {
+      target.route(publicPrefix, ext.publicRoutes)
+    }
+    if (ext.lazyAdminRoutes) {
+      mountLazyRoutesAt(target, adminPrefix, ext.lazyAdminRoutes)
+    }
+    if (ext.lazyPublicRoutes) {
+      mountLazyRoutesAt(target, publicPrefix, ext.lazyPublicRoutes)
+    }
+    if (ext.lazyRoutes) {
+      mountLazyRoutePaths(target, ext.lazyRoutes.paths, ext.lazyRoutes.load)
+    }
+    if (ext.webhookRoutes) {
+      target.route(`/v1/${moduleName}`, ext.webhookRoutes)
+    }
+  }
+
+  function buildBundleRouteApp(bundle: HonoBundle): AnyHono {
+    const pluginRoutes = new OpenAPIHono()
+    const bundleExpanded: ExpandedHonoBundles = expandHonoBundles([bundle])
+    for (const mod of bundleExpanded.modules) mountModuleRoutesInto(pluginRoutes, mod)
+    for (const ext of bundleExpanded.extensions) mountExtensionRoutesInto(pluginRoutes, ext)
+    return pluginRoutes
+  }
+
   // Mount module routes
   for (const mod of allModules) {
     const moduleName = mod.module.name
@@ -666,6 +835,15 @@ export function mountApp<TBindings extends VoyantBindings>(
     if (ext.webhookRoutes) {
       app.route(`/v1/${moduleName}`, ext.webhookRoutes)
     }
+  }
+
+  for (const plugin of lazyPlugins) {
+    if (!plugin.routes || plugin.routes.length === 0) continue
+    deferLazyRoutePaths(`plugin:${plugin.name}`, plugin.routes, async () => {
+      const bundle = await loadLazyBundle(plugin)
+      applyLazyBundleContributions([bundle])
+      return buildBundleRouteApp(bundle)
+    })
   }
 
   for (const mountLazyRoutes of deferredLazyRouteMounts) {

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -28,6 +28,7 @@ export {
   encodeStorageKeyPath,
   resolveStoredDocumentDownload,
 } from "./document-download.js"
+export { type AsyncMethodProvider, lazyProvider } from "./lazy-provider.js"
 export {
   createLazyRouteHandler,
   type LazyHonoRoutes,
@@ -71,13 +72,17 @@ export type {
   ExpandedHonoBundles,
   ExpandedHonoPlugins,
   HonoBundle,
+  HonoBundleInput,
   HonoPlugin,
+  LazyHonoBundle,
 } from "./plugin.js"
 export {
   defineHonoBundle,
   defineHonoPlugin,
+  defineLazyHonoBundle,
   expandHonoBundles,
   expandHonoPlugins,
+  isLazyHonoBundle,
 } from "./plugin.js"
 export type {
   CreatePublicCapabilityOptions,

--- a/packages/hono/src/lazy-provider.ts
+++ b/packages/hono/src/lazy-provider.ts
@@ -1,0 +1,70 @@
+// biome-ignore lint/suspicious/noExplicitAny: provider proxies preserve arbitrary service method signatures -- owner: hono runtime.
+type AnyAsyncFunction = (...args: any[]) => Promise<unknown>
+
+export type AsyncMethodProvider<T extends object> = {
+  [K in keyof T]: T[K] extends (...args: infer Args) => infer Result
+    ? (...args: Args) => Promise<Awaited<Result>>
+    : never
+}
+
+/**
+ * Build a memoized proxy for a provider/service value that is expensive to
+ * import eagerly. Method calls and direct function calls resolve the target on
+ * first use, cache it for the isolate/process, and retry after a failed load.
+ *
+ * This helper is only for async provider seams. Object providers must expose
+ * async methods only; plain properties and sync-returning methods are outside
+ * the contract because a proxy cannot distinguish `service.flag` from
+ * `service.method` until call time.
+ */
+export function lazyProvider<T extends AnyAsyncFunction>(load: () => Promise<T>): T
+export function lazyProvider<T extends object>(
+  load: () => Promise<AsyncMethodProvider<T>>,
+): AsyncMethodProvider<T>
+export function lazyProvider<T extends object | AnyAsyncFunction>(
+  load: () => Promise<T>,
+): T | AsyncMethodProvider<Extract<T, object>> {
+  let targetPromise: Promise<T> | undefined
+
+  function resolveTarget() {
+    if (!targetPromise) {
+      targetPromise = load().catch((error) => {
+        targetPromise = undefined
+        throw error
+      })
+    }
+    return targetPromise
+  }
+
+  const callable = async (...args: Parameters<AnyAsyncFunction>) => {
+    const target = await resolveTarget()
+    if (typeof target !== "function") {
+      throw new TypeError("Lazy provider target is not callable")
+    }
+    return target(...args)
+  }
+
+  return new Proxy(callable, {
+    apply: (_target, thisArg, args) =>
+      resolveTarget().then((target) => {
+        if (typeof target !== "function") {
+          throw new TypeError("Lazy provider target is not callable")
+        }
+        return Reflect.apply(target, thisArg, args)
+      }),
+    get: (_target, prop) => {
+      if (prop === "then") return undefined
+      if (prop === "toString") return () => "[lazy provider]"
+      if (prop === Symbol.toStringTag) return "LazyProvider"
+      return async (...args: Parameters<AnyAsyncFunction>) => {
+        const target = await resolveTarget()
+        const value = Reflect.get(target, prop, target)
+        if (typeof value !== "function") {
+          if (args.length === 0) return value
+          throw new TypeError(`Lazy provider property "${String(prop)}" is not callable`)
+        }
+        return Reflect.apply(value, target, args)
+      }
+    },
+  }) as T | AsyncMethodProvider<Extract<T, object>>
+}

--- a/packages/hono/src/lib/db-selector.ts
+++ b/packages/hono/src/lib/db-selector.ts
@@ -25,7 +25,6 @@ export interface PathDbSelectorOptions<TBindings extends VoyantBindings> {
 export function createPathDbSelector<TBindings extends VoyantBindings>(
   options: PathDbSelectorOptions<TBindings>,
 ): DbFactorySelector<TBindings> {
-  const prefixes = [...new Set(options.transactionalPrefixes)]
   const transactional = {
     factory: options.transactionalFactory,
     mustSupportTransactions: true,
@@ -36,6 +35,7 @@ export function createPathDbSelector<TBindings extends VoyantBindings>(
   }
   return {
     select(path: string) {
+      const prefixes = [...new Set(options.transactionalPrefixes)]
       for (const prefix of prefixes) {
         if (path === prefix || path.startsWith(`${prefix}/`)) return transactional
       }

--- a/packages/hono/src/plugin.ts
+++ b/packages/hono/src/plugin.ts
@@ -62,11 +62,72 @@ export interface HonoBundle {
 /** @deprecated Prefer {@link HonoBundle}. */
 export type HonoPlugin = HonoBundle
 
+const LAZY_HONO_BUNDLE = Symbol.for("voyant.hono.lazyBundle")
+
+/**
+ * Lazy bundle declaration. The bundle's heavy runtime graph is imported only
+ * when a declared route matcher is hit, unless `loadOnBootstrap` asks the app
+ * to load it during request/headless bootstrap. `name` and `anonymous` remain
+ * eager metadata so duplicate checks and auth allow-lists stay fail-closed.
+ */
+export interface LazyHonoBundle {
+  readonly [LAZY_HONO_BUNDLE]: true
+  /** Unique bundle identifier matching the loaded bundle's `name`. */
+  name: string
+  /** Optional version tag for diagnostics. */
+  version?: string
+  /**
+   * Absolute unauthenticated paths contributed by the eventual bundle. Declare
+   * webhook/callback paths here so the first matching request can pass auth
+   * before the bundle has been imported.
+   */
+  anonymous?: string[]
+  /**
+   * Absolute route matchers the eventual bundle may serve. Required for lazy
+   * bundles that contribute HTTP routes because Hono routes must be registered
+   * before the first request builds the matcher.
+   */
+  routes?: readonly string[]
+  /**
+   * Module names whose lazy-loaded routes must receive a transaction-capable DB
+   * client. This is eager metadata so the first matching request is routed to
+   * `dbTransactional` before the bundle implementation is imported.
+   */
+  transactionalModules?: readonly string[]
+  /**
+   * Absolute API path prefixes whose lazy-loaded routes must receive the
+   * transaction-capable DB client. Use this when only a subset of the lazy
+   * bundle's explicit `routes` require transactions.
+   */
+  transactionalPaths?: readonly string[]
+  /**
+   * Load this bundle during app bootstrap instead of waiting for a declared
+   * route matcher. Set this for lazy bundles that contribute subscribers,
+   * workflow metadata, container services, or bootstraps needed before a
+   * bundle-owned route is hit.
+   */
+  loadOnBootstrap?: boolean
+  /** Loads and constructs the real bundle. Memoized by `mountApp`. */
+  load: () => Promise<HonoBundle>
+}
+
+export type HonoBundleInput = HonoBundle | LazyHonoBundle
+
 /**
  * Identity helper — returns the bundle unchanged, purely for IDE inference.
  */
 export function defineHonoBundle<P extends HonoBundle>(bundle: P): P {
   return bundle
+}
+
+export function defineLazyHonoBundle<P extends Omit<LazyHonoBundle, typeof LAZY_HONO_BUNDLE>>(
+  bundle: P,
+): P & LazyHonoBundle {
+  return { ...bundle, [LAZY_HONO_BUNDLE]: true } as P & LazyHonoBundle
+}
+
+export function isLazyHonoBundle(bundle: HonoBundleInput): bundle is LazyHonoBundle {
+  return (bundle as LazyHonoBundle)[LAZY_HONO_BUNDLE] === true
 }
 
 /** @deprecated Prefer {@link defineHonoBundle}. */

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -20,7 +20,7 @@ import type { Hono } from "hono"
 
 import type { HonoExtension, HonoModule } from "./module.js"
 import type { Reporter } from "./observability/reporter.js"
-import type { HonoBundle } from "./plugin.js"
+import type { HonoBundleInput } from "./plugin.js"
 
 export interface VoyantExecutionContext {
   waitUntil?: (promise: Promise<unknown>) => void
@@ -248,7 +248,7 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
   dbTransactionalPaths?: string[]
   modules?: HonoModule[]
   extensions?: HonoExtension[]
-  plugins?: HonoBundle[]
+  plugins?: HonoBundleInput[]
   eventBus?: EventBus
   link?: LinkService
   query?: QueryGraphContext | VoyantQueryRuntime

--- a/packages/hono/tests/unit/create-app.test.ts
+++ b/packages/hono/tests/unit/create-app.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 
 import type { CompositionRegistry } from "../../src/composition.js"
 import { createApp } from "../../src/create-app.js"
+import { lazyProvider } from "../../src/lazy-provider.js"
 
 interface Caps {
   greeting: string
@@ -51,5 +52,43 @@ describe("createApp (config-driven front door)", () => {
     const app = build()
     const res = await app.request("/v1/admin/not-mounted/x", {}, {} as never)
     expect(res.status).toBe(404)
+  })
+
+  it("supports memoized lazy provider values", async () => {
+    interface LazyCaps {
+      service: { greet: () => Promise<string> }
+    }
+
+    let loads = 0
+    const lazyRegistry: CompositionRegistry<LazyCaps> = {
+      modules: {
+        "@voyant-travel/lazy-demo": ({ capabilities }) => ({
+          module: { name: "lazy-demo" },
+          adminRoutes: new Hono().get("/ping", async (c) =>
+            c.text(await capabilities.service.greet()),
+          ),
+        }),
+      },
+    }
+
+    const app = createApp<Record<string, never>, LazyCaps>({
+      manifest: { modules: ["@voyant-travel/lazy-demo"] },
+      registry: lazyRegistry,
+      capabilities: {
+        service: lazyProvider(async () => {
+          loads += 1
+          return { greet: async () => "lazy-pong" }
+        }),
+      },
+      db: () => ({}) as never,
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    expect(loads).toBe(0)
+    const first = await app.request("/v1/admin/lazy-demo/ping", {}, {} as never)
+    const second = await app.request("/v1/admin/lazy-demo/ping", {}, {} as never)
+    expect(await first.text()).toBe("lazy-pong")
+    expect(await second.text()).toBe("lazy-pong")
+    expect(loads).toBe(1)
   })
 })

--- a/packages/hono/tests/unit/plugin.test.ts
+++ b/packages/hono/tests/unit/plugin.test.ts
@@ -1,4 +1,5 @@
 import { type Actor, createEventBus } from "@voyant-travel/core"
+import { VOYANT_DB_SUPPORTS_TRANSACTIONS } from "@voyant-travel/db/transaction-capability"
 import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
@@ -7,10 +8,12 @@ import type { HonoExtension, HonoModule } from "../../src/module.js"
 import {
   defineHonoBundle,
   defineHonoPlugin,
+  defineLazyHonoBundle,
   expandHonoBundles,
   expandHonoPlugins,
+  type HonoBundleInput,
 } from "../../src/plugin.js"
-import type { VoyantBindings } from "../../src/types.js"
+import type { DbFactory, VoyantBindings, VoyantDb } from "../../src/types.js"
 
 const TEST_ENV: VoyantBindings = { DATABASE_URL: "postgres://test" }
 const TEST_CTX = {
@@ -18,6 +21,13 @@ const TEST_CTX = {
   passThroughOnException: () => {},
   // biome-ignore lint/suspicious/noExplicitAny: mock ExecutionContext for tests -- owner: hono; existing suppression is intentional pending typed cleanup.
 } as any
+
+function fakeDb(supportsTransactions: boolean): VoyantDb {
+  const handle: Record<PropertyKey, unknown> = {
+    [VOYANT_DB_SUPPORTS_TRANSACTIONS]: supportsTransactions,
+  }
+  return handle as VoyantDb
+}
 
 function makeModule(name: string, surface: "admin" | "public"): HonoModule {
   const routes = new Hono().get("/ping", (c) => c.json({ name, surface }))
@@ -77,7 +87,7 @@ describe("expandHonoPlugins", () => {
 })
 
 describe("mountApp with plugins", () => {
-  function build(plugins: ReturnType<typeof defineHonoPlugin>[], actor: Actor = "staff") {
+  function build(plugins: HonoBundleInput[], actor: Actor = "staff") {
     return mountApp({
       // biome-ignore lint/suspicious/noExplicitAny: test doesn't use db -- owner: hono; existing suppression is intentional pending typed cleanup.
       db: () => ({}) as any,
@@ -128,7 +138,7 @@ describe("mountApp with plugins", () => {
     })
   }
 
-  function buildUnauthenticated(plugins: ReturnType<typeof defineHonoPlugin>[]) {
+  function buildUnauthenticated(plugins: HonoBundleInput[]) {
     return mountApp({
       db: () => ({}) as never,
       plugins,
@@ -206,6 +216,72 @@ describe("mountApp with plugins", () => {
         plugins: [p1, p2],
       }),
     ).toThrow(/Duplicate (plugin|bundle) name/)
+  })
+
+  it("loads lazy plugin bundles on first request instead of app construction", async () => {
+    let loads = 0
+    const app = build([
+      defineLazyHonoBundle({
+        name: "lazy-widgets",
+        routes: ["/v1/admin/lazy-widgets/ping"],
+        load: async () => {
+          loads += 1
+          return defineHonoBundle({
+            name: "lazy-widgets",
+            modules: [makeModule("lazy-widgets", "admin")],
+          })
+        },
+      }),
+    ])
+
+    expect(loads).toBe(0)
+    const first = await app.request("/v1/admin/lazy-widgets/ping", {}, TEST_ENV, TEST_CTX)
+    const second = await app.request("/v1/admin/lazy-widgets/ping", {}, TEST_ENV, TEST_CTX)
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(loads).toBe(1)
+  })
+
+  it("routes the first lazy transactional plugin request to dbTransactional", async () => {
+    const defaultFactory = vi.fn<DbFactory>(() => fakeDb(false))
+    const transactionalFactory = vi.fn<DbFactory>(() => fakeDb(true))
+    let loads = 0
+    const app = mountApp({
+      db: defaultFactory,
+      dbTransactional: transactionalFactory,
+      plugins: [
+        defineLazyHonoBundle({
+          name: "lazy-ledger",
+          routes: ["/v1/admin/lazy-ledger/commit"],
+          transactionalModules: ["lazy-ledger"],
+          load: async () => {
+            loads += 1
+            return defineHonoBundle({
+              name: "lazy-ledger",
+              modules: [
+                {
+                  module: { name: "lazy-ledger", requiresTransactionalDb: true },
+                  adminRoutes: new Hono().post("/commit", (c) => c.json({ ok: true })),
+                },
+              ],
+            })
+          },
+        }),
+      ],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const res = await app.request(
+      "/v1/admin/lazy-ledger/commit",
+      { method: "POST" },
+      TEST_ENV,
+      TEST_CTX,
+    )
+
+    expect(res.status).toBe(200)
+    expect(loads).toBe(1)
+    expect(transactionalFactory).toHaveBeenCalled()
+    expect(defaultFactory).not.toHaveBeenCalled()
   })
 
   it("wires plugin subscribers to the app event bus", async () => {

--- a/scripts/measure-static-import-closure.mjs
+++ b/scripts/measure-static-import-closure.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/**
+ * Measure the static ESM import closure for a built JavaScript entry.
+ *
+ * This walks only static `import` / `export ... from` edges and deliberately
+ * stops at dynamic `import(...)` boundaries. It is meant for built Worker chunks
+ * where startup cost tracks the files reachable from an entry before request
+ * routing resolves lazy chunks.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { dirname, extname, isAbsolute, join, relative, resolve } from "node:path"
+
+const args = process.argv.slice(2)
+const entryArg = args.shift()
+
+if (!entryArg) {
+  console.error("Usage: node scripts/measure-static-import-closure.mjs <entry.js> [--top N]")
+  process.exit(1)
+}
+
+let topCount = 20
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i]
+  if (arg === "--top") {
+    topCount = Number(args[++i])
+    if (!Number.isInteger(topCount) || topCount <= 0) {
+      throw new Error("--top must be a positive integer")
+    }
+    continue
+  }
+  throw new Error(`Unknown argument: ${arg}`)
+}
+
+const entry = resolve(process.cwd(), entryArg)
+const visited = new Set()
+const edges = new Map()
+
+walk(entry)
+
+const files = [...visited].sort()
+const rows = files.map((file) => ({ file, bytes: statSync(file).size }))
+const totalBytes = rows.reduce((sum, row) => sum + row.bytes, 0)
+
+console.log("Static import closure")
+console.log(`entry: ${relative(process.cwd(), entry)}`)
+console.log(`files: ${files.length}`)
+console.log(`bytes: ${totalBytes} (${formatBytes(totalBytes)})`)
+console.log("")
+console.log("Largest files:")
+for (const row of rows.sort((a, b) => b.bytes - a.bytes).slice(0, topCount)) {
+  console.log(`${formatBytes(row.bytes).padStart(10)}  ${relative(process.cwd(), row.file)}`)
+}
+
+function walk(file) {
+  const resolved = resolve(file)
+  if (visited.has(resolved)) return
+  if (!existsSync(resolved)) {
+    throw new Error(`Import target does not exist: ${resolved}`)
+  }
+  visited.add(resolved)
+
+  const source = readFileSync(resolved, "utf-8")
+  const imports = staticImports(source)
+  edges.set(resolved, imports)
+
+  for (const specifier of imports) {
+    if (!specifier.startsWith(".") && !specifier.startsWith("/")) continue
+    const target = resolveImport(dirname(resolved), specifier)
+    walk(target)
+  }
+}
+
+function staticImports(source) {
+  const imports = []
+  const pattern =
+    /(?:^|[;\n])\s*(?:import\s*(?:[^'"();]*?\s*from\s*)?|export\s*(?:[^'"();]*?\s*from\s*))["']([^"']+)["']/gs
+  let match = pattern.exec(source)
+  while (match) {
+    imports.push(match[1])
+    match = pattern.exec(source)
+  }
+  return imports
+}
+
+function resolveImport(fromDir, specifier) {
+  const candidate = isAbsolute(specifier) ? specifier : join(fromDir, specifier)
+  if (existsSync(candidate) && statSync(candidate).isFile()) return candidate
+  if (!extname(candidate)) {
+    for (const ext of [".js", ".mjs", ".cjs"]) {
+      const withExt = `${candidate}${ext}`
+      if (existsSync(withExt) && statSync(withExt).isFile()) return withExt
+    }
+  }
+  throw new Error(`Could not resolve ${specifier} from ${fromDir}`)
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  const kib = bytes / 1024
+  if (kib < 1024) return `${kib.toFixed(1)} KiB`
+  return `${(kib / 1024).toFixed(2)} MiB`
+}

--- a/starters/operator/src/api/app.ts
+++ b/starters/operator/src/api/app.ts
@@ -1,6 +1,6 @@
 import { BULK_REINDEX_SERVICE_KEY } from "@voyant-travel/commerce"
 import { createVoyantApp } from "@voyant-travel/framework"
-import { netopiaHonoBundle } from "@voyant-travel/plugin-netopia"
+import { defineLazyHonoBundle } from "@voyant-travel/hono"
 import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyant-travel/workflow-runs"
 import { OPERATOR_APP_NAME, operatorReporter } from "../lib/observability"
 import authHandler, {
@@ -13,7 +13,6 @@ import {
   deploymentLocalExtensions,
   deploymentLocalModules,
 } from "./composition"
-import { createBulkReindexProductsService } from "./lib/bulk-reindex-service"
 import { dbFromEnvForApp, httpDbFromEnvForApp } from "./lib/db"
 import { OPERATOR_PUBLIC_PATHS } from "./public-paths"
 import { bookingScheduleBundle } from "./routes/booking-schedule"
@@ -23,9 +22,9 @@ import {
   generateContractPdfForBooking,
 } from "./runtime/operator-runtime-adapter"
 import { tripsPaymentBundle } from "./runtime/trips-runtime"
-import { catalogBridgeBundle } from "./subscribers/catalog-bridge"
+import { catalogBridgeBundle } from "./subscribers/catalog-bridge-bundle"
 import { createCatalogCheckoutBundle } from "./subscribers/catalog-checkout-finalize-runtime"
-import { smartbillOperatorBundle } from "./subscribers/smartbill"
+import { smartbillOperatorBundle } from "./subscribers/smartbill-bundle"
 
 /**
  * Process-wide registry of workflow runners. Bundles register their
@@ -100,7 +99,8 @@ export const app = createVoyantApp<CloudflareBindings, ReturnType<typeof buildOp
   plugins: [
     {
       name: "operator-promotions-runtime",
-      bootstrap: ({ bindings, container }) => {
+      bootstrap: async ({ bindings, container }) => {
+        const { createBulkReindexProductsService } = await import("./lib/bulk-reindex-service")
         container.register(
           BULK_REINDEX_SERVICE_KEY,
           createBulkReindexProductsService(bindings as CloudflareBindings),
@@ -120,7 +120,13 @@ export const app = createVoyantApp<CloudflareBindings, ReturnType<typeof buildOp
     tripsPaymentBundle,
     smartbillOperatorBundle,
     channelPushBundle,
-    netopiaHonoBundle(),
+    defineLazyHonoBundle({
+      name: "netopia",
+      routes: ["/v1/admin/finance/providers/netopia/*", "/v1/finance/providers/netopia/callback"],
+      anonymous: ["/v1/finance/providers/netopia/callback"],
+      transactionalModules: ["finance"],
+      load: async () => import("@voyant-travel/plugin-netopia").then((m) => m.netopiaHonoBundle()),
+    }),
   ],
   auth: {
     handler: () => ({

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -19,6 +19,11 @@
  */
 
 import { OpenAPIHono } from "@hono/zod-openapi"
+import type {
+  CatalogSearchRuntime,
+  EmbeddingProvider,
+  IndexerAdapter,
+} from "@voyant-travel/catalog"
 import { chartersModule } from "@voyant-travel/charters"
 import { cruisesModule } from "@voyant-travel/cruises"
 import {
@@ -28,7 +33,7 @@ import {
   frameworkComposition,
   modulesFromGlob,
 } from "@voyant-travel/framework"
-import type { VoyantDb } from "@voyant-travel/hono"
+import { lazyProvider, type VoyantDb } from "@voyant-travel/hono"
 import type {
   CompositionManifest,
   CompositionRegistry,
@@ -37,17 +42,15 @@ import type {
 } from "@voyant-travel/hono/composition"
 import { createMiceHonoModule } from "@voyant-travel/mice"
 import { miceBookingExtension } from "@voyant-travel/mice/booking-extension"
-import { createNetopiaCheckoutStarter } from "@voyant-travel/plugin-netopia"
 import { createRealtimeHonoModule } from "@voyant-travel/realtime"
-import { relationshipsService } from "@voyant-travel/relationships"
+import type { StorefrontIntakePersistence } from "@voyant-travel/storefront"
 import { Hono } from "hono"
 import { resolveOperatorCustomFields } from "../lib/custom-fields"
 import { resolveNotificationProviders } from "../lib/notifications"
 import { operatorRealtimeBridgeRoutes, resolveRealtimeProviders } from "../lib/realtime"
 import { resolveBookingRequirementsProductSnapshot } from "./lib/booking-requirements-product-snapshot"
-import { buildCatalogContext } from "./lib/catalog-context"
 import { createChannelPushExtension } from "./routes/channel-push"
-import { AUTO_GENERATE_CONTRACT_OPTIONS } from "./runtime/contract-document-runtime"
+import { AUTO_GENERATE_CONTRACT_OPTIONS } from "./runtime/contract-document-variables"
 import {
   createOperatorBookingPiiService,
   createOperatorDocumentStorage,
@@ -62,10 +65,15 @@ import {
   resolveBankTransferDetails,
   resolvePublicCheckoutBaseUrlFromBindings,
 } from "./runtime/payment-config"
-import { createRelationshipsStorefrontIntakePersistence } from "./runtime/storefront-intake-runtime"
 import { createOperatorTripsRoutesOptions } from "./runtime/trips-runtime"
 import { recordPaidBookingCancellationSettlement } from "./subscribers/booking-cancellation-settlement"
 import { closeTerminalBookingPaymentSchedules } from "./subscribers/booking-payment-cleanup"
+
+type AsyncMethodProvider<T extends object> = {
+  [K in keyof T]: T[K] extends (...args: infer Args) => infer Result
+    ? (...args: Args) => Promise<Awaited<Result>>
+    : never
+}
 
 /**
  * The operator deployment's capability container. Every template-specific
@@ -88,7 +96,7 @@ export interface OperatorCapabilities extends FrameworkProviders {
   createBookingPiiService: typeof createOperatorBookingPiiService
   autoGenerateContractOnConfirmed: typeof AUTO_GENERATE_CONTRACT_OPTIONS
   resolveBankTransferDetails: typeof resolveBankTransferDetails
-  relationshipsService: typeof relationshipsService
+  relationshipsService: FrameworkProviders["relationshipsService"]
   closePaymentSchedulesForBooking: typeof closeTerminalBookingPaymentSchedules
   recordCancellationFinancialSettlement: typeof recordPaidBookingCancellationSettlement
   createTripsRoutesOptions: typeof createOperatorTripsRoutesOptions
@@ -114,23 +122,28 @@ export function buildOperatorProviders(): OperatorCapabilities {
     createBookingPiiService: createOperatorBookingPiiService,
     autoGenerateContractOnConfirmed: AUTO_GENERATE_CONTRACT_OPTIONS,
     resolveBankTransferDetails,
-    relationshipsService,
+    relationshipsService: lazyProvider<FrameworkProviders["relationshipsService"]>(async () =>
+      import("@voyant-travel/relationships").then(
+        (m) =>
+          m.relationshipsService as AsyncMethodProvider<FrameworkProviders["relationshipsService"]>,
+      ),
+    ),
     closePaymentSchedulesForBooking: closeTerminalBookingPaymentSchedules,
     recordCancellationFinancialSettlement: recordPaidBookingCancellationSettlement,
     // Adapt the deployment's catalog context into the package's search runtime
     // shape (the framework catalog factory consumes this directly).
-    resolveCatalogRuntime: (c) => {
-      const ctx = buildCatalogContext(c)
-      return {
-        indexer: ctx.catalog.indexer,
-        embeddings: ctx.catalog.embeddings,
-        defaultScope: ctx.defaultScope,
-      }
-    },
+    resolveCatalogRuntime: createLazyCatalogSearchRuntime,
     createTripsRoutesOptions: createOperatorTripsRoutesOptions,
     resolveBookingRequirementsProductSnapshot,
-    storefrontIntakePersistence: createRelationshipsStorefrontIntakePersistence(),
-    netopiaCheckoutStarter: createNetopiaCheckoutStarter(),
+    storefrontIntakePersistence: lazyProvider<StorefrontIntakePersistence>(async () =>
+      import("./runtime/storefront-intake-runtime").then(
+        (m) =>
+          m.createRelationshipsStorefrontIntakePersistence() as AsyncMethodProvider<StorefrontIntakePersistence>,
+      ),
+    ),
+    netopiaCheckoutStarter: lazyProvider(async () =>
+      import("@voyant-travel/plugin-netopia").then((m) => m.createNetopiaCheckoutStarter()),
+    ),
     createChannelPushExtension,
     // Lazy route-bundle loaders for the `operator/*` standard families — each
     // wires this deployment's providers into the package-owned route bundle.
@@ -225,6 +238,116 @@ export function buildOperatorProviders(): OperatorCapabilities {
   }
 }
 
+function createLazyCatalogSearchRuntime(
+  c: Parameters<OperatorCapabilities["resolveCatalogRuntime"]>[0],
+): CatalogSearchRuntime {
+  const env = c.env as CloudflareBindings & {
+    VOYANT_API_KEY?: string
+    VOYANT_CLOUD_API_KEY?: string
+    VOYANT_CLOUD_API_URL?: string
+    TENANT_ID?: string
+    TYPESENSE_HOST?: string
+    TYPESENSE_ADMIN_API_KEY?: string
+    TYPESENSE_API_KEY?: string
+  }
+  const actor = c.var.actor ?? "staff"
+  const audience: CatalogSearchRuntime["defaultScope"]["audience"] =
+    actor === "staff" ? "staff" : actor
+  const embeddings = createLazyCatalogEmbeddingProvider(env)
+
+  return {
+    indexer: createLazyCatalogIndexer(env, embeddings),
+    embeddings,
+    defaultScope: {
+      locale: "en-GB",
+      audience,
+      market: "default",
+    },
+  }
+}
+
+function createLazyCatalogEmbeddingProvider(
+  env: CloudflareBindings & {
+    VOYANT_API_KEY?: string
+    VOYANT_CLOUD_API_KEY?: string
+    VOYANT_CLOUD_API_URL?: string
+  },
+): EmbeddingProvider | undefined {
+  if (!(env.VOYANT_API_KEY ?? env.VOYANT_CLOUD_API_KEY)) return undefined
+  let providerPromise: Promise<EmbeddingProvider | undefined> | undefined
+  return {
+    capabilities: {
+      modelId: "gemini/gemini-embedding-001/v1",
+      dimensions: 3072,
+      maxTokensPerInput: 2048,
+      maxBatchSize: 100,
+      supportedLanguages: null,
+    },
+    async embed(texts) {
+      providerPromise ??= import("./lib/catalog-runtime").then((m) => m.buildEmbeddingProvider(env))
+      const provider = await providerPromise
+      if (!provider) throw new Error("Catalog embedding provider is not configured")
+      return provider.embed(texts)
+    },
+  }
+}
+
+function createLazyCatalogIndexer(
+  env: CloudflareBindings & {
+    TYPESENSE_HOST?: string
+    TYPESENSE_ADMIN_API_KEY?: string
+    TYPESENSE_API_KEY?: string
+  },
+  embeddings: EmbeddingProvider | undefined,
+): IndexerAdapter | undefined {
+  const host = env.TYPESENSE_HOST
+  const apiKey = env.TYPESENSE_ADMIN_API_KEY ?? env.TYPESENSE_API_KEY
+  if (!host || !apiKey) return undefined
+  try {
+    new URL(host)
+  } catch {
+    return undefined
+  }
+
+  let indexerPromise: Promise<IndexerAdapter | undefined> | undefined
+  const loadIndexer = async () => {
+    indexerPromise ??= import("./lib/catalog-runtime").then((m) =>
+      m.buildTypesenseIndexer(env, embeddings),
+    )
+    const indexer = await indexerPromise
+    if (!indexer) throw new Error("Catalog indexer is not configured")
+    return indexer
+  }
+
+  const vectorDimensions = embeddings?.capabilities.dimensions ?? null
+  return {
+    capabilities: {
+      supportsKeywordSearch: true,
+      supportsHybridSearch: vectorDimensions != null,
+      supportsVectorFields: vectorDimensions != null,
+      vectorDimensions,
+      maxVectorsPerDocument: null,
+      supportsCrossAudienceFederation: true,
+      supportsAdminDenormalization: true,
+    },
+    async ensureCollection(slice, registry) {
+      return (await loadIndexer()).ensureCollection(slice, registry)
+    },
+    async upsert(slice, documents) {
+      return (await loadIndexer()).upsert(slice, documents)
+    },
+    async delete(slice, ids) {
+      return (await loadIndexer()).delete(slice, ids)
+    },
+    async search(slice, request) {
+      return (await loadIndexer()).search(slice, request)
+    },
+    async bulkReindex(slice, stream, options) {
+      return (await loadIndexer()).bulkReindex(slice, stream, options)
+    },
+  }
+}
+
 /**
  * The deployment-local module factories — the only two families that aren't
  * package-owned standard (Better-Auth team invitations + the operator's own
@@ -311,10 +434,10 @@ export const deploymentLocalModules: Record<string, ModuleFactory<OperatorCapabi
   // MICE group-program spine (voyant#1489). Operator-local (niche) — NOT in the
   // framework standard set. Room blocks (the standard allotment primitive it
   // links to) ship in accommodations via the framework composition.
-  "@voyant-travel/mice": () =>
+  "@voyant-travel/mice": ({ capabilities }) =>
     createMiceHonoModule({
       resolveDelegatePersonById: async (db, personId) =>
-        (await relationshipsService.getPersonById(db, personId)) != null,
+        (await capabilities.relationshipsService.getPersonById(db, personId)) != null,
     }),
 }
 

--- a/starters/operator/src/api/runtime/card-payment.ts
+++ b/starters/operator/src/api/runtime/card-payment.ts
@@ -1,5 +1,5 @@
 import type { CardPaymentStarter } from "@voyant-travel/finance/card-payment"
-import { netopiaCardPaymentStarter } from "@voyant-travel/plugin-netopia"
+import { lazyProvider } from "@voyant-travel/hono"
 
 /**
  * The card-payment processor for this deployment. Every checkout surface
@@ -7,4 +7,6 @@ import { netopiaCardPaymentStarter } from "@voyant-travel/plugin-netopia"
  * through this single starter. To use a different processor, replace the
  * right-hand side with that provider's CardPaymentStarter — nothing else changes.
  */
-export const cardPaymentStarter: CardPaymentStarter = netopiaCardPaymentStarter()
+export const cardPaymentStarter: CardPaymentStarter = lazyProvider(async () =>
+  import("@voyant-travel/plugin-netopia").then((m) => m.netopiaCardPaymentStarter()),
+)

--- a/starters/operator/src/api/runtime/operator-runtime-adapter.ts
+++ b/starters/operator/src/api/runtime/operator-runtime-adapter.ts
@@ -1,5 +1,4 @@
-import { buildBookingRouteRuntime, createBookingPiiService } from "@voyant-travel/bookings"
-import { createVoyantDataFxExchangeRateResolver } from "@voyant-travel/finance"
+import type { InvoiceSettlementPoller, ResolveInvoiceExchangeRate } from "@voyant-travel/finance"
 import type { VoyantDb } from "@voyant-travel/hono"
 import {
   type CloudWorkflowsClientEnv,
@@ -14,11 +13,7 @@ import {
   readDocumentContentBase64,
   resolveDocumentDownloadUrl,
 } from "../lib/storage"
-import { createSmartbillSettlementPollers } from "../subscribers/smartbill"
-import {
-  generateContractPdfForBooking,
-  resolveContractDocumentGenerator,
-} from "./contract-document-runtime"
+import type { generateContractPdfForBooking as generateContractPdfForBookingImpl } from "./contract-document-runtime"
 
 export function operatorBindings(bindings: unknown): CloudflareBindings {
   return bindings as CloudflareBindings
@@ -51,11 +46,27 @@ export function createOperatorDocumentStorage(bindings: unknown) {
 }
 
 export function resolveOperatorContractDocumentGenerator(bindings: unknown) {
-  return resolveContractDocumentGenerator(operatorBindings(bindings)) ?? undefined
+  const env = operatorBindings(bindings)
+  if (!createDocumentStorage(env)) return undefined
+
+  const generator: NonNullable<
+    ReturnType<typeof import("./contract-document-runtime").resolveContractDocumentGenerator>
+  > = async (context) => {
+    const { resolveContractDocumentGenerator } = await import("./contract-document-runtime")
+    const resolved = resolveContractDocumentGenerator(env)
+    if (!resolved) {
+      throw new Error("Contract document generator is not configured")
+    }
+    return resolved(context)
+  }
+  return generator
 }
 
 export async function createOperatorBookingPiiService(bindings: unknown) {
   const env = operatorBindings(bindings)
+  const { buildBookingRouteRuntime, createBookingPiiService } = await import(
+    "@voyant-travel/bookings"
+  )
   const runtime = buildBookingRouteRuntime(env)
   try {
     return createBookingPiiService({ kms: await runtime.getKmsProvider() })
@@ -68,14 +79,36 @@ export function createOperatorInvoiceExchangeRateResolver(bindings: unknown) {
   const env = operatorBindings(bindings)
   const apiKey = resolveVoyantDataApiKey(env)
   if (!apiKey) return undefined
-  return createVoyantDataFxExchangeRateResolver({
-    apiKey,
-    baseUrl: env.VOYANT_CLOUD_API_URL,
-  })
+  let resolver: ResolveInvoiceExchangeRate | undefined
+  return async (input: Parameters<ResolveInvoiceExchangeRate>[0]) => {
+    if (!resolver) {
+      const { createVoyantDataFxExchangeRateResolver } = await import("@voyant-travel/finance")
+      resolver = createVoyantDataFxExchangeRateResolver({
+        apiKey,
+        baseUrl: env.VOYANT_CLOUD_API_URL,
+      })
+    }
+    return resolver(input)
+  }
 }
 
 export function createOperatorInvoiceSettlementPollers(bindings: unknown) {
-  return createSmartbillSettlementPollers(operatorBindings(bindings))
+  const env = operatorBindings(bindings)
+  if (!isSmartbillConfigured(env)) return {} as Record<string, InvoiceSettlementPoller>
+
+  let poller: InvoiceSettlementPoller | undefined
+  return {
+    smartbill: async (context: Parameters<InvoiceSettlementPoller>[0]) => {
+      if (!poller) {
+        const { createSmartbillSettlementPollers } = await import("../subscribers/smartbill")
+        poller = createSmartbillSettlementPollers(env).smartbill
+      }
+      if (!poller) {
+        throw new Error("SmartBill settlement poller is not configured")
+      }
+      return poller(context)
+    },
+  }
 }
 
 export function operatorWorkflowCloudEnv(env: CloudflareBindings): CloudWorkflowsClientEnv {
@@ -101,4 +134,23 @@ export function createOperatorWorkflowDriver(bindings: unknown) {
   return createInMemoryDriver()
 }
 
-export { generateContractPdfForBooking }
+export async function generateContractPdfForBooking(
+  ...args: Parameters<typeof generateContractPdfForBookingImpl>
+): ReturnType<typeof generateContractPdfForBookingImpl> {
+  const { generateContractPdfForBooking } = await import("./contract-document-runtime")
+  return generateContractPdfForBooking(...args)
+}
+
+function isSmartbillConfigured(env: CloudflareBindings) {
+  return Boolean(
+    nonEmpty(env.SMARTBILL_USERNAME) &&
+      (nonEmpty(env.SMARTBILL_API_TOKEN) ?? nonEmpty(env.SMARTBILL_TOKEN)) &&
+      nonEmpty(env.SMARTBILL_COMPANY_VAT_CODE) &&
+      (nonEmpty(env.SMARTBILL_INVOICE_SERIES_NAME) ?? nonEmpty(env.SMARTBILL_SERIES_NAME)),
+  )
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/starters/operator/src/api/subscribers/catalog-bridge-bundle.ts
+++ b/starters/operator/src/api/subscribers/catalog-bridge-bundle.ts
@@ -1,0 +1,9 @@
+import type { HonoBundle } from "@voyant-travel/hono/plugin"
+
+export const catalogBridgeBundle: HonoBundle = {
+  name: "catalog-bridge",
+  bootstrap: async (ctx) => {
+    const { catalogBridgeBundle } = await import("./catalog-bridge")
+    await catalogBridgeBundle.bootstrap?.(ctx)
+  },
+}

--- a/starters/operator/src/api/subscribers/smartbill-bundle.ts
+++ b/starters/operator/src/api/subscribers/smartbill-bundle.ts
@@ -1,0 +1,41 @@
+import type { HonoBundle } from "@voyant-travel/hono/plugin"
+
+type SmartbillEnv = CloudflareBindings & {
+  SMARTBILL_USERNAME?: string
+  SMARTBILL_API_TOKEN?: string
+  SMARTBILL_TOKEN?: string
+  SMARTBILL_COMPANY_VAT_CODE?: string
+  SMARTBILL_SERIES_NAME?: string
+  SMARTBILL_INVOICE_SERIES_NAME?: string
+  SMARTBILL_PROFORMA_SERIES_NAME?: string
+}
+
+export const smartbillOperatorBundle: HonoBundle = {
+  name: "operator-smartbill",
+  bootstrap: async (ctx) => {
+    const env = ctx.bindings as SmartbillEnv
+    if (!isSmartbillConfigured(env)) {
+      console.warn(
+        "[smartbill] Runtime bootstrap skipped: set SMARTBILL_USERNAME, SMARTBILL_TOKEN or SMARTBILL_API_TOKEN, SMARTBILL_COMPANY_VAT_CODE, and SMARTBILL_SERIES_NAME to enable SmartBill sync.",
+      )
+      return
+    }
+
+    const { smartbillOperatorBundle } = await import("./smartbill")
+    await smartbillOperatorBundle.bootstrap?.(ctx)
+  },
+}
+
+function isSmartbillConfigured(env: SmartbillEnv) {
+  return Boolean(
+    nonEmpty(env.SMARTBILL_USERNAME) &&
+      (nonEmpty(env.SMARTBILL_API_TOKEN) ?? nonEmpty(env.SMARTBILL_TOKEN)) &&
+      nonEmpty(env.SMARTBILL_COMPANY_VAT_CODE) &&
+      (nonEmpty(env.SMARTBILL_INVOICE_SERIES_NAME) ?? nonEmpty(env.SMARTBILL_SERIES_NAME)),
+  )
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}


### PR DESCRIPTION
## Summary
- add `lazyProvider` as an async-method-only provider seam and lazy Hono bundle registration for plugin route/bootstrap seams
- narrow the framework relationships provider surface to the async methods it consumes
- move operator Netopia, SmartBill, catalog bridge/bulk reindex, contract document, booking PII, finance FX/settlement, relationships, storefront intake, and catalog search runtime edges behind lazy request/bootstrap-time imports

## Root Cause
Lazy route composition deferred package route modules, but deployment providers and plugin bundles still value-imported heavy service graphs from the eager app module. Those imports kept finance/relationships/Netopia/SmartBill/catalog/contract-adjacent chunks reachable from the Worker API closure.

Closes #2926

## Closure Measurement
Built the operator API app and measured static imports only, stopping at dynamic `import(...)` boundaries:

- command: `node scripts/measure-static-import-closure.mjs starters/operator/dist/server/assets/app-DDhuPueJ.js --top 30`
- result: 94 files, 12,219,287 bytes (11.65 MiB)
- confirmed in the generated app chunk that catalog runtime, contract runtime, Netopia, SmartBill, bulk reindex, and relationships implementations are reached through dynamic imports rather than static imports
- residual closure remains large because shared SSR/UI and remaining non-provider route graphs still dominate; this PR resolves the provider/plugin seam rather than the full Worker split problem

Note: `pnpm --filter operator build` needed a temporary local peer symlink for `@voyant-travel/relationships-react` under `packages/mice-react/node_modules` because Vite/Rolldown otherwise cannot resolve that peer from the workspace package source. The symlink was removed after measurement.

## Validation
- `pnpm --filter @voyant-travel/hono test -- --runInBand`
- `pnpm --filter @voyant-travel/hono typecheck`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework build`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator build` with the temporary peer symlink workaround described above
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:fast` (migration replay parity skipped because `TEST_DATABASE_URL` is not set)

## Reviewer Follow-up
- addressed the lazy transactional metadata review thread by adding eager `transactionalModules` / `transactionalPaths` metadata to lazy Hono bundles
- `mountApp` now folds that metadata into the DB selector before auth/db middleware can acquire the first request DB
- added a regression test asserting the first request to a transactional lazy plugin route uses `dbTransactional` before the bundle is loaded
