### PR TITLE
Promote media routes in managed runtime

### DIFF
--- a/.changeset/managed-media-route-loader.md
+++ b/.changeset/managed-media-route-loader.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Promote the operator media route family into the source-free managed runtime defaults.

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -215,6 +215,23 @@ describe("managed profile runtime entry", () => {
     expect(await response.text()).toBe("%PDF-1.4")
   })
 
+  it("wires package-owned media routes in the default managed providers", async () => {
+    const env = createManagedProfileNodeEnv({
+      DATABASE_URL: "managed-profile-test-db",
+      APP_URL: "https://api.example.test",
+    })
+    await env.MEDIA_BUCKET?.put("uploads/test.txt", "hello", {
+      httpMetadata: { contentType: "text/plain" },
+    })
+    const app = await createManagedProfileProviders().loadMediaRoutes()
+
+    const response = await app.request("/v1/admin/media/uploads/test.txt", {}, env)
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toBe("text/plain")
+    expect(await response.text()).toBe("hello")
+  })
+
   it("wires package-owned action-ledger health routes in the default managed providers", async () => {
     const app = await createManagedProfileProviders().loadActionLedgerHealthRoutes()
 

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -3,7 +3,8 @@
 // provider defaults stay together so Cloud boot behavior is auditable.
 import { readFile } from "node:fs/promises"
 
-import { getVoyantCloudClient } from "@voyant-travel/cloud-sdk"
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { type CreateVideoUploadInput, getVoyantCloudClient } from "@voyant-travel/cloud-sdk"
 import type { EventBus } from "@voyant-travel/core"
 import { createDbClient } from "@voyant-travel/db"
 import type { ResolveInvoiceExchangeRate } from "@voyant-travel/finance"
@@ -43,6 +44,7 @@ import {
   type R2BucketShim,
 } from "@voyant-travel/runtime"
 import { createR2Provider, type R2BucketLike } from "@voyant-travel/storage/providers/r2"
+import type { VideoUploadTicketRequest } from "@voyant-travel/storage/routes"
 import type { PaymentLinkRoutesOptions } from "@voyant-travel/storefront/payment-link"
 import { createCloudWorkflowDriver } from "@voyant-travel/workflows/client"
 import { createInMemoryDriver } from "@voyant-travel/workflows-orchestrator/in-memory"
@@ -277,7 +279,7 @@ export function createManagedProfileProviders(
     loadMcpAdminRoutes: emptyRoutes,
     loadCatalogBookingRoutes: emptyRoutes,
     loadCatalogContentRoutes: emptyRoutes,
-    loadMediaRoutes: emptyRoutes,
+    loadMediaRoutes: createManagedMediaRoutes,
     loadPaymentLinkRoutes: async () => createManagedPaymentLinkRoutes(),
     loadContractDocumentRoutes: async () => createManagedContractDocumentRoutes(),
     loadBookingScheduleAdminRoutes: emptyRoutes,
@@ -468,6 +470,17 @@ function createStorageProvider(bucket: R2BucketLike | undefined, publicBaseUrl?:
 
 function createDocumentStorage(bindings: unknown) {
   return createStorageProvider((bindings as ManagedProfileRuntimeEnv).DOCUMENTS_BUCKET)
+}
+
+function createMediaStorage(bindings: unknown) {
+  const env = bindings as ManagedProfileRuntimeEnv
+  const base = resolveManagedApiBaseUrl(env)
+  return createStorageProvider(env.MEDIA_BUCKET, base ? `${base}/v1/admin/media/` : undefined)
+}
+
+function resolveManagedApiBaseUrl(env: ManagedProfileRuntimeEnv): string | null {
+  const base = env.API_BASE_URL?.trim() || env.APP_URL?.trim()
+  return base ? base.replace(/\/+$/, "") : null
 }
 
 async function readDocumentContentBase64(
@@ -761,6 +774,65 @@ function metadataRecord(value: unknown): Record<string, unknown> | null {
   return null
 }
 
+async function createManagedMediaRoutes() {
+  const [{ createProductBrochureRoutes }, { createMediaRoutes }] = await Promise.all([
+    import("@voyant-travel/inventory/routes-brochure"),
+    import("@voyant-travel/storage/routes"),
+  ])
+
+  const app = new OpenAPIHono()
+  app.route(
+    "/",
+    createMediaRoutes({
+      resolveStorage: (c) => createMediaStorage(c.env),
+      guessServedMimeType: guessMimeType,
+      signVideoUploadTicket: createManagedVideoUploadTicket,
+    }),
+  )
+  app.route(
+    "/v1/admin/products",
+    createProductBrochureRoutes({
+      resolveStorage: (c) => createMediaStorage(c.env),
+      resolvePrinter: () => null,
+    }),
+  )
+  return app
+}
+
+function createManagedVideoUploadTicket(
+  c: Context,
+  input: VideoUploadTicketRequest,
+): Promise<unknown> {
+  const env = c.env as ManagedProfileRuntimeEnv
+  const apiKey = env.VOYANT_API_KEY?.trim() || env.VOYANT_CLOUD_API_KEY?.trim()
+  if (!apiKey) {
+    throw new Error("Voyant Cloud video upload provider is not configured.")
+  }
+  const cloud = getVoyantCloudClient(
+    {
+      VOYANT_CLOUD_API_KEY: apiKey,
+      ...(env.VOYANT_CLOUD_API_URL ? { VOYANT_CLOUD_API_URL: env.VOYANT_CLOUD_API_URL } : {}),
+    },
+    { apiKey },
+  )
+  return cloud.video.videos.createUpload(toCreateVideoUploadInput(input))
+}
+
+function toCreateVideoUploadInput(input: VideoUploadTicketRequest): CreateVideoUploadInput {
+  const output: CreateVideoUploadInput = {
+    fileSize: input.fileSize,
+    maxDurationSeconds: input.maxDurationSeconds,
+  }
+  if (input.name !== undefined) output.name = input.name
+  if (input.requireSignedUrls !== undefined) output.requireSignedUrls = input.requireSignedUrls
+  if (input.allowedOrigins !== undefined) output.allowedOrigins = input.allowedOrigins
+  if (input.thumbnailTimestampPct !== undefined) {
+    output.thumbnailTimestampPct = input.thumbnailTimestampPct
+  }
+  if (input.meta !== undefined) output.meta = input.meta
+  return output
+}
+
 async function createManagedContractDocumentRoutes() {
   return createContractDocumentRoutes({
     generateContract: (env, db, eventBus, bookingId, opts) =>
@@ -828,12 +900,36 @@ function guessMimeType(key: string): string {
     case "jpg":
     case "jpeg":
       return "image/jpeg"
+    case "gif":
+      return "image/gif"
     case "webp":
       return "image/webp"
+    case "svg":
+      return "image/svg+xml"
+    case "mp4":
+      return "video/mp4"
+    case "webm":
+      return "video/webm"
+    case "mov":
+      return "video/quicktime"
     case "json":
       return "application/json"
     case "txt":
       return "text/plain"
+    case "csv":
+      return "text/csv"
+    case "xml":
+      return "application/xml"
+    case "zip":
+      return "application/zip"
+    case "doc":
+      return "application/msword"
+    case "docx":
+      return "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    case "xls":
+      return "application/vnd.ms-excel"
+    case "xlsx":
+      return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     default:
       return "application/octet-stream"
   }

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -88,7 +88,6 @@ export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
   "operator/mcp",
   "operator/catalog-booking",
   "operator/catalog-content",
-  "operator/media",
   "@voyant-travel/distribution/channel-push-extension",
   "operator/booking-schedule-extension",
   "operator/quote-version-snapshot-extension",

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -212,6 +212,7 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.modules).not.toContain("@voyant-travel/storefront")
     expect(bridge.manifest.modules).not.toContain("@voyant-travel/storefront/customer-portal")
     expect(bridge.manifest.modules).not.toContain("@voyant-travel/storefront/verification")
+    expect(bridge.manifest.modules).toContain("operator/media")
     expect(bridge.manifest.modules).toContain("operator/payment-link")
     expect(bridge.manifest.modules).toContain("operator/contract-document")
     expect(bridge.manifest.extensions).toContain("operator/action-ledger-health-extension")


### PR DESCRIPTION
## Summary

Promotes `operator/media` out of the source-free unsupported set and wires the managed runtime default provider to the package-owned media route factories.

The managed loader now composes:
- `@voyant-travel/storage/routes` for `/v1/admin/uploads`, `/v1/admin/uploads/video`, and `/v1/admin/media/*`
- `@voyant-travel/inventory/routes-brochure` for `/v1/admin/products/:id/brochure/generate`

Storage resolves from the managed `MEDIA_BUCKET` binding, served media URLs use `API_BASE_URL`/`APP_URL` when available, and video upload tickets call the Voyant Cloud video API only when `VOYANT_API_KEY` or `VOYANT_CLOUD_API_KEY` is configured. Without a video provider key, the ticket signer fails explicitly instead of falling back to a fake local provider.

Closes #2995.

## Validation

- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts profile.test.ts`
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm verify:fast`
- `pnpm verify:package-exports`
- pre-push hook replayed full `pnpm test` successfully from cache