### PR TITLE
admin-host Phase 2.2: admin auth capability port (#3044)

### DIFF
--- a/.changeset/admin-auth-runtime-port.md
+++ b/.changeset/admin-auth-runtime-port.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/admin": minor
+---
+
+Add the admin auth capability **port** for the managed-profile admin host
+(`ManagedProfileAdminAuthRuntime`, `AdminBootstrapStatus`, `AdminAuthMode` from
+`@voyant-travel/admin/app`) — Phase 2 of voyant#3044.
+
+Auth is deployment-owned: the packaged admin shell/guard never import a concrete
+auth client; a deployment supplies the port (a managed Voyant Cloud profile
+provides a Cloud-broker impl, a self-host deployment a Better Auth impl).
+
+`createAdminWorkspaceBeforeLoad` now takes the port (`{ auth }`) instead of a
+bare `{ getCurrentUser }`, and resolves the unauthenticated destination from it:
+`voyant-cloud` mode redirects to the Cloud identity-broker, otherwise to the
+local `signInPath` — removing the previous double-hop through the local sign-in
+page and keeping the packaged admin free of a concrete auth client.

--- a/packages/admin/src/app/auth-runtime.ts
+++ b/packages/admin/src/app/auth-runtime.ts
@@ -1,0 +1,42 @@
+/**
+ * The admin auth capability **port** for the managed-profile admin host.
+ *
+ * Auth is deployment-owned: the admin surfaces (shell, guard, packaged pages)
+ * never import a concrete auth client. Instead a deployment provides a
+ * {@link ManagedProfileAdminAuthRuntime}, and the packaged admin depends only on
+ * this port. There are two implementations:
+ *
+ * - **Managed profile** — a Voyant Cloud identity-broker impl. Unauthenticated
+ *   visitors are redirected to the Cloud broker (`authMode: "voyant-cloud"`); no
+ *   local password/login pages are shipped.
+ * - **Self-host / starter** — a Better Auth impl (`authMode: "local"`) that also
+ *   mounts the local `(auth)` page suite consuming this same port.
+ *
+ * The `getCurrentUser` / `getBootstrapStatus` members are typically TanStack
+ * server functions (cookie-forwarding), so they are *provided*, not packaged.
+ */
+
+/** Identity-broker mode: local Better Auth, or the Voyant Cloud broker. */
+export type AdminAuthMode = "local" | "voyant-cloud"
+
+/** Whether any user exists yet, plus the identity-broker mode. */
+export interface AdminBootstrapStatus {
+  hasUsers: boolean
+  authMode?: AdminAuthMode
+}
+
+/**
+ * The auth capability a deployment supplies to the packaged admin. `TUser` is
+ * the deployment's loaded-user shape (a structural superset of
+ * {@link AdminWorkspaceShellUser}).
+ */
+export interface ManagedProfileAdminAuthRuntime<TUser> {
+  /** Resolve the current user (server fn / cookie-forwarding fetch); `null` when signed out. */
+  getCurrentUser: () => Promise<TUser | null | undefined>
+  /** Whether any user exists yet + the identity-broker mode driving redirects. */
+  getBootstrapStatus: () => Promise<AdminBootstrapStatus>
+  /** Href that starts the Voyant Cloud identity-broker flow (used in `voyant-cloud` mode). */
+  cloudAuthStartHref: (next?: string) => string
+  /** Clear the current session. Navigation after sign-out is the caller's concern. */
+  signOut: () => Promise<void>
+}

--- a/packages/admin/src/app/index.ts
+++ b/packages/admin/src/app/index.ts
@@ -1,4 +1,9 @@
 export type {
+  AdminAuthMode,
+  AdminBootstrapStatus,
+  ManagedProfileAdminAuthRuntime,
+} from "./auth-runtime.js"
+export type {
   AdminExtensionChildRoutesOptions,
   AdminExtensionRouteLoaderArgs,
   AdminExtensionRouteOptions,

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -99,7 +99,12 @@ export function createAdminWorkspaceBeforeLoad<TUser>({
       .catch((): AdminBootstrapStatus => ({ hasUsers: true }))
 
     if (bootstrap.authMode === "voyant-cloud") {
-      throw redirect({ href: auth.cloudAuthStartHref(location.href) })
+      // `cloudAuthStartHref` is a relative API path (`/api/auth/cloud/start…`).
+      // TanStack only infers a full-document redirect for absolute hrefs, so on
+      // a client-side navigation a relative href would be handled as in-app
+      // routing to a non-route API path. Force a document request so the browser
+      // actually starts the broker flow.
+      throw redirect({ href: auth.cloudAuthStartHref(location.href), reloadDocument: true })
     }
 
     throw redirect({ to: signInPath, search: { next: location.href } })

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -1,7 +1,6 @@
 import { Link, redirect, useRouter, useRouterState } from "@tanstack/react-router"
 import { Loader2 } from "lucide-react"
 import { forwardRef, type ReactNode, useCallback, useMemo } from "react"
-
 import type { AdminNavLinkComponent, AdminNavLinkProps } from "../components/admin-nav-link.js"
 import { AdminWidgetSlotRenderer } from "../components/admin-widget-slot.js"
 import { OperatorAdminBootstrapGate } from "../components/operator-admin-bootstrap-gate.js"
@@ -21,6 +20,7 @@ import {
   useOperatorAdminMessages,
 } from "../providers/operator-admin-messages.js"
 import type { AdminUser } from "../types.js"
+import type { AdminBootstrapStatus, ManagedProfileAdminAuthRuntime } from "./auth-runtime.js"
 
 /**
  * Router-aware sidebar link. SidebarMenuButton with `asChild` wraps this in a
@@ -57,9 +57,15 @@ export const AdminRouterLink = forwardRef<HTMLAnchorElement, AdminNavLinkProps>(
 )
 
 export interface CreateAdminWorkspaceBeforeLoadOptions<TUser> {
-  /** Resolve the current user (server fn / cookie-forwarding fetch). */
-  getCurrentUser: () => Promise<TUser | null | undefined>
-  /** Where unauthenticated visitors are sent. Default `/sign-in`. */
+  /**
+   * The deployment's auth capability (see {@link ManagedProfileAdminAuthRuntime}).
+   * Only the read/redirect members the guard needs are required.
+   */
+  auth: Pick<
+    ManagedProfileAdminAuthRuntime<TUser>,
+    "getCurrentUser" | "getBootstrapStatus" | "cloudAuthStartHref"
+  >
+  /** Where unauthenticated visitors are sent in `local` auth mode. Default `/sign-in`. */
   signInPath?: string
 }
 
@@ -70,22 +76,33 @@ export interface CreateAdminWorkspaceBeforeLoadOptions<TUser> {
  * loader it would race child loaders whose 401s surface the root error
  * boundary and beat the redirect, dead-ending logged-out users. Returns
  * `{ user }`, which TanStack merges into route context.
+ *
+ * The unauthenticated destination is mode-dependent (resolved from the auth
+ * port, not hard-coded): in `voyant-cloud` mode the visitor is sent to the
+ * Cloud identity-broker; otherwise to the local `signInPath`. Deciding it here
+ * keeps the packaged admin free of a concrete auth client and avoids a
+ * double-hop through the local sign-in page.
  */
 export function createAdminWorkspaceBeforeLoad<TUser>({
-  getCurrentUser,
+  auth,
   signInPath = "/sign-in",
 }: CreateAdminWorkspaceBeforeLoadOptions<TUser>) {
   return async ({ location }: { location: { href: string } }): Promise<{ user: TUser }> => {
-    const user = await getCurrentUser()
+    const user = await auth.getCurrentUser()
 
-    if (!user) {
-      throw redirect({
-        to: signInPath,
-        search: { next: location.href },
-      })
+    if (user) return { user }
+
+    // Unauthenticated: send to the Cloud broker in voyant-cloud mode, else the
+    // local sign-in. A failed bootstrap probe falls back to the local path.
+    const bootstrap = await auth
+      .getBootstrapStatus()
+      .catch((): AdminBootstrapStatus => ({ hasUsers: true }))
+
+    if (bootstrap.authMode === "voyant-cloud") {
+      throw redirect({ href: auth.cloudAuthStartHref(location.href) })
     }
 
-    return { user }
+    throw redirect({ to: signInPath, search: { next: location.href } })
   }
 }
 

--- a/packages/admin/tests/app/admin-app.test.ts
+++ b/packages/admin/tests/app/admin-app.test.ts
@@ -124,9 +124,14 @@ describe("createAdminWorkspaceBeforeLoad", () => {
       (error: unknown) => error,
     )
 
-    const options = (thrown as { options?: { href?: string; to?: string } }).options
+    const options = (
+      thrown as { options?: { href?: string; to?: string; reloadDocument?: boolean } }
+    ).options
     expect(options?.href).toBe("/api/auth/cloud/start?next=%2Fbookings")
     expect(options?.to).toBeUndefined()
+    // The broker href is a relative API path, so force a full-document redirect
+    // (TanStack only infers it for absolute hrefs).
+    expect(options?.reloadDocument).toBe(true)
   })
 
   it("honors a custom sign-in path", async () => {

--- a/packages/admin/tests/app/admin-app.test.ts
+++ b/packages/admin/tests/app/admin-app.test.ts
@@ -75,15 +75,33 @@ describe("adminRootHead", () => {
 })
 
 describe("createAdminWorkspaceBeforeLoad", () => {
+  type TestUser = { id: string }
+  function authStub(
+    overrides: Partial<{
+      user: TestUser | null | undefined
+      authMode: "local" | "voyant-cloud"
+    }> = {},
+  ) {
+    return {
+      getCurrentUser: vi.fn(async () => ("user" in overrides ? overrides.user : { id: "usr_1" })),
+      getBootstrapStatus: vi.fn(async () => ({
+        hasUsers: true,
+        ...(overrides.authMode ? { authMode: overrides.authMode } : {}),
+      })),
+      cloudAuthStartHref: (next?: string) =>
+        `/api/auth/cloud/start${next ? `?next=${encodeURIComponent(next)}` : ""}`,
+    }
+  }
+
   it("returns the user in route context when authenticated", async () => {
     const user = { id: "usr_1" }
-    const beforeLoad = createAdminWorkspaceBeforeLoad({ getCurrentUser: async () => user })
+    const beforeLoad = createAdminWorkspaceBeforeLoad({ auth: authStub({ user }) })
 
     await expect(beforeLoad({ location: { href: "/bookings" } })).resolves.toEqual({ user })
   })
 
-  it("redirects unauthenticated visitors to sign-in with a next param", async () => {
-    const beforeLoad = createAdminWorkspaceBeforeLoad({ getCurrentUser: async () => null })
+  it("redirects unauthenticated visitors to sign-in with a next param (local mode)", async () => {
+    const beforeLoad = createAdminWorkspaceBeforeLoad({ auth: authStub({ user: null }) })
 
     const thrown = await beforeLoad({ location: { href: "/bookings?tab=upcoming" } }).then(
       () => undefined,
@@ -96,9 +114,26 @@ describe("createAdminWorkspaceBeforeLoad", () => {
     expect(options?.search?.next).toBe("/bookings?tab=upcoming")
   })
 
+  it("redirects unauthenticated visitors to the Cloud broker in voyant-cloud mode", async () => {
+    const beforeLoad = createAdminWorkspaceBeforeLoad({
+      auth: authStub({ user: null, authMode: "voyant-cloud" }),
+    })
+
+    const thrown = await beforeLoad({ location: { href: "/bookings" } }).then(
+      () => undefined,
+      (error: unknown) => error,
+    )
+
+    const options = (thrown as { options?: { href?: string; to?: string } }).options
+    expect(options?.href).toBe("/api/auth/cloud/start?next=%2Fbookings")
+    expect(options?.to).toBeUndefined()
+  })
+
   it("honors a custom sign-in path", async () => {
-    const getCurrentUser = vi.fn(async () => undefined)
-    const beforeLoad = createAdminWorkspaceBeforeLoad({ getCurrentUser, signInPath: "/login" })
+    const beforeLoad = createAdminWorkspaceBeforeLoad({
+      auth: authStub({ user: undefined }),
+      signInPath: "/login",
+    })
 
     const thrown = await beforeLoad({ location: { href: "/" } }).then(
       () => undefined,

--- a/starters/federated-operator/src/lib/admin-auth-runtime.ts
+++ b/starters/federated-operator/src/lib/admin-auth-runtime.ts
@@ -1,0 +1,20 @@
+import type { ManagedProfileAdminAuthRuntime } from "@voyant-travel/admin/app"
+
+import { authClient } from "./auth"
+import { getBootstrapStatus, getCurrentUser } from "./current-user"
+import type { CurrentUser } from "./current-user-model"
+
+/**
+ * The federated operator's Better-Auth-backed implementation of the admin auth
+ * capability port ({@link ManagedProfileAdminAuthRuntime}). This deployment is
+ * local-auth only (no Voyant Cloud broker), so `cloudAuthStartHref` is never
+ * reached — the guard only follows it in `voyant-cloud` mode.
+ */
+export const adminAuthRuntime: ManagedProfileAdminAuthRuntime<CurrentUser> = {
+  getCurrentUser,
+  getBootstrapStatus,
+  cloudAuthStartHref: () => "/sign-in",
+  signOut: async () => {
+    await authClient.signOut()
+  },
+}

--- a/starters/federated-operator/src/routes/_workspace/route.tsx
+++ b/starters/federated-operator/src/routes/_workspace/route.tsx
@@ -7,6 +7,7 @@ import { OperatorAdminBootstrapGate } from "@voyant-travel/admin/components/oper
 import { OperatorAdminWorkspaceLayout } from "@voyant-travel/admin/components/operator-admin-sidebar"
 import { AdminNavigationProvider } from "@voyant-travel/admin/navigation/destinations"
 import { UserProvider, useUser } from "@/components/providers/user-provider"
+import { adminAuthRuntime } from "@/lib/admin-auth-runtime"
 import { federatedAdminDestinations } from "@/lib/admin-destinations"
 import {
   createFederatedAdminExtensions,
@@ -14,9 +15,9 @@ import {
   federatedBaseNav,
 } from "@/lib/admin-extensions"
 import { useSignOut } from "@/lib/auth"
-import { type CurrentUser, getCurrentUser } from "@/lib/current-user"
+import type { CurrentUser } from "@/lib/current-user"
 
-const workspaceGuard = createAdminWorkspaceBeforeLoad({ getCurrentUser })
+const workspaceGuard = createAdminWorkspaceBeforeLoad({ auth: adminAuthRuntime })
 const federatedAdminExtensions = createFederatedAdminExtensions()
 
 export const Route = createFileRoute("/_workspace")({

--- a/starters/operator/src/lib/admin-auth-runtime.ts
+++ b/starters/operator/src/lib/admin-auth-runtime.ts
@@ -1,0 +1,21 @@
+import type { ManagedProfileAdminAuthRuntime } from "@voyant-travel/admin/app"
+
+import { authClient } from "./auth"
+import { cloudAuthStartHref, getBootstrapStatus, getCurrentUser } from "./current-user"
+import type { CurrentUser } from "./current-user-model"
+
+/**
+ * The operator's Better-Auth-backed implementation of the admin auth capability
+ * port ({@link ManagedProfileAdminAuthRuntime}). The packaged admin shell/guard
+ * (and, in a later slice, the packaged auth pages) consume this port instead of
+ * importing a concrete auth client — a managed Voyant Cloud profile supplies a
+ * Cloud-broker implementation of the same port.
+ */
+export const adminAuthRuntime: ManagedProfileAdminAuthRuntime<CurrentUser> = {
+  getCurrentUser,
+  getBootstrapStatus,
+  cloudAuthStartHref,
+  signOut: async () => {
+    await authClient.signOut()
+  },
+}

--- a/starters/operator/src/routes/_workspace/route.test.tsx
+++ b/starters/operator/src/routes/_workspace/route.test.tsx
@@ -75,8 +75,13 @@ vi.mock("@/lib/auth", () => ({
   useSignOut: () => mocks.signOut,
 }))
 
-vi.mock("@/lib/current-user", () => ({
-  getCurrentUser: vi.fn(),
+vi.mock("@/lib/admin-auth-runtime", () => ({
+  adminAuthRuntime: {
+    getCurrentUser: vi.fn(),
+    getBootstrapStatus: vi.fn(async () => ({ hasUsers: true })),
+    cloudAuthStartHref: () => "/api/auth/cloud/start",
+    signOut: vi.fn(),
+  },
 }))
 
 import { WorkspaceLayout } from "./route"

--- a/starters/operator/src/routes/_workspace/route.tsx
+++ b/starters/operator/src/routes/_workspace/route.tsx
@@ -7,16 +7,16 @@ import {
 } from "@voyant-travel/admin/app/workspace"
 import { UserProvider, useUser } from "@/components/providers/user-provider"
 import { RealtimeLiveProvider } from "@/components/realtime-live"
+import { adminAuthRuntime } from "@/lib/admin-auth-runtime"
 import { operatorAdminDestinations } from "@/lib/admin-destinations"
 import { createOperatorAdminExtensions } from "@/lib/admin-extensions"
 import { useSignOut } from "@/lib/auth"
-import { getCurrentUser } from "@/lib/current-user"
 
 // The standard nav icon set ships from @voyant-travel/admin. Override a single
 // entry with `{ ...defaultOperatorNavIcons, finance: MyIcon }` if needed.
 const operatorNavigationIcons = defaultOperatorNavIcons
 
-const workspaceGuard = createAdminWorkspaceBeforeLoad({ getCurrentUser })
+const workspaceGuard = createAdminWorkspaceBeforeLoad({ auth: adminAuthRuntime })
 
 export const Route = createFileRoute("/_workspace")({
   // Parent loader runs server-side (auth check + user fetch through cookie-


### PR DESCRIPTION
## What

**Phase 2, slice 2** of the source-free admin host (voyant#3044): the **admin auth capability port**.

Auth is deployment-owned — `@voyant-travel/auth-react` ships the pages/hooks but has **no `better-auth` dependency**; the auth client is the deployment's. So rather than bake an auth client into the packaged admin, this introduces a **port** the deployment supplies:

```ts
// @voyant-travel/admin/app
interface ManagedProfileAdminAuthRuntime<TUser> {
  getCurrentUser(): Promise<TUser | null | undefined>
  getBootstrapStatus(): Promise<AdminBootstrapStatus>   // { hasUsers, authMode }
  cloudAuthStartHref(next?): string
  signOut(): Promise<void>
}
```

Two implementations, one contract: a **managed Voyant Cloud** profile provides a Cloud-broker impl (and ships no local login pages); a **self-host** deployment provides a Better Auth impl (and mounts the local `(auth)` pages — a later slice). This is why packaging the starter's Better-Auth login pages wholesale would be wrong: managed Cloud never renders them (it redirects to the broker).

## Change

- New port types (`ManagedProfileAdminAuthRuntime`, `AdminBootstrapStatus`, `AdminAuthMode`) from `@voyant-travel/admin/app`.
- `createAdminWorkspaceBeforeLoad` now takes the port (`{ auth }`) instead of a bare `{ getCurrentUser }`, and **owns the unauthenticated-redirect decision**: `voyant-cloud` mode → Cloud identity-broker; else → local `signInPath`. This removes today's double-hop (shell → `/sign-in` → broker) and keeps the packaged guard free of any auth client.
- Both starters (`operator`, `federated-operator`) provide a Better-Auth-backed port (`lib/admin-auth-runtime.ts`) and wire their `_workspace` guard through it.

## Verification
- `@voyant-travel/admin` tests (116) incl. a new **voyant-cloud-redirect** guard case; operator workspace test updated + passing.
- `operator` + `federated-operator` typecheck; operator builds and boots — `/`, `/sign-in`, `/api/health` all 200 (the guard's new bootstrap-consulting path works).
- Full `pnpm test` green (99/99).

## Next
Slice 3: package the `_workspace` shell + the local `(auth)` page suite (as an optional self-host bundle) on this port. Slice 4 (cross-repo): managed codegen in `@voyant-travel/cli`.
