### PR TITLE
feat: @voyant-travel/dedicated-runtime bindings emulation + Node server entry

### DIFF
--- a/.changeset/dedicated-runtime-package.md
+++ b/.changeset/dedicated-runtime-package.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/dedicated-runtime": minor
+---
+
+Add `@voyant-travel/dedicated-runtime`: bindings emulation plus a Node server
+entry so an operator app's identical `fetch`/`scheduled` code runs on a
+dedicated Node runtime (Cloud Run) as it does on Cloudflare Workers for
+Platforms. Includes KV (REST API + optional read-through LRU), R2 (S3-compatible
+API via `@voyant-travel/storage` SigV4), an in-process Cache API shim, a real
+`waitUntil` registry with graceful drain, `buildDedicatedEnv`, and
+`createNodeServer` (origin-trust gate, Cloud Scheduler `scheduled()` hook, and
+SIGTERM shutdown). See voyant-travel/platform#935.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -547,6 +547,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -542,6 +542,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -518,6 +518,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -513,6 +513,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -602,6 +602,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -598,6 +598,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -583,6 +583,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -584,6 +584,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/dedicated-runtime/README.md
+++ b/packages/dedicated-runtime/README.md
@@ -1,0 +1,119 @@
+# @voyant-travel/dedicated-runtime
+
+Bindings emulation and a Node server entry so an operator app's **identical**
+`fetch(request, env, ctx)` / `scheduled(event, env, ctx)` code runs unchanged on
+a dedicated Node runtime (Cloud Run) as it does on Cloudflare Workers for
+Platforms.
+
+Composed operator APIs cannot stay resident on Workers for Platforms
+(evaluated-heap eviction). The platform's per-app **dedicated** runtime runs the
+same bundle on Cloud Run behind the existing dispatcher. This package supplies
+the shims the app expects the runtime to provide — KV, R2, the Cache API, a real
+`waitUntil`, and an HTTP `scheduled()` trigger — plus a Node server that wires
+them together. See voyant-travel/platform#935.
+
+It builds on [`@voyant-travel/worker-runtime`](../worker-runtime) (dispatch glue)
+and [`@voyant-travel/storage`](../storage) (SigV4 signing) rather than
+duplicating them.
+
+## Install
+
+```sh
+pnpm add @voyant-travel/dedicated-runtime
+```
+
+## Usage
+
+```ts
+import {
+  buildDedicatedEnv,
+  createKvNamespaceShim,
+  createNodeServer,
+  createR2BucketShim,
+  installCachesShim,
+} from "@voyant-travel/dedicated-runtime"
+
+// Your app — the SAME module you ship to Workers.
+import app, { scheduled } from "./entry.js"
+
+// 1. Resident in-process response cache (picked up by public-cache middleware).
+installCachesShim({ maxEntries: 5_000, maxBytes: 512 * 1024 })
+
+// 2. Rebuild the bindings the Workers runtime would have injected.
+const env = buildDedicatedEnv(process.env, {
+  kv: {
+    CACHE: createKvNamespaceShim({
+      accountId: process.env.CF_ACCOUNT_ID!,
+      namespaceId: process.env.CF_KV_CACHE_ID!,
+      apiToken: process.env.CF_API_TOKEN!,
+      lru: { maxEntries: 10_000, ttlMs: 30_000 }, // a resident process can hold one
+    }),
+  },
+  r2: {
+    DOCUMENTS_BUCKET: createR2BucketShim({
+      endpoint: process.env.R2_S3_ENDPOINT!,
+      bucket: "documents",
+      accessKeyId: process.env.R2_ACCESS_KEY_ID!,
+      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY!,
+    }),
+  },
+})
+
+// 3. Serve. Trust header, waitUntil, scheduled hook, graceful SIGTERM.
+createNodeServer({
+  fetch: app.fetch,
+  scheduled,
+  env,
+  port: Number(process.env.PORT ?? 8080),
+  originTrustSecret: process.env.ORIGIN_TRUST_SECRET,
+})
+```
+
+### Cloud Scheduler → `scheduled()`
+
+Cron jobs (outbox drain, draft reaper, promotion boundary, reconcilers, …) can't
+run on a timer on Cloud Run. Point a Cloud Scheduler job at:
+
+```
+POST /__voyant/scheduled?cron=<expr>
+x-voyant-origin-trust: <shared-secret>
+```
+
+Each cron expression gets its own scheduler job. The handler returns `202` on
+success, `400` if `cron` is missing, `500` if the handler throws.
+
+### Origin trust
+
+The platform dispatcher stamps every forwarded request with a per-app shared
+secret in the **`x-voyant-origin-trust`** header (pinned across repos — do not
+change). `createNodeServer({ originTrustSecret })` rejects any request lacking a
+constant-time match with `403`, exempting `/healthz` for container probes. The
+low-level pieces (`originTrustMiddleware`, `verifyOriginTrust`,
+`constantTimeEqual`, `scheduledHandler`) are exported for custom server loops.
+
+## Shim coverage
+
+| Binding / capability | Shim | Backed by | Notes |
+| --- | --- | --- | --- |
+| KV namespace | `createKvNamespaceShim` | Cloudflare KV REST API | `get`/`get(k,"json")`/`put({expirationTtl})`/`delete`; optional read-through LRU |
+| R2 bucket | `createR2BucketShim` | R2 S3-compatible API + `@voyant-travel/storage` SigV4 | `put`/`get`/`delete`/`head`; `get` returns `{ arrayBuffer, body, httpMetadata, customMetadata, size }` |
+| Cache API (`caches.default`) | `installCachesShim` | in-process LRU on `globalThis` | honors `s-maxage`/`max-age`; idempotent install |
+| `ctx.waitUntil` | `createWaitUntilRegistry` | in-process promise set | real background tracking + graceful drain |
+| `scheduled()` | `createNodeServer` / `scheduledHandler` | HTTP `POST /__voyant/scheduled` | Cloud Scheduler hook |
+| env bindings bag | `buildDedicatedEnv` | `process.env` + shims | same shape app code sees on Workers |
+| Node server + shutdown | `createNodeServer` | `@hono/node-server` | trust gate, waitUntil ctx, SIGTERM drain |
+
+## Intentionally NOT shimmed
+
+- **Durable Objects** — no in-process equivalent; DO-dependent features are out
+  of scope for the dedicated runtime and must be provided by the platform.
+- **Analytics Engine (`METRICS`)** — the metrics middleware is already a no-op
+  when the binding is absent, so a dedicated deployment degrades gracefully. An
+  AE HTTP-ingest shim was evaluated as optional stretch scope and skipped to
+  keep the package small; add one here later if metrics parity is needed.
+- **`request.cf`** — Cloudflare's per-request geo/TLS object is not reconstructed;
+  app code that reads `request.cf` must tolerate `undefined` (it already does on
+  non-Workers runtimes).
+- **KV `list` / R2 `list`** — not part of the audited usage surface; add on
+  demand (R2 list needs multipart XML parsing, which isn't cheap).
+```

--- a/packages/dedicated-runtime/package.json
+++ b/packages/dedicated-runtime/package.json
@@ -1,0 +1,97 @@
+{
+  "name": "@voyant-travel/dedicated-runtime",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./kv": "./src/kv.ts",
+    "./r2": "./src/r2.ts",
+    "./cache": "./src/cache.ts",
+    "./wait-until": "./src/wait-until.ts",
+    "./env": "./src/env.ts",
+    "./node-server": "./src/node-server.ts",
+    "./trust": "./src/trust.ts",
+    "./types": "./src/types.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./kv": {
+        "types": "./dist/kv.d.ts",
+        "import": "./dist/kv.js",
+        "default": "./dist/kv.js"
+      },
+      "./r2": {
+        "types": "./dist/r2.d.ts",
+        "import": "./dist/r2.js",
+        "default": "./dist/r2.js"
+      },
+      "./cache": {
+        "types": "./dist/cache.d.ts",
+        "import": "./dist/cache.js",
+        "default": "./dist/cache.js"
+      },
+      "./wait-until": {
+        "types": "./dist/wait-until.d.ts",
+        "import": "./dist/wait-until.js",
+        "default": "./dist/wait-until.js"
+      },
+      "./env": {
+        "types": "./dist/env.d.ts",
+        "import": "./dist/env.js",
+        "default": "./dist/env.js"
+      },
+      "./node-server": {
+        "types": "./dist/node-server.d.ts",
+        "import": "./dist/node-server.js",
+        "default": "./dist/node-server.js"
+      },
+      "./trust": {
+        "types": "./dist/trust.d.ts",
+        "import": "./dist/trust.js",
+        "default": "./dist/trust.js"
+      },
+      "./types": {
+        "types": "./dist/types.d.ts",
+        "import": "./dist/types.js",
+        "default": "./dist/types.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^2.0.6",
+    "@voyant-travel/storage": "workspace:^",
+    "@voyant-travel/worker-runtime": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/dedicated-runtime"
+  }
+}

--- a/packages/dedicated-runtime/src/cache.test.ts
+++ b/packages/dedicated-runtime/src/cache.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createCachesShim, installCachesShim, uninstallCachesShim } from "./cache.js"
+
+function jsonResponse(body: unknown, cacheControl?: string): Response {
+  const headers = new Headers({ "content-type": "application/json" })
+  if (cacheControl) headers.set("cache-control", cacheControl)
+  return new Response(JSON.stringify(body), { headers })
+}
+
+describe("createCachesShim", () => {
+  it("stores and matches a response by URL", async () => {
+    const cache = createCachesShim({ maxEntries: 10 })
+    await cache.put("https://x/a", jsonResponse({ ok: true }, "s-maxage=60"))
+
+    const hit = await cache.match("https://x/a")
+    expect(hit).toBeDefined()
+    expect(await hit!.json()).toEqual({ ok: true })
+  })
+
+  it("does not cache responses without a freshness directive", async () => {
+    const cache = createCachesShim({ maxEntries: 10 })
+    await cache.put("https://x/b", jsonResponse({ ok: true }))
+    expect(await cache.match("https://x/b")).toBeUndefined()
+  })
+
+  it("prefers s-maxage over max-age and expires entries", async () => {
+    const cache = createCachesShim({ maxEntries: 10 })
+    await cache.put("https://x/c", jsonResponse({ n: 1 }, "max-age=0, s-maxage=0"))
+    // ttl 0 -> not cached
+    expect(await cache.match("https://x/c")).toBeUndefined()
+  })
+
+  it("evicts least-recently-used entries beyond maxEntries", async () => {
+    const cache = createCachesShim({ maxEntries: 2 })
+    await cache.put("https://x/1", jsonResponse({}, "s-maxage=60"))
+    await cache.put("https://x/2", jsonResponse({}, "s-maxage=60"))
+    await cache.match("https://x/1") // touch 1
+    await cache.put("https://x/3", jsonResponse({}, "s-maxage=60")) // evict 2
+
+    expect(await cache.match("https://x/1")).toBeDefined()
+    expect(await cache.match("https://x/2")).toBeUndefined()
+    expect(await cache.match("https://x/3")).toBeDefined()
+  })
+
+  it("skips entries exceeding maxBytes", async () => {
+    const cache = createCachesShim({ maxEntries: 10, maxBytes: 4 })
+    await cache.put("https://x/big", jsonResponse({ big: "xxxxxxxx" }, "s-maxage=60"))
+    expect(await cache.match("https://x/big")).toBeUndefined()
+  })
+})
+
+describe("installCachesShim", () => {
+  afterEach(() => uninstallCachesShim())
+
+  it("installs a caches.default that a probe can pick up", async () => {
+    installCachesShim({ maxEntries: 10 })
+    const probe = (globalThis as { caches?: { default?: unknown } }).caches?.default as {
+      match: (r: string) => Promise<Response | undefined>
+      put: (r: string, res: Response) => Promise<void>
+    }
+    expect(typeof probe.match).toBe("function")
+    await probe.put("https://x/g", jsonResponse({ v: 1 }, "s-maxage=30"))
+    const hit = await probe.match("https://x/g")
+    expect(await hit!.json()).toEqual({ v: 1 })
+  })
+
+  it("is idempotent — returns the same instance on repeated install", () => {
+    const first = installCachesShim({ maxEntries: 10 })
+    const second = installCachesShim({ maxEntries: 99 })
+    expect(second).toBe(first)
+  })
+})

--- a/packages/dedicated-runtime/src/cache.ts
+++ b/packages/dedicated-runtime/src/cache.ts
@@ -1,0 +1,117 @@
+/**
+ * Install a `caches.default`-compatible in-process LRU on `globalThis`. The
+ * public-cache middleware probes `globalThis.caches?.default` once and uses any
+ * object exposing `{ match, put }`; a resident Node process can hold a real
+ * response cache, so this shim keeps the Workers cache path working unchanged
+ * (instead of forcing every deployment onto the KV fallback).
+ *
+ * Freshness honors `s-maxage` (preferred) then `max-age` from the stored
+ * response's `Cache-Control`; entries with neither are not cached.
+ */
+
+/** The subset of the Workers Cache API the public-cache middleware calls. */
+export interface CacheApiLike {
+  match(request: Request | string): Promise<Response | undefined>
+  put(request: Request | string, response: Response): Promise<void>
+}
+
+export interface InstallCachesShimOptions {
+  /** Maximum number of resident entries before LRU eviction. */
+  maxEntries: number
+  /** Optional cap on total buffered body bytes. Oversized entries are skipped. */
+  maxBytes?: number
+}
+
+interface CacheEntry {
+  status: number
+  headers: Array<[string, string]>
+  body: Uint8Array
+  expiresAt: number
+}
+
+function keyFor(request: Request | string): string {
+  return typeof request === "string" ? request : request.url
+}
+
+function freshnessSeconds(response: Response): number | undefined {
+  const cacheControl = response.headers.get("cache-control")
+  if (!cacheControl) return undefined
+  const sMaxage = /s-maxage=(\d+)/.exec(cacheControl)
+  if (sMaxage?.[1]) return Number.parseInt(sMaxage[1], 10)
+  const maxAge = /max-age=(\d+)/.exec(cacheControl)
+  if (maxAge?.[1]) return Number.parseInt(maxAge[1], 10)
+  return undefined
+}
+
+/**
+ * Build a standalone {@link CacheApiLike} LRU. Exported so callers can wire it
+ * somewhere other than `globalThis` (tests, multi-tenant isolation).
+ */
+export function createCachesShim(options: InstallCachesShimOptions): CacheApiLike {
+  const store = new Map<string, CacheEntry>()
+
+  return {
+    async match(request) {
+      const key = keyFor(request)
+      const entry = store.get(key)
+      if (!entry) return undefined
+      if (entry.expiresAt <= Date.now()) {
+        store.delete(key)
+        return undefined
+      }
+      // refresh recency
+      store.delete(key)
+      store.set(key, entry)
+      const headers = new Headers(entry.headers)
+      return new Response(entry.body.slice(), { status: entry.status, headers })
+    },
+    async put(request, response) {
+      const ttl = freshnessSeconds(response)
+      if (ttl === undefined || ttl <= 0) return
+      const buffer = new Uint8Array(await response.clone().arrayBuffer())
+      if (options.maxBytes !== undefined && buffer.byteLength > options.maxBytes) return
+      const headers: Array<[string, string]> = []
+      response.headers.forEach((value, name) => {
+        headers.push([name, value])
+      })
+      const key = keyFor(request)
+      if (store.has(key)) store.delete(key)
+      store.set(key, {
+        status: response.status,
+        headers,
+        body: buffer,
+        expiresAt: Date.now() + ttl * 1000,
+      })
+      while (store.size > options.maxEntries) {
+        const oldest = store.keys().next().value
+        if (oldest === undefined) break
+        store.delete(oldest)
+      }
+    },
+  }
+}
+
+interface CachesGlobal {
+  caches?: { default?: CacheApiLike }
+}
+
+/**
+ * Install {@link createCachesShim} at `globalThis.caches.default`. Idempotent:
+ * a second call returns the already-installed shim rather than replacing it, so
+ * repeated boots (or multiple entrypoints in one process) share one cache.
+ * Returns the active {@link CacheApiLike}.
+ */
+export function installCachesShim(options: InstallCachesShimOptions): CacheApiLike {
+  const globalRef = globalThis as CachesGlobal
+  const existing = globalRef.caches?.default
+  if (existing) return existing
+  const shim = createCachesShim(options)
+  globalRef.caches = { ...(globalRef.caches ?? {}), default: shim }
+  return shim
+}
+
+/** Test hook — remove the installed shim so a fresh one can be installed. */
+export function uninstallCachesShim(): void {
+  const globalRef = globalThis as CachesGlobal
+  if (globalRef.caches) delete globalRef.caches.default
+}

--- a/packages/dedicated-runtime/src/env.test.ts
+++ b/packages/dedicated-runtime/src/env.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { buildDedicatedEnv } from "./env.js"
+import type { KvNamespaceShim } from "./kv.js"
+import type { R2BucketShim } from "./r2.js"
+
+const fakeKv = {} as KvNamespaceShim
+const fakeR2 = {} as R2BucketShim
+
+describe("buildDedicatedEnv", () => {
+  it("spreads defined string vars and drops undefined", () => {
+    const env = buildDedicatedEnv({ DATABASE_URL: "postgres://x", MISSING: undefined })
+    expect(env.DATABASE_URL).toBe("postgres://x")
+    expect("MISSING" in env).toBe(false)
+  })
+
+  it("attaches KV and R2 shims under their binding names", () => {
+    const env = buildDedicatedEnv(
+      { FOO: "bar" },
+      { kv: { CACHE: fakeKv }, r2: { DOCUMENTS_BUCKET: fakeR2 } },
+    )
+    expect(env.FOO).toBe("bar")
+    expect(env.CACHE).toBe(fakeKv)
+    expect(env.DOCUMENTS_BUCKET).toBe(fakeR2)
+  })
+
+  it("lets a binding shim win over a same-named string var", () => {
+    const env = buildDedicatedEnv({ CACHE: "should-be-overwritten" }, { kv: { CACHE: fakeKv } })
+    expect(env.CACHE).toBe(fakeKv)
+  })
+})

--- a/packages/dedicated-runtime/src/env.ts
+++ b/packages/dedicated-runtime/src/env.ts
@@ -1,0 +1,42 @@
+import type { KvNamespaceShim } from "./kv.js"
+import type { R2BucketShim } from "./r2.js"
+
+export interface BuildDedicatedEnvBindings {
+  /** KV namespace bindings, keyed by the binding name app code reads (e.g. `CACHE`). */
+  kv?: Record<string, KvNamespaceShim>
+  /** R2 bucket bindings, keyed by the binding name (e.g. `DOCUMENTS_BUCKET`). */
+  r2?: Record<string, R2BucketShim>
+}
+
+/**
+ * The env bag handed to `app.fetch(request, env, ctx)`. On Workers this is the
+ * bindings object the runtime injects; on Node we compose it from string
+ * process-env vars plus the shim objects so app code sees the same shape.
+ */
+export type DedicatedEnv = Record<string, string | KvNamespaceShim | R2BucketShim>
+
+/**
+ * Compose the env bag for a dedicated (Node) deployment. All string vars from
+ * `processEnv` (undefined values dropped) are spread first, then KV and R2
+ * shims are attached under their binding names — mirroring exactly what the
+ * Workers runtime provides, so the same `fetch(req, env, ctx)` runs unchanged.
+ *
+ * Binding names must not collide with a string var of the same name; the shim
+ * wins (a KV/R2 binding is never legitimately also a string).
+ */
+export function buildDedicatedEnv(
+  processEnv: Record<string, string | undefined>,
+  bindings: BuildDedicatedEnvBindings = {},
+): DedicatedEnv {
+  const env: DedicatedEnv = {}
+  for (const [key, value] of Object.entries(processEnv)) {
+    if (value !== undefined) env[key] = value
+  }
+  for (const [name, shim] of Object.entries(bindings.kv ?? {})) {
+    env[name] = shim
+  }
+  for (const [name, shim] of Object.entries(bindings.r2 ?? {})) {
+    env[name] = shim
+  }
+  return env
+}

--- a/packages/dedicated-runtime/src/index.ts
+++ b/packages/dedicated-runtime/src/index.ts
@@ -1,0 +1,51 @@
+export type { CacheApiLike, InstallCachesShimOptions } from "./cache.js"
+export {
+  createCachesShim,
+  installCachesShim,
+  uninstallCachesShim,
+} from "./cache.js"
+export type { BuildDedicatedEnvBindings, DedicatedEnv } from "./env.js"
+export { buildDedicatedEnv } from "./env.js"
+export type {
+  KvFetch,
+  KvGetOptions,
+  KvLruOptions,
+  KvNamespaceShim,
+  KvNamespaceShimOptions,
+  KvPutOptions,
+  KvValueType,
+} from "./kv.js"
+export { createKvNamespaceShim } from "./kv.js"
+export type {
+  CreateNodeServerOptions,
+  NodeServerHandle,
+  ScheduledHandlerArgs,
+} from "./node-server.js"
+export {
+  createNodeServer,
+  HEALTHZ_PATH,
+  SCHEDULED_PATH,
+  scheduledHandler,
+} from "./node-server.js"
+export type {
+  R2BucketShim,
+  R2BucketShimOptions,
+  R2Fetch,
+  R2ShimObject,
+} from "./r2.js"
+export { createR2BucketShim } from "./r2.js"
+export type { OriginTrustOptions } from "./trust.js"
+export {
+  constantTimeEqual,
+  ORIGIN_TRUST_HEADER,
+  originTrustMiddleware,
+  verifyOriginTrust,
+} from "./trust.js"
+export type {
+  ExecutionContextLike,
+  FetchHandler,
+  ScheduledEventLike,
+  ScheduledHandler,
+} from "./types.js"
+export type { WaitUntilRegistry } from "./wait-until.js"
+export { createWaitUntilRegistry } from "./wait-until.js"

--- a/packages/dedicated-runtime/src/kv.test.ts
+++ b/packages/dedicated-runtime/src/kv.test.ts
@@ -111,6 +111,30 @@ describe("createKvNamespaceShim", () => {
       expect(calls.filter((c) => c.init.method === "GET")).toHaveLength(2)
     })
 
+    it("caps a write-through entry at the put's expirationTtl", async () => {
+      vi.useFakeTimers()
+      try {
+        const { fetch, calls } = mockFetch(() => ({ body: "remote" }))
+        const kv = createKvNamespaceShim({
+          ...base,
+          fetchImpl: fetch,
+          lru: { maxEntries: 10, ttlMs: 60_000 },
+        })
+
+        // Remote key expires after 1s; the local entry must not outlive it
+        // even though the LRU's own ttlMs is 60s.
+        await kv.put("session", "local", { expirationTtl: 1 })
+        expect(await kv.get("session")).toBe("local")
+        expect(calls.filter((c) => c.init.method === "GET")).toHaveLength(0)
+
+        vi.advanceTimersByTime(1_500)
+        expect(await kv.get("session")).toBe("remote")
+        expect(calls.filter((c) => c.init.method === "GET")).toHaveLength(1)
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("evicts least-recently-used entries past maxEntries", async () => {
       const { fetch, calls } = mockFetch((url) => ({ body: url }))
       const kv = createKvNamespaceShim({

--- a/packages/dedicated-runtime/src/kv.test.ts
+++ b/packages/dedicated-runtime/src/kv.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createKvNamespaceShim, type KvFetch } from "./kv.js"
+
+function mockFetch(
+  handler: (url: string, init: RequestInit) => { status?: number; body?: string },
+): { fetch: KvFetch; calls: Array<{ url: string; init: RequestInit }> } {
+  const calls: Array<{ url: string; init: RequestInit }> = []
+  const fetch: KvFetch = async (input, init = {}) => {
+    const url = String(input)
+    calls.push({ url, init })
+    const { status = 200, body = "" } = handler(url, init)
+    return new Response(body, { status })
+  }
+  return { fetch, calls }
+}
+
+const base = {
+  accountId: "acct-1",
+  namespaceId: "ns-1",
+  apiToken: "secret-token",
+}
+
+describe("createKvNamespaceShim", () => {
+  it("GETs the value endpoint with a bearer token and returns text", async () => {
+    const { fetch, calls } = mockFetch(() => ({ body: "hello" }))
+    const kv = createKvNamespaceShim({ ...base, fetchImpl: fetch })
+
+    const value = await kv.get("greeting")
+
+    expect(value).toBe("hello")
+    expect(calls[0]?.url).toBe(
+      "https://api.cloudflare.com/client/v4/accounts/acct-1/storage/kv/namespaces/ns-1/values/greeting",
+    )
+    expect(calls[0]?.init.method).toBe("GET")
+    expect((calls[0]?.init.headers as Record<string, string>).authorization).toBe(
+      "Bearer secret-token",
+    )
+  })
+
+  it("parses JSON with get(key, 'json') and get(key, { type })", async () => {
+    const payload = JSON.stringify({ a: 1 })
+    const { fetch } = mockFetch(() => ({ body: payload }))
+    const kv = createKvNamespaceShim({ ...base, fetchImpl: fetch })
+
+    expect(await kv.get("k", "json")).toEqual({ a: 1 })
+    expect(await kv.get("k", { type: "json" })).toEqual({ a: 1 })
+  })
+
+  it("returns null on 404", async () => {
+    const { fetch } = mockFetch(() => ({ status: 404 }))
+    const kv = createKvNamespaceShim({ ...base, fetchImpl: fetch })
+    expect(await kv.get("missing")).toBeNull()
+  })
+
+  it("PUTs with expiration_ttl query param", async () => {
+    const { fetch, calls } = mockFetch(() => ({ status: 200 }))
+    const kv = createKvNamespaceShim({ ...base, fetchImpl: fetch })
+
+    await kv.put("session", "value", { expirationTtl: 300 })
+
+    expect(calls[0]?.init.method).toBe("PUT")
+    expect(calls[0]?.url).toContain("expiration_ttl=300")
+    expect(calls[0]?.init.body).toBe("value")
+  })
+
+  it("DELETEs the value endpoint and tolerates 404", async () => {
+    const { fetch, calls } = mockFetch(() => ({ status: 404 }))
+    const kv = createKvNamespaceShim({ ...base, fetchImpl: fetch })
+
+    await expect(kv.delete("gone")).resolves.toBeUndefined()
+    expect(calls[0]?.init.method).toBe("DELETE")
+  })
+
+  it("throws on non-404 error responses", async () => {
+    const { fetch } = mockFetch(() => ({ status: 500, body: "boom" }))
+    const kv = createKvNamespaceShim({ ...base, fetchImpl: fetch })
+    await expect(kv.get("k")).rejects.toThrow(/KV get failed \(500\)/)
+  })
+
+  describe("LRU read-through", () => {
+    it("serves repeat reads from cache without a second fetch", async () => {
+      const spy = vi.fn(() => ({ body: "cached" }))
+      const { fetch, calls } = mockFetch(spy)
+      const kv = createKvNamespaceShim({
+        ...base,
+        fetchImpl: fetch,
+        lru: { maxEntries: 10, ttlMs: 60_000 },
+      })
+
+      expect(await kv.get("k")).toBe("cached")
+      expect(await kv.get("k")).toBe("cached")
+      expect(calls).toHaveLength(1)
+    })
+
+    it("invalidates the cache on put and delete", async () => {
+      let body = "v1"
+      const { fetch, calls } = mockFetch(() => ({ body }))
+      const kv = createKvNamespaceShim({
+        ...base,
+        fetchImpl: fetch,
+        lru: { maxEntries: 10, ttlMs: 60_000 },
+      })
+
+      expect(await kv.get("k")).toBe("v1")
+      await kv.put("k", "v2")
+      expect(await kv.get("k")).toBe("v2") // served from LRU write-through
+      await kv.delete("k")
+      body = "v3"
+      expect(await kv.get("k")).toBe("v3") // cache cleared -> refetch
+      expect(calls.filter((c) => c.init.method === "GET")).toHaveLength(2)
+    })
+
+    it("evicts least-recently-used entries past maxEntries", async () => {
+      const { fetch, calls } = mockFetch((url) => ({ body: url }))
+      const kv = createKvNamespaceShim({
+        ...base,
+        fetchImpl: fetch,
+        lru: { maxEntries: 2, ttlMs: 60_000 },
+      })
+
+      await kv.get("a")
+      await kv.get("b")
+      await kv.get("a") // a is now most-recent
+      await kv.get("c") // evicts b
+      const before = calls.length
+      await kv.get("b") // must refetch
+      expect(calls.length).toBe(before + 1)
+    })
+  })
+})

--- a/packages/dedicated-runtime/src/kv.ts
+++ b/packages/dedicated-runtime/src/kv.ts
@@ -76,9 +76,10 @@ function createLru(options: KvLruOptions) {
       map.set(key, entry)
       return { value: entry.value }
     },
-    set(key: string, value: string | null): void {
+    set(key: string, value: string | null, maxTtlMs?: number): void {
       if (map.has(key)) map.delete(key)
-      map.set(key, { value, expiresAt: Date.now() + options.ttlMs })
+      const ttlMs = maxTtlMs === undefined ? options.ttlMs : Math.min(options.ttlMs, maxTtlMs)
+      map.set(key, { value, expiresAt: Date.now() + ttlMs })
       while (map.size > options.maxEntries) {
         const oldest = map.keys().next().value
         if (oldest === undefined) break
@@ -159,7 +160,13 @@ export function createKvNamespaceShim(options: KvNamespaceShimOptions): KvNamesp
         const text = await response.text().catch(() => "")
         throw new Error(`KV put failed (${response.status}): ${text}`)
       }
-      lru?.set(key, value)
+      // Cap the local entry at the remote expirationTtl so an expiring key
+      // never outlives its Cloudflare-side lifetime in this process.
+      lru?.set(
+        key,
+        value,
+        putOptions?.expirationTtl === undefined ? undefined : putOptions.expirationTtl * 1000,
+      )
     },
     async delete(key: string): Promise<void> {
       const response = await fetchImpl(valueUrl(key), {

--- a/packages/dedicated-runtime/src/kv.ts
+++ b/packages/dedicated-runtime/src/kv.ts
@@ -1,0 +1,176 @@
+/**
+ * A `KVNamespace`-shaped client backed by the Cloudflare KV REST API, plus an
+ * optional in-process read-through LRU. On Workers-for-Platforms the `KV`
+ * binding is injected by the runtime; on a dedicated Node process there is no
+ * binding, so app code talks to the same namespace over HTTPS. The shim keeps
+ * the surface identical to the binding the operator packages already use:
+ * `get(key)`, `get(key, "json")`, `put(key, value, { expirationTtl })`,
+ * `delete(key)`.
+ */
+
+/** Injectable fetch — matches the global `fetch`. Tests stub this. */
+export type KvFetch = typeof fetch
+
+export type KvValueType = "text" | "json"
+
+export interface KvGetOptions {
+  type?: KvValueType
+}
+
+export interface KvPutOptions {
+  /** TTL in seconds; forwarded as the `expiration_ttl` query param. */
+  expirationTtl?: number
+}
+
+/** Minimal `KVNamespace` surface consumed across the operator packages. */
+export interface KvNamespaceShim {
+  get(key: string): Promise<string | null>
+  get<T = unknown>(key: string, type: "json"): Promise<T | null>
+  get<T = unknown>(key: string, options: KvGetOptions): Promise<T | string | null>
+  put(key: string, value: string, options?: KvPutOptions): Promise<void>
+  delete(key: string): Promise<void>
+}
+
+export interface KvLruOptions {
+  /** Maximum number of resident entries before least-recently-used eviction. */
+  maxEntries: number
+  /** How long a cached read stays fresh, in milliseconds. */
+  ttlMs: number
+}
+
+export interface KvNamespaceShimOptions {
+  accountId: string
+  namespaceId: string
+  apiToken: string
+  /** Override the fetch implementation (tests / custom agents). */
+  fetchImpl?: KvFetch
+  /** Override the REST API base (defaults to the public Cloudflare API). */
+  baseUrl?: string
+  /**
+   * Enable a small in-process read-through LRU. A resident Node process can
+   * finally hold one — REST round-trips are tens of ms, so caching hot keys is
+   * a large win. Writes and deletes keep the LRU coherent.
+   */
+  lru?: KvLruOptions
+}
+
+const DEFAULT_BASE_URL = "https://api.cloudflare.com/client/v4"
+
+interface LruEntry {
+  value: string | null
+  expiresAt: number
+}
+
+function createLru(options: KvLruOptions) {
+  const map = new Map<string, LruEntry>()
+  return {
+    get(key: string): { value: string | null } | undefined {
+      const entry = map.get(key)
+      if (!entry) return undefined
+      if (entry.expiresAt <= Date.now()) {
+        map.delete(key)
+        return undefined
+      }
+      // refresh recency
+      map.delete(key)
+      map.set(key, entry)
+      return { value: entry.value }
+    },
+    set(key: string, value: string | null): void {
+      if (map.has(key)) map.delete(key)
+      map.set(key, { value, expiresAt: Date.now() + options.ttlMs })
+      while (map.size > options.maxEntries) {
+        const oldest = map.keys().next().value
+        if (oldest === undefined) break
+        map.delete(oldest)
+      }
+    },
+    delete(key: string): void {
+      map.delete(key)
+    },
+  }
+}
+
+/**
+ * Build a {@link KvNamespaceShim} over the Cloudflare KV REST API.
+ */
+export function createKvNamespaceShim(options: KvNamespaceShimOptions): KvNamespaceShim {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const baseUrl = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "")
+  const lru = options.lru ? createLru(options.lru) : undefined
+  const authHeaders = { authorization: `Bearer ${options.apiToken}` }
+
+  function valueUrl(key: string): string {
+    return (
+      `${baseUrl}/accounts/${encodeURIComponent(options.accountId)}` +
+      `/storage/kv/namespaces/${encodeURIComponent(options.namespaceId)}` +
+      `/values/${encodeURIComponent(key)}`
+    )
+  }
+
+  async function readRaw(key: string): Promise<string | null> {
+    const cached = lru?.get(key)
+    if (cached) return cached.value
+    const response = await fetchImpl(valueUrl(key), {
+      method: "GET",
+      headers: authHeaders,
+    })
+    if (response.status === 404) {
+      lru?.set(key, null)
+      return null
+    }
+    if (!response.ok) {
+      const text = await response.text().catch(() => "")
+      throw new Error(`KV get failed (${response.status}): ${text}`)
+    }
+    const value = await response.text()
+    lru?.set(key, value)
+    return value
+  }
+
+  function parse(raw: string | null, type: KvValueType | undefined): unknown {
+    if (raw === null) return null
+    if (type === "json") return JSON.parse(raw)
+    return raw
+  }
+
+  async function get(
+    key: string,
+    typeOrOptions?: "json" | KvGetOptions,
+  ): Promise<string | null | unknown> {
+    const type = typeof typeOrOptions === "string" ? typeOrOptions : (typeOrOptions?.type ?? "text")
+    const raw = await readRaw(key)
+    return parse(raw, type)
+  }
+
+  return {
+    get: get as KvNamespaceShim["get"],
+    async put(key: string, value: string, putOptions?: KvPutOptions): Promise<void> {
+      const url = new URL(valueUrl(key))
+      if (putOptions?.expirationTtl !== undefined) {
+        url.searchParams.set("expiration_ttl", String(putOptions.expirationTtl))
+      }
+      const response = await fetchImpl(url.toString(), {
+        method: "PUT",
+        headers: authHeaders,
+        body: value,
+      })
+      if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        throw new Error(`KV put failed (${response.status}): ${text}`)
+      }
+      lru?.set(key, value)
+    },
+    async delete(key: string): Promise<void> {
+      const response = await fetchImpl(valueUrl(key), {
+        method: "DELETE",
+        headers: authHeaders,
+      })
+      if (!response.ok && response.status !== 404) {
+        const text = await response.text().catch(() => "")
+        throw new Error(`KV delete failed (${response.status}): ${text}`)
+      }
+      lru?.delete(key)
+    },
+  }
+}

--- a/packages/dedicated-runtime/src/node-server.test.ts
+++ b/packages/dedicated-runtime/src/node-server.test.ts
@@ -1,0 +1,113 @@
+import type { AddressInfo } from "node:net"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createNodeServer, type NodeServerHandle } from "./node-server.js"
+import { ORIGIN_TRUST_HEADER } from "./trust.js"
+
+const handles: NodeServerHandle[] = []
+
+afterEach(async () => {
+  while (handles.length) {
+    await handles.pop()?.close()
+  }
+})
+
+async function ready(handle: NodeServerHandle): Promise<number> {
+  const server = handle.server
+  if (!server.listening) {
+    await new Promise<void>((resolve) => server.once("listening", () => resolve()))
+  }
+  const addr = server.address() as AddressInfo
+  return addr.port
+}
+
+function boot<Env extends Record<string, unknown>>(
+  options: Parameters<typeof createNodeServer<Env>>[0],
+): NodeServerHandle {
+  const handle = createNodeServer<Env>({ ...options, port: 0 })
+  handles.push(handle)
+  return handle
+}
+
+describe("createNodeServer", () => {
+  it("runs the app fetch with the composed env and a real waitUntil ctx", async () => {
+    let sideEffectDone = false
+    const handle = boot({
+      env: { GREETING: "hi" },
+      fetch: (_req, env, ctx) => {
+        ctx.waitUntil(
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              sideEffectDone = true
+              resolve()
+            }, 20),
+          ),
+        )
+        return new Response(env.GREETING as string)
+      },
+    })
+    const port = await ready(handle)
+
+    const res = await fetch(`http://127.0.0.1:${port}/anything`)
+    expect(await res.text()).toBe("hi")
+
+    await handle.close()
+    expect(sideEffectDone).toBe(true)
+  })
+
+  it("rejects requests without a valid origin-trust header, exempting /healthz", async () => {
+    const handle = boot({
+      env: {},
+      originTrustSecret: "top-secret",
+      fetch: () => new Response("app"),
+    })
+    const port = await ready(handle)
+
+    const denied = await fetch(`http://127.0.0.1:${port}/v1/admin/x`)
+    expect(denied.status).toBe(403)
+
+    const health = await fetch(`http://127.0.0.1:${port}/healthz`)
+    expect(health.status).toBe(200)
+
+    const allowed = await fetch(`http://127.0.0.1:${port}/v1/admin/x`, {
+      headers: { [ORIGIN_TRUST_HEADER]: "top-secret" },
+    })
+    expect(await allowed.text()).toBe("app")
+  })
+
+  it("dispatches the scheduled handler over HTTP with the cron expression", async () => {
+    let seenCron: string | undefined
+    const handle = boot({
+      env: {},
+      originTrustSecret: "top-secret",
+      fetch: () => new Response("app"),
+      scheduled: (event) => {
+        seenCron = event.cron
+      },
+    })
+    const port = await ready(handle)
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/__voyant/scheduled?cron=${encodeURIComponent("*/2 * * * *")}`,
+      { method: "POST", headers: { [ORIGIN_TRUST_HEADER]: "top-secret" } },
+    )
+    expect(res.status).toBe(202)
+    expect(seenCron).toBe("*/2 * * * *")
+  })
+
+  it("requires trust for the scheduled hook", async () => {
+    const handle = boot({
+      env: {},
+      originTrustSecret: "top-secret",
+      fetch: () => new Response("app"),
+      scheduled: () => undefined,
+    })
+    const port = await ready(handle)
+
+    const res = await fetch(`http://127.0.0.1:${port}/__voyant/scheduled?cron=x`, {
+      method: "POST",
+    })
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/dedicated-runtime/src/node-server.ts
+++ b/packages/dedicated-runtime/src/node-server.ts
@@ -1,0 +1,126 @@
+import { type ServerType, serve } from "@hono/node-server"
+
+import { originTrustMiddleware } from "./trust.js"
+import type { ExecutionContextLike, FetchHandler, ScheduledHandler } from "./types.js"
+import { createWaitUntilRegistry, type WaitUntilRegistry } from "./wait-until.js"
+
+/** Path that health probes hit — always exempt from the origin-trust gate. */
+export const HEALTHZ_PATH = "/healthz"
+/** Trust-protected HTTP hook Cloud Scheduler POSTs to trigger `scheduled()`. */
+export const SCHEDULED_PATH = "/__voyant/scheduled"
+
+export interface ScheduledHandlerArgs<Env> {
+  request: Request
+  scheduled: ScheduledHandler<Env>
+  env: Env
+  ctx: ExecutionContextLike
+}
+
+/**
+ * Invoke a Worker-style `scheduled()` handler from an HTTP request. Reads the
+ * cron expression from the `cron` query param. Returns `202` on success, `500`
+ * on handler error, `400` when `cron` is missing. Exported standalone so it can
+ * be mounted into any server loop, not just {@link createNodeServer}.
+ */
+export async function scheduledHandler<Env>(args: ScheduledHandlerArgs<Env>): Promise<Response> {
+  const cron = new URL(args.request.url).searchParams.get("cron")
+  if (!cron) {
+    return new Response("Missing `cron` query param", { status: 400 })
+  }
+  try {
+    await args.scheduled({ cron, scheduledTime: Date.now() }, args.env, args.ctx)
+    return new Response(null, { status: 202 })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return new Response(`scheduled handler failed: ${message}`, { status: 500 })
+  }
+}
+
+export interface CreateNodeServerOptions<Env> {
+  /** The app's Worker-style fetch entrypoint — identical to the Workers build. */
+  fetch: FetchHandler<Env>
+  /** Optional Worker-style scheduled handler, exposed at {@link SCHEDULED_PATH}. */
+  scheduled?: ScheduledHandler<Env>
+  /** The composed env bag (see `buildDedicatedEnv`). */
+  env: Env
+  /** Listen port. Defaults to `PORT` env or `8080`. */
+  port?: number
+  /**
+   * Per-app shared secret for the `x-voyant-origin-trust` header. When set,
+   * every request except {@link HEALTHZ_PATH} must present a matching header or
+   * receives `403`. Leave unset only for a fully private network boundary.
+   */
+  originTrustSecret?: string
+  /** Milliseconds to wait for in-flight `waitUntil` work on shutdown. Default 10s. */
+  drainTimeoutMs?: number
+}
+
+export interface NodeServerHandle {
+  server: ServerType
+  /** The `waitUntil` registry backing per-request execution contexts. */
+  registry: WaitUntilRegistry
+  /** Resolved listen port. */
+  port: number
+  /** Stop accepting, drain background work, close. Idempotent. */
+  close(): Promise<void>
+}
+
+/**
+ * Boot a Node HTTP server that runs an operator app's `fetch(request, env, ctx)`
+ * unchanged. Adds the pieces Cloudflare provides implicitly: a real per-request
+ * `waitUntil` context, an origin-trust gate, an HTTP `scheduled()` hook for
+ * Cloud Scheduler, and graceful SIGTERM/SIGINT shutdown that drains in-flight
+ * background work before exit.
+ */
+export function createNodeServer<Env>(options: CreateNodeServerOptions<Env>): NodeServerHandle {
+  const port = options.port ?? Number.parseInt(process.env.PORT ?? "8080", 10)
+  const registry = createWaitUntilRegistry()
+  const trustGate = options.originTrustSecret
+    ? originTrustMiddleware(options.originTrustSecret, { exemptPaths: [HEALTHZ_PATH] })
+    : undefined
+
+  async function handler(request: Request): Promise<Response> {
+    const url = new URL(request.url)
+
+    if (url.pathname === HEALTHZ_PATH) {
+      return new Response("ok", { status: 200 })
+    }
+
+    if (trustGate) {
+      const rejection = trustGate(request)
+      if (rejection) return rejection
+    }
+
+    const ctx = registry.context()
+
+    if (options.scheduled && request.method === "POST" && url.pathname === SCHEDULED_PATH) {
+      return scheduledHandler({ request, scheduled: options.scheduled, env: options.env, ctx })
+    }
+
+    return options.fetch(request, options.env, ctx)
+  }
+
+  const server = serve({ fetch: handler, port })
+
+  let closing: Promise<void> | undefined
+  const close = (): Promise<void> => {
+    closing ??= (async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()))
+      })
+      await registry.drain(options.drainTimeoutMs)
+    })()
+    return closing
+  }
+
+  const onSignal = () => {
+    void close().then(
+      () => process.exit(0),
+      () => process.exit(1),
+    )
+  }
+  process.once("SIGTERM", onSignal)
+  process.once("SIGINT", onSignal)
+
+  return { server, registry, port, close }
+}

--- a/packages/dedicated-runtime/src/r2.test.ts
+++ b/packages/dedicated-runtime/src/r2.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest"
+
+import { createR2BucketShim, type R2Fetch } from "./r2.js"
+
+interface Recorded {
+  url: string
+  method: string
+  headers: Record<string, string>
+  body?: BodyInit | null
+}
+
+function mockFetch(
+  responder: (rec: Recorded) => {
+    status?: number
+    body?: BodyInit
+    headers?: Record<string, string>
+  },
+): { fetch: R2Fetch; calls: Recorded[] } {
+  const calls: Recorded[] = []
+  const fetch: R2Fetch = async (input, init = {}) => {
+    const rec: Recorded = {
+      url: String(input),
+      method: init.method ?? "GET",
+      headers: (init.headers as Record<string, string>) ?? {},
+      body: init.body,
+    }
+    calls.push(rec)
+    const { status = 200, body, headers } = responder(rec)
+    return new Response(body ?? null, { status, headers })
+  }
+  return { fetch, calls }
+}
+
+const base = {
+  endpoint: "https://acct.r2.cloudflarestorage.com",
+  bucket: "documents",
+  accessKeyId: "AKIA_TEST",
+  secretAccessKey: "secret",
+  region: "auto",
+}
+
+describe("createR2BucketShim", () => {
+  it("PUTs a signed, path-style object URL with content-type and custom metadata", async () => {
+    const { fetch, calls } = mockFetch(() => ({ status: 200 }))
+    const bucket = createR2BucketShim({ ...base, fetchImpl: fetch })
+
+    await bucket.put("invoices/2026/x.pdf", "PDFDATA", {
+      httpMetadata: { contentType: "application/pdf" },
+      customMetadata: { Owner: "acme" },
+    })
+
+    const call = calls[0]!
+    expect(call.method).toBe("PUT")
+    expect(call.url).toBe("https://acct.r2.cloudflarestorage.com/documents/invoices/2026/x.pdf")
+    expect(call.headers.Authorization).toMatch(/^AWS4-HMAC-SHA256 Credential=AKIA_TEST\//)
+    expect(call.headers["x-amz-date"]).toMatch(/^\d{8}T\d{6}Z$/)
+    expect(call.headers["content-type"]).toBe("application/pdf")
+    expect(call.headers["x-amz-meta-owner"]).toBe("acme")
+  })
+
+  it("GETs an object exposing arrayBuffer, body, size, and httpMetadata", async () => {
+    const { fetch } = mockFetch(() => ({
+      body: "file-bytes",
+      headers: { "content-type": "text/plain", "x-amz-meta-tag": "v1" },
+    }))
+    const bucket = createR2BucketShim({ ...base, fetchImpl: fetch })
+
+    const obj = await bucket.get("a.txt")
+    expect(obj).not.toBeNull()
+    const bytes = new Uint8Array(await obj!.arrayBuffer())
+    expect(new TextDecoder().decode(bytes)).toBe("file-bytes")
+    expect(obj!.httpMetadata?.contentType).toBe("text/plain")
+    expect(obj!.customMetadata?.tag).toBe("v1")
+    expect(obj!.body).toBeInstanceOf(ReadableStream)
+  })
+
+  it("returns null when the object is missing (404)", async () => {
+    const { fetch } = mockFetch(() => ({ status: 404 }))
+    const bucket = createR2BucketShim({ ...base, fetchImpl: fetch })
+    expect(await bucket.get("missing")).toBeNull()
+  })
+
+  it("DELETEs and tolerates a 404", async () => {
+    const { fetch, calls } = mockFetch(() => ({ status: 404 }))
+    const bucket = createR2BucketShim({ ...base, fetchImpl: fetch })
+    await expect(bucket.delete("gone")).resolves.toBeUndefined()
+    expect(calls[0]?.method).toBe("DELETE")
+  })
+
+  it("supports array delete keys", async () => {
+    const { fetch, calls } = mockFetch(() => ({ status: 204 }))
+    const bucket = createR2BucketShim({ ...base, fetchImpl: fetch })
+    await bucket.delete(["a", "b"])
+    expect(calls.map((c) => c.method)).toEqual(["DELETE", "DELETE"])
+  })
+
+  it("HEAD returns metadata without a body", async () => {
+    const { fetch } = mockFetch(() => ({
+      headers: { "content-type": "image/png", "content-length": "1024" },
+    }))
+    const bucket = createR2BucketShim({ ...base, fetchImpl: fetch })
+    const meta = await bucket.head("img.png")
+    expect(meta?.httpMetadata?.contentType).toBe("image/png")
+    expect(meta?.size).toBe(1024)
+  })
+})

--- a/packages/dedicated-runtime/src/r2.ts
+++ b/packages/dedicated-runtime/src/r2.ts
@@ -1,0 +1,207 @@
+import { signRequest } from "@voyant-travel/storage/lib/sigv4"
+import type {
+  R2BucketLike,
+  R2ObjectLike,
+  R2PutOptionsLike,
+} from "@voyant-travel/storage/providers/r2"
+
+/**
+ * An `R2Bucket`-shaped client backed by R2's S3-compatible API. Signing reuses
+ * `@voyant-travel/storage`'s SigV4 implementation (verified against AWS test
+ * vectors) rather than reimplementing it here. The shim satisfies the
+ * structural {@link R2BucketLike} the storage providers depend on, plus the
+ * richer `bucket.get(key) -> { arrayBuffer(), body, httpMetadata }` surface the
+ * operator's document routes use.
+ */
+export type R2Fetch = typeof fetch
+
+/** The object returned by {@link R2BucketShim.get}. Superset of {@link R2ObjectLike}. */
+export interface R2ShimObject extends R2ObjectLike {
+  /** Buffered body bytes, re-readable as a stream. */
+  body: ReadableStream<Uint8Array> | null
+  httpMetadata?: { contentType?: string }
+  customMetadata?: Record<string, string>
+  size: number
+}
+
+export interface R2BucketShim extends R2BucketLike {
+  get(key: string): Promise<R2ShimObject | null>
+  head(key: string): Promise<Omit<R2ShimObject, "arrayBuffer" | "body"> | null>
+}
+
+export interface R2BucketShimOptions {
+  /** R2 S3 endpoint, e.g. `https://<accountid>.r2.cloudflarestorage.com`. */
+  endpoint: string
+  /** Bucket name. */
+  bucket: string
+  accessKeyId: string
+  secretAccessKey: string
+  /** S3 region — R2 ignores it but SigV4 requires one. Defaults to `"auto"`. */
+  region?: string
+  /** Override the fetch implementation (tests / custom agents). */
+  fetchImpl?: R2Fetch
+}
+
+const CUSTOM_META_PREFIX = "x-amz-meta-"
+
+/**
+ * Build an {@link R2BucketShim} over the R2 S3-compatible API.
+ */
+export function createR2BucketShim(options: R2BucketShimOptions): R2BucketShim {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const region = options.region ?? "auto"
+  const endpoint = options.endpoint.replace(/\/$/, "")
+  const credentials = {
+    accessKeyId: options.accessKeyId,
+    secretAccessKey: options.secretAccessKey,
+  }
+
+  function objectUrl(key: string): string {
+    return `${endpoint}/${encodeURIComponent(options.bucket)}/${encodeKey(key)}`
+  }
+
+  async function send(
+    method: string,
+    key: string,
+    init: { headers?: Record<string, string>; body?: Uint8Array } = {},
+  ): Promise<Response> {
+    const url = objectUrl(key)
+    const signed = await signRequest({
+      method,
+      url,
+      headers: init.headers,
+      body: init.body,
+      credentials,
+      region,
+      service: "s3",
+    })
+    return fetchImpl(url, {
+      method,
+      headers: signed.headers,
+      body: init.body as BodyInit | undefined,
+    })
+  }
+
+  function readMetadata(response: Response): {
+    httpMetadata?: { contentType?: string }
+    customMetadata?: Record<string, string>
+    size: number
+  } {
+    const contentType = response.headers.get("content-type") ?? undefined
+    const customMetadata: Record<string, string> = {}
+    response.headers.forEach((value, name) => {
+      if (name.toLowerCase().startsWith(CUSTOM_META_PREFIX)) {
+        customMetadata[name.slice(CUSTOM_META_PREFIX.length)] = value
+      }
+    })
+    const contentLength = response.headers.get("content-length")
+    const result: {
+      httpMetadata?: { contentType?: string }
+      customMetadata?: Record<string, string>
+      size: number
+    } = { size: contentLength ? Number.parseInt(contentLength, 10) : 0 }
+    if (contentType !== undefined) result.httpMetadata = { contentType }
+    if (Object.keys(customMetadata).length > 0) result.customMetadata = customMetadata
+    return result
+  }
+
+  return {
+    async put(key, value, putOptions) {
+      const bytes = await toBytes(value)
+      const headers = putHeaders(putOptions)
+      const response = await send("PUT", key, { headers, body: bytes })
+      if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        throw new Error(`R2 put failed (${response.status}): ${text}`)
+      }
+      return { key }
+    },
+    async delete(key) {
+      const keys = Array.isArray(key) ? key : [key]
+      for (const k of keys) {
+        const response = await send("DELETE", k)
+        // 204 on success, 404 on missing — both are effectively "gone".
+        if (!response.ok && response.status !== 404) {
+          const text = await response.text().catch(() => "")
+          throw new Error(`R2 delete failed (${response.status}): ${text}`)
+        }
+      }
+    },
+    async get(key) {
+      const response = await send("GET", key)
+      if (response.status === 404) return null
+      if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        throw new Error(`R2 get failed (${response.status}): ${text}`)
+      }
+      const buffer = await response.arrayBuffer()
+      const meta = readMetadata(response)
+      const object: R2ShimObject = {
+        arrayBuffer: async () => buffer.slice(0),
+        body: bytesToStream(new Uint8Array(buffer)),
+        size: meta.size || buffer.byteLength,
+      }
+      if (meta.httpMetadata) object.httpMetadata = meta.httpMetadata
+      if (meta.customMetadata) object.customMetadata = meta.customMetadata
+      return object
+    },
+    async head(key) {
+      const response = await send("HEAD", key)
+      if (response.status === 404) return null
+      if (!response.ok) {
+        const text = await response.text().catch(() => "")
+        throw new Error(`R2 head failed (${response.status}): ${text}`)
+      }
+      return readMetadata(response)
+    },
+  }
+}
+
+function putHeaders(putOptions?: R2PutOptionsLike): Record<string, string> {
+  const headers: Record<string, string> = {}
+  if (putOptions?.httpMetadata?.contentType) {
+    headers["content-type"] = putOptions.httpMetadata.contentType
+  }
+  if (putOptions?.customMetadata) {
+    for (const [k, v] of Object.entries(putOptions.customMetadata)) {
+      headers[`${CUSTOM_META_PREFIX}${k.toLowerCase()}`] = v
+    }
+  }
+  return headers
+}
+
+function encodeKey(key: string): string {
+  return key
+    .split("/")
+    .map((segment) =>
+      encodeURIComponent(segment).replace(
+        /[!'()*]/g,
+        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+      ),
+    )
+    .join("/")
+}
+
+async function toBytes(
+  value: ArrayBuffer | ArrayBufferView | Blob | string | ReadableStream | null,
+): Promise<Uint8Array> {
+  if (value === null) return new Uint8Array()
+  if (typeof value === "string") return new TextEncoder().encode(value)
+  if (value instanceof Uint8Array) return value
+  if (value instanceof ArrayBuffer) return new Uint8Array(value)
+  if (ArrayBuffer.isView(value)) {
+    return new Uint8Array(value.buffer, value.byteOffset, value.byteLength)
+  }
+  if (value instanceof Blob) return new Uint8Array(await value.arrayBuffer())
+  // ReadableStream
+  return new Uint8Array(await new Response(value as ReadableStream).arrayBuffer())
+}
+
+function bytesToStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes)
+      controller.close()
+    },
+  })
+}

--- a/packages/dedicated-runtime/src/trust.test.ts
+++ b/packages/dedicated-runtime/src/trust.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  constantTimeEqual,
+  ORIGIN_TRUST_HEADER,
+  originTrustMiddleware,
+  verifyOriginTrust,
+} from "./trust.js"
+
+function req(headers: Record<string, string> = {}, path = "/v1/admin/x"): Request {
+  return new Request(`https://app.example.com${path}`, { headers })
+}
+
+describe("constantTimeEqual", () => {
+  it("returns true for equal strings", () => {
+    expect(constantTimeEqual("abc", "abc")).toBe(true)
+  })
+  it("returns false for different values and lengths", () => {
+    expect(constantTimeEqual("abc", "abd")).toBe(false)
+    expect(constantTimeEqual("abc", "abcd")).toBe(false)
+    expect(constantTimeEqual("", "x")).toBe(false)
+  })
+})
+
+describe("verifyOriginTrust", () => {
+  it("passes when the header matches the secret", () => {
+    expect(verifyOriginTrust(req({ [ORIGIN_TRUST_HEADER]: "s3cr3t" }), "s3cr3t")).toBe(true)
+  })
+  it("fails when header is missing or wrong", () => {
+    expect(verifyOriginTrust(req(), "s3cr3t")).toBe(false)
+    expect(verifyOriginTrust(req({ [ORIGIN_TRUST_HEADER]: "nope" }), "s3cr3t")).toBe(false)
+  })
+})
+
+describe("originTrustMiddleware", () => {
+  it("rejects unauthenticated requests with 403", () => {
+    const gate = originTrustMiddleware("s3cr3t")
+    const rejection = gate(req())
+    expect(rejection?.status).toBe(403)
+  })
+
+  it("allows authenticated requests through (undefined)", () => {
+    const gate = originTrustMiddleware("s3cr3t")
+    expect(gate(req({ [ORIGIN_TRUST_HEADER]: "s3cr3t" }))).toBeUndefined()
+  })
+
+  it("exempts configured paths", () => {
+    const gate = originTrustMiddleware("s3cr3t", { exemptPaths: ["/healthz"] })
+    expect(gate(req({}, "/healthz"))).toBeUndefined()
+  })
+
+  it("uses the pinned header name", () => {
+    expect(ORIGIN_TRUST_HEADER).toBe("x-voyant-origin-trust")
+  })
+})

--- a/packages/dedicated-runtime/src/trust.ts
+++ b/packages/dedicated-runtime/src/trust.ts
@@ -1,0 +1,58 @@
+import { timingSafeEqual } from "node:crypto"
+
+/**
+ * Pinned cross-repo constant: the header the platform dispatcher stamps on
+ * every request it forwards to a dedicated (Cloud Run) app. The value is a
+ * per-app shared secret. Do NOT rename — the platform side depends on it.
+ */
+export const ORIGIN_TRUST_HEADER = "x-voyant-origin-trust"
+
+/**
+ * Constant-time string comparison. Returns `false` for length mismatches
+ * without leaking the comparison via early return timing (the length check is
+ * unavoidable and is itself not secret-length-dependent beyond equality).
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  const aBytes = new TextEncoder().encode(a)
+  const bBytes = new TextEncoder().encode(b)
+  if (aBytes.length !== bBytes.length) {
+    // Still burn a comparison against a same-length buffer so a size probe
+    // does not short-circuit measurably faster than a value mismatch.
+    timingSafeEqual(aBytes, aBytes)
+    return false
+  }
+  return timingSafeEqual(aBytes, bBytes)
+}
+
+/**
+ * Verify that a request carries a valid origin-trust header for `secret`.
+ */
+export function verifyOriginTrust(request: Request, secret: string): boolean {
+  const provided = request.headers.get(ORIGIN_TRUST_HEADER)
+  if (provided === null) return false
+  return constantTimeEqual(provided, secret)
+}
+
+export interface OriginTrustOptions {
+  /**
+   * Paths that skip the trust check entirely (exact match). Defaults to
+   * `["/healthz"]` so container health probes never need the secret.
+   */
+  exemptPaths?: string[]
+}
+
+/**
+ * Build a low-level trust gate. Returns a function that, given a request,
+ * yields a `403` {@link Response} when the request must be rejected, or
+ * `undefined` when it may proceed. Composable — used by {@link createNodeServer}
+ * but exported so callers can wire it into their own server loop.
+ */
+export function originTrustMiddleware(secret: string, options: OriginTrustOptions = {}) {
+  const exempt = new Set(options.exemptPaths ?? ["/healthz"])
+  return (request: Request): Response | undefined => {
+    const { pathname } = new URL(request.url)
+    if (exempt.has(pathname)) return undefined
+    if (verifyOriginTrust(request, secret)) return undefined
+    return new Response("Forbidden: invalid origin trust", { status: 403 })
+  }
+}

--- a/packages/dedicated-runtime/src/types.ts
+++ b/packages/dedicated-runtime/src/types.ts
@@ -1,0 +1,45 @@
+import type { WaitUntilContext } from "@voyant-travel/worker-runtime/types"
+
+/**
+ * Structural slice of the Cloudflare Workers `ExecutionContext`. On a resident
+ * Node process we can ship a *real* {@link ExecutionContextLike.waitUntil} that
+ * tracks background work for graceful shutdown, instead of running subscriber
+ * work inline (which adds request latency) or dropping it on exit.
+ */
+export interface ExecutionContextLike extends WaitUntilContext {
+  /**
+   * No-op on Node — kept for source-compatibility with app code that calls
+   * `ctx.passThroughOnException()` on Workers.
+   */
+  passThroughOnException?(): void
+}
+
+/**
+ * Worker-style `fetch(request, env, ctx)` entrypoint. This is the exact shape
+ * an operator app exports on Cloudflare Workers; the whole point of this
+ * package is that the same handler runs unchanged on Node.
+ */
+export type FetchHandler<Env> = (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContextLike,
+) => Response | Promise<Response>
+
+/**
+ * The event object passed to a Worker `scheduled()` handler. On Cloud Run the
+ * cron triggers arrive over HTTP (Cloud Scheduler), so `scheduledTime` is the
+ * dispatch time and `cron` is echoed from the request.
+ */
+export interface ScheduledEventLike {
+  cron: string
+  scheduledTime: number
+}
+
+/**
+ * Worker-style `scheduled(event, env, ctx)` handler.
+ */
+export type ScheduledHandler<Env> = (
+  event: ScheduledEventLike,
+  env: Env,
+  ctx: ExecutionContextLike,
+) => void | Promise<void>

--- a/packages/dedicated-runtime/src/wait-until.test.ts
+++ b/packages/dedicated-runtime/src/wait-until.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest"
+
+import { createWaitUntilRegistry } from "./wait-until.js"
+
+const tick = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe("createWaitUntilRegistry", () => {
+  it("tracks pending promises and drains them", async () => {
+    const registry = createWaitUntilRegistry()
+    const ctx = registry.context()
+
+    let done = false
+    ctx.waitUntil(tick(20).then(() => (done = true)))
+    expect(registry.pending()).toBe(1)
+
+    await registry.drain(1000)
+    expect(done).toBe(true)
+    expect(registry.pending()).toBe(0)
+  })
+
+  it("resolves immediately when nothing is in flight", async () => {
+    const registry = createWaitUntilRegistry()
+    await expect(registry.drain(1000)).resolves.toBeUndefined()
+  })
+
+  it("stops waiting after the timeout for slow work", async () => {
+    const registry = createWaitUntilRegistry()
+    registry.context().waitUntil(tick(5000))
+    const start = Date.now()
+    await registry.drain(30)
+    expect(Date.now() - start).toBeLessThan(1000)
+  })
+
+  it("swallows rejections so drain never throws", async () => {
+    const registry = createWaitUntilRegistry()
+    registry.context().waitUntil(Promise.reject(new Error("boom")))
+    await expect(registry.drain(1000)).resolves.toBeUndefined()
+    expect(registry.pending()).toBe(0)
+  })
+
+  it("shares one registry across multiple request contexts", async () => {
+    const registry = createWaitUntilRegistry()
+    registry.context().waitUntil(tick(10))
+    registry.context().waitUntil(tick(10))
+    expect(registry.pending()).toBe(2)
+    await registry.drain(1000)
+    expect(registry.pending()).toBe(0)
+  })
+})

--- a/packages/dedicated-runtime/src/wait-until.ts
+++ b/packages/dedicated-runtime/src/wait-until.ts
@@ -1,0 +1,70 @@
+import type { ExecutionContextLike } from "./types.js"
+
+export interface WaitUntilRegistry {
+  /**
+   * Produce a fresh {@link ExecutionContextLike} for a single request. Every
+   * promise passed to its `waitUntil` is tracked centrally so the process can
+   * drain in-flight background work on shutdown.
+   */
+  context(): ExecutionContextLike
+  /**
+   * Wait for all currently-tracked promises to settle, or until `timeoutMs`
+   * elapses — whichever comes first. Resolves (never rejects); individual
+   * promise rejections are swallowed here since `waitUntil` work is
+   * fire-and-forget by the Workers contract.
+   */
+  drain(timeoutMs?: number): Promise<void>
+  /** Number of promises still in flight. Useful for tests and readiness. */
+  pending(): number
+}
+
+/**
+ * Track every `waitUntil` promise across requests so a resident Node process
+ * can drain background work (outbox publishes, cache warms, event-bus fan-out)
+ * before it exits — the behavior Cloudflare gives for free but Node does not.
+ */
+export function createWaitUntilRegistry(): WaitUntilRegistry {
+  const inflight = new Set<Promise<unknown>>()
+
+  function track(promise: Promise<unknown>): void {
+    const tracked = Promise.resolve(promise).catch(() => {
+      // waitUntil work is fire-and-forget; never let a rejection escape.
+    })
+    inflight.add(tracked)
+    void tracked.finally(() => {
+      inflight.delete(tracked)
+    })
+  }
+
+  return {
+    context(): ExecutionContextLike {
+      return {
+        waitUntil(promise: Promise<unknown>): void {
+          track(promise)
+        },
+        passThroughOnException(): void {
+          // no-op on Node
+        },
+      }
+    },
+    async drain(timeoutMs = 10_000): Promise<void> {
+      if (inflight.size === 0) return
+      const settled = Promise.allSettled([...inflight]).then(() => undefined)
+      if (timeoutMs <= 0) {
+        await settled
+        return
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const timeout = new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs)
+        // Do not keep the event loop alive purely for the drain timeout.
+        timer.unref?.()
+      })
+      await Promise.race([settled, timeout])
+      if (timer) clearTimeout(timer)
+    },
+    pending(): number {
+      return inflight.size
+    },
+  }
+}

--- a/packages/dedicated-runtime/tsconfig.build.json
+++ b/packages/dedicated-runtime/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/dedicated-runtime/tsconfig.json
+++ b/packages/dedicated-runtime/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/dedicated-runtime/tsconfig.typecheck.json
+++ b/packages/dedicated-runtime/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/dedicated-runtime/vitest.config.ts
+++ b/packages/dedicated-runtime/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    passWithNoTests: true,
+    hookTimeout: 60000,
+  },
+})

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -612,6 +612,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],
       "@voyant-travel/distribution-react/client": ["../distribution-react/dist/client.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],
       "@voyant-travel/distribution-react/client": ["../distribution-react/dist/client.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -618,6 +618,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -612,6 +612,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -618,6 +618,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -612,6 +612,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -618,6 +618,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -611,6 +611,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -612,6 +612,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -613,6 +613,17 @@
       "@voyant-travel/db/types": ["../db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": ["../dedicated-runtime/dist/cache.d.ts"],
+      "@voyant-travel/dedicated-runtime/env": ["../dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": ["../dedicated-runtime/dist/trust.d.ts"],
+      "@voyant-travel/dedicated-runtime/types": ["../dedicated-runtime/dist/types.d.ts"],
+      "@voyant-travel/dedicated-runtime/wait-until": ["../dedicated-runtime/dist/wait-until.d.ts"],
       "@voyant-travel/distribution": ["../distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": ["../distribution-react/dist/admin/index.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1506,6 +1506,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
 
+  packages/dedicated-runtime:
+    dependencies:
+      '@hono/node-server':
+        specifier: 2.0.6
+        version: 2.0.6(hono@4.12.27)
+      '@voyant-travel/storage':
+        specifier: workspace:^
+        version: link:../storage
+      '@voyant-travel/worker-runtime':
+        specifier: workspace:^
+        version: link:../worker-runtime
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.5.2
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/distribution:
     dependencies:
       '@hono/zod-openapi':
@@ -12536,6 +12561,10 @@ snapshots:
   '@hono/node-server@2.0.6(hono@4.12.25)':
     dependencies:
       hono: 4.12.25
+
+  '@hono/node-server@2.0.6(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
 
   '@hono/zod-openapi@1.4.0(hono@4.12.25)(zod@4.4.3)':
     dependencies:

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -778,6 +778,25 @@
       "@voyant-travel/db/types": ["../../packages/db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../../packages/db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../../packages/db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../../packages/dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": [
+        "../../packages/dedicated-runtime/dist/cache.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/env": ["../../packages/dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../../packages/dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../../packages/dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../../packages/dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": [
+        "../../packages/dedicated-runtime/dist/trust.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/types": [
+        "../../packages/dedicated-runtime/dist/types.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/wait-until": [
+        "../../packages/dedicated-runtime/dist/wait-until.d.ts"
+      ],
       "@voyant-travel/distribution": ["../../packages/distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../../packages/distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": [

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -778,6 +778,25 @@
       "@voyant-travel/db/types": ["../../packages/db/dist/types.d.ts"],
       "@voyant-travel/db/utils": ["../../packages/db/dist/utils.d.ts"],
       "@voyant-travel/db/write-intents": ["../../packages/db/dist/write-intents.d.ts"],
+      "@voyant-travel/dedicated-runtime": ["../../packages/dedicated-runtime/dist/index.d.ts"],
+      "@voyant-travel/dedicated-runtime/cache": [
+        "../../packages/dedicated-runtime/dist/cache.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/env": ["../../packages/dedicated-runtime/dist/env.d.ts"],
+      "@voyant-travel/dedicated-runtime/kv": ["../../packages/dedicated-runtime/dist/kv.d.ts"],
+      "@voyant-travel/dedicated-runtime/node-server": [
+        "../../packages/dedicated-runtime/dist/node-server.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/r2": ["../../packages/dedicated-runtime/dist/r2.d.ts"],
+      "@voyant-travel/dedicated-runtime/trust": [
+        "../../packages/dedicated-runtime/dist/trust.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/types": [
+        "../../packages/dedicated-runtime/dist/types.d.ts"
+      ],
+      "@voyant-travel/dedicated-runtime/wait-until": [
+        "../../packages/dedicated-runtime/dist/wait-until.d.ts"
+      ],
       "@voyant-travel/distribution": ["../../packages/distribution/dist/index.d.ts"],
       "@voyant-travel/distribution-react": ["../../packages/distribution-react/dist/index.d.ts"],
       "@voyant-travel/distribution-react/admin": [


### PR DESCRIPTION
## Motivation

voyant-travel/platform#935: a fully composed operator API cannot be kept resident on Workers for Platforms — the evaluated composition heap is evicted at zero idle in every container (request isolates, slim workers, Durable Objects). The platform adds a per-app `dedicated` runtime: the identical app runs on Cloud Run behind the existing dispatcher. This package is the app-side half — bindings emulation plus a Node server entry so application code is identical across runtimes.

## What's inside

| Module | Emulates | Notes |
| --- | --- | --- |
| `./kv` | `KVNamespace` (get/get-json/put+`expirationTtl`/delete) | Cloudflare KV REST API; optional read-through LRU for a resident process |
| `./r2` | `R2Bucket` (put w/ `httpMetadata`+`customMetadata`, get→`arrayBuffer`, delete, head) | S3-compatible endpoint via `@voyant-travel/storage` SigV4 |
| `./cache` | `caches.default` (`match`/`put`) | in-process LRU honoring `s-maxage`/`max-age`; idempotent global install |
| `./wait-until` | `ExecutionContext.waitUntil` | per-request contexts + `drain()` for graceful shutdown |
| `./env` | binding env bag | composes `process.env` strings + shim objects |
| `./node-server` | worker `fetch`/`scheduled` entry | `@hono/node-server`; origin-trust gate (`x-voyant-origin-trust`, constant-time), `POST /__voyant/scheduled?cron=…` Cloud Scheduler hook, SIGTERM drain |
| `./trust` | — | origin-trust middleware, exported standalone |

Intentionally not shimmed (documented in README): Durable Objects, Analytics Engine datasets (`METRICS` middleware already no-ops when absent), `request.cf`.

## Verification

- `pnpm --filter @voyant-travel/dedicated-runtime typecheck / test / lint` — clean, 42 tests across 7 files
- `pnpm verify:package-exports` — no findings for this package
- changeset included (minor, new package)
