### PR TITLE
Fix channelled default catalog slices

### DIFF
--- a/starters/operator/src/api/lib/catalog-runtime.test.ts
+++ b/starters/operator/src/api/lib/catalog-runtime.test.ts
@@ -2,7 +2,7 @@ import { marketLocales, markets } from "@voyant-travel/commerce"
 import { channels } from "@voyant-travel/distribution"
 import { describe, expect, it } from "vitest"
 
-import { loadCatalogSlices } from "./catalog-runtime"
+import { CATALOG_VERTICALS, loadCatalogSlices } from "./catalog-runtime"
 
 type TableRows = Map<object, unknown[]>
 
@@ -19,6 +19,31 @@ function createSelectDb(rowsByTable: TableRows) {
 }
 
 describe("loadCatalogSlices", () => {
+  it("materializes channelled default-market customer slices for active channels", async () => {
+    const rowsByTable: TableRows = new Map()
+    rowsByTable.set(markets, [])
+    rowsByTable.set(marketLocales, [])
+    rowsByTable.set(channels, [{ id: "chan_website" }])
+
+    const slices = await loadCatalogSlices(createSelectDb(rowsByTable) as never)
+
+    for (const vertical of CATALOG_VERTICALS) {
+      expect(slices).toContainEqual({
+        vertical,
+        locale: "en-GB",
+        audience: "customer",
+        market: "default",
+      })
+      expect(slices).toContainEqual({
+        vertical,
+        locale: "en-GB",
+        audience: "customer",
+        market: "default",
+        channel: "chan_website",
+      })
+    }
+  })
+
   it("preserves legacy unchannelled customer slices when active channels exist", async () => {
     const rowsByTable: TableRows = new Map()
     rowsByTable.set(markets, [

--- a/starters/operator/src/api/lib/catalog-runtime.ts
+++ b/starters/operator/src/api/lib/catalog-runtime.ts
@@ -121,6 +121,14 @@ export async function loadCatalogSlices(db: AnyDrizzleDb): Promise<IndexerSlice[
 
   const activeChannelIds = channelRows.map((channel) => channel.id)
   const customerChannels = [undefined, ...activeChannelIds]
+  const defaultChannelSlices = activeChannelIds.flatMap((channel) =>
+    DEFAULT_SLICES.filter(
+      (slice) => slice.audience === "customer" && slice.market === "default" && !slice.channel,
+    ).map((slice) => ({
+      ...slice,
+      channel,
+    })),
+  )
 
   const marketSlices = marketRows.flatMap((market) => {
     const locales = localesByMarket.get(market.id) ?? new Set([market.defaultLanguageTag])
@@ -138,7 +146,7 @@ export async function loadCatalogSlices(db: AnyDrizzleDb): Promise<IndexerSlice[
     )
   })
 
-  return uniqueSlices([...DEFAULT_SLICES, ...marketSlices])
+  return uniqueSlices([...DEFAULT_SLICES, ...defaultChannelSlices, ...marketSlices])
 }
 
 function uniqueSlices(slices: ReadonlyArray<IndexerSlice>): IndexerSlice[] {


### PR DESCRIPTION
## Summary

Fixes #2950.

This updates the operator catalog runtime so active sales channels also materialize customer slices for the default market. The new slices are derived from `DEFAULT_SLICES`, so future default customer locales or verticals get the same channel coverage without duplicating the list.

## Impact

A storefront configured with `VOYANT_STOREFRONT_CHANNEL_ID` can search the same default-market channel collection that `loadCatalogSlices()` now creates during reindex, avoiding empty public catalog results when active products have active channel mappings.

## Validation

- `pnpm --filter operator test -- src/api/lib/catalog-runtime.test.ts`
- `pnpm --filter operator lint`
- `pnpm --filter operator typecheck`
- Commit hook affected verification: 186 tasks successful
- Pre-push test gate: 98 tasks successful