### PR TITLE
vite-config: package the Node SSR build config (nodeSsr) (#3044)

### DIFF
--- a/.changeset/vite-config-node-ssr.md
+++ b/.changeset/vite-config-node-ssr.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/vite-config": minor
+---
+
+Add a `nodeSsr` option to `voyantStartViteConfig` that folds in the load-bearing
+Node SSR build config — `ssr.target: "node"`, `ssr.noExternal` for
+`@voyant-travel/*` / `@pxmstudio/*`, and `ssr.resolve.conditions` (source-first)
+— which Node-only Voyant apps (voyant#2966) previously hand-merged on top of the
+preset.
+
+With `nodeSsr: true` a Voyant TanStack Start app's `vite.config.ts` shrinks to a
+single `voyantStartViteConfig(...)` call and copies no build config — the
+last piece the source-free managed admin host (voyant#3044) still duplicated.
+The operator and managed-operator starters adopt it.

--- a/docs/architecture/managed-admin-host.md
+++ b/docs/architecture/managed-admin-host.md
@@ -1,8 +1,45 @@
 # Managed profile admin host — source-free admin UI serving
 
-- **Status:** Plan (2026-07-08)
+- **Status:** Realized (2026-07-08) — the source-free host works end to end; see status below.
 - **Tracks:** voyant#3044 · Parent: voyant#2983 · Sibling: voyant#2987 (API runtime entry, shipped)
 - **Related:** Packaged Admin RFC (#1643/#1649), `@voyant-travel/vite-config`, platform#953/#954
+
+## Implementation status
+
+`starters/managed-operator/` **is** the source-free managed admin host — it serves
+the full standard admin (SSR + client) from published packages, with the only
+route file being `src/routes/__root.tsx` and every page built at runtime.
+
+Shipped:
+
+- **Serving seam** — `@voyant-travel/admin-host` (`serveManagedProfileAdmin`,
+  `createManagedProfileAdminSsrHandler`) — #3046.
+- **Runtime glue** — `@voyant-travel/admin-app/runtime` (fetcher, api-url,
+  admin-path normalize) — #3048.
+- **Auth port** — `ManagedProfileAdminAuthRuntime` in `@voyant-travel/admin/app`;
+  `createAdminWorkspaceBeforeLoad` consumes it — #3051.
+- **User provider** — `@voyant-travel/admin-react/user` — #3053.
+- **Source-free host + runtime composition** — `starters/managed-operator`, the
+  code-based router, and the runtime route/destination builders
+  (`buildAdminExtensionRoutes` incl. layout children, `buildAdminExtensionDestinations`)
+  — #3055.
+- **Packaged build config** — `voyantStartViteConfig({ nodeSsr: true })` folds in
+  the Node SSR target/`noExternal`/resolve-conditions; the app `vite.config.ts`
+  copies **no** build config — #3057.
+
+**Key finding that changed the plan:** the cross-repo `voyant admin generate`
+codegen is **not** needed. `buildAdminExtensionRoutes` builds the whole admin
+route tree at runtime from the packaged `create<Module>AdminExtension` factories,
+so the entire goal is voyant-repo-only. The codegen remains a compile-time
+typed-link DX nicety for source-backed hosts, not a runtime requirement.
+
+Remaining (non-blocking): compose the real `/api` (`loadManagedProfileRuntime`,
+#2987) with admin serving in one process (managed-operator stubs `/api`);
+widget-slot cross-package wiring; snapshot module-subsetting (#2104/#2107);
+extract `managed-operator`'s thin entry into a Cloud-image template (platform#954).
+
+The phased plan below is retained as the design record; where it says "Phase 3 /
+future," read the status above for what actually shipped.
 
 ## Problem
 
@@ -54,8 +91,9 @@ Packaged already (RFC #1649):
   and per-domain pages under `@voyant-travel/<domain>-react/admin`.
 - **Build config** — `@voyant-travel/vite-config` `voyantStartViteConfig(...)`
   owns vendor chunking (`manualChunks`), SSR `optimizeDeps`, the `@` alias, and
-  dev-tunnel hosts. The starter `vite.config.ts` only instantiates plugins and
-  adds the Node `ssr` target/`noExternal`/resolve-conditions.
+  dev-tunnel hosts, and — via `nodeSsr: true` (#3057) — the Node `ssr`
+  target/`noExternal`/resolve-conditions. The app `vite.config.ts` only
+  instantiates plugins; it copies no build config.
 
 Still starter-owned (blocks source-free):
 
@@ -210,16 +248,20 @@ in packages; the *route map* is emitted per build.
 
 ### Phase 3 — Framework-owned build entry (no copied vite config)
 
-Provide a build path that produces the admin client + SSR bundle from packages +
-a snapshot, with no starter `vite.config.ts` copy.
+Produce the admin client + SSR bundle from packages with no copied build config.
 
-- Extend `@voyant-travel/vite-config` with a `voyantManagedProfileAdminViteConfig(...)`
-  that bundles the Node `ssr` target/`noExternal`/resolve-conditions currently in
-  the starter `vite.config.ts`, and points the TanStack Start route source at the
-  packaged shell (Phase 2).
-- A thin, profile-agnostic build entry (config + `index.html` + client/server
-  entry) Cloud copies **verbatim** (or a generator emits) — carrying no app
-  logic, only the packaged config instantiation.
+- **Shipped (#3057):** `@voyant-travel/vite-config`'s `voyantStartViteConfig`
+  gained `nodeSsr: true`, which folds in the Node `ssr`
+  target/`noExternal`/resolve-conditions the app previously hand-merged. The
+  managed-operator (and operator) `vite.config.ts` is now a single
+  `voyantStartViteConfig(...)` call and copies no build config. (Route source is
+  the code-based router, not a "packaged shell" — see the status section; the
+  earlier `voyantManagedProfileAdminViteConfig` idea was unnecessary.)
+- **Remaining:** a thin, profile-agnostic build entry (`vite.config.ts` +
+  `index.html` + `__root.tsx` + `src/{router,server,entry,start}.ts`) that Cloud
+  copies **verbatim** (or a generator emits) — carrying no app logic, only the
+  packaged-config instantiation. `starters/managed-operator/` is that entry today;
+  extracting it into a template package is the platform#954 follow-up.
 - **Acceptance:** `createManagedProfileAdmin` end-to-end — a build in a scratch
   dir with only published packages + a snapshot + the thin entry produces
   `dist/client` + `dist/server`, and `node server.js` serves SSR admin + `/api`

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -125,6 +125,24 @@ export interface VoyantStartViteConfigOptions {
   extraManualChunks?: (id: string) => string | undefined
   /** Extra SSR optimizeDeps entries appended to the Voyant set. */
   ssrOptimizeDepsInclude?: readonly string[]
+  /**
+   * Build the SSR/server environment for a Node runtime (voyant#2966: Voyant
+   * deployments are Node-only — no `@cloudflare/vite-plugin`). Adds the
+   * load-bearing Node-SSR config the app would otherwise hand-merge:
+   *
+   * - `ssr.target: "node"` so `node:` builtins the API graph uses resolve
+   *   instead of being externalized for the browser;
+   * - `ssr.noExternal` for `@voyant-travel/*` / `@pxmstudio/*` so workspace
+   *   packages (whose `exports` point at `.js`-specifier TS source) are bundled
+   *   into the server build rather than left unresolvable at runtime;
+   * - `ssr.resolve.conditions` with `development` ahead of `node` so those
+   *   packages resolve from `./src` and the app build stands alone (no
+   *   prebuilt `dist` / `turbo ^build` needed).
+   *
+   * This is the config a Cloud-built managed admin image would otherwise copy;
+   * packaging it keeps it a version bump, not a copy (voyant#3044).
+   */
+  nodeSsr?: boolean
 }
 
 /**
@@ -133,7 +151,7 @@ export interface VoyantStartViteConfigOptions {
  * `vite.config.ts` shrinks to plugin instantiation + this call.
  */
 export function voyantStartViteConfig(options: VoyantStartViteConfigOptions): UserConfig {
-  const { appRootUrl, plugins, allowedHosts = true, extraManualChunks } = options
+  const { appRootUrl, plugins, allowedHosts = true, extraManualChunks, nodeSsr } = options
 
   return {
     server: {
@@ -158,6 +176,15 @@ export function voyantStartViteConfig(options: VoyantStartViteConfigOptions): Us
       optimizeDeps: {
         include: [...VOYANT_SSR_OPTIMIZE_DEPS, ...(options.ssrOptimizeDepsInclude ?? [])],
       },
+      ...(nodeSsr
+        ? {
+            target: "node" as const,
+            noExternal: [/^@voyant-travel\//, /^@pxmstudio\//],
+            resolve: {
+              conditions: ["development", "module", "node", "import", "default"],
+            },
+          }
+        : {}),
     },
     plugins,
   }

--- a/starters/managed-operator/vite.config.ts
+++ b/starters/managed-operator/vite.config.ts
@@ -9,53 +9,28 @@ import {
 } from "@voyant-travel/vite-config"
 import { defineConfig } from "vite"
 
-// Load-bearing build config (vendor chunking, SSR optimizeDeps, dev-tunnel
-// hosts, `@` alias) is versioned in @voyant-travel/vite-config; this file only
-// instantiates the app's plugins.
-//
-// The operator is Node-only (voyant#2966): there is no `@cloudflare/vite-plugin`,
-// so the `ssr` environment builds a plain Node bundle. `src/server.ts` runs the
-// app's `fetch` under `createNodeServer` and serves the client build.
-const base = voyantStartViteConfig({
-  appRootUrl: import.meta.url,
-  plugins: [
-    devtools(),
-    tailwindcss(),
-    tanstackStart({
-      router: {
-        routeFileIgnorePattern: VOYANT_ROUTE_FILE_IGNORE_PATTERN,
-      },
-    }),
-    viteReact(),
-    // Opt-in: `ANALYZE=1 pnpm build` emits dist/stats.html with a treemap
-    // of all client chunks.
-    createAnalyzePlugin(import.meta.url),
-  ],
-})
-
-export default defineConfig({
-  ...base,
-  ssr: {
-    ...(base.ssr ?? {}),
-    // Target the SSR/server environment at Node so `node:` builtins the API
-    // graph uses (async_hooks, etc.) resolve instead of being externalized for
-    // the browser. Previously `@cloudflare/vite-plugin` owned this (as workerd);
-    // the operator is now Node-only (voyant#2966).
-    target: "node",
-    // Bundle the workspace packages into the server build. Their `exports` point
-    // at TS source (`./src/*.ts`) using `.js`-extension specifiers that Node
-    // cannot resolve at runtime without a loader; bundling resolves them at build
-    // time. The old workerd build bundled everything for the same reason. A
-    // resident Node process loads the graph once, so there is no cold-start cost.
-    noExternal: [/^@voyant-travel\//, /^@pxmstudio\//],
-    // Resolve workspace-package exports from SOURCE by putting `development`
-    // ahead of `node` — a few subpaths (e.g. `@voyant-travel/workflows-orchestrator/in-memory`)
-    // export `node` → prebuilt `dist`, which would force the whole dependency
-    // graph to be built before the operator. With `development` first they
-    // resolve to `./src` and get bundled, so `pnpm --filter operator build`
-    // stands alone (no `turbo ^build` / prebuilt dist needed — see Dockerfile).
-    resolve: {
-      conditions: ["development", "module", "node", "import", "default"],
-    },
-  },
-})
+// The ENTIRE load-bearing build config — vendor chunking, SSR optimizeDeps, the
+// Node SSR target/noExternal/resolve (voyant#2966), `@` alias, dev-tunnel hosts
+// — is versioned in `@voyant-travel/vite-config`. This source-free managed admin
+// host copies NO build config: `vite.config.ts` is just plugin instantiation +
+// `nodeSsr: true`, so a Cloud image tracks the framework version, not a copy
+// (voyant#3044).
+export default defineConfig(
+  voyantStartViteConfig({
+    appRootUrl: import.meta.url,
+    nodeSsr: true,
+    plugins: [
+      devtools(),
+      tailwindcss(),
+      tanstackStart({
+        router: {
+          routeFileIgnorePattern: VOYANT_ROUTE_FILE_IGNORE_PATTERN,
+        },
+      }),
+      viteReact(),
+      // Opt-in: `ANALYZE=1 pnpm build` emits dist/stats.html with a treemap
+      // of all client chunks.
+      createAnalyzePlugin(import.meta.url),
+    ],
+  }),
+)

--- a/starters/operator/vite.config.ts
+++ b/starters/operator/vite.config.ts
@@ -9,53 +9,29 @@ import {
 } from "@voyant-travel/vite-config"
 import { defineConfig } from "vite"
 
-// Load-bearing build config (vendor chunking, SSR optimizeDeps, dev-tunnel
-// hosts, `@` alias) is versioned in @voyant-travel/vite-config; this file only
-// instantiates the app's plugins.
+// The load-bearing build config (vendor chunking, SSR optimizeDeps, the Node SSR
+// target/noExternal/resolve, `@` alias, dev-tunnel hosts) is versioned in
+// @voyant-travel/vite-config; this file only instantiates the app's plugins.
 //
 // The operator is Node-only (voyant#2966): there is no `@cloudflare/vite-plugin`,
-// so the `ssr` environment builds a plain Node bundle. `src/server.ts` runs the
-// app's `fetch` under `createNodeServer` and serves the client build.
-const base = voyantStartViteConfig({
-  appRootUrl: import.meta.url,
-  plugins: [
-    devtools(),
-    tailwindcss(),
-    tanstackStart({
-      router: {
-        routeFileIgnorePattern: VOYANT_ROUTE_FILE_IGNORE_PATTERN,
-      },
-    }),
-    viteReact(),
-    // Opt-in: `ANALYZE=1 pnpm build` emits dist/stats.html with a treemap
-    // of all client chunks.
-    createAnalyzePlugin(import.meta.url),
-  ],
-})
-
-export default defineConfig({
-  ...base,
-  ssr: {
-    ...(base.ssr ?? {}),
-    // Target the SSR/server environment at Node so `node:` builtins the API
-    // graph uses (async_hooks, etc.) resolve instead of being externalized for
-    // the browser. Previously `@cloudflare/vite-plugin` owned this (as workerd);
-    // the operator is now Node-only (voyant#2966).
-    target: "node",
-    // Bundle the workspace packages into the server build. Their `exports` point
-    // at TS source (`./src/*.ts`) using `.js`-extension specifiers that Node
-    // cannot resolve at runtime without a loader; bundling resolves them at build
-    // time. The old workerd build bundled everything for the same reason. A
-    // resident Node process loads the graph once, so there is no cold-start cost.
-    noExternal: [/^@voyant-travel\//, /^@pxmstudio\//],
-    // Resolve workspace-package exports from SOURCE by putting `development`
-    // ahead of `node` — a few subpaths (e.g. `@voyant-travel/workflows-orchestrator/in-memory`)
-    // export `node` → prebuilt `dist`, which would force the whole dependency
-    // graph to be built before the operator. With `development` first they
-    // resolve to `./src` and get bundled, so `pnpm --filter operator build`
-    // stands alone (no `turbo ^build` / prebuilt dist needed — see Dockerfile).
-    resolve: {
-      conditions: ["development", "module", "node", "import", "default"],
-    },
-  },
-})
+// so `nodeSsr` builds a plain Node bundle. `src/server.ts` runs the app's
+// `fetch` under `createNodeServer` and serves the client build.
+export default defineConfig(
+  voyantStartViteConfig({
+    appRootUrl: import.meta.url,
+    nodeSsr: true,
+    plugins: [
+      devtools(),
+      tailwindcss(),
+      tanstackStart({
+        router: {
+          routeFileIgnorePattern: VOYANT_ROUTE_FILE_IGNORE_PATTERN,
+        },
+      }),
+      viteReact(),
+      // Opt-in: `ANALYZE=1 pnpm build` emits dist/stats.html with a treemap
+      // of all client chunks.
+      createAnalyzePlugin(import.meta.url),
+    ],
+  }),
+)


### PR DESCRIPTION
## What

Package the last piece of build config the source-free managed admin host still copied (voyant#3044, follow-up to #3055).

`voyantStartViteConfig` gains a **`nodeSsr`** option that folds in the load-bearing Node SSR config Node-only Voyant apps (#2966) previously hand-merged on top of the preset:
- `ssr.target: "node"` (so `node:` builtins in the API graph resolve, not externalized for the browser),
- `ssr.noExternal` for `@voyant-travel/*` / `@pxmstudio/*` (bundle workspace packages whose `exports` point at `.js`-specifier TS source),
- `ssr.resolve.conditions` source-first (so the app build stands alone, no prebuilt `dist`).

With `nodeSsr: true`, a Voyant TanStack Start app's `vite.config.ts` is a **single `voyantStartViteConfig(...)` call and copies no build config** — closing the "copies no vite/SSR config" criterion of #3044. A Cloud image now tracks the framework version, not a copied SSR block.

## Change
- `@voyant-travel/vite-config`: new `nodeSsr` option (minor).
- `starters/managed-operator` + `starters/operator`: `vite.config.ts` simplified to a single call (the hand-merged `ssr` block deleted).

## Verification
Both starters build + boot with the packaged config (byte-identical SSR settings to the old manual block):
- operator: `/` + `/api/health` 200.
- managed-operator: `/` + `/bookings` + `/settings/team` 200.

`pnpm test` 100/100; agent-quality + dependency-version gates green.
