### PR TITLE
Promote quote snapshot routes in managed runtime

### DIFF
--- a/.changeset/quote-snapshot-managed-runtime.md
+++ b/.changeset/quote-snapshot-managed-runtime.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/framework": minor
+"@voyant-travel/quotes": minor
+---
+
+Support package-owned quote-version snapshot routes in source-free managed runtime wiring.

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -260,6 +260,13 @@ describe("managed profile runtime entry", () => {
     expect(app.routes.length).toBeGreaterThan(0)
   }, 10000)
 
+  it("wires package-owned quote-version snapshot routes in the default managed providers", async () => {
+    const app = await createManagedProfileProviders().loadQuoteVersionSnapshotRoutes()
+
+    expect(app.fetch).toEqual(expect.any(Function))
+    expect(app.routes.length).toBeGreaterThan(0)
+  }, 10000)
+
   it("wires package-owned action-ledger health routes in the default managed providers", async () => {
     const app = await createManagedProfileProviders().loadActionLedgerHealthRoutes()
 

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -303,7 +303,7 @@ export function createManagedProfileProviders(
     loadContractDocumentRoutes: async () => createManagedContractDocumentRoutes(),
     loadBookingScheduleAdminRoutes: emptyRoutes,
     loadPaymentPolicyPublicRoutes: emptyRoutes,
-    loadQuoteVersionSnapshotRoutes: emptyRoutes,
+    loadQuoteVersionSnapshotRoutes: createManagedQuoteVersionSnapshotRoutes,
     loadBookingMaintenanceRoutes: createManagedBookingMaintenanceRoutes,
     loadActionLedgerHealthRoutes: createManagedActionLedgerHealthRoutes,
     loadProposalAdminRoutes: emptyRoutes,
@@ -865,6 +865,13 @@ async function createManagedCatalogCheckoutRoutes() {
     resolveBookingTaxSettings,
     getOwnedProductName: getManagedOwnedProductName,
     resolveBankTransferInstructions: resolveManagedCheckoutBankTransferInstructions,
+  })
+}
+
+async function createManagedQuoteVersionSnapshotRoutes() {
+  const { createQuoteVersionSnapshotRoutes } = await import("@voyant-travel/quotes")
+  return createQuoteVersionSnapshotRoutes({
+    resolveDb: dbFromContext,
   })
 }
 

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -90,7 +90,6 @@ export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
   "operator/catalog-content",
   "@voyant-travel/distribution/channel-push-extension",
   "operator/booking-schedule-extension",
-  "operator/quote-version-snapshot-extension",
   "operator/proposal-extension",
 ] as const
 

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -219,6 +219,7 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.extensions).toContain("operator/action-ledger-health-extension")
     expect(bridge.manifest.extensions).toContain("operator/catalog-offers-extension")
     expect(bridge.manifest.extensions).toContain("operator/catalog-checkout-extension")
+    expect(bridge.manifest.extensions).toContain("operator/quote-version-snapshot-extension")
     for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS) {
       expect([...bridge.manifest.modules, ...bridge.manifest.extensions]).not.toContain(specifier)
       expect(bridge.exclude).toContain(specifier)

--- a/packages/quotes/src/index.ts
+++ b/packages/quotes/src/index.ts
@@ -40,6 +40,7 @@ export type {
   PublicQuoteVersionProposal,
   PublicQuoteVersionProposalLine,
   QuoteProposalRoutesOptions,
+  QuoteVersionSnapshotRoutesOptions,
   RequestPublicProposalEditsResult,
   SendQuoteVersionResult,
 } from "./proposal-routes.js"

--- a/packages/quotes/src/proposal-routes.ts
+++ b/packages/quotes/src/proposal-routes.ts
@@ -89,6 +89,11 @@ export interface QuoteProposalRoutesOptions {
   ): Promise<PublicProposalFeedbackRecord | null>
 }
 
+export interface QuoteVersionSnapshotRoutesOptions {
+  /** Resolve the concrete transactional db for a request. */
+  resolveDb(c: Context): PostgresJsDatabase
+}
+
 type OperatorProposalRouteEnv = {
   Bindings: Record<string, unknown>
   Variables: {
@@ -302,7 +307,7 @@ export function createQuoteProposalPublicRoutes(
 
 /** Build the Trip-snapshot freeze route (relative path; mount at `/v1/admin/trips`). */
 export function createQuoteVersionSnapshotRoutes(
-  options: QuoteProposalRoutesOptions,
+  options: QuoteVersionSnapshotRoutesOptions,
 ): Hono<OperatorQuoteVersionSnapshotRouteEnv> {
   const app = new Hono<OperatorQuoteVersionSnapshotRouteEnv>()
   app.post("/:envelopeId/quote-versions/:quoteVersionId/snapshot", (c) =>
@@ -952,7 +957,7 @@ function canonicalSnapshotValue(value: unknown): unknown {
 
 async function handleFreezeQuoteVersionSnapshot(
   c: Context<OperatorQuoteVersionSnapshotRouteEnv>,
-  options: QuoteProposalRoutesOptions,
+  options: QuoteVersionSnapshotRoutesOptions,
 ) {
   const envelopeId = c.req.param("envelopeId")
   const quoteVersionId = c.req.param("quoteVersionId")


### PR DESCRIPTION
Summary:
- wire package-owned quote-version snapshot routes into the source-free managed runtime
- narrow the quotes snapshot route options to the DB resolver it actually needs
- remove operator/quote-version-snapshot-extension from the source-free unsupported manifest

Closes #3000.

Verification:
- pnpm --filter @voyant-travel/quotes typecheck
- pnpm --filter @voyant-travel/quotes lint
- pnpm --filter @voyant-travel/quotes test -- proposal-routes.test.ts
- pnpm --filter @voyant-travel/quotes build
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter @voyant-travel/framework lint
- pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts profile.test.ts
- pnpm verify:package-exports
- pnpm verify:fast
- pre-push pnpm test (cached replay)