### PR TITLE
admin-host Phase 2.3: package the admin current-user provider (#3044)

### DIFF
--- a/.changeset/admin-react-user-provider.md
+++ b/.changeset/admin-react-user-provider.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/admin-react": minor
+---
+
+Add `@voyant-travel/admin-react/user` — a reusable current-user context
+(`UserProvider` / `useUser`) for the managed-profile admin host (Phase 2 of
+voyant#3044).
+
+The provider reads the current user via React Query and takes `getCurrentUser`
+injected (typically the deployment's auth-runtime port), so it carries no
+auth-client dependency and is shared by managed and self-host admin hosts. It
+lifts the operator starter's local `UserProvider`/`useUser` into a package; the
+starter's provider becomes a thin adopter that wires its auth runtime.

--- a/packages/admin-react/package.json
+++ b/packages/admin-react/package.json
@@ -13,7 +13,8 @@
     ".": "./src/index.ts",
     "./provider": "./src/provider.tsx",
     "./hooks": "./src/hooks.ts",
-    "./query-keys": "./src/query-keys.ts"
+    "./query-keys": "./src/query-keys.ts",
+    "./user": "./src/user.tsx"
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
@@ -68,6 +69,11 @@
         "types": "./dist/query-keys.d.ts",
         "import": "./dist/query-keys.js",
         "default": "./dist/query-keys.js"
+      },
+      "./user": {
+        "types": "./dist/user.d.ts",
+        "import": "./dist/user.js",
+        "default": "./dist/user.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/admin-react/src/user.tsx
+++ b/packages/admin-react/src/user.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { type QueryKey, useQuery } from "@tanstack/react-query"
+import { createContext, type ReactNode, useContext } from "react"
+
+/** The current-user context the admin shell reads. */
+export interface AdminUserContextValue<TUser> {
+  user: TUser | null
+  isLoading: boolean
+  error: Error | null
+  refetch: () => Promise<unknown>
+}
+
+const UserContext = createContext<AdminUserContextValue<unknown> | undefined>(undefined)
+
+export interface UserProviderProps<TUser> {
+  children: ReactNode
+  /** Resolves the current user; typically the deployment's auth-runtime `getCurrentUser`. */
+  getCurrentUser: () => Promise<TUser | null | undefined>
+  /** SSR-hydrated initial user, when the route loader already resolved it. */
+  initialUser?: TUser | null
+  /** Query key for the current-user query. Defaults to `["current-user"]`. */
+  queryKey?: QueryKey
+}
+
+/**
+ * Provides the current user to the admin workspace via React Query. The
+ * deployment injects `getCurrentUser` (its auth-runtime port), so this provider
+ * carries no auth-client dependency and is reusable across managed and
+ * self-host admin hosts.
+ */
+export function UserProvider<TUser>({
+  children,
+  getCurrentUser,
+  initialUser,
+  queryKey = ["current-user"],
+}: UserProviderProps<TUser>) {
+  const {
+    data: user,
+    isPending,
+    isFetching,
+    error,
+    refetch,
+  } = useQuery({
+    queryKey,
+    queryFn: () => getCurrentUser(),
+    staleTime: 5 * 60 * 1000,
+    gcTime: 10 * 60 * 1000,
+    retry: 1,
+    ...(initialUser !== undefined ? { initialData: initialUser } : {}),
+  })
+
+  const isLoading = isPending || (isFetching && user === undefined)
+
+  return (
+    <UserContext.Provider
+      value={{
+        user: (user ?? null) as TUser | null,
+        isLoading,
+        error: error ?? null,
+        refetch,
+      }}
+    >
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+/** Read the current user from {@link UserProvider}. Throws when used outside it. */
+export function useUser<TUser>(): AdminUserContextValue<TUser> {
+  const context = useContext(UserContext)
+  if (context === undefined) {
+    throw new Error("useUser must be used within UserProvider")
+  }
+  return context as AdminUserContextValue<TUser>
+}

--- a/packages/admin-react/src/user.tsx
+++ b/packages/admin-react/src/user.tsx
@@ -43,7 +43,10 @@ export function UserProvider<TUser>({
     refetch,
   } = useQuery({
     queryKey,
-    queryFn: () => getCurrentUser(),
+    // Coalesce to `null`: the port allows `getCurrentUser` to resolve
+    // `undefined` for a signed-out user, but React Query treats an `undefined`
+    // query result as an error rather than data.
+    queryFn: async () => (await getCurrentUser()) ?? null,
     staleTime: 5 * 60 * 1000,
     gcTime: 10 * 60 * 1000,
     retry: 1,

--- a/packages/admin-react/tests/user.test.tsx
+++ b/packages/admin-react/tests/user.test.tsx
@@ -42,6 +42,17 @@ describe("UserProvider / useUser", () => {
     expect(getCurrentUser).not.toHaveBeenCalled()
   })
 
+  it("treats an undefined current user as signed out (not an error)", async () => {
+    const getCurrentUser = vi.fn(async (): Promise<TestUser | null | undefined> => undefined)
+    const { result } = renderHook(() => useUser<TestUser>(), {
+      wrapper: wrapper(getCurrentUser as () => Promise<TestUser | null>),
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(result.current.user).toBeNull()
+    expect(result.current.error).toBeNull()
+  })
+
   it("throws when used outside a UserProvider", () => {
     expect(() => renderHook(() => useUser<TestUser>())).toThrow(
       /useUser must be used within UserProvider/,

--- a/packages/admin-react/tests/user.test.tsx
+++ b/packages/admin-react/tests/user.test.tsx
@@ -1,0 +1,50 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { UserProvider, useUser } from "../src/user.js"
+
+type TestUser = { id: string; email: string }
+
+function wrapper(getCurrentUser: () => Promise<TestUser | null>, initialUser?: TestUser | null) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <UserProvider<TestUser> getCurrentUser={getCurrentUser} initialUser={initialUser}>
+          {children}
+        </UserProvider>
+      </QueryClientProvider>
+    )
+  }
+}
+
+describe("UserProvider / useUser", () => {
+  it("exposes the fetched current user", async () => {
+    const user: TestUser = { id: "usr_1", email: "staff@example.test" }
+    const { result } = renderHook(() => useUser<TestUser>(), {
+      wrapper: wrapper(vi.fn(async () => user)),
+    })
+
+    await waitFor(() => expect(result.current.user).toEqual(user))
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("hydrates from initialUser without a fetch", () => {
+    const initial: TestUser = { id: "usr_2", email: "hydrated@example.test" }
+    const getCurrentUser = vi.fn(async (): Promise<TestUser | null> => null)
+    const { result } = renderHook(() => useUser<TestUser>(), {
+      wrapper: wrapper(getCurrentUser, initial),
+    })
+
+    expect(result.current.user).toEqual(initial)
+    expect(getCurrentUser).not.toHaveBeenCalled()
+  })
+
+  it("throws when used outside a UserProvider", () => {
+    expect(() => renderHook(() => useUser<TestUser>())).toThrow(
+      /useUser must be used within UserProvider/,
+    )
+  })
+})

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -72,6 +72,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/allotments": ["../allotments/dist/index.d.ts"],
       "@voyant-travel/auth": ["../auth/dist/index.d.ts"],
       "@voyant-travel/auth-react": ["../auth-react/dist/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -67,6 +67,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/allotments": ["../allotments/dist/index.d.ts"],
       "@voyant-travel/auth": ["../auth/dist/index.d.ts"],
       "@voyant-travel/auth-react": ["../auth-react/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -73,6 +73,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -72,6 +72,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -67,6 +67,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -67,6 +67,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -73,6 +73,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -67,6 +67,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -73,6 +73,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -67,6 +67,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -73,6 +73,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -66,6 +66,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -67,6 +67,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -68,6 +68,7 @@
       "@voyant-travel/admin-react/hooks": ["../admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": ["../admin/dist/app/extension-routes.d.ts"],
       "@voyant-travel/admin/app/root": ["../admin/dist/app/root.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4506,6 +4506,9 @@ importers:
       '@voyant-travel/admin-host':
         specifier: workspace:^
         version: link:../../packages/admin-host
+      '@voyant-travel/admin-react':
+        specifier: workspace:^
+        version: link:../../packages/admin-react
       '@voyant-travel/auth':
         specifier: workspace:^
         version: link:../../packages/auth

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -49,6 +49,7 @@
     "@voyant-travel/admin": "workspace:^",
     "@voyant-travel/admin-app": "workspace:^",
     "@voyant-travel/admin-host": "workspace:^",
+    "@voyant-travel/admin-react": "workspace:^",
     "@voyant-travel/auth": "workspace:^",
     "@voyant-travel/auth-react": "workspace:^",
     "@voyant-travel/availability": "workspace:^",

--- a/starters/operator/src/components/providers/user-provider.tsx
+++ b/starters/operator/src/components/providers/user-provider.tsx
@@ -1,17 +1,21 @@
-import { useQuery } from "@tanstack/react-query"
-import { createContext, type ReactNode, useContext } from "react"
+"use client"
 
-import { type CurrentUser, getCurrentUserQueryOptions } from "@/lib/current-user"
+import {
+  type AdminUserContextValue,
+  UserProvider as AdminUserProvider,
+  useUser as useAdminUser,
+} from "@voyant-travel/admin-react/user"
+import type { ReactNode } from "react"
 
-type UserContextValue = {
-  user: CurrentUser | null
-  isLoading: boolean
-  error: Error | null
-  refetch: () => Promise<unknown>
-}
+import { adminAuthRuntime } from "@/lib/admin-auth-runtime"
+import type { CurrentUser } from "@/lib/current-user"
 
-const UserContext = createContext<UserContextValue | undefined>(undefined)
-
+/**
+ * Operator current-user provider — a thin adopter of the packaged
+ * `@voyant-travel/admin-react/user` provider, wired to the deployment's auth
+ * runtime (`getCurrentUser`). Kept as a local module so the ~app-wide `useUser`
+ * import path and the `CurrentUser` type stay stable.
+ */
 export function UserProvider({
   children,
   initialUser,
@@ -19,34 +23,16 @@ export function UserProvider({
   children: ReactNode
   initialUser?: CurrentUser | null
 }) {
-  const {
-    data: user,
-    isPending,
-    isFetching,
-    error,
-    refetch,
-  } = useQuery(getCurrentUserQueryOptions(initialUser))
-
-  const isLoading = isPending || (isFetching && user === undefined)
-
   return (
-    <UserContext.Provider
-      value={{
-        user: user ?? null,
-        isLoading,
-        error: error ? error : null,
-        refetch,
-      }}
+    <AdminUserProvider<CurrentUser>
+      getCurrentUser={adminAuthRuntime.getCurrentUser}
+      initialUser={initialUser}
     >
       {children}
-    </UserContext.Provider>
+    </AdminUserProvider>
   )
 }
 
-export function useUser() {
-  const context = useContext(UserContext)
-  if (context === undefined) {
-    throw new Error("useUser must be used within UserProvider")
-  }
-  return context
+export function useUser(): AdminUserContextValue<CurrentUser> {
+  return useAdminUser<CurrentUser>()
 }

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -91,6 +91,7 @@
       "@voyant-travel/admin-react/hooks": ["../../packages/admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../../packages/admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../../packages/admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../../packages/admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../../packages/admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": [
         "../../packages/admin/dist/app/extension-routes.d.ts"

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -91,6 +91,7 @@
       "@voyant-travel/admin-react/hooks": ["../../packages/admin-react/dist/hooks.d.ts"],
       "@voyant-travel/admin-react/provider": ["../../packages/admin-react/dist/provider.d.ts"],
       "@voyant-travel/admin-react/query-keys": ["../../packages/admin-react/dist/query-keys.d.ts"],
+      "@voyant-travel/admin-react/user": ["../../packages/admin-react/dist/user.d.ts"],
       "@voyant-travel/admin/app": ["../../packages/admin/dist/app/index.d.ts"],
       "@voyant-travel/admin/app/extension-routes": [
         "../../packages/admin/dist/app/extension-routes.d.ts"


### PR DESCRIPTION
## What

**Phase 2, slice 3** of the source-free admin host (voyant#3044): package the reusable **current-user provider**.

New subpath `@voyant-travel/admin-react/user` — `UserProvider` / `useUser`, a current-user React Query context that takes `getCurrentUser` **injected** (the deployment's auth-runtime port from slice 2), so it carries no auth-client dependency and is shared by managed and self-host admin hosts. The operator starter's local provider becomes a thin adopter wired to `adminAuthRuntime`.

## Scope note (design finding)

Investigating the `_workspace` shell showed its composition is **deployment-specific**: `RealtimeLiveProvider` wires module-specific React-Query key roots, cloud-sdk channels, and the auth client. Like auth, that composition doesn't extract cleanly — the managed host will author its own thin `_workspace` composition from the packaged pieces (shell chrome + auth port + this user provider), rather than reusing the starter's. So this slice packages the cleanly-reusable current-user context; the remaining route-tree assembly is the cross-repo codegen (`@voyant-travel/cli`) + the managed composition.

## Verification
- admin-react typecheck + tests (7, incl. 3 new provider tests: fetch, initialUser hydration, out-of-provider throw).
- operator typechecks, builds (client + server), and boots — `/` + `/api/health` 200; operator suite 238 passing.
- Adds the missing `@voyant-travel/admin-react` dependency to the operator starter (the import surfaced it wasn't declared).
