### PR TITLE
Module subsetting: cascade standard-extension exclusion from declared ownership (#2104)

### DIFF
--- a/.changeset/framework-extension-ownership-cascade.md
+++ b/.changeset/framework-extension-ownership-cascade.md
@@ -25,6 +25,12 @@ now-absent surface — e.g. removing `bookings` while
   now use the single source of truth (the hand-maintained ownership map
   previously duplicated in `profile.ts` is removed).
 
+The pure subset math (`subsetStandardManifest`, `ownedExtensionsForExcludedModules`,
+`FRAMEWORK_EXTENSION_OWNERSHIP`) lives in `manifest.js`, so the lightweight
+`@voyant-travel/framework/profile` subpath no longer transitively imports the
+runtime composition graph (`create-app.js` → `composition-lazy.js` → `@hono/zod-openapi`).
+Snapshot/requirements math stays free of runtime bundle weight.
+
 Schema stays whole: subsetting gates runtime + admin surfaces only; the standard
 migration bundle is unchanged (an unselected module's tables are migrated but
 inert). This keeps the fixed-operator and subset paths on the same single-bundle

--- a/.changeset/framework-extension-ownership-cascade.md
+++ b/.changeset/framework-extension-ownership-cascade.md
@@ -1,0 +1,31 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Module subsetting: cascade standard-extension exclusion from declared ownership
+(voyant#2104, ADR-0007 follow-up a).
+
+Excluding a standard module now drops the extensions it owns in the **core**
+`subsetStandardManifest` primitive, not only in the managed-profile wrapper.
+Previously a direct `createVoyantApp({ exclude })` caller (self-host, tooling,
+tests) could drop a module while an augmenting extension stayed mounted on the
+now-absent surface — e.g. removing `bookings` while
+`@voyant-travel/finance/bookings-create-extension` (mounting under
+`/v1/admin/bookings`) leaked.
+
+- `FRAMEWORK_EXTENSION_OWNERSHIP` — declares which standard module(s) each
+  standard extension augments, co-located with `FRAMEWORK_RUNTIME_MANIFEST` /
+  `FRAMEWORK_CAPABILITY_GRAPH` and typed against them so it cannot drift. An
+  extension's mount prefix is a path, not a foreign key to a module `name`, so
+  path-mounted extensions with no same-named module (e.g.
+  `operator/proposal-extension` under `quote-versions`) cascade by declaration
+  rather than an unsound name-match.
+- `ownedExtensionsForExcludedModules(excluded)` — the shared, exported cascade
+  helper. `subsetStandardManifest` and the managed-profile exclude computation
+  now use the single source of truth (the hand-maintained ownership map
+  previously duplicated in `profile.ts` is removed).
+
+Schema stays whole: subsetting gates runtime + admin surfaces only; the standard
+migration bundle is unchanged (an unselected module's tables are migrated but
+inert). This keeps the fixed-operator and subset paths on the same single-bundle
+managed-migration model.

--- a/packages/framework/src/create-app.test.ts
+++ b/packages/framework/src/create-app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import { subsetStandardManifest } from "./create-app.js"
-import { FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
+import { ownedExtensionsForExcludedModules, subsetStandardManifest } from "./create-app.js"
+import { FRAMEWORK_EXTENSION_OWNERSHIP, FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
 
 describe("subsetStandardManifest (ADR-0007 module subsetting)", () => {
   it("returns the full standard set when nothing is excluded", () => {
@@ -38,6 +38,44 @@ describe("subsetStandardManifest (ADR-0007 module subsetting)", () => {
       expect(() => subsetStandardManifest({ exclude: ["@voyant-travel/relationships"] })).toThrow(
         /cannot exclude required module.*relationships/,
       )
+    })
+  })
+
+  describe("extension-ownership cascade (voyant#2104)", () => {
+    it("cascades: excluding a module drops the extensions it owns", () => {
+      const { modules, extensions } = subsetStandardManifest({
+        exclude: ["@voyant-travel/bookings"],
+      })
+      expect(modules).not.toContain("@voyant-travel/bookings")
+      // Every extension owned by bookings must be gone — none may leak onto the
+      // now-absent bookings surface.
+      const ownership: Record<string, readonly string[]> = FRAMEWORK_EXTENSION_OWNERSHIP
+      for (const [extension, owners] of Object.entries(ownership)) {
+        if (owners.includes("@voyant-travel/bookings")) {
+          expect(extensions).not.toContain(extension)
+        }
+      }
+      // A path-mounted extension whose owner survives stays mounted.
+      expect(extensions).toContain("operator/catalog-offers-extension")
+    })
+
+    it("cascades path-mounted extensions with no same-named module", () => {
+      // `operator/proposal-extension` mounts under `quote-versions` and is owned
+      // by quotes — a name-match check would never catch it.
+      const { extensions } = subsetStandardManifest({ exclude: ["@voyant-travel/quotes"] })
+      expect(extensions).not.toContain("operator/proposal-extension")
+      expect(extensions).not.toContain("operator/quote-version-snapshot-extension")
+    })
+
+    it("does not drop extensions when no owner is excluded", () => {
+      const { extensions } = subsetStandardManifest({ exclude: ["@voyant-travel/flights"] })
+      expect(extensions).toEqual([...FRAMEWORK_RUNTIME_MANIFEST.extensions])
+    })
+
+    it("ownedExtensionsForExcludedModules is declaration-driven, not name-matched", () => {
+      const owned = ownedExtensionsForExcludedModules(["@voyant-travel/quotes"])
+      expect(owned).toContain("operator/proposal-extension")
+      expect(ownedExtensionsForExcludedModules([])).toEqual([])
     })
   })
 })

--- a/packages/framework/src/create-app.ts
+++ b/packages/framework/src/create-app.ts
@@ -42,7 +42,11 @@ import {
   type ModuleFactory,
 } from "@voyant-travel/hono/composition"
 import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
-import { FRAMEWORK_CAPABILITY_GRAPH, FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
+import {
+  FRAMEWORK_CAPABILITY_GRAPH,
+  FRAMEWORK_EXTENSION_OWNERSHIP,
+  FRAMEWORK_RUNTIME_MANIFEST,
+} from "./manifest.js"
 
 /**
  * Config for {@link createVoyantApp}: the injected providers + deployment-local
@@ -90,6 +94,24 @@ export interface SubsetOptions {
 }
 
 /**
+ * The standard extensions owned by any of the excluded specifiers — an extension
+ * whose declared owner module (see `FRAMEWORK_EXTENSION_OWNERSHIP`) is being
+ * removed. Excluding a module must cascade to these, or the removed surface
+ * partially leaks: e.g. dropping `bookings` while `finance/bookings-create-extension`
+ * (mounting under `/v1/admin/bookings`) stays mounted (voyant#2104). Ownership is
+ * declared, not name-matched, so path-mounted extensions cascade correctly.
+ */
+export function ownedExtensionsForExcludedModules(excluded: Iterable<string>): string[] {
+  const excludedSet = excluded instanceof Set ? excluded : new Set(excluded)
+  const owned: string[] = []
+  for (const extension of FRAMEWORK_RUNTIME_MANIFEST.extensions) {
+    const owners = FRAMEWORK_EXTENSION_OWNERSHIP[extension]
+    if (owners.some((owner) => excludedSet.has(owner))) owned.push(extension)
+  }
+  return owned
+}
+
+/**
  * Apply `exclude` to the standard set (ADR-0007), returning the module/extension
  * specifiers that should mount. Pure and provider-free, so it is unit-testable and
  * reusable by tooling (`db doctor`). Throws — fail-loud at boot, never a runtime
@@ -124,6 +146,15 @@ export function subsetStandardManifest({ exclude = [] }: SubsetOptions = {}): {
           "They are foundational and cannot be removed.",
       )
     }
+  }
+
+  // Cascade: dropping a module also drops the standard extensions it owns. They
+  // mount under the module's surface, so leaving them would partially leak the
+  // removed surface. Ownership is declared (`FRAMEWORK_EXTENSION_OWNERSHIP`), so
+  // path-mounted extensions cascade by declaration rather than an unsound
+  // name-match (voyant#2104). Idempotent — already-excluded extensions no-op.
+  for (const extension of ownedExtensionsForExcludedModules(excludeSet)) {
+    excludeSet.add(extension)
   }
 
   const modules = FRAMEWORK_RUNTIME_MANIFEST.modules.filter((m) => !excludeSet.has(m))

--- a/packages/framework/src/create-app.ts
+++ b/packages/framework/src/create-app.ts
@@ -34,19 +34,13 @@
  */
 
 import { type CreateAppConfig, createApp, type VoyantBindings } from "@voyant-travel/hono"
-import {
-  type CapabilityGraph,
-  type CompositionRegistry,
-  type ExtensionFactory,
-  findCapabilityGaps,
-  type ModuleFactory,
+import type {
+  CompositionRegistry,
+  ExtensionFactory,
+  ModuleFactory,
 } from "@voyant-travel/hono/composition"
 import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
-import {
-  FRAMEWORK_CAPABILITY_GRAPH,
-  FRAMEWORK_EXTENSION_OWNERSHIP,
-  FRAMEWORK_RUNTIME_MANIFEST,
-} from "./manifest.js"
+import { subsetStandardManifest } from "./manifest.js"
 
 /**
  * Config for {@link createVoyantApp}: the injected providers + deployment-local
@@ -85,96 +79,6 @@ export interface CreateVoyantAppConfig<
    * yet wired (ADR-0007 "Deferred to v2").
    */
   exclude?: readonly string[]
-}
-
-/** Options for {@link subsetStandardManifest}. See {@link CreateVoyantAppConfig}. */
-export interface SubsetOptions {
-  /** Specifiers to remove entirely (rejected if unknown, `isRequired`, or depended-on). */
-  exclude?: readonly string[]
-}
-
-/**
- * The standard extensions owned by any of the excluded specifiers — an extension
- * whose declared owner module (see `FRAMEWORK_EXTENSION_OWNERSHIP`) is being
- * removed. Excluding a module must cascade to these, or the removed surface
- * partially leaks: e.g. dropping `bookings` while `finance/bookings-create-extension`
- * (mounting under `/v1/admin/bookings`) stays mounted (voyant#2104). Ownership is
- * declared, not name-matched, so path-mounted extensions cascade correctly.
- */
-export function ownedExtensionsForExcludedModules(excluded: Iterable<string>): string[] {
-  const excludedSet = excluded instanceof Set ? excluded : new Set(excluded)
-  const owned: string[] = []
-  for (const extension of FRAMEWORK_RUNTIME_MANIFEST.extensions) {
-    const owners = FRAMEWORK_EXTENSION_OWNERSHIP[extension]
-    if (owners.some((owner) => excludedSet.has(owner))) owned.push(extension)
-  }
-  return owned
-}
-
-/**
- * Apply `exclude` to the standard set (ADR-0007), returning the module/extension
- * specifiers that should mount. Pure and provider-free, so it is unit-testable and
- * reusable by tooling (`db doctor`). Throws — fail-loud at boot, never a runtime
- * 500 — when `exclude` names a specifier absent from the standard set (a typo),
- * names an `isRequired` module, or leaves a still-mounted module's `requires`
- * unmet (drop the consumers too).
- */
-export function subsetStandardManifest({ exclude = [] }: SubsetOptions = {}): {
-  modules: string[]
-  extensions: string[]
-} {
-  const excludeSet = new Set(exclude)
-
-  if (excludeSet.size > 0) {
-    const known = new Set<string>([
-      ...FRAMEWORK_RUNTIME_MANIFEST.modules,
-      ...FRAMEWORK_RUNTIME_MANIFEST.extensions,
-    ])
-    const unknown = [...excludeSet].filter((spec) => !known.has(spec)).sort()
-    if (unknown.length > 0) {
-      throw new Error(
-        `createVoyantApp: exclude names ${unknown.length} specifier(s) not in the standard set: ` +
-          `${unknown.join(", ")}. Only standard framework modules/extensions can be excluded.`,
-      )
-    }
-
-    const graph: CapabilityGraph = FRAMEWORK_CAPABILITY_GRAPH
-    const required = [...excludeSet].filter((spec) => graph[spec]?.isRequired).sort()
-    if (required.length > 0) {
-      throw new Error(
-        `createVoyantApp: cannot exclude required module(s): ${required.join(", ")}. ` +
-          "They are foundational and cannot be removed.",
-      )
-    }
-  }
-
-  // Cascade: dropping a module also drops the standard extensions it owns. They
-  // mount under the module's surface, so leaving them would partially leak the
-  // removed surface. Ownership is declared (`FRAMEWORK_EXTENSION_OWNERSHIP`), so
-  // path-mounted extensions cascade by declaration rather than an unsound
-  // name-match (voyant#2104). Idempotent — already-excluded extensions no-op.
-  for (const extension of ownedExtensionsForExcludedModules(excludeSet)) {
-    excludeSet.add(extension)
-  }
-
-  const modules = FRAMEWORK_RUNTIME_MANIFEST.modules.filter((m) => !excludeSet.has(m))
-  const extensions = FRAMEWORK_RUNTIME_MANIFEST.extensions.filter((e) => !excludeSet.has(e))
-
-  // The capability graph is validated over what actually mounts: dropping a
-  // module a still-mounted module depends on — without also dropping the consumer
-  // — fails loudly here rather than as a runtime 500.
-  const gaps = findCapabilityGaps(modules, FRAMEWORK_CAPABILITY_GRAPH)
-  if (gaps.length > 0) {
-    const detail = gaps
-      .map((g) => `"${g.capability}" (required by ${g.requiredBy.join(", ")})`)
-      .join("; ")
-    throw new Error(
-      `createVoyantApp: exclude leaves unmet capabilities: ${detail}. ` +
-        "Exclude the consumers too (capability replacement is a future release).",
-    )
-  }
-
-  return { modules, extensions }
 }
 
 /**

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -19,12 +19,7 @@
  */
 
 export { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
-export {
-  type CreateVoyantAppConfig,
-  createVoyantApp,
-  ownedExtensionsForExcludedModules,
-  subsetStandardManifest,
-} from "./create-app.js"
+export { type CreateVoyantAppConfig, createVoyantApp } from "./create-app.js"
 export {
   type DeploymentExtensionDeclaration,
   type DeploymentModuleDeclaration,
@@ -39,6 +34,8 @@ export {
   FRAMEWORK_EXTENSION_OWNERSHIP,
   FRAMEWORK_RUNTIME_MANIFEST,
   type FrameworkManifest,
+  ownedExtensionsForExcludedModules,
+  subsetStandardManifest,
 } from "./manifest.js"
 export {
   type DefineVoyantProjectInput,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -22,6 +22,7 @@ export { type FrameworkProviders, frameworkComposition } from "./composition-laz
 export {
   type CreateVoyantAppConfig,
   createVoyantApp,
+  ownedExtensionsForExcludedModules,
   subsetStandardManifest,
 } from "./create-app.js"
 export {
@@ -35,6 +36,7 @@ export {
 } from "./discover-modules.js"
 export {
   FRAMEWORK_CAPABILITY_GRAPH,
+  FRAMEWORK_EXTENSION_OWNERSHIP,
   FRAMEWORK_RUNTIME_MANIFEST,
   type FrameworkManifest,
 } from "./manifest.js"

--- a/packages/framework/src/manifest.test.ts
+++ b/packages/framework/src/manifest.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
-import { ownedExtensionsForExcludedModules, subsetStandardManifest } from "./create-app.js"
-import { FRAMEWORK_EXTENSION_OWNERSHIP, FRAMEWORK_RUNTIME_MANIFEST } from "./manifest.js"
+import {
+  FRAMEWORK_EXTENSION_OWNERSHIP,
+  FRAMEWORK_RUNTIME_MANIFEST,
+  ownedExtensionsForExcludedModules,
+  subsetStandardManifest,
+} from "./manifest.js"
 
 describe("subsetStandardManifest (ADR-0007 module subsetting)", () => {
   it("returns the full standard set when nothing is excluded", () => {

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -111,3 +111,55 @@ export const FRAMEWORK_CAPABILITY_GRAPH = {
   "@voyant-travel/commerce": { isRequired: true },
   "@voyant-travel/relationships": { isRequired: true },
 } as const satisfies CapabilityGraph
+
+/**
+ * Which standard module(s) each standard extension augments (voyant#2104,
+ * ADR-0007 follow-up a). An extension's mount prefix is a *path*, not a foreign
+ * key to a module `name` — the standard set legitimately ships path-mounted
+ * extensions with no same-named module (e.g. `operator/proposal-extension`
+ * mounts under `quote-versions`), so a name-match orphan check is unsound.
+ * Ownership is therefore *declared* here, co-located with the manifest it is
+ * typed against, so excluding a module can cascade to its extensions safely
+ * (see `ownedExtensionsForExcludedModules` / `subsetStandardManifest`).
+ *
+ * An extension is owned by every listed module: excluding *any* owner drops it,
+ * because the extension augments a surface that owner contributes.
+ */
+export const FRAMEWORK_EXTENSION_OWNERSHIP = {
+  "@voyant-travel/bookings/booking-supplier-extension": ["@voyant-travel/bookings"],
+  "@voyant-travel/finance/bookings-create-extension": [
+    "@voyant-travel/finance",
+    "@voyant-travel/bookings",
+  ],
+  "@voyant-travel/inventory/booking-extension": [
+    "@voyant-travel/inventory",
+    "@voyant-travel/bookings",
+  ],
+  "@voyant-travel/inventory/authoring/extension": ["@voyant-travel/inventory"],
+  "@voyant-travel/quotes/booking-extension": ["@voyant-travel/quotes", "@voyant-travel/bookings"],
+  "@voyant-travel/distribution": ["@voyant-travel/distribution", "@voyant-travel/bookings"],
+  "@voyant-travel/distribution/channel-push-extension": ["@voyant-travel/distribution"],
+  "@voyant-travel/finance/booking-tax-extension": [
+    "@voyant-travel/finance",
+    "@voyant-travel/bookings",
+    "@voyant-travel/operator-settings",
+  ],
+  "operator/booking-schedule-extension": [
+    "@voyant-travel/finance",
+    "@voyant-travel/bookings",
+    "@voyant-travel/operator-settings",
+  ],
+  "operator/quote-version-snapshot-extension": ["@voyant-travel/quotes", "@voyant-travel/trips"],
+  "operator/booking-maintenance-extension": [
+    "@voyant-travel/bookings",
+    "@voyant-travel/commerce",
+    "@voyant-travel/operator-settings",
+  ],
+  "operator/action-ledger-health-extension": ["@voyant-travel/action-ledger"],
+  "operator/proposal-extension": ["@voyant-travel/quotes"],
+  "operator/catalog-offers-extension": ["@voyant-travel/catalog"],
+  "operator/catalog-checkout-extension": ["@voyant-travel/catalog", "@voyant-travel/commerce"],
+} as const satisfies Record<
+  (typeof FRAMEWORK_RUNTIME_MANIFEST.extensions)[number],
+  readonly (typeof FRAMEWORK_RUNTIME_MANIFEST.modules)[number][]
+>

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -18,7 +18,7 @@
  * Workstream B of the consolidated-deployments RFC: the standard registry's
  * factories live in this package alongside the manifest (the "which + order").
  */
-import type { CapabilityGraph } from "@voyant-travel/hono/composition"
+import { type CapabilityGraph, findCapabilityGaps } from "@voyant-travel/hono/composition"
 
 export interface FrameworkManifest {
   modules: readonly string[]
@@ -163,3 +163,94 @@ export const FRAMEWORK_EXTENSION_OWNERSHIP = {
   (typeof FRAMEWORK_RUNTIME_MANIFEST.extensions)[number],
   readonly (typeof FRAMEWORK_RUNTIME_MANIFEST.modules)[number][]
 >
+
+/** Options for {@link subsetStandardManifest}. */
+export interface SubsetOptions {
+  /** Specifiers to remove entirely (rejected if unknown, `isRequired`, or depended-on). */
+  exclude?: readonly string[]
+}
+
+/**
+ * The standard extensions owned by any of the excluded specifiers — an extension
+ * whose declared owner module (see `FRAMEWORK_EXTENSION_OWNERSHIP`) is being
+ * removed. Excluding a module must cascade to these, or the removed surface
+ * partially leaks: e.g. dropping `bookings` while `finance/bookings-create-extension`
+ * (mounting under `/v1/admin/bookings`) stays mounted (voyant#2104). Ownership is
+ * declared, not name-matched, so path-mounted extensions cascade correctly.
+ */
+export function ownedExtensionsForExcludedModules(excluded: Iterable<string>): string[] {
+  const excludedSet = excluded instanceof Set ? excluded : new Set(excluded)
+  const owned: string[] = []
+  for (const extension of FRAMEWORK_RUNTIME_MANIFEST.extensions) {
+    const owners = FRAMEWORK_EXTENSION_OWNERSHIP[extension]
+    if (owners.some((owner) => excludedSet.has(owner))) owned.push(extension)
+  }
+  return owned
+}
+
+/**
+ * Apply `exclude` to the standard set (ADR-0007), returning the module/extension
+ * specifiers that should mount. Pure and provider-free (manifest math only, no
+ * runtime composition), so it is unit-testable, reusable by tooling (`db doctor`),
+ * and safe to import from the lightweight `@voyant-travel/framework/profile`
+ * subpath. Throws — fail-loud at boot, never a runtime 500 — when `exclude` names
+ * a specifier absent from the standard set (a typo), names an `isRequired` module,
+ * or leaves a still-mounted module's `requires` unmet (drop the consumers too).
+ */
+export function subsetStandardManifest({ exclude = [] }: SubsetOptions = {}): {
+  modules: string[]
+  extensions: string[]
+} {
+  const excludeSet = new Set(exclude)
+
+  if (excludeSet.size > 0) {
+    const known = new Set<string>([
+      ...FRAMEWORK_RUNTIME_MANIFEST.modules,
+      ...FRAMEWORK_RUNTIME_MANIFEST.extensions,
+    ])
+    const unknown = [...excludeSet].filter((spec) => !known.has(spec)).sort()
+    if (unknown.length > 0) {
+      throw new Error(
+        `createVoyantApp: exclude names ${unknown.length} specifier(s) not in the standard set: ` +
+          `${unknown.join(", ")}. Only standard framework modules/extensions can be excluded.`,
+      )
+    }
+
+    const graph: CapabilityGraph = FRAMEWORK_CAPABILITY_GRAPH
+    const required = [...excludeSet].filter((spec) => graph[spec]?.isRequired).sort()
+    if (required.length > 0) {
+      throw new Error(
+        `createVoyantApp: cannot exclude required module(s): ${required.join(", ")}. ` +
+          "They are foundational and cannot be removed.",
+      )
+    }
+  }
+
+  // Cascade: dropping a module also drops the standard extensions it owns. They
+  // mount under the module's surface, so leaving them would partially leak the
+  // removed surface. Ownership is declared (`FRAMEWORK_EXTENSION_OWNERSHIP`), so
+  // path-mounted extensions cascade by declaration rather than an unsound
+  // name-match (voyant#2104). Idempotent — already-excluded extensions no-op.
+  for (const extension of ownedExtensionsForExcludedModules(excludeSet)) {
+    excludeSet.add(extension)
+  }
+
+  const modules = FRAMEWORK_RUNTIME_MANIFEST.modules.filter((m) => !excludeSet.has(m))
+  const extensions = FRAMEWORK_RUNTIME_MANIFEST.extensions.filter((e) => !excludeSet.has(e))
+
+  // The capability graph is validated over what actually mounts: dropping a
+  // module a still-mounted module depends on — without also dropping the consumer
+  // — fails loudly here rather than as a runtime 500.
+  const gaps = findCapabilityGaps(modules, FRAMEWORK_CAPABILITY_GRAPH)
+  if (gaps.length > 0) {
+    const detail = gaps
+      .map((g) => `"${g.capability}" (required by ${g.requiredBy.join(", ")})`)
+      .join("; ")
+    throw new Error(
+      `createVoyantApp: exclude leaves unmet capabilities: ${detail}. ` +
+        "Exclude the consumers too (capability replacement is a future release).",
+    )
+  }
+
+  return { modules, extensions }
+}

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -1,4 +1,4 @@
-import { subsetStandardManifest } from "./create-app.js"
+import { ownedExtensionsForExcludedModules, subsetStandardManifest } from "./create-app.js"
 import {
   FRAMEWORK_RUNTIME_MANIFEST,
   FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET,
@@ -68,45 +68,6 @@ const CUSTOMER_APP_MODULE_SPECIFIERS = new Set([
 const OPERATOR_DEFAULT_MODULE_SPECIFIERS = FRAMEWORK_RUNTIME_MANIFEST.modules.filter(
   (specifier) => !CUSTOMER_APP_MODULE_SPECIFIERS.has(specifier),
 )
-
-const STANDARD_EXTENSION_MODULE_OWNERS = {
-  "@voyant-travel/bookings/booking-supplier-extension": ["@voyant-travel/bookings"],
-  "@voyant-travel/finance/bookings-create-extension": [
-    "@voyant-travel/finance",
-    "@voyant-travel/bookings",
-  ],
-  "@voyant-travel/inventory/booking-extension": [
-    "@voyant-travel/inventory",
-    "@voyant-travel/bookings",
-  ],
-  "@voyant-travel/inventory/authoring/extension": ["@voyant-travel/inventory"],
-  "@voyant-travel/quotes/booking-extension": ["@voyant-travel/quotes", "@voyant-travel/bookings"],
-  "@voyant-travel/distribution": ["@voyant-travel/distribution", "@voyant-travel/bookings"],
-  "@voyant-travel/distribution/channel-push-extension": ["@voyant-travel/distribution"],
-  "@voyant-travel/finance/booking-tax-extension": [
-    "@voyant-travel/finance",
-    "@voyant-travel/bookings",
-    "@voyant-travel/operator-settings",
-  ],
-  "operator/booking-schedule-extension": [
-    "@voyant-travel/finance",
-    "@voyant-travel/bookings",
-    "@voyant-travel/operator-settings",
-  ],
-  "operator/quote-version-snapshot-extension": ["@voyant-travel/quotes", "@voyant-travel/trips"],
-  "operator/booking-maintenance-extension": [
-    "@voyant-travel/bookings",
-    "@voyant-travel/commerce",
-    "@voyant-travel/operator-settings",
-  ],
-  "operator/action-ledger-health-extension": ["@voyant-travel/action-ledger"],
-  "operator/proposal-extension": ["@voyant-travel/quotes"],
-  "operator/catalog-offers-extension": ["@voyant-travel/catalog"],
-  "operator/catalog-checkout-extension": ["@voyant-travel/catalog", "@voyant-travel/commerce"],
-} as const satisfies Record<
-  (typeof FRAMEWORK_RUNTIME_MANIFEST.extensions)[number],
-  readonly string[]
->
 
 export function defineVoyantProject(input: DefineVoyantProjectInput): VoyantProjectManifest {
   const manifest: VoyantProjectManifest = {
@@ -338,17 +299,6 @@ function computeCreateVoyantAppExclude(project: VoyantProjectManifest): string[]
 
   subsetStandardManifest({ exclude: ordered })
   return ordered
-}
-
-function ownedExtensionsForExcludedModules(excludedModules: Set<string>): string[] {
-  const extensions: string[] = []
-  for (const extensionSpecifier of FRAMEWORK_RUNTIME_MANIFEST.extensions) {
-    const owners = STANDARD_EXTENSION_MODULE_OWNERS[extensionSpecifier]
-    if (owners.some((owner) => excludedModules.has(owner))) {
-      extensions.push(extensionSpecifier)
-    }
-  }
-  return unique(extensions)
 }
 
 function resolvedExcludedModuleIds(project: VoyantProjectManifest): string[] {

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -1,7 +1,8 @@
-import { ownedExtensionsForExcludedModules, subsetStandardManifest } from "./create-app.js"
 import {
   FRAMEWORK_RUNTIME_MANIFEST,
   FRAMEWORK_SOURCE_FREE_UNSUPPORTED_SPECIFIER_SET,
+  ownedExtensionsForExcludedModules,
+  subsetStandardManifest,
 } from "./manifest.js"
 import { resourceRequirementsFor } from "./profile-requirements.js"
 import {


### PR DESCRIPTION
## Module subsetting: cascade standard-extension exclusion from declared ownership

Closes part of #2104 (ADR-0007 follow-up a — the non-schema half).

### Problem

`createVoyantApp({ exclude })` filtered the module **and** extension manifest lists independently. Excluding a module therefore left any *augmenting* extension mounted on the now-absent surface unless the caller also listed every owned extension specifier by hand — a partial-surface leak (verified during #2103 review). The managed-profile wrapper (`computeCreateVoyantAppExclude`) cascaded ownership, but the **core** `subsetStandardManifest` primitive did not, so a direct caller (self-host, tooling, tests) got the leak. Ownership was also hand-maintained in `profile.ts`, far from the manifest it must stay in sync with.

### Fix

- **`FRAMEWORK_EXTENSION_OWNERSHIP`** (`manifest.ts`) — declares which standard module(s) each standard extension augments, co-located with `FRAMEWORK_RUNTIME_MANIFEST` / `FRAMEWORK_CAPABILITY_GRAPH` and typed against them so it cannot drift. An extension's mount prefix is a *path*, not a foreign key to a module `name`, so path-mounted extensions with no same-named module (e.g. `operator/proposal-extension` under `quote-versions`) cascade **by declaration** rather than an unsound name-match.
- **`subsetStandardManifest`** now cascades: excluding a module drops the extensions it owns, in the core primitive. Every `exclude` caller is safe, not just the managed path.
- **`ownedExtensionsForExcludedModules`** — shared, exported cascade helper. The duplicated ownership map + helper in `profile.ts` is removed; there is now a single source of truth.
- Both are exported from the package index so tooling (a future `voyant db doctor`) can read the ownership graph.

### Scope note — schema stays whole

This is the **runtime + admin** half of #2104. The schema-side decision (see #2104 discussion) is that subsetting does **not** carve the migration bundle: an unselected module's tables are migrated but inert. The standard single-bundle managed-migration model is unchanged, so the fixed-operator and subset paths stay on the same predictable path. The remaining #2104 item is `voyant db doctor` treating inert unselected-module tables as expected-absent rather than drift (no doctor implementation exists yet).

### Tests

`create-app.test.ts` adds cascade coverage: module→owned-extension drop, the path-mounted case (`proposal` under `quote-versions`), the no-owner-excluded no-op, and the helper's declaration-driven behaviour. Framework package: typecheck + lint clean, 101/101 tests pass.
