### PR TITLE
Expose auth cross-subdomain cookie config

### DIFF
--- a/.changeset/auth-cookie-domain.md
+++ b/.changeset/auth-cookie-domain.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Expose Better Auth advanced options so deployments can configure cross-subdomain session cookies.

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -233,6 +233,12 @@ export interface CreateBetterAuthOptions<
   /** Better Auth rate-limit config. Defaults to secondary storage when present. */
   rateLimit?: BetterAuthOptions["rateLimit"]
   /**
+   * Additional Better Auth advanced options. Voyant still supplies
+   * `useSecureCookies` by default unless overridden here or via the top-level
+   * `useSecureCookies` compatibility option.
+   */
+  advanced?: BetterAuthOptions["advanced"]
+  /**
    * Controls Better Auth's Secure cookie flag. Defaults to secure except in
    * explicit local development (`NODE_ENV=development`).
    */
@@ -424,7 +430,11 @@ export function createBetterAuth<
       },
     },
     advanced: {
-      useSecureCookies: options.useSecureCookies ?? process.env.NODE_ENV !== "development",
+      ...options.advanced,
+      useSecureCookies:
+        options.useSecureCookies ??
+        options.advanced?.useSecureCookies ??
+        process.env.NODE_ENV !== "development",
     },
   } as ResolvedCreateBetterAuthOptions<UserOptions, Plugins>
 

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -4,6 +4,14 @@ import type { CreateBetterAuthOptions } from "../../src/server.js"
 
 type BetterAuthConfig = {
   advanced: {
+    crossSubDomainCookies?: {
+      enabled: boolean
+      domain?: string
+    }
+    defaultCookieAttributes?: {
+      domain?: string
+      sameSite?: string
+    }
     useSecureCookies: boolean
   }
   databaseHooks: {
@@ -103,6 +111,38 @@ describe("createBetterAuth", () => {
     })
 
     expect(latestBetterAuthConfig().advanced.useSecureCookies).toBe(false)
+  })
+
+  it("forwards Better Auth advanced cookie options", async () => {
+    const { createBetterAuth } = await import("../../src/server.js")
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "https://auth.example.com",
+      advanced: {
+        crossSubDomainCookies: {
+          enabled: true,
+          domain: ".example.com",
+        },
+        defaultCookieAttributes: {
+          domain: ".example.com",
+          sameSite: "lax",
+        },
+      },
+    })
+
+    expect(latestBetterAuthConfig().advanced).toMatchObject({
+      crossSubDomainCookies: {
+        enabled: true,
+        domain: ".example.com",
+      },
+      defaultCookieAttributes: {
+        domain: ".example.com",
+        sameSite: "lax",
+      },
+      useSecureCookies: true,
+    })
   })
 
   it("forwards Better Auth user options and keeps Voyant's default change-email setting", async () => {

--- a/starters/operator/env.d.ts
+++ b/starters/operator/env.d.ts
@@ -18,6 +18,11 @@ interface CloudflareBindings {
   INTERNAL_API_KEY: string
   SESSION_CLAIMS_SECRET: string
   BETTER_AUTH_SECRET: string
+  /**
+   * Optional parent domain for Better Auth cookies in split UI/API
+   * deployments, e.g. `.example.com` for `admin.example.com` + `api.example.com`.
+   */
+  AUTH_COOKIE_DOMAIN?: string
   DATABASE_URL: string
   /**
    * Optional comma-separated connection strings of same-region Neon read

--- a/starters/operator/src/api/auth/cookie-domain.test.ts
+++ b/starters/operator/src/api/auth/cookie-domain.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import { buildBetterAuthCookieAdvancedOptions } from "./cookie-domain"
+
+describe("buildBetterAuthCookieAdvancedOptions", () => {
+  it("leaves Better Auth cookie defaults untouched when AUTH_COOKIE_DOMAIN is unset", () => {
+    expect(buildBetterAuthCookieAdvancedOptions({})).toBeUndefined()
+    expect(buildBetterAuthCookieAdvancedOptions({ AUTH_COOKIE_DOMAIN: "   " })).toBeUndefined()
+  })
+
+  it("enables cross-subdomain Better Auth cookies for the configured domain", () => {
+    expect(buildBetterAuthCookieAdvancedOptions({ AUTH_COOKIE_DOMAIN: " .example.com " })).toEqual({
+      crossSubDomainCookies: {
+        enabled: true,
+        domain: ".example.com",
+      },
+      defaultCookieAttributes: {
+        domain: ".example.com",
+      },
+    })
+  })
+})

--- a/starters/operator/src/api/auth/cookie-domain.ts
+++ b/starters/operator/src/api/auth/cookie-domain.ts
@@ -1,0 +1,22 @@
+import type { CreateBetterAuthOptions } from "@voyant-travel/auth/server"
+
+type BetterAuthAdvancedOptions = NonNullable<CreateBetterAuthOptions["advanced"]>
+
+export function buildBetterAuthCookieAdvancedOptions(
+  env: Pick<CloudflareBindings, "AUTH_COOKIE_DOMAIN">,
+):
+  | Pick<BetterAuthAdvancedOptions, "crossSubDomainCookies" | "defaultCookieAttributes">
+  | undefined {
+  const domain = env.AUTH_COOKIE_DOMAIN?.trim()
+  if (!domain) return undefined
+
+  return {
+    crossSubDomainCookies: {
+      enabled: true,
+      domain,
+    },
+    defaultCookieAttributes: {
+      domain,
+    },
+  }
+}

--- a/starters/operator/src/api/auth/handler.ts
+++ b/starters/operator/src/api/auth/handler.ts
@@ -46,6 +46,7 @@ import { resolveEmailReplyTo } from "../../lib/notifications"
 import { OPERATOR_APP_NAME, operatorReporter } from "../../lib/observability"
 import { tryGetCloudClient } from "../../lib/voyant-cloud"
 import { dbFromEnvForApp } from "../lib/db"
+import { buildBetterAuthCookieAdvancedOptions } from "./cookie-domain"
 
 // Type ctx so that `c.get("db")` resolves to the parent app's middleware-
 // set `VoyantDb` (the per-request Pool the `dbFromEnvForApp` factory
@@ -287,6 +288,7 @@ function buildBetterAuth(
     baseURL: getAuthBaseUrl(env),
     basePath: "/auth",
     trustedOrigins: getTrustedOrigins(env),
+    advanced: buildBetterAuthCookieAdvancedOptions(env),
     secondaryStorage: betterAuthSecondaryStorage(env),
     customerSignupSurfaces: options.customerSignup ? ["customer"] : undefined,
     plugins: cloudAuthExchange


### PR DESCRIPTION
## Summary

- Exposes Better Auth `advanced` options through `CreateBetterAuthOptions`, preserving Voyant's existing secure-cookie default.
- Adds operator `AUTH_COOKIE_DOMAIN` wiring for split UI/API deployments so auth cookies can be scoped to a parent domain.
- Adds focused unit coverage for package pass-through and operator env parsing.

Fixes #2951.

## Validation

- `pnpm exec vitest run tests/unit/create-better-auth.test.ts` in `packages/auth`
- `pnpm exec vitest run src/api/auth/cookie-domain.test.ts` in `starters/operator`
- `pnpm --filter @voyant-travel/auth typecheck`
- Commit hook: full `turbo run typecheck --continue` passed, 186 tasks
- Push hook: full test lane passed, 98 tasks