### PR TITLE
Follow up managed source-free runtime surfaces

### DIFF
--- a/.changeset/managed-runtime-source-free-followups.md
+++ b/.changeset/managed-runtime-source-free-followups.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Mount cruise catalog-content routes in the source-free managed runtime and add a provider-neutral card-payment starter hook for managed payment links.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -41,6 +41,7 @@
     "@voyant-travel/trips": "workspace:*",
     "@voyant-travel/cloud-sdk": "^0.11.0",
     "@voyant-travel/connect-sdk": "0.9.1",
+    "@voyant-travel/cruises": "workspace:*",
     "@voyant-travel/db": "workspace:*",
     "@voyant-travel/mcp": "workspace:*",
     "@voyant-travel/plugin-voyant-connect": "^0.3.2",

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -74,6 +74,9 @@ export interface FrameworkProviders {
   financeCheckoutPolicy?: import("@voyant-travel/finance").FinanceHonoModuleOptions["policy"]
   financePaymentScheduleLineDescriptionFormat?: import("@voyant-travel/finance").FinanceHonoModuleOptions["paymentScheduleLineDescriptionFormat"]
   resolvePaymentStarters?: import("@voyant-travel/finance").FinanceHonoModuleOptions["resolvePaymentStarters"]
+  resolveCardPaymentStarter?: (
+    bindings: unknown,
+  ) => import("@voyant-travel/finance/card-payment").CardPaymentStarter | null
   notificationsAutoConfirmAndDispatch?: CreateNotificationsHonoModuleOptions["autoConfirmAndDispatch"]
   createChannelPushExtension: () => HonoExtension
   loadFlightAdminRoutes: LazyRoutesLoader
@@ -193,6 +196,8 @@ const CATALOG_CONTENT_ROUTE_PATHS = [
   "/v1/public/products/:id/content",
   "/v1/admin/cruises/:id/content",
   "/v1/public/cruises/:id/content",
+  "/v1/admin/cruises/:id/sailings/:sailingExternalId/pricing",
+  "/v1/public/cruises/:id/sailings/:sailingExternalId/pricing",
   "/v1/admin/accommodations/:id/content",
   "/v1/public/accommodations/:id/content",
 ] as const

--- a/packages/framework/src/composition-policy.test.ts
+++ b/packages/framework/src/composition-policy.test.ts
@@ -140,4 +140,20 @@ describe("frameworkComposition policy injection", () => {
       }),
     )
   })
+
+  it("registers all cruise catalog-content lazy route shapes", () => {
+    const catalogContent = frameworkComposition.modules["operator/catalog-content"]?.(
+      compositionContext(),
+    )
+    if (Array.isArray(catalogContent)) throw new Error("expected a single catalog-content module")
+
+    expect(catalogContent?.lazyRoutes?.paths).toEqual(
+      expect.arrayContaining([
+        "/v1/admin/cruises/:id/content",
+        "/v1/public/cruises/:id/content",
+        "/v1/admin/cruises/:id/sailings/:sailingExternalId/pricing",
+        "/v1/public/cruises/:id/sailings/:sailingExternalId/pricing",
+      ]),
+    )
+  })
 })

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -185,6 +185,8 @@ const CATALOG_CONTENT_ROUTE_PATHS = [
   "/v1/public/products/:id/content",
   "/v1/admin/cruises/:id/content",
   "/v1/public/cruises/:id/content",
+  "/v1/admin/cruises/:id/sailings/:sailingExternalId/pricing",
+  "/v1/public/cruises/:id/sailings/:sailingExternalId/pricing",
   "/v1/admin/accommodations/:id/content",
   "/v1/public/accommodations/:id/content",
 ] as const
@@ -354,6 +356,10 @@ export interface FrameworkProviders {
   financePaymentScheduleLineDescriptionFormat?: FinanceHonoModuleOptions["paymentScheduleLineDescriptionFormat"]
   /** Configured pay-by-link starters, keyed by payment provider id. */
   resolvePaymentStarters?: import("@voyant-travel/finance").FinanceHonoModuleOptions["resolvePaymentStarters"]
+  /** Configured hosted card-payment starter for checkout/payment-link surfaces. */
+  resolveCardPaymentStarter?: (
+    bindings: unknown,
+  ) => import("@voyant-travel/finance/card-payment").CardPaymentStarter | null
   /**
    * Booking-confirmed notification auto-dispatch policy. Optional: omitted
    * deployments keep the standard booking-confirmation auto-send.

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -2,7 +2,8 @@ import { mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { describe, expect, it } from "vitest"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   createManagedProfileNodeEnv,
@@ -24,6 +25,44 @@ const localProviders = {
   scheduledJobs: "none",
   workflows: "none",
 } satisfies VoyantProjectProviders
+
+function makePaymentLinkDb(rows: unknown[][]) {
+  let cursor = 0
+  const builder: Record<string, unknown> = {}
+  const chain = () => builder
+  builder.select = chain
+  builder.from = chain
+  builder.where = chain
+  builder.orderBy = chain
+  builder.limit = chain
+  // biome-ignore lint/suspicious/noThenProperty: test stub mimics a thenable drizzle query builder -- owner: framework.
+  ;(builder as { then: unknown }).then = (
+    resolve: (value: unknown) => unknown,
+    reject?: (reason: unknown) => unknown,
+  ) => {
+    try {
+      const value = rows[cursor++] ?? []
+      return Promise.resolve(value).then(resolve, reject)
+    } catch (err) {
+      return Promise.reject(err)
+    }
+  }
+  return builder
+}
+
+async function mountManagedPaymentLinkApp(
+  providers: ReturnType<typeof createManagedProfileProviders>,
+  db: unknown,
+) {
+  const routes = await providers.loadPaymentLinkRoutes()
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("db" as never, db as never)
+    await next()
+  })
+  app.route("/", routes)
+  return app
+}
 
 describe("managed profile runtime entry", () => {
   it("loads a local source-free profile snapshot without starter-local glue", async () => {
@@ -203,6 +242,75 @@ describe("managed profile runtime entry", () => {
     })
   }, 10000)
 
+  it("keeps managed payment-link card starts explicitly unconfigured by default", async () => {
+    const db = makePaymentLinkDb([
+      [
+        {
+          id: "ps_1",
+          status: "pending",
+          redirectUrl: null,
+          payerName: null,
+          payerEmail: null,
+          notes: null,
+        },
+      ],
+    ])
+    const app = await mountManagedPaymentLinkApp(createManagedProfileProviders(), db)
+
+    const response = await app.request("/v1/public/payment-link/ps_1/start-card", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(503)
+    expect(await response.json()).toEqual({ error: "Card processor not configured" })
+  }, 10000)
+
+  it("starts managed payment-link cards through the provider-neutral card starter", async () => {
+    const db = makePaymentLinkDb([
+      [
+        {
+          id: "ps_1",
+          status: "requires_redirect",
+          redirectUrl: "https://pay.example.test/stale",
+          payerName: "Ada Lovelace",
+          payerEmail: "ada@example.test",
+          notes: "Deposit",
+        },
+      ],
+    ])
+    const startCardPayment = vi.fn(async () => ({
+      redirectUrl: "https://pay.example.test/fresh",
+    }))
+    const app = await mountManagedPaymentLinkApp(
+      createManagedProfileProviders({
+        resolveCardPaymentStarter: () => startCardPayment,
+      }),
+      db,
+    )
+
+    const response = await app.request("/v1/public/payment-link/ps_1/start-card", {
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { redirectUrl: "https://pay.example.test/fresh" },
+    })
+    expect(startCardPayment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        db,
+        sessionId: "ps_1",
+        billing: expect.objectContaining({
+          email: "ada@example.test",
+          firstName: "Ada",
+          lastName: "Lovelace",
+        }),
+        description: "Deposit",
+      }),
+    )
+  }, 10000)
+
   it("wires package-owned contract document routes in the default managed providers", async () => {
     const env = createManagedProfileNodeEnv({ DATABASE_URL: "managed-profile-test-db" })
     await env.DOCUMENTS_BUCKET?.put("contracts/test.pdf", new TextEncoder().encode("%PDF-1.4"))
@@ -304,9 +412,15 @@ describe("managed profile runtime entry", () => {
 
   it("wires package-owned catalog content routes in the default managed providers", async () => {
     const app = await createManagedProfileProviders().loadCatalogContentRoutes()
+    const response = await app.request("/v1/admin/cruises/!!!invalid/content")
 
     expect(app.fetch).toEqual(expect.any(Function))
     expect(app.routes.length).toBeGreaterThan(0)
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: "invalid_key",
+      detail: "Unrecognized cruise key: !!!invalid",
+    })
   }, 10000)
 
   it("wires package-owned catalog checkout routes in the default managed providers", async () => {

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -38,6 +38,7 @@ import type {
 import { type CreateVideoUploadInput, getVoyantCloudClient } from "@voyant-travel/cloud-sdk"
 import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
 import type { EventBus } from "@voyant-travel/core"
+import { createCruiseContentRoutes } from "@voyant-travel/cruises/routes-content"
 import { createDbClient } from "@voyant-travel/db/runtime"
 import { createChannelPushExtension as createDistributionChannelPushExtension } from "@voyant-travel/distribution"
 import {
@@ -336,7 +337,8 @@ export function createManagedProfileApp(options: {
 export function createManagedProfileProviders(
   overrides: Partial<FrameworkProviders> = {},
 ): FrameworkProviders {
-  const providers: FrameworkProviders = {
+  let providers: FrameworkProviders
+  const defaults: FrameworkProviders = {
     resolveNotificationProviders: resolveManagedNotificationProviders,
     resolvePublicCheckoutBaseUrl: resolvePublicCheckoutBaseUrl,
     resolveDocumentDownloadUrl: resolveDocumentDownloadUrl,
@@ -360,13 +362,15 @@ export function createManagedProfileProviders(
     createTripsRoutesOptions: async () => ({}),
     storefrontIntakePersistence: createNoopStorefrontIntakePersistence(),
     resolvePaymentStarters: () => ({}),
+    resolveCardPaymentStarter: () => null,
     createChannelPushExtension: createManagedChannelPushExtension,
     loadFlightAdminRoutes: createManagedFlightAdminRoutes,
     loadMcpAdminRoutes: createManagedMcpAdminRoutes,
     loadCatalogBookingRoutes: createManagedCatalogBookingRoutes,
     loadCatalogContentRoutes: createManagedCatalogContentRoutes,
     loadMediaRoutes: createManagedMediaRoutes,
-    loadPaymentLinkRoutes: async () => createManagedPaymentLinkRoutes(),
+    loadPaymentLinkRoutes: async () =>
+      createManagedPaymentLinkRoutes(providers.resolveCardPaymentStarter),
     loadContractDocumentRoutes: async () => createManagedContractDocumentRoutes(),
     loadBookingScheduleAdminRoutes: createManagedBookingScheduleAdminRoutes,
     loadPaymentPolicyPublicRoutes: createManagedPaymentPolicyPublicRoutes,
@@ -378,7 +382,8 @@ export function createManagedProfileProviders(
     loadCatalogOffersRoutes: createManagedCatalogOffersRoutes,
     loadCatalogCheckoutRoutes: createManagedCatalogCheckoutRoutes,
   }
-  return { ...providers, ...overrides }
+  providers = { ...defaults, ...overrides }
+  return providers
 }
 
 export function createManagedProfileNodeEnv(
@@ -1120,10 +1125,26 @@ async function createManagedCatalogContentRoutes() {
     }),
   )
   app.route(
+    "/v1/admin/cruises",
+    createCruiseContentRoutes({
+      resolveRegistry: resolveManagedSourceAdapterRegistry,
+      defaultAcceptMachineTranslated: false,
+      allowOwnedKeys: true,
+    }),
+  )
+  app.route(
     "/v1/public/accommodations",
     createAccommodationContentRoutes({
       resolveRegistry: resolveManagedSourceAdapterRegistry,
       defaultAcceptMachineTranslated: true,
+    }),
+  )
+  app.route(
+    "/v1/public/cruises",
+    createCruiseContentRoutes({
+      resolveRegistry: resolveManagedSourceAdapterRegistry,
+      defaultAcceptMachineTranslated: true,
+      allowOwnedKeys: true,
     }),
   )
   return app
@@ -1627,7 +1648,9 @@ async function rejectManagedFlightConnectorRequest(): Promise<never> {
   )
 }
 
-async function createManagedPaymentLinkRoutes() {
+async function createManagedPaymentLinkRoutes(
+  resolveCardPaymentStarter: FrameworkProviders["resolveCardPaymentStarter"],
+) {
   const { createPaymentLinkRoutes } = await import("@voyant-travel/storefront/payment-link")
   return createPaymentLinkRoutes({
     resolveBankTransferDetails: async (c) => {
@@ -1640,9 +1663,41 @@ async function createManagedPaymentLinkRoutes() {
       }
     },
     resolvePublicCheckoutBaseUrl: (c) => resolvePublicCheckoutBaseUrl(c.env),
-    startCardPayment: async () => ({ configured: false }),
+    startCardPayment: (c, session) =>
+      startManagedPaymentLinkCardPayment(c, session, resolveCardPaymentStarter),
     resolveTripData: resolveManagedPaymentLinkTripData,
   })
+}
+
+async function startManagedPaymentLinkCardPayment(
+  c: Context,
+  session: Parameters<PaymentLinkRoutesOptions["startCardPayment"]>[1],
+  resolveCardPaymentStarter: FrameworkProviders["resolveCardPaymentStarter"],
+): ReturnType<PaymentLinkRoutesOptions["startCardPayment"]> {
+  const starter = resolveCardPaymentStarter?.(c.env) ?? null
+  if (!starter) return { configured: false }
+
+  const [first, ...rest] = (session.payerName ?? "").trim().split(/\s+/)
+  const last = rest.length > 0 ? rest.join(" ") : "Customer"
+  const result = await starter(c, {
+    db: dbFromContext(c),
+    sessionId: session.id,
+    billing: {
+      email: session.payerEmail ?? "tbd@example.com",
+      phone: "0000000000",
+      firstName: first || "Customer",
+      lastName: last,
+      city: "TBD",
+      country: 642,
+      state: "TBD",
+      postalCode: "00000",
+      details: "Pending - customer to confirm at payment.",
+    },
+    description: session.notes ?? `Payment ${session.id}`,
+  })
+
+  if (!result) return { configured: false }
+  return { configured: true, redirectUrl: result.redirectUrl }
 }
 
 const resolveManagedPaymentLinkTripData: NonNullable<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1940,6 +1940,9 @@ importers:
       '@voyant-travel/connect-sdk':
         specifier: 0.9.1
         version: 0.9.1
+      '@voyant-travel/cruises':
+        specifier: workspace:*
+        version: link:../cruises
       '@voyant-travel/db':
         specifier: workspace:*
         version: link:../db

--- a/scripts/generate-framework-bom.mjs
+++ b/scripts/generate-framework-bom.mjs
@@ -29,6 +29,7 @@ const runtimePackages = JSON.parse(readFileSync(MANIFEST, "utf-8")).runtimePacka
 const frameworkRuntimeEntryDeps = {
   "@voyant-travel/cloud-sdk": "^0.11.0",
   "@voyant-travel/connect-sdk": "0.9.1",
+  "@voyant-travel/cruises": "workspace:*",
   "@voyant-travel/db": "workspace:*",
   "@voyant-travel/mcp": "workspace:*",
   "@voyant-travel/plugin-voyant-connect": "^0.3.2",


### PR DESCRIPTION
## Summary
- Mount package-owned cruise catalog-content routes in the source-free managed runtime for admin and public prefixes.
- Add a provider-neutral managed card-payment starter hook and wire payment-link start-card through it.
- Add managed-runtime coverage for cruise content mounting plus configured/unconfigured card starts.

Closes #3007.
Closes #3021.

## Tests
- pnpm --filter @voyant-travel/framework test -- managed-runtime.test.ts
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter @voyant-travel/framework lint
- pre-commit checks during commit
- push hook: pnpm test