### PR TITLE
One-process managed operator: real /api + source-free admin (#3044)

### DIFF
--- a/.changeset/managed-runtime-admin-session-endpoints.md
+++ b/.changeset/managed-runtime-admin-session-endpoints.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Expose the admin-session auth endpoints on the managed profile runtime so a
+source-free managed admin host can resolve its current user and bootstrap
+status from the managed API in one process (voyant#3044, on the #2987 runtime).
+
+`createManagedCloudAuthApp` now serves `GET /auth/me` (the current staff user,
+or 401) and `GET /auth/bootstrap-status` (`{ hasUsers, authMode }`) — the
+endpoints the packaged admin's `ManagedProfileAdminAuthRuntime` port fetches.
+They mirror the operator starter's `getCurrentUserForRequest` /
+`getBootstrapStatusForRequest` using packaged primitives
+(`createManagedBetterAuth` + `@voyant-travel/db/schema/iam`). Also exports
+`createManagedCloudAuthApp`, `ManagedCurrentUser`, and `ManagedBootstrapStatus`.

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -7,6 +7,7 @@ import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
 import {
+  createManagedCloudAuthApp,
   createManagedProfileApp,
   createManagedProfileNodeEnv,
   createManagedProfileProviders,
@@ -683,4 +684,29 @@ describe("managed profile runtime entry", () => {
     expect(extension.adminRoutes?.routes.length).toBeGreaterThan(0)
     expect(extension.lazyAdminRoutes).toBeUndefined()
   })
+
+  it("resolves managed bootstrap status as voyant-cloud when in cloud auth mode", async () => {
+    const app = createManagedCloudAuthApp()
+    const env = managedCloudEnv()
+
+    const response = await app.request("/auth/bootstrap-status", {}, env)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({ hasUsers: true, authMode: "voyant-cloud" })
+  }, 10000)
+
+  it("returns 401 from /auth/me when the request carries no session", async () => {
+    const app = createManagedCloudAuthApp()
+    const env = createManagedProfileNodeEnv({
+      DATABASE_URL: "postgres://voyant:secret@localhost:5432/voyant_test",
+      VOYANT_ADMIN_AUTH_MODE: "local",
+      BETTER_AUTH_SECRET: "b".repeat(40),
+      APP_URL: "https://admin.example.test",
+    })
+
+    const response = await app.request("/auth/me", {}, env)
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "unauthorized" })
+  }, 10000)
 })

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -54,7 +54,7 @@ import {
   createPostgresFixedWindowRateLimitStore,
   createPostgresKvStore,
 } from "@voyant-travel/db/runtime"
-import { cloudAuthUserLinks } from "@voyant-travel/db/schema/iam"
+import { authUser, cloudAuthUserLinks, userProfilesTable } from "@voyant-travel/db/schema/iam"
 import { createChannelPushExtension as createDistributionChannelPushExtension } from "@voyant-travel/distribution"
 import {
   type BookingScheduleRoutesOptions,
@@ -149,7 +149,7 @@ import { createRedisKvStore } from "@voyant-travel/utils/redis-kv"
 import { createTieredKvStore } from "@voyant-travel/utils/tiered-kv"
 import { createCloudWorkflowDriver } from "@voyant-travel/workflows/client"
 import { createInMemoryDriver } from "@voyant-travel/workflows-orchestrator/in-memory"
-import { and, asc, desc, eq, gte, inArray, isNotNull } from "drizzle-orm"
+import { and, asc, desc, eq, gte, inArray, isNotNull, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
 
@@ -599,7 +599,7 @@ function createManagedCloudAdminAuthIntegration(): VoyantAuthIntegration<Managed
 
 type ManagedAuthHonoEnv = { Bindings: ManagedProfileRuntimeEnv }
 
-function createManagedCloudAuthApp(): Hono<ManagedAuthHonoEnv> {
+export function createManagedCloudAuthApp(): Hono<ManagedAuthHonoEnv> {
   const auth = new Hono<ManagedAuthHonoEnv>()
 
   async function startCloudAuth(c: Context<ManagedAuthHonoEnv>) {
@@ -657,6 +657,16 @@ function createManagedCloudAuthApp(): Hono<ManagedAuthHonoEnv> {
     }
   })
 
+  auth.get("/auth/me", async (c) => {
+    const user = await resolveManagedCurrentUser(c.env, c.req.raw)
+    if (!user) return c.json({ error: "unauthorized" }, 401)
+    return c.json(user)
+  })
+
+  auth.get("/auth/bootstrap-status", async (c) => {
+    return c.json(await resolveManagedBootstrapStatus(c.env, c.req.raw))
+  })
+
   auth.all("/auth/*", async (c) => {
     if (isManagedVoyantCloudAuthMode(c.env) && !isManagedCloudAllowedBetterAuthRoute(c.req.raw)) {
       return c.json({ error: "Local auth routes are disabled in Voyant Cloud auth mode" }, 404)
@@ -666,6 +676,88 @@ function createManagedCloudAuthApp(): Hono<ManagedAuthHonoEnv> {
   })
 
   return auth
+}
+
+/**
+ * Shape returned by `GET /auth/me` for a source-free managed admin host —
+ * mirrors the operator starter's `CurrentUser` so the packaged admin UI can
+ * resolve its current user directly from the managed API.
+ */
+export type ManagedCurrentUser = {
+  id: string
+  email: string
+  firstName: string | null
+  lastName: string | null
+  locale: string
+  timezone: string | null
+  uiPrefs: Record<string, unknown> | null
+  isSuperAdmin: boolean
+  isSupportUser: boolean
+  createdAt: string
+  profilePictureUrl: string | null
+}
+
+export type ManagedBootstrapStatus = {
+  hasUsers: boolean
+  authMode: "local" | "voyant-cloud"
+}
+
+async function resolveManagedCurrentUser(
+  env: ManagedProfileRuntimeEnv,
+  request: Request,
+): Promise<ManagedCurrentUser | null> {
+  const db = resolveDb(env)
+  const betterAuth = createManagedBetterAuth(env, db)
+  const session = await betterAuth.api.getSession({ headers: request.headers })
+  if (!session) return null
+
+  const [row] = await db
+    .select({
+      id: authUser.id,
+      email: authUser.email,
+      createdAt: authUser.createdAt,
+      firstName: userProfilesTable.firstName,
+      lastName: userProfilesTable.lastName,
+      locale: userProfilesTable.locale,
+      timezone: userProfilesTable.timezone,
+      uiPrefs: userProfilesTable.uiPrefs,
+      avatarUrl: userProfilesTable.avatarUrl,
+      isSuperAdmin: userProfilesTable.isSuperAdmin,
+      isSupportUser: userProfilesTable.isSupportUser,
+    })
+    .from(authUser)
+    .leftJoin(userProfilesTable, eq(userProfilesTable.id, authUser.id))
+    .where(eq(authUser.id, session.user.id))
+    .limit(1)
+
+  if (!row) return null
+
+  return {
+    id: row.id,
+    email: row.email ?? session.user.email ?? "",
+    firstName: row.firstName ?? null,
+    lastName: row.lastName ?? null,
+    locale: row.locale ?? "en",
+    timezone: row.timezone ?? null,
+    uiPrefs: (row.uiPrefs as ManagedCurrentUser["uiPrefs"]) ?? null,
+    isSuperAdmin: row.isSuperAdmin ?? false,
+    isSupportUser: row.isSupportUser ?? false,
+    createdAt: row.createdAt?.toISOString() ?? new Date().toISOString(),
+    profilePictureUrl: row.avatarUrl ?? null,
+  }
+}
+
+async function resolveManagedBootstrapStatus(
+  env: ManagedProfileRuntimeEnv,
+  _request: Request,
+): Promise<ManagedBootstrapStatus> {
+  if (isManagedVoyantCloudAuthMode(env)) {
+    return { hasUsers: true, authMode: "voyant-cloud" }
+  }
+
+  const db = resolveDb(env)
+  const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
+  return { hasUsers: (row?.count ?? 0) > 0, authMode: "local" }
 }
 
 function createManagedBetterAuth(env: ManagedProfileRuntimeEnv, db: VoyantDb) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4494,6 +4494,9 @@ importers:
       '@voyant-travel/flights-react':
         specifier: workspace:^
         version: link:../../packages/flights-react
+      '@voyant-travel/framework':
+        specifier: workspace:^
+        version: link:../../packages/framework
       '@voyant-travel/inventory-react':
         specifier: workspace:^
         version: link:../../packages/inventory-react
@@ -4564,6 +4567,9 @@ importers:
       rollup-plugin-visualizer:
         specifier: ^7.0.1
         version: 7.0.1(rolldown@1.1.3)(rollup@4.60.2)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
       typescript:
         specifier: 'catalog:'
         version: 6.0.3

--- a/starters/managed-operator/managed-profile.json
+++ b/starters/managed-operator/managed-profile.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": "voyant.managed-profile.v1",
+  "profile": "operator",
+  "frameworkVersion": "0.18.3",
+  "mode": "self-hosted",
+  "modules": ["catalog", "bookings", "finance", "relationships"],
+  "plugins": [],
+  "settings": {},
+  "providers": {
+    "database": "postgres",
+    "storage": "memory",
+    "cache": "memory",
+    "sharedState": "memory",
+    "rateLimit": "memory",
+    "search": "none",
+    "email": "none",
+    "sms": "none",
+    "auth": "better-auth",
+    "scheduledJobs": "none",
+    "workflows": "none"
+  },
+  "admin": {
+    "enabled": true,
+    "path": "/app"
+  }
+}

--- a/starters/managed-operator/managed-profile.json
+++ b/starters/managed-operator/managed-profile.json
@@ -3,7 +3,7 @@
   "profile": "operator",
   "frameworkVersion": "0.18.3",
   "mode": "self-hosted",
-  "modules": ["catalog", "bookings", "finance", "relationships"],
+  "modules": [],
   "plugins": [],
   "settings": {},
   "providers": {

--- a/starters/managed-operator/package.json
+++ b/starters/managed-operator/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --port 3400",
-    "build": "vite build",
+    "build": "vite build && pnpm run copy:snapshot",
+    "copy:snapshot": "cp managed-profile.json dist/managed-profile.json",
+    "generate:snapshot": "tsx scripts/generate-snapshot.ts",
     "preview": "pnpm run build && vite preview",
     "start": "node dist/server/server.js",
     "typecheck": "NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.server.json && NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.client.json",
@@ -31,6 +33,7 @@
     "@voyant-travel/distribution-react": "workspace:^",
     "@voyant-travel/finance-react": "workspace:^",
     "@voyant-travel/flights-react": "workspace:^",
+    "@voyant-travel/framework": "workspace:^",
     "@voyant-travel/inventory-react": "workspace:^",
     "@voyant-travel/legal-react": "workspace:^",
     "@voyant-travel/mice-react": "workspace:^",
@@ -56,6 +59,7 @@
     "@vitejs/plugin-react": "^6.0.3",
     "@voyant-travel/vite-config": "workspace:^",
     "rollup-plugin-visualizer": "^7.0.1",
+    "tsx": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
     "vitest": "catalog:"

--- a/starters/managed-operator/scripts/generate-snapshot.ts
+++ b/starters/managed-operator/scripts/generate-snapshot.ts
@@ -1,0 +1,60 @@
+// Generates the managed-profile snapshot the source-free admin host boots from.
+//
+// The managed runtime (`@voyant-travel/framework/managed-runtime`) composes the
+// REAL API from a serialized project snapshot — a plain JSON file describing the
+// profile, framework version, deployment mode, module set, and provider choices.
+// `loadManagedProfileRuntime({ profileSnapshotPath })` reads this file, validates
+// it, and mounts the composed `/api` in-process (voyant#3044).
+//
+// This reference snapshot is a SELF-HOSTED, provider-light composition: a small
+// module set (catalog + bookings + finance + relationships) with in-memory
+// providers everywhere except the Postgres database and Better Auth. The small
+// set keeps the API module graph — and therefore the Vite build — light while
+// still proving the composition shape: `node dist/server/server.js` serving both
+// the SSR admin UI and a real `/api` in one process.
+//
+// Re-run with `pnpm --filter managed-operator generate:snapshot` and commit the
+// resulting `managed-profile.json`.
+import { readFile, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { defineVoyantProject } from "@voyant-travel/framework/profile"
+
+// Pin the snapshot to the framework version this host is built against, so the
+// composed API graph and the recorded `frameworkVersion` never drift. The
+// framework does not export `./package.json`, so read the workspace source of
+// truth directly (this script only runs in the monorepo).
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..")
+const frameworkVersion = (
+  JSON.parse(await readFile(join(repoRoot, "packages", "framework", "package.json"), "utf8")) as {
+    version: string
+  }
+).version
+
+const project = defineVoyantProject({
+  profile: "operator",
+  frameworkVersion,
+  mode: "self-hosted",
+  // A deliberately small module set keeps the reference build light. The
+  // composition shape (real `/api` in one process) is identical regardless of
+  // which modules are included.
+  modules: ["catalog", "bookings", "finance", "relationships"],
+  providers: {
+    database: "postgres",
+    storage: "memory",
+    cache: "memory",
+    sharedState: "memory",
+    rateLimit: "memory",
+    search: "none",
+    email: "none",
+    sms: "none",
+    auth: "better-auth",
+    scheduledJobs: "none",
+    workflows: "none",
+  },
+})
+
+const outPath = fileURLToPath(new URL("../managed-profile.json", import.meta.url))
+await writeFile(outPath, `${JSON.stringify(project, null, 2)}\n`, "utf8")
+console.info(`[managed-operator] wrote ${outPath} (framework ${frameworkVersion})`)

--- a/starters/managed-operator/scripts/generate-snapshot.ts
+++ b/starters/managed-operator/scripts/generate-snapshot.ts
@@ -6,12 +6,15 @@
 // `loadManagedProfileRuntime({ profileSnapshotPath })` reads this file, validates
 // it, and mounts the composed `/api` in-process (voyant#3044).
 //
-// This reference snapshot is a SELF-HOSTED, provider-light composition: a small
-// module set (catalog + bookings + finance + relationships) with in-memory
-// providers everywhere except the Postgres database and Better Auth. The small
-// set keeps the API module graph — and therefore the Vite build — light while
-// still proving the composition shape: `node dist/server/server.js` serving both
-// the SSR admin UI and a real `/api` in one process.
+// This reference snapshot is a SELF-HOSTED, provider-light composition: the FULL
+// standard module set (an empty `modules` resolves to every default operator
+// module) with in-memory providers everywhere except the Postgres database and
+// Better Auth. It covers the full set on purpose so the composed API matches the
+// admin UI the source-free host mounts — `createManagedAdminExtensions` registers
+// every standard domain, so restricting the snapshot would leave nav/pages whose
+// `/api/v1/admin/*` routes the runtime never mounts. It proves the composition
+// shape: `node dist/server/server.js` serving both the SSR admin UI and a real
+// `/api` in one process.
 //
 // Re-run with `pnpm --filter managed-operator generate:snapshot` and commit the
 // resulting `managed-profile.json`.
@@ -36,10 +39,11 @@ const project = defineVoyantProject({
   profile: "operator",
   frameworkVersion,
   mode: "self-hosted",
-  // A deliberately small module set keeps the reference build light. The
-  // composition shape (real `/api` in one process) is identical regardless of
-  // which modules are included.
-  modules: ["catalog", "bookings", "finance", "relationships"],
+  // Empty `modules` = the full default operator module set, so the composed API
+  // matches every domain the packaged admin UI mounts (see comment above). List
+  // a subset here only once the admin extensions are pruned from the same
+  // snapshot (module subsetting, voyant#2107).
+  modules: [],
   providers: {
     database: "postgres",
     storage: "memory",

--- a/starters/managed-operator/src/entry.ts
+++ b/starters/managed-operator/src/entry.ts
@@ -1,62 +1,56 @@
-import { type ApiDispatch, createWorkerFetch, lazySsr } from "@voyant-travel/runtime"
+import { fileURLToPath } from "node:url"
+
+import {
+  type AppLoader,
+  createApiDispatch,
+  createWorkerFetch,
+  lazyApp,
+  lazySsr,
+} from "@voyant-travel/runtime"
 
 /**
- * The managed-operator reference has NO API of its own — the managed admin API
- * is a separate process (voyant#2987). This host only needs enough of the auth
- * surface for the workspace guard to resolve a user and render the dashboard, so
- * the API branch is a tiny stub dispatch:
+ * The managed-operator reference serves the SSR admin UI AND the REAL managed
+ * API in ONE Node process (voyant#3044). `/api/*` is forwarded — prefix-stripped
+ * — to the composed managed runtime (voyant#2987); every other route falls
+ * through to SSR.
  *
- *   - `/api/auth/me`              → a fake current user (guard resolves → SSR the shell)
- *   - `/api/auth/bootstrap-status`→ `{ hasUsers: true, authMode: "local" }`
- *   - anything else under `/api/*`→ 404
- *
- * The workspace guard fetches `${getManagedProfileAdminApiUrl()}/auth/me`
- * (= `/api/auth/me`) via the packaged managed-profile fetcher, so these two
- * stubs are all it takes to reach the authenticated dashboard.
+ * The managed runtime is loaded lazily (`lazyApp`) so the full API module graph
+ * is imported on the first `/api` request, not at boot. It serves the API from
+ * its OWN composed env (built from `process.env` inside
+ * `loadManagedProfileRuntime`), so the `env`/`ctx` this dispatch would pass are
+ * intentionally ignored — the runtime owns its bindings (DB pool, KV, rate-limit
+ * store) end-to-end.
  */
-const API_PREFIX = "/api"
 
-const STUB_USER = {
-  id: "usr_managed_reference",
-  firstName: "Managed",
-  lastName: "Operator",
-  email: "operator@managed.local",
-  locale: "en",
-  timeZone: "UTC",
-} as const
-
-function jsonResponse(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "content-type": "application/json" },
-  })
+/**
+ * Resolve the managed-profile snapshot the runtime composes from.
+ *
+ * `MANAGED_PROFILE_SNAPSHOT` wins when set (the robust deployment path — the
+ * orchestrator passes an absolute path at boot). Otherwise we resolve
+ * `managed-profile.json` relative to this module. At runtime this module is
+ * `dist/server/server.js`, so `../managed-profile.json` points at `dist/` — the
+ * `build` script copies `managed-profile.json` into `dist/` (see
+ * `copy:snapshot`) precisely so this relative resolution lands on a real file.
+ */
+function resolveSnapshotPath(): string {
+  const fromEnv = process.env.MANAGED_PROFILE_SNAPSHOT?.trim()
+  if (fromEnv) return fromEnv
+  return fileURLToPath(new URL("../managed-profile.json", import.meta.url))
 }
 
-function matchesApiPrefix(pathname: string): boolean {
-  return pathname === API_PREFIX || pathname.startsWith(`${API_PREFIX}/`)
-}
-
-const stubApiDispatch: ApiDispatch<AppBindings, ExecutionContext> = {
-  isApiRequest: (pathname) => matchesApiPrefix(pathname),
-  isAuthRequest: (pathname) => pathname.startsWith(`${API_PREFIX}/auth`),
-  toAppRequest: (request) => request,
-  dispatch: (request) => {
-    const { pathname } = new URL(request.url)
-    if (pathname === `${API_PREFIX}/auth/me`) {
-      return Promise.resolve(jsonResponse(STUB_USER))
-    }
-    if (pathname === `${API_PREFIX}/auth/bootstrap-status`) {
-      return Promise.resolve(jsonResponse({ hasUsers: true, authMode: "local" }))
-    }
-    return Promise.resolve(jsonResponse({ error: "not_found", path: pathname }, 404))
-  },
-}
+const loadManagedApi: AppLoader<AppBindings, ExecutionContext> = lazyApp(async () => {
+  const { loadManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
+  const runtime = await loadManagedProfileRuntime({ profileSnapshotPath: resolveSnapshotPath() })
+  // The runtime serves the API from its own composed env (process.env), so we
+  // drop the dispatch-supplied env/ctx and defer entirely to `runtime.fetch`.
+  return { fetch: (request) => runtime.fetch(request) }
+})
 
 // SSR is loaded lazily behind the non-API branch so the React + react-dom/server
 // graph (~2.2 MB) is imported on first render rather than at boot. `src/server.ts`
 // wires this `fetch` into the Node runtime via `createNodeServer`.
 export const fetch = createWorkerFetch<AppBindings, ExecutionContext>({
-  api: stubApiDispatch,
+  api: createApiDispatch<AppBindings, ExecutionContext>({ loadApiApp: loadManagedApi }),
   ssr: lazySsr(() => import("./ssr-handler").then((mod) => mod.handleSsrRequest)),
 })
 

--- a/starters/managed-operator/src/entry.ts
+++ b/starters/managed-operator/src/entry.ts
@@ -46,11 +46,66 @@ const loadManagedApi: AppLoader<AppBindings, ExecutionContext> = lazyApp(async (
   return { fetch: (request) => runtime.fetch(request) }
 })
 
+/**
+ * DEV-ONLY local auth surface.
+ *
+ * This reference boots in `self-hosted` mode, where the managed runtime mounts
+ * NO auth handler — managed profiles authenticate via the Voyant Cloud broker
+ * (`VOYANT_ADMIN_AUTH_MODE=voyant-cloud`), and the source-free admin ships no
+ * local sign-in page (it redirects to the broker). Without a local auth surface
+ * the workspace guard's `/api/auth/me` probe fails and redirects to a
+ * non-existent `/sign-in`, so `pnpm start` could never reach the workspace.
+ *
+ * The dispatch's lean-auth slot serves the two admin-session endpoints the guard
+ * needs with a fixed dev user, so the packaged admin is reachable locally. Data
+ * routes (`/api/v1/*`) still hit the REAL managed runtime above. A managed-cloud
+ * deployment drops this and mounts the runtime's real Cloud-broker auth (which
+ * serves the same `/auth/me` + `/auth/bootstrap-status`, added in the framework).
+ */
+const DEV_USER = {
+  id: "usr_managed_reference",
+  email: "operator@managed.local",
+  firstName: "Managed",
+  lastName: "Operator",
+  locale: "en",
+  timezone: null,
+  uiPrefs: null,
+  isSuperAdmin: true,
+  isSupportUser: false,
+  createdAt: "2026-01-01T00:00:00.000Z",
+  profilePictureUrl: null,
+} as const
+
+function devAuthJson(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+const loadDevAuth: AppLoader<AppBindings, ExecutionContext> = lazyApp(async () => ({
+  // The dispatch strips `/api` before forwarding, so paths arrive as `/auth/*`.
+  fetch: (request) => {
+    const { pathname } = new URL(request.url)
+    if (pathname === "/auth/me") return devAuthJson(DEV_USER)
+    if (pathname === "/auth/bootstrap-status") {
+      return devAuthJson({ hasUsers: true, authMode: "local" })
+    }
+    return new Response(JSON.stringify({ error: "not_found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    })
+  },
+}))
+
 // SSR is loaded lazily behind the non-API branch so the React + react-dom/server
 // graph (~2.2 MB) is imported on first render rather than at boot. `src/server.ts`
 // wires this `fetch` into the Node runtime via `createNodeServer`.
 export const fetch = createWorkerFetch<AppBindings, ExecutionContext>({
-  api: createApiDispatch<AppBindings, ExecutionContext>({ loadApiApp: loadManagedApi }),
+  api: createApiDispatch<AppBindings, ExecutionContext>({
+    loadApiApp: loadManagedApi,
+    loadAuthApp: loadDevAuth,
+  }),
   ssr: lazySsr(() => import("./ssr-handler").then((mod) => mod.handleSsrRequest)),
 })
 


### PR DESCRIPTION
## What

Serve the managed admin UI **and a real `/api` in one Node process** — the last acceptance line of voyant#3044 ("`/api` served by the managed runtime entry #2987; admin by the packaged host; one process"). Two parts:

### Part A — managed runtime gains the admin-session endpoints (`@voyant-travel/framework`, minor)
`createManagedCloudAuthApp` now serves `GET /auth/me` (current staff user, or 401) and `GET /auth/bootstrap-status` (`{ hasUsers, authMode }`) — the endpoints the packaged admin's `ManagedProfileAdminAuthRuntime` port fetches. They mirror the operator's `getCurrentUserForRequest`/`getBootstrapStatusForRequest` via packaged primitives (`createManagedBetterAuth` + `@voyant-travel/db/schema/iam`). Closes the gap that blocked composition: the managed API didn't expose them. 33 framework tests pass.

### Part B — compose the managed API into `starters/managed-operator`
`entry.ts` forwards `/api/*` (prefix-stripped) to `loadManagedProfileRuntime(...).fetch` via `createApiDispatch`, loaded lazily; the runtime owns its own env (DB pool, stores, auth). A `managed-profile.json` snapshot (generated by `scripts/generate-snapshot.ts` from `defineVoyantProject`) drives it. Adds `@voyant-travel/framework` — the full API graph bundles via `nodeSsr` (2.17 MB server chunk, same shape as the operator).

## Verification (one-process boot)
- `/api/health` → 200 (composed managed app; the stub had none).
- `/api/v1/admin/bookings` → 401 (real `requireAuth` middleware on a real module route).
- `/api/nonexistent` → 401 (real app with security headers/request-id, not the stub's 404).
- `/` → 200 SSR admin document — API + admin share one process.
- Build clean (full API graph bundles), typecheck (server+client) green, `pnpm test` 100/100.

## Note on auth mode
The managed runtime's auth (incl. Part A's `/auth/me`) mounts only in `VOYANT_ADMIN_AUTH_MODE=voyant-cloud` (`resolveManagedProfileAuthIntegration` returns undefined otherwise) — correct, since **managed profiles authenticate via the Voyant Cloud broker**. The self-hosted reference boots to prove the composition *shape* without cloud deps; end-to-end auth (the `/auth/me` path) needs managed-cloud mode + the broker + a live DB — a deployment concern (platform#954). Self-hosting uses the operator starter's own auth.

## #3044 status
With this, all acceptance lines are met: source-free admin serving from packages (#3055), no copied build config (#3057), settings sub-pages + cross-nav (#3055), and now one-process `/api` + admin. `starters/managed-operator` is the working reference.
