### PR TITLE
Operator dev env: use .env (Node-native), drop wrangler .dev.vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ cd my-travel-app
 pnpm install
 
 # 3. Configure the app
-cp .dev.vars.example .dev.vars
-# set your secrets in .dev.vars, and DATABASE_URL in .env
+cp .env.example .env
+# set your secrets (DATABASE_URL, BETTER_AUTH_SECRET, …) in .env
 
 # 4. Run the app
 pnpm db:migrate

--- a/apps/catalog-demo-api/README.md
+++ b/apps/catalog-demo-api/README.md
@@ -20,7 +20,7 @@ pnpm db:migrate             # creates catalog_demo_inventory + catalog_demo_orde
 pnpm dev                    # listens on :3330 by default
 ```
 
-Then in your operator starter (e.g. `starters/operator/.dev.vars`):
+Then in your operator starter (e.g. `starters/operator/.env`):
 
 ```
 CATALOG_DEMO_API_URL=http://localhost:3330

--- a/apps/flights-demo-api/README.md
+++ b/apps/flights-demo-api/README.md
@@ -31,8 +31,8 @@ pnpm --dir apps/flights-demo-api db:migrate
 pnpm --dir apps/flights-demo-api dev
 ```
 
-Then in your starter (e.g. `starters/operator/.dev.vars` in the repository, or
-`.dev.vars` in a packaged starter):
+Then in your starter (e.g. `starters/operator/.env` in the repository, or
+`.env` in a packaged starter):
 
 ```
 FLIGHTS_DEMO_API_URL=http://localhost:3320

--- a/starters/operator/.env.example
+++ b/starters/operator/.env.example
@@ -1,13 +1,20 @@
-# Cloudflare Workers runtime secrets — loaded by wrangler in dev.
-# Copy to `.dev.vars` and fill in values. Never commit .dev.vars.
-#
-# Public vars (APP_URL, DASH_BASE_URL, PUBLIC_CHECKOUT_BASE_URL,
-# GCP_* non-key fields, EMAIL_FROM) already live in wrangler.jsonc under
-# env.dev.vars — only secrets belong here.
+# Operator dev/local environment. The operator is Node-only (voyant#2966): copy
+# this to `.env`, fill in values, and it is loaded via `node --env-file` by
+# `pnpm dev` and `pnpm start`. Never commit `.env`. In real deployments the
+# process env comes from the platform (no `.env` file), and platform values win.
 
-# Database (Neon Postgres — accessed via the Neon serverless HTTP driver in
-# both dev and prod; no Hyperdrive binding required)
+# Runtime URLs + mode. These were `wrangler.jsonc` `vars` under the old Workers
+# build; on Node they live here. `APP_URL` is the API base; `DASH_BASE_URL` the
+# dashboard origin. Match your dev port (3300).
+APP_URL="http://localhost:3300/api"
+DASH_BASE_URL="http://localhost:3300"
+EMAIL_FROM="Voyant <voyant@notifications.example.com>"
+
+# Database (Postgres). On Node the pooled node-postgres lane is the production
+# default — set DATABASE_URL_DIRECT to the direct endpoint; DATABASE_URL is the
+# neon-http/WS fallback.
 DATABASE_URL="postgresql://user:password@host/dbname?sslmode=require"
+# DATABASE_URL_DIRECT="postgresql://user:password@direct-host/dbname?sslmode=require"
 
 # Auth
 BETTER_AUTH_SECRET="<generate with: openssl rand -base64 32>"
@@ -16,7 +23,7 @@ INTERNAL_API_KEY="<generate with: openssl rand -hex 32>"
 # Local dev and self-hosted deployments use Better Auth local flows. Voyant
 # Cloud deployments set this to "voyant-cloud"; in that mode local sign-in,
 # sign-up, password reset, invites, and local OAuth are blocked server-side.
-# VOYANT_ADMIN_AUTH_MODE="local"
+VOYANT_ADMIN_AUTH_MODE="local"
 # Cloud mode broker settings are injected by Voyant Cloud deployments.
 # VOYANT_CLOUD_ADMIN_AUTH_START_URL="https://dash.voyantcloud.com/admin-auth/start"
 # VOYANT_CLOUD_ADMIN_AUTH_EXCHANGE_URL="https://api.voyant.travel/cloud/v1/admin-auth/exchange"
@@ -28,9 +35,9 @@ INTERNAL_API_KEY="<generate with: openssl rand -hex 32>"
 # VOYANT_CLOUD_APP_ID="app_..."
 # VOYANT_CLOUD_ENVIRONMENT="production"
 
-# CORS / URLs
-API_BASE_URL="http://localhost:3100/api"
-CORS_ALLOWLIST="http://localhost:3100"
+# CORS / URLs (match your dev port, 3300)
+API_BASE_URL="http://localhost:3300/api"
+CORS_ALLOWLIST="http://localhost:3300"
 
 # Voyant API (canonical email / sms / verify / vault / connect provider).
 # Optional for local/self-hosted no-cloud development. Leave unset/empty to
@@ -57,9 +64,7 @@ UNSPLASH_ACCESS_KEY=""
 
 # KMS provider — "local" for dev, "env" for self-managed symmetric keys,
 # "gcp" for Cloud KMS, "aws" for AWS KMS, "voyant-cloud" for Vault KMS.
-# wrangler.jsonc defaults this to "local" for the dev env; override here if
-# you need to test a different provider locally.
-# KMS_PROVIDER="local"
+KMS_PROVIDER="local"
 
 # KMS_PROVIDER=local: master key (base64-encoded 32 bytes).
 KMS_LOCAL_KEY="<generate with: openssl rand -base64 32>"

--- a/starters/operator/.env.example
+++ b/starters/operator/.env.example
@@ -1,7 +1,8 @@
 # Operator dev/local environment. The operator is Node-only (voyant#2966): copy
-# this to `.env`, fill in values, and it is loaded via `node --env-file` by
-# `pnpm dev` and `pnpm start`. Never commit `.env`. In real deployments the
-# process env comes from the platform (no `.env` file), and platform values win.
+# this to `.env`, fill in values, and it is loaded into process.env by `pnpm dev`
+# and `pnpm start` (a Node `--require` preload). Never commit `.env`. In real
+# deployments the process env comes from the platform (no `.env` file), and
+# already-set platform values always win.
 
 # Runtime URLs + mode. These were `wrangler.jsonc` `vars` under the old Workers
 # build; on Node they live here. `APP_URL` is the API base; `DASH_BASE_URL` the

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -29,8 +29,9 @@ pnpm -F operator dev          # Vite dev server + SSR (port 3300)
 pnpm -F operator dev:worker   # Voyant Workflows dev loop (port 3310)
 ```
 
-`.env` is loaded via Node's `--env-file` by `pnpm dev` and `pnpm start` (the
-Node convention — there is no wrangler `.dev.vars` anymore). `pnpm dev` serves
+`.env` is loaded into the process by `pnpm dev` and `pnpm start` (via a Node
+`--require` preload — the Node convention; there is no wrangler `.dev.vars`
+anymore). `pnpm dev` serves
 the SSR dashboard, the `/api/*` routes, and Better Auth with hot-reload — the
 same `src/server.ts` handler runs under Vite's dev server. The first `/api/*`
 request compiles the API module graph on demand (a few seconds), then it's warm.

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -24,15 +24,16 @@ See [docs/architecture/deployment-targets.md](../../docs/architecture/deployment
 ## Quick start
 
 ```bash
+cp .env.example .env          # fill in DATABASE_URL, BETTER_AUTH_SECRET, …
 pnpm -F operator dev          # Vite dev server + SSR (port 3300)
 pnpm -F operator dev:worker   # Voyant Workflows dev loop (port 3310)
 ```
 
-`pnpm dev` gives UI/SSR hot-reload. For a full local Node runtime that also serves
-the `/v1/*` API (the composed API graph relies on the Vite build, so it does not
-run under the dev module runner), use the production lane below —
-`pnpm -F operator build && PORT=3300 pnpm -F operator start`. Wiring the dev
-server to proxy `/api/*` through the Hono app is a tracked follow-up.
+`.env` is loaded via Node's `--env-file` by `pnpm dev` and `pnpm start` (the
+Node convention — there is no wrangler `.dev.vars` anymore). `pnpm dev` serves
+the SSR dashboard, the `/api/*` routes, and Better Auth with hot-reload — the
+same `src/server.ts` handler runs under Vite's dev server. The first `/api/*`
+request compiles the API module graph on demand (a few seconds), then it's warm.
 
 ## Production (Node)
 
@@ -69,7 +70,7 @@ a legacy fallback for both of those specialized keys.
 ## Flights Demo API
 
 The operator starter is wired to the standalone flights demo API when
-`FLIGHTS_DEMO_API_URL` is set in `.dev.vars`. The service runs on port `3320`
+`FLIGHTS_DEMO_API_URL` is set in `.env`. The service runs on port `3320`
 and owns a separate Postgres database for demo flight orders.
 
 From the monorepo root or from an extracted packaged starter:
@@ -82,7 +83,7 @@ pnpm --dir apps/flights-demo-api db:migrate
 pnpm --dir apps/flights-demo-api dev
 ```
 
-Then keep this in `.dev.vars`:
+Then keep this in `.env`:
 
 ```bash
 FLIGHTS_DEMO_API_URL="http://localhost:3320"

--- a/starters/operator/drizzle.config.ts
+++ b/starters/operator/drizzle.config.ts
@@ -21,7 +21,7 @@ import { schema } from "./drizzle.schemas.generated.ts"
 const customDeploymentSchemas = ["./src/modules/*/schema.ts", "./src/extensions/*/schema.ts"]
 
 // An explicitly-provided DATABASE_URL (CI, the migration-replay oracle, ad-hoc
-// `DATABASE_URL=… pnpm db:push`) must WIN — `.dev.vars` is loaded with
+// `DATABASE_URL=… pnpm db:push`) must WIN — `.env` is loaded with
 // `override: true` for local `pnpm dev` ergonomics, but without this guard it
 // silently clobbers the caller's DATABASE_URL and redirects every db command at
 // the local dev DB. Capture the explicit value first, then restore it last.
@@ -29,7 +29,7 @@ const explicitDatabaseUrl = process.env.DATABASE_URL
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
-config({ path: ".dev.vars", override: true })
+config({ path: ".env", override: true })
 if (explicitDatabaseUrl) process.env.DATABASE_URL = explicitDatabaseUrl
 
 function resolveDatabaseUrl(): string {

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -4,10 +4,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "node --env-file-if-exists=.env node_modules/vite/bin/vite.js dev --port 3300",
+    "dev": "node -r ./scripts/env-preload.cjs node_modules/vite/bin/vite.js dev --port 3300",
     "build": "vite build",
     "preview": "pnpm run build && vite preview",
-    "start": "node --env-file-if-exists=.env dist/server/server.js",
+    "start": "node -r ./scripts/env-preload.cjs dist/server/server.js",
     "typecheck": "NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.server.json && NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.client.json",
     "test": "vitest run --passWithNoTests",
     "generate:openapi": "UPDATE_OPENAPI=1 vitest run src/api/openapi.test.ts",

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -4,10 +4,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "vite dev --port 3300",
+    "dev": "node --env-file-if-exists=.env node_modules/vite/bin/vite.js dev --port 3300",
     "build": "vite build",
     "preview": "pnpm run build && vite preview",
-    "start": "node dist/server/server.js",
+    "start": "node --env-file-if-exists=.env dist/server/server.js",
     "typecheck": "NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.server.json && NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.client.json",
     "test": "vitest run --passWithNoTests",
     "generate:openapi": "UPDATE_OPENAPI=1 vitest run src/api/openapi.test.ts",

--- a/starters/operator/scripts/backfill-custom-fields.ts
+++ b/starters/operator/scripts/backfill-custom-fields.ts
@@ -19,7 +19,7 @@ import { Client } from "pg"
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
-config({ path: ".dev.vars", override: true })
+config({ path: ".env", override: true })
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) {

--- a/starters/operator/scripts/backfill-custom-fields.ts
+++ b/starters/operator/scripts/backfill-custom-fields.ts
@@ -16,10 +16,15 @@
 import { config } from "dotenv"
 import { Client } from "pg"
 
+const explicitDatabaseUrl = process.env.DATABASE_URL
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
 config({ path: ".env", override: true })
+// An explicitly-provided DATABASE_URL (`DATABASE_URL=… tsx scripts/backfill-…`)
+// must WIN over the local `.env` (loaded with override:true for dev ergonomics),
+// which would otherwise redirect a backfill/--clear at the local dev DB.
+if (explicitDatabaseUrl) process.env.DATABASE_URL = explicitDatabaseUrl
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) {

--- a/starters/operator/scripts/env-preload.cjs
+++ b/starters/operator/scripts/env-preload.cjs
@@ -1,0 +1,12 @@
+// Node-native env loading for the `dev` and `start` lanes: load `.env` (if
+// present, from the CWD) into process.env before the app boots — the equivalent
+// of what wrangler did on Workers. Preloaded with `node -r ./scripts/env-preload.cjs`
+// so it works across the whole supported Node range (>=20): `--require` is
+// always available, `process.loadEnvFile` is used when present (Node 20.12+) and
+// no-ops otherwise, and the call never overwrites already-set / platform env.
+// Real deployments have no `.env`, so this is a no-op there.
+try {
+  process.loadEnvFile?.(".env")
+} catch {
+  // no `.env` file — rely on the ambient process.env
+}

--- a/starters/operator/scripts/migrate.ts
+++ b/starters/operator/scripts/migrate.ts
@@ -39,9 +39,9 @@ const explicitDatabaseUrl = process.env.DATABASE_URL
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
-config({ path: ".dev.vars", override: true })
+config({ path: ".env", override: true })
 // An explicitly-provided DATABASE_URL (CI, the migration-replay oracle, ad-hoc
-// runs) must WIN over `.dev.vars` (loaded with `override: true` for local-dev
+// runs) must WIN over `.env` (loaded with `override: true` for local-dev
 // ergonomics), which would otherwise redirect every run at the local dev DB.
 if (explicitDatabaseUrl) process.env.DATABASE_URL = explicitDatabaseUrl
 

--- a/starters/operator/scripts/reindex.ts
+++ b/starters/operator/scripts/reindex.ts
@@ -68,7 +68,7 @@ import { asTypesenseClient } from "./lib/typesense-sdk-client.js"
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
-config({ path: ".dev.vars", override: true })
+config({ path: ".env", override: true })
 
 const databaseUrl = process.env.DATABASE_URL
 const typesenseHost = process.env.TYPESENSE_HOST

--- a/starters/operator/scripts/reindex.ts
+++ b/starters/operator/scripts/reindex.ts
@@ -65,10 +65,14 @@ import {
 } from "./lib/reindex-stale-documents.js"
 import { asTypesenseClient } from "./lib/typesense-sdk-client.js"
 
+const explicitDatabaseUrl = process.env.DATABASE_URL
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
 config({ path: ".env", override: true })
+// An explicitly-provided DATABASE_URL must WIN over the local `.env` (loaded
+// with override:true), which would otherwise reindex the wrong database.
+if (explicitDatabaseUrl) process.env.DATABASE_URL = explicitDatabaseUrl
 
 const databaseUrl = process.env.DATABASE_URL
 const typesenseHost = process.env.TYPESENSE_HOST

--- a/starters/operator/scripts/seed.ts
+++ b/starters/operator/scripts/seed.ts
@@ -9,7 +9,7 @@
  * matching finance docs, a cancellation policy, and a customer contract.
  *
  * Run:   pnpm seed -- --confirm
- * Target: the DATABASE_URL in starters/operator/.dev.vars
+ * Target: the DATABASE_URL in starters/operator/.env
  */
 
 import { readFileSync } from "node:fs"
@@ -157,16 +157,15 @@ function parseDotEnv(path: string): Record<string, string> {
 }
 
 /**
- * Match drizzle.config.ts load order with `.dev.vars` as the final local
+ * Match drizzle.config.ts load order with `.env` as the final local
  * override. This keeps seed, migrate, and local worker runtime aligned.
  */
 function loadEnv(): Record<string, string> {
   const merged: Record<string, string> = {}
   const files = [
-    resolve(TEMPLATE_DIR, ".env"),
     resolve(TEMPLATE_DIR, "../../.env"),
     resolve(TEMPLATE_DIR, "../../.env.local"),
-    resolve(TEMPLATE_DIR, ".dev.vars"),
+    resolve(TEMPLATE_DIR, ".env"),
   ]
   for (const file of files) {
     const parsed = parseDotEnv(file)
@@ -182,7 +181,7 @@ const confirmed = args.includes("--confirm") || args.includes("-y")
 const env = { ...loadEnv(), ...process.env }
 const DATABASE_URL = env.DATABASE_URL
 if (!DATABASE_URL) {
-  console.error("DATABASE_URL not set (checked .dev.vars and process.env)")
+  console.error("DATABASE_URL not set (checked .env and process.env)")
   process.exit(1)
 }
 if (!confirmed) {

--- a/starters/operator/scripts/sync-sources.ts
+++ b/starters/operator/scripts/sync-sources.ts
@@ -51,7 +51,7 @@ import { asTypesenseClient } from "./lib/typesense-sdk-client.js"
 config({ path: ".env" })
 config({ path: "../../.env" })
 config({ path: "../../.env.local" })
-config({ path: ".dev.vars", override: true })
+config({ path: ".env", override: true })
 
 const typesenseHost = process.env.TYPESENSE_HOST
 const typesenseKey = process.env.TYPESENSE_ADMIN_API_KEY ?? process.env.TYPESENSE_API_KEY


### PR DESCRIPTION
Follow-up on the Node-only operator (#2974 / #2976): fix the dev/local **env** story.

## Problem
The operator is Node-only, but its dev env still used the wrangler **`.dev.vars`** convention — and `src/server.ts` never loaded it (wrangler did, on Workers). So `pnpm dev` / `pnpm start` booted with **no secrets** and 500'd on "Missing BETTER_AUTH_SECRET". (This — not any routing bug — is what made `/api` look broken; the earlier README caveat was a mis-diagnosis.)

## Fix
- **`.env`, loaded the Node way.** `dev` and `start` run under `node --env-file-if-exists=.env` — no code loader, no dependency; already-set/platform env wins, and the file is absent in real deployments (no-op there).
- **`.dev.vars.example` → `.env.example`**, folding in the public vars the deleted `wrangler.jsonc` used to provide (`APP_URL`, `DASH_BASE_URL`, `EMAIL_FROM`, `VOYANT_ADMIN_AUTH_MODE`, `KMS_PROVIDER`).
- Operator scripts + `drizzle.config.ts` read `.env`; operator/root/demo-api READMEs updated. **`federated-operator` stays on `.dev.vars`** — it's still a Workers/wrangler deployment.
- Corrects the operator README dev note (dev serves `/api/*` fine).

## Verified
With `.env` present, `pnpm dev` → `/api/auth/get-session` **200**, `/api/openapi.json` **401** (auth), SSR `/` **200** — no missing-secret errors.
