### PR TITLE
Fix framework BOM generator utils workspace range

### DIFF
--- a/scripts/generate-framework-bom.mjs
+++ b/scripts/generate-framework-bom.mjs
@@ -36,7 +36,7 @@ const frameworkRuntimeEntryDeps = {
   "@voyant-travel/runtime": "workspace:*",
   "@voyant-travel/storage": "workspace:*",
   "@voyant-travel/tools": "workspace:*",
-  "@voyant-travel/utils": "workspace:^",
+  "@voyant-travel/utils": "workspace:*",
   "@voyant-travel/workflows": "workspace:*",
   "@voyant-travel/workflows-orchestrator": "workspace:*",
   "drizzle-orm": "catalog:",


### PR DESCRIPTION
Follow-up to #3029. That PR fixed `packages/framework/package.json` (and lockfile) to `workspace:*`, unblocking `verify:release-config`, but the release then failed later in `verify:architecture` at **`verify:framework-bom`**:

```
Framework BOM drift — packages/framework/package.json dependencies are stale
```

The BOM generator (`scripts/generate-framework-bom.mjs`) still had `@voyant-travel/utils` as `workspace:^` in its hardcoded `frameworkRuntimeEntryDeps` map, so it wanted to rewrite the (now-correct) file back to `workspace:^`. Every other in-repo dep in that map is `workspace:*` — which is the BOM's whole purpose (pnpm publishes `workspace:*` as the exact tested version for a deterministic set). This aligns the generator with the file.

The BOM-generator fix was originally pushed to #3029's branch but landed after that PR auto-merged, so it needs its own PR.

Verified locally: `node scripts/generate-framework-bom.mjs` → "check-framework-bom: OK (19 pinned runtime deps)"; re-emit produces no diff against the current `package.json`.

No changeset — no publishable package contents change (script-only fix; framework is already bumped by #3026's `node-shared-store-providers` changeset).