### PR TITLE
Make trips route options lazy

### DIFF
--- a/.changeset/lazy-trips-route-options.md
+++ b/.changeset/lazy-trips-route-options.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/trips": patch
+---
+
+Allow trips route options to be provided lazily so deployment-specific booking and payment runtime wiring is not imported into the eager API composition closure.

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -26,7 +26,7 @@ import type { CreateNotificationsHonoModuleOptions } from "@voyant-travel/notifi
 import type { relationshipsService } from "@voyant-travel/relationships"
 import type { StorefrontIntakePersistence } from "@voyant-travel/storefront"
 import type { StorefrontVerificationRoutesOptions } from "@voyant-travel/storefront/verification"
-import type { TripsRoutesOptions } from "@voyant-travel/trips"
+import type { TripsRoutesOptionsProvider } from "@voyant-travel/trips"
 import type { Hono } from "hono"
 
 // biome-ignore lint/suspicious/noExplicitAny: lazy sub-apps keep route-specific Hono env generics -- owner: framework composition.
@@ -46,7 +46,7 @@ export interface FrameworkProviders {
   customFields?: BookingsHonoModuleOptions["customFields"]
   resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) => Promise<string | null>
   resolveNotificationProviders: NonNullable<StorefrontVerificationRoutesOptions["resolveProviders"]>
-  createTripsRoutesOptions: () => TripsRoutesOptions
+  createTripsRoutesOptions: TripsRoutesOptionsProvider
   resolveDb: NonNullable<CreateLegalHonoModuleOptions["resolveDb"]>
   createOperatorDocumentStorage: NonNullable<CreateLegalHonoModuleOptions["resolveDocumentStorage"]>
   resolveContractDocumentGenerator: NonNullable<
@@ -733,7 +733,7 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
       const unit = createLazyUnit(() =>
         import("@voyant-travel/trips").then((m) => {
           const trips = m.createTripsHonoModule({
-            ...capabilities.createTripsRoutesOptions(),
+            routesOptions: capabilities.createTripsRoutesOptions,
             publicRoutes: true,
           })
           return { ...trips, module: { ...trips.module, requiresTransactionalDb: true } }

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -118,7 +118,7 @@ import {
   createStorefrontVerificationHonoModule,
   type StorefrontVerificationRoutesOptions,
 } from "@voyant-travel/storefront/verification"
-import { createTripsHonoModule, type TripsRoutesOptions } from "@voyant-travel/trips"
+import { createTripsHonoModule, type TripsRoutesOptionsProvider } from "@voyant-travel/trips"
 
 /**
  * Combined "extras" surface — inventory + bookings package extras routes mounted
@@ -305,8 +305,8 @@ export interface FrameworkProviders {
   resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) => Promise<string | null>
   /** Resolves the notification providers for the verification challenge. */
   resolveNotificationProviders: NonNullable<StorefrontVerificationRoutesOptions["resolveProviders"]>
-  /** Deployment-built trips route options (connector, payment wiring, …). */
-  createTripsRoutesOptions: () => TripsRoutesOptions
+  /** Deployment-built trips route options (connector, payment wiring, ...). */
+  createTripsRoutesOptions: TripsRoutesOptionsProvider
   /** Out-of-request db handle for legal's booking.confirmed subscriber. */
   resolveDb: NonNullable<CreateLegalHonoModuleOptions["resolveDb"]>
   /** Per-request document storage backend (legal contract documents). */
@@ -676,7 +676,7 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
       // (admin/public/legacy) needs the transactional client, so the whole
       // module is name-based transactional (ADR-0008); no deployment path list.
       const trips = createTripsHonoModule({
-        ...capabilities.createTripsRoutesOptions(),
+        routesOptions: capabilities.createTripsRoutesOptions,
         publicRoutes: true,
       })
       return { ...trips, module: { ...trips.module, requiresTransactionalDb: true } }

--- a/packages/trips/src/index.ts
+++ b/packages/trips/src/index.ts
@@ -1,7 +1,12 @@
 import type { Module } from "@voyant-travel/core"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
-import { createTripsRoutes, type TripsRoutesOptions, tripsRoutes } from "./routes.js"
+import {
+  createTripsRoutes,
+  type TripsRoutesOptions,
+  type TripsRoutesOptionsInput,
+  tripsRoutes,
+} from "./routes.js"
 
 export {
   type CatalogAdapterContext,
@@ -41,7 +46,12 @@ export {
   type FlightComponentAdapterOptions,
   previewFlightCancellation,
 } from "./flight-component.js"
-export type { TripsRoutes, TripsRoutesOptions } from "./routes.js"
+export type {
+  TripsRoutes,
+  TripsRoutesOptions,
+  TripsRoutesOptionsInput,
+  TripsRoutesOptionsProvider,
+} from "./routes.js"
 export { createTripsRoutes } from "./routes.js"
 
 export const tripsModule: Module = {
@@ -55,19 +65,46 @@ export const tripsHonoModule: HonoModule = {
 
 export interface TripsHonoModuleOptions extends TripsRoutesOptions {
   publicRoutes?: boolean
+  routesOptions?: TripsRoutesOptionsInput
 }
 
 export function createTripsHonoModule(options: TripsHonoModuleOptions = {}) {
-  const { publicRoutes = false, ...routeOptions } = options
-  const routes = createTripsRoutes({ ...routeOptions, surface: "admin" })
+  const { publicRoutes = false, routesOptions, ...routeOptions } = options
+  const resolvedRouteOptions = memoizeTripsRouteOptionsInput(routesOptions ?? routeOptions)
+  const routes = createTripsRoutes(withTripsRouteSurface(resolvedRouteOptions, "admin"))
   const honoModule: HonoModule = {
     module: tripsModule,
     adminRoutes: routes,
   }
   if (publicRoutes) {
-    honoModule.publicRoutes = createTripsRoutes({ ...routeOptions, surface: "public" })
+    honoModule.publicRoutes = createTripsRoutes(
+      withTripsRouteSurface(resolvedRouteOptions, "public"),
+    )
   }
   return honoModule
+}
+
+function memoizeTripsRouteOptionsInput(options: TripsRoutesOptionsInput): TripsRoutesOptionsInput {
+  if (typeof options !== "function") return options
+
+  let optionsPromise: Promise<TripsRoutesOptions> | undefined
+  return () => {
+    optionsPromise ??= Promise.resolve()
+      .then(options)
+      .catch((error) => {
+        optionsPromise = undefined
+        throw error
+      })
+    return optionsPromise
+  }
+}
+
+function withTripsRouteSurface(
+  options: TripsRoutesOptionsInput,
+  surface: NonNullable<TripsRoutesOptions["surface"]>,
+): TripsRoutesOptionsInput {
+  if (typeof options !== "function") return { ...options, surface }
+  return async () => ({ ...(await options()), surface })
 }
 
 export { tripsRoutes } from "./routes.js"

--- a/packages/trips/src/routes.ts
+++ b/packages/trips/src/routes.ts
@@ -88,7 +88,10 @@ export interface TripsRoutesOptions {
   sourceCandidatesDeps?: TripsRouteDeps<SourceRequirementCandidatesDeps>
 }
 
-export type TripsRouteDeps<T> = T | ((c: Context<Env>) => T | undefined)
+export type TripsRouteDeps<T> = T | ((c: Context<Env>) => T | Promise<T | undefined> | undefined)
+export type TripsRoutesOptionsProvider = () => TripsRoutesOptions | Promise<TripsRoutesOptions>
+export type TripsRoutesOptionsInput = TripsRoutesOptions | TripsRoutesOptionsProvider
+type ResolveTripsRoutesOptions = () => Promise<TripsRoutesOptions>
 
 const priceTripBodySchema = priceTripSchema.omit({ envelopeId: true })
 const createTripSnapshotBodySchema = createTripSnapshotSchema.omit({ envelopeId: true })
@@ -318,10 +321,41 @@ function isInternalErrorMessage(message: string): boolean {
   )
 }
 
-function resolveRouteDeps<T>(c: Context<Env>, deps: TripsRouteDeps<T> | undefined) {
+function createTripsRoutesOptionsResolver(
+  options: TripsRoutesOptionsInput = {},
+): ResolveTripsRoutesOptions {
+  if (typeof options !== "function") return () => Promise.resolve(options)
+
+  const provider = options
+  let optionsPromise: Promise<TripsRoutesOptions> | undefined
+  return () => {
+    optionsPromise ??= Promise.resolve()
+      .then(provider)
+      .catch((error) => {
+        optionsPromise = undefined
+        throw error
+      })
+    return optionsPromise
+  }
+}
+
+async function resolveRouteDeps<T>(c: Context<Env>, deps: TripsRouteDeps<T> | undefined) {
   if (typeof deps !== "function") return deps
-  const resolver = deps as (c: Context<Env>) => T | undefined
+  const resolver = deps as (c: Context<Env>) => T | Promise<T | undefined> | undefined
   return resolver(c)
+}
+
+async function isPublicRouteSurface(readOptions: ResolveTripsRoutesOptions): Promise<boolean> {
+  return isPublicSurface(await readOptions())
+}
+
+async function resolveConfiguredRouteDeps<T>(
+  c: Context<Env>,
+  readOptions: ResolveTripsRoutesOptions,
+  select: (options: TripsRoutesOptions) => TripsRouteDeps<T> | undefined,
+) {
+  const options = await readOptions()
+  return resolveRouteDeps(c, select(options))
 }
 
 const envelopeIdParamSchema = z.object({ envelopeId: z.string() })
@@ -1113,7 +1147,7 @@ const cancelComponentsRoute = createRoute({
 // each child's `.openapi()` registry definitions into the parent spec while
 // keeping per-chain type-inference cost bounded. See voyant#2114 / voyant#2208.
 
-function createEnvelopeRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
+function createEnvelopeRoutes(readOptions: ResolveTripsRoutesOptions): OpenAPIHono<Env> {
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .openapi(listTripsRoute, async (c) =>
       c.json(await tripsService.listTrips(c.get("db"), c.req.valid("query")), 200),
@@ -1133,7 +1167,7 @@ function createEnvelopeRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       return c.json({ data: trip }, 200)
     })
     .openapi(updateTripRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const envelope = await tripsService.updateTrip(
           c.get("db"),
@@ -1148,8 +1182,12 @@ function createEnvelopeRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(reshopTripRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
-      const deps = resolveRouteDeps(c, options.sourceCandidatesDeps)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.sourceCandidatesDeps,
+      )
       if (!deps) {
         return c.json({ error: "Trips availability-sourcing dependencies are not configured" }, 501)
       }
@@ -1167,10 +1205,10 @@ function createEnvelopeRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
     })
 }
 
-function createSnapshotRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
+function createSnapshotRoutes(readOptions: ResolveTripsRoutesOptions): OpenAPIHono<Env> {
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .openapi(listSnapshotsRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       return c.json(
         {
           data: await tripsService.listTripSnapshots(c.get("db"), c.req.valid("param").envelopeId),
@@ -1179,7 +1217,7 @@ function createSnapshotRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       )
     })
     .openapi(createSnapshotRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const snapshot = await tripsService.freezeTripSnapshot(c.get("db"), {
           ...c.req.valid("json"),
@@ -1192,7 +1230,7 @@ function createSnapshotRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(getSnapshotRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       const snapshot = await tripsService.getTripSnapshotById(
         c.get("db"),
         c.req.valid("param").snapshotId,
@@ -1202,7 +1240,7 @@ function createSnapshotRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
     })
 }
 
-function createComponentRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
+function createComponentRoutes(readOptions: ResolveTripsRoutesOptions): OpenAPIHono<Env> {
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .openapi(addComponentRoute, async (c) => {
       try {
@@ -1217,7 +1255,7 @@ function createComponentRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(reorderComponentsRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const components = await tripsService.reorderComponents(c.get("db"), {
           ...c.req.valid("json"),
@@ -1230,7 +1268,7 @@ function createComponentRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(updateComponentRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const component = await tripsService.updateComponent(
           c.get("db"),
@@ -1245,7 +1283,7 @@ function createComponentRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(updateComponentRefsRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const component = await tripsService.updateComponentRefs(
           c.get("db"),
@@ -1260,7 +1298,7 @@ function createComponentRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(deleteComponentRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const component = await tripsService.removeComponent(
           c.get("db"),
@@ -1275,10 +1313,10 @@ function createComponentRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
     })
 }
 
-function createRequirementRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
+function createRequirementRoutes(readOptions: ResolveTripsRoutesOptions): OpenAPIHono<Env> {
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .openapi(addRequirementRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const requirement = await tripsService.addRequirement(c.get("db"), {
           ...c.req.valid("json"),
@@ -1291,7 +1329,7 @@ function createRequirementRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> 
       }
     })
     .openapi(listRequirementsRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const data = await tripsService.listEnvelopeRequirements(
           c.get("db"),
@@ -1304,8 +1342,12 @@ function createRequirementRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> 
       }
     })
     .openapi(sourceCandidatesRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
-      const deps = resolveRouteDeps(c, options.sourceCandidatesDeps)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.sourceCandidatesDeps,
+      )
       if (!deps) {
         return c.json({ error: "Trips availability-sourcing dependencies are not configured" }, 501)
       }
@@ -1322,7 +1364,7 @@ function createRequirementRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> 
       }
     })
     .openapi(selectCandidateRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
         const result = await tripsService.selectCandidate(c.get("db"), {
           ...c.req.valid("json"),
@@ -1335,8 +1377,12 @@ function createRequirementRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> 
       }
     })
     .openapi(reshopRequirementRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
-      const deps = resolveRouteDeps(c, options.sourceCandidatesDeps)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.sourceCandidatesDeps,
+      )
       if (!deps) {
         return c.json({ error: "Trips availability-sourcing dependencies are not configured" }, 501)
       }
@@ -1354,10 +1400,14 @@ function createRequirementRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> 
     })
 }
 
-function createLifecycleRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
+function createLifecycleRoutes(readOptions: ResolveTripsRoutesOptions): OpenAPIHono<Env> {
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .openapi(priceTripRoute, async (c) => {
-      const deps = resolveRouteDeps(c, options.priceTripDeps)
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.priceTripDeps,
+      )
       if (!deps) {
         return c.json({ error: "Trips price dependencies are not configured" }, 501)
       }
@@ -1374,7 +1424,11 @@ function createLifecycleRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(reserveTripRoute, async (c) => {
-      const deps = resolveRouteDeps(c, options.reserveTripDeps)
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.reserveTripDeps,
+      )
       if (!deps) {
         return c.json({ error: "Trips reserve dependencies are not configured" }, 501)
       }
@@ -1394,7 +1448,11 @@ function createLifecycleRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(checkoutTripRoute, async (c) => {
-      const deps = resolveRouteDeps(c, options.startCheckoutDeps)
+      const deps = await resolveConfiguredRouteDeps(
+        c,
+        readOptions,
+        (options) => options.startCheckoutDeps,
+      )
       if (!deps) {
         return c.json({ error: "Trips checkout dependencies are not configured" }, 501)
       }
@@ -1411,9 +1469,13 @@ function createLifecycleRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(cancellationPreviewRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
-        const deps = resolveRouteDeps(c, options.cancelTripComponentsDeps)
+        const deps = await resolveConfiguredRouteDeps(
+          c,
+          readOptions,
+          (options) => options.cancelTripComponentsDeps,
+        )
         const result = await tripsService.previewCancellation(
           c.get("db"),
           { ...c.req.valid("json"), envelopeId: c.req.valid("param").envelopeId },
@@ -1426,9 +1488,13 @@ function createLifecycleRoutes(options: TripsRoutesOptions): OpenAPIHono<Env> {
       }
     })
     .openapi(cancelComponentsRoute, async (c) => {
-      if (isPublicSurface(options)) return publicForbidden(c)
+      if (await isPublicRouteSurface(readOptions)) return publicForbidden(c)
       try {
-        const deps = resolveRouteDeps(c, options.cancelTripComponentsDeps)
+        const deps = await resolveConfiguredRouteDeps(
+          c,
+          readOptions,
+          (options) => options.cancelTripComponentsDeps,
+        )
         const result = await tripsService.cancelComponents(
           c.get("db"),
           { ...c.req.valid("json"), envelopeId: c.req.valid("param").envelopeId },
@@ -1448,14 +1514,15 @@ function createHealthRoutes(): OpenAPIHono<Env> {
   )
 }
 
-export function createTripsRoutes(options: TripsRoutesOptions = {}): OpenAPIHono<Env> {
+export function createTripsRoutes(options: TripsRoutesOptionsInput = {}): OpenAPIHono<Env> {
+  const readOptions = createTripsRoutesOptionsResolver(options)
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .route("/", createHealthRoutes())
-    .route("/", createEnvelopeRoutes(options))
-    .route("/", createSnapshotRoutes(options))
-    .route("/", createComponentRoutes(options))
-    .route("/", createRequirementRoutes(options))
-    .route("/", createLifecycleRoutes(options))
+    .route("/", createEnvelopeRoutes(readOptions))
+    .route("/", createSnapshotRoutes(readOptions))
+    .route("/", createComponentRoutes(readOptions))
+    .route("/", createRequirementRoutes(readOptions))
+    .route("/", createLifecycleRoutes(readOptions))
 }
 
 export const tripsRoutes = createTripsRoutes()

--- a/packages/trips/tests/routes.test.ts
+++ b/packages/trips/tests/routes.test.ts
@@ -112,6 +112,55 @@ describe("trips routes", () => {
     expect(reshop.status).toBe(501)
   })
 
+  it("resolves lazy route options only when an injected dependency is needed", async () => {
+    vi.spyOn(tripsService, "reserveTrip")
+      .mockResolvedValueOnce({
+        envelope: { id: "trip_123", status: "reserved" },
+        components: [],
+        reservationPlanId: "trpl_1",
+        reserved: [],
+        failures: [],
+        compensations: [],
+        warnings: [],
+      } as never)
+      .mockResolvedValueOnce({
+        envelope: { id: "trip_123", status: "reserved" },
+        components: [],
+        reservationPlanId: "trpl_1",
+        reserved: [],
+        failures: [],
+        compensations: [],
+        warnings: [],
+      } as never)
+    const submitReservationPlan = vi.fn()
+    const routeOptions = vi.fn(async () => ({
+      reserveTripDeps: { submitReservationPlan },
+    }))
+    const app = appWithDb(createTripsRoutes(routeOptions))
+
+    expect(routeOptions).not.toHaveBeenCalled()
+
+    const health = await app.request("/health")
+    expect(health.status).toBe(200)
+    expect(routeOptions).not.toHaveBeenCalled()
+
+    const firstReserve = await app.request("/trip_123/reserve", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    })
+    expect(firstReserve.status).toBe(200)
+    expect(routeOptions).toHaveBeenCalledTimes(1)
+
+    const secondReserve = await app.request("/trip_123/reserve", {
+      method: "POST",
+      body: JSON.stringify({}),
+      headers: { "content-type": "application/json" },
+    })
+    expect(secondReserve.status).toBe(200)
+    expect(routeOptions).toHaveBeenCalledTimes(1)
+  })
+
   it("returns a conflict response when reserve produces component failures", async () => {
     vi.spyOn(tripsService, "reserveTrip").mockResolvedValueOnce({
       envelope: { id: "trip_123", status: "failed" },

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -65,7 +65,6 @@ import {
   resolveBankTransferDetails,
   resolvePublicCheckoutBaseUrlFromBindings,
 } from "./runtime/payment-config"
-import { createOperatorTripsRoutesOptions } from "./runtime/trips-runtime"
 import { recordPaidBookingCancellationSettlement } from "./subscribers/booking-cancellation-settlement"
 import { closeTerminalBookingPaymentSchedules } from "./subscribers/booking-payment-cleanup"
 
@@ -99,7 +98,7 @@ export interface OperatorCapabilities extends FrameworkProviders {
   relationshipsService: FrameworkProviders["relationshipsService"]
   closePaymentSchedulesForBooking: typeof closeTerminalBookingPaymentSchedules
   recordCancellationFinancialSettlement: typeof recordPaidBookingCancellationSettlement
-  createTripsRoutesOptions: typeof createOperatorTripsRoutesOptions
+  createTripsRoutesOptions: FrameworkProviders["createTripsRoutesOptions"]
   resolveBookingRequirementsProductSnapshot: typeof resolveBookingRequirementsProductSnapshot
 }
 
@@ -133,7 +132,8 @@ export function buildOperatorProviders(): OperatorCapabilities {
     // Adapt the deployment's catalog context into the package's search runtime
     // shape (the framework catalog factory consumes this directly).
     resolveCatalogRuntime: createLazyCatalogSearchRuntime,
-    createTripsRoutesOptions: createOperatorTripsRoutesOptions,
+    createTripsRoutesOptions: () =>
+      import("./runtime/trips-runtime").then((m) => m.createOperatorTripsRoutesOptions()),
     resolveBookingRequirementsProductSnapshot,
     storefrontIntakePersistence: lazyProvider<StorefrontIntakePersistence>(async () =>
       import("./runtime/storefront-intake-runtime").then(

--- a/starters/operator/src/api/runtime/mcp-runtime.ts
+++ b/starters/operator/src/api/runtime/mcp-runtime.ts
@@ -225,20 +225,23 @@ function createTripsToolServices(c: Context): TripsToolServices {
     createTrip: (input) => tripsService.createTrip(c.var.db, input),
     addComponent: (input) => tripsService.addComponent(c.var.db, input),
     removeComponent: (componentId) => tripsService.removeComponent(c.var.db, componentId),
-    priceTrip: (input) => {
-      const deps = resolveDeps(c, options.priceTripDeps)
+    priceTrip: async (input) => {
+      const deps = await resolveDeps(c, options.priceTripDeps)
       if (!deps) throw new Error("Trips price dependencies are not configured")
       return tripsService.priceTrip(c.var.db, input, deps)
     },
-    reserveTrip: (input) => {
-      const deps = resolveDeps(c, options.reserveTripDeps)
+    reserveTrip: async (input) => {
+      const deps = await resolveDeps(c, options.reserveTripDeps)
       if (!deps) throw new Error("Trips reserve dependencies are not configured")
       return tripsService.reserveTrip(c.var.db, input, deps)
     },
   }
 }
 
-function resolveDeps<T>(c: Context, deps: T | ((c: Context) => T | undefined) | undefined) {
+function resolveDeps<T>(
+  c: Context,
+  deps: T | ((c: Context) => T | Promise<T | undefined> | undefined) | undefined,
+) {
   if (typeof deps !== "function") return deps
-  return (deps as (c: Context) => T | undefined)(c)
+  return (deps as (c: Context) => T | Promise<T | undefined> | undefined)(c)
 }


### PR DESCRIPTION
## Summary

- Add lazy, memoized trips route option providers while keeping the existing eager `TripsRoutesOptions` object API.
- Pass `createTripsRoutesOptions` through framework composition instead of synchronously spreading it.
- Dynamically import the operator trips runtime so booking/PDF route wiring is outside the eager API composition closure.
- Update MCP trips tool wiring to await the now-async-capable dependency resolver.

## Root Cause

`createTripsRoutesOptions` was consumed synchronously during module composition. In the operator starter that forced `runtime/trips-runtime` into the eager API graph, pulling booking-engine/PDF-related runtime code into Worker startup even though those deps are only needed on trips execution paths.

## Impact

Trips route options now resolve on first handler use and are memoized. The framework can mount trips routes without importing the operator booking/PDF runtime graph into the eager composition closure.

Closes #2941.

## Validation

- `pnpm --filter @voyant-travel/trips test`
- `pnpm --filter @voyant-travel/trips typecheck`
- `pnpm --filter @voyant-travel/trips lint`
- `pnpm --filter @voyant-travel/trips build`
- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm --filter @voyant-travel/framework build`
- `pnpm --filter operator typecheck`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:package-exports`
- Commit hook: 186 successful tasks
- Pre-push hook: 98 successful test tasks