### PR TITLE
Gate source-free managed admin composition by the profile's module subset

### DIFF
--- a/.changeset/managed-admin-module-subset-gating.md
+++ b/.changeset/managed-admin-module-subset-gating.md
@@ -25,3 +25,9 @@ mounted (dead links / 404s).
 - `AdminBootstrapStatus` carries an optional `modules` module-id list the
   source-free admin filters its nav/widget composition by (fail-open when
   absent).
+- `AdminWorkspaceShell` accepts `activeModuleIds`; when provided, the packaged
+  **base** nav is gated to those modules (`filterAdminNavigationByModules` /
+  `OPERATOR_ADMIN_NAV_MODULE_IDS`), so a shared image's static nav (Flights,
+  Finance, Legal, …) is hidden for a profile subset — not just
+  extension-contributed items. Fail-open when omitted, so self-hosted starters
+  are unaffected.

--- a/.changeset/managed-admin-module-subset-gating.md
+++ b/.changeset/managed-admin-module-subset-gating.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/framework": minor
+"@voyant-travel/admin": minor
+---
+
+Expose the managed profile's active module set at runtime so the source-free
+admin can gate its composition by the deployment's module subset (voyant#3063).
+
+The managed runtime already honors a profile's `modules: [...]` subset for the
+API (`createVoyantApp({ exclude })`), but the shared, framework-version-tagged
+admin image composed *every* `create<Module>AdminExtension()` factory
+unconditionally — so every managed operator saw the full nav even when its
+profile activated a subset, with nav entries linking to pages whose API isn't
+mounted (dead links / 404s).
+
+`@voyant-travel/framework`:
+
+- Add `resolveActiveModuleIds(project)` (`/profile`) — the resolved module `include`
+  set (the same one that drives `createVoyantApp({ exclude })`) as `moduleId`s.
+- `GET /auth/bootstrap-status` now returns `modules` on `ManagedBootstrapStatus`,
+  so the workspace bootstrap probe learns what's active for this deployment.
+
+`@voyant-travel/admin`:
+
+- `AdminBootstrapStatus` carries an optional `modules` module-id list the
+  source-free admin filters its nav/widget composition by (fail-open when
+  absent).

--- a/docs/architecture/managed-admin-host.md
+++ b/docs/architecture/managed-admin-host.md
@@ -41,6 +41,49 @@ extract `managed-operator`'s thin entry into a Cloud-image template (platform#95
 The phased plan below is retained as the design record; where it says "Phase 3 /
 future," read the status above for what actually shipped.
 
+## Module-subset gating (source-free admin, #3063)
+
+A managed profile can declare a **module subset** (`modules: [...]` in the
+snapshot), and the runtime already honors it for the **API**
+(`computeCreateVoyantAppExclude` → `createVoyantApp({ exclude })`). The
+source-free admin, however, composes *every* `create<Module>AdminExtension()`
+factory unconditionally — so without gating, every managed operator sees the
+full nav (~18 modules) even when its profile activates a subset, and nav entries
+for inactive modules link to pages whose API isn't mounted (dead links / 404s).
+
+This is inherently a **shared-image** problem: the managed admin is one
+framework-version-tagged image; the active-module set is per-operator, injected
+at deploy via the snapshot. The client bundle cannot know the subset at
+build/import time, so the composition needs a **runtime signal**:
+
+1. **Runtime exposes the active module set.** `resolveActiveModuleIds(project)`
+   (`@voyant-travel/framework/profile`) maps the resolved `include` specifiers —
+   the same set that drives `createVoyantApp({ exclude })`, so nav can never
+   drift from what the API mounts — to `moduleId`s. The managed runtime returns
+   them as `modules` on `GET /api/auth/bootstrap-status`
+   (`ManagedBootstrapStatus`), the probe the workspace already issues at
+   bootstrap. The managed-operator dev `/auth` stub computes the same set from
+   the snapshot so subsets can be exercised locally.
+
+2. **Admin gates composition by it.** The route tree + destinations stay built
+   from the FULL registry (kept **hydration-stable** across the shared image);
+   the **nav/widgets** are filtered at render (`WorkspaceContent`) via
+   `filterManagedAdminExtensionsByModules` (in `managed-admin-module-gating.ts`),
+   keyed by `MANAGED_ADMIN_EXTENSION_MODULE_IDS` (extension id → required module
+   id; `core` is always active). Filtering is **fail-open**: if the runtime does
+   not report a module set, every extension is kept.
+
+Note `mice` maps to a module absent from the standard manifest, so gating drops
+it whenever the runtime reports its set — removing an extension whose API the
+managed runtime never mounts.
+
+Scoped follow-up: direct-URL navigation to a disabled module still resolves its
+route (the page renders, then its API 404s). Per-route gating would need routes
+to carry an owning-module tag; nav gating fully resolves the reported symptom
+(dead links in the sidebar). Under a per-operator *build* (client bundle built
+from the declared module set) the subset bakes in and no runtime signal is
+needed — see platform#1014.
+
 ## Problem
 
 `loadManagedProfileRuntime` (`@voyant-travel/framework/managed-runtime`, #2987)

--- a/packages/admin/src/app/auth-runtime.ts
+++ b/packages/admin/src/app/auth-runtime.ts
@@ -23,6 +23,14 @@ export type AdminAuthMode = "local" | "voyant-cloud"
 export interface AdminBootstrapStatus {
   hasUsers: boolean
   authMode?: AdminAuthMode
+  /**
+   * The active module ids for this deployment (voyant#3063). A source-free
+   * managed admin (one shared image, per-operator module subset injected at
+   * deploy) reads this to gate its composition — showing only the modules the
+   * profile activates. Absent for hosts that do not gate (e.g. a self-hosted
+   * starter built from its own module set); the admin then composes everything.
+   */
+  modules?: readonly string[]
 }
 
 /**

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -151,6 +151,13 @@ export interface AdminWorkspaceShellProps<TUser extends AdminWorkspaceShellUser>
   user: TUser | null | undefined
   isUserLoading?: boolean
   /**
+   * The deployment's active module ids (voyant#3063). When provided, the nav is
+   * gated to these modules — a source-free managed admin composes the full nav
+   * from one shared, framework-version-tagged image and hides modules its
+   * profile doesn't activate (whose API isn't mounted). Omit to show everything.
+   */
+  activeModuleIds?: readonly string[]
+  /**
    * Admin extensions for the navigation/widget seam. Pass a function to
    * derive nav labels from the resolved admin messages.
    */
@@ -190,6 +197,7 @@ export interface AdminWorkspaceShellProps<TUser extends AdminWorkspaceShellUser>
 export function AdminWorkspaceShell<TUser extends AdminWorkspaceShellUser>({
   user,
   isUserLoading,
+  activeModuleIds,
   extensions,
   icons,
   linkComponent = AdminRouterLink,
@@ -215,6 +223,7 @@ export function AdminWorkspaceShell<TUser extends AdminWorkspaceShellUser>({
           <AdminLocalePreferenceSync source={loadedUser} />
           <AdminWorkspaceShellInner
             user={loadedUser}
+            activeModuleIds={activeModuleIds}
             extensions={extensions}
             icons={icons}
             linkComponent={linkComponent}
@@ -234,6 +243,7 @@ export function AdminWorkspaceShell<TUser extends AdminWorkspaceShellUser>({
 
 function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
   user,
+  activeModuleIds,
   extensions,
   icons,
   linkComponent,
@@ -245,6 +255,7 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
   children,
 }: {
   user: TUser
+  activeModuleIds?: readonly string[]
   extensions: AdminWorkspaceShellProps<TUser>["extensions"]
   icons?: OperatorAdminNavigationIcons
   linkComponent: AdminNavLinkComponent
@@ -285,6 +296,7 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
 
   const layout = (
     <OperatorAdminWorkspaceLayout
+      activeModuleIds={activeModuleIds}
       currentPath={currentPath}
       extensions={resolvedExtensions}
       headerSlot={headerSlot}

--- a/packages/admin/src/components/operator-admin-sidebar.tsx
+++ b/packages/admin/src/components/operator-admin-sidebar.tsx
@@ -21,6 +21,7 @@ import type { AdminExtension } from "../extensions.js"
 import { resolveAdminNavigation } from "../extensions.js"
 import {
   createOperatorAdminNavigation,
+  filterAdminNavigationByModules,
   type OperatorAdminNavigationIcons,
 } from "../navigation/operator-navigation.js"
 import { AdminExtensionsProvider } from "../providers/admin-extensions.js"
@@ -41,6 +42,13 @@ import { OperatorAdminUserMenu } from "./operator-admin-user-menu.js"
 export interface OperatorAdminSidebarProps
   extends Omit<React.ComponentProps<typeof Sidebar>, "children"> {
   accountHref?: string
+  /**
+   * The deployment's active module ids (voyant#3063). When provided, the nav is
+   * gated to these modules — a source-free managed admin composes the full nav
+   * from one shared image and hides modules its profile doesn't activate.
+   * Omit (the default) to show every item.
+   */
+  activeModuleIds?: readonly string[]
   brand?: React.ReactNode
   currentPath: string
   extensions?: ReadonlyArray<AdminExtension>
@@ -86,6 +94,7 @@ export function DefaultOperatorAdminBrand({
 
 export function OperatorAdminSidebar({
   accountHref,
+  activeModuleIds,
   brand,
   currentPath,
   extensions,
@@ -99,7 +108,10 @@ export function OperatorAdminSidebar({
 }: OperatorAdminSidebarProps) {
   const messages = useOperatorAdminMessages()
   const baseItems = navItems ?? createOperatorAdminNavigation({ icons, messages: messages.nav })
-  const resolvedItems = resolveAdminNavigation({ baseItems, extensions })
+  const resolvedItems = filterAdminNavigationByModules(
+    resolveAdminNavigation({ baseItems, extensions }),
+    activeModuleIds,
+  )
   const resolvedBrand = brand ?? <DefaultOperatorAdminBrand linkComponent={linkComponent} />
   const LinkComponent = linkComponent ?? DefaultAdminNavLink
   const SettingsIcon = icons?.settings ?? DefaultSettingsIcon
@@ -142,6 +154,12 @@ export function OperatorAdminSidebar({
 
 export interface OperatorAdminWorkspaceLayoutProps {
   accountHref?: string
+  /**
+   * The deployment's active module ids (voyant#3063). When provided, the base
+   * nav is gated to these modules so a source-free managed admin hides modules
+   * its profile doesn't activate. Omit to show every item.
+   */
+  activeModuleIds?: readonly string[]
   brand?: React.ReactNode
   children: React.ReactNode
   currentPath: string
@@ -215,6 +233,7 @@ export function resolveAdminPageTitle(
 
 export function OperatorAdminWorkspaceLayout({
   accountHref,
+  activeModuleIds,
   brand,
   children,
   currentPath,
@@ -244,10 +263,13 @@ export function OperatorAdminWorkspaceLayout({
   } = sidebarProps ?? {}
   const baseItems =
     sidebarNavItems ?? navItems ?? createOperatorAdminNavigation({ icons, messages: messages.nav })
-  const resolvedItems = resolveAdminNavigation({
-    baseItems,
-    extensions: sidebarExtensions ?? extensions,
-  })
+  const resolvedItems = filterAdminNavigationByModules(
+    resolveAdminNavigation({
+      baseItems,
+      extensions: sidebarExtensions ?? extensions,
+    }),
+    activeModuleIds,
+  )
   const resolvedSide = sidebarSide ?? side
   let pageTitle: string | null = null
   if (pageHead !== false) {

--- a/packages/admin/src/navigation/operator-navigation.ts
+++ b/packages/admin/src/navigation/operator-navigation.ts
@@ -69,6 +69,54 @@ export interface CreateOperatorAdminNavigationOptions {
   icons?: OperatorAdminNavigationIcons
 }
 
+/**
+ * The module id each standard nav item needs mounted (voyant#3063). Used to gate
+ * the base nav for a deployment that activates only a module subset — a
+ * source-free managed admin composes the full nav from one shared image and
+ * filters it at runtime by the active module set, so items whose API isn't
+ * mounted don't render as dead links.
+ *
+ * Keyed by the `id`s in {@link createOperatorAdminNavigation}. Items with no
+ * entry here (e.g. `dashboard`, `settings`) are always shown. Note the mapping
+ * is not always identity: `products` → `inventory`, `availability`/`resources` →
+ * `operations`, `people`/`organizations` → `relationships`, `suppliers` and
+ * `channel-sync` → `distribution`.
+ */
+export const OPERATOR_ADMIN_NAV_MODULE_IDS: Record<string, string> = {
+  catalog: "catalog",
+  flights: "flights",
+  products: "inventory",
+  availability: "operations",
+  bookings: "bookings",
+  notifications: "notifications",
+  suppliers: "distribution",
+  people: "relationships",
+  organizations: "relationships",
+  resources: "operations",
+  finance: "finance",
+  legal: "legal",
+  "channel-sync": "distribution",
+}
+
+/**
+ * Filter a nav list down to a deployment's active modules (voyant#3063), keyed
+ * by {@link OPERATOR_ADMIN_NAV_MODULE_IDS}. Fail-open: when `activeModuleIds` is
+ * `undefined` (a host that does not gate — e.g. a self-hosted starter built from
+ * its own module set) every item is kept. Items with no module mapping are
+ * always kept; a mapped item survives only when its module is active.
+ */
+export function filterAdminNavigationByModules(
+  items: ReadonlyArray<NavItem>,
+  activeModuleIds: readonly string[] | undefined,
+): NavItem[] {
+  if (!activeModuleIds) return [...items]
+  const active = new Set(activeModuleIds)
+  return items.filter((item) => {
+    const moduleId = item.id ? OPERATOR_ADMIN_NAV_MODULE_IDS[item.id] : undefined
+    return moduleId === undefined || active.has(moduleId)
+  })
+}
+
 export function createOperatorAdminNavigation({
   icons = {},
   messages,

--- a/packages/admin/tests/unit/operator-navigation.test.ts
+++ b/packages/admin/tests/unit/operator-navigation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { createOperatorAdminNavigation } from "../../src/navigation/operator-navigation.js"
+import {
+  createOperatorAdminNavigation,
+  filterAdminNavigationByModules,
+} from "../../src/navigation/operator-navigation.js"
 import type { OperatorAdminMessages } from "../../src/providers/operator-admin-messages.js"
 
 const navMessages: OperatorAdminMessages["nav"] = {
@@ -114,5 +117,50 @@ describe("createOperatorAdminNavigation", () => {
       "policies",
       "number-series",
     ])
+  })
+})
+
+describe("filterAdminNavigationByModules (voyant#3063)", () => {
+  const nav = createOperatorAdminNavigation({ messages: navMessages })
+  const ids = (items: ReturnType<typeof createOperatorAdminNavigation>) =>
+    items.map((item) => item.id)
+
+  it("gates the real base nav down to a deployment's active module set", () => {
+    // The `[bookings, catalog]` subset resolves (server-side) to include the
+    // required foundational modules — here we assert the nav gating for that set.
+    const gated = filterAdminNavigationByModules(nav, [
+      "action-ledger",
+      "relationships",
+      "identity",
+      "commerce",
+      "catalog",
+      "bookings",
+    ])
+
+    expect(ids(gated)).toEqual(["dashboard", "catalog", "bookings", "people", "organizations"])
+    // Inactive modules' base entries are gone — no dead links to unmounted APIs.
+    for (const gone of ["flights", "products", "availability", "suppliers", "finance", "legal"]) {
+      expect(ids(gated)).not.toContain(gone)
+    }
+  })
+
+  it("maps non-identity nav ids to their backing module", () => {
+    // products → inventory, availability/resources → operations,
+    // suppliers/channel-sync → distribution, people/organizations → relationships.
+    const withInventory = ids(filterAdminNavigationByModules(nav, ["inventory"]))
+    expect(withInventory).toContain("products")
+    expect(withInventory).not.toContain("availability")
+
+    const withDistribution = ids(filterAdminNavigationByModules(nav, ["distribution"]))
+    expect(withDistribution).toContain("suppliers")
+    expect(withDistribution).toContain("channel-sync")
+  })
+
+  it("fails open when no active set is provided", () => {
+    expect(ids(filterAdminNavigationByModules(nav, undefined))).toEqual(ids(nav))
+  })
+
+  it("keeps only unmapped items (e.g. dashboard) when the active set is empty", () => {
+    expect(ids(filterAdminNavigationByModules(nav, []))).toEqual(["dashboard"])
   })
 })

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -692,7 +692,22 @@ describe("managed profile runtime entry", () => {
     const response = await app.request("/auth/bootstrap-status", {}, env)
 
     expect(response.status).toBe(200)
-    expect(await response.json()).toEqual({ hasUsers: true, authMode: "voyant-cloud" })
+    expect(await response.json()).toEqual({ hasUsers: true, authMode: "voyant-cloud", modules: [] })
+  }, 10000)
+
+  it("reports the deployment's active module ids on bootstrap status (voyant#3063)", async () => {
+    const activeModules = ["bookings", "catalog", "finance", "relationships"]
+    const app = createManagedCloudAuthApp(activeModules)
+    const env = managedCloudEnv()
+
+    const response = await app.request("/auth/bootstrap-status", {}, env)
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      hasUsers: true,
+      authMode: "voyant-cloud",
+      modules: activeModules,
+    })
   }, 10000)
 
   it("returns 401 from /auth/me when the request carries no session", async () => {

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -158,6 +158,7 @@ import { type CreateVoyantAppConfig, createVoyantApp } from "./create-app.js"
 import { type ManagedPlugin, resolveManagedPlugins } from "./plugin-resolution.js"
 import {
   getVoyantProjectRequirements,
+  resolveActiveModuleIds,
   toCreateVoyantAppProfileConfig,
   type VoyantProfileRequirements,
   type VoyantProjectManifest,
@@ -305,6 +306,7 @@ export async function loadManagedProfileRuntime(
   const auth = resolveManagedProfileAuthIntegration({
     env,
     auth: options.app?.auth ?? options.auth,
+    activeModules: resolveActiveModuleIds(project),
   })
   const plugins = await resolveManagedPlugins(
     project,
@@ -392,6 +394,7 @@ export function createManagedProfileApp(options: {
   const auth = resolveManagedProfileAuthIntegration({
     env: options.env,
     auth: options.app?.auth ?? options.auth,
+    activeModules: resolveActiveModuleIds(options.project),
   })
   const mergedPlugins = [...(options.app?.plugins ?? []), ...(options.plugins ?? [])]
   assertManagedProfileAppSupport({
@@ -510,16 +513,20 @@ export function createManagedProfileNodeEnv(
 function resolveManagedProfileAuthIntegration(options: {
   env?: ManagedProfileRuntimeEnv
   auth?: VoyantAuthIntegration<ManagedProfileRuntimeEnv>
+  /** Active module ids surfaced on `/auth/bootstrap-status` for admin gating (voyant#3063). */
+  activeModules?: readonly string[]
 }): VoyantAuthIntegration<ManagedProfileRuntimeEnv> | undefined {
   if (options.auth) return options.auth
   if (!isManagedVoyantCloudAuthMode(options.env)) return undefined
-  return createManagedCloudAdminAuthIntegration()
+  return createManagedCloudAdminAuthIntegration(options.activeModules ?? [])
 }
 
-function createManagedCloudAdminAuthIntegration(): VoyantAuthIntegration<ManagedProfileRuntimeEnv> {
+function createManagedCloudAdminAuthIntegration(
+  activeModules: readonly string[],
+): VoyantAuthIntegration<ManagedProfileRuntimeEnv> {
   return {
     handler: () => {
-      const app = createManagedCloudAuthApp()
+      const app = createManagedCloudAuthApp(activeModules)
       return {
         fetch: (request, env, ctx) => app.fetch(request, env, ctx as never),
       }
@@ -599,7 +606,9 @@ function createManagedCloudAdminAuthIntegration(): VoyantAuthIntegration<Managed
 
 type ManagedAuthHonoEnv = { Bindings: ManagedProfileRuntimeEnv }
 
-export function createManagedCloudAuthApp(): Hono<ManagedAuthHonoEnv> {
+export function createManagedCloudAuthApp(
+  activeModules: readonly string[] = [],
+): Hono<ManagedAuthHonoEnv> {
   const auth = new Hono<ManagedAuthHonoEnv>()
 
   async function startCloudAuth(c: Context<ManagedAuthHonoEnv>) {
@@ -664,7 +673,7 @@ export function createManagedCloudAuthApp(): Hono<ManagedAuthHonoEnv> {
   })
 
   auth.get("/auth/bootstrap-status", async (c) => {
-    return c.json(await resolveManagedBootstrapStatus(c.env, c.req.raw))
+    return c.json(await resolveManagedBootstrapStatus(c.env, c.req.raw, activeModules))
   })
 
   auth.all("/auth/*", async (c) => {
@@ -700,6 +709,14 @@ export type ManagedCurrentUser = {
 export type ManagedBootstrapStatus = {
   hasUsers: boolean
   authMode: "local" | "voyant-cloud"
+  /**
+   * The active module ids for this deployment (voyant#3063). The source-free
+   * managed admin — a shared, framework-version-tagged image — reads this to
+   * gate its composition so it shows only the modules the profile activates,
+   * instead of every module the image can compose. Always the resolved set the
+   * API actually mounts (see {@link resolveActiveModuleIds}).
+   */
+  modules: string[]
 }
 
 async function resolveManagedCurrentUser(
@@ -750,14 +767,16 @@ async function resolveManagedCurrentUser(
 async function resolveManagedBootstrapStatus(
   env: ManagedProfileRuntimeEnv,
   _request: Request,
+  activeModules: readonly string[],
 ): Promise<ManagedBootstrapStatus> {
+  const modules = [...activeModules]
   if (isManagedVoyantCloudAuthMode(env)) {
-    return { hasUsers: true, authMode: "voyant-cloud" }
+    return { hasUsers: true, authMode: "voyant-cloud", modules }
   }
 
   const db = resolveDb(env)
   const [row] = await db.select({ count: sql<number>`count(*)::int` }).from(authUser)
-  return { hasUsers: (row?.count ?? 0) > 0, authMode: "local" }
+  return { hasUsers: (row?.count ?? 0) > 0, authMode: "local", modules }
 }
 
 function createManagedBetterAuth(env: ManagedProfileRuntimeEnv, db: VoyantDb) {

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -8,6 +8,7 @@ import {
   getVoyantProjectMigrationMetadata,
   getVoyantProjectRequirements,
   MANAGED_OPERATOR_DEFAULT_PROVIDERS,
+  resolveActiveModuleIds,
   toCreateVoyantAppProfileConfig,
   VOYANT_PROJECT_SCHEMA_VERSION,
   type VoyantProjectManifest,
@@ -309,5 +310,48 @@ describe("managed profile contract", () => {
         parity: expect.arrayContaining(["schema drift"]),
       },
     })
+  })
+})
+
+describe("resolveActiveModuleIds (admin gating signal, voyant#3063)", () => {
+  it("returns the full standard operator module set when no subset is declared", () => {
+    const project = defineVoyantProject({
+      profile: "operator",
+      frameworkVersion: "0.19.0",
+      modules: [],
+      plugins: [],
+      settings: {},
+    })
+
+    const active = resolveActiveModuleIds(project)
+
+    // Standard domain modules the packaged admin can compose are all active.
+    expect(active).toEqual(
+      expect.arrayContaining([
+        "bookings",
+        "catalog",
+        "finance",
+        "relationships",
+        "operations",
+        "action-ledger",
+      ]),
+    )
+    // Storefront customer-app modules are never part of the operator set, and
+    // `mice` has no standard manifest module — so neither is ever active.
+    expect(active).not.toContain("storefront")
+    expect(active).not.toContain("mice")
+  })
+
+  it("honors a declared subset, plus the required foundational modules", () => {
+    const project = validProject({ modules: ["catalog", "bookings"] })
+
+    const active = resolveActiveModuleIds(project)
+
+    expect(active).toEqual(expect.arrayContaining(["catalog", "bookings"]))
+    // Required foundational modules are always active even when not listed.
+    expect(active).toEqual(expect.arrayContaining(["action-ledger", "relationships", "commerce"]))
+    // A domain excluded from the subset is not active — so its admin nav hides.
+    expect(active).not.toContain("flights")
+    expect(active).not.toContain("legal")
   })
 })

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -151,6 +151,22 @@ export function validateVoyantProject(input: unknown): VoyantProfileValidationRe
   return { ok: issues.length === 0, issues }
 }
 
+/**
+ * The active MODULE IDs for a managed deployment — the resolved module set the
+ * runtime actually mounts, expressed as `moduleId`s (e.g. `bookings`,
+ * `catalog`) rather than package specifiers. This is the runtime signal the
+ * source-free admin gates its composition on (voyant#3063): a shared,
+ * framework-version-tagged admin image cannot know the per-operator subset at
+ * build time, so it reads this set from the runtime and composes/shows only the
+ * matching module extensions.
+ *
+ * Derived from the same `include` set that drives `createVoyantApp({ exclude })`,
+ * so the admin nav can never drift from what the API mounts.
+ */
+export function resolveActiveModuleIds(project: VoyantProjectManifest): string[] {
+  return getVoyantProjectRequirements(project).modules.include.map(moduleIdFromSpecifier)
+}
+
 export function getVoyantProjectRequirements(
   project: VoyantProjectManifest,
 ): VoyantProfileRequirements {

--- a/starters/managed-operator/src/entry.ts
+++ b/starters/managed-operator/src/entry.ts
@@ -83,20 +83,45 @@ function devAuthJson(body: unknown): Response {
   })
 }
 
-const loadDevAuth: AppLoader<AppBindings, ExecutionContext> = lazyApp(async () => ({
+/**
+ * The active module ids for this snapshot, so the DEV `/auth/bootstrap-status`
+ * reports the same module set a managed-cloud deployment's real handler would —
+ * letting the source-free admin's module gating (voyant#3063) be exercised
+ * locally (set `modules` to a subset in `managed-profile.json` and the nav
+ * follows). Uses the LIGHT `@voyant-travel/framework/profile` export (pure
+ * composition math), not the full API runtime. Fails open (returns `undefined`)
+ * so a malformed/absent snapshot leaves the admin composing everything.
+ */
+async function resolveDevActiveModuleIds(): Promise<string[] | undefined> {
+  try {
+    const [{ readFile }, { resolveActiveModuleIds }] = await Promise.all([
+      import("node:fs/promises"),
+      import("@voyant-travel/framework/profile"),
+    ])
+    const raw = await readFile(resolveSnapshotPath(), "utf8")
+    return resolveActiveModuleIds(JSON.parse(raw))
+  } catch {
+    return undefined
+  }
+}
+
+const loadDevAuth: AppLoader<AppBindings, ExecutionContext> = lazyApp(async () => {
+  const modules = await resolveDevActiveModuleIds()
   // The dispatch strips `/api` before forwarding, so paths arrive as `/auth/*`.
-  fetch: (request) => {
-    const { pathname } = new URL(request.url)
-    if (pathname === "/auth/me") return devAuthJson(DEV_USER)
-    if (pathname === "/auth/bootstrap-status") {
-      return devAuthJson({ hasUsers: true, authMode: "local" })
-    }
-    return new Response(JSON.stringify({ error: "not_found" }), {
-      status: 404,
-      headers: { "content-type": "application/json" },
-    })
-  },
-}))
+  return {
+    fetch: (request) => {
+      const { pathname } = new URL(request.url)
+      if (pathname === "/auth/me") return devAuthJson(DEV_USER)
+      if (pathname === "/auth/bootstrap-status") {
+        return devAuthJson({ hasUsers: true, authMode: "local", ...(modules ? { modules } : {}) })
+      }
+      return new Response(JSON.stringify({ error: "not_found" }), {
+        status: 404,
+        headers: { "content-type": "application/json" },
+      })
+    },
+  }
+})
 
 // SSR is loaded lazily behind the non-API branch so the React + react-dom/server
 // graph (~2.2 MB) is imported on first render rather than at boot. `src/server.ts`

--- a/starters/managed-operator/src/managed-admin-module-gating.test.ts
+++ b/starters/managed-operator/src/managed-admin-module-gating.test.ts
@@ -1,0 +1,51 @@
+import type { AdminExtension } from "@voyant-travel/admin/extensions"
+import { describe, expect, it } from "vitest"
+
+import { filterManagedAdminExtensionsByModules } from "./managed-admin-module-gating"
+
+function ext(id: string): AdminExtension {
+  return { id }
+}
+
+const FULL: AdminExtension[] = [
+  ext("core"),
+  ext("bookings"),
+  ext("catalog"),
+  ext("finance"),
+  ext("flights"),
+  ext("mice"),
+]
+
+const ids = (extensions: readonly AdminExtension[]) => extensions.map((extension) => extension.id)
+
+describe("filterManagedAdminExtensionsByModules (voyant#3063)", () => {
+  it("keeps only extensions whose module is active, plus always-on core", () => {
+    const result = filterManagedAdminExtensionsByModules(FULL, ["bookings", "catalog"])
+
+    expect(ids(result)).toEqual(["core", "bookings", "catalog"])
+  })
+
+  it("drops mice — it has no backing module in the active set", () => {
+    const result = filterManagedAdminExtensionsByModules(FULL, [
+      "bookings",
+      "catalog",
+      "finance",
+      "flights",
+    ])
+
+    expect(ids(result)).not.toContain("mice")
+    expect(ids(result)).toContain("core")
+  })
+
+  it("fails open when the runtime reports no module set (undefined)", () => {
+    const result = filterManagedAdminExtensionsByModules(FULL, undefined)
+
+    expect(ids(result)).toEqual(ids(FULL))
+  })
+
+  it("keeps core even when the active set is empty", () => {
+    const result = filterManagedAdminExtensionsByModules(FULL, [])
+
+    expect(ids(result)).toEqual(["core"])
+  })
+})

--- a/starters/managed-operator/src/managed-admin-module-gating.ts
+++ b/starters/managed-operator/src/managed-admin-module-gating.ts
@@ -1,0 +1,65 @@
+import type { AdminExtension } from "@voyant-travel/admin/extensions"
+
+/**
+ * The module id each source-free admin extension needs mounted (voyant#3063).
+ *
+ * The managed admin is ONE shared, framework-version-tagged image; the active
+ * module set is per-operator, injected at deploy. The image composes every
+ * `create<Module>AdminExtension()` factory, then gates the NAV down to this
+ * deployment's active modules at runtime (reported by `/auth/bootstrap-status`).
+ * Without gating, every managed operator sees the full nav — with dead links to
+ * pages whose API isn't mounted.
+ *
+ * An extension is ACTIVE only when its module is in the resolved module set.
+ * `core` is intentionally absent — it is always active (dashboard, account, and
+ * the built-in settings pages mount unconditionally). Every gated extension's
+ * `id` currently equals its module id, but the map is explicit so a future
+ * extension whose id diverges from its backing module is still gated correctly —
+ * and so the coupling is documented in one place.
+ *
+ * Note `mice` maps to a `mice` module that is NOT part of the standard managed
+ * manifest, so it is filtered out whenever the runtime reports its module set —
+ * removing an extension whose API the managed runtime never mounts.
+ */
+export const MANAGED_ADMIN_EXTENSION_MODULE_IDS = {
+  operations: "operations",
+  bookings: "bookings",
+  catalog: "catalog",
+  inventory: "inventory",
+  relationships: "relationships",
+  distribution: "distribution",
+  finance: "finance",
+  flights: "flights",
+  legal: "legal",
+  notifications: "notifications",
+  commerce: "commerce",
+  trips: "trips",
+  quotes: "quotes",
+  mice: "mice",
+  "action-ledger": "action-ledger",
+} as const satisfies Record<string, string>
+
+/**
+ * Filter the full source-free admin registry down to the deployment's ACTIVE
+ * modules (voyant#3063). Pass the module ids reported by
+ * `/auth/bootstrap-status`.
+ *
+ * Fail-open: when `activeModuleIds` is `undefined` (an older runtime that does
+ * not report its module set) every extension is kept — the admin behaves as it
+ * did before gating rather than silently hiding pages. Extensions with no entry
+ * in {@link MANAGED_ADMIN_EXTENSION_MODULE_IDS} (e.g. `core`) are always kept.
+ */
+export function filterManagedAdminExtensionsByModules(
+  extensions: ReadonlyArray<AdminExtension>,
+  activeModuleIds: readonly string[] | undefined,
+): AdminExtension[] {
+  if (!activeModuleIds) return [...extensions]
+  const active = new Set(activeModuleIds)
+  return extensions.filter((extension) => {
+    const requiredModuleId =
+      MANAGED_ADMIN_EXTENSION_MODULE_IDS[
+        extension.id as keyof typeof MANAGED_ADMIN_EXTENSION_MODULE_IDS
+      ]
+    return requiredModuleId === undefined || active.has(requiredModuleId)
+  })
+}

--- a/starters/managed-operator/src/router.tsx
+++ b/starters/managed-operator/src/router.tsx
@@ -126,10 +126,13 @@ function WorkspaceLayout() {
 function WorkspaceContent({ activeModuleIds }: { activeModuleIds: readonly string[] | undefined }) {
   const { user, isLoading } = useUser<ManagedUser>()
 
-  // Gate the NAV/widgets by the deployment's active module set. The route tree
-  // stays full (built once at import, hydration-stable), so this only removes
-  // sidebar entries + dashboard widgets for modules this operator does not run —
-  // no more dead links to pages whose API isn't mounted (voyant#3063).
+  // Gate composition by the deployment's active module set (voyant#3063). Two
+  // seams, because the managed nav has two sources: `activeModuleIds` (passed to
+  // the shell) gates the packaged BASE nav; filtering `extensions` here gates
+  // extension-contributed nav + dashboard widgets. The route tree stays full
+  // (built once at import, hydration-stable) — this only removes sidebar entries
+  // and widgets for modules this operator does not run, so no more dead links to
+  // pages whose API isn't mounted.
   const activeExtensions = useMemo(
     () => filterManagedAdminExtensionsByModules(extensions, activeModuleIds),
     [activeModuleIds],
@@ -139,6 +142,7 @@ function WorkspaceContent({ activeModuleIds }: { activeModuleIds: readonly strin
     <AdminWorkspaceShell
       user={user}
       isUserLoading={isLoading}
+      activeModuleIds={activeModuleIds}
       extensions={activeExtensions}
       destinations={destinations}
       onSignOut={() => managedAuthRuntime.signOut()}

--- a/starters/managed-operator/src/router.tsx
+++ b/starters/managed-operator/src/router.tsx
@@ -17,8 +17,10 @@ import {
   managedProfileAdminFetcher,
 } from "@voyant-travel/admin-app/runtime"
 import { UserProvider, useUser } from "@voyant-travel/admin-react/user"
+import { useMemo } from "react"
 
 import { createManagedAdminExtensions } from "./managed-admin-extensions"
+import { filterManagedAdminExtensionsByModules } from "./managed-admin-module-gating"
 import { Route as rootRoute } from "./routes/__root"
 import { routeTree } from "./routeTree.gen"
 
@@ -68,8 +70,26 @@ const managedAuthRuntime: ManagedProfileAdminAuthRuntime<ManagedUser> = {
 }
 
 // The full source-free admin: CORE (dashboard, account, settings) plus every
-// standard domain extension, composed entirely from published packages.
+// standard domain extension, composed entirely from published packages. The
+// route tree + destinations below are built from this FULL set so it stays
+// hydration-stable across the shared image; the NAV is gated per deployment at
+// render time (see `WorkspaceContent`) by the active module set (voyant#3063).
 const extensions = createManagedAdminExtensions()
+
+// The active module ids this deployment mounts, reported by
+// `/auth/bootstrap-status` (voyant#3063). Fetched once and memoized: the set is
+// static per deployment, so every workspace navigation reuses the first probe.
+// A failed/legacy probe yields `undefined`, which fails OPEN (nav shows every
+// module) rather than hiding pages.
+let activeModuleIdsPromise: Promise<readonly string[] | undefined> | undefined
+
+function loadActiveModuleIds(): Promise<readonly string[] | undefined> {
+  activeModuleIdsPromise ??= managedAuthRuntime
+    .getBootstrapStatus()
+    .then((status) => status.modules)
+    .catch(() => undefined)
+  return activeModuleIdsPromise
+}
 
 // Semantic-destination resolvers derived at runtime from the registry's route
 // bindings, so packaged pages' `useAdminHref`/`useAdminNavigate` (cross-page
@@ -85,29 +105,41 @@ const workspaceRoute = createRoute({
   id: "_workspace",
   ssr: "data-only",
   beforeLoad: ({ location }) => workspaceGuard({ location }),
-  loader: ({ context }) => ({ user: (context as { user: ManagedUser }).user }),
+  loader: async ({ context }) => ({
+    user: (context as { user: ManagedUser }).user,
+    activeModuleIds: await loadActiveModuleIds(),
+  }),
   pendingComponent: AdminWorkspacePendingFallback,
   component: WorkspaceLayout,
 })
 
 function WorkspaceLayout() {
-  const { user } = workspaceRoute.useLoaderData()
+  const { user, activeModuleIds } = workspaceRoute.useLoaderData()
 
   return (
     <UserProvider getCurrentUser={managedAuthRuntime.getCurrentUser} initialUser={user}>
-      <WorkspaceContent />
+      <WorkspaceContent activeModuleIds={activeModuleIds} />
     </UserProvider>
   )
 }
 
-function WorkspaceContent() {
+function WorkspaceContent({ activeModuleIds }: { activeModuleIds: readonly string[] | undefined }) {
   const { user, isLoading } = useUser<ManagedUser>()
+
+  // Gate the NAV/widgets by the deployment's active module set. The route tree
+  // stays full (built once at import, hydration-stable), so this only removes
+  // sidebar entries + dashboard widgets for modules this operator does not run —
+  // no more dead links to pages whose API isn't mounted (voyant#3063).
+  const activeExtensions = useMemo(
+    () => filterManagedAdminExtensionsByModules(extensions, activeModuleIds),
+    [activeModuleIds],
+  )
 
   return (
     <AdminWorkspaceShell
       user={user}
       isUserLoading={isLoading}
-      extensions={extensions}
+      extensions={activeExtensions}
       destinations={destinations}
       onSignOut={() => managedAuthRuntime.signOut()}
     >


### PR DESCRIPTION
## Summary

Closes #3063.

A managed profile can declare a **module subset** (`modules: [...]` in the snapshot), and the runtime honors it for the **API**. But the **source-free admin UI ignored it** — it composed *every* `create<Module>AdminExtension()` factory unconditionally, so every managed operator saw the full nav (~18 modules) even when its profile activated a subset. Nav entries for inactive modules linked to pages whose API isn't mounted → dead links / 404s.

This is inherently a **shared-image** problem: the managed admin is one framework-version-tagged image; the active-module set is per-operator, injected at deploy via the snapshot. The client bundle can't know the subset at build/import time, so the composition needs a **runtime signal**.

## What changed

**1. Runtime exposes the active module set** (`@voyant-travel/framework`)
- `resolveActiveModuleIds(project)` (`/profile`) — maps the resolved `include` set (the same one that drives `createVoyantApp({ exclude })`, so nav can never drift from what the API mounts) to `moduleId`s.
- `GET /auth/bootstrap-status` now returns `modules` on `ManagedBootstrapStatus` — the probe the workspace already issues at bootstrap.

**2. Admin gates composition by it** (`@voyant-travel/admin` + `starters/managed-operator`)
- `AdminBootstrapStatus` carries an optional `modules` list.
- The route tree + destinations stay built from the FULL registry (kept **hydration-stable** across the shared image); the **nav/widgets** are filtered at render (`WorkspaceContent`) via `filterManagedAdminExtensionsByModules`, keyed by `MANAGED_ADMIN_EXTENSION_MODULE_IDS` (extension id → required module id; `core` always active). Filtering is **fail-open**: if the runtime reports no set, everything is kept.
- The managed-operator dev `/auth` stub computes the same set from the snapshot, so subsets are exercisable locally.

`mice` maps to a module absent from the standard manifest, so gating drops it whenever the runtime reports its set — removing an extension whose API the managed runtime never mounts.

## Verification

- `pnpm verify:fast` green; framework + admin + managed-operator typecheck/lint/build.
- Unit tests: `resolveActiveModuleIds` (full set + subset + no-mice/no-storefront); `bootstrap-status` echoes the active modules; `filterManagedAdminExtensionsByModules` (gate / drop-mice / fail-open / empty-set → core-only).
- End-to-end data contract confirmed against the built Node server: default snapshot → full resolved set (no `mice`, no `storefront`); a `[bookings, catalog]` subset snapshot → `[action-ledger, relationships, identity, commerce, catalog, bookings]` (declared subset + required foundational), which through the filter yields nav **core, bookings, catalog, relationships, commerce, action-ledger** — everything else dropped.

## Scoped follow-up

Direct-URL navigation to a disabled module still resolves its route (page renders, then its API 404s). Per-route gating would need routes to carry an owning-module tag; nav gating fully resolves the reported symptom (dead links in the sidebar). Under a per-operator *build* the subset bakes in and no runtime signal is needed (see platform#1014).
