### PR TITLE
Managed profile: snapshot plugin resolution

### DIFF
--- a/.changeset/managed-profile-snapshot-plugins.md
+++ b/.changeset/managed-profile-snapshot-plugins.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Resolve a managed profile's `plugins` list at boot so the standard `operator`
+profile can run snapshot-declared plugins source-free (issue #2983).
+
+`@voyant-travel/framework/managed-runtime` now imports each `plugins[]` npm
+specifier and invokes its managed-plugin factory (`voyantPlugin` /
+`createVoyantPlugin` / `createPlugin` / a `default` factory) with the plugin's
+`settings[specifier]` and the deployment env, then registers the result like a
+starter's inline `plugins: [...]`. A declared plugin that exposes no managed
+entry fails loud at boot instead of being silently dropped. The previous
+blanket "snapshot plugins are not yet resolved" boot error is removed.
+
+`importPluginModule` is injectable on `loadManagedProfileRuntime` /
+`ManagedProfileRuntimeOptions` so Cloud (or tests) can resolve plugins from a
+pre-bundled registry instead of node resolution. `resolveManagedPlugins` and
+the managed-plugin factory/context types are exported from
+`@voyant-travel/framework/managed-runtime`.

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -284,7 +284,46 @@ describe("managed profile runtime entry", () => {
     expect(await response.json()).toEqual({ error: "Unauthorized" })
   })
 
-  it("rejects snapshot plugins instead of silently ignoring them", async () => {
+  it("resolves snapshot plugins from published specifiers and boots source-free", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          plugins: ["@third-party/plugin-regional-accounting"],
+          settings: { "@third-party/plugin-regional-accounting": { fiscalRegion: "RO" } },
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    const factory = vi.fn((ctx: { settings: unknown }) => ({
+      name: "regional-accounting",
+      version: "1.0.0",
+      settings: ctx.settings,
+    }))
+
+    const runtime = await loadManagedProfileRuntime({
+      profileSnapshotPath: snapshotPath,
+      env: { DATABASE_URL: "managed-profile-test-db" },
+      importPluginModule: async () => ({ voyantPlugin: factory }),
+    })
+
+    expect(runtime.app.fetch).toEqual(expect.any(Function))
+    expect(factory).toHaveBeenCalledWith(
+      expect.objectContaining({
+        specifier: "@third-party/plugin-regional-accounting",
+        settings: { fiscalRegion: "RO" },
+      }),
+    )
+  })
+
+  it("fails fast when a snapshot plugin exposes no managed-plugin entry", async () => {
     const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
     const snapshotPath = join(dir, "managed-profile.json")
     await writeFile(
@@ -304,11 +343,10 @@ describe("managed profile runtime entry", () => {
     await expect(
       loadManagedProfileRuntime({
         profileSnapshotPath: snapshotPath,
-        env: {
-          DATABASE_URL: "managed-profile-test-db",
-        },
+        env: { DATABASE_URL: "managed-profile-test-db" },
+        importPluginModule: async () => ({ notAFactory: 42 }),
       }),
-    ).rejects.toThrow(/snapshot plugins are not yet resolved/)
+    ).rejects.toThrow(/does not export a managed-plugin entry/)
   })
 
   it("builds managed Node bindings from plain env/secrets", () => {

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -155,6 +155,7 @@ import { type Context, Hono } from "hono"
 
 import type { FrameworkProviders } from "./composition-lazy.js"
 import { type CreateVoyantAppConfig, createVoyantApp } from "./create-app.js"
+import { type ManagedPlugin, resolveManagedPlugins } from "./plugin-resolution.js"
 import {
   getVoyantProjectRequirements,
   toCreateVoyantAppProfileConfig,
@@ -162,6 +163,14 @@ import {
   type VoyantProjectManifest,
   validateVoyantProject,
 } from "./profile.js"
+
+export {
+  type ManagedPlugin,
+  type ResolveManagedPluginsOptions,
+  resolveManagedPlugins,
+  type VoyantManagedPluginContext,
+  type VoyantManagedPluginFactory,
+} from "./plugin-resolution.js"
 
 export interface ManagedProfileRuntimeEnv extends VoyantBindings {
   TENANT_ID?: string
@@ -227,6 +236,12 @@ export interface ManagedProfileRuntimeOptions {
       "providers" | "exclude"
     >
   >
+  /**
+   * Override how snapshot `plugins` specifiers are imported. Defaults to dynamic
+   * `import()`; injectable so Cloud (or tests) can resolve plugins from a
+   * pre-bundled registry instead of node resolution.
+   */
+  importPluginModule?: (specifier: string) => Promise<Record<string, unknown>>
 }
 
 export interface ManagedProfileRuntime {
@@ -291,11 +306,17 @@ export async function loadManagedProfileRuntime(
     env,
     auth: options.app?.auth ?? options.auth,
   })
+  const plugins = await resolveManagedPlugins(
+    project,
+    toPluginEnvRecord(env),
+    options.importPluginModule ? { importModule: options.importPluginModule } : {},
+  )
   assertManagedProfileRuntimeSupport({
     project,
     requirements,
     env,
     hasAuthIntegration: Boolean(auth),
+    hasResolvedPlugins: plugins.length > 0,
   })
   const app = createManagedProfileApp({
     project,
@@ -303,6 +324,7 @@ export async function loadManagedProfileRuntime(
     auth,
     providers: options.providers,
     app: options.app,
+    plugins,
   })
 
   return {
@@ -360,14 +382,22 @@ export function createManagedProfileApp(options: {
       "providers" | "exclude"
     >
   >
+  /**
+   * Plugins resolved from the snapshot's `plugins` list (see
+   * {@link resolveManagedPlugins}), merged after any `app.plugins`. When the
+   * snapshot declares plugins, either these or `app.plugins` must be non-empty.
+   */
+  plugins?: ManagedPlugin[]
 }) {
   const auth = resolveManagedProfileAuthIntegration({
     env: options.env,
     auth: options.app?.auth ?? options.auth,
   })
+  const mergedPlugins = [...(options.app?.plugins ?? []), ...(options.plugins ?? [])]
   assertManagedProfileAppSupport({
     project: options.project,
     hasAuthIntegration: Boolean(auth),
+    hasResolvedPlugins: mergedPlugins.length > 0,
   })
   const bridge = toCreateVoyantAppProfileConfig(options.project)
   return createVoyantApp<ManagedProfileRuntimeEnv, FrameworkProviders>({
@@ -384,6 +414,13 @@ export function createManagedProfileApp(options: {
       projectId: options.env?.VOYANT_CLOUD_APP_SLUG ?? options.project.profile,
     },
     ...options.app,
+    // Managed integration bundles are registered like a starter's inline
+    // `plugins: [...]`; core plugins (subscribers/workflows) and Hono bundles
+    // (routes) both flatten through `registerPlugins` at `createApp` boot.
+    plugins: mergedPlugins as CreateVoyantAppConfig<
+      ManagedProfileRuntimeEnv,
+      FrameworkProviders
+    >["plugins"],
     basePath: options.app?.basePath ?? "/api",
     auth,
     exclude: bridge.exclude,
@@ -878,9 +915,14 @@ function assertManagedProfileRuntimeSupport(options: {
   requirements: VoyantProfileRequirements
   env: ManagedProfileRuntimeEnv
   hasAuthIntegration: boolean
+  hasResolvedPlugins: boolean
 }) {
   const issues = [
-    ...managedProfileAppSupportIssues(options.project, options.hasAuthIntegration),
+    ...managedProfileAppSupportIssues(
+      options.project,
+      options.hasAuthIntegration,
+      options.hasResolvedPlugins,
+    ),
     ...managedProfileEnvIssues(options.requirements, options.env),
   ]
   if (issues.length > 0) {
@@ -891,8 +933,13 @@ function assertManagedProfileRuntimeSupport(options: {
 function assertManagedProfileAppSupport(options: {
   project: VoyantProjectManifest
   hasAuthIntegration: boolean
+  hasResolvedPlugins: boolean
 }) {
-  const issues = managedProfileAppSupportIssues(options.project, options.hasAuthIntegration)
+  const issues = managedProfileAppSupportIssues(
+    options.project,
+    options.hasAuthIntegration,
+    options.hasResolvedPlugins,
+  )
   if (issues.length > 0) {
     throw new Error(`Managed profile app is not ready to start:\n${formatIssues(issues)}`)
   }
@@ -901,11 +948,12 @@ function assertManagedProfileAppSupport(options: {
 function managedProfileAppSupportIssues(
   project: VoyantProjectManifest,
   hasAuthIntegration: boolean,
+  hasResolvedPlugins: boolean,
 ): string[] {
   const issues: string[] = []
-  if (project.plugins.length > 0) {
+  if (project.plugins.length > 0 && !hasResolvedPlugins) {
     issues.push(
-      `snapshot plugins are not yet resolved by @voyant-travel/framework/managed-runtime: ${project.plugins.join(
+      `snapshot plugins were declared but not resolved by @voyant-travel/framework/managed-runtime: ${project.plugins.join(
         ", ",
       )}`,
     )
@@ -1376,6 +1424,15 @@ function dbFromContext(c: Context): PostgresJsDatabase {
 
 function managedEnv(c: Context): ManagedProfileRuntimeEnv {
   return (c.env ?? {}) as ManagedProfileRuntimeEnv
+}
+
+/**
+ * Flatten the runtime env bag (string vars + provider bindings) into a plain
+ * record for plugin factories to read secrets/connection config from. A real
+ * mapper rather than a cast — the managed env has no index signature.
+ */
+function toPluginEnvRecord(env: ManagedProfileRuntimeEnv): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(env))
 }
 
 function connectApiKey(env: ManagedProfileRuntimeEnv): string | undefined {

--- a/packages/framework/src/plugin-resolution.test.ts
+++ b/packages/framework/src/plugin-resolution.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveManagedPlugins } from "./plugin-resolution.js"
+
+function project(plugins: string[], settings: Record<string, unknown> = {}) {
+  return { plugins, settings } as Parameters<typeof resolveManagedPlugins>[0]
+}
+
+describe("resolveManagedPlugins", () => {
+  it("returns an empty list when the profile declares no plugins", async () => {
+    const importModule = vi.fn()
+    const resolved = await resolveManagedPlugins(project([]), {}, { importModule })
+    expect(resolved).toEqual([])
+    expect(importModule).not.toHaveBeenCalled()
+  })
+
+  it("invokes a `voyantPlugin` factory with settings + env and returns the bundle", async () => {
+    const env = { STRIPE_SECRET: "sk_test" }
+    const factory = vi.fn((ctx) => ({ name: "stripe", context: ctx }))
+    const resolved = await resolveManagedPlugins(
+      project(["@voyant-travel/plugin-stripe"], {
+        "@voyant-travel/plugin-stripe": { mode: "live" },
+      }),
+      env,
+      { importModule: async () => ({ voyantPlugin: factory }) },
+    )
+
+    expect(factory).toHaveBeenCalledWith({
+      specifier: "@voyant-travel/plugin-stripe",
+      settings: { mode: "live" },
+      env,
+    })
+    expect(resolved).toHaveLength(1)
+    expect((resolved[0] as { name: string }).name).toBe("stripe")
+  })
+
+  it("accepts a `default` export that is already a built plugin object", async () => {
+    const resolved = await resolveManagedPlugins(
+      project(["@acme/plugin"]),
+      {},
+      {
+        importModule: async () => ({ default: { name: "acme" } }),
+      },
+    )
+    expect((resolved[0] as { name: string }).name).toBe("acme")
+  })
+
+  it("resolves plugins in profile order", async () => {
+    const resolved = await resolveManagedPlugins(
+      project(["@a/one", "@b/two"]),
+      {},
+      {
+        importModule: async (specifier) => ({
+          voyantPlugin: () => ({ name: specifier }),
+        }),
+      },
+    )
+    expect(resolved.map((p) => (p as { name: string }).name)).toEqual(["@a/one", "@b/two"])
+  })
+
+  it("throws a specifier-named error when no managed-plugin entry is exported", async () => {
+    await expect(
+      resolveManagedPlugins(
+        project(["@bad/plugin"]),
+        {},
+        {
+          importModule: async () => ({ somethingElse: true }),
+        },
+      ),
+    ).rejects.toThrow(/@bad\/plugin.*does not export a managed-plugin entry/)
+  })
+
+  it("wraps an import failure with the specifier", async () => {
+    await expect(
+      resolveManagedPlugins(
+        project(["@missing/plugin"]),
+        {},
+        {
+          importModule: async () => {
+            throw new Error("Cannot find module")
+          },
+        },
+      ),
+    ).rejects.toThrow(/Failed to import managed plugin "@missing\/plugin": Cannot find module/)
+  })
+
+  it("throws when a factory returns a non-plugin value", async () => {
+    await expect(
+      resolveManagedPlugins(
+        project(["@weird/plugin"]),
+        {},
+        {
+          importModule: async () => ({ voyantPlugin: () => 123 }),
+        },
+      ),
+    ).rejects.toThrow(/resolved to a value without a "name"/)
+  })
+})

--- a/packages/framework/src/plugin-resolution.ts
+++ b/packages/framework/src/plugin-resolution.ts
@@ -1,0 +1,152 @@
+/**
+ * Resolve a managed profile's `plugins` list into runnable bundles.
+ *
+ * The managed profile contract (`defineVoyantProject`) records plugins as npm
+ * specifier strings — e.g. `"@voyant-travel/plugin-stripe"` — plus per-plugin
+ * config under `settings[specifier]`. A source-free managed deployment can't
+ * hand `createVoyantApp` an inline plugin object the way a starter fork does, so
+ * the runtime resolves each specifier at boot: it imports the package, finds its
+ * managed-plugin factory, and invokes it with the plugin's settings and the
+ * deployment env. The resulting bundles are passed to `createVoyantApp` exactly
+ * as a starter's inline `plugins: [...]` would be.
+ *
+ * ## Managed-plugin entry contract
+ *
+ * A package participates in managed profiles by exporting a factory named
+ * `voyantPlugin` (preferred), `createVoyantPlugin`, or `createPlugin`, or a
+ * `default` export that is a factory:
+ *
+ * ```ts
+ * import { definePlugin } from "@voyant-travel/core"
+ *
+ * export const voyantPlugin: VoyantManagedPluginFactory = ({ settings }) =>
+ *   stripePlugin(parseStripeSettings(settings))
+ * ```
+ *
+ * The factory receives {@link VoyantManagedPluginContext} (`settings` from the
+ * profile, `env` for secrets/bindings) and returns a bundle. A package may also
+ * export an already-built plugin object under one of those names; it is used
+ * as-is. Node-first managed runtimes support dynamic `import()`, so no bundling
+ * or registry indirection is required.
+ */
+
+import type { Plugin } from "@voyant-travel/core"
+import type { HonoBundleInput } from "@voyant-travel/hono/plugin"
+
+import type { VoyantProjectJsonValue, VoyantProjectManifest } from "./profile-types.js"
+
+/** A resolved managed plugin — either a Hono bundle or a transport-agnostic core plugin. */
+export type ManagedPlugin = HonoBundleInput | Plugin
+
+/** Context handed to a managed-plugin factory at resolution time. */
+export interface VoyantManagedPluginContext {
+  /** The npm specifier the plugin was resolved from. */
+  specifier: string
+  /** The plugin's config from the profile `settings[specifier]`, if any. */
+  settings: VoyantProjectJsonValue | undefined
+  /** The deployment env bag (secrets, connection config, bindings). */
+  env: Record<string, unknown>
+}
+
+/** A managed-plugin factory: profile settings + env in, a plugin bundle out. */
+export type VoyantManagedPluginFactory = (
+  context: VoyantManagedPluginContext,
+) => ManagedPlugin | Promise<ManagedPlugin>
+
+export interface ResolveManagedPluginsOptions {
+  /**
+   * Module loader, injectable for tests. Defaults to dynamic `import()`, which a
+   * Node-first managed runtime supports for published plugin packages.
+   */
+  importModule?: (specifier: string) => Promise<Record<string, unknown>>
+}
+
+const FACTORY_EXPORT_NAMES = [
+  "voyantPlugin",
+  "createVoyantPlugin",
+  "createPlugin",
+  "default",
+] as const
+
+/**
+ * Resolve every specifier in `project.plugins` to a runnable bundle, in profile
+ * order. Throws a specifier-named error when a package exposes no managed-plugin
+ * entry or its factory fails — a managed profile must fail loud at boot, never
+ * silently drop a configured integration.
+ */
+export async function resolveManagedPlugins(
+  project: Pick<VoyantProjectManifest, "plugins" | "settings">,
+  env: Record<string, unknown>,
+  options: ResolveManagedPluginsOptions = {},
+): Promise<ManagedPlugin[]> {
+  const importModule = options.importModule ?? defaultImportModule
+  const resolved: ManagedPlugin[] = []
+  for (const specifier of project.plugins) {
+    let mod: Record<string, unknown>
+    try {
+      mod = await importModule(specifier)
+    } catch (error) {
+      throw new Error(`Failed to import managed plugin "${specifier}": ${errorMessage(error)}`)
+    }
+    const factory = pickPluginFactory(mod, specifier)
+    const context: VoyantManagedPluginContext = {
+      specifier,
+      settings: project.settings[specifier],
+      env,
+    }
+    let bundle: ManagedPlugin
+    try {
+      bundle = await factory(context)
+    } catch (error) {
+      throw new Error(`Managed plugin "${specifier}" factory threw: ${errorMessage(error)}`)
+    }
+    resolved.push(assertPluginShape(bundle, specifier))
+  }
+  return resolved
+}
+
+function pickPluginFactory(
+  mod: Record<string, unknown>,
+  specifier: string,
+): VoyantManagedPluginFactory {
+  for (const name of FACTORY_EXPORT_NAMES) {
+    const candidate = mod[name]
+    if (typeof candidate === "function") {
+      return candidate as VoyantManagedPluginFactory
+    }
+    if (isPluginObject(candidate)) {
+      const built = candidate
+      return () => built
+    }
+  }
+  throw new Error(
+    `Managed plugin "${specifier}" does not export a managed-plugin entry. ` +
+      `Export one of: ${FACTORY_EXPORT_NAMES.join(", ")} (a factory or a built plugin).`,
+  )
+}
+
+function assertPluginShape(bundle: unknown, specifier: string): ManagedPlugin {
+  if (!isPluginObject(bundle)) {
+    throw new Error(
+      `Managed plugin "${specifier}" resolved to a value without a "name" — ` +
+        "a plugin factory must return a plugin/bundle object.",
+    )
+  }
+  return bundle as ManagedPlugin
+}
+
+function isPluginObject(value: unknown): value is ManagedPlugin {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { name?: unknown }).name === "string"
+  )
+}
+
+function defaultImportModule(specifier: string): Promise<Record<string, unknown>> {
+  return import(specifier) as Promise<Record<string, unknown>>
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}


### PR DESCRIPTION
## What

Resolves a managed profile's `plugins` list at boot, so Cloud can instantiate the standard `operator` profile from published packages plus a serialized profile snapshot — including snapshot-declared plugins — without cloning a starter fork.

Framework readiness track for **#2983**.

> **Scope note:** the Redis/Postgres shared-state stores this profile relies on landed separately on `main` ("Implement Node shared store providers"), which already wires `CACHE`/`RATE_LIMIT` off `REDIS_URL` and removed the "Redis not implemented" boot error. This PR was rebased onto that and now carries **only** the remaining plugin-resolution seam. The other open sub-issues (#2104/#2107 module subsetting, #2170 published-package gap) remain their own tracks.

## Changes (`@voyant-travel/framework/managed-runtime`)

- **`resolveManagedPlugins`** — imports each `plugins[]` npm specifier and invokes its managed-plugin factory (`voyantPlugin` / `createVoyantPlugin` / `createPlugin` / a `default` factory) with the plugin's `settings[specifier]` + deployment env, then registers the result like a starter's inline `plugins: [...]` (core plugins and Hono bundles both flatten through `registerPlugins`).
- A declared plugin that exposes **no** managed entry fails loud at boot instead of being silently dropped; the previous blanket `"snapshot plugins are not yet resolved"` throw is removed.
- **`importPluginModule`** is injectable on `loadManagedProfileRuntime` / `ManagedProfileRuntimeOptions` so Cloud (or tests) can resolve plugins from a pre-bundled registry instead of node resolution.
- `resolveManagedPlugins` and the managed-plugin factory/context types are exported from `@voyant-travel/framework/managed-runtime`.

## Tests / verification

- New `plugin-resolution` unit tests (factory shapes, ordering, settings/env injection, fail-loud on missing entry / non-plugin return / import failure).
- Updated managed-runtime tests: the old "rejects plugins" case now asserts resolve-and-boot; added an unresolvable-plugin case.
- Framework typecheck, lint, and tests green; pre-commit hooks passed.

## Changeset

Included — `@voyant-travel/framework` `minor`.
