### PR TITLE
Format booking journey side panel dates instead of raw ISO

### DIFF
--- a/.changeset/tidy-pans-shine.md
+++ b/.changeset/tidy-pans-shine.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Format the booking journey side panel stay date range and check-in/check-out rows with locale-aware dates instead of raw ISO strings

--- a/packages/bookings-react/src/journey/components/side-panel.stepHeadline.test.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.stepHeadline.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { getBookingsUiI18n } from "../../i18n/provider.js"
 import { emptyDraft, patchConfigure } from "../lib/draft-state.js"
@@ -20,5 +20,28 @@ describe("stepHeadline — departure stay range (#2967)", () => {
     expect(text).toContain(" → ")
     expect(text).not.toContain("2026-07-06")
     expect(text).not.toContain("2026-07-09")
+  })
+
+  // Date-only strings parse as UTC midnight, so naive local-time rendering
+  // shifts the calendar date back a day for viewers west of UTC.
+  it("does not shift date-only values in timezones west of UTC", () => {
+    vi.stubEnv("TZ", "America/New_York")
+    const messages = getBookingsUiI18n({}).messages
+    const draft = patchConfigure(
+      emptyDraft({ module: "accommodations", id: "acc-1", sourceKind: "" }),
+      { dateRange: { checkIn: "2026-07-06", checkOut: "2026-07-09" } },
+    )
+
+    const text = stepHeadline("departure", draft, messages)
+
+    // Day numbers must stay 6 and 9, not slide to 5 and 8.
+    expect(text).toMatch(/\b6\b/)
+    expect(text).toMatch(/\b9\b/)
+    expect(text).not.toMatch(/\b5\b/)
+    expect(text).not.toMatch(/\b8\b/)
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
   })
 })

--- a/packages/bookings-react/src/journey/components/side-panel.stepHeadline.test.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.stepHeadline.test.tsx
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { getBookingsUiI18n } from "../../i18n/provider.js"
+import { emptyDraft, patchConfigure } from "../lib/draft-state.js"
+import { stepHeadline } from "./side-panel.js"
+
+// The departure summary line used to interpolate the draft's raw YYYY-MM-DD
+// check-in/check-out values (#2967). It now formats them with the locale-aware
+// helper, so the summary must no longer echo the raw ISO strings.
+describe("stepHeadline — departure stay range (#2967)", () => {
+  it("formats the check-in/check-out range instead of showing raw ISO dates", () => {
+    const messages = getBookingsUiI18n({}).messages
+    const draft = patchConfigure(
+      emptyDraft({ module: "accommodations", id: "acc-1", sourceKind: "" }),
+      { dateRange: { checkIn: "2026-07-06", checkOut: "2026-07-09" } },
+    )
+
+    const text = stepHeadline("departure", draft, messages)
+
+    expect(text).toContain(" → ")
+    expect(text).not.toContain("2026-07-06")
+    expect(text).not.toContain("2026-07-09")
+  })
+})

--- a/packages/bookings-react/src/journey/components/side-panel.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.tsx
@@ -588,9 +588,13 @@ function formatTaxRate(rate: number): string {
 function formatConfigureDate(iso: string): string {
   const date = new Date(iso)
   if (Number.isNaN(date.getTime())) return iso
+  // Date-only strings parse as UTC midnight; render them in UTC so the
+  // calendar date is not shifted for viewers in timezones west of UTC.
+  const timeZone = /^\d{4}-\d{2}-\d{2}$/.test(iso) ? "UTC" : undefined
   return new Intl.DateTimeFormat(undefined, {
     year: "numeric",
     month: "short",
     day: "numeric",
+    timeZone,
   }).format(date)
 }

--- a/packages/bookings-react/src/journey/components/side-panel.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.tsx
@@ -218,7 +218,8 @@ export function stepHeadline(
   switch (step) {
     case "departure": {
       const range = draft.configure?.dateRange
-      if (range?.checkIn && range?.checkOut) return `${range.checkIn} → ${range.checkOut}`
+      if (range?.checkIn && range?.checkOut)
+        return `${formatConfigureDate(range.checkIn)} → ${formatConfigureDate(range.checkOut)}`
       // Never surface the raw slot id — show the departure date.
       return draft.configure?.departureDate
         ? formatConfigureDate(draft.configure.departureDate)
@@ -334,10 +335,16 @@ function DepartureDetails({
         />
       ) : null}
       {range?.checkIn ? (
-        <Row label={messages.bookingJourney.sidePanel.checkIn} value={range.checkIn} />
+        <Row
+          label={messages.bookingJourney.sidePanel.checkIn}
+          value={formatConfigureDate(range.checkIn)}
+        />
       ) : null}
       {range?.checkOut ? (
-        <Row label={messages.bookingJourney.sidePanel.checkOut} value={range.checkOut} />
+        <Row
+          label={messages.bookingJourney.sidePanel.checkOut}
+          value={formatConfigureDate(range.checkOut)}
+        />
       ) : null}
     </dl>
   )


### PR DESCRIPTION
Fixes #2967.

The booking journey side panel interpolated the draft's raw `YYYY-MM-DD` check-in/check-out values into the departure summary (`2026-07-06 → 2026-07-08`) and the check-in/check-out rows, alongside dates that were already human-formatted.

Both sites now go through the existing locale-aware `formatConfigureDate` helper in the same file (Intl.DateTimeFormat with a raw-value fallback), keeping the `→` separator. No new formatter or dependency.

- Adds a focused test asserting the departure headline no longer echoes raw ISO strings
- Adds a patch changeset for `@voyant-travel/bookings-react`

Verified: `pnpm --filter @voyant-travel/bookings-react typecheck` / `test` (115 passing) / `lint` all green.
