### PR TITLE
Package a source-free Operator Profile settings page for managed profiles

### DIFF
--- a/.changeset/operator-settings-react-source-free-page.md
+++ b/.changeset/operator-settings-react-source-free-page.md
@@ -1,0 +1,23 @@
+---
+"@voyant-travel/operator-settings-react": minor
+---
+
+Add `@voyant-travel/operator-settings-react` — the source-free React UI for the
+**Operator Profile** settings page, the packaged companion to the API-only
+`@voyant-travel/operator-settings` (voyant#3061, under #2983).
+
+The page edits the operator's contract identity (trading name, legal name, VAT
+id, trade-register number, contact, license, signatory, payment
+instructions/collection defaults, checkout links) that populates `operator.*`
+in contract templates, reading and writing the `/v1/admin/settings/operator-*`
+routes already mounted on the managed runtime. It resolves its API surface from
+the admin runtime context and its copy from the shared operator admin messages,
+so a package-only, source-free admin can mount it with no starter source.
+
+`@voyant-travel/operator-settings-react/settings` exports
+`createOperatorProfileSettingsExtraPage()`, an `AdminCoreSettingsExtraPage`
+descriptor to spread into
+`createAdminCoreExtension({ settings: { extraPages: [...] } })`; the root exports
+the `OperatorProfileSettingsPage` component. The managed-operator host mounts it
+(closing the last GENERAL settings gap for managed profiles), and the operator
+starter adopts it in place of its former app-custom page.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1120,6 +1120,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1115,6 +1115,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1091,6 +1091,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1086,6 +1086,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1175,6 +1175,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -1171,6 +1171,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1156,6 +1156,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1157,6 +1157,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1172,6 +1172,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1173,6 +1173,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1175,6 +1175,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1170,6 +1170,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1185,6 +1185,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1186,6 +1186,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1176,6 +1176,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1171,6 +1171,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1184,6 +1184,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1185,6 +1185,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1186,6 +1186,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1072,6 +1072,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1067,6 +1067,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/operator-settings-react/README.md
+++ b/packages/operator-settings-react/README.md
@@ -1,0 +1,38 @@
+# @voyant-travel/operator-settings-react
+
+Source-free React UI for the **Operator Profile** settings page — the packaged
+companion to the API-only `@voyant-travel/operator-settings`.
+
+The page edits the operator's legal-entity/contract identity (trading name,
+legal name, VAT id, trade-register number, contact, license, signatory, payment
+instructions/collection defaults, and checkout links) that populates
+`operator.*` in contract templates. It reads and writes the
+`/v1/admin/settings/operator-*` routes that `@voyant-travel/operator-settings`
+mounts on the runtime.
+
+It resolves its API surface from the admin runtime context
+(`useVoyantReactContext`) and its copy from the shared operator admin messages
+(`useOperatorAdminMessages`), so a **package-only, source-free admin** (e.g. the
+managed operator host) can render it without importing any starter source.
+
+## Usage
+
+```tsx
+import { createAdminCoreExtension } from "@voyant-travel/admin-app/core-extension"
+import { createOperatorProfileSettingsExtraPage } from "@voyant-travel/operator-settings-react/settings"
+
+createAdminCoreExtension({
+  settings: {
+    extraPages: [createOperatorProfileSettingsExtraPage()],
+  },
+})
+```
+
+`createOperatorProfileSettingsExtraPage()` returns an
+`AdminCoreSettingsExtraPage` descriptor placed in the General settings group
+(leading order `10`, Building icon). The page component itself is exported from
+the package root as `OperatorProfileSettingsPage` for direct mounting.
+
+## License
+
+Apache-2.0

--- a/packages/operator-settings-react/package.json
+++ b/packages/operator-settings-react/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "@voyant-travel/operator-settings-react",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/operator-settings-react"
+  },
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./settings": "./src/settings.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/admin-app": "workspace:^",
+    "@voyant-travel/finance": "workspace:^",
+    "@voyant-travel/finance-react": "workspace:^",
+    "@voyant-travel/ui": "workspace:^",
+    "lucide-react": "^0.475.0 || ^1.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "sonner": "^2.0.7"
+  },
+  "dependencies": {
+    "@voyant-travel/react": "workspace:^"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.101.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/admin-app": "workspace:^",
+    "@voyant-travel/finance": "workspace:^",
+    "@voyant-travel/finance-react": "workspace:^",
+    "@voyant-travel/ui": "workspace:^",
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "lucide-react": "^1.23.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "sonner": "^2.0.7",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./settings": {
+        "types": "./dist/settings.d.ts",
+        "import": "./dist/settings.js",
+        "default": "./dist/settings.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/operator-settings-react/src/index.ts
+++ b/packages/operator-settings-react/src/index.ts
@@ -1,0 +1,1 @@
+export { OperatorProfileSettingsPage } from "./operator-profile-settings-page.js"

--- a/packages/operator-settings-react/src/operator-profile-settings-page.tsx
+++ b/packages/operator-settings-react/src/operator-profile-settings-page.tsx
@@ -1,20 +1,29 @@
 "use client"
 
 /**
- * Settings -> Operator profile.
+ * Settings -> Operator profile (source-free, package-delivered).
  *
- * Operator identity, payment instructions, and operator-level
- * booking payment defaults live in separate API/storage concepts, but
- * remain one operational settings form.
+ * Operator identity, payment instructions, and operator-level booking payment
+ * defaults live in separate API/storage concepts, but remain one operational
+ * settings form. This is the packaged counterpart of the operator starter's
+ * former app-custom page: it resolves its API surface from the admin runtime
+ * context ({@link useVoyantReactContext}) and its copy from the shared operator
+ * admin messages, so a source-free managed admin can mount it in one line via
+ * `createAdminCoreExtension({ settings: { extraPages: [...] } })`.
+ *
+ * It talks to the `@voyant-travel/operator-settings` routes already mounted on
+ * the managed runtime (`/v1/admin/settings/operator-*`).
  */
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useOperatorAdminMessages } from "@voyant-travel/admin/providers/operator-admin-messages"
 import {
   noDepositPolicy,
   normalizePaymentPolicy,
   type PaymentPolicy,
 } from "@voyant-travel/finance/payment-policy"
 import { PaymentPolicyForm, PaymentPolicyPreview } from "@voyant-travel/finance-react/ui"
+import { useVoyantReactContext } from "@voyant-travel/react"
 import {
   Button,
   Card,
@@ -30,9 +39,6 @@ import { PhoneInput } from "@voyant-travel/ui/components/phone-input"
 import { Loader2 } from "lucide-react"
 import { useEffect, useState } from "react"
 import { toast } from "sonner"
-
-import { useAdminMessages } from "@/lib/admin-i18n"
-import { getApiUrl } from "@/lib/env"
 
 interface OperatorProfileForm {
   name?: string | null
@@ -94,21 +100,18 @@ const EMPTY_FORM: OperatorProfileForm = {
   invoicePayUrlTemplate: "",
 }
 
-function OperatorProfilePage() {
+export function OperatorProfileSettingsPage() {
   const queryClient = useQueryClient()
-  const t = useAdminMessages().settings.operatorProfilePage
+  const { baseUrl, fetcher } = useVoyantReactContext()
+  const t = useOperatorAdminMessages().settings.operatorProfilePage
 
   const { data, isPending } = useQuery({
     queryKey: ["operator-profile-settings"],
     queryFn: async (): Promise<OperatorProfileForm | null> => {
       const [profileRes, instructionsRes, defaultsRes] = await Promise.all([
-        fetch(`${getApiUrl()}/v1/admin/settings/operator-profile`, { credentials: "include" }),
-        fetch(`${getApiUrl()}/v1/admin/settings/operator-payment-instructions`, {
-          credentials: "include",
-        }),
-        fetch(`${getApiUrl()}/v1/admin/settings/operator-payment-defaults`, {
-          credentials: "include",
-        }),
+        fetcher(`${baseUrl}/v1/admin/settings/operator-profile`),
+        fetcher(`${baseUrl}/v1/admin/settings/operator-payment-instructions`),
+        fetcher(`${baseUrl}/v1/admin/settings/operator-payment-defaults`),
       ])
       if (!profileRes.ok && !instructionsRes.ok && !defaultsRes.ok) return null
 
@@ -147,11 +150,11 @@ function OperatorProfilePage() {
 
   const save = useMutation({
     mutationFn: async (next: OperatorProfileForm) => {
+      const jsonHeaders = { "content-type": "application/json" }
       const responses = await Promise.all([
-        fetch(`${getApiUrl()}/v1/admin/settings/operator-profile`, {
+        fetcher(`${baseUrl}/v1/admin/settings/operator-profile`, {
           method: "PATCH",
-          credentials: "include",
-          headers: { "content-type": "application/json" },
+          headers: jsonHeaders,
           body: JSON.stringify({
             name: next.name ?? null,
             legalName: next.legalName ?? null,
@@ -167,10 +170,9 @@ function OperatorProfilePage() {
             signatoryRole: next.signatoryRole ?? null,
           }),
         }),
-        fetch(`${getApiUrl()}/v1/admin/settings/operator-payment-instructions`, {
+        fetcher(`${baseUrl}/v1/admin/settings/operator-payment-instructions`, {
           method: "PATCH",
-          credentials: "include",
-          headers: { "content-type": "application/json" },
+          headers: jsonHeaders,
           body: JSON.stringify({
             bankTransferBeneficiary: next.bankTransferBeneficiary ?? null,
             iban: next.iban ?? null,
@@ -178,10 +180,9 @@ function OperatorProfilePage() {
             notes: next.notes ?? null,
           }),
         }),
-        fetch(`${getApiUrl()}/v1/admin/settings/operator-payment-defaults`, {
+        fetcher(`${baseUrl}/v1/admin/settings/operator-payment-defaults`, {
           method: "PATCH",
-          credentials: "include",
-          headers: { "content-type": "application/json" },
+          headers: jsonHeaders,
           body: JSON.stringify({
             customerPaymentPolicy: next.customerPaymentPolicy ?? null,
             bookingCheckoutUrlTemplate: next.bookingCheckoutUrlTemplate || null,
@@ -474,5 +475,3 @@ function OperatorProfilePage() {
     </form>
   )
 }
-
-export const OperatorSettingsPage = OperatorProfilePage

--- a/packages/operator-settings-react/src/settings.ts
+++ b/packages/operator-settings-react/src/settings.ts
@@ -1,0 +1,44 @@
+import { adminRoutePageModule } from "@voyant-travel/admin/extensions"
+import type { AdminCoreSettingsExtraPage } from "@voyant-travel/admin-app/core-extension"
+import { Building } from "lucide-react"
+
+/**
+ * Options for {@link createOperatorProfileSettingsExtraPage}. All optional —
+ * the defaults reproduce the operator starter's placement (General group,
+ * leading order 10, Building icon) so a source-free admin renders the page
+ * identically.
+ */
+export interface OperatorProfileSettingsExtraPageOptions {
+  /** Path relative to the settings base path. Default `"/operator"`. */
+  path?: string
+  /** Position within the General group. Default `10` (leads the group). */
+  order?: number
+}
+
+/**
+ * The packaged Operator Profile settings page as an
+ * {@link AdminCoreSettingsExtraPage} descriptor. Spread the result into
+ * `createAdminCoreExtension({ settings: { extraPages: [...] } })` to mount the
+ * page — the same shape the operator starter uses, but source-free so the
+ * managed (package-only) admin can render it.
+ *
+ * The `page` thunk lazy-imports the heavy React page so it stays out of the
+ * chunk that evaluates the extension registry.
+ */
+export function createOperatorProfileSettingsExtraPage(
+  options: OperatorProfileSettingsExtraPageOptions = {},
+): AdminCoreSettingsExtraPage {
+  return {
+    id: "operator",
+    path: options.path ?? "/operator",
+    title: "Operator Profile",
+    label: (messages) => messages.settings.operator,
+    icon: Building,
+    group: "general",
+    order: options.order ?? 10,
+    page: () =>
+      import("./operator-profile-settings-page.js").then((module) =>
+        adminRoutePageModule(module.OperatorProfileSettingsPage),
+      ),
+  }
+}

--- a/packages/operator-settings-react/tsconfig.build.json
+++ b/packages/operator-settings-react/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+}

--- a/packages/operator-settings-react/tsconfig.json
+++ b/packages/operator-settings-react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/react-library.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/operator-settings-react/tsconfig.typecheck.json
+++ b/packages/operator-settings-react/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1184,6 +1184,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1185,6 +1185,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1186,6 +1186,10 @@
       "@voyant-travel/operations/schema": ["../operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": ["../operator-settings-react/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../operator-settings/dist/hono-module.d.ts"
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3113,6 +3113,58 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
 
+  packages/operator-settings-react:
+    dependencies:
+      '@voyant-travel/react':
+        specifier: workspace:^
+        version: link:../react
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@voyant-travel/admin':
+        specifier: workspace:^
+        version: link:../admin
+      '@voyant-travel/admin-app':
+        specifier: workspace:^
+        version: link:../admin-app
+      '@voyant-travel/finance':
+        specifier: workspace:^
+        version: link:../finance
+      '@voyant-travel/finance-react':
+        specifier: workspace:^
+        version: link:../finance-react
+      '@voyant-travel/ui':
+        specifier: workspace:^
+        version: link:../ui
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      lucide-react:
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/plugins/catalog-demo:
     dependencies:
       '@voyant-travel/catalog':
@@ -4512,6 +4564,9 @@ importers:
       '@voyant-travel/operations-react':
         specifier: workspace:^
         version: link:../../packages/operations-react
+      '@voyant-travel/operator-settings-react':
+        specifier: workspace:^
+        version: link:../../packages/operator-settings-react
       '@voyant-travel/quotes-react':
         specifier: workspace:^
         version: link:../../packages/quotes-react
@@ -4780,6 +4835,9 @@ importers:
       '@voyant-travel/operator-settings':
         specifier: workspace:^
         version: link:../../packages/operator-settings
+      '@voyant-travel/operator-settings-react':
+        specifier: workspace:^
+        version: link:../../packages/operator-settings-react
       '@voyant-travel/plugin-catalog-demo':
         specifier: workspace:^
         version: link:../../packages/plugins/catalog-demo

--- a/starters/managed-operator/package.json
+++ b/starters/managed-operator/package.json
@@ -39,6 +39,7 @@
     "@voyant-travel/mice-react": "workspace:^",
     "@voyant-travel/notifications-react": "workspace:^",
     "@voyant-travel/operations-react": "workspace:^",
+    "@voyant-travel/operator-settings-react": "workspace:^",
     "@voyant-travel/quotes-react": "workspace:^",
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/runtime": "workspace:^",

--- a/starters/managed-operator/src/managed-admin-extensions.tsx
+++ b/starters/managed-operator/src/managed-admin-extensions.tsx
@@ -21,6 +21,7 @@ import { createLegalAdminExtension } from "@voyant-travel/legal-react/admin"
 import { createMiceAdminExtension } from "@voyant-travel/mice-react/admin"
 import { createNotificationsAdminExtension } from "@voyant-travel/notifications-react/admin"
 import { createOperationsAdminExtension } from "@voyant-travel/operations-react/admin"
+import { createOperatorProfileSettingsExtraPage } from "@voyant-travel/operator-settings-react/settings"
 import { createQuotesAdminExtension } from "@voyant-travel/quotes-react/admin"
 import { createRelationshipsAdminExtension } from "@voyant-travel/relationships-react/admin"
 import { createTripsAdminExtension } from "@voyant-travel/trips-react/admin"
@@ -237,7 +238,15 @@ export function createManagedAdminExtensions(): AdminExtension[] {
   return [
     ...withManagedRouteMessagesProviders(
       createAdminExtensionRegistry(
-        createAdminCoreExtension(),
+        // The Operator Profile settings page is the one GENERAL settings item
+        // that is not a built-in core page — it edits the operator's
+        // contract identity via `@voyant-travel/operator-settings`'s
+        // `/v1/admin/settings/operator-*` routes (already mounted on the
+        // managed runtime). Mount the packaged, source-free page as an extra
+        // settings page so the managed admin matches the operator starter.
+        createAdminCoreExtension({
+          settings: { extraPages: [createOperatorProfileSettingsExtraPage()] },
+        }),
         createOperationsAdminExtension(),
         createBookingsAdminExtension(),
         createCatalogAdminExtension({

--- a/starters/managed-operator/tsconfig.client.json
+++ b/starters/managed-operator/tsconfig.client.json
@@ -1500,6 +1500,12 @@
       "@voyant-travel/operations/schema": ["../../packages/operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../../packages/operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../../packages/operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": [
+        "../../packages/operator-settings-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../../packages/operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../../packages/operator-settings/dist/hono-module.d.ts"
       ],

--- a/starters/managed-operator/tsconfig.server.json
+++ b/starters/managed-operator/tsconfig.server.json
@@ -1501,6 +1501,12 @@
       "@voyant-travel/operations/schema": ["../../packages/operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../../packages/operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../../packages/operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": [
+        "../../packages/operator-settings-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../../packages/operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../../packages/operator-settings/dist/hono-module.d.ts"
       ],

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -93,6 +93,7 @@
     "@voyant-travel/operations": "workspace:^",
     "@voyant-travel/operations-react": "workspace:^",
     "@voyant-travel/operator-settings": "workspace:^",
+    "@voyant-travel/operator-settings-react": "workspace:^",
     "@voyant-travel/plugin-catalog-demo": "workspace:^",
     "@voyant-travel/plugin-flights-demo": "workspace:^",
     "@voyant-travel/plugin-netopia": "^0.105.18",

--- a/starters/operator/src/lib/admin-extensions.tsx
+++ b/starters/operator/src/lib/admin-extensions.tsx
@@ -11,16 +11,9 @@ import {
   createAdminExtensionRegistry,
 } from "@voyant-travel/admin/extensions"
 import { createAdminCoreExtension } from "@voyant-travel/admin-app/core-extension"
+import { createOperatorProfileSettingsExtraPage } from "@voyant-travel/operator-settings-react/settings"
 import { Button } from "@voyant-travel/ui/components/button"
-import {
-  Building,
-  CalendarRange,
-  FileText,
-  Route,
-  ScrollText,
-  SlidersHorizontal,
-  Tag,
-} from "lucide-react"
+import { CalendarRange, FileText, Route, ScrollText, SlidersHorizontal, Tag } from "lucide-react"
 import { generatedAdminExtensionFactories } from "@/admin.extensions.generated"
 import type { AdminMessages } from "@/lib/admin-i18n"
 
@@ -277,10 +270,11 @@ function withOperatorRouteMessagesProviders(
 //   aggregates through TanStack Start server functions that read the
 //   database directly (cookie-authenticated), which no package can own —
 //   the package page consumes the same dashboard query keys client-side.
-// - the Operator Profile settings page: an app-custom page (it talks to the
-//   operator starter's `/v1/admin/settings/operator-*` endpoints, which
-//   have no packaged client yet) spliced into the packaged settings layout
-//   as an extra page, leading the General group.
+// - the Operator Profile settings page: package-delivered by
+//   `@voyant-travel/operator-settings-react` (it talks to the
+//   `/v1/admin/settings/operator-*` endpoints), spliced into the packaged
+//   settings layout as an extra page, leading the General group — the same
+//   descriptor the source-free managed admin mounts.
 function createCoreExtension() {
   return createAdminCoreExtension({
     dashboard: {
@@ -304,19 +298,11 @@ function createCoreExtension() {
     },
     settings: {
       extraPages: [
-        {
-          id: "operator",
-          path: "/operator",
-          title: "Operator Profile",
-          label: (messages) => messages.settings.operator,
-          icon: Building,
-          group: "general",
-          order: 10,
-          page: () =>
-            import("@/components/voyant/settings/operator-settings-page").then((module) =>
-              adminRoutePageModule(module.OperatorSettingsPage),
-            ),
-        },
+        // The Operator Profile page is now package-delivered
+        // (@voyant-travel/operator-settings-react) so the source-free managed
+        // admin can render the same page; the starter mounts the packaged
+        // descriptor instead of an app-custom source component.
+        createOperatorProfileSettingsExtraPage(),
         {
           id: "custom-fields",
           path: "/custom-fields",

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1501,6 +1501,12 @@
       "@voyant-travel/operations/schema": ["../../packages/operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../../packages/operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../../packages/operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": [
+        "../../packages/operator-settings-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../../packages/operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../../packages/operator-settings/dist/hono-module.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1501,6 +1501,12 @@
       "@voyant-travel/operations/schema": ["../../packages/operations/dist/schema.d.ts"],
       "@voyant-travel/operations/validation": ["../../packages/operations/dist/validation.d.ts"],
       "@voyant-travel/operator-settings": ["../../packages/operator-settings/dist/index.d.ts"],
+      "@voyant-travel/operator-settings-react": [
+        "../../packages/operator-settings-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/operator-settings-react/settings": [
+        "../../packages/operator-settings-react/dist/settings.d.ts"
+      ],
       "@voyant-travel/operator-settings/hono-module": [
         "../../packages/operator-settings/dist/hono-module.d.ts"
       ],


### PR DESCRIPTION
Closes #3061.

## Problem

The source-free managed operator admin (composed only from published
`@voyant-travel/*` packages, #2983 / #3044) was missing the **Operator
Profile** settings page — the only GENERAL/PRODUCTS settings item absent. This
was a **UI-packaging gap, not an API gap**: `@voyant-travel/operator-settings`
already ships the service + routes and the managed runtime mounts them
(`/v1/admin/settings/operator-*`), but the page itself lived as app-custom
source in the operator starter (`operator-settings-page.tsx`), so a package-only
admin had nowhere to load it from. Managed operators therefore could not edit
their contract identity even though the data layer was fully present.

## Change

Adds **`@voyant-travel/operator-settings-react`**, the packaged React UI
companion to the API-only `@voyant-travel/operator-settings`:

- Root export `OperatorProfileSettingsPage` — the page component. It resolves
  its API surface from the admin runtime context (`useVoyantReactContext`) and
  its copy from the shared operator admin messages (`useOperatorAdminMessages`,
  reusing the existing `@voyant-travel/i18n` catalog), so it renders with **no
  starter source**.
- `./settings` export `createOperatorProfileSettingsExtraPage()` — an
  `AdminCoreSettingsExtraPage` descriptor (General group, leading order 10,
  Building icon) to spread into
  `createAdminCoreExtension({ settings: { extraPages: [...] } })`. The heavy
  page is behind a lazy `page` thunk so it stays out of the extension-registry
  chunk.

Wiring:

- **managed-operator** mounts it via `createAdminCoreExtension`'s
  `settings.extraPages`, closing the last GENERAL settings gap for managed
  profiles.
- **operator** starter adopts the packaged descriptor and its ~480-line
  app-custom page is deleted — both admins now render the same page from one
  source of truth.

The `./settings` subpath name (rather than `./admin`) is deliberate: this is a
settings extra-page, not a nav-contributing domain admin extension, so it
correctly stays outside the `<module>-react/admin` codegen/drift convention.

## Verification

- `pnpm --filter @voyant-travel/operator-settings-react build` + `lint`
- `pnpm --filter managed-operator --filter operator typecheck` — both pass
- `verify:dep-paths`, `verify:dist-configs`, `verify:package-exports`,
  `verify:client-package-boundaries`, `verify:admin-composition-drift`,
  `verify:dependency-versions`, `verify:lockstep-membership` — all pass
- `pnpm release:plan` — clean (new package bumps minor; no mixed changeset)

Live in-browser smoke against a managed runtime is recommended as a follow-up;
the page JSX is byte-identical to the shipped operator page, with only the i18n
hook and fetcher wiring changed (both proven equivalent — `operatorFetcher` is
literally `managedProfileAdminFetcher`).