### PR TITLE
Validate booking journey email addresses

### DIFF
--- a/.changeset/booking-email-validation.md
+++ b/.changeset/booking-email-validation.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/bookings-react": patch
+---
+
+Reject malformed booking draft email addresses in contracts and gate the booking journey when billing or traveler emails are syntactically invalid.

--- a/packages/bookings-react/src/i18n/en-journey.ts
+++ b/packages/bookings-react/src/i18n/en-journey.ts
@@ -48,6 +48,7 @@ export const bookingsUiEnJourney = {
       dependencyExcludes: "{dependent} can't be combined with {master}.",
       dependencyLimitPerMaster: "At most {limit} {dependent} per {master}.",
       dependencyLimitSum: "At most {limit} {dependent} allowed.",
+      invalidEmail: "Enter a valid email address.",
     },
     warnings: {
       phoneMissing: "Phone number not set — useful for last-minute supplier contact.",

--- a/packages/bookings-react/src/i18n/messages-journey.ts
+++ b/packages/bookings-react/src/i18n/messages-journey.ts
@@ -46,6 +46,7 @@ export type BookingsUiJourneyMessages = {
       dependencyExcludes: string
       dependencyLimitPerMaster: string
       dependencyLimitSum: string
+      invalidEmail: string
     }
     warnings: {
       phoneMissing: string

--- a/packages/bookings-react/src/i18n/ro-journey.ts
+++ b/packages/bookings-react/src/i18n/ro-journey.ts
@@ -49,6 +49,7 @@ export const bookingsUiRoJourney = {
       dependencyExcludes: "{dependent} nu poate fi combinat cu {master}.",
       dependencyLimitPerMaster: "Maximum {limit} {dependent} per {master}.",
       dependencyLimitSum: "Maximum {limit} {dependent} permis.",
+      invalidEmail: "Introdu o adresa de email valida.",
     },
     warnings: {
       phoneMissing: "Numarul de telefon lipseste - util pentru contact furnizor in ultimul moment.",

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -9,6 +9,7 @@ import {
 } from "@voyant-travel/catalog-contracts/booking-engine/draft-shape"
 import { type BookingsUiMessages, formatMessage } from "../../i18n/index.js"
 import { type Draft, totalPax } from "../lib/draft-state.js"
+import { isValidOptionalEmail } from "../lib/email-validation.js"
 import { evaluatePaxBandDependencies } from "../lib/pax-band-dependencies.js"
 import { findPaidScheduleRowsMissingPaymentDate } from "../lib/payment-schedule.js"
 import type { JourneyStep } from "../types.js"
@@ -138,12 +139,15 @@ export function canAdvanceFromStep(
       // collect an individual contact name (and the manual contact inputs are
       // hidden), so requiring one would lock the step with no way to satisfy it.
       if (draft.billing.buyerType === "B2B") {
-        return Boolean(draft.billing.organizationId)
+        return (
+          Boolean(draft.billing.organizationId) && isValidOptionalEmail(draft.billing.contact.email)
+        )
       }
       const c = draft.billing.contact
       return (
         c.firstName.length > 0 &&
         c.lastName.length > 0 &&
+        isValidOptionalEmail(c.email) &&
         (c.email.length > 0 || Boolean(c.phone?.trim()))
       )
     }
@@ -162,13 +166,36 @@ export function canAdvanceFromStep(
       }
       // Hard-reject only on canonical traveler fields (firstName, lastName);
       // other required fields surface as warnings, fillable later.
-      return draft.travelers.every((t) => t.firstName && t.lastName)
+      return draft.travelers.every(
+        (t) => t.firstName && t.lastName && isValidOptionalEmail(t.email),
+      )
     }
     case "payment":
       return findPaidScheduleRowsMissingPaymentDate(draft.paymentSchedules) === null
     default:
       return true
   }
+}
+
+export function validationErrorsForStep(
+  step: JourneyStep,
+  draft: Draft,
+  messages: BookingsUiMessages,
+): ReadonlyArray<string> {
+  const errors: string[] = []
+  switch (step) {
+    case "billing":
+      if (!isValidOptionalEmail(draft.billing.contact.email)) {
+        errors.push(messages.bookingJourney.validation.invalidEmail)
+      }
+      break
+    case "travelers":
+      if (draft.travelers.some((t) => !isValidOptionalEmail(t.email))) {
+        errors.push(messages.bookingJourney.validation.invalidEmail)
+      }
+      break
+  }
+  return errors
 }
 
 /**

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -45,6 +45,7 @@ import {
   makeHoldSignature,
   resolveInitialStatus,
   stackedStepComplete,
+  validationErrorsForStep,
   warningsForStep,
 } from "./booking-journey-rules.js"
 import { ConfigureStepSkeleton } from "./configure-step-skeleton.js"
@@ -552,6 +553,7 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
             shape={shape}
             renderLeadContactPicker={props.renderLeadContactPicker}
             renderExtras={billingExtrasSlot}
+            errors={validationErrorsForStep("billing", draft, messages)}
             warnings={warningsForStep("billing", draft, shape, messages)}
           />
         )
@@ -562,6 +564,7 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
             setDraft={setDraft}
             shape={shape}
             renderTravelerContactPicker={props.renderTravelerContactPicker}
+            errors={validationErrorsForStep("travelers", draft, messages)}
             warnings={warningsForStep("travelers", draft, shape, messages)}
           />
         )

--- a/packages/bookings-react/src/journey/components/journey-steps/billing-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/billing-step.tsx
@@ -7,8 +7,15 @@ import { Label } from "@voyant-travel/ui/components/label"
 import { RadioGroup, RadioGroupItem } from "@voyant-travel/ui/components/radio-group"
 import { useBookingsUiMessagesOrDefault } from "../../../i18n/index.js"
 import { patchBilling, setBillingBuyerType } from "../../lib/draft-state.js"
+import { isValidOptionalEmail } from "../../lib/email-validation.js"
 import type { LeadContactPickerProps } from "../../types.js"
-import { Field, JourneyWarnings, PhoneField, type StepCommonProps } from "./shared.js"
+import {
+  Field,
+  JourneyErrors,
+  JourneyWarnings,
+  PhoneField,
+  type StepCommonProps,
+} from "./shared.js"
 
 // ─────────────────────────────────────────────────────────────────
 // Billing
@@ -20,13 +27,18 @@ export function BillingStep({
   renderLeadContactPicker,
   renderExtras,
   warnings,
+  errors,
 }: StepCommonProps & {
   renderLeadContactPicker?: (props: LeadContactPickerProps) => React.ReactNode
   renderExtras?: () => React.ReactNode
   warnings?: ReadonlyArray<string>
+  errors?: ReadonlyArray<string>
 }): React.ReactElement {
   const messages = useBookingsUiMessagesOrDefault()
   const billing = draft.billing
+  const emailError = isValidOptionalEmail(billing.contact.email)
+    ? undefined
+    : messages.bookingJourney.validation.invalidEmail
   // Merge each partial from the picker (person record, org record, address
   // lookup) into the billing draft without clobbering the other slices.
   const apply: LeadContactPickerProps["apply"] = (next) => {
@@ -127,6 +139,7 @@ export function BillingStep({
                 label={messages.bookingJourney.billing.email}
                 type="email"
                 value={billing.contact.email}
+                error={emailError}
                 onChange={(v) =>
                   setDraft(
                     patchBilling(draft, {
@@ -253,6 +266,7 @@ export function BillingStep({
         )}
 
         {renderExtras ? <div>{renderExtras()}</div> : null}
+        <JourneyErrors errors={errors} />
         <JourneyWarnings warnings={warnings} />
       </CardContent>
     </Card>

--- a/packages/bookings-react/src/journey/components/journey-steps/shared.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/shared.tsx
@@ -54,6 +54,21 @@ export function JourneyWarnings({
   )
 }
 
+export function JourneyErrors({
+  errors,
+}: {
+  errors?: ReadonlyArray<string>
+}): React.ReactElement | null {
+  if (!errors || errors.length === 0) return null
+  return (
+    <ul className="space-y-1 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive text-sm">
+      {errors.map((error) => (
+        <li key={error}>{error}</li>
+      ))}
+    </ul>
+  )
+}
+
 export function Field({
   id,
   label,
@@ -61,6 +76,7 @@ export function Field({
   onChange,
   type,
   placeholder,
+  error,
 }: {
   id: string
   label: string
@@ -68,7 +84,9 @@ export function Field({
   onChange: (v: string) => void
   type?: string
   placeholder?: string
+  error?: string
 }): React.ReactElement {
+  const errorId = `${id}-error`
   return (
     <div className="space-y-1">
       <Label htmlFor={id}>{label}</Label>
@@ -77,8 +95,15 @@ export function Field({
         type={type ?? "text"}
         value={value}
         placeholder={placeholder}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? errorId : undefined}
         onChange={(e) => onChange(e.target.value)}
       />
+      {error ? (
+        <p id={errorId} className="text-destructive text-xs" role="alert">
+          {error}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/packages/bookings-react/src/journey/components/journey-steps/travelers-step.tsx
+++ b/packages/bookings-react/src/journey/components/journey-steps/travelers-step.tsx
@@ -14,6 +14,7 @@ import {
   setTravelers,
   totalPax,
 } from "../../lib/draft-state.js"
+import { isValidOptionalEmail } from "../../lib/email-validation.js"
 import type { TravelerContactPickerProps } from "../../types.js"
 import { PaxDependencyWarnings, PaxValidation } from "./configure-steps.js"
 import {
@@ -21,6 +22,7 @@ import {
   cryptoRowId,
   DateField,
   Field,
+  JourneyErrors,
   JourneyWarnings,
   PhoneField,
   SelectField,
@@ -62,9 +64,11 @@ export function TravelersStep({
   shape,
   renderTravelerContactPicker,
   warnings,
+  errors,
 }: StepCommonProps & {
   renderTravelerContactPicker?: (props: TravelerContactPickerProps) => React.ReactNode
   warnings?: ReadonlyArray<string>
+  errors?: ReadonlyArray<string>
 }): React.ReactElement {
   const messages = useBookingsUiMessagesOrDefault()
   const travelers = draft.travelers
@@ -165,6 +169,7 @@ export function TravelersStep({
 
         <PaxValidation draft={draft} shape={shape} />
         <PaxDependencyWarnings draft={draft} shape={shape} />
+        <JourneyErrors errors={errors} />
         <JourneyWarnings warnings={warnings} />
       </CardContent>
     </Card>
@@ -218,6 +223,9 @@ function TravelerCard({
   // documents) always show.
   const showIdentity = !renderTravelerContactPicker
   const gridHasContent = showIdentity || Boolean(dobField) || dynamicFields.length > 0
+  const emailError = isValidOptionalEmail(traveler.email)
+    ? undefined
+    : messages.bookingJourney.validation.invalidEmail
 
   // Live age from DOB — surfaces in the header so the user gets feedback as
   // they pick a date.
@@ -359,6 +367,7 @@ function TravelerCard({
                   label={messages.bookingJourney.billing.email}
                   type="email"
                   value={traveler.email ?? ""}
+                  error={emailError}
                   onChange={(v) => patchRow({ email: v })}
                 />
               ) : null}

--- a/packages/bookings-react/src/journey/lib/email-validation.ts
+++ b/packages/bookings-react/src/journey/lib/email-validation.ts
@@ -1,0 +1,11 @@
+import { z } from "zod"
+
+const emailSchema = z.email()
+
+export function isValidEmail(value: string): boolean {
+  return emailSchema.safeParse(value).success
+}
+
+export function isValidOptionalEmail(value: string | null | undefined): boolean {
+  return !value || isValidEmail(value)
+}

--- a/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
+++ b/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from "vitest"
-
+import { bookingsUiEn } from "../../src/i18n/en.js"
 import {
   buildCommitParty,
   buildCommitPaymentIntent,
   canAdvanceFromStep,
   defaultMinimalShape,
+  validationErrorsForStep,
 } from "../../src/journey/components/booking-journey-rules.js"
 import { emptyDraft, patchBilling, patchConfigure } from "../../src/journey/lib/draft-state.js"
 
@@ -45,6 +46,45 @@ describe("booking-journey-rules", () => {
     })
 
     expect(canAdvanceFromStep("billing", draft, shape, true)).toBe(false)
+  })
+
+  it("blocks a malformed B2C billing email even when phone is present", () => {
+    const shape = defaultMinimalShape()
+    const draft = patchBilling(emptyDraft(ENTITY, { buyerType: "B2C" }), {
+      contact: {
+        firstName: "Test",
+        lastName: "Traveler",
+        email: "not-an-email",
+        phone: "+15550100000",
+      },
+    })
+
+    expect(canAdvanceFromStep("billing", draft, shape, true)).toBe(false)
+    expect(validationErrorsForStep("billing", draft, bookingsUiEn)).toContain(
+      "Enter a valid email address.",
+    )
+  })
+
+  it("blocks malformed traveler emails", () => {
+    const shape = defaultMinimalShape()
+    const draft = {
+      ...emptyDraft(ENTITY),
+      configure: { ...emptyDraft(ENTITY).configure, pax: { adult: 1 } },
+      travelers: [
+        {
+          rowId: "row_1",
+          firstName: "Test",
+          lastName: "Traveler",
+          email: "not-an-email",
+          band: "adult" as const,
+        },
+      ],
+    }
+
+    expect(canAdvanceFromStep("travelers", draft, shape, true)).toBe(false)
+    expect(validationErrorsForStep("travelers", draft, bookingsUiEn)).toContain(
+      "Enter a valid email address.",
+    )
   })
 
   it("does not commit a stale organization id for an individual buyer", () => {

--- a/packages/catalog-contracts/src/booking-engine/draft-contracts.test.ts
+++ b/packages/catalog-contracts/src/booking-engine/draft-contracts.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+
+import { bookingDraftV1, travelerEntryV1 } from "./draft-contracts.js"
+
+const ENTITY = {
+  module: "products",
+  id: "prod_1",
+  sourceKind: "owned",
+}
+
+describe("booking draft contracts", () => {
+  it("rejects malformed billing contact emails", () => {
+    const parsed = bookingDraftV1.safeParse({
+      entity: ENTITY,
+      billing: {
+        contact: {
+          firstName: "Test",
+          lastName: "Traveler",
+          email: "not-an-email",
+        },
+      },
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it("accepts empty or syntactically valid draft contact emails", () => {
+    expect(
+      bookingDraftV1.safeParse({
+        entity: ENTITY,
+        billing: {
+          contact: {
+            firstName: "Test",
+            lastName: "Traveler",
+            email: "",
+          },
+        },
+      }).success,
+    ).toBe(true)
+
+    expect(
+      bookingDraftV1.safeParse({
+        entity: ENTITY,
+        billing: {
+          contact: {
+            firstName: "Test",
+            lastName: "Traveler",
+            email: "test@example.com",
+          },
+        },
+      }).success,
+    ).toBe(true)
+  })
+
+  it("accepts empty traveler emails but rejects malformed values", () => {
+    expect(
+      travelerEntryV1.safeParse({
+        firstName: "Test",
+        lastName: "Traveler",
+        email: "",
+      }).success,
+    ).toBe(true)
+
+    expect(
+      travelerEntryV1.safeParse({
+        firstName: "Test",
+        lastName: "Traveler",
+        email: "not-an-email",
+      }).success,
+    ).toBe(false)
+  })
+})

--- a/packages/catalog-contracts/src/booking-engine/draft-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/draft-contracts.ts
@@ -5,6 +5,8 @@ import { z } from "zod"
 export const paxBandCodeSchema = z.enum(["adult", "child", "infant", "senior", "student", "other"])
 export type PaxBandCode = z.infer<typeof paxBandCodeSchema>
 
+const optionalEmailStringV1 = z.union([z.literal(""), z.email()])
+
 export const travelerEntryV1 = z.object({
   /** Stable client-side row id — the wizard uses it to keep
    *  travelers stable across re-renders and to attach passengers
@@ -12,7 +14,7 @@ export const travelerEntryV1 = z.object({
   rowId: z.string().min(1).optional(),
   firstName: z.string().min(1).max(255),
   lastName: z.string().min(1).max(255),
-  email: z.string().email().optional(),
+  email: optionalEmailStringV1.optional(),
   phone: z.string().max(50).optional(),
   /** Linked CRM person, when the traveler was picked from (or copied as)
    *  an existing contact. Lets the picker reflect the selection and the
@@ -342,7 +344,7 @@ export const bookingDraftV1 = z.object({
       contact: z.object({
         firstName: z.string().default(""),
         lastName: z.string().default(""),
-        email: z.string().default(""),
+        email: optionalEmailStringV1.default(""),
         phone: z.string().optional(),
         /** CRM person id when the lead was picked from CRM (vs typed). */
         personId: z.string().optional(),


### PR DESCRIPTION
## Summary

Closes #2955.

- Reject malformed billing and traveler email strings in booking draft contracts while preserving empty optional email fields.
- Gate billing/traveler journey advancement when a supplied email is malformed, with inline field and step errors.
- Add focused unit coverage for contract parsing and journey advancement rules, plus a patch changeset for the touched packages.

## Validation

- `pnpm --filter @voyant-travel/bookings-react test -- booking-journey-rules.test.ts`
- `pnpm --filter @voyant-travel/catalog-contracts test -- draft-contracts.test.ts`
- `pnpm --filter @voyant-travel/bookings-react typecheck`
- `pnpm --filter @voyant-travel/catalog-contracts typecheck`
- `pnpm --filter @voyant-travel/bookings-react lint`
- `pnpm --filter @voyant-travel/catalog-contracts lint`
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm verify:fast`

Notes: the first default-heap `pnpm verify:fast` run failed only when `@voyant-travel/inventory` build/typecheck exhausted the Node heap; the high-heap rerun passed. The fast lane reports a non-failing file-size warning for `packages/catalog-contracts/src/booking-engine/draft-contracts.ts`, and existing React `act(...)` warnings appear in bookings-react tests.