### PR TITLE
Promote catalog checkout routes in managed runtime

### DIFF
--- a/.changeset/catalog-checkout-managed-runtime.md
+++ b/.changeset/catalog-checkout-managed-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Support package-owned catalog-checkout routes in source-free managed runtime wiring.

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -253,6 +253,13 @@ describe("managed profile runtime entry", () => {
     expect(await response.json()).toEqual({ departureAirports: [] })
   }, 10000)
 
+  it("wires package-owned catalog checkout routes in the default managed providers", async () => {
+    const app = await createManagedProfileProviders().loadCatalogCheckoutRoutes()
+
+    expect(app.fetch).toEqual(expect.any(Function))
+    expect(app.routes.length).toBeGreaterThan(0)
+  }, 10000)
+
   it("wires package-owned action-ledger health routes in the default managed providers", async () => {
     const app = await createManagedProfileProviders().loadActionLedgerHealthRoutes()
 

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -116,6 +116,9 @@ export interface ManagedProfileRuntimeEnv extends VoyantBindings {
   BANK_TRANSFER_BENEFICIARY?: string
   BANK_TRANSFER_IBAN?: string
   BANK_TRANSFER_NOTES?: string
+  STOREFRONT_BANK_BENEFICIARY?: string
+  STOREFRONT_BANK_IBAN?: string
+  STOREFRONT_BANK_NAME?: string
   ORIGIN_TRUST_SECRET?: string
   PORT?: string
 }
@@ -306,7 +309,7 @@ export function createManagedProfileProviders(
     loadProposalAdminRoutes: emptyRoutes,
     loadProposalPublicRoutes: emptyRoutes,
     loadCatalogOffersRoutes: createManagedCatalogOffersRoutes,
-    loadCatalogCheckoutRoutes: emptyRoutes,
+    loadCatalogCheckoutRoutes: createManagedCatalogCheckoutRoutes,
   }
   return { ...providers, ...overrides }
 }
@@ -820,6 +823,49 @@ function createManagedCatalogOffersRouteOptions(): CatalogOffersRouteModuleOptio
 async function createManagedCatalogOffersRoutes() {
   const { createCatalogOffersAdminRoutes } = await import("@voyant-travel/catalog/offers")
   return createCatalogOffersAdminRoutes(createManagedCatalogOffersRouteOptions())
+}
+
+async function getManagedOwnedProductName(
+  db: PostgresJsDatabase,
+  entityModule: string,
+  entityId: string,
+): Promise<string | null> {
+  if (entityModule !== "products") return null
+  const { productsService } = await import("@voyant-travel/inventory")
+  const product = await productsService.getProductById(db, entityId)
+  return product?.name ?? null
+}
+
+async function resolveManagedCheckoutBankTransferInstructions(
+  db: PostgresJsDatabase,
+  env: Record<string, string | undefined>,
+) {
+  const [operatorProfile, paymentInstructions] = await Promise.all([
+    getOperatorProfile(db),
+    getOperatorPaymentInstructions(db),
+  ])
+
+  return {
+    beneficiary:
+      paymentInstructions?.bankTransferBeneficiary ||
+      operatorProfile?.legalName ||
+      operatorProfile?.name ||
+      env.BANK_TRANSFER_BENEFICIARY ||
+      env.STOREFRONT_BANK_BENEFICIARY ||
+      "-",
+    iban: paymentInstructions?.iban || env.BANK_TRANSFER_IBAN || env.STOREFRONT_BANK_IBAN || "-",
+    bankName:
+      paymentInstructions?.bank || env.BANK_TRANSFER_BANK_NAME || env.STOREFRONT_BANK_NAME || "-",
+  }
+}
+
+async function createManagedCatalogCheckoutRoutes() {
+  const { createCatalogCheckoutRoutes } = await import("@voyant-travel/commerce/checkout")
+  return createCatalogCheckoutRoutes({
+    resolveBookingTaxSettings,
+    getOwnedProductName: getManagedOwnedProductName,
+    resolveBankTransferInstructions: resolveManagedCheckoutBankTransferInstructions,
+  })
 }
 
 async function createManagedActionLedgerHealthRoutes() {

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -92,7 +92,6 @@ export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
   "operator/booking-schedule-extension",
   "operator/quote-version-snapshot-extension",
   "operator/proposal-extension",
-  "operator/catalog-checkout-extension",
 ] as const
 
 export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET = new Set<string>(

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -218,6 +218,7 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.extensions).toContain("operator/booking-maintenance-extension")
     expect(bridge.manifest.extensions).toContain("operator/action-ledger-health-extension")
     expect(bridge.manifest.extensions).toContain("operator/catalog-offers-extension")
+    expect(bridge.manifest.extensions).toContain("operator/catalog-checkout-extension")
     for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS) {
       expect([...bridge.manifest.modules, ...bridge.manifest.extensions]).not.toContain(specifier)
       expect(bridge.exclude).toContain(specifier)


### PR DESCRIPTION
Summary:
- wire package-owned catalog-checkout routes into source-free managed runtime
- add managed checkout options for tax settings, owned product names, and bank-transfer instructions
- remove operator/catalog-checkout-extension from the source-free unsupported manifest

Closes #3005.

Verification:
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter @voyant-travel/framework lint
- pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts profile.test.ts
- pnpm verify:package-exports
- pnpm verify:fast
- pre-push pnpm test (cached replay)