### PR TITLE
Promote channel-push extension in managed runtime

### DIFF
--- a/.changeset/channel-push-managed-runtime.md
+++ b/.changeset/channel-push-managed-runtime.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/distribution": patch
+"@voyant-travel/framework": patch
+---
+
+Promote the package-owned channel-push extension factory into the managed runtime.

--- a/packages/distribution/src/channel-push/admin-routes.ts
+++ b/packages/distribution/src/channel-push/admin-routes.ts
@@ -23,16 +23,16 @@ import {
   infraWebhookDeliveriesTable,
 } from "@voyant-travel/db/schema/infra"
 import { and, desc, eq, gte, sql } from "drizzle-orm"
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 
 import { channelBookingLinks, channels } from "../schema.js"
 import { reconcileAvailability, reconcileBookingLinks, reconcileContent } from "./reconciler.js"
 import { triggerBookingPushForBookingWithResult } from "./subscriber.js"
+import type { ChannelPushDeps } from "./types.js"
 
 type Env = {
   Variables: {
-    db: PostgresJsDatabase
+    db: ChannelPushDeps["db"]
     userId?: string
   }
 }

--- a/packages/distribution/src/channel-push/extension.ts
+++ b/packages/distribution/src/channel-push/extension.ts
@@ -1,0 +1,40 @@
+import type { SourceAdapterRegistry } from "@voyant-travel/catalog/booking-engine"
+import type { Extension } from "@voyant-travel/core"
+import type { HonoExtension } from "@voyant-travel/hono/module"
+import type { Context } from "hono"
+import { Hono } from "hono"
+
+import { createChannelPushAdminRoutes } from "./admin-routes.js"
+import { type ChannelPushDeps, type ChannelPushLogger, setChannelPushDeps } from "./types.js"
+
+type ChannelPushExtensionEnv = {
+  Variables: {
+    db: ChannelPushDeps["db"]
+    userId?: string
+  }
+}
+
+export interface ChannelPushExtensionOptions {
+  resolveRegistry: (c: Context<ChannelPushExtensionEnv>) => SourceAdapterRegistry
+  resolveDb?: (c: Context<ChannelPushExtensionEnv>) => ChannelPushDeps["db"]
+  logger?: ChannelPushLogger
+}
+
+export const channelPushExtensionDef: Extension = {
+  name: "channel-push",
+  module: "distribution",
+}
+
+export function createChannelPushExtension(options: ChannelPushExtensionOptions): HonoExtension {
+  const adminRoutes = new Hono<ChannelPushExtensionEnv>()
+  adminRoutes.use("*", async (c, next) => {
+    setChannelPushDeps({
+      db: options.resolveDb?.(c) ?? c.get("db"),
+      registry: options.resolveRegistry(c),
+      ...(options.logger ? { logger: options.logger } : {}),
+    })
+    await next()
+  })
+  adminRoutes.route("/", createChannelPushAdminRoutes())
+  return { extension: channelPushExtensionDef, adminRoutes }
+}

--- a/packages/distribution/src/channel-push/index.ts
+++ b/packages/distribution/src/channel-push/index.ts
@@ -36,6 +36,11 @@ export {
   upsertContentIntent,
 } from "./content-push.js"
 export {
+  type ChannelPushExtensionOptions,
+  channelPushExtensionDef,
+  createChannelPushExtension,
+} from "./extension.js"
+export {
   type ChannelPushPluginOptions,
   channelPushPlugin,
 } from "./plugin.js"

--- a/packages/distribution/tests/unit/channel-push-extension.test.ts
+++ b/packages/distribution/tests/unit/channel-push-extension.test.ts
@@ -1,0 +1,45 @@
+import { createSourceAdapterRegistry } from "@voyant-travel/catalog/booking-engine"
+import { Hono } from "hono"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createChannelPushExtension } from "../../src/channel-push/extension.js"
+import {
+  type ChannelPushDeps,
+  clearChannelPushDeps,
+  getChannelPushDeps,
+} from "../../src/channel-push/types.js"
+
+describe("channel-push extension", () => {
+  afterEach(() => {
+    clearChannelPushDeps()
+  })
+
+  it("mounts package-owned admin routes and wires channel-push deps per request", async () => {
+    const db = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("db should not be called by this route")
+        },
+      },
+    ) as ChannelPushDeps["db"]
+    const registry = createSourceAdapterRegistry()
+    const extension = createChannelPushExtension({
+      resolveDb: () => db,
+      resolveRegistry: () => registry,
+    })
+    const app = new Hono()
+    if (extension.adminRoutes) {
+      app.route("/", extension.adminRoutes)
+    }
+
+    const response = await app.request("/reconcile/not-a-flow", { method: "POST" })
+
+    expect(extension.extension).toEqual({ name: "channel-push", module: "distribution" })
+    expect(extension.adminRoutes?.routes.length).toBeGreaterThan(0)
+    expect(extension.lazyAdminRoutes).toBeUndefined()
+    expect(response.status).toBe(400)
+    expect(getChannelPushDeps()?.db).toBe(db)
+    expect(getChannelPushDeps()?.registry).toBe(registry)
+  })
+})

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -328,4 +328,13 @@ describe("managed profile runtime entry", () => {
     expect(app.fetch).toEqual(expect.any(Function))
     expect(app.routes.length).toBeGreaterThan(0)
   })
+
+  it("wires package-owned channel-push routes in the default managed providers", () => {
+    const extension = createManagedProfileProviders().createChannelPushExtension()
+
+    expect(extension.extension).toEqual({ name: "channel-push", module: "distribution" })
+    expect(extension.adminRoutes?.fetch).toEqual(expect.any(Function))
+    expect(extension.adminRoutes?.routes.length).toBeGreaterThan(0)
+    expect(extension.lazyAdminRoutes).toBeUndefined()
+  })
 })

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -16,6 +16,10 @@ import {
   catalogTools,
   executeSemanticSearch,
 } from "@voyant-travel/catalog"
+import {
+  createSourceAdapterRegistry,
+  type SourceAdapterRegistry,
+} from "@voyant-travel/catalog/booking-engine"
 import type {
   CatalogOffersAirportLabel,
   CatalogOffersConnectClient,
@@ -27,6 +31,7 @@ import { type CreateVideoUploadInput, getVoyantCloudClient } from "@voyant-trave
 import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
 import type { EventBus } from "@voyant-travel/core"
 import { createDbClient } from "@voyant-travel/db/runtime"
+import { createChannelPushExtension as createDistributionChannelPushExtension } from "@voyant-travel/distribution"
 import {
   type BookingScheduleRoutesOptions,
   financeService,
@@ -198,6 +203,7 @@ type AsyncMethodProvider<T extends object> = {
 }
 
 let pooledDb: { url: string; db: VoyantDb } | undefined
+let managedChannelPushRegistry: SourceAdapterRegistry | undefined
 
 export async function loadManagedProfileRuntime(
   options: ManagedProfileRuntimeOptions,
@@ -327,7 +333,7 @@ export function createManagedProfileProviders(
     createTripsRoutesOptions: async () => ({}),
     storefrontIntakePersistence: createNoopStorefrontIntakePersistence(),
     resolvePaymentStarters: () => ({}),
-    createChannelPushExtension: createEmptyChannelPushExtension,
+    createChannelPushExtension: createManagedChannelPushExtension,
     loadFlightAdminRoutes: createManagedFlightAdminRoutes,
     loadMcpAdminRoutes: createManagedMcpAdminRoutes,
     loadCatalogBookingRoutes: emptyRoutes,
@@ -1657,11 +1663,15 @@ function guessMimeType(key: string): string {
 
 const emptyRoutes: LazyRoutesLoader = async () => new Hono()
 
-function createEmptyChannelPushExtension(): HonoExtension {
-  return {
-    extension: { name: "channel-push", module: "distribution" },
-    lazyAdminRoutes: emptyRoutes,
-  }
+function createManagedChannelPushExtension(): HonoExtension {
+  return createDistributionChannelPushExtension({
+    resolveRegistry: resolveManagedChannelPushRegistry,
+  })
+}
+
+function resolveManagedChannelPushRegistry(): SourceAdapterRegistry {
+  managedChannelPushRegistry ??= createSourceAdapterRegistry()
+  return managedChannelPushRegistry
 }
 
 function createNoopExecutionContext(): ExecutionContextLike {

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -86,7 +86,6 @@ export const FRAMEWORK_RUNTIME_MANIFEST = {
 export const FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS = [
   "operator/catalog-booking",
   "operator/catalog-content",
-  "@voyant-travel/distribution/channel-push-extension",
   "operator/proposal-extension",
 ] as const
 

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -221,6 +221,10 @@ describe("managed profile contract", () => {
     expect(bridge.manifest.extensions).toContain("operator/catalog-checkout-extension")
     expect(bridge.manifest.extensions).toContain("operator/quote-version-snapshot-extension")
     expect(bridge.manifest.extensions).toContain("operator/booking-schedule-extension")
+    expect(bridge.manifest.extensions).toContain(
+      "@voyant-travel/distribution/channel-push-extension",
+    )
+    expect(bridge.exclude).not.toContain("@voyant-travel/distribution/channel-push-extension")
     expect(bridge.manifest.modules).toContain("@voyant-travel/flights")
     expect(bridge.manifest.modules).toContain("operator/mcp")
     for (const specifier of FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIERS) {

--- a/starters/operator/src/api/routes/channel-push.ts
+++ b/starters/operator/src/api/routes/channel-push.ts
@@ -18,25 +18,21 @@
  * Per docs/architecture/channel-push-architecture.md §10 (Phase D-G).
  */
 
-import type { Extension } from "@voyant-travel/core"
 import {
-  createChannelPushAdminRoutes,
+  createChannelPushExtension as createDistributionChannelPushExtension,
   processAvailabilityPushIntents,
   processBookingPush,
   processContentPushIntents,
   resolveAllotmentTargetsForSlot,
   resolveBookingPushTargets,
   resolveContentPushTargets,
-  setChannelPushDeps,
   upsertAvailabilityIntent,
   upsertContentIntent,
   upsertPendingBookingLinks,
 } from "@voyant-travel/distribution"
-import type { VoyantDb } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import type { HonoBundle } from "@voyant-travel/hono/plugin"
 import type { NeonDatabase } from "drizzle-orm/neon-serverless"
-import { Hono } from "hono"
 
 import {
   type BookingEngineEnv,
@@ -170,11 +166,6 @@ export const channelPushBundle: HonoBundle = {
   },
 }
 
-const channelPushExtensionDef: Extension = {
-  name: "channel-push",
-  module: "distribution",
-}
-
 /**
  * Channel-push admin API as a composed distribution extension.
  *
@@ -197,14 +188,7 @@ const channelPushExtensionDef: Extension = {
  * Per docs/architecture/channel-push-architecture.md §9 + §14.5.
  */
 export function createChannelPushExtension(): HonoExtension {
-  const adminRoutes = new Hono<{ Variables: { db: VoyantDb } }>()
-  adminRoutes.use("*", async (c, next) => {
-    setChannelPushDeps({
-      db: c.get("db") as NeonDatabase,
-      registry: getBookingEngineRegistryFromContext(c),
-    })
-    await next()
+  return createDistributionChannelPushExtension({
+    resolveRegistry: getBookingEngineRegistryFromContext,
   })
-  adminRoutes.route("/", createChannelPushAdminRoutes())
-  return { extension: channelPushExtensionDef, adminRoutes }
 }


### PR DESCRIPTION
## Summary
- move the channel-push Hono extension wrapper into the distribution package
- wire the managed runtime default provider to the package-owned channel-push extension with a managed source adapter registry
- remove channel-push from the source-free unsupported set and cover the managed profile/runtime path

Closes #2998

## Validation
- pnpm --filter @voyant-travel/distribution build
- pnpm --filter @voyant-travel/distribution typecheck
- pnpm --filter @voyant-travel/distribution test -- channel-push-extension.test.ts channel-push-retry.test.ts
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts profile.test.ts
- pnpm --filter @voyant-travel/framework lint
- pnpm --filter @voyant-travel/distribution lint
- pnpm --filter operator typecheck
- pnpm verify:package-exports
- pnpm verify:fast