### PR TITLE
Fix React vendor chunk package boundary

### DIFF
--- a/.changeset/tame-react-vendor-boundary.md
+++ b/.changeset/tame-react-vendor-boundary.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/vite-config": patch
+---
+
+Anchor the React vendor chunk heuristic to actual `react`, `react-dom`, and `scheduler` package boundaries so third-party package internals such as Better Auth's `dist/client/react/*` subpaths stay out of the eager React chunk.

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -13,21 +13,31 @@ import type { PluginOption, UserConfig } from "vite"
  * can hoist the JSX runtime into another vendor chunk, forcing every
  * React-using chunk to import that chunk just to get `jsx`/`jsxs`.
  */
+function isNodeModulePackage(id: string, packageName: string): boolean {
+  return id.includes(`/node_modules/${packageName}/`)
+}
+
 export function voyantVendorChunk(id: string): string | undefined {
-  if (!id.includes("node_modules")) return undefined
+  const normalizedId = id.replaceAll("\\", "/")
+  if (!normalizedId.includes("node_modules")) return undefined
 
   if (
-    id.includes("/react/") ||
-    id.includes("/react-dom/") ||
-    id.includes("/scheduler/") ||
-    id.match(/\/react\/jsx-(dev-)?runtime\b/)
+    isNodeModulePackage(normalizedId, "react") ||
+    isNodeModulePackage(normalizedId, "react-dom") ||
+    isNodeModulePackage(normalizedId, "scheduler")
   ) {
     return "react"
   }
-  if (id.includes("/clsx/") || id.includes("/tailwind-merge/")) return "class-utils"
-  if (id.includes("/@tiptap/") || id.includes("/prosemirror-")) return "tiptap"
-  if (id.includes("/recharts/")) return "recharts"
-  if (id.includes("/pdf-lib/") || id.includes("/@pdf-lib/")) return "pdf-lib"
+  if (normalizedId.includes("/clsx/") || normalizedId.includes("/tailwind-merge/")) {
+    return "class-utils"
+  }
+  if (normalizedId.includes("/@tiptap/") || normalizedId.includes("/prosemirror-")) {
+    return "tiptap"
+  }
+  if (normalizedId.includes("/recharts/")) return "recharts"
+  if (normalizedId.includes("/pdf-lib/") || normalizedId.includes("/@pdf-lib/")) {
+    return "pdf-lib"
+  }
   return undefined
 }
 

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -38,6 +38,12 @@ describe("voyantVendorChunk", () => {
     expect(voyantVendorChunk("/repo/node_modules/zod/index.js")).toBeUndefined()
     // react-hook-form must NOT match the /react/ pin.
     expect(voyantVendorChunk("/repo/node_modules/react-hook-form/dist/index.js")).toBeUndefined()
+    expect(
+      voyantVendorChunk("/repo/node_modules/better-auth/dist/client/react/index.js"),
+    ).toBeUndefined()
+    expect(
+      voyantVendorChunk("/repo/node_modules/@better-auth/utils/dist/client/react/error-codes.js"),
+    ).toBeUndefined()
   })
 })
 


### PR DESCRIPTION
## Summary

- Anchor `voyantVendorChunk` React matching to actual `react`, `react-dom`, and `scheduler` package boundaries under `node_modules`.
- Keep third-party package internals such as Better Auth's `dist/client/react/*` subpaths out of the eager React vendor chunk.
- Add regression coverage and a patch changeset for `@voyant-travel/vite-config`.

## Root Cause

The previous heuristic used a broad `id.includes("/react/")` check. That matched any dependency path containing a `react` directory, including Better Auth's browser hook integration, which let shared Better Auth utilities co-locate with `react-dom` in the SSR/worker bundle.

## Validation

- `pnpm --filter @voyant-travel/vite-config test`
- `pnpm --filter @voyant-travel/vite-config typecheck`
- `pnpm --filter @voyant-travel/vite-config lint`
- `pnpm verify:fast` (`verify-migration-replay-parity` skipped because `TEST_DATABASE_URL` is not set; local tasks passed)
- Push hook `pnpm test` completed successfully from cache

Closes #2945