### PR TITLE
Add managed profile runtime entry

### DIFF
--- a/.changeset/standard-managed-runtime.md
+++ b/.changeset/standard-managed-runtime.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add the published `@voyant-travel/framework/managed-runtime` entry for booting
+a standard managed profile from a serialized profile snapshot without
+starter-local imports. Managed Cloud boot now fails fast when required substrate,
+auth integration, or snapshot plugin resolution is missing, and source-free
+profile composition excludes standard surfaces whose route loaders still live in
+the operator starter.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -34,6 +34,12 @@ workload class well. On Node none of it is necessary.
   adds a real per-request `waitUntil` (background work tracked + drained on
   shutdown), an origin-trust gate, an HTTP `scheduled()` hook, graceful
   SIGTERM/SIGINT drain, and serves the client build (`dist/client`).
+- **Managed Cloud entry:** `@voyant-travel/framework/managed-runtime` boots
+  managed product profiles from serialized profile snapshots without importing
+  starter-local files. Cloud packages this framework-owned entry with
+  provisioned env/secrets; storefront/site artifacts remain separate apps that
+  consume the managed API for the selected profile. Today that profile is the
+  standard managed `operator` profile, but the entry is not named after it.
 - **Bindings are real Node providers, not Cloudflare emulation.** In-process KV
   (`createMemoryKvNamespace`) backs `CACHE`/`RATE_LIMIT`; object storage is
   S3-backed in prod (`createR2BucketShim`) or in-process in dev

--- a/docs/architecture/managed-profile-runtime.md
+++ b/docs/architecture/managed-profile-runtime.md
@@ -1,0 +1,37 @@
+# Managed profile runtime
+
+Status: active rule
+
+`@voyant-travel/framework/managed-runtime` is the framework-owned runtime entry
+for managed product profiles. It is the source-free boundary: code in this entry
+must not import starter-local files, clone a tenant repository, or copy starter
+glue.
+
+The entry loads JSON produced by `defineVoyantProject(...)`, validates it with
+the managed profile contract, bridges it through
+`toCreateVoyantAppProfileConfig(...)`, builds the standard `createVoyantApp(...)`
+profile graph, and exposes a Node server bootstrap through
+`createNodeServer(...)`.
+
+Cloud-managed resources are declared by `getVoyantProjectRequirements(...)` and
+validated before boot. The entry must fail fast when required managed substrate
+is missing instead of silently falling back to process-local storage. Local and
+self-hosted profiles may still use explicit memory providers for offline/dev
+execution.
+
+The source-free managed runtime is not yet a complete managed Cloud image by
+itself. Redis-backed `CACHE`/`RATE_LIMIT` bindings, Voyant Cloud admin auth
+broker integration, snapshot plugin resolution, and route families still backed
+by starter-local loaders must be promoted to package/framework-owned exports
+before the corresponding managed Cloud surfaces can be enabled. Until then, the
+managed Cloud profile bridge excludes those starter-local surfaces and rejects
+explicit attempts to include them.
+
+Storefront, site, blog, and shop apps remain separate Cloud applications that
+consume the managed API for the profile; they are not bundled by this runtime
+entry.
+
+The self-host/demo starter may continue to provide richer deployment-local
+modules, admin shell, auth UI, and example routes. Those files are not part of
+the standard managed runtime contract unless promoted to a package export and
+consumed through `@voyant-travel/framework/managed-runtime`.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -736,6 +736,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -731,6 +731,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -707,6 +707,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -702,6 +702,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -791,6 +791,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -787,6 +787,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -772,6 +772,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -773,6 +773,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -788,6 +788,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -789,6 +789,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -791,6 +791,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -786,6 +786,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./profile": "./src/profile.ts"
+    "./profile": "./src/profile.ts",
+    "./managed-runtime": "./src/managed-runtime.ts"
   },
   "files": [
     "dist"
@@ -37,7 +38,13 @@
     "@voyant-travel/quotes": "workspace:*",
     "@voyant-travel/relationships": "workspace:*",
     "@voyant-travel/storefront": "workspace:*",
-    "@voyant-travel/trips": "workspace:*"
+    "@voyant-travel/trips": "workspace:*",
+    "@voyant-travel/cloud-sdk": "^0.11.0",
+    "@voyant-travel/db": "workspace:*",
+    "@voyant-travel/runtime": "workspace:*",
+    "@voyant-travel/storage": "workspace:*",
+    "@voyant-travel/workflows": "workspace:*",
+    "@voyant-travel/workflows-orchestrator": "workspace:*"
   },
   "peerDependencies": {
     "@hono/zod-openapi": "^1.4.0",
@@ -62,6 +69,10 @@
       "./profile": {
         "types": "./dist/profile.d.ts",
         "import": "./dist/profile.js"
+      },
+      "./managed-runtime": {
+        "types": "./dist/managed-runtime.d.ts",
+        "import": "./dist/managed-runtime.js"
       }
     }
   },

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -13,10 +13,7 @@ import {
   promotionAffectedAllFilter,
 } from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
 import type { BootstrapHandler } from "@voyant-travel/core"
-import type {
-  CheckoutNotificationDelivery,
-  CheckoutPaymentStarter,
-} from "@voyant-travel/finance/checkout"
+import type { CheckoutNotificationDelivery } from "@voyant-travel/finance/checkout"
 import type { CheckoutReminderRunRecord } from "@voyant-travel/finance/checkout-validation"
 import type { LazyRoutesLoader } from "@voyant-travel/hono"
 import type { CompositionRegistry } from "@voyant-travel/hono/composition"
@@ -76,7 +73,7 @@ export interface FrameworkProviders {
   >
   financeCheckoutPolicy?: import("@voyant-travel/finance").FinanceHonoModuleOptions["policy"]
   financePaymentScheduleLineDescriptionFormat?: import("@voyant-travel/finance").FinanceHonoModuleOptions["paymentScheduleLineDescriptionFormat"]
-  netopiaCheckoutStarter: CheckoutPaymentStarter
+  resolvePaymentStarters?: import("@voyant-travel/finance").FinanceHonoModuleOptions["resolvePaymentStarters"]
   notificationsAutoConfirmAndDispatch?: CreateNotificationsHonoModuleOptions["autoConfirmAndDispatch"]
   createChannelPushExtension: () => HonoExtension
   loadFlightAdminRoutes: LazyRoutesLoader
@@ -532,9 +529,7 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
                 ),
             }
           },
-          resolvePaymentStarters: (): Record<string, CheckoutPaymentStarter> => ({
-            netopia: capabilities.netopiaCheckoutStarter,
-          }),
+          resolvePaymentStarters: capabilities.resolvePaymentStarters,
           policy: capabilities.financeCheckoutPolicy,
           paymentScheduleLineDescriptionFormat:
             capabilities.financePaymentScheduleLineDescriptionFormat,

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -70,10 +70,7 @@ import {
   createFinanceHonoModule,
   type FinanceHonoModuleOptions,
 } from "@voyant-travel/finance"
-import type {
-  CheckoutNotificationDelivery,
-  CheckoutPaymentStarter,
-} from "@voyant-travel/finance/checkout"
+import type { CheckoutNotificationDelivery } from "@voyant-travel/finance/checkout"
 import type { CheckoutReminderRunRecord } from "@voyant-travel/finance/checkout-validation"
 import {
   createPublicDocumentDeliveryHonoModule,
@@ -355,8 +352,8 @@ export interface FrameworkProviders {
    * Optional: omitted deployments keep the finance module default.
    */
   financePaymentScheduleLineDescriptionFormat?: FinanceHonoModuleOptions["paymentScheduleLineDescriptionFormat"]
-  /** The configured pay-by-link starter (Netopia; env resolved lazily). */
-  netopiaCheckoutStarter: CheckoutPaymentStarter
+  /** Configured pay-by-link starters, keyed by payment provider id. */
+  resolvePaymentStarters?: import("@voyant-travel/finance").FinanceHonoModuleOptions["resolvePaymentStarters"]
   /**
    * Booking-confirmed notification auto-dispatch policy. Optional: omitted
    * deployments keep the standard booking-confirmation auto-send.
@@ -517,9 +514,7 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
                 ),
             }
           },
-          resolvePaymentStarters: (): Record<string, CheckoutPaymentStarter> => ({
-            netopia: capabilities.netopiaCheckoutStarter,
-          }),
+          resolvePaymentStarters: capabilities.resolvePaymentStarters,
           policy: capabilities.financeCheckoutPolicy,
           paymentScheduleLineDescriptionFormat:
             capabilities.financePaymentScheduleLineDescriptionFormat,

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -1,0 +1,180 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  createManagedProfileNodeEnv,
+  createManagedProfileProviders,
+  loadManagedProfileRuntime,
+} from "./managed-runtime.js"
+import { defineVoyantProject, type VoyantProjectProviders } from "./profile.js"
+
+const localProviders = {
+  database: "postgres",
+  storage: "memory",
+  cache: "memory",
+  sharedState: "memory",
+  rateLimit: "memory",
+  search: "none",
+  email: "none",
+  sms: "none",
+  auth: "better-auth",
+  scheduledJobs: "none",
+  workflows: "none",
+} satisfies VoyantProjectProviders
+
+describe("managed profile runtime entry", () => {
+  it("loads a local source-free profile snapshot without starter-local glue", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    const runtime = await loadManagedProfileRuntime({
+      profileSnapshotPath: snapshotPath,
+      env: {
+        DATABASE_URL: "managed-profile-test-db",
+      },
+    })
+
+    expect(runtime.project.profile).toBe("operator")
+    expect(runtime.requirements.modules.createVoyantAppExclude).toContain("@voyant-travel/flights")
+    expect(runtime.app.fetch).toEqual(expect.any(Function))
+  })
+
+  it("fails fast when a managed-cloud profile is missing required runtime substrate", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+        }),
+      ),
+    )
+
+    await expect(
+      loadManagedProfileRuntime({
+        profileSnapshotPath: snapshotPath,
+        env: {
+          DATABASE_URL: "managed-profile-test-db",
+        },
+      }),
+    ).rejects.toThrow(/REDIS_URL|admin auth integration|R2_S3_ENDPOINT/)
+  })
+
+  it("rejects snapshot plugins instead of silently ignoring them", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          plugins: ["@voyant-travel/plugin-netopia"],
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    await expect(
+      loadManagedProfileRuntime({
+        profileSnapshotPath: snapshotPath,
+        env: {
+          DATABASE_URL: "managed-profile-test-db",
+        },
+      }),
+    ).rejects.toThrow(/snapshot plugins are not yet resolved/)
+  })
+
+  it("builds managed Node bindings from plain env/secrets", () => {
+    const env = createManagedProfileNodeEnv({
+      DATABASE_URL: "managed-profile-test-db",
+      R2_S3_ENDPOINT: "https://r2.example.test",
+      R2_ACCESS_KEY_ID: "access",
+      R2_SECRET_ACCESS_KEY: "secret",
+      R2_BUCKET_MEDIA: "media",
+      R2_BUCKET_DOCUMENTS: "documents",
+    })
+
+    expect(env.CACHE).toBeDefined()
+    expect(env.RATE_LIMIT).toBeDefined()
+    expect(env.MEDIA_BUCKET).toBeDefined()
+    expect(env.DOCUMENTS_BUCKET).toBeDefined()
+  })
+
+  it("preserves injected KV and R2 bindings", () => {
+    const kv = {
+      get: async () => null,
+      put: async () => {},
+      delete: async () => {},
+    }
+    const bucket = {
+      get: async () => null,
+      head: async () => null,
+      put: async () => ({ key: "x" }),
+      delete: async () => {},
+    }
+
+    const env = createManagedProfileNodeEnv({
+      DATABASE_URL: "managed-profile-test-db",
+      CACHE: kv,
+      RATE_LIMIT: kv,
+      MEDIA_BUCKET: bucket,
+      DOCUMENTS_BUCKET: bucket,
+    })
+
+    expect(env.CACHE).toBe(kv)
+    expect(env.RATE_LIMIT).toBe(kv)
+    expect(env.MEDIA_BUCKET).toBe(bucket)
+    expect(env.DOCUMENTS_BUCKET).toBe(bucket)
+  })
+
+  it("keeps the runtime entry free of starter/operator imports", async () => {
+    const source = await readFile(new URL("./managed-runtime.ts", import.meta.url), "utf8")
+
+    expect(source).not.toContain("starters/operator")
+    expect(source).not.toContain("../../starters")
+    expect(createManagedProfileProviders()).toBeDefined()
+  })
+
+  it("keeps payment starters provider-neutral", async () => {
+    const defaultProviders = createManagedProfileProviders()
+    expect(defaultProviders.resolvePaymentStarters?.({})).toEqual({})
+    expect(defaultProviders).not.toHaveProperty("netopiaCheckoutStarter")
+
+    const providers = createManagedProfileProviders({
+      resolvePaymentStarters: () => ({
+        stripe: async () => ({
+          provider: "stripe",
+          paymentSessionId: "ps_test",
+          redirectUrl: "https://pay.example.test/session",
+          externalReference: null,
+          providerSessionId: "checkout_session",
+          providerPaymentId: null,
+          response: null,
+        }),
+      }),
+    })
+
+    expect(Object.keys(providers.resolvePaymentStarters?.({}) ?? {})).toEqual(["stripe"])
+  })
+})

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -1,0 +1,620 @@
+// agent-quality: file-size exception -- this entry is the managed profile
+// runtime composition boundary: profile validation, env binding assembly, and
+// provider defaults stay together so Cloud boot behavior is auditable.
+import { readFile } from "node:fs/promises"
+
+import { getVoyantCloudClient } from "@voyant-travel/cloud-sdk"
+import { createDbClient } from "@voyant-travel/db"
+import type { ResolveInvoiceExchangeRate } from "@voyant-travel/finance"
+import type {
+  LazyRoutesLoader,
+  VoyantAuthIntegration,
+  VoyantBindings,
+  VoyantDb,
+} from "@voyant-travel/hono"
+import type { HonoExtension } from "@voyant-travel/hono/module"
+import {
+  createVoyantCloudEmailProvider,
+  createVoyantCloudSmsProvider,
+  type NotificationProvider,
+} from "@voyant-travel/notifications"
+import {
+  type CreateNodeServerOptions,
+  composeNodeEnv,
+  createMemoryKvNamespace,
+  createMemoryR2Bucket,
+  createNodeServer,
+  createR2BucketShim,
+  type ExecutionContextLike,
+  type KvNamespaceShim,
+  type NodeServerHandle,
+  type R2BucketShim,
+} from "@voyant-travel/runtime"
+import { createR2Provider, type R2BucketLike } from "@voyant-travel/storage/providers/r2"
+import { createCloudWorkflowDriver } from "@voyant-travel/workflows/client"
+import { createInMemoryDriver } from "@voyant-travel/workflows-orchestrator/in-memory"
+import { Hono } from "hono"
+
+import type { FrameworkProviders } from "./composition-lazy.js"
+import { type CreateVoyantAppConfig, createVoyantApp } from "./create-app.js"
+import {
+  getVoyantProjectRequirements,
+  toCreateVoyantAppProfileConfig,
+  type VoyantProfileRequirements,
+  type VoyantProjectManifest,
+  validateVoyantProject,
+} from "./profile.js"
+
+export interface ManagedProfileRuntimeEnv extends VoyantBindings {
+  DATABASE_URL_DIRECT?: string
+  DATABASE_URL_REPLICAS?: string
+  R2_S3_ENDPOINT?: string
+  R2_ACCESS_KEY_ID?: string
+  R2_SECRET_ACCESS_KEY?: string
+  R2_BUCKET_MEDIA?: string
+  R2_BUCKET_DOCUMENTS?: string
+  MEDIA_BUCKET?: R2BucketShim
+  DOCUMENTS_BUCKET?: R2BucketShim
+  MEDIA_PUBLIC_BASE_URL?: string
+  API_BASE_URL?: string
+  REDIS_URL?: string
+  EMAIL_FROM?: string
+  EMAIL_REPLY_TO?: string
+  PUBLIC_CHECKOUT_BASE_URL?: string
+  VOYANT_API_KEY?: string
+  VOYANT_CLOUD_API_KEY?: string
+  VOYANT_CLOUD_API_URL?: string
+  VOYANT_DATA_API_KEY?: string
+  VOYANT_ADMIN_AUTH_MODE?: string
+  VOYANT_CLOUD_DEPLOYMENT_ID?: string
+  VOYANT_CLOUD_ADMIN_AUTH_START_URL?: string
+  VOYANT_CLOUD_ADMIN_AUTH_EXCHANGE_URL?: string
+  VOYANT_CLOUD_ADMIN_AUTH_JWKS_URL?: string
+  VOYANT_CLOUD_ADMIN_AUTH_REVALIDATE_URL?: string
+  VOYANT_CLOUD_ADMIN_AUTH_CLIENT_TOKEN?: string
+  SESSION_CLAIMS_SECRET?: string
+  BETTER_AUTH_SECRET?: string
+  VOYANT_CLOUD_WORKFLOWS_URL?: string
+  VOYANT_CLOUD_WORKFLOW_TRIGGER_TOKEN?: string
+  VOYANT_CLOUD_APP_SLUG?: string
+  VOYANT_CLOUD_ENVIRONMENT?: "production" | "preview" | "development"
+  BANK_TRANSFER_BANK_NAME?: string
+  BANK_TRANSFER_BENEFICIARY?: string
+  BANK_TRANSFER_IBAN?: string
+  BANK_TRANSFER_NOTES?: string
+  ORIGIN_TRUST_SECRET?: string
+  PORT?: string
+}
+
+export interface ManagedProfileRuntimeOptions {
+  profileSnapshotPath: string
+  env?: Record<string, unknown> | ManagedProfileRuntimeEnv
+  auth?: VoyantAuthIntegration<ManagedProfileRuntimeEnv>
+  providers?: Partial<FrameworkProviders>
+  app?: Partial<
+    Omit<
+      CreateVoyantAppConfig<ManagedProfileRuntimeEnv, FrameworkProviders>,
+      "providers" | "exclude"
+    >
+  >
+}
+
+export interface ManagedProfileRuntime {
+  project: VoyantProjectManifest
+  requirements: VoyantProfileRequirements
+  env: ManagedProfileRuntimeEnv
+  app: ReturnType<typeof createManagedProfileApp>
+  fetch: (
+    request: Request,
+    env?: ManagedProfileRuntimeEnv,
+    ctx?: ExecutionContextLike,
+  ) => Response | Promise<Response>
+  start: (options?: Partial<CreateNodeServerOptions<ManagedProfileRuntimeEnv>>) => NodeServerHandle
+}
+
+type AsyncMethodProvider<T extends object> = {
+  [K in keyof T]: T[K] extends (...args: infer Args) => infer Result
+    ? (...args: Args) => Promise<Awaited<Result>>
+    : never
+}
+
+let pooledDb: { url: string; db: VoyantDb } | undefined
+
+export async function loadManagedProfileRuntime(
+  options: ManagedProfileRuntimeOptions,
+): Promise<ManagedProfileRuntime> {
+  const project = await loadManagedProfileSnapshot(options.profileSnapshotPath)
+  const env = createManagedProfileNodeEnv(options.env ?? process.env)
+  const requirements = getVoyantProjectRequirements(project)
+  assertManagedProfileRuntimeSupport({
+    project,
+    requirements,
+    env,
+    hasAuthIntegration: Boolean(options.auth ?? options.app?.auth),
+  })
+  const app = createManagedProfileApp({
+    project,
+    env,
+    auth: options.auth,
+    providers: options.providers,
+    app: options.app,
+  })
+
+  return {
+    project,
+    requirements,
+    env,
+    app,
+    fetch: (request, bindings = env, ctx = createNoopExecutionContext()) =>
+      app.fetch(request, bindings, toHonoExecutionContext(ctx)),
+    start: (serverOptions = {}) =>
+      createNodeServer<ManagedProfileRuntimeEnv>({
+        fetch: (request, bindings, ctx) =>
+          app.fetch(request, bindings, toHonoExecutionContext(ctx)),
+        env,
+        port: Number.parseInt(env.PORT ?? "8080", 10),
+        ...(env.ORIGIN_TRUST_SECRET ? { originTrustSecret: env.ORIGIN_TRUST_SECRET } : {}),
+        ...serverOptions,
+      }),
+  }
+}
+
+export async function startManagedProfileRuntime(
+  options: ManagedProfileRuntimeOptions & {
+    server?: Partial<CreateNodeServerOptions<ManagedProfileRuntimeEnv>>
+  },
+): Promise<NodeServerHandle> {
+  const runtime = await loadManagedProfileRuntime(options)
+  return runtime.start(options.server)
+}
+
+export async function loadManagedProfileSnapshot(
+  profileSnapshotPath: string,
+): Promise<VoyantProjectManifest> {
+  const raw = await readFile(profileSnapshotPath, "utf8")
+  const parsed = JSON.parse(raw) as unknown
+  const validation = validateVoyantProject(parsed)
+  if (!validation.ok) {
+    throw new Error(
+      `Invalid managed profile snapshot:\n${validation.issues
+        .map((issue) => `- ${issue.path || "<root>"}: ${issue.message}`)
+        .join("\n")}`,
+    )
+  }
+  return parsed as VoyantProjectManifest
+}
+
+export function createManagedProfileApp(options: {
+  project: VoyantProjectManifest
+  env?: ManagedProfileRuntimeEnv
+  auth?: VoyantAuthIntegration<ManagedProfileRuntimeEnv>
+  providers?: Partial<FrameworkProviders>
+  app?: Partial<
+    Omit<
+      CreateVoyantAppConfig<ManagedProfileRuntimeEnv, FrameworkProviders>,
+      "providers" | "exclude"
+    >
+  >
+}) {
+  assertManagedProfileAppSupport({
+    project: options.project,
+    hasAuthIntegration: Boolean(options.auth ?? options.app?.auth),
+  })
+  const bridge = toCreateVoyantAppProfileConfig(options.project)
+  return createVoyantApp<ManagedProfileRuntimeEnv, FrameworkProviders>({
+    db: dbFromEnvForApp,
+    dbTransactional: dbFromEnvForApp,
+    outbox: true,
+    workflows: {
+      driver: (bindings) =>
+        createManagedProfileWorkflowDriver(
+          bindings as ManagedProfileRuntimeEnv,
+          options.project.profile,
+        ),
+      environment: options.env?.VOYANT_CLOUD_ENVIRONMENT ?? "development",
+      projectId: options.env?.VOYANT_CLOUD_APP_SLUG ?? options.project.profile,
+    },
+    auth: options.auth,
+    ...options.app,
+    exclude: bridge.exclude,
+    providers: createManagedProfileProviders(options.providers),
+  })
+}
+
+export function createManagedProfileProviders(
+  overrides: Partial<FrameworkProviders> = {},
+): FrameworkProviders {
+  const providers: FrameworkProviders = {
+    resolveNotificationProviders: resolveManagedNotificationProviders,
+    resolvePublicCheckoutBaseUrl: resolvePublicCheckoutBaseUrl,
+    resolveDocumentDownloadUrl: resolveDocumentDownloadUrl,
+    readDocumentContentBase64: readDocumentContentBase64,
+    resolveDb: resolveDb,
+    createOperatorDocumentStorage: createDocumentStorage,
+    resolveContractDocumentGenerator: () => undefined,
+    createBookingPiiService: async () => null,
+    autoGenerateContractOnConfirmed: {
+      enabled: false,
+      templateSlug: "customer-sales-agreement",
+    },
+    resolveBankTransferDetails,
+    relationshipsService: lazyRelationshipsService(),
+    closePaymentSchedulesForBooking: async () => {},
+    recordCancellationFinancialSettlement: async () => null,
+    resolveBookingRequirementsProductSnapshot: async () => null,
+    resolveCatalogRuntime: (c) => ({
+      indexer: undefined,
+      embeddings: undefined,
+      defaultScope: {
+        locale: "en-GB",
+        audience: c.var.actor === "staff" ? "staff" : (c.var.actor ?? "customer"),
+        market: "default",
+      },
+    }),
+    createInvoiceExchangeRateResolver: createInvoiceExchangeRateResolver,
+    createInvoiceSettlementPollers: () => ({}),
+    createTripsRoutesOptions: async () => ({}),
+    storefrontIntakePersistence: createNoopStorefrontIntakePersistence(),
+    resolvePaymentStarters: () => ({}),
+    createChannelPushExtension: createEmptyChannelPushExtension,
+    loadFlightAdminRoutes: emptyRoutes,
+    loadMcpAdminRoutes: emptyRoutes,
+    loadCatalogBookingRoutes: emptyRoutes,
+    loadCatalogContentRoutes: emptyRoutes,
+    loadMediaRoutes: emptyRoutes,
+    loadPaymentLinkRoutes: emptyRoutes,
+    loadContractDocumentRoutes: emptyRoutes,
+    loadBookingScheduleAdminRoutes: emptyRoutes,
+    loadPaymentPolicyPublicRoutes: emptyRoutes,
+    loadQuoteVersionSnapshotRoutes: emptyRoutes,
+    loadBookingMaintenanceRoutes: emptyRoutes,
+    loadActionLedgerHealthRoutes: emptyRoutes,
+    loadProposalAdminRoutes: emptyRoutes,
+    loadProposalPublicRoutes: emptyRoutes,
+    loadCatalogOffersRoutes: emptyRoutes,
+    loadCatalogCheckoutRoutes: emptyRoutes,
+  }
+  return { ...providers, ...overrides }
+}
+
+export function createManagedProfileNodeEnv(
+  processEnv: Record<string, unknown> | ManagedProfileRuntimeEnv,
+): ManagedProfileRuntimeEnv {
+  const raw: Record<string, unknown> = Object.fromEntries(Object.entries(processEnv))
+  const stringEnv = Object.fromEntries(
+    Object.entries(raw).filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  )
+  return composeNodeEnv<ManagedProfileRuntimeEnv>(stringEnv, {
+    kv: {
+      CACHE: isKvNamespace(raw.CACHE) ? raw.CACHE : createMemoryKvNamespace(),
+      RATE_LIMIT: isKvNamespace(raw.RATE_LIMIT) ? raw.RATE_LIMIT : createMemoryKvNamespace(),
+    },
+    r2: {
+      MEDIA_BUCKET: isR2Bucket(raw.MEDIA_BUCKET)
+        ? raw.MEDIA_BUCKET
+        : objectStore(stringEnv.R2_BUCKET_MEDIA, stringEnv),
+      DOCUMENTS_BUCKET: isR2Bucket(raw.DOCUMENTS_BUCKET)
+        ? raw.DOCUMENTS_BUCKET
+        : objectStore(stringEnv.R2_BUCKET_DOCUMENTS, stringEnv),
+    },
+  })
+}
+
+function assertManagedProfileRuntimeSupport(options: {
+  project: VoyantProjectManifest
+  requirements: VoyantProfileRequirements
+  env: ManagedProfileRuntimeEnv
+  hasAuthIntegration: boolean
+}) {
+  const issues = [
+    ...managedProfileAppSupportIssues(options.project, options.hasAuthIntegration),
+    ...managedProfileEnvIssues(options.requirements, options.env),
+  ]
+  if (issues.length > 0) {
+    throw new Error(`Managed profile runtime is not ready to start:\n${formatIssues(issues)}`)
+  }
+}
+
+function assertManagedProfileAppSupport(options: {
+  project: VoyantProjectManifest
+  hasAuthIntegration: boolean
+}) {
+  const issues = managedProfileAppSupportIssues(options.project, options.hasAuthIntegration)
+  if (issues.length > 0) {
+    throw new Error(`Managed profile app is not ready to start:\n${formatIssues(issues)}`)
+  }
+}
+
+function managedProfileAppSupportIssues(
+  project: VoyantProjectManifest,
+  hasAuthIntegration: boolean,
+): string[] {
+  const issues: string[] = []
+  if (project.plugins.length > 0) {
+    issues.push(
+      `snapshot plugins are not yet resolved by @voyant-travel/framework/managed-runtime: ${project.plugins.join(
+        ", ",
+      )}`,
+    )
+  }
+  if (project.mode === "managed-cloud" && !hasAuthIntegration) {
+    issues.push(
+      "managed-cloud profiles require an injected admin auth integration until the Voyant Cloud auth broker is packaged in the managed runtime",
+    )
+  }
+  return issues
+}
+
+function managedProfileEnvIssues(
+  requirements: VoyantProfileRequirements,
+  env: ManagedProfileRuntimeEnv,
+): string[] {
+  const issues: string[] = []
+  for (const resource of requirements.resources) {
+    if (resource.required && resource.provider === "redis") {
+      issues.push(
+        "Redis-backed CACHE/RATE_LIMIT bindings for REDIS_URL are not implemented in @voyant-travel/framework/managed-runtime yet",
+      )
+    }
+    for (const requirement of resource.env) {
+      if (!requirement.required) continue
+      const value = getEnvValue(env, requirement.name)
+      const present =
+        typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+      if (!present) {
+        issues.push(
+          `${requirement.kind} ${requirement.name} is required for ${resource.resourceKey}`,
+        )
+      }
+    }
+  }
+  return [...new Set(issues)]
+}
+
+function formatIssues(issues: readonly string[]): string {
+  return issues.map((issue) => `- ${issue}`).join("\n")
+}
+
+function getEnvValue(env: ManagedProfileRuntimeEnv, name: string): unknown {
+  return Reflect.get(env, name)
+}
+
+function dbUrl(env: ManagedProfileRuntimeEnv): string {
+  const url = env.DATABASE_URL_DIRECT?.trim() || env.DATABASE_URL?.trim()
+  if (!url) throw new Error("Managed profile runtime requires DATABASE_URL.")
+  return url
+}
+
+function resolveDb(env: unknown): VoyantDb {
+  const bindings = env as ManagedProfileRuntimeEnv
+  const url = dbUrl(bindings)
+  if (pooledDb?.url !== url) {
+    const replicas = parseReplicaUrls(bindings.DATABASE_URL_REPLICAS, url)
+    pooledDb = {
+      url,
+      db: createDbClient(url, {
+        adapter: "node",
+        ...(replicas.length > 0 ? { replicas } : {}),
+      }) as VoyantDb,
+    }
+  }
+  return pooledDb.db
+}
+
+function dbFromEnvForApp(env: ManagedProfileRuntimeEnv): VoyantDb {
+  return resolveDb(env)
+}
+
+function parseReplicaUrls(raw: string | undefined, primaryUrl: string): string[] {
+  if (!raw) return []
+  return raw
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0 && entry !== primaryUrl)
+}
+
+function objectStore(
+  bucket: string | undefined,
+  env: Record<string, string | undefined>,
+): R2BucketShim {
+  if (env.R2_S3_ENDPOINT && env.R2_ACCESS_KEY_ID && env.R2_SECRET_ACCESS_KEY && bucket) {
+    return createR2BucketShim({
+      endpoint: env.R2_S3_ENDPOINT,
+      bucket,
+      accessKeyId: env.R2_ACCESS_KEY_ID,
+      secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+    })
+  }
+  return createMemoryR2Bucket()
+}
+
+function isKvNamespace(value: unknown): value is KvNamespaceShim {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "get" in value &&
+    "put" in value &&
+    "delete" in value
+  )
+}
+
+function isR2Bucket(value: unknown): value is R2BucketShim {
+  return typeof value === "object" && value !== null && "get" in value && "put" in value
+}
+
+function createStorageProvider(bucket: R2BucketLike | undefined, publicBaseUrl?: string) {
+  if (!bucket) return null
+  return createR2Provider({
+    bucket,
+    ...(publicBaseUrl ? { publicBaseUrl } : {}),
+  })
+}
+
+function createDocumentStorage(bindings: unknown) {
+  return createStorageProvider((bindings as ManagedProfileRuntimeEnv).DOCUMENTS_BUCKET)
+}
+
+async function readDocumentContentBase64(
+  bindings: unknown,
+  storageKey: string,
+): Promise<string | null> {
+  const object = await (bindings as ManagedProfileRuntimeEnv).DOCUMENTS_BUCKET?.get(storageKey)
+  if (!object) return null
+  return arrayBufferToBase64(await object.arrayBuffer())
+}
+
+async function resolveDocumentDownloadUrl(
+  bindings: unknown,
+  storageKey: string,
+): Promise<string | null> {
+  const env = bindings as ManagedProfileRuntimeEnv
+  const base = env.API_BASE_URL?.trim() || env.APP_URL?.trim()
+  if (!base) return null
+  return `${base.replace(/\/+$/, "")}/v1/admin/documents/files/${encodeURIComponent(storageKey)}`
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  if (typeof Buffer !== "undefined") {
+    return Buffer.from(buffer).toString("base64")
+  }
+  const bytes = new Uint8Array(buffer)
+  let binary = ""
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    binary += String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}
+
+function resolvePublicCheckoutBaseUrl(bindings: unknown): string | null {
+  const env = bindings as ManagedProfileRuntimeEnv
+  return (
+    env.PUBLIC_CHECKOUT_BASE_URL?.trim() ||
+    env.DASH_BASE_URL?.trim() ||
+    env.APP_URL?.trim().replace(/\/api\/?$/, "") ||
+    null
+  )
+}
+
+function resolveBankTransferDetails(bindings: unknown) {
+  const env = bindings as ManagedProfileRuntimeEnv
+  if (!env.BANK_TRANSFER_BENEFICIARY || !env.BANK_TRANSFER_IBAN) return null
+  return {
+    provider: "bank-transfer" as const,
+    beneficiary: env.BANK_TRANSFER_BENEFICIARY,
+    iban: env.BANK_TRANSFER_IBAN,
+    bankName: env.BANK_TRANSFER_BANK_NAME ?? null,
+    notes: env.BANK_TRANSFER_NOTES ?? null,
+  }
+}
+
+function resolveManagedNotificationProviders(bindings: unknown) {
+  const env = bindings as ManagedProfileRuntimeEnv
+  const apiKey = env.VOYANT_API_KEY?.trim() || env.VOYANT_CLOUD_API_KEY?.trim()
+  if (!apiKey) return []
+  const cloud = getVoyantCloudClient(
+    {
+      VOYANT_CLOUD_API_KEY: apiKey,
+      ...(env.VOYANT_CLOUD_API_URL ? { VOYANT_CLOUD_API_URL: env.VOYANT_CLOUD_API_URL } : {}),
+    },
+    { apiKey },
+  )
+  const from = env.EMAIL_FROM?.trim() || "Voyant <noreply@voyantcloud.app>"
+  const replyTo = resolveEmailReplyTo(env.EMAIL_REPLY_TO)
+  const providers: NotificationProvider[] = [
+    createVoyantCloudEmailProvider({
+      client: cloud,
+      from,
+      ...(replyTo ? { replyTo } : {}),
+    }),
+    createVoyantCloudSmsProvider({ client: cloud }),
+  ]
+  return providers
+}
+
+function resolveEmailReplyTo(value: string | undefined): string[] | null {
+  if (!value) return null
+  const addresses = value
+    .split(",")
+    .map((address) => address.trim())
+    .filter(Boolean)
+  return addresses.length > 0 ? addresses : null
+}
+
+function createInvoiceExchangeRateResolver(
+  bindings: unknown,
+): ResolveInvoiceExchangeRate | undefined {
+  const env = bindings as ManagedProfileRuntimeEnv
+  const apiKey = env.VOYANT_DATA_API_KEY?.trim() || env.VOYANT_API_KEY?.trim()
+  if (!apiKey) return undefined
+  return async (input) => {
+    const { createVoyantDataFxExchangeRateResolver } = await import("@voyant-travel/finance")
+    return createVoyantDataFxExchangeRateResolver({
+      apiKey,
+      baseUrl: env.VOYANT_CLOUD_API_URL,
+    })(input)
+  }
+}
+
+function createManagedProfileWorkflowDriver(env: ManagedProfileRuntimeEnv, defaultAppSlug: string) {
+  if (env.VOYANT_CLOUD_WORKFLOWS_URL?.trim() && env.VOYANT_CLOUD_WORKFLOW_TRIGGER_TOKEN?.trim()) {
+    return () =>
+      createCloudWorkflowDriver({
+        env: {
+          VOYANT_CLOUD_WORKFLOWS_URL: env.VOYANT_CLOUD_WORKFLOWS_URL,
+          VOYANT_CLOUD_WORKFLOW_TRIGGER_TOKEN: env.VOYANT_CLOUD_WORKFLOW_TRIGGER_TOKEN,
+          VOYANT_CLOUD_APP_SLUG: env.VOYANT_CLOUD_APP_SLUG ?? defaultAppSlug,
+          VOYANT_CLOUD_ENVIRONMENT: env.VOYANT_CLOUD_ENVIRONMENT,
+        },
+      })
+  }
+  return createInMemoryDriver()
+}
+
+function lazyRelationshipsService(): FrameworkProviders["relationshipsService"] {
+  let servicePromise: Promise<FrameworkProviders["relationshipsService"]> | undefined
+  const load = async () => {
+    servicePromise ??= import("@voyant-travel/relationships").then(
+      (m) =>
+        m.relationshipsService as AsyncMethodProvider<FrameworkProviders["relationshipsService"]>,
+    )
+    return servicePromise
+  }
+  return {
+    getPersonById: async (...args) => (await load()).getPersonById(...args),
+    getOrganizationById: async (...args) => (await load()).getOrganizationById(...args),
+    loadPersonTravelSnapshot: async (...args) => (await load()).loadPersonTravelSnapshot(...args),
+    upsertPersonFromContact: async (...args) => (await load()).upsertPersonFromContact(...args),
+  }
+}
+
+function createNoopStorefrontIntakePersistence(): FrameworkProviders["storefrontIntakePersistence"] {
+  return {
+    findSignal: async () => null,
+    createPerson: async () => null,
+    createCustomerSignal: async () => null,
+    updateCustomerSignal: async () => null,
+    deleteCustomerSignal: async () => {},
+    deletePerson: async () => {},
+  }
+}
+
+const emptyRoutes: LazyRoutesLoader = async () => new Hono()
+
+function createEmptyChannelPushExtension(): HonoExtension {
+  return {
+    extension: { name: "channel-push", module: "distribution" },
+    lazyAdminRoutes: emptyRoutes,
+  }
+}
+
+function createNoopExecutionContext(): ExecutionContextLike {
+  return { waitUntil: () => {} }
+}
+
+function toHonoExecutionContext(ctx: ExecutionContextLike) {
+  return {
+    waitUntil: (promise: Promise<unknown>) => ctx.waitUntil(promise),
+    passThroughOnException: () => ctx.passThroughOnException?.(),
+    props: undefined,
+  }
+}

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -83,6 +83,28 @@ export const FRAMEWORK_RUNTIME_MANIFEST = {
   ],
 } as const satisfies FrameworkManifest
 
+export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
+  "@voyant-travel/flights",
+  "operator/mcp",
+  "operator/catalog-booking",
+  "operator/catalog-content",
+  "operator/media",
+  "operator/payment-link",
+  "operator/contract-document",
+  "@voyant-travel/distribution/channel-push-extension",
+  "operator/booking-schedule-extension",
+  "operator/quote-version-snapshot-extension",
+  "operator/booking-maintenance-extension",
+  "operator/action-ledger-health-extension",
+  "operator/proposal-extension",
+  "operator/catalog-offers-extension",
+  "operator/catalog-checkout-extension",
+] as const
+
+export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET = new Set<string>(
+  FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS,
+)
+
 /**
  * The standard set's capability dependency graph (ADR-0007). `isRequired` marks
  * foundational modules a deployment may not `exclude`; `createVoyantApp` throws a

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
+import {
+  FRAMEWORK_RUNTIME_MANIFEST,
+  FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS,
+} from "./manifest.js"
 import {
   defineVoyantProject,
   getVoyantProjectMigrationMetadata,
@@ -209,6 +212,25 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.modules).not.toContain("@voyant-travel/storefront")
     expect(bridge.manifest.modules).not.toContain("@voyant-travel/storefront/customer-portal")
     expect(bridge.manifest.modules).not.toContain("@voyant-travel/storefront/verification")
+    for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS) {
+      expect([...bridge.manifest.modules, ...bridge.manifest.extensions]).not.toContain(specifier)
+      expect(bridge.exclude).toContain(specifier)
+    }
+  })
+
+  it("rejects explicit managed-cloud modules that still require starter-local glue", () => {
+    const result = validateVoyantProject({
+      ...validProject({ plugins: [] }),
+      modules: ["catalog", "flights"],
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        path: "modules",
+        code: "invalid_module_subset",
+      }),
+    ])
   })
 
   it("rejects website artifacts because customer-facing apps are separate", () => {

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -1,5 +1,8 @@
 import { subsetStandardManifest } from "./create-app.js"
-import { FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
+import {
+  FRAMEWORK_RUNTIME_MANIFEST,
+  FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET,
+} from "./manifest.js"
 import { resourceRequirementsFor } from "./profile-requirements.js"
 import {
   type DefineVoyantProjectInput,
@@ -262,6 +265,19 @@ function computeCreateVoyantAppExclude(project: VoyantProjectManifest): string[]
   const excluded = new Set<string>()
   const include = project.modules.length > 0 ? project.modules : OPERATOR_DEFAULT_MODULE_SPECIFIERS
 
+  if (project.mode === "managed-cloud" && project.modules.length > 0) {
+    const unsupported = project.modules
+      .map((ref) => moduleSpecifierFromReference(ref, "module"))
+      .filter((specifier) => FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET.has(specifier))
+    if (unsupported.length > 0) {
+      throw new Error(
+        `Managed Cloud source-free profiles cannot include starter-local module(s): ${unique(
+          unsupported,
+        ).join(", ")}.`,
+      )
+    }
+  }
+
   if (include.length > 0) {
     const includedSpecifiers = new Set<string>(
       include.map((ref) => moduleSpecifierFromReference(ref, "module")),
@@ -278,6 +294,12 @@ function computeCreateVoyantAppExclude(project: VoyantProjectManifest): string[]
 
   for (const extension of ownedExtensionsForExcludedModules(excluded)) {
     excluded.add(extension)
+  }
+
+  if (project.mode === "managed-cloud") {
+    for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET) {
+      excluded.add(specifier)
+    }
   }
 
   const ordered = [

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -801,6 +801,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["./dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["./dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["./dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
@@ -1479,5 +1480,6 @@
       "@voyant-travel/workflows/testing": ["../workflows/dist/testing/index.d.ts"]
     }
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
 }

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -802,6 +802,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["./dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["./dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["./dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -807,6 +807,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -802,6 +802,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -801,6 +801,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -802,6 +802,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -802,6 +802,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -807,6 +807,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -802,6 +802,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -800,6 +800,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -801,6 +801,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -802,6 +802,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1931,9 +1931,15 @@ importers:
       '@voyant-travel/catalog':
         specifier: workspace:*
         version: link:../catalog
+      '@voyant-travel/cloud-sdk':
+        specifier: ^0.11.0
+        version: 0.11.0(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/commerce':
         specifier: workspace:*
         version: link:../commerce
+      '@voyant-travel/db':
+        specifier: workspace:*
+        version: link:../db
       '@voyant-travel/distribution':
         specifier: workspace:*
         version: link:../distribution
@@ -1970,12 +1976,24 @@ importers:
       '@voyant-travel/relationships':
         specifier: workspace:*
         version: link:../relationships
+      '@voyant-travel/runtime':
+        specifier: workspace:*
+        version: link:../runtime
+      '@voyant-travel/storage':
+        specifier: workspace:*
+        version: link:../storage
       '@voyant-travel/storefront':
         specifier: workspace:*
         version: link:../storefront
       '@voyant-travel/trips':
         specifier: workspace:*
         version: link:../trips
+      '@voyant-travel/workflows':
+        specifier: workspace:*
+        version: link:../workflows
+      '@voyant-travel/workflows-orchestrator':
+        specifier: workspace:*
+        version: link:../workflows-orchestrator
     devDependencies:
       '@hono/zod-openapi':
         specifier: 'catalog:'

--- a/scripts/generate-framework-bom.mjs
+++ b/scripts/generate-framework-bom.mjs
@@ -26,11 +26,22 @@ const SRC = join(ROOT, "packages/framework/src/runtime-packages.generated.ts")
 const EMIT = process.argv.includes("--emit")
 
 const runtimePackages = JSON.parse(readFileSync(MANIFEST, "utf-8")).runtimePackages
+const frameworkRuntimeEntryDeps = {
+  "@voyant-travel/cloud-sdk": "^0.11.0",
+  "@voyant-travel/db": "workspace:*",
+  "@voyant-travel/runtime": "workspace:*",
+  "@voyant-travel/storage": "workspace:*",
+  "@voyant-travel/workflows": "workspace:*",
+  "@voyant-travel/workflows-orchestrator": "workspace:*",
+}
 
 // BOM dependencies: one entry per runtime module, pinned via workspace:* (pnpm
 // publishes these as the exact current version → a deterministic set).
 const deps = {}
 for (const name of [...runtimePackages].sort()) deps[name] = "workspace:*"
+for (const name of Object.keys(frameworkRuntimeEntryDeps).sort()) {
+  deps[name] = frameworkRuntimeEntryDeps[name]
+}
 
 const pkg = JSON.parse(readFileSync(PKG, "utf-8"))
 const nextPkg = `${JSON.stringify({ ...pkg, dependencies: deps }, null, 2)}\n`

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -141,9 +141,11 @@ export function buildOperatorProviders(): OperatorCapabilities {
           m.createRelationshipsStorefrontIntakePersistence() as AsyncMethodProvider<StorefrontIntakePersistence>,
       ),
     ),
-    netopiaCheckoutStarter: lazyProvider(async () =>
-      import("@voyant-travel/plugin-netopia").then((m) => m.createNetopiaCheckoutStarter()),
-    ),
+    resolvePaymentStarters: () => ({
+      netopia: lazyProvider(async () =>
+        import("@voyant-travel/plugin-netopia").then((m) => m.createNetopiaCheckoutStarter()),
+      ),
+    }),
     createChannelPushExtension,
     // Lazy route-bundle loaders for the `operator/*` standard families — each
     // wires this deployment's providers into the package-owned route bundle.

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1015,6 +1015,9 @@
       "@voyant-travel/framework-migrations": [
         "../../packages/framework-migrations/dist/index.d.ts"
       ],
+      "@voyant-travel/framework/managed-runtime": [
+        "../../packages/framework/dist/managed-runtime.d.ts"
+      ],
       "@voyant-travel/framework/profile": ["../../packages/framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../../packages/hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../../packages/hono/dist/app.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1015,6 +1015,9 @@
       "@voyant-travel/framework-migrations": [
         "../../packages/framework-migrations/dist/index.d.ts"
       ],
+      "@voyant-travel/framework/managed-runtime": [
+        "../../packages/framework/dist/managed-runtime.d.ts"
+      ],
       "@voyant-travel/framework/profile": ["../../packages/framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../../packages/hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../../packages/hono/dist/app.d.ts"],


### PR DESCRIPTION
## Summary
- Add published `@voyant-travel/framework/managed-runtime` entry for loading a managed product profile snapshot and booting the Node runtime without starter-local imports.
- Resolve managed runtime providers from env/secrets, including DB, object storage, workflows, notifications, bank transfer details, exchange rates, and provider-neutral payment starters.
- Move the operator starter's Netopia checkout wiring behind generic `resolvePaymentStarters`, and document that `operator` is one managed profile rather than the package subpath.
- Address review feedback by failing fast on missing managed-cloud substrate/auth/plugin support and excluding standard surfaces whose loaders still live in the operator starter instead of mounting empty route apps.

Closes #2987.

## Follow-ups
- #2991 `@voyant-travel/flights`
- #2992 `operator/mcp`
- #2993 `operator/catalog-booking`
- #2994 `operator/catalog-content`
- #2995 `operator/media`
- #2996 `operator/payment-link`
- #2997 `operator/contract-document`
- #2998 `@voyant-travel/distribution/channel-push-extension`
- #2999 `operator/booking-schedule-extension`
- #3000 `operator/quote-version-snapshot-extension`
- #3001 `operator/booking-maintenance-extension`
- #3002 `operator/action-ledger-health-extension`
- #3003 `operator/proposal-extension`
- #3004 `operator/catalog-offers-extension`
- #3005 `operator/catalog-checkout-extension`

## Verification
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts profile.test.ts`
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm verify:fast`
- pre-commit staged checks
- pre-push test hook