### PR TITLE
Narrow notifications document imports

### DIFF
--- a/.changeset/narrow-notifications-document-imports.md
+++ b/.changeset/narrow-notifications-document-imports.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/notifications": patch
+---
+
+Narrow document-related table imports to schema-only legal and finance package surfaces so notification root imports no longer pull document renderer code into cold-start bundles.

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -1,7 +1,7 @@
 import { bookings } from "@voyant-travel/bookings/schema"
 import type { EventBus } from "@voyant-travel/core"
 import { invoiceRenditions, invoices } from "@voyant-travel/finance/schema"
-import { contractAttachments, contracts } from "@voyant-travel/legal/contracts"
+import { contractAttachments, contracts } from "@voyant-travel/legal/schema"
 import { and, desc, eq, ne, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 

--- a/packages/notifications/src/service-deliveries.ts
+++ b/packages/notifications/src/service-deliveries.ts
@@ -1,5 +1,5 @@
 import { bookings } from "@voyant-travel/bookings/schema"
-import { invoices, paymentSessions } from "@voyant-travel/finance"
+import { invoices, paymentSessions } from "@voyant-travel/finance/schema"
 import { desc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 

--- a/packages/notifications/src/service-reminder-booking-context.ts
+++ b/packages/notifications/src/service-reminder-booking-context.ts
@@ -1,5 +1,5 @@
 import { bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
-import { bookingPaymentSchedules, invoices, paymentSessions } from "@voyant-travel/finance"
+import { bookingPaymentSchedules, invoices, paymentSessions } from "@voyant-travel/finance/schema"
 import { and, asc, desc, eq, gt, isNull, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 

--- a/packages/notifications/src/service-reminder-stage-runs.ts
+++ b/packages/notifications/src/service-reminder-stage-runs.ts
@@ -1,5 +1,5 @@
 import { bookings, bookingTravelers } from "@voyant-travel/bookings/schema"
-import { bookingPaymentSchedules, invoices } from "@voyant-travel/finance"
+import { bookingPaymentSchedules, invoices } from "@voyant-travel/finance/schema"
 import { desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 

--- a/packages/notifications/src/service-reminders.ts
+++ b/packages/notifications/src/service-reminders.ts
@@ -1,4 +1,4 @@
-import { bookingPaymentSchedules } from "@voyant-travel/finance"
+import { bookingPaymentSchedules } from "@voyant-travel/finance/schema"
 import { and, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 

--- a/packages/notifications/src/service-sequence-targets.ts
+++ b/packages/notifications/src/service-sequence-targets.ts
@@ -1,5 +1,5 @@
 import { bookings } from "@voyant-travel/bookings/schema"
-import { bookingPaymentSchedules, invoices } from "@voyant-travel/finance"
+import { bookingPaymentSchedules, invoices } from "@voyant-travel/finance/schema"
 import { and, eq, gt, gte, inArray, lte, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 

--- a/packages/notifications/src/service-shared.ts
+++ b/packages/notifications/src/service-shared.ts
@@ -1,5 +1,5 @@
 import { bookingItems, bookingTravelers } from "@voyant-travel/bookings/schema"
-import type { bookingPaymentSchedules } from "@voyant-travel/finance"
+import type { bookingPaymentSchedules } from "@voyant-travel/finance/schema"
 import { listResponse } from "@voyant-travel/types"
 import { and, desc, eq } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"

--- a/packages/notifications/tests/unit/module.test.ts
+++ b/packages/notifications/tests/unit/module.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { createContainer, createEventBus } from "@voyant-travel/core"
 import { describe, expect, it, vi } from "vitest"
 
@@ -7,6 +10,18 @@ import {
 } from "../../src/index.js"
 
 describe("createNotificationsHonoModule.bootstrap", () => {
+  it("keeps document-related table imports on schema-only package surfaces", () => {
+    const srcDir = fileURLToPath(new URL("../../src", import.meta.url))
+    const files = collectTypeScriptFiles(srcDir)
+    const sources = files.map((file) => [file, readFileSync(file, "utf8")] as const)
+
+    for (const [file, source] of sources) {
+      expect(source, file).not.toContain("@voyant-travel/legal/contracts")
+      expect(source, file).not.toContain('from "@voyant-travel/finance"')
+      expect(source, file).not.toContain("from '@voyant-travel/finance'")
+    }
+  })
+
   it("registers the resolved route runtime once", async () => {
     const resolveProviders = vi.fn(() => [
       {
@@ -43,3 +58,13 @@ describe("createNotificationsHonoModule.bootstrap", () => {
     expect(runtime.eventBus).toBe(eventBus)
   })
 })
+
+function collectTypeScriptFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      return collectTypeScriptFiles(path)
+    }
+    return entry.isFile() && path.endsWith(".ts") ? [path] : []
+  })
+}


### PR DESCRIPTION
## Summary

- move notifications document table reads to schema-only legal and finance package subpaths
- add a regression test that prevents reintroducing broad legal contracts or finance root imports in notifications source
- add a patch changeset for `@voyant-travel/notifications`

## Validation

- `pnpm --filter @voyant-travel/notifications lint`
- `pnpm --filter @voyant-travel/notifications typecheck`
- `pnpm --filter @voyant-travel/notifications test`
- `pnpm --filter @voyant-travel/notifications build`
- `pnpm verify:fast`
- `pnpm exec esbuild packages/notifications/src/index.ts --bundle --platform=node --format=esm --metafile=/tmp/notifications-meta.json --outfile=/tmp/notifications-bundle.js` then checked `pdf-lib`, `pdf-renderer`, `service-documents`, and `@voyant-travel/legal/contracts`: all `0`

Fixes #2944