### PR TITLE
Add vertical enrichment seam for public booking overview (#2969)

### DIFF
--- a/.changeset/public-overview-vertical-enrichment.md
+++ b/.changeset/public-overview-vertical-enrichment.md
@@ -1,0 +1,23 @@
+---
+"@voyant-travel/bookings": minor
+"@voyant-travel/bookings-contracts": minor
+"@voyant-travel/accommodations": minor
+"@voyant-travel/framework": minor
+---
+
+Add a vertical enrichment seam to the public guest-booking overview so
+storefront "manage my booking" / confirmation surfaces can render
+accommodation specifics from the public API alone (issue #2969).
+
+Deployments can register a per-`booking_item_type` enricher via the new
+`overviewItemEnrichers` option on the bookings route runtime. Each enricher
+receives the overview items of its type and returns an opaque `details`
+block that is attached to the matching overview item, keyed by booking item
+id. Enrichment is best-effort — a failing enricher is skipped rather than
+failing the guest-authorized overview.
+
+`@voyant-travel/accommodations` ships the first enricher
+(`enrichStayBookingOverviewItems`, exported from
+`@voyant-travel/accommodations/booking-overview-enricher`), contributing
+property, room type, rate plan, meal plan and per-night rate details. The
+framework composition wires it to the `accommodation` item type.

--- a/packages/accommodations/package.json
+++ b/packages/accommodations/package.json
@@ -10,6 +10,7 @@
     "./content-shape": "./src/content-shape.ts",
     "./service-content": "./src/service-content.ts",
     "./service-content-synthesizer": "./src/service-content-synthesizer.ts",
+    "./booking-overview-enricher": "./src/booking-overview-enricher.ts",
     "./service-owned-stays": "./src/service-owned-stays.ts",
     "./catalog-policy": "./src/catalog-policy.ts",
     "./service-catalog-plane": "./src/service-catalog-plane.ts",
@@ -83,6 +84,11 @@
         "types": "./dist/service-content-synthesizer.d.ts",
         "import": "./dist/service-content-synthesizer.js",
         "default": "./dist/service-content-synthesizer.js"
+      },
+      "./booking-overview-enricher": {
+        "types": "./dist/booking-overview-enricher.d.ts",
+        "import": "./dist/booking-overview-enricher.js",
+        "default": "./dist/booking-overview-enricher.js"
       },
       "./service-owned-stays": {
         "types": "./dist/service-owned-stays.d.ts",

--- a/packages/accommodations/src/booking-overview-enricher.ts
+++ b/packages/accommodations/src/booking-overview-enricher.ts
@@ -1,0 +1,226 @@
+import type { BookingOverviewEnricherItem } from "@voyant-travel/bookings"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { facilities, facilityAddressProjections, properties } from "@voyant-travel/operations"
+import { asc, eq, inArray } from "drizzle-orm"
+
+import { stayBookingItems, stayDailyRates } from "./schema-bookings.js"
+import { mealPlans, ratePlans, roomTypes } from "./schema-inventory.js"
+
+/**
+ * Postal address for the stay's property, projected from the facility
+ * address projection. Any field may be null when the source projection is
+ * sparse.
+ */
+export interface StayBookingOverviewAddress {
+  fullText: string | null
+  line1: string | null
+  line2: string | null
+  city: string | null
+  region: string | null
+  postalCode: string | null
+  country: string | null
+}
+
+/**
+ * Guest-facing accommodation recap for a single booking item. Enough to
+ * render "Deluxe King, Bed & Breakfast, 2 nights at Acme Grand Hotel,
+ * €120/night" on a storefront "manage my booking" / confirmation page.
+ */
+export interface StayBookingOverviewDetails {
+  kind: "accommodation"
+  property: {
+    id: string
+    name: string | null
+    checkInTime: string | null
+    checkOutTime: string | null
+    address: StayBookingOverviewAddress | null
+  }
+  roomType: { id: string; name: string | null }
+  ratePlan: { id: string; name: string | null }
+  mealPlan: { id: string; name: string | null } | null
+  checkInDate: string
+  checkOutDate: string
+  nightCount: number
+  roomCount: number
+  adults: number
+  children: number
+  infants: number
+  confirmationCode: string | null
+  voucherCode: string | null
+  status: string
+  dailyRates: Array<{
+    date: string
+    sellCurrency: string
+    sellAmountCents: number | null
+  }>
+}
+
+function uniqueDefined(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))]
+}
+
+/**
+ * Public-overview enricher for `accommodation` booking items (issue #2969).
+ *
+ * Given the core booking items, joins the accommodations stay tables
+ * (`stay_booking_items`, `stay_daily_rates`) plus room type / rate plan /
+ * meal plan and the property (facility name + address projection) to return
+ * a `StayBookingOverviewDetails` per booking item, keyed by the core
+ * `booking_items.id`. Wired into `@voyant-travel/bookings` at composition
+ * time via `overviewItemEnrichers` so the bookings package never imports
+ * accommodations.
+ */
+export const enrichStayBookingOverviewItems = async (
+  db: AnyDrizzleDb,
+  items: ReadonlyArray<BookingOverviewEnricherItem>,
+): Promise<Map<string, StayBookingOverviewDetails>> => {
+  const result = new Map<string, StayBookingOverviewDetails>()
+
+  const bookingItemIds = uniqueDefined(items.map((item) => item.id))
+  if (bookingItemIds.length === 0) {
+    return result
+  }
+
+  const stays = await db
+    .select()
+    .from(stayBookingItems)
+    .where(inArray(stayBookingItems.bookingItemId, bookingItemIds))
+
+  if (stays.length === 0) {
+    return result
+  }
+
+  const propertyIds = uniqueDefined(stays.map((stay) => stay.propertyId))
+  const roomTypeIds = uniqueDefined(stays.map((stay) => stay.roomTypeId))
+  const ratePlanIds = uniqueDefined(stays.map((stay) => stay.ratePlanId))
+  const mealPlanIds = uniqueDefined(stays.map((stay) => stay.mealPlanId))
+  const stayIds = uniqueDefined(stays.map((stay) => stay.id))
+
+  const [propertyRows, roomTypeRows, ratePlanRows, mealPlanRows, dailyRateRows] = await Promise.all(
+    [
+      propertyIds.length > 0
+        ? db
+            .select({
+              id: properties.id,
+              checkInTime: properties.checkInTime,
+              checkOutTime: properties.checkOutTime,
+              name: facilities.name,
+              addressFullText: facilityAddressProjections.fullText,
+              addressLine1: facilityAddressProjections.line1,
+              addressLine2: facilityAddressProjections.line2,
+              city: facilityAddressProjections.city,
+              region: facilityAddressProjections.region,
+              postalCode: facilityAddressProjections.postalCode,
+              country: facilityAddressProjections.country,
+            })
+            .from(properties)
+            .innerJoin(facilities, eq(facilities.id, properties.facilityId))
+            .leftJoin(
+              facilityAddressProjections,
+              eq(facilityAddressProjections.facilityId, properties.facilityId),
+            )
+            .where(inArray(properties.id, propertyIds))
+        : Promise.resolve([]),
+      roomTypeIds.length > 0
+        ? db
+            .select({ id: roomTypes.id, name: roomTypes.name })
+            .from(roomTypes)
+            .where(inArray(roomTypes.id, roomTypeIds))
+        : Promise.resolve([]),
+      ratePlanIds.length > 0
+        ? db
+            .select({ id: ratePlans.id, name: ratePlans.name })
+            .from(ratePlans)
+            .where(inArray(ratePlans.id, ratePlanIds))
+        : Promise.resolve([]),
+      mealPlanIds.length > 0
+        ? db
+            .select({ id: mealPlans.id, name: mealPlans.name })
+            .from(mealPlans)
+            .where(inArray(mealPlans.id, mealPlanIds))
+        : Promise.resolve([]),
+      stayIds.length > 0
+        ? db
+            .select({
+              stayBookingItemId: stayDailyRates.stayBookingItemId,
+              date: stayDailyRates.date,
+              sellCurrency: stayDailyRates.sellCurrency,
+              sellAmountCents: stayDailyRates.sellAmountCents,
+            })
+            .from(stayDailyRates)
+            .where(inArray(stayDailyRates.stayBookingItemId, stayIds))
+            .orderBy(asc(stayDailyRates.date))
+        : Promise.resolve([]),
+    ],
+  )
+
+  const propertyById = new Map(propertyRows.map((row) => [row.id, row]))
+  const roomTypeById = new Map(roomTypeRows.map((row) => [row.id, row]))
+  const ratePlanById = new Map(ratePlanRows.map((row) => [row.id, row]))
+  const mealPlanById = new Map(mealPlanRows.map((row) => [row.id, row]))
+
+  const dailyRatesByStayId = new Map<
+    string,
+    Array<{ date: string; sellCurrency: string; sellAmountCents: number | null }>
+  >()
+  for (const rate of dailyRateRows) {
+    const bucket = dailyRatesByStayId.get(rate.stayBookingItemId) ?? []
+    bucket.push({
+      date: rate.date,
+      sellCurrency: rate.sellCurrency,
+      sellAmountCents: rate.sellAmountCents ?? null,
+    })
+    dailyRatesByStayId.set(rate.stayBookingItemId, bucket)
+  }
+
+  for (const stay of stays) {
+    const property = propertyById.get(stay.propertyId)
+    const roomType = roomTypeById.get(stay.roomTypeId)
+    const ratePlan = ratePlanById.get(stay.ratePlanId)
+    const mealPlan = stay.mealPlanId ? mealPlanById.get(stay.mealPlanId) : undefined
+
+    const hasAddress =
+      property != null &&
+      (property.addressFullText != null ||
+        property.addressLine1 != null ||
+        property.city != null ||
+        property.country != null)
+
+    result.set(stay.bookingItemId, {
+      kind: "accommodation",
+      property: {
+        id: stay.propertyId,
+        name: property?.name ?? null,
+        checkInTime: property?.checkInTime ?? null,
+        checkOutTime: property?.checkOutTime ?? null,
+        address: hasAddress
+          ? {
+              fullText: property?.addressFullText ?? null,
+              line1: property?.addressLine1 ?? null,
+              line2: property?.addressLine2 ?? null,
+              city: property?.city ?? null,
+              region: property?.region ?? null,
+              postalCode: property?.postalCode ?? null,
+              country: property?.country ?? null,
+            }
+          : null,
+      },
+      roomType: { id: stay.roomTypeId, name: roomType?.name ?? null },
+      ratePlan: { id: stay.ratePlanId, name: ratePlan?.name ?? null },
+      mealPlan: stay.mealPlanId ? { id: stay.mealPlanId, name: mealPlan?.name ?? null } : null,
+      checkInDate: stay.checkInDate,
+      checkOutDate: stay.checkOutDate,
+      nightCount: stay.nightCount,
+      roomCount: stay.roomCount,
+      adults: stay.adults,
+      children: stay.children,
+      infants: stay.infants,
+      confirmationCode: stay.confirmationCode ?? null,
+      voucherCode: stay.voucherCode ?? null,
+      status: stay.status,
+      dailyRates: dailyRatesByStayId.get(stay.id) ?? [],
+    })
+  }
+
+  return result
+}

--- a/packages/accommodations/tests/unit/booking-overview-enricher.test.ts
+++ b/packages/accommodations/tests/unit/booking-overview-enricher.test.ts
@@ -1,0 +1,166 @@
+import type { BookingOverviewEnricherItem } from "@voyant-travel/bookings"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { properties } from "@voyant-travel/operations"
+import { describe, expect, it } from "vitest"
+
+import {
+  enrichStayBookingOverviewItems,
+  type StayBookingOverviewDetails,
+} from "../../src/booking-overview-enricher.js"
+import { stayBookingItems, stayDailyRates } from "../../src/schema-bookings.js"
+import { mealPlans, ratePlans, roomTypes } from "../../src/schema-inventory.js"
+
+// Minimal drizzle-query fake: keys canned rows by the first `.from()` table and
+// treats every builder step (join / where / orderBy) as a pass-through so the
+// enricher's real join/group/shape logic runs against the provided rows.
+class FakeQuery {
+  constructor(private readonly rows: unknown[]) {}
+  from() {
+    return this
+  }
+  innerJoin() {
+    return this
+  }
+  leftJoin() {
+    return this
+  }
+  where() {
+    // Terminal step: an awaitable that also supports a trailing `.orderBy()`.
+    return Object.assign(Promise.resolve(this.rows), {
+      orderBy: () => Promise.resolve(this.rows),
+    })
+  }
+}
+
+function fakeDb(rowsByTable: Map<unknown, unknown[]>): AnyDrizzleDb {
+  return {
+    select() {
+      return {
+        from(table: unknown) {
+          return new FakeQuery(rowsByTable.get(table) ?? [])
+        },
+      }
+    },
+  } as AnyDrizzleDb
+}
+
+function items(...ids: string[]): BookingOverviewEnricherItem[] {
+  return ids.map((id) => ({ id, itemType: "accommodation", productId: null, optionId: null }))
+}
+
+const baseStay = {
+  id: "staybi_1",
+  bookingItemId: "bkit_1",
+  propertyId: "prop_1",
+  roomTypeId: "room_1",
+  ratePlanId: "rate_1",
+  mealPlanId: "meal_1" as string | null,
+  checkInDate: "2026-09-01",
+  checkOutDate: "2026-09-03",
+  nightCount: 2,
+  roomCount: 1,
+  adults: 2,
+  children: 0,
+  infants: 0,
+  confirmationCode: "CONF-1",
+  voucherCode: null,
+  status: "reserved",
+}
+
+const baseProperty = {
+  id: "prop_1",
+  checkInTime: "15:00",
+  checkOutTime: "11:00",
+  name: "Acme Grand Hotel",
+  addressFullText: "1 Ocean Dr, Split, HR",
+  addressLine1: "1 Ocean Dr",
+  addressLine2: null,
+  city: "Split",
+  region: null,
+  postalCode: "21000",
+  country: "HR",
+}
+
+describe("enrichStayBookingOverviewItems", () => {
+  it("builds a full accommodation recap keyed by booking item id", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[]>([
+        [stayBookingItems, [baseStay]],
+        [properties, [baseProperty]],
+        [roomTypes, [{ id: "room_1", name: "Deluxe King" }]],
+        [ratePlans, [{ id: "rate_1", name: "Best Available" }]],
+        [mealPlans, [{ id: "meal_1", name: "Bed & Breakfast" }]],
+        [
+          stayDailyRates,
+          [
+            {
+              stayBookingItemId: "staybi_1",
+              date: "2026-09-01",
+              sellCurrency: "EUR",
+              sellAmountCents: 12_000,
+            },
+            {
+              stayBookingItemId: "staybi_1",
+              date: "2026-09-02",
+              sellCurrency: "EUR",
+              sellAmountCents: 12_000,
+            },
+          ],
+        ],
+      ]),
+    )
+
+    const result = await enrichStayBookingOverviewItems(db, items("bkit_1"))
+    const details = result.get("bkit_1") as StayBookingOverviewDetails
+
+    expect(details.kind).toBe("accommodation")
+    expect(details.property.name).toBe("Acme Grand Hotel")
+    expect(details.property.checkInTime).toBe("15:00")
+    expect(details.property.address).toMatchObject({ city: "Split", country: "HR" })
+    expect(details.roomType.name).toBe("Deluxe King")
+    expect(details.ratePlan.name).toBe("Best Available")
+    expect(details.mealPlan).toMatchObject({ id: "meal_1", name: "Bed & Breakfast" })
+    expect(details.nightCount).toBe(2)
+    expect(details.confirmationCode).toBe("CONF-1")
+    expect(details.dailyRates).toHaveLength(2)
+    expect(details.dailyRates[0]).toMatchObject({ date: "2026-09-01", sellAmountCents: 12_000 })
+  })
+
+  it("returns a null meal plan and null address when those are absent", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[]>([
+        [stayBookingItems, [{ ...baseStay, mealPlanId: null }]],
+        [
+          properties,
+          [
+            {
+              ...baseProperty,
+              addressFullText: null,
+              addressLine1: null,
+              city: null,
+              country: null,
+            },
+          ],
+        ],
+        [roomTypes, [{ id: "room_1", name: "Deluxe King" }]],
+        [ratePlans, [{ id: "rate_1", name: "Best Available" }]],
+        [mealPlans, []],
+        [stayDailyRates, []],
+      ]),
+    )
+
+    const details = (await enrichStayBookingOverviewItems(db, items("bkit_1"))).get(
+      "bkit_1",
+    ) as StayBookingOverviewDetails
+
+    expect(details.mealPlan).toBeNull()
+    expect(details.property.address).toBeNull()
+    expect(details.dailyRates).toEqual([])
+  })
+
+  it("returns an empty map when no stay rows match", async () => {
+    const db = fakeDb(new Map<unknown, unknown[]>([[stayBookingItems, []]]))
+    const result = await enrichStayBookingOverviewItems(db, items("bkit_1", "bkit_2"))
+    expect(result.size).toBe(0)
+  })
+})

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -16,6 +16,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/bookings-contracts/src/validation-public.ts
+++ b/packages/bookings-contracts/src/validation-public.ts
@@ -215,6 +215,17 @@ export const publicBookingSessionItemSchema = z.object({
   travelerLinks: z.array(publicBookingSessionItemTravelerSchema),
 })
 
+/**
+ * Overview items carry an optional vertical `details` block contributed by
+ * a package's public-overview enricher (e.g. accommodations adds property /
+ * room / rate-plan / nightly-rate specifics). Opaque here so the bookings
+ * contract stays vertical-agnostic; each vertical documents its own shape.
+ * See issue #2969.
+ */
+export const publicBookingOverviewItemSchema = publicBookingSessionItemSchema.extend({
+  details: z.unknown().optional(),
+})
+
 export const publicBookingSessionAllocationSchema = z.object({
   id: z.string(),
   bookingItemId: z.string().nullable(),
@@ -354,7 +365,7 @@ export const publicBookingOverviewSchema = z.object({
   cancelledAt: z.string().nullable(),
   completedAt: z.string().nullable(),
   travelers: z.array(publicBookingOverviewTravelerSchema),
-  items: z.array(publicBookingSessionItemSchema),
+  items: z.array(publicBookingOverviewItemSchema),
   documents: z.array(publicBookingOverviewDocumentSchema),
   fulfillments: z.array(publicBookingOverviewFulfillmentSchema),
 })
@@ -387,3 +398,5 @@ export type PublicGuestBookingLookupResponse = z.infer<
 export type InternalBookingOverviewLookupQuery = z.infer<
   typeof internalBookingOverviewLookupQuerySchema
 >
+export type PublicBookingOverviewItem = z.infer<typeof publicBookingOverviewItemSchema>
+export type PublicBookingOverview = z.infer<typeof publicBookingOverviewSchema>

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -131,6 +131,8 @@ export function createBookingsHonoModule(options: BookingsHonoModuleOptions = {}
 export const bookingsHonoModule: HonoModule = createBookingsHonoModule()
 
 export type {
+  BookingOverviewEnricherItem,
+  BookingOverviewItemEnricher,
   BookingPersonResolverContact,
   BookingRouteRuntime,
   BookingRouteRuntimeOptions,

--- a/packages/bookings/src/overview-enrichment.ts
+++ b/packages/bookings/src/overview-enrichment.ts
@@ -1,0 +1,80 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { BookingOverviewItemEnricher } from "./route-runtime.js"
+
+/**
+ * Minimal shape an overview item must satisfy to be enriched. The public
+ * overview items carry many more fields; enrichers only read these.
+ */
+export interface EnrichableOverviewItem {
+  id: string
+  itemType: string
+  productId: string | null
+  optionId: string | null
+}
+
+/**
+ * Attach vertical `details` blocks to public-overview items using the
+ * deployment-registered enrichers (issue #2969). Items are grouped by
+ * `itemType`; each registered enricher is invoked ONCE with its group and
+ * returns a `Map<bookingItemId, details>` that is merged back onto the
+ * matching items.
+ *
+ * Enrichment is best-effort: a throwing or absent enricher leaves the
+ * affected items without a `details` field rather than failing the whole
+ * overview — this rides inside an already guest-authorized snapshot and a
+ * "manage my booking" surface must not 500 because a detail join broke.
+ */
+export async function applyOverviewEnrichers<T extends EnrichableOverviewItem>(
+  db: PostgresJsDatabase,
+  items: T[],
+  enrichers?: Partial<Record<string, BookingOverviewItemEnricher>>,
+): Promise<Array<T & { details?: unknown }>> {
+  if (!enrichers || items.length === 0) {
+    return items
+  }
+
+  const itemsByType = new Map<string, T[]>()
+  for (const item of items) {
+    const group = itemsByType.get(item.itemType)
+    if (group) {
+      group.push(item)
+    } else {
+      itemsByType.set(item.itemType, [item])
+    }
+  }
+
+  const detailsByItemId = new Map<string, unknown>()
+  await Promise.all(
+    [...itemsByType.entries()].map(async ([itemType, group]) => {
+      const enrich = enrichers[itemType]
+      if (!enrich) return
+      try {
+        const result = await enrich(
+          db,
+          group.map((item) => ({
+            id: item.id,
+            itemType: item.itemType,
+            productId: item.productId,
+            optionId: item.optionId,
+          })),
+        )
+        for (const [bookingItemId, details] of result) {
+          detailsByItemId.set(bookingItemId, details)
+        }
+      } catch (error) {
+        // Best-effort: skip this vertical's details, keep the overview.
+        console.error(`[bookings] overview enricher for "${itemType}" failed`, error)
+      }
+    }),
+  )
+
+  if (detailsByItemId.size === 0) {
+    return items
+  }
+
+  return items.map((item) => {
+    const details = detailsByItemId.get(item.id)
+    return details === undefined ? item : { ...item, details }
+  })
+}

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -98,6 +98,33 @@ export type RecordCancellationFinancialSettlement = (
   | null
   | undefined
 
+/**
+ * Item passed to a public-overview enricher. Carries only the core
+ * booking-item fields a vertical package needs to look up its own
+ * detail rows — the enricher joins on `id` (the core `booking_items.id`).
+ */
+export interface BookingOverviewEnricherItem {
+  id: string
+  itemType: string
+  productId: string | null
+  optionId: string | null
+}
+
+/**
+ * Vertical enrichment seam for the public guest-booking overview. A
+ * deployment wires one enricher per `booking_item_type` (e.g.
+ * `accommodation`). Each enricher is invoked ONCE with all overview items
+ * of its type and returns a map keyed by the core `booking_items.id` →
+ * an opaque `details` block that is attached to the matching overview
+ * item. Kept in the route-runtime so verticals inject their detail joins
+ * at composition time without the bookings package importing them
+ * (avoids the accommodations→bookings dependency cycle). See issue #2969.
+ */
+export type BookingOverviewItemEnricher = (
+  db: PostgresJsDatabase,
+  items: ReadonlyArray<BookingOverviewEnricherItem>,
+) => Promise<Map<string, unknown>>
+
 export interface BookingRouteRuntime {
   getKmsProvider(): Promise<KmsProvider>
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
@@ -109,6 +136,8 @@ export interface BookingRouteRuntime {
   recordCancellationFinancialSettlement?: RecordCancellationFinancialSettlement
   /** Deployment custom-field registry — validates `customFields` on write. */
   customFields?: CustomFieldRegistryResolver
+  /** Per-`booking_item_type` public-overview enrichers (issue #2969). */
+  overviewItemEnrichers?: Partial<Record<string, BookingOverviewItemEnricher>>
 }
 
 /**
@@ -132,6 +161,7 @@ export interface BookingRouteRuntimeOptions {
   closePaymentSchedulesForBooking?: ClosePaymentSchedulesForBooking
   recordCancellationFinancialSettlement?: RecordCancellationFinancialSettlement
   customFields?: CustomFieldRegistryResolver
+  overviewItemEnrichers?: Partial<Record<string, BookingOverviewItemEnricher>>
 }
 
 function buildRuntimeEnv(bindings: KmsBindings): Record<string, string | undefined> {
@@ -169,5 +199,6 @@ export function buildBookingRouteRuntime(
     closePaymentSchedulesForBooking: options.closePaymentSchedulesForBooking,
     recordCancellationFinancialSettlement: options.recordCancellationFinancialSettlement,
     customFields: options.customFields,
+    overviewItemEnrichers: options.overviewItemEnrichers,
   }
 }

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -1,3 +1,7 @@
+// agent-quality: file-size exception — intentional: this public route module
+// predates the 600-line limit (686 lines on main before the overview
+// enrichment change) and splitting the OpenAPI route group is out of scope for
+// the additive #2969 wiring; tracked for a follow-up split.
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { idempotencyKey, openApiValidationHook, UnauthorizedApiError } from "@voyant-travel/hono"
 import type { Context, MiddlewareHandler } from "hono"
@@ -643,14 +647,19 @@ export const publicBookingRoutes = publicBookingApp
       )
       if (rateLimited) return rateLimited
     }
+    const overviewEnrichers = getRouteRuntime(c).overviewItemEnrichers
     const overview = query.email
-      ? await publicBookingsService.getOverview(c.get("db"), {
-          bookingId: query.bookingId,
-          bookingNumber: query.bookingNumber,
-          bookingCode: query.bookingCode,
-          email: query.email,
-        })
-      : await publicBookingsService.getOverviewByGuestAccess(c.get("db"), query)
+      ? await publicBookingsService.getOverview(
+          c.get("db"),
+          {
+            bookingId: query.bookingId,
+            bookingNumber: query.bookingNumber,
+            bookingCode: query.bookingCode,
+            email: query.email,
+          },
+          overviewEnrichers,
+        )
+      : await publicBookingsService.getOverviewByGuestAccess(c.get("db"), query, overviewEnrichers)
     if (!overview) {
       if (!query.email) {
         throw new UnauthorizedApiError("Missing guest booking access capability")
@@ -670,7 +679,11 @@ export const publicBookingRoutes = publicBookingApp
     const rateLimited = await enforceGuestBookingLookupRateLimit(c, input.bookingCode)
     if (rateLimited) return rateLimited
 
-    const overview = await publicBookingsService.getOverview(c.get("db"), input)
+    const overview = await publicBookingsService.getOverview(
+      c.get("db"),
+      input,
+      getRouteRuntime(c).overviewItemEnrichers,
+    )
     if (!overview) {
       return notFound(c, "Booking overview not found")
     }

--- a/packages/bookings/src/service-public-core.ts
+++ b/packages/bookings/src/service-public-core.ts
@@ -1,7 +1,7 @@
 // agent-quality: file-size exception -- owner: bookings; existing service module stays co-located until a dedicated split preserves behavior and tests.
 import { and, asc, desc, eq, inArray, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
+import { applyOverviewEnrichers } from "./overview-enrichment.js"
 import {
   departurePriceOverridesRef,
   optionPriceRulesRef,
@@ -12,6 +12,7 @@ import {
 } from "./pricing-ref.js"
 import { optionUnitsRef, productOptionsRef, productsRef } from "./products-ref.js"
 import type {
+  BookingOverviewItemEnricher,
   BookingPersonResolverContact,
   ResolveBookingBillingPerson,
   ResolveBookingTravelerPerson,
@@ -561,6 +562,7 @@ async function buildOverviewSnapshot(
     bookingCode?: string | null
     email?: string | null
   },
+  enrichers?: Partial<Record<string, BookingOverviewItemEnricher>>,
 ) {
   const bookingLookupNumber = query.bookingNumber ?? query.bookingCode ?? null
   const [booking] = await db
@@ -645,6 +647,32 @@ async function buildOverviewSnapshot(
     itemLinksByItemId.set(link.bookingItemId, existing)
   }
 
+  const overviewItems = items.map((item) => ({
+    id: item.id,
+    title: item.title,
+    description: item.description ?? null,
+    itemType: item.itemType,
+    status: item.status,
+    serviceDate: normalizeDate(item.serviceDate),
+    startsAt: normalizeDateTime(item.startsAt),
+    endsAt: normalizeDateTime(item.endsAt),
+    quantity: item.quantity,
+    sellCurrency: item.sellCurrency,
+    unitSellAmountCents: item.unitSellAmountCents ?? null,
+    totalSellAmountCents: item.totalSellAmountCents ?? null,
+    costCurrency: item.costCurrency ?? null,
+    unitCostAmountCents: item.unitCostAmountCents ?? null,
+    totalCostAmountCents: item.totalCostAmountCents ?? null,
+    notes: item.notes ?? null,
+    productId: item.productId ?? null,
+    optionId: item.optionId ?? null,
+    optionUnitId: item.optionUnitId ?? null,
+    pricingCategoryId: item.pricingCategoryId ?? null,
+    travelerLinks: itemLinksByItemId.get(item.id) ?? [],
+  }))
+
+  const enrichedItems = await applyOverviewEnrichers(db, overviewItems, enrichers)
+
   return {
     bookingId: booking.id,
     bookingNumber: booking.bookingNumber,
@@ -664,29 +692,7 @@ async function buildOverviewSnapshot(
       lastName: participant.lastName,
       isPrimary: participant.isPrimary,
     })),
-    items: items.map((item) => ({
-      id: item.id,
-      title: item.title,
-      description: item.description ?? null,
-      itemType: item.itemType,
-      status: item.status,
-      serviceDate: normalizeDate(item.serviceDate),
-      startsAt: normalizeDateTime(item.startsAt),
-      endsAt: normalizeDateTime(item.endsAt),
-      quantity: item.quantity,
-      sellCurrency: item.sellCurrency,
-      unitSellAmountCents: item.unitSellAmountCents ?? null,
-      totalSellAmountCents: item.totalSellAmountCents ?? null,
-      costCurrency: item.costCurrency ?? null,
-      unitCostAmountCents: item.unitCostAmountCents ?? null,
-      totalCostAmountCents: item.totalCostAmountCents ?? null,
-      notes: item.notes ?? null,
-      productId: item.productId ?? null,
-      optionId: item.optionId ?? null,
-      optionUnitId: item.optionUnitId ?? null,
-      pricingCategoryId: item.pricingCategoryId ?? null,
-      travelerLinks: itemLinksByItemId.get(item.id) ?? [],
-    })),
+    items: enrichedItems,
     documents: documents.map((document) => ({
       id: document.id,
       travelerId: document.travelerId ?? null,
@@ -1762,15 +1768,27 @@ export const publicBookingsService = {
     return session ? { status: "ok" as const, session } : { status: "not_found" as const }
   },
 
-  async getOverview(db: PostgresJsDatabase, query: PublicBookingOverviewLookupQuery) {
-    return buildOverviewSnapshot(db, query)
+  async getOverview(
+    db: PostgresJsDatabase,
+    query: PublicBookingOverviewLookupQuery,
+    enrichers?: Partial<Record<string, BookingOverviewItemEnricher>>,
+  ) {
+    return buildOverviewSnapshot(db, query, enrichers)
   },
 
-  async getOverviewByGuestAccess(db: PostgresJsDatabase, query: PublicBookingOverviewAccessQuery) {
-    return buildOverviewSnapshot(db, query)
+  async getOverviewByGuestAccess(
+    db: PostgresJsDatabase,
+    query: PublicBookingOverviewAccessQuery,
+    enrichers?: Partial<Record<string, BookingOverviewItemEnricher>>,
+  ) {
+    return buildOverviewSnapshot(db, query, enrichers)
   },
 
-  async getOverviewByLookup(db: PostgresJsDatabase, query: InternalBookingOverviewLookupQuery) {
-    return buildOverviewSnapshot(db, query)
+  async getOverviewByLookup(
+    db: PostgresJsDatabase,
+    query: InternalBookingOverviewLookupQuery,
+    enrichers?: Partial<Record<string, BookingOverviewItemEnricher>>,
+  ) {
+    return buildOverviewSnapshot(db, query, enrichers)
   },
 }

--- a/packages/bookings/tests/unit/overview-enrichment.test.ts
+++ b/packages/bookings/tests/unit/overview-enrichment.test.ts
@@ -1,0 +1,78 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import { applyOverviewEnrichers } from "../../src/overview-enrichment.js"
+import type { BookingOverviewItemEnricher } from "../../src/route-runtime.js"
+
+// The helper never touches the db itself — enrichers do — so a stub is fine.
+const db = {} as PostgresJsDatabase
+
+function item(id: string, itemType: string) {
+  return { id, itemType, productId: null, optionId: null, title: `item-${id}` }
+}
+
+describe("applyOverviewEnrichers", () => {
+  it("returns items unchanged when no enrichers are registered", async () => {
+    const items = [item("bkit_1", "accommodation"), item("bkit_2", "unit")]
+    const result = await applyOverviewEnrichers(db, items, undefined)
+    expect(result).toBe(items)
+    expect(result.every((entry) => !("details" in entry))).toBe(true)
+  })
+
+  it("attaches details only to items the enricher resolves, leaving others untouched", async () => {
+    const items = [
+      item("bkit_1", "accommodation"),
+      item("bkit_2", "accommodation"),
+      item("bkit_3", "unit"),
+    ]
+
+    const enrich: BookingOverviewItemEnricher = async (_db, given) => {
+      // Only the items of the registered type are handed to the enricher.
+      expect(given.map((entry) => entry.id)).toEqual(["bkit_1", "bkit_2"])
+      return new Map<string, unknown>([["bkit_1", { kind: "accommodation", nights: 2 }]])
+    }
+
+    const result = await applyOverviewEnrichers(db, items, { accommodation: enrich })
+
+    const byId = new Map(result.map((entry) => [entry.id, entry]))
+    expect(byId.get("bkit_1")).toMatchObject({ details: { kind: "accommodation", nights: 2 } })
+    expect("details" in byId.get("bkit_2")!).toBe(false)
+    expect("details" in byId.get("bkit_3")!).toBe(false)
+  })
+
+  it("invokes each enricher once with only its item-type group", async () => {
+    const items = [
+      item("bkit_1", "accommodation"),
+      item("bkit_2", "transport"),
+      item("bkit_3", "accommodation"),
+    ]
+    const accommodation = vi.fn(async () => new Map<string, unknown>())
+    const transport = vi.fn(async () => new Map<string, unknown>())
+
+    await applyOverviewEnrichers(db, items, { accommodation, transport })
+
+    expect(accommodation).toHaveBeenCalledTimes(1)
+    expect(transport).toHaveBeenCalledTimes(1)
+    expect(accommodation.mock.calls[0]![1].map((entry) => entry.id)).toEqual(["bkit_1", "bkit_3"])
+    expect(transport.mock.calls[0]![1].map((entry) => entry.id)).toEqual(["bkit_2"])
+  })
+
+  it("swallows a throwing enricher and still returns the overview items", async () => {
+    const items = [item("bkit_1", "accommodation"), item("bkit_2", "transport")]
+
+    const boom: BookingOverviewItemEnricher = async () => {
+      throw new Error("detail join blew up")
+    }
+    const transport: BookingOverviewItemEnricher = async () =>
+      new Map<string, unknown>([["bkit_2", { kind: "transport" }]])
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    const result = await applyOverviewEnrichers(db, items, { accommodation: boom, transport })
+    errorSpy.mockRestore()
+
+    const byId = new Map(result.map((entry) => [entry.id, entry]))
+    // Failed vertical is skipped; the healthy vertical still enriches.
+    expect("details" in byId.get("bkit_1")!).toBe(false)
+    expect(byId.get("bkit_2")).toMatchObject({ details: { kind: "transport" } })
+  })
+})

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -16,6 +16,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -15,6 +15,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -10,6 +10,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -10,6 +10,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -16,6 +16,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -568,38 +568,44 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
       )
     },
     "@voyant-travel/bookings": ({ capabilities }) => {
-      const unit = createLazyUnit(() =>
-        import("@voyant-travel/bookings").then((m) =>
-          m.createBookingsHonoModule({
-            resolveTravelSnapshot: (db, personId, { kms }) =>
-              capabilities.relationshipsService.loadPersonTravelSnapshot(db, personId, { kms }),
-            resolveBillingPerson: async (db, contact, ctx) =>
-              (
-                await capabilities.relationshipsService.upsertPersonFromContact(db, contact, {
-                  source: ctx.source,
-                  sourceRef: ctx.sourceRef,
-                })
-              )?.id ?? null,
-            resolveTravelerPerson: async (db, contact, ctx) =>
-              (
-                await capabilities.relationshipsService.upsertPersonFromContact(db, contact, {
-                  source: ctx.source,
-                  sourceRef: ctx.sourceRef,
-                  requireContactPoint: true,
-                })
-              )?.id ?? null,
-            resolveBillingPersonById: async (db, personId) =>
-              (await capabilities.relationshipsService.getPersonById(db, personId)) != null,
-            resolveBillingOrganizationById: async (db, organizationId) =>
-              (await capabilities.relationshipsService.getOrganizationById(db, organizationId)) !=
-              null,
-            closePaymentSchedulesForBooking: capabilities.closePaymentSchedulesForBooking,
-            recordCancellationFinancialSettlement:
-              capabilities.recordCancellationFinancialSettlement,
-            customFields: capabilities.customFields,
-          }),
-        ),
-      )
+      const unit = createLazyUnit(async () => {
+        const [bookings, accommodationsOverview] = await Promise.all([
+          import("@voyant-travel/bookings"),
+          import("@voyant-travel/accommodations/booking-overview-enricher"),
+        ])
+        return bookings.createBookingsHonoModule({
+          resolveTravelSnapshot: (db, personId, { kms }) =>
+            capabilities.relationshipsService.loadPersonTravelSnapshot(db, personId, { kms }),
+          resolveBillingPerson: async (db, contact, ctx) =>
+            (
+              await capabilities.relationshipsService.upsertPersonFromContact(db, contact, {
+                source: ctx.source,
+                sourceRef: ctx.sourceRef,
+              })
+            )?.id ?? null,
+          resolveTravelerPerson: async (db, contact, ctx) =>
+            (
+              await capabilities.relationshipsService.upsertPersonFromContact(db, contact, {
+                source: ctx.source,
+                sourceRef: ctx.sourceRef,
+                requireContactPoint: true,
+              })
+            )?.id ?? null,
+          resolveBillingPersonById: async (db, personId) =>
+            (await capabilities.relationshipsService.getPersonById(db, personId)) != null,
+          resolveBillingOrganizationById: async (db, organizationId) =>
+            (await capabilities.relationshipsService.getOrganizationById(db, organizationId)) !=
+            null,
+          closePaymentSchedulesForBooking: capabilities.closePaymentSchedulesForBooking,
+          recordCancellationFinancialSettlement: capabilities.recordCancellationFinancialSettlement,
+          customFields: capabilities.customFields,
+          // Vertical enrichment seam (issue #2969): keep lazy composition in
+          // sync with the eager registry used by non-lazy deployments.
+          overviewItemEnrichers: {
+            accommodation: accommodationsOverview.enrichStayBookingOverviewItems,
+          },
+        })
+      })
       return withAnonymous(
         {
           module: { name: "bookings", requiresTransactionalDb: true },

--- a/packages/framework/src/composition-policy.test.ts
+++ b/packages/framework/src/composition-policy.test.ts
@@ -3,6 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
 
 const mocks = vi.hoisted(() => ({
+  createBookingsHonoModule: vi.fn((options: unknown) => ({
+    module: { name: "bookings" },
+    adminRoutes: {},
+    publicRoutes: {},
+    options,
+  })),
   createFinanceHonoModule: vi.fn((options: unknown) => ({
     module: { name: "finance" },
     options,
@@ -11,6 +17,15 @@ const mocks = vi.hoisted(() => ({
     module: { name: "notifications" },
     options,
   })),
+  enrichStayBookingOverviewItems: vi.fn(),
+}))
+
+vi.mock("@voyant-travel/accommodations/booking-overview-enricher", () => ({
+  enrichStayBookingOverviewItems: mocks.enrichStayBookingOverviewItems,
+}))
+
+vi.mock("@voyant-travel/bookings", () => ({
+  createBookingsHonoModule: mocks.createBookingsHonoModule,
 }))
 
 vi.mock("@voyant-travel/finance", () => ({
@@ -39,8 +54,33 @@ function compositionContext(
 
 describe("frameworkComposition policy injection", () => {
   beforeEach(() => {
+    mocks.createBookingsHonoModule.mockClear()
     mocks.createFinanceHonoModule.mockClear()
     mocks.createNotificationsHonoModule.mockClear()
+  })
+
+  it("wires accommodation overview enrichment into the standard bookings module", async () => {
+    const bookings = frameworkComposition.modules["@voyant-travel/bookings"]?.(
+      compositionContext({
+        relationshipsService: {
+          getOrganizationById: vi.fn(),
+          getPersonById: vi.fn(),
+          loadPersonTravelSnapshot: vi.fn(),
+          upsertPersonFromContact: vi.fn(),
+        },
+        closePaymentSchedulesForBooking: vi.fn(),
+      }),
+    )
+    if (Array.isArray(bookings)) throw new Error("expected a single bookings module")
+    await bookings?.lazyPublicRoutes?.()
+
+    expect(mocks.createBookingsHonoModule).toHaveBeenCalledWith(
+      expect.objectContaining({
+        overviewItemEnrichers: {
+          accommodation: mocks.enrichStayBookingOverviewItems,
+        },
+      }),
+    )
   })
 
   it("passes injected finance checkout policy to the standard finance module", async () => {

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -37,6 +37,7 @@
 
 import { OpenAPIHono } from "@hono/zod-openapi"
 import { accommodationsHonoModule } from "@voyant-travel/accommodations"
+import { enrichStayBookingOverviewItems } from "@voyant-travel/accommodations/booking-overview-enricher"
 import { actionLedgerHonoModule } from "@voyant-travel/action-ledger"
 import {
   type BookingsHonoModuleOptions,
@@ -583,6 +584,12 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
           closePaymentSchedulesForBooking: capabilities.closePaymentSchedulesForBooking,
           recordCancellationFinancialSettlement: capabilities.recordCancellationFinancialSettlement,
           customFields: capabilities.customFields,
+          // Vertical enrichment seam (issue #2969): accommodations contributes
+          // property / room / rate-plan / nightly-rate specifics to the public
+          // guest-booking overview, keyed by the `accommodation` item type.
+          overviewItemEnrichers: {
+            accommodation: enrichStayBookingOverviewItems,
+          },
         }),
         true,
       ),

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -10,6 +10,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -16,6 +16,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -10,6 +10,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/openapi/spec/admin/bookings.json
+++ b/packages/openapi/spec/admin/bookings.json
@@ -815,7 +815,8 @@
                                     "isPrimary"
                                   ]
                                 }
-                              }
+                              },
+                              "details": {}
                             },
                             "required": [
                               "id",

--- a/packages/openapi/spec/storefront/bookings.json
+++ b/packages/openapi/spec/storefront/bookings.json
@@ -5438,7 +5438,8 @@
                                     "isPrimary"
                                   ]
                                 }
-                              }
+                              },
+                              "details": {}
                             },
                             "required": [
                               "id",
@@ -5964,7 +5965,8 @@
                                         "isPrimary"
                                       ]
                                     }
-                                  }
+                                  },
+                                  "details": {}
                                 },
                                 "required": [
                                   "id",

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -16,6 +16,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -9,6 +9,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -10,6 +10,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -11,6 +11,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../accommodations/dist/catalog-policy.d.ts"
       ],

--- a/starters/operator/openapi/admin/bookings.json
+++ b/starters/operator/openapi/admin/bookings.json
@@ -815,7 +815,8 @@
                                     "isPrimary"
                                   ]
                                 }
-                              }
+                              },
+                              "details": {}
                             },
                             "required": [
                               "id",

--- a/starters/operator/openapi/storefront/bookings.json
+++ b/starters/operator/openapi/storefront/bookings.json
@@ -5438,7 +5438,8 @@
                                     "isPrimary"
                                   ]
                                 }
-                              }
+                              },
+                              "details": {}
                             },
                             "required": [
                               "id",
@@ -5964,7 +5965,8 @@
                                         "isPrimary"
                                       ]
                                     }
-                                  }
+                                  },
+                                  "details": {}
                                 },
                                 "required": [
                                   "id",

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -14,6 +14,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../../packages/accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../../packages/accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../../packages/accommodations/dist/catalog-policy.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -14,6 +14,9 @@
       "@voyant-travel/accommodations/booking-engine": [
         "../../packages/accommodations/dist/booking-engine/index.d.ts"
       ],
+      "@voyant-travel/accommodations/booking-overview-enricher": [
+        "../../packages/accommodations/dist/booking-overview-enricher.d.ts"
+      ],
       "@voyant-travel/accommodations/catalog-policy": [
         "../../packages/accommodations/dist/catalog-policy.d.ts"
       ],


### PR DESCRIPTION
## Summary

Closes #2969.

The public guest-booking overview (`getOverviewByLookup` / `getOverviewByGuestAccess` in `packages/bookings/src/service-public-core.ts`, plus the guest-lookup and checkout-status routes) exposed booking status, dates, travelers and totals but **none of the accommodation specifics** a storefront "manage my booking" / confirmation page needs (property, room type, rate plan, meal plan, per-night rates).

This implements **Option 1** from the issue — a generalizable *vertical enrichment seam* — rather than a one-off accommodations route, so the guest-auth logic stays in one place and cruises/flights/etc. can plug in the same way later.

## How it works

- **bookings**: new `overviewItemEnrichers` option on the booking route runtime, threaded through the existing route-runtime injection path into all three public-overview entrypoints. `applyOverviewEnrichers` groups overview items by `booking_item_type` and invokes each registered enricher **once** per type, merging an opaque `details` block back onto matching items by booking-item id. Enrichment is **best-effort** — a throwing or absent enricher is skipped and the overview still returns (a guest "manage my booking" surface must not 500 because a detail join broke).
- **bookings-contracts**: optional `details` on the public overview item schema.
- **accommodations**: `enrichStayBookingOverviewItems` joins `stay_booking_items` / `stay_daily_rates` + room type / rate plan / meal plan + property (facility name & address projection) into a guest-facing recap. Exported from the new `@voyant-travel/accommodations/booking-overview-enricher` subpath.
- **framework**: composition wires the accommodations enricher to the `accommodation` item type.

Crucially, the seam keeps the dependency direction correct — the bookings package never imports any vertical, avoiding the accommodations→bookings cycle. This obsoletes the downstream `GET /v1/public/stay-bookings/:bookingId` workaround the pms starter had to add.

## Tests / verification

- New unit tests: `packages/bookings/tests/unit/overview-enrichment.test.ts`, `packages/accommodations/tests/unit/booking-overview-enricher.test.ts`.
- `pnpm --filter @voyant-travel/bookings --filter @voyant-travel/accommodations test` — green.
- `typecheck` green for bookings, bookings-contracts, accommodations, framework.
- Regenerated + committed the OpenAPI artifacts (both the `@voyant-travel/openapi` and operator gates) for the new optional `details` field.
- Full pre-push suite (98 tasks) green.

## Changeset

`minor` for `@voyant-travel/bookings`, `@voyant-travel/bookings-contracts`, `@voyant-travel/accommodations`, `@voyant-travel/framework`.
