### PR TITLE
Add catalog batch quote endpoint

### DIFF
--- a/.changeset/batch-catalog-quotes.md
+++ b/.changeset/batch-catalog-quotes.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/accommodations": minor
+"@voyant-travel/catalog": minor
+"@voyant-travel/catalog-contracts": minor
+"@voyant-travel/framework": patch
+---
+
+Add a bounded catalog batch quote endpoint for room/rate price matrices, plus an accommodations batch stay quote path that shares room/date availability and rate reads across selections.

--- a/packages/accommodations/src/booking-engine/handler.ts
+++ b/packages/accommodations/src/booking-engine/handler.ts
@@ -22,8 +22,10 @@ import type {
   BookingDraftShape,
   CommitOwnedRequest,
   CommitOwnedResult,
+  ComputeQuoteBatchResult,
   ComputeQuoteRequest,
   ComputeQuoteResult,
+  ComputeQuotesRequest,
   OwnedBookingHandler,
   OwnedHandlerContext,
 } from "@voyant-travel/catalog/booking-engine"
@@ -34,6 +36,7 @@ import {
   type OwnedStayQuoteResult,
   type QuoteOwnedStayInput,
   quoteOwnedStay,
+  quoteOwnedStaysBatch,
 } from "../service-owned-stays.js"
 
 interface DraftLike {
@@ -176,6 +179,57 @@ export function createAccommodationBookingHandler(
         pricing,
         shape,
       }
+    },
+
+    async computeQuotes(
+      ctx: OwnedHandlerContext,
+      request: ComputeQuotesRequest,
+    ): Promise<ReadonlyArray<ComputeQuoteBatchResult>> {
+      const prepared = await Promise.all(
+        request.selections.map(async (selection) => {
+          const content = await options.loadContent(ctx, selection.entityId)
+          const shape = content
+            ? buildAccommodationDraftShape(content, {
+                minNights: options.defaultMinNights,
+                maxNights: options.defaultMaxNights,
+              })
+            : undefined
+          const draft = (selection.draft ?? {}) as DraftLike
+          return {
+            selection,
+            shape,
+            quoteInput: content ? quoteInputFromDraft(draft, request.scope.currency) : undefined,
+            invalidReason: content ? undefined : "property_not_found",
+          }
+        }),
+      )
+      const quotable = prepared.flatMap((item) =>
+        item.quoteInput
+          ? [{ selectionId: item.selection.selectionId, input: item.quoteInput }]
+          : [],
+      )
+      const quotes = quotable.length
+        ? await quoteOwnedStaysBatch(
+            ctx.db,
+            quotable.map((item) => item.input),
+          )
+        : []
+      const quoteBySelectionId = new Map(
+        quotable.map((item, index) => [item.selectionId, quotes[index]]),
+      )
+
+      return prepared.map(({ selection, shape, invalidReason }) => {
+        const quote = quoteBySelectionId.get(selection.selectionId)
+        return {
+          selectionId: selection.selectionId,
+          result: {
+            available: quote?.status === "ok" ? quote.available : !invalidReason,
+            invalidReason: invalidReason ?? quoteInvalidReason(quote),
+            pricing: quote?.status === "ok" ? pricingFromOwnedStayQuote(quote) : undefined,
+            shape,
+          },
+        }
+      })
     },
 
     async commit(

--- a/packages/accommodations/src/booking-engine/handler.ts
+++ b/packages/accommodations/src/booking-engine/handler.ts
@@ -45,7 +45,17 @@ interface DraftLike {
     dateRange?: { checkIn?: string; checkOut?: string }
   }
   accommodation?: {
-    rooms?: ReadonlyArray<{ optionUnitId: string; quantity: number; ratePlanId?: string }>
+    rooms?: ReadonlyArray<{
+      optionUnitId: string
+      quantity: number
+      ratePlanId?: string
+      adult?: number
+      adults?: number
+      child?: number
+      children?: number
+      infant?: number
+      infants?: number
+    }>
   }
   billing?: {
     contact?: { firstName?: string; lastName?: string; email?: string; phone?: string }
@@ -400,21 +410,45 @@ function quoteInputFromDraft(
   currency: string | undefined,
 ): QuoteOwnedStayInput | undefined {
   const range = draft.configure?.dateRange
-  const firstRoom = draft.accommodation?.rooms?.[0]
+  const rooms = draft.accommodation?.rooms ?? []
+  const firstRoom = rooms[0]
   if (!range?.checkIn || !range?.checkOut || !firstRoom?.ratePlanId) return undefined
+  const roomCount = rooms.reduce((sum, room) => sum + Math.max(1, room.quantity), 0)
+  const occupancies = occupanciesFromRooms(rooms)
   return {
     roomTypeId: firstRoom.optionUnitId,
     ratePlanId: firstRoom.ratePlanId,
     checkIn: range.checkIn,
     checkOut: range.checkOut,
-    roomCount: firstRoom.quantity,
+    roomCount: roomCount || firstRoom.quantity,
     occupancy: {
       adults: draft.configure?.pax?.adult ?? draft.travelers?.length ?? 1,
       children: draft.configure?.pax?.child ?? 0,
       infants: draft.configure?.pax?.infant ?? 0,
     },
+    occupancies,
     currency,
   }
+}
+
+function occupanciesFromRooms(
+  rooms: NonNullable<DraftLike["accommodation"]>["rooms"],
+): QuoteOwnedStayInput["occupancies"] {
+  const occupancies = rooms?.flatMap((room) => {
+    const adults = room.adults ?? room.adult
+    const children = room.children ?? room.child
+    const infants = room.infants ?? room.infant
+    if (typeof adults !== "number" && typeof children !== "number" && typeof infants !== "number") {
+      return []
+    }
+    const occupancy = {
+      ...(typeof adults === "number" ? { adults } : {}),
+      ...(typeof children === "number" ? { children } : {}),
+      ...(typeof infants === "number" ? { infants } : {}),
+    }
+    return Array.from({ length: Math.max(1, room.quantity) }, () => occupancy)
+  })
+  return occupancies && occupancies.length > 0 ? occupancies : undefined
 }
 
 function pricingFromOwnedStayQuote(

--- a/packages/accommodations/src/service-owned-stays.ts
+++ b/packages/accommodations/src/service-owned-stays.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: accommodations; owned stay quote, batch quote, and search resolution share the same pure resolver helpers and stay co-located until a dedicated service split preserves behavior and tests.
 import type { OwnedSearchContext } from "@voyant-travel/catalog"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { facilityAddressProjections, properties } from "@voyant-travel/operations"
@@ -300,6 +301,104 @@ export async function quoteOwnedStay(
     rates: rateRows,
     inventory: inventoryRows,
     overlappingBookings,
+  })
+}
+
+export async function quoteOwnedStaysBatch(
+  db: AnyDrizzleDb,
+  inputs: ReadonlyArray<QuoteOwnedStayInput>,
+): Promise<OwnedStayQuoteResult[]> {
+  const results = new Map<number, OwnedStayQuoteResult>()
+  const groups = new Map<string, Array<{ index: number; input: QuoteOwnedStayInput }>>()
+
+  inputs.forEach((input, index) => {
+    const nights = eachStayNight(input.checkIn, input.checkOut)
+    if (nights.length === 0) {
+      results.set(index, { status: "invalid_range", reason: "check_out_after_check_in" })
+      return
+    }
+    const key = [input.roomTypeId, input.checkIn, input.checkOut].join("\u001f")
+    const group = groups.get(key) ?? []
+    group.push({ index, input })
+    groups.set(key, group)
+  })
+
+  await Promise.all(
+    [...groups.values()].map(async (group) => {
+      const first = group[0]
+      if (!first) return
+      const nights = eachStayNight(first.input.checkIn, first.input.checkOut)
+      const ratePlanIds = distinct(group.map(({ input }) => input.ratePlanId))
+      const [roomRow, ratePlanRows, rateRows, inventoryRows, overlappingBookings] =
+        await Promise.all([
+          db.select().from(roomTypes).where(eq(roomTypes.id, first.input.roomTypeId)).limit(1),
+          db.select().from(ratePlans).where(inArray(ratePlans.id, ratePlanIds)),
+          db
+            .select()
+            .from(ratePlanDailyRates)
+            .where(
+              and(
+                eq(ratePlanDailyRates.roomTypeId, first.input.roomTypeId),
+                inArray(ratePlanDailyRates.ratePlanId, ratePlanIds),
+                inArray(ratePlanDailyRates.date, nights),
+              ),
+            ),
+          db
+            .select()
+            .from(roomTypeDailyInventory)
+            .where(
+              and(
+                eq(roomTypeDailyInventory.roomTypeId, first.input.roomTypeId),
+                inArray(roomTypeDailyInventory.date, nights),
+              ),
+            ),
+          db
+            .select({
+              checkInDate: stayBookingItems.checkInDate,
+              checkOutDate: stayBookingItems.checkOutDate,
+              roomCount: stayBookingItems.roomCount,
+            })
+            .from(stayBookingItems)
+            .where(
+              and(
+                eq(stayBookingItems.roomTypeId, first.input.roomTypeId),
+                eq(stayBookingItems.status, "reserved"),
+                lt(stayBookingItems.checkInDate, first.input.checkOut),
+                gt(stayBookingItems.checkOutDate, first.input.checkIn),
+              ),
+            ),
+        ])
+
+      const room = roomRow[0]
+      if (!room) {
+        for (const { index } of group) results.set(index, { status: "room_not_found" })
+        return
+      }
+      const plansById = new Map(ratePlanRows.map((plan) => [plan.id, plan]))
+      for (const { index, input } of group) {
+        const ratePlan = plansById.get(input.ratePlanId)
+        if (!ratePlan) {
+          results.set(index, { status: "rate_plan_not_found" })
+          continue
+        }
+        results.set(
+          index,
+          resolveOwnedStayQuote(input, {
+            room,
+            ratePlan,
+            rates: rateRows.filter((rate) => rate.ratePlanId === input.ratePlanId),
+            inventory: inventoryRows,
+            overlappingBookings,
+          }),
+        )
+      }
+    }),
+  )
+
+  return inputs.map((_, index) => {
+    const result = results.get(index)
+    if (!result) throw new Error(`quoteOwnedStaysBatch: missing result ${index}`)
+    return result
   })
 }
 

--- a/packages/accommodations/tests/unit/booking-handler.test.ts
+++ b/packages/accommodations/tests/unit/booking-handler.test.ts
@@ -2,21 +2,99 @@ import type { OwnedHandlerContext } from "@voyant-travel/catalog/booking-engine"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { createAccommodationBookingHandler } from "../../src/booking-engine/index.js"
-import { quoteOwnedStay } from "../../src/service-owned-stays.js"
+import { quoteOwnedStay, quoteOwnedStaysBatch } from "../../src/service-owned-stays.js"
 
 vi.mock("../../src/service-owned-stays.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../../src/service-owned-stays.js")>()
   return {
     ...actual,
     quoteOwnedStay: vi.fn(),
+    quoteOwnedStaysBatch: vi.fn(),
   }
 })
 
 const mockQuoteOwnedStay = vi.mocked(quoteOwnedStay)
+const mockQuoteOwnedStaysBatch = vi.mocked(quoteOwnedStaysBatch)
 
 describe("createAccommodationBookingHandler", () => {
   beforeEach(() => {
     mockQuoteOwnedStay.mockReset()
+    mockQuoteOwnedStaysBatch.mockReset()
+  })
+
+  it("batch quotes room/rate selections through the shared stay batch service", async () => {
+    mockQuoteOwnedStaysBatch.mockResolvedValue([
+      {
+        status: "ok",
+        available: true,
+        propertyId: "prop_1",
+        roomTypeId: "room_1",
+        ratePlanId: "rate_bar",
+        roomCount: 1,
+        nights: 2,
+        currency: "USD",
+        nightlyRates: [],
+        totalAmountCents: 20_000,
+        availability: { requestedRooms: 1, minimumRemainingRooms: 2, nights: [] },
+      },
+      {
+        status: "rates_missing",
+        missingDates: ["2026-09-02"],
+      },
+    ])
+    const handler = createAccommodationBookingHandler({
+      loadContent: async () =>
+        ({
+          room_types: [{ id: "room_1", name: "Standard", max_occupancy: 2 }],
+          rate_plans: [
+            {
+              id: "rate_bar",
+              name: "BAR",
+              description: null,
+              charge_frequency: "per_night",
+              cancellation_policy: null,
+              inclusions: [],
+              applies_to_room_type_ids: [],
+            },
+          ],
+        }) as never,
+    })
+
+    const result = await handler.computeQuotes?.({ db: {} } as OwnedHandlerContext, {
+      entityModule: "accommodations",
+      scope: { locale: "en-GB", audience: "customer", market: "default", currency: "USD" },
+      selections: [
+        {
+          selectionId: "0",
+          entityId: "room_1",
+          draft: {
+            configure: { dateRange: { checkIn: "2026-09-01", checkOut: "2026-09-03" } },
+            accommodation: {
+              rooms: [{ optionUnitId: "room_1", quantity: 1, ratePlanId: "rate_bar" }],
+            },
+          },
+        },
+        {
+          selectionId: "1",
+          entityId: "room_1",
+          draft: {
+            configure: { dateRange: { checkIn: "2026-09-01", checkOut: "2026-09-03" } },
+            accommodation: {
+              rooms: [{ optionUnitId: "room_1", quantity: 1, ratePlanId: "rate_nr" }],
+            },
+          },
+        },
+      ],
+    })
+
+    expect(mockQuoteOwnedStaysBatch).toHaveBeenCalledWith({}, [
+      expect.objectContaining({ roomTypeId: "room_1", ratePlanId: "rate_bar" }),
+      expect.objectContaining({ roomTypeId: "room_1", ratePlanId: "rate_nr" }),
+    ])
+    expect(result).toMatchObject([
+      { selectionId: "0", result: { available: true, pricing: { base_amount: 20_000 } } },
+      { selectionId: "1", result: { available: true, invalidReason: "rates_missing" } },
+    ])
   })
 
   it("returns the bridge booking id as the canonical commit booking id", async () => {

--- a/packages/accommodations/tests/unit/booking-handler.test.ts
+++ b/packages/accommodations/tests/unit/booking-handler.test.ts
@@ -70,7 +70,10 @@ describe("createAccommodationBookingHandler", () => {
           draft: {
             configure: { dateRange: { checkIn: "2026-09-01", checkOut: "2026-09-03" } },
             accommodation: {
-              rooms: [{ optionUnitId: "room_1", quantity: 1, ratePlanId: "rate_bar" }],
+              rooms: [
+                { optionUnitId: "room_1", quantity: 1, adults: 2, ratePlanId: "rate_bar" },
+                { optionUnitId: "room_1", quantity: 1, adults: 2, ratePlanId: "rate_bar" },
+              ],
             },
           },
         },
@@ -88,7 +91,13 @@ describe("createAccommodationBookingHandler", () => {
     })
 
     expect(mockQuoteOwnedStaysBatch).toHaveBeenCalledWith({}, [
-      expect.objectContaining({ roomTypeId: "room_1", ratePlanId: "rate_bar" }),
+      expect.objectContaining({
+        roomTypeId: "room_1",
+        ratePlanId: "rate_bar",
+        roomCount: 2,
+        occupancy: { adults: 1, children: 0, infants: 0 },
+        occupancies: [{ adults: 2 }, { adults: 2 }],
+      }),
       expect.objectContaining({ roomTypeId: "room_1", ratePlanId: "rate_nr" }),
     ])
     expect(result).toMatchObject([

--- a/packages/accommodations/tests/unit/service-owned-stays.test.ts
+++ b/packages/accommodations/tests/unit/service-owned-stays.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../src/schema-inventory.js"
 import {
   eachStayNight,
+  quoteOwnedStaysBatch,
   type ResolveOwnedStayQuoteRecords,
   resolveOwnedStayQuote,
   searchOwnedStays,
@@ -363,6 +364,83 @@ describe("resolveOwnedStayQuote", () => {
     if (result.status !== "ok") return
     expect(result.totalAmountCents).toBe(40_000)
     expect(result.nightlyRates[0]?.quantity).toBe(4)
+  })
+})
+
+describe("quoteOwnedStaysBatch", () => {
+  it("resolves multiple rate plans for one room/date range from shared records", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[] | QueuedRows>([
+        [roomTypes, [room()]],
+        [
+          ratePlans,
+          [
+            ratePlan({ id: "rate_bar", mealPlanId: "meal_bb" }),
+            ratePlan({ id: "rate_flex", mealPlanId: "meal_hb" }),
+          ],
+        ],
+        [
+          ratePlanDailyRates,
+          [
+            dailyRate({
+              id: "bar_1",
+              ratePlanId: "rate_bar",
+              date: "2026-09-01",
+              sellAmountCents: 10_000,
+            }),
+            dailyRate({
+              id: "bar_2",
+              ratePlanId: "rate_bar",
+              date: "2026-09-02",
+              sellAmountCents: 11_000,
+            }),
+            dailyRate({
+              id: "flex_1",
+              ratePlanId: "rate_flex",
+              date: "2026-09-01",
+              sellAmountCents: 12_000,
+            }),
+            dailyRate({
+              id: "flex_2",
+              ratePlanId: "rate_flex",
+              date: "2026-09-02",
+              sellAmountCents: 13_000,
+            }),
+          ],
+        ],
+        [
+          roomTypeDailyInventory,
+          [
+            dailyInventory({ date: "2026-09-01", capacity: 3 }),
+            dailyInventory({ date: "2026-09-02", capacity: 3 }),
+          ],
+        ],
+      ]),
+    )
+
+    const [bar, flex] = await quoteOwnedStaysBatch(db, [
+      {
+        roomTypeId: "room_std",
+        ratePlanId: "rate_bar",
+        checkIn: "2026-09-01",
+        checkOut: "2026-09-03",
+        occupancy: { adults: 2 },
+      },
+      {
+        roomTypeId: "room_std",
+        ratePlanId: "rate_flex",
+        checkIn: "2026-09-01",
+        checkOut: "2026-09-03",
+        occupancy: { adults: 2 },
+      },
+    ])
+
+    expect(bar).toMatchObject({ status: "ok", ratePlanId: "rate_bar", totalAmountCents: 21_000 })
+    expect(flex).toMatchObject({
+      status: "ok",
+      ratePlanId: "rate_flex",
+      totalAmountCents: 25_000,
+    })
   })
 })
 

--- a/packages/catalog-contracts/src/booking-engine/engine-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/engine-contracts.ts
@@ -37,6 +37,42 @@ export const quoteResponseV1 = z.object({
   upstreamPayload: z.record(z.string(), z.unknown()).optional(),
 })
 
+export const quoteBatchCriteriaV1 = z.object({
+  checkIn: z.string().min(1).optional(),
+  checkOut: z.string().min(1).optional(),
+  occupancy: z.record(z.string(), z.number().int().nonnegative()).optional(),
+  roomCount: z.number().int().positive().optional(),
+})
+
+export const quoteBatchSelectionV1 = z.object({
+  entityModule: z.string(),
+  entityId: z.string(),
+  ratePlanId: z.string().optional(),
+  sourceKind: z.string().optional(),
+  sourceProvider: z.string().optional(),
+  sourceConnectionId: z.string().optional(),
+  sourceRef: z.string().optional(),
+  parameters: z.record(z.string(), z.unknown()).optional(),
+  draft: z.record(z.string(), z.unknown()).optional(),
+})
+
+export const quoteBatchRequestV1 = z.object({
+  criteria: quoteBatchCriteriaV1.optional(),
+  scope: quoteScopeV1.partial().optional(),
+  parameters: z.record(z.string(), z.unknown()).optional(),
+  draft: z.record(z.string(), z.unknown()).optional(),
+  ttlMs: z.number().int().positive().optional(),
+  selections: z.array(quoteBatchSelectionV1).min(1).max(30),
+})
+
+export const quoteBatchResultV1 = quoteResponseV1.extend({
+  selection: quoteBatchSelectionV1,
+})
+
+export const quoteBatchResponseV1 = z.object({
+  results: z.array(quoteBatchResultV1),
+})
+
 /**
  * Mirrors flights' `paymentIntent` discriminated union from
  * `catalog-flights-architecture.md` §3.1. Default `{ type: "hold" }`
@@ -79,6 +115,11 @@ export const bookResponseV1 = z.object({
 
 export type QuoteRequestV1 = z.infer<typeof quoteRequestV1>
 export type QuoteResponseV1 = z.infer<typeof quoteResponseV1>
+export type QuoteBatchCriteriaV1 = z.infer<typeof quoteBatchCriteriaV1>
+export type QuoteBatchSelectionV1 = z.infer<typeof quoteBatchSelectionV1>
+export type QuoteBatchRequestV1 = z.infer<typeof quoteBatchRequestV1>
+export type QuoteBatchResultV1 = z.infer<typeof quoteBatchResultV1>
+export type QuoteBatchResponseV1 = z.infer<typeof quoteBatchResponseV1>
 export type BookRequestV1 = z.infer<typeof bookRequestV1>
 export type BookResponseV1 = z.infer<typeof bookResponseV1>
 

--- a/packages/catalog/src/booking-engine/contracts.test.ts
+++ b/packages/catalog/src/booking-engine/contracts.test.ts
@@ -4,6 +4,8 @@ import {
   bookingDraftV1,
   bookRequestV1,
   pricingBreakdownV1,
+  quoteBatchRequestV1,
+  quoteBatchResponseV1,
   quoteRequestV1,
   quoteResponseV1,
 } from "./contracts.js"
@@ -133,6 +135,56 @@ describe("V1 contracts", () => {
         expiresAt: new Date(Date.now() + 60_000).toISOString(),
         available: false,
         invalidReason: "out_of_stock",
+      })
+      expect(result.success).toBe(true)
+    })
+  })
+
+  describe("quoteBatchRequestV1", () => {
+    it("caps batch quote selections", () => {
+      const selection = {
+        entityModule: "accommodations",
+        entityId: "room_1",
+        ratePlanId: "rate_1",
+      }
+      expect(
+        quoteBatchRequestV1.safeParse({
+          criteria: { checkIn: "2026-09-01", checkOut: "2026-09-03" },
+          selections: [selection],
+        }).success,
+      ).toBe(true)
+      expect(
+        quoteBatchRequestV1.safeParse({
+          selections: Array.from({ length: 31 }, () => selection),
+        }).success,
+      ).toBe(false)
+    })
+  })
+
+  describe("quoteBatchResponseV1", () => {
+    it("validates per-selection quote results", () => {
+      const result = quoteBatchResponseV1.safeParse({
+        results: [
+          {
+            selection: {
+              entityModule: "accommodations",
+              entityId: "room_1",
+              ratePlanId: "rate_1",
+            },
+            quoteId: "q1",
+            quotedAt: new Date().toISOString(),
+            expiresAt: new Date(Date.now() + 60_000).toISOString(),
+            available: true,
+            pricing: {
+              currency: "USD",
+              lines: [],
+              taxes: [],
+              subtotal: 10000,
+              taxTotal: 0,
+              total: 10000,
+            },
+          },
+        ],
       })
       expect(result.success).toBe(true)
     })

--- a/packages/catalog/src/booking-engine/index.ts
+++ b/packages/catalog/src/booking-engine/index.ts
@@ -160,8 +160,11 @@ export {
 export {
   type CommitOwnedRequest,
   type CommitOwnedResult,
+  type ComputeQuoteBatchResult,
+  type ComputeQuoteBatchSelection,
   type ComputeQuoteRequest,
   type ComputeQuoteResult,
+  type ComputeQuotesRequest,
   createOwnedBookingHandlerRegistry,
   type HoldRequest,
   type HoldResult,
@@ -181,10 +184,13 @@ export {
   DEFAULT_QUOTE_TTL_MS,
   type QuoteContentEnricher,
   type QuoteContentEnrichmentInput,
+  type QuoteEntityBatchRequest,
+  type QuoteEntityBatchResult,
   type QuoteEntityDeps,
   type QuoteEntityRequest,
   type QuoteEntityResult,
   type QuoteScope,
+  quoteEntitiesBatch,
   quoteEntity,
 } from "./quote.js"
 export {
@@ -193,6 +199,9 @@ export {
 } from "./registry.js"
 export {
   type CatalogBookingAdapterContextInput,
+  type CatalogBookingBatchQuoteBody,
+  type CatalogBookingBatchQuoteSelection,
+  type CatalogBookingBatchQuoteTransformInput,
   type CatalogBookingBookBody,
   type CatalogBookingBookTransformInput,
   type CatalogBookingCommittedEvent,

--- a/packages/catalog/src/booking-engine/owned-handler.ts
+++ b/packages/catalog/src/booking-engine/owned-handler.ts
@@ -83,6 +83,24 @@ export interface ComputeQuoteResult {
   upstreamPayload?: Record<string, unknown>
 }
 
+export interface ComputeQuoteBatchSelection {
+  selectionId: string
+  entityId: string
+  parameters?: Record<string, unknown>
+  draft?: unknown
+}
+
+export interface ComputeQuotesRequest {
+  entityModule: string
+  scope: OwnedQuoteScope
+  selections: ReadonlyArray<ComputeQuoteBatchSelection>
+}
+
+export interface ComputeQuoteBatchResult {
+  selectionId: string
+  result: ComputeQuoteResult
+}
+
 export interface CommitOwnedRequest {
   entityModule: string
   entityId: string
@@ -162,6 +180,16 @@ export interface OwnedBookingHandler {
    * promo windows, which are explicitly OK to vary).
    */
   computeQuote(ctx: OwnedHandlerContext, request: ComputeQuoteRequest): Promise<ComputeQuoteResult>
+
+  /**
+   * Optional batch quote primitive for verticals that can share availability
+   * and rate reads across selections. The engine falls back to `computeQuote`
+   * for handlers that do not implement it.
+   */
+  computeQuotes?(
+    ctx: OwnedHandlerContext,
+    request: ComputeQuotesRequest,
+  ): Promise<ReadonlyArray<ComputeQuoteBatchResult>>
 
   /**
    * Commit the draft to a booking row. Phase A handlers map the

--- a/packages/catalog/src/booking-engine/quote.ts
+++ b/packages/catalog/src/booking-engine/quote.ts
@@ -18,7 +18,11 @@ import type { LiveResolveResult, SourceAdapterContext } from "../adapter/contrac
 import type { PricingBasis } from "../snapshot/schema.js"
 
 import type { BookingDraftShape } from "./draft-shape.js"
-import type { OwnedBookingHandlerRegistry } from "./owned-handler.js"
+import type {
+  ComputeQuoteResult,
+  OwnedBookingHandlerRegistry,
+  OwnedHandlerContext,
+} from "./owned-handler.js"
 import { OWNED_SOURCE_KIND } from "./owned-handler.js"
 import type {
   CodeStatus,
@@ -82,6 +86,15 @@ export interface QuoteEntityResult {
    * journey hardcodes a minimal shape until templates wire content).
    */
   shape?: BookingDraftShape
+}
+
+export interface QuoteEntityBatchRequest extends QuoteEntityRequest {
+  selectionId: string
+}
+
+export interface QuoteEntityBatchResult {
+  selectionId: string
+  result: QuoteEntityResult
 }
 
 /**
@@ -185,10 +198,110 @@ export async function quoteEntity(
   deps: QuoteEntityDeps,
   request: QuoteEntityRequest,
 ): Promise<QuoteEntityResult> {
-  const ttlMs = request.ttlMs ?? DEFAULT_QUOTE_TTL_MS
-  const quotedAt = new Date()
-  const expiresAt = new Date(quotedAt.getTime() + ttlMs)
+  const [first] = await quoteEntitiesBatch(db, deps, [{ ...request, selectionId: "selection_0" }])
+  if (!first) throw new Error("quoteEntity: batch returned no rows")
+  return first.result
+}
 
+export async function quoteEntitiesBatch(
+  db: AnyDrizzleDb,
+  deps: QuoteEntityDeps,
+  requests: ReadonlyArray<QuoteEntityBatchRequest>,
+): Promise<QuoteEntityBatchResult[]> {
+  const computedBySelection = await computeRawQuotes(db, deps, requests)
+  const results: QuoteEntityBatchResult[] = []
+  for (const request of requests) {
+    const computed = computedBySelection.get(request.selectionId)
+    if (!computed) {
+      throw new Error(`quoteEntitiesBatch: missing computed result ${request.selectionId}`)
+    }
+    results.push({
+      selectionId: request.selectionId,
+      result: await persistComputedQuote(db, deps, request, computed),
+    })
+  }
+  return results
+}
+
+interface RawQuoteComputation {
+  available: boolean
+  failedReason?: string
+  pricing?: PricingBasis
+  upstreamPayload?: Record<string, unknown>
+  ownedShape?: BookingDraftShape
+}
+
+async function computeRawQuotes(
+  db: AnyDrizzleDb,
+  deps: QuoteEntityDeps,
+  requests: ReadonlyArray<QuoteEntityBatchRequest>,
+): Promise<Map<string, RawQuoteComputation>> {
+  const results = new Map<string, RawQuoteComputation>()
+  const fallback: QuoteEntityBatchRequest[] = []
+  const groups = new Map<string, QuoteEntityBatchRequest[]>()
+
+  for (const request of requests) {
+    if (request.sourceKind !== OWNED_SOURCE_KIND || !deps.ownedHandlers) {
+      fallback.push(request)
+      continue
+    }
+    const handler = deps.ownedHandlers.resolveOrThrow(request.entityModule)
+    if (!handler.computeQuotes) {
+      fallback.push(request)
+      continue
+    }
+    const key = [
+      request.entityModule,
+      request.scope.locale,
+      request.scope.audience,
+      request.scope.market,
+      request.scope.currency ?? "",
+      request.adapterContext.connection_id,
+    ].join("\u001f")
+    const group = groups.get(key) ?? []
+    group.push(request)
+    groups.set(key, group)
+  }
+
+  for (const group of groups.values()) {
+    const first = group[0]
+    if (!first || first.sourceKind !== OWNED_SOURCE_KIND || !deps.ownedHandlers) continue
+    const handler = deps.ownedHandlers.resolveOrThrow(first.entityModule)
+    const ctx: OwnedHandlerContext = { db, adapterContext: first.adapterContext }
+    const batch = await handler.computeQuotes?.(ctx, {
+      entityModule: first.entityModule,
+      scope: first.scope,
+      selections: group.map((request) => ({
+        selectionId: request.selectionId,
+        entityId: request.entityId,
+        parameters: request.parameters,
+        draft: (request.parameters as { draft?: unknown } | undefined)?.draft,
+      })),
+    })
+    const returned = new Set<string>()
+    for (const item of batch ?? []) {
+      returned.add(item.selectionId)
+      results.set(item.selectionId, rawFromOwnedResult(item.result))
+    }
+    for (const request of group) {
+      if (!returned.has(request.selectionId)) fallback.push(request)
+    }
+  }
+
+  await Promise.all(
+    fallback.map(async (request) => {
+      results.set(request.selectionId, await computeRawQuote(db, deps, request))
+    }),
+  )
+
+  return results
+}
+
+async function computeRawQuote(
+  db: AnyDrizzleDb,
+  deps: QuoteEntityDeps,
+  request: QuoteEntityRequest,
+): Promise<RawQuoteComputation> {
   // Two dispatch arms:
   //   - Owned: handler registry keyed by entity_module. Returns a
   //     ComputeQuoteResult directly — pricing, shape, availability.
@@ -243,6 +356,24 @@ export async function quoteEntity(
     pricing = available ? liveValuesToPricing(liveValues, request.scope.currency) : undefined
     upstreamPayload = liveValues as Record<string, unknown> | undefined
   }
+
+  return { available, failedReason, pricing, upstreamPayload, ownedShape }
+}
+
+async function persistComputedQuote(
+  db: AnyDrizzleDb,
+  deps: QuoteEntityDeps,
+  request: QuoteEntityRequest,
+  computed: RawQuoteComputation,
+): Promise<QuoteEntityResult> {
+  const ttlMs = request.ttlMs ?? DEFAULT_QUOTE_TTL_MS
+  const quotedAt = new Date()
+  const expiresAt = new Date(quotedAt.getTime() + ttlMs)
+  let available = computed.available
+  let failedReason = computed.failedReason
+  const pricing = computed.pricing
+  const upstreamPayload = computed.upstreamPayload
+  const ownedShape = computed.ownedShape
 
   // Promotion evaluation — runs only for the products vertical in v1
   // (other verticals would need their own bridge to the evaluator).
@@ -367,6 +498,16 @@ export async function quoteEntity(
     pricing,
     upstreamPayload,
     shape,
+  }
+}
+
+function rawFromOwnedResult(result: ComputeQuoteResult): RawQuoteComputation {
+  return {
+    available: result.available,
+    failedReason: result.invalidReason,
+    pricing: result.pricing,
+    upstreamPayload: result.upstreamPayload,
+    ownedShape: result.shape,
   }
 }
 

--- a/packages/catalog/src/booking-engine/routes-contracts.ts
+++ b/packages/catalog/src/booking-engine/routes-contracts.ts
@@ -22,6 +22,27 @@ const quoteScopeSchema = z
   })
   .optional()
 
+const batchCriteriaSchema = z
+  .object({
+    checkIn: z.string().min(1).optional(),
+    checkOut: z.string().min(1).optional(),
+    occupancy: z.record(z.string(), z.number().int().nonnegative()).optional(),
+    roomCount: z.number().int().positive().optional(),
+  })
+  .optional()
+
+const batchSelectionSchema = z.object({
+  entityModule: z.string().min(1),
+  entityId: z.string().min(1),
+  ratePlanId: z.string().min(1).optional(),
+  sourceKind: z.string().min(1).optional(),
+  sourceProvider: z.string().min(1).optional(),
+  sourceConnectionId: z.string().min(1).optional(),
+  sourceRef: z.string().min(1).optional(),
+  parameters: recordSchema.optional(),
+  draft: recordSchema.optional(),
+})
+
 export const quoteBodySchema = z.object({
   entityModule: z.string().min(1),
   entityId: z.string().min(1),
@@ -33,6 +54,15 @@ export const quoteBodySchema = z.object({
   parameters: recordSchema.optional(),
   draft: recordSchema.optional(),
   ttlMs: z.number().int().positive().optional(),
+})
+
+export const batchQuoteBodySchema = z.object({
+  criteria: batchCriteriaSchema,
+  scope: quoteScopeSchema,
+  parameters: recordSchema.optional(),
+  draft: recordSchema.optional(),
+  ttlMs: z.number().int().positive().optional(),
+  selections: z.array(batchSelectionSchema).min(1).max(30),
 })
 
 export const bookBodySchema = z
@@ -81,6 +111,8 @@ export const holdReleaseBodySchema = z.object({
 })
 
 export type CatalogBookingQuoteBody = z.infer<typeof quoteBodySchema>
+export type CatalogBookingBatchQuoteBody = z.infer<typeof batchQuoteBodySchema>
+export type CatalogBookingBatchQuoteSelection = z.infer<typeof batchSelectionSchema>
 export type CatalogBookingBookBody = z.infer<typeof bookBodySchema>
 export type CatalogBookingDraftBody = z.infer<typeof draftBodySchema>
 export type CatalogBookingHoldPlaceBody = z.infer<typeof holdPlaceBodySchema>
@@ -131,6 +163,18 @@ export interface CatalogBookingQuoteTransformInput {
   request: CatalogBookingQuoteBody
   provenance: CatalogBookingProvenance
   result: QuoteEntityResult
+}
+
+export interface CatalogBookingBatchQuoteTransformInput {
+  c: Context
+  db: AnyDrizzleDb
+  request: CatalogBookingBatchQuoteBody
+  results: Array<{
+    selection: CatalogBookingBatchQuoteSelection
+    request: CatalogBookingQuoteBody
+    provenance: CatalogBookingProvenance
+    result: QuoteEntityResult
+  }>
 }
 
 export interface CatalogBookingBookTransformInput {
@@ -200,6 +244,21 @@ export interface CatalogBookingRoutesOptions {
     input: CatalogBookingPrepareBookParametersInput,
   ): Promise<Record<string, unknown>> | Record<string, unknown>
   transformQuoteResult?(input: CatalogBookingQuoteTransformInput): Promise<QuoteEntityResult>
+  transformBatchQuoteResults?(input: CatalogBookingBatchQuoteTransformInput):
+    | Promise<
+        Array<{
+          selection: CatalogBookingBatchQuoteSelection
+          request: CatalogBookingQuoteBody
+          provenance: CatalogBookingProvenance
+          result: QuoteEntityResult
+        }>
+      >
+    | Array<{
+        selection: CatalogBookingBatchQuoteSelection
+        request: CatalogBookingQuoteBody
+        provenance: CatalogBookingProvenance
+        result: QuoteEntityResult
+      }>
   transformBookResult?(input: CatalogBookingBookTransformInput): Promise<BookEntityResult>
   onDraftConsumedError?(event: CatalogBookingDraftConsumedError): void
   onCommitted?(event: CatalogBookingCommittedEvent): Promise<void> | void

--- a/packages/catalog/src/booking-engine/routes.test.ts
+++ b/packages/catalog/src/booking-engine/routes.test.ts
@@ -241,6 +241,7 @@ describe("createCatalogBookingRoutes", () => {
           checkIn: "2026-09-01",
           checkOut: "2026-09-03",
           occupancy: { adult: 2 },
+          roomCount: 2,
         },
         selections: [
           { entityModule: "accommodations", entityId: "room_1", ratePlanId: "rate_bar" },
@@ -284,7 +285,10 @@ describe("createCatalogBookingRoutes", () => {
                 pax: { adult: 2 },
               }),
               accommodation: {
-                rooms: [{ optionUnitId: "room_1", quantity: 1, ratePlanId: "rate_bar" }],
+                rooms: [
+                  { optionUnitId: "room_1", quantity: 1, adults: 2, ratePlanId: "rate_bar" },
+                  { optionUnitId: "room_1", quantity: 1, adults: 2, ratePlanId: "rate_bar" },
+                ],
               },
             }),
             ratePlanId: "rate_bar",

--- a/packages/catalog/src/booking-engine/routes.test.ts
+++ b/packages/catalog/src/booking-engine/routes.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: catalog; booking-engine route tests stay co-located to cover the shared quote/book/draft/hold route factory until a dedicated split preserves route setup coverage.
 import { handleApiError } from "@voyant-travel/hono"
 import { Hono } from "hono"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -13,7 +14,7 @@ import {
   updateBookingDraft,
 } from "./drafts-service.js"
 import { createOwnedBookingHandlerRegistry, type OwnedBookingHandler } from "./owned-handler.js"
-import { quoteEntity } from "./quote.js"
+import { quoteEntitiesBatch, quoteEntity } from "./quote.js"
 import { createSourceAdapterRegistry } from "./registry.js"
 import {
   type CatalogBookingRoutesOptions,
@@ -23,7 +24,7 @@ import {
 
 vi.mock("./quote.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./quote.js")>()
-  return { ...actual, quoteEntity: vi.fn() }
+  return { ...actual, quoteEntity: vi.fn(), quoteEntitiesBatch: vi.fn() }
 })
 
 vi.mock("./book.js", async (importOriginal) => {
@@ -77,6 +78,7 @@ describe("createCatalogBookingRoutes", () => {
     vi.mocked(deleteBookingDraft).mockReset()
     vi.mocked(getBookingDraft).mockReset()
     vi.mocked(markDraftConsumed).mockReset()
+    vi.mocked(quoteEntitiesBatch).mockReset()
     vi.mocked(quoteEntity).mockReset()
     vi.mocked(updateBookingDraft).mockReset()
   })
@@ -196,6 +198,106 @@ describe("createCatalogBookingRoutes", () => {
           credentials: { token: "secret" },
         },
       }),
+    )
+  })
+
+  it("batch quotes bounded selections with shared criteria", async () => {
+    vi.mocked(quoteEntitiesBatch).mockResolvedValue([
+      {
+        selectionId: "0",
+        result: {
+          quoteId: "quote_room_1_bar",
+          quotedAt: new Date("2026-05-05T10:00:00.000Z"),
+          expiresAt: new Date("2026-05-05T10:10:00.000Z"),
+          available: true,
+          pricing,
+        },
+      },
+      {
+        selectionId: "1",
+        result: {
+          quoteId: "quote_room_1_nr",
+          quotedAt: new Date("2026-05-05T10:00:00.000Z"),
+          expiresAt: new Date("2026-05-05T10:10:00.000Z"),
+          available: false,
+          invalidReason: "rates_missing",
+        },
+      },
+    ])
+    const resolveEntityProvenance = vi.fn(async () => ({ sourceKind: "owned" }))
+    const transformQuoteResult = vi.fn(async ({ result }) => result)
+    const { app, ownedHandlers } = createTestApp({
+      resolveCorrelationId: () => "req_batch",
+      resolveEntityProvenance,
+      transformQuoteResult,
+      transformBatchQuoteResults: async ({ results }) => results,
+    })
+
+    const response = await app.request("/v1/public/catalog/quotes/batch", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        criteria: {
+          checkIn: "2026-09-01",
+          checkOut: "2026-09-03",
+          occupancy: { adult: 2 },
+        },
+        selections: [
+          { entityModule: "accommodations", entityId: "room_1", ratePlanId: "rate_bar" },
+          { entityModule: "accommodations", entityId: "room_1", ratePlanId: "rate_nr" },
+        ],
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      results: [
+        {
+          selection: { entityModule: "accommodations", entityId: "room_1", ratePlanId: "rate_bar" },
+          quoteId: "quote_room_1_bar",
+          available: true,
+          pricing: { total: 12150 },
+        },
+        {
+          selection: { entityModule: "accommodations", entityId: "room_1", ratePlanId: "rate_nr" },
+          quoteId: "quote_room_1_nr",
+          available: false,
+          invalidReason: "rates_missing",
+        },
+      ],
+    })
+    expect(resolveEntityProvenance).toHaveBeenCalledTimes(2)
+    expect(transformQuoteResult).toHaveBeenCalledTimes(2)
+    expect(quoteEntitiesBatch).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ registry, ownedHandlers }),
+      [
+        expect.objectContaining({
+          selectionId: "0",
+          entityModule: "accommodations",
+          entityId: "room_1",
+          sourceKind: "owned",
+          parameters: expect.objectContaining({
+            draft: expect.objectContaining({
+              configure: expect.objectContaining({
+                dateRange: { checkIn: "2026-09-01", checkOut: "2026-09-03" },
+                pax: { adult: 2 },
+              }),
+              accommodation: {
+                rooms: [{ optionUnitId: "room_1", quantity: 1, ratePlanId: "rate_bar" }],
+              },
+            }),
+            ratePlanId: "rate_bar",
+          }),
+          adapterContext: { connection_id: "owned", correlation_id: "req_batch" },
+        }),
+        expect.objectContaining({
+          selectionId: "1",
+          parameters: expect.objectContaining({
+            ratePlanId: "rate_nr",
+          }),
+        }),
+      ],
     )
   })
 

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -1022,13 +1022,26 @@ function mergeBatchDraft(
       : {}),
     ...(criteria.occupancy ? { pax: { ...criteria.occupancy } } : {}),
   }
-  const rooms = [
-    {
-      optionUnitId: selection.entityId,
-      quantity: criteria.roomCount ?? 1,
-      ...(selection.ratePlanId ? { ratePlanId: selection.ratePlanId } : {}),
-    },
-  ]
+  const roomCount = criteria.roomCount ?? 1
+  const roomOccupancy = criteria.occupancy
+    ? {
+        ...(typeof criteria.occupancy.adult === "number"
+          ? { adults: criteria.occupancy.adult }
+          : {}),
+        ...(typeof criteria.occupancy.child === "number"
+          ? { children: criteria.occupancy.child }
+          : {}),
+        ...(typeof criteria.occupancy.infant === "number"
+          ? { infants: criteria.occupancy.infant }
+          : {}),
+      }
+    : {}
+  const rooms = Array.from({ length: roomCount }, () => ({
+    optionUnitId: selection.entityId,
+    quantity: 1,
+    ...roomOccupancy,
+    ...(selection.ratePlanId ? { ratePlanId: selection.ratePlanId } : {}),
+  }))
   return {
     ...(draft ?? {}),
     configure: nextConfigure,

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -32,7 +32,9 @@ import {
   type BookResponseV1,
   bookResponseV1,
   type PricingBreakdownV1,
+  type QuoteBatchResponseV1,
   type QuoteResponseV1,
+  quoteBatchResponseV1,
   quoteResponseV1,
 } from "./contracts.js"
 import {
@@ -55,10 +57,14 @@ import {
   RESERVE_FAILED,
 } from "./errors.js"
 import { OWNED_SOURCE_KIND } from "./owned-handler.js"
-import { type QuoteEntityResult, quoteEntity } from "./quote.js"
+import { type QuoteEntityResult, quoteEntitiesBatch, quoteEntity } from "./quote.js"
 import {
+  batchQuoteBodySchema,
   bookBodySchema,
   type CatalogBookingAdapterContextInput,
+  type CatalogBookingBatchQuoteBody,
+  type CatalogBookingBatchQuoteSelection,
+  type CatalogBookingBatchQuoteTransformInput,
   type CatalogBookingBookBody,
   type CatalogBookingDraftBody,
   type CatalogBookingHoldPlaceBody,
@@ -167,6 +173,43 @@ const quoteRoute = createRoute({
     },
     503: {
       description: "No adapter/handler registered for this vertical",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+  },
+})
+
+const batchQuoteRoute = createRoute({
+  method: "post",
+  path: "/quotes/batch",
+  request: {
+    body: {
+      required: true,
+      content: { "application/json": { schema: batchQuoteBodySchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "Batch quote results for the requested selections",
+      content: { "application/json": { schema: quoteBatchResponseV1 } },
+    },
+    400: {
+      description: "invalid_request — body failed validation",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    404: {
+      description: "Quote/order referenced by the engine was not found",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    409: {
+      description: "Quote expired or conflicts with current availability",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    502: {
+      description: "Upstream reservation failed",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
+    503: {
+      description: "No adapter/handler registered for one or more selections",
       content: { "application/json": { schema: errorResponseSchema } },
     },
   },
@@ -332,6 +375,9 @@ const holdReleaseRoute = createRoute({
 
 export type {
   CatalogBookingAdapterContextInput,
+  CatalogBookingBatchQuoteBody,
+  CatalogBookingBatchQuoteSelection,
+  CatalogBookingBatchQuoteTransformInput,
   CatalogBookingBookBody,
   CatalogBookingBookTransformInput,
   CatalogBookingCommittedEvent,
@@ -357,6 +403,9 @@ export function createCatalogBookingRoutes(options: CatalogBookingRoutesOptions)
   // Runtime payloads honor the declared schemas (asserted by the contract tests).
   return new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
     .openapi(quoteRoute, async (c) => asRouteResponse(handleQuote(c, options, c.req.valid("json"))))
+    .openapi(batchQuoteRoute, async (c) =>
+      asRouteResponse(handleBatchQuote(c, options, c.req.valid("json"))),
+    )
     .openapi(bookRoute, async (c) => asRouteResponse(handleBook(c, options, c.req.valid("json"))))
     .openapi(draftPutRoute, async (c) =>
       asRouteResponse(handleDraftPut(c, options, c.req.valid("param").id, c.req.valid("json"))),
@@ -453,6 +502,111 @@ async function handleQuote(
     const transformed =
       (await options.transformQuoteResult?.({ c, db, request: body, provenance, result })) ?? result
     return c.json(serializeQuoteResult(transformed))
+  } catch (err) {
+    return bookingEngineErrorResponse(c, err)
+  }
+}
+
+async function handleBatchQuote(
+  c: Context,
+  options: CatalogBookingRoutesOptions,
+  body: CatalogBookingBatchQuoteBody,
+): Promise<Response> {
+  const db = options.resolveDb(c)
+  const correlationId = resolveCorrelationId(c, options)
+
+  try {
+    const prepared = await Promise.all(
+      body.selections.map(async (selection, index) => {
+        const request = quoteRequestFromBatchSelection(c, body, selection)
+        const provenance = request.sourceKind
+          ? {
+              sourceKind: request.sourceKind,
+              sourceProvider: request.sourceProvider,
+              sourceConnectionId: request.sourceConnectionId,
+              sourceRef: request.sourceRef,
+            }
+          : await resolveEntityProvenance(c, options, db, request.entityModule, request.entityId)
+        const adapterContext = resolveAdapterContext(c, options, {
+          db,
+          operation: "quote",
+          entityModule: request.entityModule,
+          entityId: request.entityId,
+          sourceKind: provenance.sourceKind,
+          sourceConnectionId: provenance.sourceConnectionId,
+          correlationId,
+        })
+        const scope = {
+          locale: request.scope?.locale ?? "en-GB",
+          audience: request.scope?.audience ?? defaultAudienceForPath(c),
+          market: request.scope?.market ?? "default",
+          currency: request.scope?.currency,
+        }
+        return {
+          selectionId: String(index),
+          selection,
+          request,
+          provenance,
+          engineRequest: {
+            entityModule: request.entityModule,
+            entityId: request.entityId,
+            sourceKind: provenance.sourceKind,
+            sourceProvider: provenance.sourceProvider,
+            sourceConnectionId: provenance.sourceConnectionId,
+            sourceRef: provenance.sourceRef,
+            scope,
+            parameters: engineParametersFromDraft(request.parameters, request.draft, {
+              entityModule: request.entityModule,
+              sourceKind: provenance.sourceKind,
+              sourceProvider: provenance.sourceProvider,
+            }),
+            ttlMs: request.ttlMs,
+            adapterContext,
+            selectionId: String(index),
+          },
+        }
+      }),
+    )
+    const quoted = await quoteEntitiesBatch(
+      db,
+      {
+        registry: options.resolveSourceRegistry(c),
+        ownedHandlers: options.resolveOwnedHandlers?.(c),
+        contentEnricher: options.contentEnricher,
+        onEnricherError: options.onContentEnricherError,
+        evaluatePromotions: options.resolveEvaluatePromotions?.({ c, db }),
+      },
+      prepared.map((item) => item.engineRequest),
+    )
+    const bySelectionId = new Map(quoted.map((item) => [item.selectionId, item.result]))
+    const resultItems = await Promise.all(
+      prepared.map(async (item) => {
+        const result = bySelectionId.get(item.selectionId)
+        if (!result) throw new Error(`missing batch quote result ${item.selectionId}`)
+        const transformed =
+          (await options.transformQuoteResult?.({
+            c,
+            db,
+            request: item.request,
+            provenance: item.provenance,
+            result,
+          })) ?? result
+        return {
+          selection: item.selection,
+          request: item.request,
+          provenance: item.provenance,
+          result: transformed,
+        }
+      }),
+    )
+    const transformed =
+      (await options.transformBatchQuoteResults?.({
+        c,
+        db,
+        request: body,
+        results: resultItems,
+      })) ?? resultItems
+    return c.json(serializeBatchQuoteResult(transformed))
   } catch (err) {
     return bookingEngineErrorResponse(c, err)
   }
@@ -814,6 +968,89 @@ function defaultAudienceForPath(c: Context): "staff" | "customer" {
   return c.req.path.startsWith("/v1/public/") ? "customer" : "staff"
 }
 
+function quoteRequestFromBatchSelection(
+  c: Context,
+  body: CatalogBookingBatchQuoteBody,
+  selection: CatalogBookingBatchQuoteSelection,
+): CatalogBookingQuoteBody {
+  const draft = mergeBatchDraft(body.draft, selection.draft, body.criteria, selection)
+  return {
+    entityModule: selection.entityModule,
+    entityId: selection.entityId,
+    sourceKind: selection.sourceKind,
+    sourceProvider: selection.sourceProvider,
+    sourceConnectionId: selection.sourceConnectionId,
+    sourceRef: selection.sourceRef,
+    scope: {
+      locale: body.scope?.locale ?? "en-GB",
+      audience: body.scope?.audience ?? defaultAudienceForPath(c),
+      market: body.scope?.market ?? "default",
+      currency: body.scope?.currency,
+    },
+    parameters: {
+      ...(body.parameters ?? {}),
+      ...(selection.parameters ?? {}),
+      ...(selection.ratePlanId ? { ratePlanId: selection.ratePlanId } : {}),
+    },
+    draft,
+    ttlMs: body.ttlMs,
+  }
+}
+
+function mergeBatchDraft(
+  baseDraft: Record<string, unknown> | undefined,
+  selectionDraft: Record<string, unknown> | undefined,
+  criteria: CatalogBookingBatchQuoteBody["criteria"],
+  selection: CatalogBookingBatchQuoteSelection,
+): Record<string, unknown> | undefined {
+  const draft = deepMergeRecords(baseDraft, selectionDraft)
+  if (!criteria || selection.entityModule !== "accommodations") return draft
+  const configure = asRecord(draft?.configure) ?? {}
+  const accommodation = asRecord(draft?.accommodation) ?? {}
+  const checkIn = criteria.checkIn
+  const checkOut = criteria.checkOut
+  const nextConfigure = {
+    ...configure,
+    ...(checkIn || checkOut
+      ? {
+          dateRange: {
+            ...(asRecord(configure.dateRange) ?? {}),
+            ...(checkIn ? { checkIn } : {}),
+            ...(checkOut ? { checkOut } : {}),
+          },
+        }
+      : {}),
+    ...(criteria.occupancy ? { pax: { ...criteria.occupancy } } : {}),
+  }
+  const rooms = [
+    {
+      optionUnitId: selection.entityId,
+      quantity: criteria.roomCount ?? 1,
+      ...(selection.ratePlanId ? { ratePlanId: selection.ratePlanId } : {}),
+    },
+  ]
+  return {
+    ...(draft ?? {}),
+    configure: nextConfigure,
+    accommodation: { ...accommodation, rooms },
+  }
+}
+
+function deepMergeRecords(
+  base: Record<string, unknown> | undefined,
+  override: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!base) return override
+  if (!override) return base
+  const merged = { ...base }
+  for (const [key, value] of Object.entries(override)) {
+    const baseValue = asRecord(merged[key])
+    const overrideValue = asRecord(value)
+    merged[key] = baseValue && overrideValue ? deepMergeRecords(baseValue, overrideValue) : value
+  }
+  return merged
+}
+
 function engineParametersFromDraft(
   parameters: Record<string, unknown> | undefined,
   draftPayload: unknown,
@@ -1040,6 +1277,17 @@ function serializeQuoteResult(result: QuoteEntityResult): QuoteResponseV1 {
     quotedAt: result.quotedAt.toISOString(),
     expiresAt: result.expiresAt.toISOString(),
     pricing: toPricingBreakdownV1(result.pricing),
+  })
+}
+
+function serializeBatchQuoteResult(
+  items: CatalogBookingBatchQuoteTransformInput["results"],
+): QuoteBatchResponseV1 {
+  return quoteBatchResponseV1.parse({
+    results: items.map((item) => ({
+      selection: item.selection,
+      ...serializeQuoteResult(item.result),
+    })),
   })
 }
 

--- a/packages/catalog/src/index.ts
+++ b/packages/catalog/src/index.ts
@@ -64,6 +64,9 @@ export {
 } from "./booking-engine/operator-routes.js"
 export {
   type CatalogBookingAdapterContextInput,
+  type CatalogBookingBatchQuoteBody,
+  type CatalogBookingBatchQuoteSelection,
+  type CatalogBookingBatchQuoteTransformInput,
   type CatalogBookingBookBody,
   type CatalogBookingBookTransformInput,
   type CatalogBookingCommittedEvent,

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -164,6 +164,7 @@ function withAnonymous(module: HonoModule, anonymous: HonoModule["anonymous"]): 
 
 const CATALOG_BOOKING_ROUTE_PATHS = [
   "/v1/admin/catalog/quote",
+  "/v1/admin/catalog/quotes/batch",
   "/v1/admin/catalog/book",
   "/v1/admin/catalog/drafts/:id",
   "/v1/admin/catalog/holds/place",
@@ -174,6 +175,7 @@ const CATALOG_BOOKING_ROUTE_PATHS = [
   "/v1/admin/catalog/orders/:id/cancel",
   "/v1/admin/bookings/:id/catalog-snapshot",
   "/v1/public/catalog/quote",
+  "/v1/public/catalog/quotes/batch",
   "/v1/public/catalog/book",
   "/v1/public/catalog/drafts/:id",
   "/v1/public/catalog/holds/place",
@@ -183,10 +185,12 @@ const CATALOG_BOOKING_ROUTE_PATHS = [
 
 const CATALOG_BOOKING_TRANSACTIONAL_PATHS = [
   "/v1/admin/catalog/quote",
+  "/v1/admin/catalog/quotes/batch",
   "/v1/admin/catalog/book",
   "/v1/admin/catalog/holds",
   "/v1/admin/catalog/orders",
   "/v1/public/catalog/quote",
+  "/v1/public/catalog/quotes/batch",
   "/v1/public/catalog/book",
   "/v1/public/catalog/holds",
 ] as const

--- a/packages/framework/src/composition.ts
+++ b/packages/framework/src/composition.ts
@@ -147,6 +147,7 @@ type FrameworkRelationshipsService = Pick<
 // the `load` closure that wires its providers into the route bundle.
 const CATALOG_BOOKING_ROUTE_PATHS = [
   "/v1/admin/catalog/quote",
+  "/v1/admin/catalog/quotes/batch",
   "/v1/admin/catalog/book",
   "/v1/admin/catalog/drafts/:id",
   "/v1/admin/catalog/holds/place",
@@ -157,6 +158,7 @@ const CATALOG_BOOKING_ROUTE_PATHS = [
   "/v1/admin/catalog/orders/:id/cancel",
   "/v1/admin/bookings/:id/catalog-snapshot",
   "/v1/public/catalog/quote",
+  "/v1/public/catalog/quotes/batch",
   "/v1/public/catalog/book",
   "/v1/public/catalog/drafts/:id",
   "/v1/public/catalog/holds/place",
@@ -173,10 +175,12 @@ const CATALOG_BOOKING_ROUTE_PATHS = [
 // matchers) so deployments don't hand-list them in `dbTransactionalPaths`.
 const CATALOG_BOOKING_TRANSACTIONAL_PATHS = [
   "/v1/admin/catalog/quote",
+  "/v1/admin/catalog/quotes/batch",
   "/v1/admin/catalog/book",
   "/v1/admin/catalog/holds",
   "/v1/admin/catalog/orders",
   "/v1/public/catalog/quote",
+  "/v1/public/catalog/quotes/batch",
   "/v1/public/catalog/book",
   "/v1/public/catalog/holds",
 ] as const

--- a/packages/framework/src/transactional-surface.test.ts
+++ b/packages/framework/src/transactional-surface.test.ts
@@ -43,10 +43,12 @@ describe("standard transactional surface (ADR-0008)", () => {
     const catalogBooking = modules.find((m) => m.module.name === "catalog-booking")
     expect([...(catalogBooking?.transactionalPaths ?? [])]).toEqual([
       "/v1/admin/catalog/quote",
+      "/v1/admin/catalog/quotes/batch",
       "/v1/admin/catalog/book",
       "/v1/admin/catalog/holds",
       "/v1/admin/catalog/orders",
       "/v1/public/catalog/quote",
+      "/v1/public/catalog/quotes/batch",
       "/v1/public/catalog/book",
       "/v1/public/catalog/holds",
     ])

--- a/starters/operator/openapi/admin/catalog-booking.json
+++ b/starters/operator/openapi/admin/catalog-booking.json
@@ -1574,6 +1574,1525 @@
         "x-voyant-surface": "admin"
       }
     },
+    "/v1/admin/catalog/quotes/batch": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "criteria": {
+                    "type": "object",
+                    "properties": {
+                      "checkIn": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "checkOut": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "occupancy": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "roomCount": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      }
+                    }
+                  },
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "enum": [
+                          "staff",
+                          "customer",
+                          "partner",
+                          "supplier"
+                        ]
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "draft": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "ttlMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "selections": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "entityModule": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "entityId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "ratePlanId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceKind": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceProvider": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceConnectionId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceRef": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "parameters": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "draft": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "entityModule",
+                        "entityId"
+                      ]
+                    },
+                    "minItems": 1,
+                    "maxItems": 30
+                  }
+                },
+                "required": [
+                  "selections"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch quote results for the requested selections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "quoteId": {
+                            "type": "string"
+                          },
+                          "quotedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "expiresAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "available": {
+                            "type": "boolean"
+                          },
+                          "invalidReason": {
+                            "type": "string"
+                          },
+                          "shape": {
+                            "type": "object",
+                            "properties": {
+                              "showsConfigure": {
+                                "type": "boolean"
+                              },
+                              "showsBilling": {
+                                "type": "boolean"
+                              },
+                              "showsTravelers": {
+                                "type": "boolean"
+                              },
+                              "showsAccommodation": {
+                                "type": "boolean"
+                              },
+                              "showsAddons": {
+                                "type": "boolean"
+                              },
+                              "showsPayment": {
+                                "type": "boolean"
+                              },
+                              "showsReview": {
+                                "type": "boolean",
+                                "enum": [
+                                  true
+                                ]
+                              },
+                              "configureSubSteps": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "departure"
+                                          ]
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                          "enum": [
+                                            true
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "required"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "product-option"
+                                          ]
+                                        },
+                                        "options": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "code": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "isDefault": {
+                                                "type": "boolean"
+                                              },
+                                              "units": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "unitType": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "minQuantity": {
+                                                      "type": [
+                                                        "integer",
+                                                        "null"
+                                                      ],
+                                                      "minimum": 0
+                                                    },
+                                                    "maxQuantity": {
+                                                      "type": [
+                                                        "integer",
+                                                        "null"
+                                                      ],
+                                                      "minimum": 0
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                    "name"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "options"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "option-units"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "cabin-category"
+                                          ]
+                                        },
+                                        "categories": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "capacityMin": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "capacityMax": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "description": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "categories"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "cabin-number"
+                                          ]
+                                        },
+                                        "perCategory": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string"
+                                                },
+                                                "code": {
+                                                  "type": "string"
+                                                },
+                                                "label": {
+                                                  "type": "string"
+                                                },
+                                                "capacity": {
+                                                  "type": "integer",
+                                                  "minimum": 0
+                                                },
+                                                "hasAccessibilityFeatures": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "id",
+                                                "label"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "perCategory"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "date-range"
+                                          ]
+                                        },
+                                        "minNights": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "maxNights": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "minNights",
+                                        "maxNights"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "occupancy"
+                                          ]
+                                        },
+                                        "bands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "code",
+                                              "label",
+                                              "minCount",
+                                              "maxCount"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "bands"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "air-arrangement"
+                                          ]
+                                        },
+                                        "required": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "paxBands": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "minAge": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "maxAge": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "minCount": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "maxCount": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "label",
+                                    "minCount",
+                                    "maxCount"
+                                  ]
+                                }
+                              },
+                              "paxBandsAllowedTotal": {
+                                "type": "object",
+                                "properties": {
+                                  "min": {
+                                    "type": "integer"
+                                  },
+                                  "max": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "min",
+                                  "max"
+                                ]
+                              },
+                              "paxBandDependencies": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "dependentCode": {
+                                      "type": "string"
+                                    },
+                                    "masterCode": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "requires",
+                                        "limits_per_master",
+                                        "limits_sum",
+                                        "excludes"
+                                      ]
+                                    },
+                                    "maxPerMaster": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "maxDependentSum": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "dependentCode",
+                                    "masterCode",
+                                    "type"
+                                  ]
+                                }
+                              },
+                              "travelerFields": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "value",
+                                          "label"
+                                        ]
+                                      }
+                                    },
+                                    "appliesToBands": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "label",
+                                    "type",
+                                    "required"
+                                  ]
+                                }
+                              },
+                              "bookingFields": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    },
+                                    "group": {
+                                      "type": "string",
+                                      "enum": [
+                                        "billing",
+                                        "company",
+                                        "preferences"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "label",
+                                    "type",
+                                    "required",
+                                    "group"
+                                  ]
+                                }
+                              },
+                              "accommodation": {
+                                "type": "object",
+                                "properties": {
+                                  "roomOptions": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "capacity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        },
+                                        "baseRateHint": {
+                                          "type": [
+                                            "number",
+                                            "null"
+                                          ]
+                                        },
+                                        "ratePlans": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "chargeFrequency": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "per_night",
+                                                  "per_stay"
+                                                ]
+                                              },
+                                              "cancellationPolicy": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "inclusions": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "currency": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "name"
+                                      ]
+                                    }
+                                  },
+                                  "sharedRoomAllowed": {
+                                    "type": "boolean"
+                                  },
+                                  "subSteps": {
+                                    "type": "array",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": [
+                                                "rooms"
+                                              ]
+                                            },
+                                            "options": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "capacity": {
+                                                    "type": [
+                                                      "integer",
+                                                      "null"
+                                                    ],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": [
+                                                      "number",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "per_night",
+                                                            "per_stay"
+                                                          ]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "id",
+                                                        "name"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "id",
+                                                  "name"
+                                                ]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "options",
+                                            "sharedRoomAllowed"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": [
+                                                "extensions"
+                                              ]
+                                            },
+                                            "options": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "city": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "side": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "pre",
+                                                      "post"
+                                                    ]
+                                                  },
+                                                  "nights": {
+                                                    "type": [
+                                                      "integer",
+                                                      "null"
+                                                    ],
+                                                    "minimum": 0
+                                                  },
+                                                  "pricePerPersonHint": {
+                                                    "type": [
+                                                      "number",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "id",
+                                                  "name",
+                                                  "side"
+                                                ]
+                                              }
+                                            },
+                                            "allowsPre": {
+                                              "type": "boolean"
+                                            },
+                                            "allowsPost": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "options",
+                                            "allowsPre",
+                                            "allowsPost"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "sharedRoomAllowed"
+                                ]
+                              },
+                              "addons": {
+                                "type": "object",
+                                "properties": {
+                                  "catalog": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "extras",
+                                            "excursions",
+                                            "insurance"
+                                          ]
+                                        },
+                                        "groupKey": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "pricingMode": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "unitAmountCents": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ]
+                                        },
+                                        "currency": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "pricedPerPerson": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "selectionType": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
+                                          "enum": [
+                                            "optional",
+                                            "required",
+                                            "default_selected",
+                                            "unavailable",
+                                            null
+                                          ]
+                                        },
+                                        "minQuantity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        },
+                                        "maxQuantity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        },
+                                        "defaultQuantity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "name",
+                                        "kind"
+                                      ]
+                                    }
+                                  },
+                                  "groups": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "extras",
+                                            "excursions",
+                                            "insurance"
+                                          ]
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "groupBy": {
+                                          "type": "string",
+                                          "enum": [
+                                            "port",
+                                            "day"
+                                          ]
+                                        },
+                                        "perGuestSelection": {
+                                          "type": "boolean"
+                                        },
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "kind": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "extras",
+                                                  "excursions",
+                                                  "insurance"
+                                                ]
+                                              },
+                                              "groupKey": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "pricingMode": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "unitAmountCents": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "currency": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "pricedPerPerson": {
+                                                "type": [
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              },
+                                              "selectionType": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "enum": [
+                                                  "optional",
+                                                  "required",
+                                                  "default_selected",
+                                                  "unavailable",
+                                                  null
+                                                ]
+                                              },
+                                              "minQuantity": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "minimum": 0
+                                              },
+                                              "maxQuantity": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "minimum": 0
+                                              },
+                                              "defaultQuantity": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name",
+                                              "kind"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "label",
+                                        "perGuestSelection",
+                                        "items"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "paymentIntents": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "hold",
+                                    "card",
+                                    "bank_transfer",
+                                    "ticket_on_credit",
+                                    "inquiry"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "showsConfigure",
+                              "showsBilling",
+                              "showsTravelers",
+                              "showsAccommodation",
+                              "showsAddons",
+                              "showsPayment",
+                              "showsReview",
+                              "paxBands",
+                              "paxBandsAllowedTotal",
+                              "travelerFields",
+                              "bookingFields",
+                              "paymentIntents"
+                            ]
+                          },
+                          "pricing": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 3
+                              },
+                              "lines": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": [
+                                        "base",
+                                        "addon",
+                                        "accommodation",
+                                        "supplement",
+                                        "discount",
+                                        "fee"
+                                      ]
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "quantity": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "unitAmount": {
+                                      "type": "integer"
+                                    },
+                                    "totalAmount": {
+                                      "type": "integer"
+                                    },
+                                    "taxIncluded": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "label",
+                                    "unitAmount",
+                                    "totalAmount"
+                                  ]
+                                }
+                              },
+                              "taxes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "rate": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "amount": {
+                                      "type": "integer"
+                                    },
+                                    "base": {
+                                      "type": "integer"
+                                    },
+                                    "includedInPrice": {
+                                      "type": "boolean"
+                                    },
+                                    "scope": {
+                                      "type": "string",
+                                      "enum": [
+                                        "included",
+                                        "excluded",
+                                        "withheld"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "label",
+                                    "rate",
+                                    "amount",
+                                    "base"
+                                  ]
+                                }
+                              },
+                              "subtotal": {
+                                "type": "integer"
+                              },
+                              "taxTotal": {
+                                "type": "integer"
+                              },
+                              "total": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "currency",
+                              "lines",
+                              "taxes",
+                              "subtotal",
+                              "taxTotal",
+                              "total"
+                            ]
+                          },
+                          "upstreamPayload": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "selection": {
+                            "type": "object",
+                            "properties": {
+                              "entityModule": {
+                                "type": "string"
+                              },
+                              "entityId": {
+                                "type": "string"
+                              },
+                              "ratePlanId": {
+                                "type": "string"
+                              },
+                              "sourceKind": {
+                                "type": "string"
+                              },
+                              "sourceProvider": {
+                                "type": "string"
+                              },
+                              "sourceConnectionId": {
+                                "type": "string"
+                              },
+                              "sourceRef": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "draft": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            },
+                            "required": [
+                              "entityModule",
+                              "entityId"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "quoteId",
+                          "quotedAt",
+                          "expiresAt",
+                          "available",
+                          "selection"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Quote/order referenced by the engine was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Quote expired or conflicts with current availability",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream reservation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No adapter/handler registered for one or more selections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postAdminCatalogQuotesBatch",
+        "summary": "POST /v1/admin/catalog/quotes/batch",
+        "tags": [
+          "catalog-booking"
+        ],
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "admin"
+      }
+    },
     "/v1/admin/catalog/book": {
       "post": {
         "requestBody": {

--- a/starters/operator/openapi/storefront/catalog-booking.json
+++ b/starters/operator/openapi/storefront/catalog-booking.json
@@ -1574,6 +1574,1525 @@
         "x-voyant-surface": "storefront"
       }
     },
+    "/v1/public/catalog/quotes/batch": {
+      "post": {
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "criteria": {
+                    "type": "object",
+                    "properties": {
+                      "checkIn": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "checkOut": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "occupancy": {
+                        "type": "object",
+                        "additionalProperties": {
+                          "type": "integer",
+                          "minimum": 0
+                        }
+                      },
+                      "roomCount": {
+                        "type": "integer",
+                        "exclusiveMinimum": 0
+                      }
+                    }
+                  },
+                  "scope": {
+                    "type": "object",
+                    "properties": {
+                      "locale": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "audience": {
+                        "type": "string",
+                        "enum": [
+                          "staff",
+                          "customer",
+                          "partner",
+                          "supplier"
+                        ]
+                      },
+                      "market": {
+                        "type": "string",
+                        "minLength": 1
+                      },
+                      "currency": {
+                        "type": "string",
+                        "minLength": 1
+                      }
+                    }
+                  },
+                  "parameters": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "draft": {
+                    "type": "object",
+                    "additionalProperties": {}
+                  },
+                  "ttlMs": {
+                    "type": "integer",
+                    "exclusiveMinimum": 0
+                  },
+                  "selections": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "entityModule": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "entityId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "ratePlanId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceKind": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceProvider": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceConnectionId": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "sourceRef": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "parameters": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        },
+                        "draft": {
+                          "type": "object",
+                          "additionalProperties": {}
+                        }
+                      },
+                      "required": [
+                        "entityModule",
+                        "entityId"
+                      ]
+                    },
+                    "minItems": 1,
+                    "maxItems": 30
+                  }
+                },
+                "required": [
+                  "selections"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Batch quote results for the requested selections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "quoteId": {
+                            "type": "string"
+                          },
+                          "quotedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "expiresAt": {
+                            "type": "string",
+                            "format": "date-time"
+                          },
+                          "available": {
+                            "type": "boolean"
+                          },
+                          "invalidReason": {
+                            "type": "string"
+                          },
+                          "shape": {
+                            "type": "object",
+                            "properties": {
+                              "showsConfigure": {
+                                "type": "boolean"
+                              },
+                              "showsBilling": {
+                                "type": "boolean"
+                              },
+                              "showsTravelers": {
+                                "type": "boolean"
+                              },
+                              "showsAccommodation": {
+                                "type": "boolean"
+                              },
+                              "showsAddons": {
+                                "type": "boolean"
+                              },
+                              "showsPayment": {
+                                "type": "boolean"
+                              },
+                              "showsReview": {
+                                "type": "boolean",
+                                "enum": [
+                                  true
+                                ]
+                              },
+                              "configureSubSteps": {
+                                "type": "array",
+                                "items": {
+                                  "oneOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "departure"
+                                          ]
+                                        },
+                                        "required": {
+                                          "type": "boolean",
+                                          "enum": [
+                                            true
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "required"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "product-option"
+                                          ]
+                                        },
+                                        "options": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "code": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "isDefault": {
+                                                "type": "boolean"
+                                              },
+                                              "units": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "object",
+                                                  "properties": {
+                                                    "id": {
+                                                      "type": "string"
+                                                    },
+                                                    "name": {
+                                                      "type": "string"
+                                                    },
+                                                    "description": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "unitType": {
+                                                      "type": [
+                                                        "string",
+                                                        "null"
+                                                      ]
+                                                    },
+                                                    "minQuantity": {
+                                                      "type": [
+                                                        "integer",
+                                                        "null"
+                                                      ],
+                                                      "minimum": 0
+                                                    },
+                                                    "maxQuantity": {
+                                                      "type": [
+                                                        "integer",
+                                                        "null"
+                                                      ],
+                                                      "minimum": 0
+                                                    }
+                                                  },
+                                                  "required": [
+                                                    "id",
+                                                    "name"
+                                                  ]
+                                                }
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "options"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "option-units"
+                                          ]
+                                        }
+                                      },
+                                      "required": [
+                                        "kind"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "cabin-category"
+                                          ]
+                                        },
+                                        "categories": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "type": "string"
+                                              },
+                                              "capacityMin": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "capacityMax": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "description": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "categories"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "cabin-number"
+                                          ]
+                                        },
+                                        "perCategory": {
+                                          "type": "object",
+                                          "additionalProperties": {
+                                            "type": "array",
+                                            "items": {
+                                              "type": "object",
+                                              "properties": {
+                                                "id": {
+                                                  "type": "string"
+                                                },
+                                                "code": {
+                                                  "type": "string"
+                                                },
+                                                "label": {
+                                                  "type": "string"
+                                                },
+                                                "capacity": {
+                                                  "type": "integer",
+                                                  "minimum": 0
+                                                },
+                                                "hasAccessibilityFeatures": {
+                                                  "type": "boolean"
+                                                }
+                                              },
+                                              "required": [
+                                                "id",
+                                                "label"
+                                              ]
+                                            }
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "perCategory"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "date-range"
+                                          ]
+                                        },
+                                        "minNights": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        },
+                                        "maxNights": {
+                                          "type": "integer",
+                                          "exclusiveMinimum": 0
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "minNights",
+                                        "maxNights"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "occupancy"
+                                          ]
+                                        },
+                                        "bands": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "code": {
+                                                "type": "string"
+                                              },
+                                              "label": {
+                                                "type": "string"
+                                              },
+                                              "minAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxAge": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "minCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              },
+                                              "maxCount": {
+                                                "type": "integer",
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "code",
+                                              "label",
+                                              "minCount",
+                                              "maxCount"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "bands"
+                                      ]
+                                    },
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "air-arrangement"
+                                          ]
+                                        },
+                                        "required": {
+                                          "type": "boolean"
+                                        }
+                                      },
+                                      "required": [
+                                        "kind"
+                                      ]
+                                    }
+                                  ]
+                                }
+                              },
+                              "paxBands": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "minAge": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "maxAge": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "minCount": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "maxCount": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "label",
+                                    "minCount",
+                                    "maxCount"
+                                  ]
+                                }
+                              },
+                              "paxBandsAllowedTotal": {
+                                "type": "object",
+                                "properties": {
+                                  "min": {
+                                    "type": "integer"
+                                  },
+                                  "max": {
+                                    "type": "integer"
+                                  }
+                                },
+                                "required": [
+                                  "min",
+                                  "max"
+                                ]
+                              },
+                              "paxBandDependencies": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "dependentCode": {
+                                      "type": "string"
+                                    },
+                                    "masterCode": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string",
+                                      "enum": [
+                                        "requires",
+                                        "limits_per_master",
+                                        "limits_sum",
+                                        "excludes"
+                                      ]
+                                    },
+                                    "maxPerMaster": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    },
+                                    "maxDependentSum": {
+                                      "type": "integer",
+                                      "minimum": 0
+                                    }
+                                  },
+                                  "required": [
+                                    "dependentCode",
+                                    "masterCode",
+                                    "type"
+                                  ]
+                                }
+                              },
+                              "travelerFields": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    },
+                                    "options": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "object",
+                                        "properties": {
+                                          "value": {
+                                            "type": "string"
+                                          },
+                                          "label": {
+                                            "type": "string"
+                                          }
+                                        },
+                                        "required": [
+                                          "value",
+                                          "label"
+                                        ]
+                                      }
+                                    },
+                                    "appliesToBands": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "label",
+                                    "type",
+                                    "required"
+                                  ]
+                                }
+                              },
+                              "bookingFields": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "key": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "type": "string"
+                                    },
+                                    "required": {
+                                      "type": "boolean"
+                                    },
+                                    "group": {
+                                      "type": "string",
+                                      "enum": [
+                                        "billing",
+                                        "company",
+                                        "preferences"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "key",
+                                    "label",
+                                    "type",
+                                    "required",
+                                    "group"
+                                  ]
+                                }
+                              },
+                              "accommodation": {
+                                "type": "object",
+                                "properties": {
+                                  "roomOptions": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "capacity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        },
+                                        "baseRateHint": {
+                                          "type": [
+                                            "number",
+                                            "null"
+                                          ]
+                                        },
+                                        "ratePlans": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "chargeFrequency": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "per_night",
+                                                  "per_stay"
+                                                ]
+                                              },
+                                              "cancellationPolicy": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "inclusions": {
+                                                "type": "array",
+                                                "items": {
+                                                  "type": "string"
+                                                }
+                                              },
+                                              "currency": {
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "name"
+                                      ]
+                                    }
+                                  },
+                                  "sharedRoomAllowed": {
+                                    "type": "boolean"
+                                  },
+                                  "subSteps": {
+                                    "type": "array",
+                                    "items": {
+                                      "oneOf": [
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": [
+                                                "rooms"
+                                              ]
+                                            },
+                                            "options": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "description": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "capacity": {
+                                                    "type": [
+                                                      "integer",
+                                                      "null"
+                                                    ],
+                                                    "minimum": 0
+                                                  },
+                                                  "baseRateHint": {
+                                                    "type": [
+                                                      "number",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "ratePlans": {
+                                                    "type": "array",
+                                                    "items": {
+                                                      "type": "object",
+                                                      "properties": {
+                                                        "id": {
+                                                          "type": "string"
+                                                        },
+                                                        "name": {
+                                                          "type": "string"
+                                                        },
+                                                        "description": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "chargeFrequency": {
+                                                          "type": "string",
+                                                          "enum": [
+                                                            "per_night",
+                                                            "per_stay"
+                                                          ]
+                                                        },
+                                                        "cancellationPolicy": {
+                                                          "type": [
+                                                            "string",
+                                                            "null"
+                                                          ]
+                                                        },
+                                                        "inclusions": {
+                                                          "type": "array",
+                                                          "items": {
+                                                            "type": "string"
+                                                          }
+                                                        },
+                                                        "currency": {
+                                                          "type": "string"
+                                                        }
+                                                      },
+                                                      "required": [
+                                                        "id",
+                                                        "name"
+                                                      ]
+                                                    }
+                                                  }
+                                                },
+                                                "required": [
+                                                  "id",
+                                                  "name"
+                                                ]
+                                              }
+                                            },
+                                            "sharedRoomAllowed": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "options",
+                                            "sharedRoomAllowed"
+                                          ]
+                                        },
+                                        {
+                                          "type": "object",
+                                          "properties": {
+                                            "kind": {
+                                              "type": "string",
+                                              "enum": [
+                                                "extensions"
+                                              ]
+                                            },
+                                            "options": {
+                                              "type": "array",
+                                              "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                  "id": {
+                                                    "type": "string"
+                                                  },
+                                                  "name": {
+                                                    "type": "string"
+                                                  },
+                                                  "city": {
+                                                    "type": [
+                                                      "string",
+                                                      "null"
+                                                    ]
+                                                  },
+                                                  "side": {
+                                                    "type": "string",
+                                                    "enum": [
+                                                      "pre",
+                                                      "post"
+                                                    ]
+                                                  },
+                                                  "nights": {
+                                                    "type": [
+                                                      "integer",
+                                                      "null"
+                                                    ],
+                                                    "minimum": 0
+                                                  },
+                                                  "pricePerPersonHint": {
+                                                    "type": [
+                                                      "number",
+                                                      "null"
+                                                    ]
+                                                  }
+                                                },
+                                                "required": [
+                                                  "id",
+                                                  "name",
+                                                  "side"
+                                                ]
+                                              }
+                                            },
+                                            "allowsPre": {
+                                              "type": "boolean"
+                                            },
+                                            "allowsPost": {
+                                              "type": "boolean"
+                                            }
+                                          },
+                                          "required": [
+                                            "kind",
+                                            "options",
+                                            "allowsPre",
+                                            "allowsPost"
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "sharedRoomAllowed"
+                                ]
+                              },
+                              "addons": {
+                                "type": "object",
+                                "properties": {
+                                  "catalog": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "id": {
+                                          "type": "string"
+                                        },
+                                        "name": {
+                                          "type": "string"
+                                        },
+                                        "description": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "extras",
+                                            "excursions",
+                                            "insurance"
+                                          ]
+                                        },
+                                        "groupKey": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "pricingMode": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "unitAmountCents": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ]
+                                        },
+                                        "currency": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ]
+                                        },
+                                        "pricedPerPerson": {
+                                          "type": [
+                                            "boolean",
+                                            "null"
+                                          ]
+                                        },
+                                        "selectionType": {
+                                          "type": [
+                                            "string",
+                                            "null"
+                                          ],
+                                          "enum": [
+                                            "optional",
+                                            "required",
+                                            "default_selected",
+                                            "unavailable",
+                                            null
+                                          ]
+                                        },
+                                        "minQuantity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        },
+                                        "maxQuantity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        },
+                                        "defaultQuantity": {
+                                          "type": [
+                                            "integer",
+                                            "null"
+                                          ],
+                                          "minimum": 0
+                                        }
+                                      },
+                                      "required": [
+                                        "id",
+                                        "name",
+                                        "kind"
+                                      ]
+                                    }
+                                  },
+                                  "groups": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "object",
+                                      "properties": {
+                                        "kind": {
+                                          "type": "string",
+                                          "enum": [
+                                            "extras",
+                                            "excursions",
+                                            "insurance"
+                                          ]
+                                        },
+                                        "label": {
+                                          "type": "string"
+                                        },
+                                        "groupBy": {
+                                          "type": "string",
+                                          "enum": [
+                                            "port",
+                                            "day"
+                                          ]
+                                        },
+                                        "perGuestSelection": {
+                                          "type": "boolean"
+                                        },
+                                        "items": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "object",
+                                            "properties": {
+                                              "id": {
+                                                "type": "string"
+                                              },
+                                              "name": {
+                                                "type": "string"
+                                              },
+                                              "description": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "kind": {
+                                                "type": "string",
+                                                "enum": [
+                                                  "extras",
+                                                  "excursions",
+                                                  "insurance"
+                                                ]
+                                              },
+                                              "groupKey": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "pricingMode": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "unitAmountCents": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ]
+                                              },
+                                              "currency": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ]
+                                              },
+                                              "pricedPerPerson": {
+                                                "type": [
+                                                  "boolean",
+                                                  "null"
+                                                ]
+                                              },
+                                              "selectionType": {
+                                                "type": [
+                                                  "string",
+                                                  "null"
+                                                ],
+                                                "enum": [
+                                                  "optional",
+                                                  "required",
+                                                  "default_selected",
+                                                  "unavailable",
+                                                  null
+                                                ]
+                                              },
+                                              "minQuantity": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "minimum": 0
+                                              },
+                                              "maxQuantity": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "minimum": 0
+                                              },
+                                              "defaultQuantity": {
+                                                "type": [
+                                                  "integer",
+                                                  "null"
+                                                ],
+                                                "minimum": 0
+                                              }
+                                            },
+                                            "required": [
+                                              "id",
+                                              "name",
+                                              "kind"
+                                            ]
+                                          }
+                                        }
+                                      },
+                                      "required": [
+                                        "kind",
+                                        "label",
+                                        "perGuestSelection",
+                                        "items"
+                                      ]
+                                    }
+                                  }
+                                }
+                              },
+                              "paymentIntents": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string",
+                                  "enum": [
+                                    "hold",
+                                    "card",
+                                    "bank_transfer",
+                                    "ticket_on_credit",
+                                    "inquiry"
+                                  ]
+                                }
+                              }
+                            },
+                            "required": [
+                              "showsConfigure",
+                              "showsBilling",
+                              "showsTravelers",
+                              "showsAccommodation",
+                              "showsAddons",
+                              "showsPayment",
+                              "showsReview",
+                              "paxBands",
+                              "paxBandsAllowedTotal",
+                              "travelerFields",
+                              "bookingFields",
+                              "paymentIntents"
+                            ]
+                          },
+                          "pricing": {
+                            "type": "object",
+                            "properties": {
+                              "currency": {
+                                "type": "string",
+                                "minLength": 3,
+                                "maxLength": 3
+                              },
+                              "lines": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "enum": [
+                                        "base",
+                                        "addon",
+                                        "accommodation",
+                                        "supplement",
+                                        "discount",
+                                        "fee"
+                                      ]
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "quantity": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "unitAmount": {
+                                      "type": "integer"
+                                    },
+                                    "totalAmount": {
+                                      "type": "integer"
+                                    },
+                                    "taxIncluded": {
+                                      "type": "boolean"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "label",
+                                    "unitAmount",
+                                    "totalAmount"
+                                  ]
+                                }
+                              },
+                              "taxes": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "code": {
+                                      "type": "string"
+                                    },
+                                    "label": {
+                                      "type": "string"
+                                    },
+                                    "rate": {
+                                      "type": "number",
+                                      "minimum": 0
+                                    },
+                                    "amount": {
+                                      "type": "integer"
+                                    },
+                                    "base": {
+                                      "type": "integer"
+                                    },
+                                    "includedInPrice": {
+                                      "type": "boolean"
+                                    },
+                                    "scope": {
+                                      "type": "string",
+                                      "enum": [
+                                        "included",
+                                        "excluded",
+                                        "withheld"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "code",
+                                    "label",
+                                    "rate",
+                                    "amount",
+                                    "base"
+                                  ]
+                                }
+                              },
+                              "subtotal": {
+                                "type": "integer"
+                              },
+                              "taxTotal": {
+                                "type": "integer"
+                              },
+                              "total": {
+                                "type": "integer"
+                              }
+                            },
+                            "required": [
+                              "currency",
+                              "lines",
+                              "taxes",
+                              "subtotal",
+                              "taxTotal",
+                              "total"
+                            ]
+                          },
+                          "upstreamPayload": {
+                            "type": "object",
+                            "additionalProperties": {}
+                          },
+                          "selection": {
+                            "type": "object",
+                            "properties": {
+                              "entityModule": {
+                                "type": "string"
+                              },
+                              "entityId": {
+                                "type": "string"
+                              },
+                              "ratePlanId": {
+                                "type": "string"
+                              },
+                              "sourceKind": {
+                                "type": "string"
+                              },
+                              "sourceProvider": {
+                                "type": "string"
+                              },
+                              "sourceConnectionId": {
+                                "type": "string"
+                              },
+                              "sourceRef": {
+                                "type": "string"
+                              },
+                              "parameters": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              },
+                              "draft": {
+                                "type": "object",
+                                "additionalProperties": {}
+                              }
+                            },
+                            "required": [
+                              "entityModule",
+                              "entityId"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "quoteId",
+                          "quotedAt",
+                          "expiresAt",
+                          "available",
+                          "selection"
+                        ]
+                      }
+                    }
+                  },
+                  "required": [
+                    "results"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid_request — body failed validation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Quote/order referenced by the engine was not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Quote expired or conflicts with current availability",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Upstream reservation failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "No adapter/handler registered for one or more selections",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "string"
+                    },
+                    "context": {
+                      "type": "object",
+                      "additionalProperties": {}
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "operationId": "postPublicCatalogQuotesBatch",
+        "summary": "POST /v1/public/catalog/quotes/batch",
+        "tags": [
+          "catalog-booking"
+        ],
+        "x-voyant-module": "catalog-booking",
+        "x-voyant-surface": "storefront"
+      }
+    },
     "/v1/public/catalog/book": {
       "post": {
         "requestBody": {


### PR DESCRIPTION
Closes #2970

## Summary
- Add bounded V1 batch quote contracts and `POST /v1/{admin,public}/catalog/quotes/batch` route support.
- Add a catalog owned-handler batch quote path that groups selections by runtime context and falls back to the existing single-quote behavior when a handler does not implement batching.
- Add accommodations batch stay quote resolution so room/date availability and rate reads are shared across room x rate-plan selections.
- Register the new catalog booking paths in framework route surfaces and regenerate operator OpenAPI artifacts.

## Validation
- `pnpm --filter @voyant-travel/catalog-contracts build`
- `pnpm --filter @voyant-travel/catalog typecheck`
- `pnpm --filter @voyant-travel/catalog test -- src/booking-engine/routes.test.ts src/booking-engine/contracts.test.ts`
- `pnpm --filter @voyant-travel/accommodations typecheck`
- `pnpm --filter @voyant-travel/accommodations test -- tests/unit/service-owned-stays.test.ts tests/unit/booking-handler.test.ts`
- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter operator exec vitest run src/api/openapi.test.ts`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- Pre-push `pnpm test` hook passed: 98/98 tasks successful.