### PR TITLE
Fix accommodation commit booking id

### DIFF
--- a/.changeset/accommodation-commit-booking-id.md
+++ b/.changeset/accommodation-commit-booking-id.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/accommodations": patch
+---
+
+Return the bridge-created booking id from accommodation booking-engine commits so catalog checkout snapshots point at the real stay booking.

--- a/packages/accommodations/src/booking-engine/handler.ts
+++ b/packages/accommodations/src/booking-engine/handler.ts
@@ -319,6 +319,7 @@ export function createAccommodationBookingHandler(
 
       return {
         status: "held",
+        bookingId: bridge.bookingId,
         orderRef: bridge.bookingNumber ?? bridge.bookingId,
         pricing: request.pricing,
         upstreamPayload: { bridgeBookingId: bridge.bookingId },

--- a/packages/accommodations/tests/unit/booking-handler.test.ts
+++ b/packages/accommodations/tests/unit/booking-handler.test.ts
@@ -1,0 +1,119 @@
+import type { OwnedHandlerContext } from "@voyant-travel/catalog/booking-engine"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createAccommodationBookingHandler } from "../../src/booking-engine/index.js"
+import { quoteOwnedStay } from "../../src/service-owned-stays.js"
+
+vi.mock("../../src/service-owned-stays.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../src/service-owned-stays.js")>()
+  return {
+    ...actual,
+    quoteOwnedStay: vi.fn(),
+  }
+})
+
+const mockQuoteOwnedStay = vi.mocked(quoteOwnedStay)
+
+describe("createAccommodationBookingHandler", () => {
+  beforeEach(() => {
+    mockQuoteOwnedStay.mockReset()
+  })
+
+  it("returns the bridge booking id as the canonical commit booking id", async () => {
+    mockQuoteOwnedStay.mockResolvedValue({
+      status: "ok",
+      available: true,
+      propertyId: "prop_1",
+      roomTypeId: "room_1",
+      ratePlanId: "rate_1",
+      mealPlanId: "meal_1",
+      roomCount: 1,
+      nights: 2,
+      currency: "USD",
+      nightlyRates: [
+        {
+          date: "2026-09-01",
+          sellCurrency: "USD",
+          sellAmountCents: 12000,
+          costCurrency: "USD",
+          costAmountCents: 9000,
+          occupancyBasis: "room",
+          includedAdults: 2,
+          includedChildren: 0,
+          includedInfants: 0,
+          quantity: 1,
+          totalAmountCents: 12000,
+        },
+        {
+          date: "2026-09-02",
+          sellCurrency: "USD",
+          sellAmountCents: 12000,
+          costCurrency: "USD",
+          costAmountCents: 9000,
+          occupancyBasis: "room",
+          includedAdults: 2,
+          includedChildren: 0,
+          includedInfants: 0,
+          quantity: 1,
+          totalAmountCents: 12000,
+        },
+      ],
+      totalAmountCents: 24000,
+      availability: {
+        requestedRooms: 1,
+        minimumRemainingRooms: 4,
+        nights: [
+          {
+            date: "2026-09-01",
+            capacity: 4,
+            booked: 0,
+            remaining: 4,
+            closed: false,
+          },
+          {
+            date: "2026-09-02",
+            capacity: 4,
+            booked: 0,
+            remaining: 4,
+            closed: false,
+          },
+        ],
+      },
+    })
+
+    const handler = createAccommodationBookingHandler({
+      loadContent: async () => null,
+      commitBridge: async () => ({
+        status: "ok",
+        bookingId: "stay_booking_123",
+        bookingNumber: "STAY-123",
+      }),
+    })
+
+    const result = await handler.commit({ db: {} } as OwnedHandlerContext, {
+      entityModule: "accommodations",
+      entityId: "prop_1",
+      bookingId: "catalog_shell_123",
+      pricing: { currency: "USD", total: "240.00" },
+      draft: {
+        configure: {
+          pax: { adult: 2 },
+          dateRange: { checkIn: "2026-09-01", checkOut: "2026-09-03" },
+        },
+        accommodation: {
+          rooms: [{ optionUnitId: "room_1", quantity: 1, ratePlanId: "rate_1" }],
+        },
+        billing: {
+          contact: { firstName: "Ada", lastName: "Lovelace", email: "ada@example.com" },
+        },
+      },
+    })
+
+    expect(result).toMatchObject({
+      status: "held",
+      bookingId: "stay_booking_123",
+      orderRef: "STAY-123",
+      upstreamPayload: { bridgeBookingId: "stay_booking_123" },
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Return the bridge-created stay booking id from accommodation booking-engine commits.
- Add a regression test covering the successful commit result contract.
- Add a patch changeset for `@voyant-travel/accommodations`.

## Root Cause

Accommodation commits wrote the real stay booking through the bridge but only exposed that id inside `upstreamPayload`. Catalog then adopted its generated shell booking id, causing checkout/finalize to operate on the wrong booking row.

Resolves #2954.

## Validation

- `pnpm --filter @voyant-travel/accommodations test`
- `pnpm --filter @voyant-travel/accommodations typecheck`
- `pnpm --filter @voyant-travel/accommodations lint`
- `pnpm exec biome check packages/accommodations/tests/unit/booking-handler.test.ts`
- `pnpm verify:fast` (passes; migration replay parity skipped because `TEST_DATABASE_URL` is not set)
- Push hooks ran cached full test lanes successfully while publishing the branch.