### PR TITLE
Promote booking maintenance routes in managed runtime

### DIFF
--- a/.changeset/booking-maintenance-managed-runtime.md
+++ b/.changeset/booking-maintenance-managed-runtime.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/commerce": minor
+"@voyant-travel/framework": minor
+---
+
+Promote booking-maintenance tax-line rebuild routes into package-owned source-free managed runtime wiring.

--- a/packages/commerce/src/checkout/index.ts
+++ b/packages/commerce/src/checkout/index.ts
@@ -48,7 +48,11 @@ export type {
   CheckoutModuleOptions,
   CheckoutStartOptions,
 } from "./options.js"
-export { createCatalogCheckoutRoutes } from "./routes.js"
+export {
+  type BookingMaintenanceRoutesOptions,
+  createBookingMaintenanceRoutes,
+  createCatalogCheckoutRoutes,
+} from "./routes.js"
 export {
   type CatalogCheckoutStartContext,
   CatalogCheckoutStartError,

--- a/packages/commerce/src/checkout/routes.ts
+++ b/packages/commerce/src/checkout/routes.ts
@@ -23,7 +23,8 @@ import type { EventBus } from "@voyant-travel/core"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
-import type { CheckoutStartOptions } from "./options.js"
+import { rebuildBookingItemTaxLines } from "./materialization-tax.js"
+import type { CheckoutModuleOptions, CheckoutStartOptions } from "./options.js"
 import {
   CatalogCheckoutStartError,
   type CheckoutStartRequestMeta,
@@ -155,6 +156,53 @@ export function createCatalogCheckoutRoutes(
         }
         throw err
       }
+    },
+  )
+}
+
+export interface BookingMaintenanceRoutesOptions {
+  resolveDb?(c: Context): PostgresJsDatabase
+  resolveBookingTaxSettings: CheckoutModuleOptions["resolveBookingTaxSettings"]
+}
+
+const rebuildBookingTaxLinesRoute = createRoute({
+  method: "post",
+  path: "/{bookingId}/rebuild-tax-lines",
+  request: {
+    params: z.object({ bookingId: z.string().trim().min(1) }),
+  },
+  responses: {
+    200: {
+      description: "Booking item tax lines were rebuilt from catalog snapshots",
+      content: {
+        "application/json": {
+          schema: z.object({
+            data: z.object({
+              rebuilt: z.number(),
+              itemsWithoutSnapshot: z.number(),
+            }),
+          }),
+        },
+      },
+    },
+    400: {
+      description: "invalid_request: route params failed validation",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+export function createBookingMaintenanceRoutes(
+  options: BookingMaintenanceRoutesOptions,
+): OpenAPIHono<CheckoutEnv> {
+  return new OpenAPIHono<CheckoutEnv>({ defaultHook: openApiValidationHook }).openapi(
+    rebuildBookingTaxLinesRoute,
+    async (c) => {
+      const db = options.resolveDb?.(c) ?? c.get("db")
+      const result = await rebuildBookingItemTaxLines(db, c.req.valid("param").bookingId, {
+        resolveBookingTaxSettings: options.resolveBookingTaxSettings,
+      })
+      return c.json({ data: result }, 200)
     },
   )
 }

--- a/packages/commerce/src/checkout/start-service.test.ts
+++ b/packages/commerce/src/checkout/start-service.test.ts
@@ -282,7 +282,7 @@ describe("startCatalogCheckout", () => {
       paymentSessionId: "ps_bank_transfer",
       reference: "BOOK-BK-1001",
     })
-  })
+  }, 10000)
 })
 
 describe("createCatalogCheckoutRoutes", () => {

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -201,7 +201,7 @@ describe("managed profile runtime entry", () => {
         },
       },
     })
-  })
+  }, 10000)
 
   it("wires package-owned contract document routes in the default managed providers", async () => {
     const env = createManagedProfileNodeEnv({ DATABASE_URL: "managed-profile-test-db" })
@@ -230,7 +230,14 @@ describe("managed profile runtime entry", () => {
     expect(response.status).toBe(200)
     expect(response.headers.get("content-type")).toBe("text/plain")
     expect(await response.text()).toBe("hello")
-  })
+  }, 10000)
+
+  it("wires package-owned booking maintenance routes in the default managed providers", async () => {
+    const app = await createManagedProfileProviders().loadBookingMaintenanceRoutes()
+
+    expect(app.fetch).toEqual(expect.any(Function))
+    expect(app.routes.length).toBeGreaterThan(0)
+  }, 10000)
 
   it("wires package-owned action-ledger health routes in the default managed providers", async () => {
     const app = await createManagedProfileProviders().loadActionLedgerHealthRoutes()

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -30,6 +30,7 @@ import {
 import {
   getOperatorPaymentInstructions,
   getOperatorProfile,
+  resolveBookingTaxSettings,
 } from "@voyant-travel/operator-settings"
 import {
   type CreateNodeServerOptions,
@@ -285,7 +286,7 @@ export function createManagedProfileProviders(
     loadBookingScheduleAdminRoutes: emptyRoutes,
     loadPaymentPolicyPublicRoutes: emptyRoutes,
     loadQuoteVersionSnapshotRoutes: emptyRoutes,
-    loadBookingMaintenanceRoutes: emptyRoutes,
+    loadBookingMaintenanceRoutes: createManagedBookingMaintenanceRoutes,
     loadActionLedgerHealthRoutes: createManagedActionLedgerHealthRoutes,
     loadProposalAdminRoutes: emptyRoutes,
     loadProposalPublicRoutes: emptyRoutes,
@@ -831,6 +832,14 @@ function toCreateVideoUploadInput(input: VideoUploadTicketRequest): CreateVideoU
   }
   if (input.meta !== undefined) output.meta = input.meta
   return output
+}
+
+async function createManagedBookingMaintenanceRoutes() {
+  const { createBookingMaintenanceRoutes } = await import("@voyant-travel/commerce/checkout")
+  return createBookingMaintenanceRoutes({
+    resolveDb: dbFromContext,
+    resolveBookingTaxSettings,
+  })
 }
 
 async function createManagedContractDocumentRoutes() {

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -91,7 +91,6 @@ export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
   "@voyant-travel/distribution/channel-push-extension",
   "operator/booking-schedule-extension",
   "operator/quote-version-snapshot-extension",
-  "operator/booking-maintenance-extension",
   "operator/proposal-extension",
   "operator/catalog-offers-extension",
   "operator/catalog-checkout-extension",

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -215,6 +215,7 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.modules).toContain("operator/media")
     expect(bridge.manifest.modules).toContain("operator/payment-link")
     expect(bridge.manifest.modules).toContain("operator/contract-document")
+    expect(bridge.manifest.extensions).toContain("operator/booking-maintenance-extension")
     expect(bridge.manifest.extensions).toContain("operator/action-ledger-health-extension")
     for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS) {
       expect([...bridge.manifest.modules, ...bridge.manifest.extensions]).not.toContain(specifier)

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -93,7 +93,11 @@ const STANDARD_EXTENSION_MODULE_OWNERS = {
     "@voyant-travel/operator-settings",
   ],
   "operator/quote-version-snapshot-extension": ["@voyant-travel/quotes", "@voyant-travel/trips"],
-  "operator/booking-maintenance-extension": ["@voyant-travel/bookings"],
+  "operator/booking-maintenance-extension": [
+    "@voyant-travel/bookings",
+    "@voyant-travel/commerce",
+    "@voyant-travel/operator-settings",
+  ],
   "operator/action-ledger-health-extension": ["@voyant-travel/action-ledger"],
   "operator/proposal-extension": ["@voyant-travel/quotes"],
   "operator/catalog-offers-extension": ["@voyant-travel/catalog"],

--- a/starters/operator/openapi/admin/bookings.json
+++ b/starters/operator/openapi/admin/bookings.json
@@ -19401,6 +19401,78 @@
         "x-voyant-module": "bookings",
         "x-voyant-surface": "admin"
       }
+    },
+    "/v1/admin/bookings/{bookingId}/rebuild-tax-lines": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1
+            },
+            "required": true,
+            "name": "bookingId",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Booking item tax lines were rebuilt from catalog snapshots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "rebuilt": {
+                          "type": "number"
+                        },
+                        "itemsWithoutSnapshot": {
+                          "type": "number"
+                        }
+                      },
+                      "required": [
+                        "rebuilt",
+                        "itemsWithoutSnapshot"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request: route params failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminBookingsByBookingIdRebuildTaxLines",
+        "summary": "POST /v1/admin/bookings/{bookingId}/rebuild-tax-lines",
+        "tags": [
+          "bookings"
+        ],
+        "x-voyant-module": "bookings",
+        "x-voyant-surface": "admin"
+      }
     }
   },
   "webhooks": {}

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -33,7 +33,7 @@ import {
   frameworkComposition,
   modulesFromGlob,
 } from "@voyant-travel/framework"
-import { lazyProvider, type VoyantDb } from "@voyant-travel/hono"
+import { lazyProvider } from "@voyant-travel/hono"
 import type {
   CompositionManifest,
   CompositionRegistry,
@@ -44,7 +44,6 @@ import { createMiceHonoModule } from "@voyant-travel/mice"
 import { miceBookingExtension } from "@voyant-travel/mice/booking-extension"
 import { createRealtimeHonoModule } from "@voyant-travel/realtime"
 import type { StorefrontIntakePersistence } from "@voyant-travel/storefront"
-import { Hono } from "hono"
 import { resolveOperatorCustomFields } from "../lib/custom-fields"
 import { resolveNotificationProviders } from "../lib/notifications"
 import { operatorRealtimeBridgeRoutes, resolveRealtimeProviders } from "../lib/realtime"
@@ -196,32 +195,19 @@ export function buildOperatorProviders(): OperatorCapabilities {
         m.createOperatorQuoteVersionSnapshotRoutes(),
       ),
     loadBookingMaintenanceRoutes: async () => {
-      const app = new Hono<{ Variables: { db: VoyantDb } }>()
-      app.post("/:bookingId/rebuild-tax-lines", async (c) => {
-        const bookingId = c.req.param("bookingId")
-        try {
-          const [
-            { rebuildBookingItemTaxLines },
-            { operatorPostgresDb },
-            { resolveBookingTaxSettings: resolveTax },
-          ] = await Promise.all([
-            import("@voyant-travel/commerce/checkout"),
-            import("./runtime/operator-runtime-adapter"),
-            import("@voyant-travel/operator-settings"),
-          ])
-          const result = await rebuildBookingItemTaxLines(
-            operatorPostgresDb(c.get("db")),
-            bookingId,
-            {
-              resolveBookingTaxSettings: resolveTax,
-            },
-          )
-          return c.json({ data: result })
-        } catch (err) {
-          return c.json({ error: err instanceof Error ? err.message : String(err) }, 500)
-        }
+      const [
+        { createBookingMaintenanceRoutes },
+        { operatorPostgresDb },
+        { resolveBookingTaxSettings },
+      ] = await Promise.all([
+        import("@voyant-travel/commerce/checkout"),
+        import("./runtime/operator-runtime-adapter"),
+        import("@voyant-travel/operator-settings"),
+      ])
+      return createBookingMaintenanceRoutes({
+        resolveDb: (c) => operatorPostgresDb(c.get("db")),
+        resolveBookingTaxSettings,
       })
-      return app
     },
     loadActionLedgerHealthRoutes: () =>
       import("./runtime/action-ledger-health-runtime").then((m) =>


### PR DESCRIPTION
## Summary
- move booking-maintenance tax-line rebuild routes into @voyant-travel/commerce package routing
- wire the route loader into the source-free managed runtime and starter composition
- remove operator/booking-maintenance-extension from the source-free unsupported manifest and regenerate operator OpenAPI

Closes #3001.

## Verification
- pnpm --filter @voyant-travel/commerce typecheck
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter operator typecheck
- pnpm --filter @voyant-travel/commerce build
- pnpm --filter @voyant-travel/commerce lint
- pnpm --filter @voyant-travel/framework lint
- pnpm --filter operator lint
- pnpm --filter @voyant-travel/commerce test -- start-service.test.ts
- pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts
- pnpm --filter operator generate:openapi
- pnpm verify:package-exports
- pnpm verify:fast
- pre-push pnpm test (cached replay)