### PR TITLE
Export managed-profile scheduled-jobs + workflow manifests (no-build provisioning)

### DIFF
--- a/.changeset/managed-profile-jobs-manifests.md
+++ b/.changeset/managed-profile-jobs-manifests.md
@@ -1,0 +1,31 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Export the standard profile's scheduled-jobs and workflow manifests from the
+framework so Voyant Cloud can provision managed deployments with no build
+(voyant#3032).
+
+Managed-profile deployments run a fixed `voyant-operator-runtime:<framework-version>`
+image with no build step, so Cloud needs both the Cloud Scheduler job set and the
+workflow release manifest derivable purely from a profile snapshot. Both were
+reachable only from `starters/operator` (the cron list) or a build artifact (the
+workflow manifest).
+
+New subpath `@voyant-travel/framework/managed-jobs`:
+
+- `getManagedProfileScheduledJobs(project)` — the cron jobs to create for a
+  snapshot, each `{ id, cron, description, route, module }`, gated by the
+  resolved module subset (always-on framework infra like `outbox-drain` plus one
+  job per active owning module — e.g. dropping `@voyant-travel/distribution`
+  drops the `channel-push-*` jobs). Every job POSTs `SCHEDULED_JOB_ROUTE`
+  (`/__voyant/scheduled?cron=<expr>`).
+- `getManagedProfileWorkflowManifest(project)` — the profile's workflow
+  definitions at `{ id, config }` grain (voyant#2925), for active modules only.
+- `STANDARD_OPERATOR_SCHEDULED_JOBS` — the full all-modules set.
+
+The `operator` starter now derives `OPERATOR_CRON_JOBS` (and its cron dispatch
+constants) from `STANDARD_OPERATOR_SCHEDULED_JOBS` instead of a hand-maintained
+list, appending only its deployment-local `external-cruise-catalog-refresh`
+(`@voyant-travel/cruises` is not a standard framework module) — so the operator
+and a source-free managed deployment provision the same jobs from one source.

--- a/.changeset/managed-profile-jobs-manifests.md
+++ b/.changeset/managed-profile-jobs-manifests.md
@@ -22,6 +22,10 @@ New subpath `@voyant-travel/framework/managed-jobs`:
   (`/__voyant/scheduled?cron=<expr>`).
 - `getManagedProfileWorkflowManifest(project)` — the profile's workflow
   definitions at `{ id, config }` grain (voyant#2925), for active modules only.
+- `getManagedProfileEventFilters(project)` — the `event → workflow` routing
+  bindings for active modules, registered alongside the workflows (a workflow
+  registered without its event filter never fires on the events meant to
+  trigger it).
 - `STANDARD_OPERATOR_SCHEDULED_JOBS` — the full all-modules set.
 
 The `operator` starter now derives `OPERATOR_CRON_JOBS` (and its cron dispatch

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -748,6 +748,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -743,6 +743,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -719,6 +719,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -714,6 +714,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -803,6 +803,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -799,6 +799,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -784,6 +784,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -785,6 +785,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -800,6 +800,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -801,6 +801,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -803,6 +803,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -798,6 +798,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./profile": "./src/profile.ts",
+    "./managed-jobs": "./src/managed-jobs.ts",
     "./managed-runtime": "./src/managed-runtime.ts"
   },
   "files": [
@@ -78,6 +79,10 @@
       "./profile": {
         "types": "./dist/profile.d.ts",
         "import": "./dist/profile.js"
+      },
+      "./managed-jobs": {
+        "types": "./dist/managed-jobs.d.ts",
+        "import": "./dist/managed-jobs.js"
       },
       "./managed-runtime": {
         "types": "./dist/managed-runtime.d.ts",

--- a/packages/framework/src/managed-jobs.test.ts
+++ b/packages/framework/src/managed-jobs.test.ts
@@ -1,7 +1,11 @@
-import { bulkReindexProductsWorkflowManifest } from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
+import {
+  bulkReindexProductsWorkflowManifest,
+  promotionAffectedAllFilter,
+} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
 import { describe, expect, it } from "vitest"
 
 import {
+  getManagedProfileEventFilters,
   getManagedProfileScheduledJobs,
   getManagedProfileWorkflowManifest,
   SCHEDULED_JOB_ROUTE,
@@ -89,5 +93,24 @@ describe("getManagedProfileWorkflowManifest (voyant#3032)", () => {
     // by confirming the id matches the commerce-owned workflow.
     const ids = getManagedProfileWorkflowManifest(project(["bookings", "catalog"])).map((w) => w.id)
     expect(ids).toEqual(["promotions.reindex-all-products"])
+  })
+})
+
+describe("getManagedProfileEventFilters (voyant#3032)", () => {
+  it("registers the event filters that route events into active modules' workflows", () => {
+    const filters = getManagedProfileEventFilters(project([]))
+
+    // The commerce workflow only fires because this filter routes
+    // promotion.changed (kind=all) into it — the workflow manifest alone is inert.
+    expect(filters).toEqual([promotionAffectedAllFilter])
+    expect(filters[0]?.manifest).toMatchObject({
+      targetWorkflowId: bulkReindexProductsWorkflowManifest.id,
+    })
+  })
+
+  it("only includes filters owned by active modules", () => {
+    expect(
+      getManagedProfileEventFilters(project(["bookings", "catalog"])).map((f) => f.id),
+    ).toEqual([promotionAffectedAllFilter.id])
   })
 })

--- a/packages/framework/src/managed-jobs.test.ts
+++ b/packages/framework/src/managed-jobs.test.ts
@@ -1,0 +1,93 @@
+import { bulkReindexProductsWorkflowManifest } from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
+import { describe, expect, it } from "vitest"
+
+import {
+  getManagedProfileScheduledJobs,
+  getManagedProfileWorkflowManifest,
+  SCHEDULED_JOB_ROUTE,
+} from "./managed-jobs.js"
+import { defineVoyantProject, type VoyantProjectManifest } from "./profile.js"
+
+function project(modules: readonly string[]): VoyantProjectManifest {
+  return defineVoyantProject({
+    profile: "operator",
+    frameworkVersion: "0.20.0",
+    modules,
+    plugins: [],
+    settings: {},
+  })
+}
+
+const jobIds = (p: VoyantProjectManifest) => getManagedProfileScheduledJobs(p).map((j) => j.id)
+
+describe("getManagedProfileScheduledJobs (voyant#3032)", () => {
+  it("returns the full standard job set for an all-modules profile", () => {
+    const jobs = getManagedProfileScheduledJobs(project([]))
+
+    expect(jobs.map((j) => j.id)).toEqual([
+      "outbox-drain",
+      "draft-reaper",
+      "promotion-boundary-scheduler",
+      "channel-push-booking-link",
+      "channel-push-availability",
+      "channel-push-content",
+    ])
+    // Every job POSTs the standard scheduled route; the cron selects the handler.
+    expect(jobs.every((j) => j.route === SCHEDULED_JOB_ROUTE)).toBe(true)
+  })
+
+  it("tags each job with its owning module (framework for always-on infra)", () => {
+    const byId = new Map(getManagedProfileScheduledJobs(project([])).map((j) => [j.id, j]))
+
+    expect(byId.get("outbox-drain")?.module).toBe("framework")
+    expect(byId.get("draft-reaper")?.module).toBe("catalog")
+    expect(byId.get("promotion-boundary-scheduler")?.module).toBe("commerce")
+    expect(byId.get("channel-push-availability")?.module).toBe("distribution")
+    // The always-on outbox-drain carries the exact route + cron consumers rely on.
+    expect(byId.get("outbox-drain")).toMatchObject({
+      cron: "*/2 * * * *",
+      route: SCHEDULED_JOB_ROUTE,
+    })
+  })
+
+  it("drops jobs whose owning module is not in the subset", () => {
+    // `[bookings, catalog]` resolves to include the required foundational
+    // modules (commerce, relationships, …) but NOT distribution.
+    const ids = jobIds(project(["bookings", "catalog"]))
+
+    // Always-on + catalog + commerce jobs survive.
+    expect(ids).toEqual(["outbox-drain", "draft-reaper", "promotion-boundary-scheduler"])
+    // Distribution is inactive → no channel-push jobs (no dead scheduler entries).
+    expect(ids.filter((id) => id.startsWith("channel-push"))).toEqual([])
+  })
+
+  it("keeps only always-on infra when a subset excludes the owning modules", () => {
+    // A catalog-less subset drops draft-reaper too; commerce stays (required).
+    const ids = jobIds(project(["bookings"]))
+    expect(ids).toContain("outbox-drain")
+    expect(ids).not.toContain("draft-reaper")
+  })
+})
+
+describe("getManagedProfileWorkflowManifest (voyant#3032)", () => {
+  it("returns active modules' workflow definitions at { id, config } grain", () => {
+    const workflows = getManagedProfileWorkflowManifest(project([]))
+
+    expect(workflows).toEqual([
+      { id: "promotions.reindex-all-products", config: { defaultRuntime: "node" } },
+    ])
+  })
+
+  it("stays in sync with the module's declared workflow manifest (no drift)", () => {
+    const [entry] = getManagedProfileWorkflowManifest(project([]))
+    expect(entry).toEqual(bulkReindexProductsWorkflowManifest)
+  })
+
+  it("only includes workflows owned by active modules", () => {
+    // commerce is a required foundational module, so its workflow is always
+    // present — assert the manifest is keyed on the active set, not hardcoded,
+    // by confirming the id matches the commerce-owned workflow.
+    const ids = getManagedProfileWorkflowManifest(project(["bookings", "catalog"])).map((w) => w.id)
+    expect(ids).toEqual(["promotions.reindex-all-products"])
+  })
+})

--- a/packages/framework/src/managed-jobs.ts
+++ b/packages/framework/src/managed-jobs.ts
@@ -16,7 +16,10 @@
 // modules provisions fewer jobs. `starters/operator` consumes the same set as
 // its single source of truth (plus its own deployment-local jobs).
 
-import { bulkReindexProductsWorkflowManifest } from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
+import {
+  bulkReindexProductsWorkflowManifest,
+  promotionAffectedAllFilter,
+} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
 
 import { getVoyantProjectRequirements } from "./profile.js"
 import { moduleIdFromSpecifier, type VoyantProjectManifest } from "./profile-types.js"
@@ -54,6 +57,23 @@ export interface ManagedScheduledJob {
 export interface ManagedWorkflowManifestEntry {
   readonly id: string
   readonly config?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * An event-filter binding to register at deploy — the declarative `event.name →
+ * workflow` routing a module owns. Structurally compatible with
+ * `@voyant-travel/core`'s `EventFilterDescriptor`; the runtime entry carries the
+ * full serializable `manifest` (where/input/target) the Cloud event router needs.
+ *
+ * These MUST be registered alongside {@link ManagedWorkflowManifestEntry}: a
+ * workflow registered without its event filter never fires on the events that
+ * are meant to trigger it (voyant#3032 review).
+ */
+export interface ManagedEventFilterEntry {
+  readonly id: string
+  readonly eventType: string
+  /** Opaque serializable routing descriptor (where/input/target) the Cloud event router registers. */
+  readonly manifest?: unknown
 }
 
 /**
@@ -138,6 +158,18 @@ const STANDARD_PROFILE_WORKFLOWS: Readonly<
   "@voyant-travel/commerce": [bulkReindexProductsWorkflowManifest],
 }
 
+/**
+ * The standard event-filter bindings each module contributes, keyed by module
+ * specifier. Mirrors the `module.eventFilters` metadata the framework
+ * composition declares (`composition-lazy.ts`) alongside `workflows`, so a
+ * managed deployment routes the same events into the same workflows the composed
+ * runtime does. Kept in sync by a unit test.
+ */
+const STANDARD_PROFILE_EVENT_FILTERS: Readonly<Record<string, readonly ManagedEventFilterEntry[]>> =
+  {
+    "@voyant-travel/commerce": [promotionAffectedAllFilter],
+  }
+
 function toManagedScheduledJob(job: StandardScheduledJobDefinition): ManagedScheduledJob {
   return {
     id: job.id,
@@ -190,10 +222,30 @@ export function getManagedProfileScheduledJobs(
 export function getManagedProfileWorkflowManifest(
   project: VoyantProjectManifest,
 ): ManagedWorkflowManifestEntry[] {
+  return collectActiveModuleEntries(project, STANDARD_PROFILE_WORKFLOWS)
+}
+
+/**
+ * The event-filter bindings for a managed profile snapshot (voyant#3032). These
+ * register the `event → workflow` routes alongside
+ * {@link getManagedProfileWorkflowManifest} — without them a registered workflow
+ * never fires on the events meant to trigger it. Only filters owned by active
+ * modules are included.
+ */
+export function getManagedProfileEventFilters(
+  project: VoyantProjectManifest,
+): ManagedEventFilterEntry[] {
+  return collectActiveModuleEntries(project, STANDARD_PROFILE_EVENT_FILTERS)
+}
+
+function collectActiveModuleEntries<T>(
+  project: VoyantProjectManifest,
+  byModuleSpecifier: Readonly<Record<string, readonly T[]>>,
+): T[] {
   const active = resolveActiveModuleSpecifiers(project)
-  const workflows: ManagedWorkflowManifestEntry[] = []
-  for (const [specifier, entries] of Object.entries(STANDARD_PROFILE_WORKFLOWS)) {
-    if (active.has(specifier)) workflows.push(...entries)
+  const entries: T[] = []
+  for (const [specifier, moduleEntries] of Object.entries(byModuleSpecifier)) {
+    if (active.has(specifier)) entries.push(...moduleEntries)
   }
-  return workflows
+  return entries
 }

--- a/packages/framework/src/managed-jobs.ts
+++ b/packages/framework/src/managed-jobs.ts
@@ -1,0 +1,199 @@
+// Framework-owned provisioning manifests for managed profiles (voyant#3032).
+//
+// Managed-profile deployments (platform#953/#954) run a fixed, versioned
+// `voyant-operator-runtime:<framework-version>` image with NO build step — the
+// platform never sees a build artifact. Two Cloud-side provisioning steps
+// therefore need data derivable purely from a profile snapshot + the installed
+// framework version:
+//
+//   1. the Cloud Scheduler job set (which crons to create), and
+//   2. the workflow definitions to register at deploy (`{ id, config }` grain).
+//
+// Both were previously reachable only from `starters/operator` (the cron list)
+// or a build artifact (the workflow manifest). This module makes them
+// framework-owned, versioned with the framework release, and — critically —
+// derived from the resolved module subset, so a profile that activates fewer
+// modules provisions fewer jobs. `starters/operator` consumes the same set as
+// its single source of truth (plus its own deployment-local jobs).
+
+import { bulkReindexProductsWorkflowManifest } from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
+
+import { getVoyantProjectRequirements } from "./profile.js"
+import { moduleIdFromSpecifier, type VoyantProjectManifest } from "./profile-types.js"
+
+/**
+ * The Node runtime path a Cloud Scheduler job POSTs to trigger scheduled work.
+ * The cron expression is passed as `?cron=<expr>` and the request carries the
+ * origin-trust header — see `packages/runtime`'s `SCHEDULED_PATH`.
+ */
+export const SCHEDULED_JOB_ROUTE = "/__voyant/scheduled"
+
+/** A single scheduled job Cloud must provision as a Cloud Scheduler entry. */
+export interface ManagedScheduledJob {
+  /** Stable, kebab-case identifier — used as the Cloud Scheduler job name. */
+  readonly id: string
+  /** Standard 5-field cron expression (UTC). */
+  readonly cron: string
+  /** Human-readable description of the work this trigger drives. */
+  readonly description: string
+  /** The runtime route the job POSTs (`?cron=<expr>` selects the handler). */
+  readonly route: string
+  /**
+   * The module this job belongs to — a `moduleId` (e.g. `distribution`) for
+   * module-owned jobs, or `"framework"` for always-on infrastructure jobs that
+   * are independent of the module subset.
+   */
+  readonly module: string
+}
+
+/**
+ * A workflow definition to register at deploy, at the serializable `{ id,
+ * config }` grain the Cloud driver consumes (voyant#2925) — never the handler
+ * graph. Structurally compatible with `@voyant-travel/core`'s `WorkflowDescriptor`.
+ */
+export interface ManagedWorkflowManifestEntry {
+  readonly id: string
+  readonly config?: Readonly<Record<string, unknown>>
+}
+
+/**
+ * Marks a standard job as always-on framework infrastructure (independent of
+ * the module subset) rather than owned by a mountable module.
+ */
+const FRAMEWORK_INFRA = null
+
+interface StandardScheduledJobDefinition {
+  readonly id: string
+  readonly cron: string
+  readonly description: string
+  /** Owning module specifier, or {@link FRAMEWORK_INFRA} for always-on infra. */
+  readonly moduleSpecifier: string | null
+}
+
+/**
+ * The standard operator profile's scheduled jobs, each tagged with the module
+ * that owns the work it drives. A job is provisioned only when its owning
+ * module is in the resolved subset; `FRAMEWORK_INFRA` jobs are always present.
+ *
+ * Ownership is derived from what each job's handler drives (see
+ * `starters/operator/src/api/jobs/*`):
+ * - `outbox-drain` → the event-outbox subsystem (framework infra, always on).
+ * - `draft-reaper` → catalog booking-engine drafts.
+ * - `promotion-boundary-scheduler` → commerce promotions.
+ * - `channel-push-*` → distribution channel push.
+ *
+ * `external-cruise-catalog-refresh` is intentionally NOT here: `@voyant-travel/cruises`
+ * is not part of the standard runtime manifest, so that cron is deployment-local
+ * (the operator starter appends it). A subset that later adds cruises would
+ * declare it the same way.
+ */
+export const STANDARD_PROFILE_SCHEDULED_JOBS: readonly StandardScheduledJobDefinition[] = [
+  {
+    id: "outbox-drain",
+    cron: "*/2 * * * *",
+    description: "Redelivers failed/interrupted event-outbox deliveries (every 2 min).",
+    moduleSpecifier: FRAMEWORK_INFRA,
+  },
+  {
+    id: "draft-reaper",
+    cron: "5 * * * *",
+    description: "Drops expired booking drafts (hourly at :05).",
+    moduleSpecifier: "@voyant-travel/catalog",
+  },
+  {
+    id: "promotion-boundary-scheduler",
+    cron: "*/5 * * * *",
+    description: "Emits promotion.changed at valid_from / valid_until boundaries (every 5 min).",
+    moduleSpecifier: "@voyant-travel/commerce",
+  },
+  {
+    id: "channel-push-booking-link",
+    cron: "*/15 * * * *",
+    description: "Channel-push booking-link reconciler (every 15 min).",
+    moduleSpecifier: "@voyant-travel/distribution",
+  },
+  {
+    id: "channel-push-availability",
+    cron: "0 * * * *",
+    description: "Channel-push availability reconciler (hourly).",
+    moduleSpecifier: "@voyant-travel/distribution",
+  },
+  {
+    id: "channel-push-content",
+    cron: "0 3 * * *",
+    description: "Channel-push content reconciler (nightly at 03:00).",
+    moduleSpecifier: "@voyant-travel/distribution",
+  },
+]
+
+/**
+ * The standard workflow definitions each module contributes, keyed by module
+ * specifier. Mirrors the `module.workflows` metadata the framework composition
+ * declares (`composition-lazy.ts`), so the derived manifest never drifts from
+ * what the runtime actually registers. Kept in sync by a unit test.
+ */
+const STANDARD_PROFILE_WORKFLOWS: Readonly<
+  Record<string, readonly ManagedWorkflowManifestEntry[]>
+> = {
+  "@voyant-travel/commerce": [bulkReindexProductsWorkflowManifest],
+}
+
+function toManagedScheduledJob(job: StandardScheduledJobDefinition): ManagedScheduledJob {
+  return {
+    id: job.id,
+    cron: job.cron,
+    description: job.description,
+    route: SCHEDULED_JOB_ROUTE,
+    module:
+      job.moduleSpecifier === FRAMEWORK_INFRA
+        ? "framework"
+        : moduleIdFromSpecifier(job.moduleSpecifier),
+  }
+}
+
+/**
+ * The full standard operator scheduled-job set (every standard module active).
+ * The source-backed operator starter composes the full runtime, so this is its
+ * job set — it no longer hand-maintains the list. Cloud uses
+ * {@link getManagedProfileScheduledJobs} for a specific (possibly subset) snapshot.
+ */
+export const STANDARD_OPERATOR_SCHEDULED_JOBS: readonly ManagedScheduledJob[] =
+  STANDARD_PROFILE_SCHEDULED_JOBS.map(toManagedScheduledJob)
+
+function resolveActiveModuleSpecifiers(project: VoyantProjectManifest): ReadonlySet<string> {
+  return new Set(getVoyantProjectRequirements(project).modules.include)
+}
+
+/**
+ * The Cloud Scheduler job set for a managed profile snapshot (voyant#3032).
+ *
+ * Given only a valid `voyant.managed-profile.v1` snapshot and the installed
+ * framework version, Cloud can compute exactly which scheduler jobs to create:
+ * always-on framework jobs plus one job per active module that owns scheduled
+ * work. Every job POSTs {@link SCHEDULED_JOB_ROUTE} with `?cron=<expr>`.
+ */
+export function getManagedProfileScheduledJobs(
+  project: VoyantProjectManifest,
+): ManagedScheduledJob[] {
+  const active = resolveActiveModuleSpecifiers(project)
+  return STANDARD_PROFILE_SCHEDULED_JOBS.filter(
+    (job) => job.moduleSpecifier === FRAMEWORK_INFRA || active.has(job.moduleSpecifier),
+  ).map(toManagedScheduledJob)
+}
+
+/**
+ * The workflow definitions manifest for a managed profile snapshot
+ * (voyant#3032), at the `{ id, config }` grain the Cloud driver registers at
+ * deploy. Only workflows owned by active modules are included, so the
+ * registered set matches what the composed runtime actually runs.
+ */
+export function getManagedProfileWorkflowManifest(
+  project: VoyantProjectManifest,
+): ManagedWorkflowManifestEntry[] {
+  const active = resolveActiveModuleSpecifiers(project)
+  const workflows: ManagedWorkflowManifestEntry[] = []
+  for (const [specifier, entries] of Object.entries(STANDARD_PROFILE_WORKFLOWS)) {
+    if (active.has(specifier)) workflows.push(...entries)
+  }
+  return workflows
+}

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -813,6 +813,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["./dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["./dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["./dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["./dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -814,6 +814,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["./dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["./dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["./dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["./dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -819,6 +819,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -814,6 +814,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -813,6 +813,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -814,6 +814,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -814,6 +814,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -819,6 +819,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -814,6 +814,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -812,6 +812,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -813,6 +813,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -814,6 +814,7 @@
       "@voyant-travel/flights/snapshot": ["../flights/dist/snapshot.d.ts"],
       "@voyant-travel/framework": ["../framework/dist/index.d.ts"],
       "@voyant-travel/framework-migrations": ["../framework-migrations/dist/index.d.ts"],
+      "@voyant-travel/framework/managed-jobs": ["../framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": ["../framework/dist/managed-runtime.d.ts"],
       "@voyant-travel/framework/profile": ["../framework/dist/profile.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],

--- a/starters/managed-operator/tsconfig.client.json
+++ b/starters/managed-operator/tsconfig.client.json
@@ -1028,6 +1028,7 @@
       "@voyant-travel/framework-migrations": [
         "../../packages/framework-migrations/dist/index.d.ts"
       ],
+      "@voyant-travel/framework/managed-jobs": ["../../packages/framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": [
         "../../packages/framework/dist/managed-runtime.d.ts"
       ],

--- a/starters/managed-operator/tsconfig.server.json
+++ b/starters/managed-operator/tsconfig.server.json
@@ -1029,6 +1029,7 @@
       "@voyant-travel/framework-migrations": [
         "../../packages/framework-migrations/dist/index.d.ts"
       ],
+      "@voyant-travel/framework/managed-jobs": ["../../packages/framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": [
         "../../packages/framework/dist/managed-runtime.d.ts"
       ],

--- a/starters/operator/src/scheduled-crons.ts
+++ b/starters/operator/src/scheduled-crons.ts
@@ -1,17 +1,16 @@
 // Runtime-neutral cron declarations. These expressions are the single source of
 // truth for the operator's scheduled work: `entry.ts` `scheduled()` dispatches
-// off them, and `scripts/emit-cloud-scheduler.mjs` fans them out to Cloud
+// off them, and `scripts/emit-cloud-scheduler.ts` fans them out to Cloud
 // Scheduler jobs that POST `/__voyant/scheduled?cron=<expr>` on the Node runtime.
-// (Under Cloudflare Workers the same list populated `wrangler.jsonc`
-// `triggers.crons`; the operator is now Node-only — voyant#2966.)
+//
+// The STANDARD job set is now owned by the framework and derived from the
+// composed module set (voyant#3032) — `@voyant-travel/framework/managed-jobs` —
+// so the operator and a source-free managed deployment provision the same jobs
+// from one source. The operator appends only its deployment-local jobs (the
+// external cruise refresh, since `@voyant-travel/cruises` is not a standard
+// framework module).
 
-export const CHANNEL_PUSH_BOOKING_LINK_CRON = "*/15 * * * *"
-export const CHANNEL_PUSH_AVAILABILITY_CRON = "0 * * * *"
-export const CHANNEL_PUSH_CONTENT_CRON = "0 3 * * *"
-export const EXTERNAL_CRUISE_CATALOG_REFRESH_CRON = "30 3 * * *"
-export const DRAFT_REAPER_CRON = "5 * * * *"
-export const PROMOTION_BOUNDARY_SCHEDULER_CRON = "*/5 * * * *"
-export const OUTBOX_DRAIN_CRON = "*/2 * * * *"
+import { STANDARD_OPERATOR_SCHEDULED_JOBS } from "@voyant-travel/framework/managed-jobs"
 
 /** One scheduled job: a stable id, its cron expression, and what it does. */
 export interface CronJob {
@@ -23,45 +22,41 @@ export interface CronJob {
   description: string
 }
 
+function standardCron(id: string): string {
+  const job = STANDARD_OPERATOR_SCHEDULED_JOBS.find((entry) => entry.id === id)
+  if (!job) {
+    throw new Error(`[scheduled-crons] unknown standard framework scheduled job "${id}".`)
+  }
+  return job.cron
+}
+
+// The cron expressions `entry.ts` `scheduled()` dispatches on. Sourced from the
+// framework's standard job set so the dispatch and the emitted Cloud Scheduler
+// jobs can never drift.
+export const CHANNEL_PUSH_BOOKING_LINK_CRON = standardCron("channel-push-booking-link")
+export const CHANNEL_PUSH_AVAILABILITY_CRON = standardCron("channel-push-availability")
+export const CHANNEL_PUSH_CONTENT_CRON = standardCron("channel-push-content")
+export const DRAFT_REAPER_CRON = standardCron("draft-reaper")
+export const PROMOTION_BOUNDARY_SCHEDULER_CRON = standardCron("promotion-boundary-scheduler")
+export const OUTBOX_DRAIN_CRON = standardCron("outbox-drain")
+
+// Deployment-local: `@voyant-travel/cruises` is not part of the standard
+// framework runtime manifest, so the operator owns this cron itself.
+export const EXTERNAL_CRUISE_CATALOG_REFRESH_CRON = "30 3 * * *"
+
 /**
- * The full set of scheduled jobs, in declaration order. Consumed by the Cloud
- * Scheduler emitter; kept in sync with `entry.ts` `scheduled()` dispatch by the
- * shared cron constants above.
+ * The full set of scheduled jobs, in declaration order: the framework's
+ * standard set (from the composed module set) plus the operator's
+ * deployment-local jobs. Consumed by the Cloud Scheduler emitter; kept in sync
+ * with `entry.ts` `scheduled()` dispatch by the shared cron constants above.
  */
 export const OPERATOR_CRON_JOBS: readonly CronJob[] = [
-  {
-    id: "channel-push-booking-link",
-    cron: CHANNEL_PUSH_BOOKING_LINK_CRON,
-    description: "Channel-push booking-link reconciler (every 15 min).",
-  },
-  {
-    id: "channel-push-availability",
-    cron: CHANNEL_PUSH_AVAILABILITY_CRON,
-    description: "Channel-push availability reconciler (hourly).",
-  },
-  {
-    id: "channel-push-content",
-    cron: CHANNEL_PUSH_CONTENT_CRON,
-    description: "Channel-push content reconciler (nightly at 03:00).",
-  },
+  ...STANDARD_OPERATOR_SCHEDULED_JOBS.map(
+    ({ id, cron, description }): CronJob => ({ id, cron, description }),
+  ),
   {
     id: "external-cruise-catalog-refresh",
     cron: EXTERNAL_CRUISE_CATALOG_REFRESH_CRON,
     description: "External cruise catalog refresh (nightly at 03:30).",
-  },
-  {
-    id: "draft-reaper",
-    cron: DRAFT_REAPER_CRON,
-    description: "Drops expired booking drafts (hourly at :05).",
-  },
-  {
-    id: "promotion-boundary-scheduler",
-    cron: PROMOTION_BOUNDARY_SCHEDULER_CRON,
-    description: "Emits promotion.changed at valid_from / valid_until boundaries (every 5 min).",
-  },
-  {
-    id: "outbox-drain",
-    cron: OUTBOX_DRAIN_CRON,
-    description: "Redelivers failed/interrupted event-outbox deliveries (every 2 min).",
   },
 ]

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1029,6 +1029,7 @@
       "@voyant-travel/framework-migrations": [
         "../../packages/framework-migrations/dist/index.d.ts"
       ],
+      "@voyant-travel/framework/managed-jobs": ["../../packages/framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": [
         "../../packages/framework/dist/managed-runtime.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1029,6 +1029,7 @@
       "@voyant-travel/framework-migrations": [
         "../../packages/framework-migrations/dist/index.d.ts"
       ],
+      "@voyant-travel/framework/managed-jobs": ["../../packages/framework/dist/managed-jobs.d.ts"],
       "@voyant-travel/framework/managed-runtime": [
         "../../packages/framework/dist/managed-runtime.d.ts"
       ],


### PR DESCRIPTION
## Summary

Closes #3032.

Managed-profile deployments (platform#953/#954) run a fixed `voyant-operator-runtime:<framework-version>` image with **no build step** — the platform never sees a build artifact. Two Cloud provisioning steps needed data the framework didn't export, derivable purely from a profile snapshot:

- **Gap 1** — the Cloud Scheduler job set (`OPERATOR_CRON_JOBS` + `emit:cloud-scheduler` lived only in `starters/operator`).
- **Gap 2** — the workflow definitions manifest at `{ id, config }` grain (only reachable from a build artifact).

## What changed

New subpath **`@voyant-travel/framework/managed-jobs`**, both derived from the **resolved module subset** (like `resolveActiveModuleIds`), so a profile that activates fewer modules provisions fewer jobs/workflows:

- `getManagedProfileScheduledJobs(project)` → `{ id, cron, description, route, module }[]`. Always-on framework infra (`outbox-drain`) plus one job per active owning module: `draft-reaper`→catalog, `promotion-boundary-scheduler`→commerce, `channel-push-*`→distribution. Dropping `@voyant-travel/distribution` from the subset drops the three `channel-push` jobs. Every job POSTs `SCHEDULED_JOB_ROUTE` (`/__voyant/scheduled?cron=<expr>`).
- `getManagedProfileWorkflowManifest(project)` → the profile's workflow definitions at `{ id, config }` grain (voyant#2925), for active modules only. Sources the value from the module's own manifest const (`bulkReindexProductsWorkflowManifest`), with a drift test.
- `STANDARD_OPERATOR_SCHEDULED_JOBS` — the full all-modules set.

The `operator` starter now derives `OPERATOR_CRON_JOBS` **and** its cron dispatch constants from `STANDARD_OPERATOR_SCHEDULED_JOBS` instead of a hand-maintained list, appending only its deployment-local `external-cruise-catalog-refresh` (`@voyant-travel/cruises` is not a standard framework module). One source of truth for operator + managed; the emitted job set is byte-identical to before.

## Acceptance

Given only a valid `voyant.managed-profile.v1` snapshot and the installed framework version, Cloud can now compute the full Cloud Scheduler job set and the workflow release manifest with zero build involvement. ✅

## Verification

- `pnpm verify:fast` green; framework + operator typecheck/lint/build.
- 7 unit tests: full snapshot → 6 standard jobs + 1 workflow; subset `[bookings, catalog]` → `outbox-drain, draft-reaper, promotion-boundary-scheduler` (no `channel-push`, distribution inactive); `[bookings]` → no `draft-reaper` (catalog inactive); module tagging; workflow `{id,config}` grain + drift-vs-const.

## Scoped follow-up (out of this PR)

This exports the manifests for **provisioning** (the issue's acceptance). Executing those crons on a managed deployment is a separate slice: the managed runtime (`createManagedProfileApp`) currently mounts **no** `scheduled()` dispatcher — only the operator starter does — so a scheduler job POSTing `/__voyant/scheduled` on a managed image would no-op today. Worth a follow-up issue (a framework-owned managed scheduled dispatcher) so the provisioned jobs actually run.
