### PR TITLE
Add channel-scoped catalog search

### DIFF
--- a/.changeset/channel-scoped-catalog-search.md
+++ b/.changeset/channel-scoped-catalog-search.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/catalog": minor
+"@voyant-travel/catalog-react": minor
+---
+
+Add channel-scoped catalog search slices so storefront and partner surfaces can query separate per-channel index collections.

--- a/docs/architecture/catalog-architecture.md
+++ b/docs/architecture/catalog-architecture.md
@@ -462,8 +462,8 @@ The search index is the place where cross-entity denormalization happens. Vertic
 Three rules govern the indexer regardless of which engine sits behind it:
 
 1. **The resolver runs in two places.** The read path (API responses) resolves one entity at a time and does not auto-traverse references. The indexer denormalizes referenced entities into the search document. Auto-traversal in the read path is forbidden — it explodes blast radius and makes overlay-merge precedence ambiguous when locales mismatch across entities.
-2. **Search documents are per-(locale, audience, market).** A document indexed for `(en-GB, customer, UK)` is distinct from `(de-DE, partner, default)`. The indexer materializes the resolver's output for each combination the deployment actively serves; for default deployments this is just `(locale × {staff, customer}, market=default)` — two document sets per locale (§5.2.2).
-3. **Reindex is targeted, not bulk.** When an editorial override changes, when a source projection updates a non-overridden field, or when a referenced entity changes (hotel inside a package), the affected document(s) get re-enqueued — scoped per entity, per locale, per audience, per market. A reverse-lookup index (`referenced_by`) supports the cross-entity case.
+2. **Search documents are per-(locale, audience, market, channel).** A document indexed for `(en-GB, customer, UK, website)` is distinct from `(en-GB, customer, UK, b2b)` and from `(de-DE, partner, default, reseller)`. The indexer materializes the resolver's output for each combination the deployment actively serves; for default deployments this is `(locale × {staff, customer}, market=default)` plus channel-scoped customer slices when distribution channels are configured (§5.2.2).
+3. **Reindex is targeted, not bulk.** When an editorial override changes, when a source projection updates a non-overridden field, when channel publication changes, or when a referenced entity changes (hotel inside a package), the affected document(s) get re-enqueued — scoped per entity, per locale, per audience, per market, per channel. A reverse-lookup index (`referenced_by`) supports the cross-entity case.
 
 Volatile-live fields **never** appear in the search index. Volatile-indexed fields appear with a TTL, refreshed via the source's freshness mode.
 
@@ -472,7 +472,7 @@ Volatile-live fields **never** appear in the search index. Volatile-indexed fiel
 Typesense is the default search engine because it fits Voyant's deployment model: open-source (Apache-2.0, aligned with Voyant's licensing posture), self-hostable (aligned with single-tenant-per-deployment), fast, low operational overhead, with first-class support for faceted search, typo tolerance, locale-aware tokenization, and hybrid keyword+vector search. The native Typesense adapter ships as part of `packages/catalog` and provides:
 
 - **Collection schema generation** from the field-policy registry. Fields with `query: "indexed-column"` and the appropriate `class` become Typesense fields with the right type / facet / sort flags. Fields with `query: "blob-only"` are stored but not indexed.
-- **Per-(locale, audience, market) collection management.** A separate Typesense collection (or filterable shard, depending on scale) per combination, with its own schema synthesized from the field policy. For default deployments this is two collections per locale (admin + customer) with `market=default`.
+- **Per-(locale, audience, market, channel) collection management.** A separate Typesense collection (or filterable shard, depending on scale) per combination, with its own schema synthesized from the field policy. Channel is optional only for legacy/default slices; channel-aware storefronts materialize one customer collection per sales surface.
 - **Document upsert / delete on reindex events** with the targeted-reindex semantics from rule 3 above.
 - **Search query construction** for the storefront and admin layers, exposing facet aggregations driven by the registry's structural fields.
 - **Bulk reindex tooling** for cold-starts and major schema changes (e.g. when a vertical's field-policy file gains a new indexed field).
@@ -485,10 +485,10 @@ The indexer surface is an abstract `IndexerAdapter` contract — the same provid
 
 The contract is intentionally narrow:
 
-- `ensureCollection(vertical, locale, audience, market, fieldPolicy)` — set up or migrate the engine-side schema for one variant slice.
+- `ensureCollection(vertical, locale, audience, market, channel, fieldPolicy)` — set up or migrate the engine-side schema for one variant slice.
 - `upsert(documents)` / `delete(ids)` — write paths from the reindex queue.
 - `search(query, filters, facets, pagination)` — read path from storefront and admin.
-- `bulkReindex(vertical, locale, audience, market, stream)` — cold-start and migration path.
+- `bulkReindex(vertical, locale, audience, market, channel, stream)` — cold-start and migration path.
 - `capabilities` — declare what the engine supports (faceting, typo tolerance, vector search, geo, etc.) so consuming code can fail fast on unsupported features rather than producing wrong results silently.
 
 Swap-in implementers can be:
@@ -586,7 +586,7 @@ Those two layers are different by design. The catalog plane supports both — it
 
 Storefront and admin search have different free-text needs, so the catalog plane materializes their index documents differently — even though both ride the same underlying engine.
 
-**Storefront search documents** are audience-scoped (per §5.4 rule 2). A customer searching the storefront hits `(vertical, locale, audience=customer, market=M)` documents and finds matches against marketing-overlayed text. Customer documents do not contain source SKUs, internal aliases, or partner-only copy — those fields are not visible to the customer audience and are not indexed in customer documents at all. Same shape for `partner` and `supplier` audiences when they exist.
+**Storefront search documents** are audience- and channel-scoped (per §5.4 rule 2). A customer searching the website storefront hits `(vertical, locale, audience=customer, market=M, channel=website)` documents and finds matches against marketing-overlayed text for products published to that channel. A B2B storefront hits its own channel slice, so products can be listed on B2B but absent from the website, or vice versa. Customer documents do not contain source SKUs, internal aliases, or partner-only copy — those fields are not visible to the customer audience and are not indexed in customer documents at all. Same shape for `partner` and `supplier` audiences when they exist.
 
 **Admin search documents** are different. Admin users have legitimate cross-audience search needs: ops types a source SKU; marketing types the storefront title; customer service types what the customer said on the phone. A single staff-audience-only index can't satisfy all three. The clean solution is **denormalization at index time**:
 
@@ -668,7 +668,7 @@ The catalog plane has five distinct caching layers, each with its own correctnes
 | **1. Source projection** | Slow-moving fields fed from upstream (title, geography, room types, cancellation rules, ship name, etc.) | Refreshed on the field's `sourceFreshness` mode — `sync` interval, `event` push, `request` on demand, `static` never; drift events flag mid-cycle changes | The vertical module's own table — technically storage, but behaves cache-like relative to the upstream source |
 | **2. Editorial overlay rows** | Override rows in the overlay store, keyed `(entity_module, entity_id, field, locale, audience, market)` | Invalidated on write to that key | DB; optionally short-TTL in-process LRU when measured |
 | **3. Resolved CatalogEntry views** | The merged result of source + overlay per `(locale, audience, market)` | Bust on either source projection update OR overlay write for that entity | Optional — **not added in v1**; per-worker LRU or distributed cache once profiling justifies it |
-| **4. Search index documents** | Per-(locale, audience, market) docs, including referenced entities (hotel inside a package's search doc); admin documents denormalize across audiences (§5.4.4) | Targeted reindex on entity change, overlay change, OR referenced-entity change (via the `referenced_by` index) | Typesense (native default — see §5.4.1); swappable to Algolia / Meilisearch / Postgres FTS / Elasticsearch via the `IndexerAdapter` contract (§5.4.2). The index *is* itself a cache. |
+| **4. Search index documents** | Per-(locale, audience, market, channel) docs, including referenced entities (hotel inside a package's search doc); admin documents denormalize across audiences (§5.4.4) | Targeted reindex on entity change, overlay change, channel publication change, OR referenced-entity change (via the `referenced_by` index) | Typesense (native default — see §5.4.1); swappable to Algolia / Meilisearch / Postgres FTS / Elasticsearch via the `IndexerAdapter` contract (§5.4.2). The index *is* itself a cache. |
 | **5. HTTP / CDN response cache** | Whole `/v1/public/*` responses for browse + product-detail | ETag + `Cache-Control` + stale-while-revalidate; busts on entity-version-token change | CDN edge (Cloudflare / Fastly / equivalent) |
 
 **Volatile-live fields are not cached at any of these layers.** `quote_price`, `inventory_count`, `bookable_now`, `hold_expiry` always go through the source adapter live. If a specific hot path measurably needs short-lived caching (5–30s), that lives **inside the source adapter**, not in the catalog plane — keeps the caching decision local to the source's tolerances rather than baked into the contract. See open question 5.
@@ -853,7 +853,7 @@ The distinction matters: most "the source is gone" events in production turn out
 | Data | Behavior on hard disconnect |
 | --- | --- |
 | Source projection rows | Soft-deleted; hard-deleted after retention window (default 30 days, configurable) |
-| Search index documents | Deleted across all `(locale, audience, market)` combinations |
+| Search index documents | Deleted across all `(locale, audience, market, channel)` combinations |
 | **Embeddings** | **Removed alongside index documents** because vectors live in the same search engine slice. |
 | Editorial overlays | Preserved for retention window (default 90 days, configurable), then GC if no reconnect — keeps marketing work recoverable on reseed |
 | Drift events history | Archived but kept — audit trail |
@@ -871,7 +871,7 @@ A hard disconnect runs as a deliberate, observable, dry-runnable job:
 1. **Initiate.** Admin triggers disconnect on a specific source connection. Requires explicit confirmation; cannot be triggered by automated failure detection.
 2. **Enumerate.** System lists affected entities — every CatalogEntry whose provenance points to this source.
 3. **Dry-run report.** Admin sees: how many entities, which verticals, how many bookings have snapshots referencing them (preserved), how many cross-references would dangle, how many overlays exist on each. Cancel here is a no-op.
-4. **Archive.** Affected entities transition to `archived` status (not deleted). Search index documents are removed across all `(locale, audience, market)` combinations; embeddings disappear with them since they share the engine.
+4. **Archive.** Affected entities transition to `archived` status (not deleted). Search index documents are removed across all `(locale, audience, market, channel)` combinations; embeddings disappear with them since they share the engine.
 5. **Soft-delete projections and overlays.** Source projection rows and editorial overlays are soft-deleted with retention timestamps so they can be restored on reconnect.
 6. **Update reverse-lookup.** `referenced_by` index updated; parents of disconnected entities receive `catalog.entity.reference.missing` events.
 7. **Emit events.** `catalog.entity.archived` per affected entity, plus a single `catalog.source.disconnected` summary event with affected counts. External webhook subscribers receive these per the visibility rules in §5.8.4.

--- a/packages/catalog-react/src/hooks/use-catalog-search.ts
+++ b/packages/catalog-react/src/hooks/use-catalog-search.ts
@@ -40,6 +40,8 @@ export interface UseCatalogSearchOptions {
   market?: string
   /** Override `defaultScope.locale`. */
   locale?: string
+  /** Override `defaultScope.channel`. */
+  channel?: string
   /**
    * Surface to call against. Operator dashboards pass `"admin"`
    * (default); storefront / partner / embedded surfaces pass
@@ -69,6 +71,7 @@ export function useCatalogSearch(options: UseCatalogSearchOptions) {
     query_embedding,
     market,
     locale,
+    channel,
     surface = "admin",
     enabled = true,
     staleTime = 30_000,
@@ -91,6 +94,7 @@ export function useCatalogSearch(options: UseCatalogSearchOptions) {
       query_embedding,
       market,
       locale,
+      channel,
     ],
     queryFn: () =>
       fetchWithValidation(
@@ -113,6 +117,7 @@ export function useCatalogSearch(options: UseCatalogSearchOptions) {
             query_embedding,
             market,
             locale,
+            channel,
           }),
         },
       ),

--- a/packages/catalog/src/indexer/contract.ts
+++ b/packages/catalog/src/indexer/contract.ts
@@ -8,8 +8,9 @@
  * contract.
  *
  * Storefront-side documents are scoped per `(vertical, locale, audience,
- * market)`. Admin-side documents denormalize text fields across audiences for
- * keyword matching (see §5.4.4); admin embedding remains audience-scoped.
+ * market, channel)`. Admin-side documents denormalize text fields across
+ * audiences for keyword matching (see §5.4.4); admin embedding remains
+ * audience-scoped.
  *
  * See `docs/architecture/catalog-architecture.md` §5.4 for the full design.
  */
@@ -22,6 +23,12 @@ export interface IndexerSlice {
   locale: string
   audience: Visibility | "staff-admin"
   market: string
+  /**
+   * Sales surface / distribution channel id. Omitted only for legacy/default
+   * slices; channel-aware storefronts should set this explicitly so website,
+   * B2B, OTA, and partner surfaces do not share one customer corpus.
+   */
+  channel?: string
 }
 
 /**

--- a/packages/catalog/src/indexer/typesense.test.ts
+++ b/packages/catalog/src/indexer/typesense.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: catalog; existing test module stays co-located until a dedicated split preserves coverage.
 import { describe, expect, it } from "vitest"
 
 import { createFieldPolicyRegistry, defineFieldPolicy } from "../contract.js"
@@ -7,6 +8,7 @@ import {
   buildDefaultTypesenseQueryBy,
   buildDefaultTypesenseSearchFields,
   buildSearchQuery,
+  collectionName,
   createTypesenseIndexer,
   type ImportFailureSummary,
   parseTypesenseImportResults,
@@ -138,6 +140,12 @@ const registry = createFieldPolicyRegistry(
 )
 
 describe("Typesense catalog indexer", () => {
+  it("includes channel in collection names when the slice is channel-scoped", () => {
+    expect(collectionName({ ...slice, channel: "chan_website" })).toBe(
+      "products__en-GB__customer__default__chan_website",
+    )
+  })
+
   it("declares known storefront card fields with numeric and boolean types", () => {
     const schema = buildCollectionSchema(slice, registry)
     expect(schema.fields.find((field) => field.name === "priceFromAmountCents")?.type).toBe("int64")

--- a/packages/catalog/src/indexer/typesense.ts
+++ b/packages/catalog/src/indexer/typesense.ts
@@ -322,7 +322,9 @@ async function retryTransientCollectionUpdate(
  * runs so existing collections survive deployments.
  */
 export function collectionName(slice: IndexerSlice, prefix = ""): string {
-  const base = `${slice.vertical}__${slice.locale}__${slice.audience}__${slice.market}`
+  const base = [slice.vertical, slice.locale, slice.audience, slice.market, slice.channel]
+    .filter((part): part is string => Boolean(part))
+    .join("__")
   return prefix ? `${prefix}__${base}` : base
 }
 

--- a/packages/catalog/src/search/routes.test.ts
+++ b/packages/catalog/src/search/routes.test.ts
@@ -169,6 +169,47 @@ describe("createCatalogSearchRoutes", () => {
     })
   })
 
+  it("uses the public default channel and allows explicit channel overrides", async () => {
+    const executeSearch = vi.fn(
+      async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => emptyResults,
+    )
+    const module = createCatalogSearchHonoModule({
+      resolveRuntime: () => ({
+        indexer: createIndexer(),
+        defaultScope: {
+          locale: "en-GB",
+          audience: "staff",
+          market: "default",
+          channel: "chan_website",
+        },
+      }),
+      executeSearch,
+    })
+    const app = new Hono()
+    app.route("/v1/admin/catalog", module.adminRoutes!)
+    app.route("/v1/public/catalog", module.publicRoutes!)
+
+    await app.request("/v1/admin/catalog/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ vertical: "products", mode: "keyword" }),
+    })
+    await app.request("/v1/public/catalog/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ vertical: "products", mode: "keyword" }),
+    })
+    await app.request("/v1/public/catalog/search", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ vertical: "products", mode: "keyword", channel: "chan_b2b" }),
+    })
+
+    expect(executeSearch.mock.calls[0]?.[0].slice.channel).toBeUndefined()
+    expect(executeSearch.mock.calls[1]?.[0].slice.channel).toBe("chan_website")
+    expect(executeSearch.mock.calls[2]?.[0].slice.channel).toBe("chan_b2b")
+  })
+
   it("downgrades semantic modes to keyword when embeddings are unavailable", async () => {
     const executeSearch = vi.fn(
       async (_input: CatalogSearchExecuteInput): Promise<SearchResults> => emptyResults,

--- a/packages/catalog/src/search/routes.ts
+++ b/packages/catalog/src/search/routes.ts
@@ -71,6 +71,7 @@ const catalogSearchBodySchema = z.object({
   query_embedding: z.array(z.number()).optional(),
   market: z.string().min(1).optional(),
   locale: z.string().min(1).optional(),
+  channel: z.string().min(1).optional(),
 })
 
 export type CatalogSearchBody = z.infer<typeof catalogSearchBodySchema>
@@ -261,6 +262,7 @@ export interface CatalogSearchRuntime {
     locale: string
     audience: IndexerSlice["audience"]
     market: string
+    channel?: string
   }
 }
 
@@ -360,6 +362,7 @@ async function handleSearch(
     locale: body.locale ?? runtime.defaultScope.locale,
     audience: resolveAudience(options, runtime),
     market: body.market ?? runtime.defaultScope.market,
+    channel: resolveChannel(options, runtime, body),
   }
   const request = buildSearchRequest(body, mode)
 
@@ -393,6 +396,15 @@ function resolveAudience(
 ): IndexerSlice["audience"] {
   if (options.surface === "public") return options.publicAudience ?? "customer"
   return options.adminAudience ?? runtime.defaultScope.audience
+}
+
+function resolveChannel(
+  options: CatalogSearchRoutesWithSurfaceOptions,
+  runtime: CatalogSearchRuntime,
+  body: CatalogSearchBody,
+): string | undefined {
+  if (body.channel) return body.channel
+  return options.surface === "public" ? runtime.defaultScope.channel : undefined
 }
 
 function buildSearchRequest(body: CatalogSearchBody, mode: SearchMode): SearchRequest {

--- a/packages/openapi/spec/admin/catalog.json
+++ b/packages/openapi/spec/admin/catalog.json
@@ -251,6 +251,10 @@
                   "locale": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "channel": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 }
               }

--- a/packages/openapi/spec/storefront/catalog.json
+++ b/packages/openapi/spec/storefront/catalog.json
@@ -251,6 +251,10 @@
                   "locale": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "channel": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 }
               }

--- a/starters/operator/openapi/admin/catalog.json
+++ b/starters/operator/openapi/admin/catalog.json
@@ -251,6 +251,10 @@
                   "locale": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "channel": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 }
               }

--- a/starters/operator/openapi/storefront/catalog.json
+++ b/starters/operator/openapi/storefront/catalog.json
@@ -251,6 +251,10 @@
                   "locale": {
                     "type": "string",
                     "minLength": 1
+                  },
+                  "channel": {
+                    "type": "string",
+                    "minLength": 1
                   }
                 }
               }

--- a/starters/operator/scripts/lib/reindex-stale-documents.test.ts
+++ b/starters/operator/scripts/lib/reindex-stale-documents.test.ts
@@ -117,6 +117,24 @@ describe("listObsoleteCatalogCollections", () => {
     ])
   })
 
+  it("returns old channel collections that no longer match active slices", () => {
+    const activeWebsiteSlice: IndexerSlice = {
+      ...customerProductsSlice,
+      channel: "chan_website",
+    }
+
+    const obsolete = listObsoleteCatalogCollections(
+      [activeWebsiteSlice],
+      [
+        "products__en-GB__customer__default__chan_website",
+        "products__en-GB__customer__default__chan_b2b",
+      ],
+      { verticals: new Set(["products"]) },
+    )
+
+    expect(obsolete).toEqual(["products__en-GB__customer__default__chan_b2b"])
+  })
+
   it("ignores unrelated and differently-prefixed Typesense collections", () => {
     const obsolete = listObsoleteCatalogCollections(
       [customerProductsSlice],

--- a/starters/operator/scripts/lib/reindex-stale-documents.ts
+++ b/starters/operator/scripts/lib/reindex-stale-documents.ts
@@ -164,10 +164,10 @@ export function listObsoleteCatalogCollections(
 }
 
 function parseCatalogCollectionName(name: string): IndexerSlice | null {
-  const [vertical, locale, audience, market, ...rest] = name.split("__")
+  const [vertical, locale, audience, market, channel, ...rest] = name.split("__")
   if (!vertical || !locale || !audience || !market || rest.length > 0) return null
   if (!isIndexerAudience(audience)) return null
-  return { vertical, locale, audience, market }
+  return { vertical, locale, audience, market, channel }
 }
 
 function isIndexerAudience(value: string): value is IndexerSlice["audience"] {

--- a/starters/operator/scripts/sync-sources.ts
+++ b/starters/operator/scripts/sync-sources.ts
@@ -38,14 +38,13 @@ import {
   type DocumentBuilder,
   type EmbeddingProvider,
   type IndexerDocument,
-  type IndexerSlice,
 } from "@voyant-travel/catalog"
 import { type SyncSourcesSummary, syncSources } from "@voyant-travel/catalog/booking-engine"
 import { config } from "dotenv"
 import { drizzle } from "drizzle-orm/postgres-js"
 import postgres from "postgres"
 import { Client as TypesenseSdkClient } from "typesense"
-import { getFieldPolicyRegistries } from "../src/api/lib/catalog-runtime.js"
+import { getFieldPolicyRegistries, loadCatalogSlices } from "../src/api/lib/catalog-runtime.js"
 import { buildSyncSourceRegistry } from "./lib/build-sync-source-registry.js"
 import { asTypesenseClient } from "./lib/typesense-sdk-client.js"
 
@@ -130,11 +129,7 @@ const indexer = createTypesenseIndexer({
 // `nextDepartureAt`).
 const fieldPolicyRegistries = getFieldPolicyRegistries()
 
-const VERTICALS = ["products", "extras", "cruises", "charters", "accommodations"] as const
-const slices: IndexerSlice[] = VERTICALS.flatMap((vertical) => [
-  { vertical, locale: "en-GB", audience: "staff", market: "default" },
-  { vertical, locale: "en-GB", audience: "customer", market: "default" },
-])
+const slices = await loadCatalogSlices(db)
 
 const indexerService = createIndexerService({
   adapter: indexer,

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -249,6 +249,7 @@ function createLazyCatalogSearchRuntime(
     TYPESENSE_HOST?: string
     TYPESENSE_ADMIN_API_KEY?: string
     TYPESENSE_API_KEY?: string
+    VOYANT_STOREFRONT_CHANNEL_ID?: string
   }
   const actor = c.var.actor ?? "staff"
   const audience: CatalogSearchRuntime["defaultScope"]["audience"] =
@@ -262,6 +263,7 @@ function createLazyCatalogSearchRuntime(
       locale: "en-GB",
       audience,
       market: "default",
+      channel: env.VOYANT_STOREFRONT_CHANNEL_ID,
     },
   }
 }

--- a/starters/operator/src/api/lib/catalog-listability.test.ts
+++ b/starters/operator/src/api/lib/catalog-listability.test.ts
@@ -4,8 +4,8 @@
  * Regression cover for issue #2617: an active + public + activated owned
  * product that is directly bookable must be listable in the *customer*
  * (direct storefront) search slice without an explicit channel mapping.
- * Channel mappings only gate distribution to external audiences
- * (partner / supplier).
+ * Channel mappings gate distribution to external audiences and channel-aware
+ * customer slices, but not legacy unchannelled customer slices.
  */
 
 import { describe, expect, it, vi } from "vitest"
@@ -14,9 +14,9 @@ import { isOwnedProductStorefrontListable } from "./catalog-listability"
 
 describe("isOwnedProductStorefrontListable", () => {
   it("lists an owned product in the customer slice without a channel mapping", async () => {
-    // The customer audience is the operator's own direct storefront: no channel
-    // lookup, always listable (the upstream gate already asserted
-    // active + public + activated).
+    // Legacy customer slices carry no channel. They remain listable for
+    // backwards compatibility; channel-aware storefront slices below are gated
+    // by the requested sales channel.
     const hasActiveChannelMapping = vi.fn(async () => false)
 
     const listable = await isOwnedProductStorefrontListable({
@@ -26,6 +26,22 @@ describe("isOwnedProductStorefrontListable", () => {
 
     expect(listable).toBe(true)
     expect(hasActiveChannelMapping).not.toHaveBeenCalled()
+  })
+
+  it("requires an active channel mapping for channel-scoped customer slices", async () => {
+    const withMapping = await isOwnedProductStorefrontListable({
+      audience: "customer",
+      channel: "chan_website",
+      hasActiveChannelMapping: async () => true,
+    })
+    const withoutMapping = await isOwnedProductStorefrontListable({
+      audience: "customer",
+      channel: "chan_b2b",
+      hasActiveChannelMapping: async () => false,
+    })
+
+    expect(withMapping).toBe(true)
+    expect(withoutMapping).toBe(false)
   })
 
   it("requires an active channel mapping for external (partner) slices", async () => {

--- a/starters/operator/src/api/lib/catalog-listability.ts
+++ b/starters/operator/src/api/lib/catalog-listability.ts
@@ -23,18 +23,20 @@ import { and, eq } from "drizzle-orm"
 export async function hasActiveSalesChannelMapping(
   db: AnyDrizzleDb,
   productId: string,
+  channelId?: string,
 ): Promise<boolean> {
+  const conditions = [
+    eq(channelProductMappings.productId, productId),
+    eq(channelProductMappings.active, true),
+    eq(channels.status, "active"),
+  ]
+  if (channelId) conditions.push(eq(channelProductMappings.channelId, channelId))
+
   const rows = await db
     .select({ id: channelProductMappings.id })
     .from(channelProductMappings)
     .innerJoin(channels, eq(channels.id, channelProductMappings.channelId))
-    .where(
-      and(
-        eq(channelProductMappings.productId, productId),
-        eq(channelProductMappings.active, true),
-        eq(channels.status, "active"),
-      ),
-    )
+    .where(and(...conditions))
     .limit(1)
 
   return rows.length > 0
@@ -42,6 +44,7 @@ export async function hasActiveSalesChannelMapping(
 
 export type OwnedProductStorefrontListabilityInput = {
   audience: IndexerSlice["audience"]
+  channel?: string
   /** Resolves whether the product is published to an active sales channel. */
   hasActiveChannelMapping: () => boolean | Promise<boolean>
 }
@@ -54,22 +57,18 @@ export type OwnedProductStorefrontListabilityInput = {
  * runs, so the caller only reaches here for an owned product that is otherwise
  * publicly sellable.
  *
- * The `customer` slice is the operator's *own direct storefront*. Owned
- * inventory that is active + public + activated is inherently sellable there —
- * its public detail, quote, and booking already resolve without any channel
- * mapping — so it MUST be listable in customer search without one. Requiring an
- * explicit `channel_product_mappings` row for the direct storefront made owned
- * products bookable-but-invisible (issue #2617).
+ * Legacy customer slices have no `channel`, so they keep the old direct
+ * storefront behavior for backward compatibility. Channel-scoped customer
+ * slices require an active mapping for that exact channel, so a website surface
+ * and a B2B surface can expose different product sets.
  *
- * Channel mappings gate *distribution to external audiences* (partner /
- * supplier slices), not visibility on the operator's own storefront. See
- * docs/architecture/catalog-supply-models.md and federated-operating-mode.md:
- * owned "sellable inventory" is directly bookable/listable; the marketplace /
- * reseller channel graph governs everything downstream of the direct channel.
+ * External audiences (partner / supplier slices) also require channel
+ * mappings. See docs/architecture/catalog-supply-models.md and
+ * federated-operating-mode.md.
  */
 export async function isOwnedProductStorefrontListable(
   input: OwnedProductStorefrontListabilityInput,
 ): Promise<boolean> {
-  if (input.audience === "customer") return true
+  if (input.audience === "customer" && !input.channel) return true
   return input.hasActiveChannelMapping()
 }

--- a/starters/operator/src/api/lib/catalog-runtime.test.ts
+++ b/starters/operator/src/api/lib/catalog-runtime.test.ts
@@ -1,0 +1,55 @@
+import { marketLocales, markets } from "@voyant-travel/commerce"
+import { channels } from "@voyant-travel/distribution"
+import { describe, expect, it } from "vitest"
+
+import { loadCatalogSlices } from "./catalog-runtime"
+
+type TableRows = Map<object, unknown[]>
+
+function createSelectDb(rowsByTable: TableRows) {
+  return {
+    select: () => ({
+      from: (table: object) => ({
+        where: () => ({
+          orderBy: () => rowsByTable.get(table) ?? [],
+        }),
+      }),
+    }),
+  }
+}
+
+describe("loadCatalogSlices", () => {
+  it("preserves legacy unchannelled customer slices when active channels exist", async () => {
+    const rowsByTable: TableRows = new Map()
+    rowsByTable.set(markets, [
+      {
+        id: "mkt_uk",
+        defaultLanguageTag: "en-GB",
+      },
+    ])
+    rowsByTable.set(marketLocales, [
+      {
+        marketId: "mkt_uk",
+        languageTag: "fr-FR",
+      },
+    ])
+    rowsByTable.set(channels, [{ id: "chan_website" }, { id: "chan_b2b" }])
+
+    const slices = await loadCatalogSlices(createSelectDb(rowsByTable) as never)
+    const productCustomerSlices = slices.filter(
+      (slice) =>
+        slice.vertical === "products" && slice.audience === "customer" && slice.market === "mkt_uk",
+    )
+
+    expect(productCustomerSlices).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ locale: "en-GB", channel: undefined }),
+        expect.objectContaining({ locale: "en-GB", channel: "chan_website" }),
+        expect.objectContaining({ locale: "en-GB", channel: "chan_b2b" }),
+        expect.objectContaining({ locale: "fr-FR", channel: undefined }),
+        expect.objectContaining({ locale: "fr-FR", channel: "chan_website" }),
+        expect.objectContaining({ locale: "fr-FR", channel: "chan_b2b" }),
+      ]),
+    )
+  })
+})

--- a/starters/operator/src/api/lib/catalog-runtime.ts
+++ b/starters/operator/src/api/lib/catalog-runtime.ts
@@ -37,6 +37,7 @@ import {
 } from "@voyant-travel/cruises/service-catalog-plane"
 import { createCruiseCabinFacetProjectionExtension } from "@voyant-travel/cruises/service-catalog-plane-cabins"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { channels } from "@voyant-travel/distribution"
 import { productCatalogPolicy } from "@voyant-travel/inventory/catalog-policy"
 import { productDeparturesCatalogPolicy } from "@voyant-travel/inventory/catalog-policy-departures"
 import { productDestinationsCatalogPolicy } from "@voyant-travel/inventory/catalog-policy-destinations"
@@ -65,8 +66,6 @@ export const CATALOG_VERTICALS = [
   "charters",
   "accommodations",
 ] as const
-
-const INDEXED_AUDIENCES = ["staff", "customer"] as const
 
 /**
  * The slice set the operator starter indexes by default — staff (admin
@@ -106,6 +105,11 @@ export async function loadCatalogSlices(db: AnyDrizzleDb): Promise<IndexerSlice[
       .where(eq(marketLocales.active, true))
       .orderBy(asc(marketLocales.sortOrder), asc(marketLocales.languageTag)),
   ])
+  const channelRows = await db
+    .select({ id: channels.id })
+    .from(channels)
+    .where(eq(channels.status, "active"))
+    .orderBy(asc(channels.createdAt))
 
   const localesByMarket = new Map<string, Set<string>>()
   for (const market of marketRows) {
@@ -115,17 +119,22 @@ export async function loadCatalogSlices(db: AnyDrizzleDb): Promise<IndexerSlice[
     localesByMarket.get(locale.marketId)?.add(locale.languageTag)
   }
 
+  const activeChannelIds = channelRows.map((channel) => channel.id)
+  const customerChannels = [undefined, ...activeChannelIds]
+
   const marketSlices = marketRows.flatMap((market) => {
     const locales = localesByMarket.get(market.id) ?? new Set([market.defaultLanguageTag])
     return CATALOG_VERTICALS.flatMap((vertical) =>
-      Array.from(locales).flatMap((locale) =>
-        INDEXED_AUDIENCES.map((audience) => ({
+      Array.from(locales).flatMap((locale) => [
+        { vertical, locale, audience: "staff" as const, market: market.id },
+        ...customerChannels.map((channel) => ({
           vertical,
           locale,
-          audience,
+          audience: "customer" as const,
           market: market.id,
+          channel,
         })),
-      ),
+      ]),
     )
   })
 
@@ -136,7 +145,13 @@ function uniqueSlices(slices: ReadonlyArray<IndexerSlice>): IndexerSlice[] {
   const seen = new Set<string>()
   const out: IndexerSlice[] = []
   for (const slice of slices) {
-    const key = `${slice.vertical}|${slice.locale}|${slice.audience}|${slice.market}`
+    const key = [
+      slice.vertical,
+      slice.locale,
+      slice.audience,
+      slice.market,
+      slice.channel ?? "",
+    ].join("|")
     if (seen.has(key)) continue
     seen.add(key)
     out.push(slice)
@@ -387,7 +402,8 @@ export function createProductsDocumentBuilder(
     isPublicAudienceListable: ({ db, product, slice }) =>
       isOwnedProductStorefrontListable({
         audience: slice.audience,
-        hasActiveChannelMapping: () => hasActiveSalesChannelMapping(db, product.id),
+        channel: slice.channel,
+        hasActiveChannelMapping: () => hasActiveSalesChannelMapping(db, product.id, slice.channel),
       }),
   })
 }


### PR DESCRIPTION
## Summary

Fixes #2617.

I checked the issue comments. The earlier unscoped storefront fix was not enough for package-upgrade consumers or multi-channel storefronts: website and B2B can expose different product sets, so customer search collections need to be channel-scoped instead of one combined customer collection.

Changes:
- add optional channel scope to catalog indexer slices and Typesense collection names
- accept channel in catalog search requests and catalog-react search hooks
- let public storefront search default to VOYANT_STOREFRONT_CHANNEL_ID while keeping admin unchannelled unless explicitly requested
- materialize customer search slices per active distribution channel in the operator runtime
- require an active exact channel mapping for channel-scoped customer listability
- update sync-sources, stale collection cleanup, OpenAPI artifacts, catalog architecture docs, and changesets

## Operational Notes

Channel-aware storefronts should either set VOYANT_STOREFRONT_CHANNEL_ID or send channel in /v1/public/catalog/search. Products are indexed into that channel collection only when they have an active channel_product_mappings row for that channel. Legacy unchannelled customer slices remain for backward compatibility when no active channels exist or callers do not request a channel.

## Validation

- pnpm --filter @voyant-travel/catalog typecheck
- pnpm --filter @voyant-travel/catalog-react typecheck
- pnpm --filter @voyant-travel/catalog build
- pnpm --filter @voyant-travel/catalog-react build
- pnpm --filter @voyant-travel/catalog test -- routes typesense
- pnpm --filter operator test -- catalog-listability
- pnpm --filter operator test -- reindex-stale-documents
- pnpm --filter operator generate:openapi
- pnpm --filter @voyant-travel/openapi generate
- pnpm lint:changed
- pnpm verify:agent-quality:changed (0 errors; warning for openapi generated-spec changeset only)
- git diff --check
- commit hook affected lint/typecheck/build: 186 successful, 186 total
- pre-push repository test hook: 98 successful, 98 total