### PR TITLE
Route React API actions through provider client

### DIFF
--- a/.changeset/provider-api-upload-urls.md
+++ b/.changeset/provider-api-upload-urls.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/finance-react": patch
+"@voyant-travel/inventory-react": patch
+---
+
+Route reusable upload and payment-link actions through the Voyant React provider API base and fetcher so split-origin deployments do not fall back to relative `/api` URLs.

--- a/packages/bookings-react/src/components/file-dropzone.test.tsx
+++ b/packages/bookings-react/src/components/file-dropzone.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+import { type VoyantFetcher, VoyantReactProvider } from "@voyant-travel/react"
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { FileDropzone } from "./file-dropzone.js"
+
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
+
+describe("FileDropzone", () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+  })
+
+  it("uploads through the provider client by default", async () => {
+    const fetcher = vi.fn<VoyantFetcher>(async () =>
+      Response.json({
+        key: "uploads/passport.pdf",
+        url: "https://cdn.example/passport.pdf",
+        mimeType: "application/pdf",
+        size: 20,
+      }),
+    )
+    const onUploaded = vi.fn()
+
+    await act(async () => {
+      root.render(
+        <VoyantReactProvider baseUrl="https://api.example.test/api/" fetcher={fetcher}>
+          <FileDropzone onUploaded={onUploaded} />
+        </VoyantReactProvider>,
+      )
+    })
+
+    const input = container.querySelector<HTMLInputElement>('input[type="file"]')
+    if (!input) throw new Error("expected file input")
+    const file = new File(["passport"], "passport.pdf", { type: "application/pdf" })
+
+    await act(async () => {
+      Object.defineProperty(input, "files", {
+        configurable: true,
+        value: [file],
+      })
+      input.dispatchEvent(new Event("change", { bubbles: true }))
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/api/v1/admin/uploads",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(FormData),
+      }),
+    )
+    expect(onUploaded).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "passport.pdf",
+        key: "uploads/passport.pdf",
+      }),
+    )
+  })
+})

--- a/packages/bookings-react/src/components/file-dropzone.tsx
+++ b/packages/bookings-react/src/components/file-dropzone.tsx
@@ -7,6 +7,7 @@ import {
   useBookingsUiI18nOrDefault,
   useBookingsUiMessagesOrDefault,
 } from "../i18n/provider.js"
+import { useVoyantBookingsContext } from "../provider.js"
 
 export interface UploadedFile {
   key: string
@@ -17,7 +18,7 @@ export interface UploadedFile {
 }
 
 export interface FileDropzoneProps {
-  /** URL of the upload endpoint (defaults to /api/v1/admin/uploads). */
+  /** URL of the upload endpoint. Defaults to the Voyant provider API base. */
   uploadUrl?: string
   /** MIME types or extensions to accept (same format as <input accept>). */
   accept?: string
@@ -36,7 +37,7 @@ export interface FileDropzoneProps {
 }
 
 export function FileDropzone({
-  uploadUrl = "/api/v1/admin/uploads",
+  uploadUrl,
   accept,
   maxSize,
   onUploaded,
@@ -45,6 +46,7 @@ export function FileDropzone({
   helperText,
   disabled,
 }: FileDropzoneProps) {
+  const client = useVoyantBookingsContext()
   const inputRef = React.useRef<HTMLInputElement>(null)
   const [isDragging, setIsDragging] = React.useState(false)
   const [isUploading, setIsUploading] = React.useState(false)
@@ -53,6 +55,7 @@ export function FileDropzone({
   const { formatNumber } = useBookingsUiI18nOrDefault()
   const messages = useBookingsUiMessagesOrDefault()
   const resolvedHelperText = helperText ?? messages.fileDropzone.helperText
+  const resolvedUploadUrl = uploadUrl ?? joinUrl(client.baseUrl, "/v1/admin/uploads")
 
   const formatSize = React.useCallback(
     (bytes: number): string => {
@@ -87,10 +90,9 @@ export function FileDropzone({
     try {
       const formData = new FormData()
       formData.append("file", file)
-      const res = await fetch(uploadUrl, {
+      const res = await client.fetcher(resolvedUploadUrl, {
         method: "POST", // i18n-literal-ok HTTP method
         body: formData,
-        credentials: "include", // i18n-literal-ok fetch credentials mode
       })
       if (!res.ok) {
         const body = await res.text()
@@ -219,4 +221,10 @@ export function FileDropzone({
       {error && <p className="text-xs text-destructive">{error}</p>}
     </div>
   )
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
 }

--- a/packages/finance-react/src/checkout-components/payment-link-landing-page.test.tsx
+++ b/packages/finance-react/src/checkout-components/payment-link-landing-page.test.tsx
@@ -5,6 +5,8 @@ import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import type { VoyantFetcher } from "../client.js"
+import { VoyantFinanceProvider } from "../provider.js"
 import { PaymentLinkLandingPage } from "./payment-link-landing-page.js"
 
 ;(
@@ -46,37 +48,39 @@ const baseSession: PublicPaymentSession = {
 describe("PaymentLinkLandingPage", () => {
   let container: HTMLDivElement
   let root: Root
-  let fetchMock: ReturnType<typeof vi.fn>
+  let fetcher: ReturnType<typeof vi.fn<VoyantFetcher>>
 
   beforeEach(() => {
     container = document.createElement("div")
     document.body.appendChild(container)
     root = createRoot(container)
-    fetchMock = vi.fn(async () => ({
-      ok: true,
-      json: async () => ({ data: { redirectUrl: null } }),
-    }))
-    vi.stubGlobal("fetch", fetchMock)
+    fetcher = vi.fn<VoyantFetcher>(async () => Response.json({ data: { redirectUrl: null } }))
   })
 
   afterEach(() => {
     act(() => root.unmount())
     container.remove()
-    vi.unstubAllGlobals()
   })
 
   it("starts active card sessions instead of following a stored redirect", async () => {
     await act(async () => {
-      root.render(<PaymentLinkLandingPage session={baseSession} />)
+      root.render(
+        <VoyantFinanceProvider baseUrl="https://api.example.test/api/" fetcher={fetcher}>
+          <PaymentLinkLandingPage session={baseSession} />
+        </VoyantFinanceProvider>,
+      )
     })
 
     await act(async () => {
       container.querySelector<HTMLButtonElement>("button")?.click()
     })
 
-    expect(fetchMock).toHaveBeenCalledWith("/api/v1/public/payment-link/ps_123/start-card", {
-      method: "POST",
-      headers: { Accept: "application/json" },
-    })
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/api/v1/public/payment-link/ps_123/start-card",
+      {
+        method: "POST",
+        headers: { Accept: "application/json" },
+      },
+    )
   })
 })

--- a/packages/finance-react/src/checkout-components/payment-link-landing-page.tsx
+++ b/packages/finance-react/src/checkout-components/payment-link-landing-page.tsx
@@ -21,6 +21,8 @@ import {
   useCheckoutUiI18nOrDefault,
   useCheckoutUiMessagesOrDefault,
 } from "../checkout-i18n/provider.js"
+import type { VoyantFetcher } from "../client.js"
+import { useVoyantFinanceContext } from "../provider.js"
 
 interface StartCardResponse {
   data?: { redirectUrl: string | null }
@@ -118,6 +120,9 @@ export function PaymentLinkLandingPage({
   summary,
   suppressNotes,
 }: PaymentLinkLandingPageProps) {
+  const { baseUrl, fetcher } = useVoyantFinanceContext()
+  const apiClient = { baseUrl, fetcher }
+
   return (
     <div className="mx-auto flex min-h-screen w-full max-w-2xl flex-col gap-6 px-4 py-8">
       {brandHeader}
@@ -128,6 +133,7 @@ export function PaymentLinkLandingPage({
         bankTransferInstructions={bankTransferInstructions}
         onPayByCard={onPayByCard}
         onRetry={onRetry}
+        apiClient={apiClient}
       />
       {brandFooter}
     </div>
@@ -181,11 +187,13 @@ function Body({
   bankTransferInstructions,
   onPayByCard,
   onRetry,
+  apiClient,
 }: {
   session: PublicPaymentSession
   bankTransferInstructions?: BankTransferInstructions
   onPayByCard?: () => void
   onRetry?: () => Promise<void> | void
+  apiClient: PaymentLinkApiClient
 }) {
   const messages = useCheckoutUiMessagesOrDefault().paymentLinkLandingPage
   // Terminal states — short-circuit body to a status panel.
@@ -220,7 +228,7 @@ function Body({
 
   // Single method — render inline without tabs.
   if (cardAvailable && !bankAvailable) {
-    return <CardPanel session={session} onPayByCard={onPayByCard} />
+    return <CardPanel session={session} onPayByCard={onPayByCard} apiClient={apiClient} />
   }
   if (bankAvailable && !cardAvailable && bankTransferInstructions) {
     return <BankTransferPanel session={session} instructions={bankTransferInstructions} />
@@ -240,7 +248,7 @@ function Body({
         </TabsTrigger>
       </TabsList>
       <TabsContent value="card" className="mt-4">
-        <CardPanel session={session} onPayByCard={onPayByCard} />
+        <CardPanel session={session} onPayByCard={onPayByCard} apiClient={apiClient} />
       </TabsContent>
       <TabsContent value="bank" className="mt-4">
         {bankTransferInstructions && (
@@ -254,9 +262,11 @@ function Body({
 function CardPanel({
   session,
   onPayByCard,
+  apiClient,
 }: {
   session: PublicPaymentSession
   onPayByCard?: () => void
+  apiClient: PaymentLinkApiClient
 }) {
   const i18n = useCheckoutUiI18nOrDefault()
   const messages = i18n.messages.paymentLinkLandingPage
@@ -278,10 +288,13 @@ function CardPanel({
     setStarting(true)
     setError(null)
     try {
-      const res = await fetch(`/api/v1/public/payment-link/${session.id}/start-card`, {
-        method: "POST",
-        headers: { Accept: "application/json" },
-      })
+      const res = await apiClient.fetcher(
+        joinUrl(apiClient.baseUrl, `/v1/public/payment-link/${session.id}/start-card`),
+        {
+          method: "POST",
+          headers: { Accept: "application/json" },
+        },
+      )
       const body = (await res.json()) as StartCardResponse
       if (!res.ok || !body.data?.redirectUrl) {
         throw new Error(body.error ?? messages.card.startFailed)
@@ -310,6 +323,17 @@ function CardPanel({
       )}
     </div>
   )
+}
+
+interface PaymentLinkApiClient {
+  baseUrl: string
+  fetcher: VoyantFetcher
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
 }
 
 function BankTransferPanel({

--- a/packages/inventory-react/src/components/product-detail/product-detail-itinerary-section.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-itinerary-section.tsx
@@ -31,53 +31,19 @@ import {
   useProductItineraryDays,
   useProductItineraryMutation,
 } from "../../index.js"
+import { useVoyantProductsContext } from "../../provider.js"
 import { ProductItineraryDialog } from "../product-itinerary-dialog.js"
-import type { ProductMediaUploadHandler } from "../product-media-section.js"
 import { useProductDetailApi, useProductDetailMessages } from "./host.js"
 import { ProductDaySheet } from "./product-day-sheet.js"
 import { ProductDetailDayRow } from "./product-detail-day-row.js"
 import { ActionMenu, EmptyState, Section } from "./product-detail-sections.js"
 import { ServiceDialog } from "./product-service-dialog.js"
-
-/**
- * Storage-only upload handler for the day media tray. The tray does its
- * own DB insert via `useProductMediaMutation.create` after this returns,
- * so this handler must NOT call the products API — only the R2 upload
- * endpoint — otherwise we'd write two media rows per file.
- */
-const uploadDayMediaToStorage: ProductMediaUploadHandler = async (file) => {
-  const formData = new FormData()
-  formData.append("file", file)
-  const res = await fetch("/api/v1/admin/uploads", {
-    method: "POST",
-    body: formData,
-    credentials: "include",
-  })
-  if (!res.ok) throw new Error(`Upload failed (${res.status})`)
-  const upload = (await res.json()) as {
-    key: string
-    url: string
-    mimeType: string
-    size: number
-  }
-  const mediaType: "image" | "video" | "document" = upload.mimeType.startsWith("video/")
-    ? "video"
-    : upload.mimeType.startsWith("image/")
-      ? "image"
-      : "document"
-  return {
-    url: upload.url,
-    name: file.name,
-    storageKey: upload.key,
-    mimeType: upload.mimeType,
-    fileSize: upload.size,
-    mediaType,
-  }
-}
+import { createDayMediaUploadHandler } from "./upload-day-media.js"
 
 export function ProductDetailItinerarySection({ productId }: { productId: string }) {
   const messages = useProductDetailMessages()
   const api = useProductDetailApi()
+  const { baseUrl, fetcher } = useVoyantProductsContext()
   const productMessages = messages.products.core
   const queryClient = useQueryClient()
   const itineraryQuery = useProductItineraries(productId)
@@ -98,6 +64,10 @@ export function ProductDetailItinerarySection({ productId }: { productId: string
   const [editingItinerary, setEditingItinerary] = useState<ProductItineraryRecord | undefined>()
   const [deleteItineraryTarget, setDeleteItineraryTarget] = useState<ProductItineraryRecord | null>(
     null,
+  )
+  const uploadDayMediaToStorage = useMemo(
+    () => createDayMediaUploadHandler({ baseUrl, fetcher }),
+    [baseUrl, fetcher],
   )
 
   const itineraries = useMemo(() => itineraryQuery.data?.data ?? [], [itineraryQuery.data?.data])

--- a/packages/inventory-react/src/components/product-detail/upload-day-media.test.ts
+++ b/packages/inventory-react/src/components/product-detail/upload-day-media.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createDayMediaUploadHandler } from "./upload-day-media.js"
+
+describe("createDayMediaUploadHandler", () => {
+  it("uploads through the provider client baseUrl and fetcher", async () => {
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        key: "uploads/day.png",
+        url: "https://cdn.example/day.png",
+        mimeType: "image/png",
+        size: 12,
+      }),
+    )
+    const upload = createDayMediaUploadHandler({
+      baseUrl: "https://api.example.test/api/",
+      fetcher,
+    })
+
+    const result = await upload(new File(["day"], "day.png", { type: "image/png" }), {
+      productId: "prod_123",
+      dayId: "day_123",
+    })
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.example.test/api/v1/admin/uploads",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.any(FormData),
+      }),
+    )
+    expect(result).toMatchObject({
+      name: "day.png",
+      storageKey: "uploads/day.png",
+      mediaType: "image",
+    })
+  })
+})

--- a/packages/inventory-react/src/components/product-detail/upload-day-media.ts
+++ b/packages/inventory-react/src/components/product-detail/upload-day-media.ts
@@ -1,0 +1,47 @@
+import type { VoyantFetcher } from "../../client.js"
+import type { ProductMediaUploadHandler } from "../product-media-section.js"
+
+export interface DayMediaUploadClient {
+  baseUrl: string
+  fetcher: VoyantFetcher
+}
+
+export function createDayMediaUploadHandler({
+  baseUrl,
+  fetcher,
+}: DayMediaUploadClient): ProductMediaUploadHandler {
+  return async (file) => {
+    const formData = new FormData()
+    formData.append("file", file)
+    const res = await fetcher(joinUrl(baseUrl, "/v1/admin/uploads"), {
+      method: "POST",
+      body: formData,
+    })
+    if (!res.ok) throw new Error(`Upload failed (${res.status})`)
+    const upload = (await res.json()) as {
+      key: string
+      url: string
+      mimeType: string
+      size: number
+    }
+    const mediaType: "image" | "video" | "document" = upload.mimeType.startsWith("video/")
+      ? "video"
+      : upload.mimeType.startsWith("image/")
+        ? "image"
+        : "document"
+    return {
+      url: upload.url,
+      name: file.name,
+      storageKey: upload.key,
+      mimeType: upload.mimeType,
+      fileSize: upload.size,
+      mediaType,
+    }
+  }
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const trimmedBase = baseUrl.endsWith("/") ? baseUrl.slice(0, -1) : baseUrl
+  const trimmedPath = path.startsWith("/") ? path : `/${path}`
+  return `${trimmedBase}${trimmedPath}`
+}


### PR DESCRIPTION
## Summary

- Route bookings document uploads, inventory day media uploads, and payment-link card starts through the Voyant React provider `baseUrl` + `fetcher` instead of raw relative `/api` fetches.
- Add focused regression tests for split-origin API bases.
- Add a patch changeset for the affected React packages.

Closes #2952

## Verification

- pnpm --filter @voyant-travel/react typecheck
- pnpm --filter @voyant-travel/inventory-react typecheck
- pnpm --filter @voyant-travel/bookings-react typecheck
- pnpm --filter @voyant-travel/finance-react typecheck
- pnpm --filter @voyant-travel/inventory-react test
- pnpm --filter @voyant-travel/bookings-react test
- pnpm --filter @voyant-travel/finance-react exec vitest run src/checkout-components/payment-link-landing-page.test.tsx
- pnpm verify:fast
- commit hook lint/typecheck completed
- pre-push hook test completed

Notes: existing non-failing warnings observed for React act noise in unrelated tests and existing component/file-size lint warnings.