### PR TITLE
Promote flights routes in managed runtime

### DIFF
--- a/.changeset/flight-managed-runtime.md
+++ b/.changeset/flight-managed-runtime.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/framework": minor
+"@voyant-travel/flights": patch
+---
+
+Support package-owned flights admin routes in source-free managed runtime wiring.

--- a/packages/flights/src/hono.ts
+++ b/packages/flights/src/hono.ts
@@ -121,7 +121,7 @@ function adapterErrorDetails(err: unknown): { message: string; status: 404 | 500
 function statusForAdapterErrorMessage(message: string): 404 | 500 | 503 {
   if (/(?:not found|_not_found\b)/i.test(message)) return 404
   if (
-    /(?:demo service is unavailable|FLIGHTS_DEMO_API_URL is not set|network connection lost|fetch failed|ECONNREFUSED|ENOTFOUND)/i.test(
+    /(?:Flight connector is not configured|demo service is unavailable|FLIGHTS_DEMO_API_URL is not set|network connection lost|fetch failed|ECONNREFUSED|ENOTFOUND)/i.test(
       message,
     )
   ) {

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -239,6 +239,32 @@ describe("managed profile runtime entry", () => {
     expect(app.routes.length).toBeGreaterThan(0)
   }, 10000)
 
+  it("wires package-owned flights routes in the default managed providers", async () => {
+    const app = await createManagedProfileProviders().loadFlightAdminRoutes()
+    const response = await app.request("/search", {
+      method: "POST",
+      body: JSON.stringify({
+        slices: [
+          {
+            origin: "OTP",
+            destination: "LHR",
+            departureDate: "2026-08-01",
+          },
+        ],
+        passengers: { adults: 1 },
+      }),
+      headers: { "content-type": "application/json" },
+    })
+
+    expect(app.fetch).toEqual(expect.any(Function))
+    expect(app.routes.length).toBeGreaterThan(0)
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({
+      error:
+        "Flight connector is not configured for this managed runtime. Override loadFlightAdminRoutes with a deployment flight connector.",
+    })
+  }, 10000)
+
   it("wires package-owned catalog offers routes in the default managed providers", async () => {
     const app = await createManagedProfileProviders().loadCatalogOffersRoutes()
     const response = await app.request("/departure-airports", {

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -22,6 +22,7 @@ import {
   type ResolveInvoiceExchangeRate,
   readPolicySourceFromInternalNotes,
 } from "@voyant-travel/finance"
+import type { FlightConnectorAdapter } from "@voyant-travel/flights"
 import type {
   LazyRoutesLoader,
   VoyantAuthIntegration,
@@ -301,7 +302,7 @@ export function createManagedProfileProviders(
     storefrontIntakePersistence: createNoopStorefrontIntakePersistence(),
     resolvePaymentStarters: () => ({}),
     createChannelPushExtension: createEmptyChannelPushExtension,
-    loadFlightAdminRoutes: emptyRoutes,
+    loadFlightAdminRoutes: createManagedFlightAdminRoutes,
     loadMcpAdminRoutes: emptyRoutes,
     loadCatalogBookingRoutes: emptyRoutes,
     loadCatalogContentRoutes: emptyRoutes,
@@ -1110,6 +1111,45 @@ async function createManagedActionLedgerHealthRoutes() {
     checkFinanceDrift: checkFinanceActionLedgerDrift,
     checkProductDrift: checkProductActionLedgerDrift,
   })
+}
+
+async function createManagedFlightAdminRoutes() {
+  const [
+    { createFlightAdminRoutes, createFlightOrderPaymentIntegration },
+    { createOrderPaymentSessions },
+  ] = await Promise.all([
+    import("@voyant-travel/flights"),
+    import("@voyant-travel/finance/order-payment-sessions"),
+  ])
+
+  return createFlightAdminRoutes({
+    resolveAdapter: resolveManagedFlightAdapter,
+    payment: createFlightOrderPaymentIntegration({
+      orderPaymentSessions: createOrderPaymentSessions({ targetType: "flight_order" }),
+    }),
+  })
+}
+
+function resolveManagedFlightAdapter(): FlightConnectorAdapter {
+  return managedFlightConnectorNotConfiguredAdapter
+}
+
+const managedFlightConnectorNotConfiguredAdapter: FlightConnectorAdapter = {
+  capabilities: {
+    provider: "unconfigured",
+    declared: [],
+  },
+  searchFlights: rejectManagedFlightConnectorRequest,
+  priceOffer: rejectManagedFlightConnectorRequest,
+  bookFlight: rejectManagedFlightConnectorRequest,
+  getOrder: rejectManagedFlightConnectorRequest,
+  cancelOrder: rejectManagedFlightConnectorRequest,
+}
+
+async function rejectManagedFlightConnectorRequest(): Promise<never> {
+  throw new Error(
+    "Flight connector is not configured for this managed runtime. Override loadFlightAdminRoutes with a deployment flight connector.",
+  )
 }
 
 async function createManagedPaymentLinkRoutes() {

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -84,7 +84,6 @@ export const FRAMEWORK_RUNTIME_MANIFEST = {
 } as const satisfies FrameworkManifest
 
 export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
-  "@voyant-travel/flights",
   "operator/mcp",
   "operator/catalog-booking",
   "operator/catalog-content",

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -221,25 +221,20 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.extensions).toContain("operator/catalog-checkout-extension")
     expect(bridge.manifest.extensions).toContain("operator/quote-version-snapshot-extension")
     expect(bridge.manifest.extensions).toContain("operator/booking-schedule-extension")
+    expect(bridge.manifest.modules).toContain("@voyant-travel/flights")
     for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS) {
       expect([...bridge.manifest.modules, ...bridge.manifest.extensions]).not.toContain(specifier)
       expect(bridge.exclude).toContain(specifier)
     }
   })
 
-  it("rejects explicit managed-cloud modules that still require starter-local glue", () => {
+  it("allows explicit managed-cloud flights modules", () => {
     const result = validateVoyantProject({
       ...validProject({ plugins: [] }),
       modules: ["catalog", "flights"],
     })
 
-    expect(result.ok).toBe(false)
-    expect(result.issues).toEqual([
-      expect.objectContaining({
-        path: "modules",
-        code: "invalid_module_subset",
-      }),
-    ])
+    expect(result.ok).toBe(true)
   })
 
   it("rejects website artifacts because customer-facing apps are separate", () => {


### PR DESCRIPTION
## Summary
- mount package-owned flights admin routes from the managed runtime default providers
- keep the managed default connector explicit and unconfigured, returning 503 until a deployment overrides the flight connector
- remove flights from the source-free unsupported set and cover default/explicit profile behavior

Closes #2991

## Validation
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter @voyant-travel/flights typecheck
- pnpm --filter @voyant-travel/framework lint
- pnpm --filter @voyant-travel/flights lint
- pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts profile.test.ts
- pnpm --filter @voyant-travel/flights test -- hono.test.ts
- pnpm verify:package-exports
- pnpm verify:fast
