### PR TITLE
Managed migration path for custom schema-owning modules (pre-built)

### DIFF
--- a/.changeset/managed-custom-module-migrations.md
+++ b/.changeset/managed-custom-module-migrations.md
@@ -1,0 +1,31 @@
+---
+"@voyant-travel/framework-migrations": minor
+"@voyant-travel/framework": minor
+---
+
+Give source-free managed images a migration path for custom schema-owning
+modules (voyant#3069, Option 1 — modules ship pre-built migrations).
+
+A managed image runs migrations with no drizzle-kit generation, so a custom
+"bring-your-own" module that owns schema previously had no way to create its
+tables. It now does, following the same per-package `migrations/` convention
+standard packages already use.
+
+`@voyant-travel/framework-migrations`:
+
+- `loadModuleBundleSource(packageName, { priority, resolveFrom })` — resolve a
+  module package's committed `migrations/` folder by name into a
+  `MigrationSource`, or `null` when it ships none (schema-less modules/plugins
+  are skipped). Ledger source name is the unscoped package name, stable across
+  source and managed modes.
+- `collectManagedMigrationSources({ modulePackages, resolveFrom })` — the
+  managed migration path: `[framework, ...customModules]` deps-first, ready for
+  `runDeploymentMigrations`.
+
+`@voyant-travel/framework`:
+
+- `getVoyantProjectMigrationMetadata(project)` now returns
+  `moduleSources: { packageName, priority }[]` derived from the snapshot's
+  `customSource.modules`, so the platform migrate booter enumerates the custom
+  schema-owning packages to apply after the framework bundle. Adds the
+  `VoyantProfileModuleMigrationSource` type.

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -110,6 +110,43 @@ There is **no long tail of D.1 databases in the wild**: exactly two deployments 
 
 Validating the D.1 single-folder collapse (2026-06-20) surfaced that the replay-parity oracle had been silently comparing against an **empty** push database: `drizzle.config.ts` loaded `.dev.vars` with `override: true`, clobbering the `DATABASE_URL` the oracle injected, so `drizzle-kit push` ran against a non-extension DB, aborted on a `gin_trgm_ops` index, and **exited 0**. Fixed by making an explicit `DATABASE_URL` win (`fix(operator): explicit DATABASE_URL must win over .dev.vars`). The lesson is encoded in Decision 7: the oracle must fail closed and assert real counts, because per-source drift detection is the only safety net D.2 has.
 
+## Managed profiles: custom module migrations (voyant#3069)
+
+A **source-free managed image** (`voyant-operator-runtime:<framework-version>`,
+platform#953/#954) runs migrations with **no drizzle-kit generation** and no
+generated schema-path list — so `discoverMigrationSources` (which maps schema
+paths → package roots) doesn't apply. The managed booter instead knows only the
+module package **names** the profile snapshot declares.
+
+Two source kinds:
+
+- **Standard-profile modules** — already baked into the shipped **framework
+  bundle** (`loadFrameworkBundleSource`, priority 0). No per-module work.
+- **Custom (bring-your-own) schema-owning modules** — declared under the
+  snapshot's `customSource.modules`. Each such package **ships its own committed
+  drizzle `migrations/` folder** (Option 1: pre-built, predictable — no
+  per-build generation), exactly as standard packages already do (`bookings`,
+  `finance`, … each ship `migrations/meta/_journal.json`).
+
+Resolution + ordering:
+
+- `loadModuleBundleSource(packageName, { priority, resolveFrom })`
+  (`@voyant-travel/framework-migrations`) resolves the package's root by name and
+  loads its `migrations/` as a `MigrationSource`, or `null` when it ships none (a
+  schema-less module/plugin — skipped). The ledger source name is the unscoped
+  package name, stable across source and managed modes.
+- `collectManagedMigrationSources({ modulePackages, resolveFrom })` returns
+  `[framework(0), ...customModules(1..n)]` deps-first — hand straight to
+  `runDeploymentMigrations`.
+- `getVoyantProjectMigrationMetadata(project)` now returns
+  `moduleSources: { packageName, priority }[]` derived from
+  `customSource.modules`, so the platform booter enumerates the packages to load
+  without a build artifact.
+
+Plugins that own no schema (e.g. `@voyant-travel/plugin-netopia`) are unaffected —
+they define no `pgTable` and ship no `migrations/`, so they resolve to `null` and
+need no migration step. Unblocks Slice 4 of platform#1016.
+
 ## References
 
 - `docs/architecture/migration-collector-d1.md` — the collector primitive + ledger D.2 reuses; the `assertSchemaAtBaseline` parity pattern.

--- a/packages/framework-migrations/src/index.ts
+++ b/packages/framework-migrations/src/index.ts
@@ -35,3 +35,10 @@ export {
   packageRootOfSchemaPath,
 } from "./discover.js"
 export { loadMigrationFolder } from "./load-folder.js"
+export {
+  type CollectManagedMigrationSourcesOptions,
+  collectManagedMigrationSources,
+  type LoadModuleBundleSourceOptions,
+  loadModuleBundleSource,
+  moduleSourceName,
+} from "./module-source.js"

--- a/packages/framework-migrations/src/module-source.test.ts
+++ b/packages/framework-migrations/src/module-source.test.ts
@@ -1,0 +1,120 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+import {
+  collectManagedMigrationSources,
+  loadModuleBundleSource,
+  moduleSourceName,
+} from "./module-source.js"
+
+const frameworkBundleDir = join(dirname(fileURLToPath(import.meta.url)), "..", "migrations")
+
+/** Write a resolvable fake package with (optionally) a migrations/ folder. */
+function writeFakePackage(
+  root: string,
+  packageName: string,
+  { withMigrations }: { withMigrations: boolean },
+): void {
+  const pkgDir = join(root, "node_modules", ...packageName.split("/"))
+  mkdirSync(pkgDir, { recursive: true })
+  writeFileSync(
+    join(pkgDir, "package.json"),
+    JSON.stringify({ name: packageName, version: "1.0.0", main: "index.js" }),
+  )
+  writeFileSync(join(pkgDir, "index.js"), "export {}\n")
+  if (!withMigrations) return
+  const migrationsDir = join(pkgDir, "migrations")
+  mkdirSync(join(migrationsDir, "meta"), { recursive: true })
+  writeFileSync(
+    join(migrationsDir, "meta", "_journal.json"),
+    JSON.stringify({
+      version: "7",
+      dialect: "postgresql",
+      entries: [{ idx: 0, tag: "0001_init", when: 1 }],
+    }),
+  )
+  writeFileSync(join(migrationsDir, "0001_init.sql"), 'CREATE TABLE "loyalty_points" ("id" text);')
+}
+
+let root: string
+let resolveFrom: string
+
+beforeAll(() => {
+  root = mkdtempSync(join(tmpdir(), "voyant-module-source-"))
+  resolveFrom = pathToFileURL(join(root, "consumer.js")).href
+  writeFakePackage(root, "@acme/loyalty", { withMigrations: true })
+  writeFakePackage(root, "@acme/analytics", { withMigrations: false })
+})
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true })
+})
+
+describe("moduleSourceName", () => {
+  it("uses the unscoped package name as the stable ledger source name", () => {
+    expect(moduleSourceName("@acme/loyalty")).toBe("loyalty")
+    expect(moduleSourceName("@voyant-travel/bookings")).toBe("bookings")
+    expect(moduleSourceName("plain-module")).toBe("plain-module")
+  })
+})
+
+describe("loadModuleBundleSource (voyant#3069)", () => {
+  it("loads a module package's pre-built migrations by name", async () => {
+    const source = await loadModuleBundleSource("@acme/loyalty", { priority: 1, resolveFrom })
+
+    expect(source).toEqual({
+      name: "loyalty",
+      priority: 1,
+      migrations: [{ tag: "0001_init", sql: 'CREATE TABLE "loyalty_points" ("id" text);' }],
+    })
+  })
+
+  it("returns null for a module that ships no migrations (owns no schema)", async () => {
+    expect(await loadModuleBundleSource("@acme/analytics", { priority: 1, resolveFrom })).toBeNull()
+  })
+
+  it("returns null for an unresolvable package", async () => {
+    expect(await loadModuleBundleSource("@acme/missing", { priority: 1, resolveFrom })).toBeNull()
+  })
+
+  it("honors an explicit migrationsDir, bypassing package resolution", async () => {
+    const source = await loadModuleBundleSource("@acme/loyalty", {
+      priority: 3,
+      name: "custom-ledger-name",
+      migrationsDir: join(root, "node_modules", "@acme", "loyalty", "migrations"),
+    })
+    expect(source?.name).toBe("custom-ledger-name")
+    expect(source?.priority).toBe(3)
+  })
+})
+
+describe("collectManagedMigrationSources (voyant#3069)", () => {
+  it("orders the framework bundle first, then custom modules deps-first", async () => {
+    const sources = await collectManagedMigrationSources({
+      frameworkBundleDir,
+      modulePackages: ["@acme/loyalty"],
+      resolveFrom,
+    })
+
+    expect(sources[0]?.name).toBe("framework")
+    expect(sources[0]?.priority).toBe(0)
+    expect(sources.map((s) => s.name)).toContain("loyalty")
+    expect(sources.find((s) => s.name === "loyalty")?.priority).toBe(1)
+  })
+
+  it("skips declared modules that ship no migrations", async () => {
+    const sources = await collectManagedMigrationSources({
+      frameworkBundleDir,
+      modulePackages: ["@acme/analytics", "@acme/loyalty"],
+      resolveFrom,
+    })
+
+    expect(sources.map((s) => s.name)).toEqual(["framework", "loyalty"])
+    // Priority is assigned only to loaded modules — no gap from the skipped one.
+    expect(sources.find((s) => s.name === "loyalty")?.priority).toBe(1)
+  })
+})

--- a/packages/framework-migrations/src/module-source.ts
+++ b/packages/framework-migrations/src/module-source.ts
@@ -1,0 +1,149 @@
+/**
+ * Load a schema-owning module PACKAGE's pre-built `migrations/` folder as a
+ * collector {@link MigrationSource}, resolved by package NAME (voyant#3069).
+ *
+ * A source-backed deployment discovers each package's migrations via its
+ * generated schema-path list ({@link discoverMigrationSources}); a **source-free
+ * managed image** has no such list — it only knows the module package NAMES its
+ * profile snapshot declares. This resolves a declared module's package root and
+ * loads its `migrations/` the same way {@link loadFrameworkBundleSource} loads
+ * the framework bundle, so the managed migrate booter can apply
+ * `[framework, ...customModules]` deps-first with no drizzle-kit generation.
+ *
+ * The convention (Option 1 of voyant#3069): a schema-owning module package ships
+ * a committed drizzle `migrations/` folder (`meta/_journal.json` + `*.sql`).
+ * Modules that own no schema (e.g. payment plugins) ship none, and resolve to
+ * `null` here — they need no migrations and are simply skipped.
+ */
+
+import { existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+
+import type { MigrationSource } from "./collector.js"
+import { loadMigrationFolder } from "./load-folder.js"
+
+export interface LoadModuleBundleSourceOptions {
+  /**
+   * Apply order across sources (lower first). MUST be greater than the framework
+   * bundle's `0` — a module's tables FK into framework tables, so the framework
+   * bundle applies first.
+   */
+  priority: number
+  /**
+   * Module specifier/file to resolve `packageName` from (a path or `file:` URL).
+   * Defaults to this module's location; pass the deployment's own location so
+   * the module resolves against the deployment's installed dependency tree.
+   */
+  resolveFrom?: string | URL
+  /**
+   * Ledger source name (recorded in `_voyant_migrations`). Defaults to the
+   * package's unscoped name so the same module records under one stable name
+   * across source and managed modes. Override only to match an existing ledger.
+   */
+  name?: string
+  /** Resolved migrations folder, bypassing package resolution (mainly for tests). */
+  migrationsDir?: string
+}
+
+/** The unscoped package name (`@acme/loyalty` → `loyalty`) used as the ledger source name. */
+export function moduleSourceName(packageName: string): string {
+  return packageName.replace(/^@[^/]+\//, "")
+}
+
+/**
+ * Walk up from a resolved entry file to the package root — the nearest ancestor
+ * whose `package.json` `name` matches `packageName`. Robust to `dist/` nesting
+ * and any scope, unlike a node_modules path regex.
+ */
+function resolvePackageRoot(packageName: string, entryPath: string): string | null {
+  let dir = dirname(entryPath)
+  for (;;) {
+    const packageJsonPath = join(dir, "package.json")
+    if (existsSync(packageJsonPath)) {
+      try {
+        const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: string }
+        if (parsed.name === packageName) return dir
+      } catch {
+        // Unreadable/partial package.json — keep walking.
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
+function resolveModuleMigrationsDir(packageName: string, resolveFrom: string | URL): string | null {
+  let entryPath: string
+  try {
+    entryPath = createRequire(resolveFrom).resolve(packageName)
+  } catch {
+    return null
+  }
+  const root = resolvePackageRoot(packageName, entryPath)
+  return root ? join(root, "migrations") : null
+}
+
+/**
+ * Load a module package's pre-built migrations as a {@link MigrationSource}, or
+ * `null` when the package ships no `migrations/` folder (it owns no schema).
+ * Throws only if a present `migrations/` folder is malformed (missing SQL a
+ * journal references) — a packaging error, surfaced rather than applied partially.
+ */
+export async function loadModuleBundleSource(
+  packageName: string,
+  options: LoadModuleBundleSourceOptions,
+): Promise<MigrationSource | null> {
+  const migrationsDir =
+    options.migrationsDir ??
+    resolveModuleMigrationsDir(packageName, options.resolveFrom ?? import.meta.url)
+  if (!migrationsDir) return null
+  if (!existsSync(join(migrationsDir, "meta", "_journal.json"))) return null
+
+  return {
+    name: options.name ?? moduleSourceName(packageName),
+    priority: options.priority,
+    migrations: await loadMigrationFolder(migrationsDir),
+  }
+}
+
+export interface CollectManagedMigrationSourcesOptions {
+  /** Framework bundle folder override (defaults to the shipped bundle). */
+  frameworkBundleDir?: string
+  /**
+   * Custom schema-owning module package names to load AFTER the framework
+   * bundle, in deps-first order (framework metadata's `moduleSources`).
+   */
+  modulePackages?: readonly string[]
+  /** Where to resolve module packages from (the deployment's location). */
+  resolveFrom?: string | URL
+}
+
+/**
+ * The ordered migration sources for a managed profile: the framework bundle
+ * (priority 0) followed by each declared custom schema-owning module's pre-built
+ * migrations (priority 1..n, in declaration order). Pass the result straight to
+ * `runDeploymentMigrations`. Modules that ship no migrations are skipped.
+ */
+export async function collectManagedMigrationSources(
+  options: CollectManagedMigrationSourcesOptions = {},
+): Promise<MigrationSource[]> {
+  // Imported lazily to keep this module usable without eagerly resolving the
+  // shipped framework bundle folder when only module sources are wanted.
+  const { loadFrameworkBundleSource } = await import("./bundle.js")
+  const sources: MigrationSource[] = [await loadFrameworkBundleSource(options.frameworkBundleDir)]
+
+  let priority = 1
+  for (const packageName of options.modulePackages ?? []) {
+    const source = await loadModuleBundleSource(packageName, {
+      priority,
+      ...(options.resolveFrom ? { resolveFrom: options.resolveFrom } : {}),
+    })
+    if (source) {
+      sources.push(source)
+      priority += 1
+    }
+  }
+  return sources
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -53,6 +53,7 @@ export {
   type VoyantProfileEnvRequirement,
   type VoyantProfileMigrationMetadata,
   type VoyantProfileModuleDefinition,
+  type VoyantProfileModuleMigrationSource,
   type VoyantProfileRequirements,
   type VoyantProfileResourceRequirement,
   type VoyantProfileValidationIssue,

--- a/packages/framework/src/profile-types.ts
+++ b/packages/framework/src/profile-types.ts
@@ -123,11 +123,32 @@ export interface VoyantProfileResourceRequirement {
   notes?: string
 }
 
+/**
+ * A custom schema-owning module the managed migrate booter must apply AFTER the
+ * framework bundle (voyant#3069). The booter resolves each package's pre-built
+ * `migrations/` folder via `loadModuleBundleSource(packageName)` and applies
+ * `[framework, ...moduleSources]` deps-first. Standard-profile modules are
+ * already in the framework bundle, so only the snapshot's `customSource.modules`
+ * appear here; a module that ships no migrations is loaded as a no-op.
+ */
+export interface VoyantProfileModuleMigrationSource {
+  /** npm package name to resolve the module's `migrations/` folder from. */
+  packageName: string
+  /** Apply order among module sources (after the framework bundle), 1-based. */
+  priority: number
+}
+
 export interface VoyantProfileMigrationMetadata {
   packageName: "@voyant-travel/framework-migrations"
   bundleId: "operator-standard-profile"
   bundleSource: "framework"
   cutlineExport: "loadCutline"
+  /**
+   * Custom schema-owning module packages (from `customSource.modules`) whose
+   * pre-built migrations apply after the framework bundle (voyant#3069). Empty
+   * for a standard profile with no bring-your-own modules.
+   */
+  moduleSources: readonly VoyantProfileModuleMigrationSource[]
   doctor: {
     command: "voyant db doctor --fail-on-drift"
     parity: readonly string[]

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -305,11 +305,28 @@ describe("managed profile contract", () => {
       bundleId: "operator-standard-profile",
       bundleSource: "framework",
       cutlineExport: "loadCutline",
+      moduleSources: [],
       doctor: {
         command: "voyant db doctor --fail-on-drift",
         parity: expect.arrayContaining(["schema drift"]),
       },
     })
+  })
+
+  it("enumerates custom schema-owning modules as ordered migration sources (voyant#3069)", () => {
+    const project = defineVoyantProject({
+      profile: "operator",
+      frameworkVersion: "0.21.0",
+      modules: [],
+      plugins: [],
+      settings: {},
+      customSource: { modules: ["@acme/loyalty", "@acme/gift-cards"] },
+    })
+
+    expect(getVoyantProjectMigrationMetadata(project).moduleSources).toEqual([
+      { packageName: "@acme/loyalty", priority: 1 },
+      { packageName: "@acme/gift-cards", priority: 2 },
+    ])
   })
 })
 

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -40,6 +40,7 @@ export {
   type VoyantProfileEnvRequirement,
   type VoyantProfileMigrationMetadata,
   type VoyantProfileModuleDefinition,
+  type VoyantProfileModuleMigrationSource,
   type VoyantProfileRequirements,
   type VoyantProfileResourceRequirement,
   type VoyantProfileValidationIssue,
@@ -193,16 +194,24 @@ export function getVoyantProjectRequirements(
 }
 
 export function getVoyantProjectMigrationMetadata(
-  project: Pick<VoyantProjectManifest, "profile">,
+  project: Pick<VoyantProjectManifest, "profile" | "customSource">,
 ): VoyantProfileMigrationMetadata {
   if (project.profile !== "operator") {
     throw new Error(`Unsupported managed profile "${String(project.profile)}".`)
   }
+  // Standard-profile modules are baked into the framework bundle; only the
+  // snapshot's custom (bring-your-own) schema-owning modules need their own
+  // pre-built migration source, applied after the framework bundle (voyant#3069).
+  const moduleSources = unique(project.customSource?.modules ?? []).map((packageName, index) => ({
+    packageName,
+    priority: index + 1,
+  }))
   return {
     packageName: "@voyant-travel/framework-migrations",
     bundleId: "operator-standard-profile",
     bundleSource: "framework",
     cutlineExport: "loadCutline",
+    moduleSources,
     doctor: {
       command: "voyant db doctor --fail-on-drift",
       parity: [


### PR DESCRIPTION
## Summary

Closes #3069.

The per-operator managed build can bake in declared **plugins** (platform#1017–#1019), but a **custom module that owns schema** had no migration path in a source-free image: the managed migrate booter runs the framework's pre-built bundle and does **no** drizzle-kit generation, so a bring-your-own schema-owning module would never create its tables.

Per the decision on the issue, this implements **Option 1 — modules ship pre-built migrations** (predictable; the migration set is published, not generated per-build), reusing the per-package `migrations/` convention standard packages already follow (`bookings`, `finance`, … each ship `migrations/meta/_journal.json`).

## What changed

**`@voyant-travel/framework-migrations`**
- `loadModuleBundleSource(packageName, { priority, resolveFrom })` — resolves a module package's committed `migrations/` folder **by name** (walks up to the package root) into a `MigrationSource`, or `null` when it ships none (a schema-less module/plugin — safely skipped). The ledger source name is the unscoped package name, stable across source and managed modes.
- `collectManagedMigrationSources({ modulePackages, resolveFrom })` — the concrete managed path: `[framework(0), ...customModules(1..n)]` deps-first, ready for `runDeploymentMigrations`.

**`@voyant-travel/framework`**
- `getVoyantProjectMigrationMetadata(project)` now returns `moduleSources: { packageName, priority }[]` derived from the snapshot's `customSource.modules`, so the platform migrate booter enumerates the custom schema-owning packages to apply after the framework bundle (no build artifact needed). Adds the `VoyantProfileModuleMigrationSource` type.

**Docs:** `docs/architecture/migration-collector-d2.md` gains a "Managed profiles: custom module migrations" section.

## Verification

- `pnpm verify:fast` + `pnpm verify:architecture` green; both packages typecheck/lint.
- framework-migrations: 7 new tests (hermetic tmp-package fixtures) — load by name; `null` for a module shipping no migrations; `null` for an unresolvable package; explicit `migrationsDir` override; `collectManagedMigrationSources` ordering (framework first, then modules deps-first) and skip-no-migrations.
- framework: `moduleSources` enumeration from `customSource.modules` (ordered, 1-based priority); standard profile → `[]`.

## Scope

Plugins that own no schema (netopia/smartbill) are unaffected — they ship no `migrations/`, resolve to `null`, and need no migration step. The managed booter itself is platform-side (it consumes this metadata + these loaders); this PR provides the voyant-repo building blocks. Unblocks Slice 4 of platform#1016.
