### PR TITLE
Managed migration path for custom schema-owning modules

### DIFF
--- a/.changeset/managed-migration-esm-and-validation-fixes.md
+++ b/.changeset/managed-migration-esm-and-validation-fixes.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/framework-migrations": patch
+"@voyant-travel/framework": patch
+---
+
+Harden the managed custom-module migration path (voyant#3069 follow-ups).
+
+- `loadModuleBundleSource` now resolves ESM-only ("import"-only `exports`)
+  packages. `require.resolve` applies the CommonJS `require` condition and throws
+  `ERR_PACKAGE_PATH_NOT_EXPORTED` for import-only packages (the repo's publish
+  shape), which silently skipped a schema-owning package's committed
+  `migrations/`. It now falls back to a `node_modules` package-root walk that
+  ignores export conditions when `require.resolve` rejects.
+- `customSource` is now validated: `validateVoyantProject` rejects a non-object
+  `customSource` or a non-string-array `customSource.modules`/`.extensions`, and
+  `getVoyantProjectMigrationMetadata` defensively coerces the value before
+  deriving migration sources — so a malformed snapshot (e.g. a string instead of
+  an array) no longer yields one "package" per character.

--- a/packages/framework-migrations/src/module-source.test.ts
+++ b/packages/framework-migrations/src/module-source.test.ts
@@ -17,14 +17,22 @@ const frameworkBundleDir = join(dirname(fileURLToPath(import.meta.url)), "..", "
 function writeFakePackage(
   root: string,
   packageName: string,
-  { withMigrations }: { withMigrations: boolean },
+  { withMigrations, esmOnly = false }: { withMigrations: boolean; esmOnly?: boolean },
 ): void {
   const pkgDir = join(root, "node_modules", ...packageName.split("/"))
   mkdirSync(pkgDir, { recursive: true })
-  writeFileSync(
-    join(pkgDir, "package.json"),
-    JSON.stringify({ name: packageName, version: "1.0.0", main: "index.js" }),
-  )
+  // `esmOnly` writes an import-only `exports` map (no `require`/`default`
+  // condition), so `require.resolve` throws ERR_PACKAGE_PATH_NOT_EXPORTED — the
+  // publish shape that must still resolve via the package-root walk.
+  const packageJson = esmOnly
+    ? {
+        name: packageName,
+        version: "1.0.0",
+        type: "module",
+        exports: { ".": { import: "./index.js" } },
+      }
+    : { name: packageName, version: "1.0.0", main: "index.js" }
+  writeFileSync(join(pkgDir, "package.json"), JSON.stringify(packageJson))
   writeFileSync(join(pkgDir, "index.js"), "export {}\n")
   if (!withMigrations) return
   const migrationsDir = join(pkgDir, "migrations")
@@ -48,6 +56,7 @@ beforeAll(() => {
   resolveFrom = pathToFileURL(join(root, "consumer.js")).href
   writeFakePackage(root, "@acme/loyalty", { withMigrations: true })
   writeFakePackage(root, "@acme/analytics", { withMigrations: false })
+  writeFakePackage(root, "@acme/esm-only", { withMigrations: true, esmOnly: true })
 })
 
 afterAll(() => {
@@ -79,6 +88,15 @@ describe("loadModuleBundleSource (voyant#3069)", () => {
 
   it("returns null for an unresolvable package", async () => {
     expect(await loadModuleBundleSource("@acme/missing", { priority: 1, resolveFrom })).toBeNull()
+  })
+
+  it("resolves ESM-only (import-only exports) packages require.resolve rejects", async () => {
+    // The publish shape used across this repo: `require.resolve` throws
+    // ERR_PACKAGE_PATH_NOT_EXPORTED, so the migrations must be found by root walk.
+    const source = await loadModuleBundleSource("@acme/esm-only", { priority: 2, resolveFrom })
+    expect(source).not.toBeNull()
+    expect(source?.name).toBe("esm-only")
+    expect(source?.migrations.length).toBeGreaterThan(0)
   })
 
   it("honors an explicit migrationsDir, bypassing package resolution", async () => {

--- a/packages/framework-migrations/src/module-source.ts
+++ b/packages/framework-migrations/src/module-source.ts
@@ -16,9 +16,10 @@
  * `null` here — they need no migrations and are simply skipped.
  */
 
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, readFileSync, statSync } from "node:fs"
 import { createRequire } from "node:module"
 import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
 
 import type { MigrationSource } from "./collector.js"
 import { loadMigrationFolder } from "./load-folder.js"
@@ -74,14 +75,58 @@ function resolvePackageRoot(packageName: string, entryPath: string): string | nu
   }
 }
 
+/** The directory to start a `node_modules` walk from, given a file/dir path or `file:` URL. */
+function toStartDir(resolveFrom: string | URL): string {
+  const path =
+    resolveFrom instanceof URL ||
+    (typeof resolveFrom === "string" && resolveFrom.startsWith("file:"))
+      ? fileURLToPath(resolveFrom)
+      : resolveFrom
+  try {
+    return statSync(path).isDirectory() ? path : dirname(path)
+  } catch {
+    return dirname(path)
+  }
+}
+
+/**
+ * Locate an installed package's root by walking `node_modules` up from
+ * `resolveFrom`, matching the `package.json` `name`. Ignores package `exports`
+ * conditions, so it resolves ESM-only ("import"-only) packages that
+ * `require.resolve` rejects with `ERR_PACKAGE_PATH_NOT_EXPORTED` — the publish
+ * shape used across this repo. Only the package root is needed here (to read its
+ * committed `migrations/`), so no entry-point resolution is required.
+ */
+function findInstalledPackageRoot(packageName: string, resolveFrom: string | URL): string | null {
+  let dir = toStartDir(resolveFrom)
+  for (;;) {
+    const packageJsonPath = join(dir, "node_modules", packageName, "package.json")
+    if (existsSync(packageJsonPath)) {
+      try {
+        const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8")) as { name?: string }
+        if (parsed.name === packageName) return dirname(packageJsonPath)
+      } catch {
+        // Unreadable/partial package.json — keep walking.
+      }
+    }
+    const parent = dirname(dir)
+    if (parent === dir) return null
+    dir = parent
+  }
+}
+
 function resolveModuleMigrationsDir(packageName: string, resolveFrom: string | URL): string | null {
-  let entryPath: string
+  let entryPath: string | null = null
   try {
     entryPath = createRequire(resolveFrom).resolve(packageName)
   } catch {
-    return null
+    // ESM-only packages (import-only `exports`) reject the CommonJS `require`
+    // condition — fall back to a package-root walk that ignores export conditions.
+    entryPath = null
   }
-  const root = resolvePackageRoot(packageName, entryPath)
+  const root = entryPath
+    ? resolvePackageRoot(packageName, entryPath)
+    : findInstalledPackageRoot(packageName, resolveFrom)
   return root ? join(root, "migrations") : null
 }
 

--- a/packages/framework/src/profile-validation.ts
+++ b/packages/framework/src/profile-validation.ts
@@ -56,6 +56,7 @@ export function validateVoyantProjectRecord(
   validatePlugins(input.plugins, issues)
   validateSettings(input.settings, issues)
   validateAdmin(input.admin, issues)
+  validateCustomSource(input.customSource, issues)
   validateNoWebsiteArtifacts(input.websites, issues)
 
   return issues
@@ -225,6 +226,41 @@ function validateAdmin(admin: unknown, issues: VoyantProfileValidationIssue[]) {
       message: 'admin.path must be an absolute path such as "/app".',
     })
   }
+}
+
+function validateCustomSource(customSource: unknown, issues: VoyantProfileValidationIssue[]) {
+  if (customSource == null) return
+  if (!isRecord(customSource)) {
+    issues.push({
+      path: "customSource",
+      code: "invalid_type",
+      message: "customSource must be an object with optional modules/extensions arrays.",
+    })
+    return
+  }
+  validateStringArray(customSource.modules, "customSource.modules", issues)
+  validateStringArray(customSource.extensions, "customSource.extensions", issues)
+}
+
+function validateStringArray(value: unknown, path: string, issues: VoyantProfileValidationIssue[]) {
+  if (value == null) return
+  if (!Array.isArray(value)) {
+    issues.push({
+      path,
+      code: "invalid_type",
+      message: `${path} must be an array of package names.`,
+    })
+    return
+  }
+  value.forEach((entry, index) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      issues.push({
+        path: `${path}[${index}]`,
+        code: "invalid_type",
+        message: `${path} entries must be non-empty package-name strings.`,
+      })
+    }
+  })
 }
 
 function validateNoWebsiteArtifacts(websites: unknown, issues: VoyantProfileValidationIssue[]) {

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -328,6 +328,34 @@ describe("managed profile contract", () => {
       { packageName: "@acme/gift-cards", priority: 2 },
     ])
   })
+
+  it("rejects a malformed customSource.modules during validation", () => {
+    const result = validateVoyantProject({
+      ...validProject({ plugins: [] }),
+      customSource: { modules: "@acme/loyalty" },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({ path: "customSource.modules", code: "invalid_type" }),
+    )
+  })
+
+  it("coerces a malformed customSource.modules to no sources rather than per-character", () => {
+    // Simulates a JSON-loaded snapshot that bypassed validation: a string is
+    // iterable, so an unguarded derivation would emit one source per character.
+    // Typed as `unknown` (a JSON boundary) and narrowed once at the call seam.
+    const malformed: unknown = {
+      profile: "operator",
+      customSource: { modules: "@acme/loyalty" },
+    }
+
+    expect(
+      getVoyantProjectMigrationMetadata(
+        malformed as Pick<VoyantProjectManifest, "profile" | "customSource">,
+      ).moduleSources,
+    ).toEqual([])
+  })
 })
 
 describe("resolveActiveModuleIds (admin gating signal, voyant#3063)", () => {

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -164,7 +164,15 @@ export function getVoyantProjectMigrationMetadata(
   // Standard-profile modules are baked into the framework bundle; only the
   // snapshot's custom (bring-your-own) schema-owning modules need their own
   // pre-built migration source, applied after the framework bundle (voyant#3069).
-  const moduleSources = unique(project.customSource?.modules ?? []).map((packageName, index) => ({
+  // Guard the JSON-loaded value: a malformed snapshot (e.g. a string instead of
+  // an array) is iterable and would otherwise yield one "package" per character.
+  const declaredModules = Array.isArray(project.customSource?.modules)
+    ? project.customSource.modules.filter(
+        (packageName): packageName is string =>
+          typeof packageName === "string" && packageName.trim().length > 0,
+      )
+    : []
+  const moduleSources = unique(declaredModules).map((packageName, index) => ({
     packageName,
     priority: index + 1,
   }))


### PR DESCRIPTION
## Managed migration path for custom schema-owning modules

Unblocks Slice 4 of platform#1016. Refs #3069, part of the #2983 managed-profile track.

### Problem

A source-free managed image runs migrations with **no drizzle-kit generation**, so a custom "bring-your-own" module that owns schema had no way to create its tables. Standard-profile modules are baked into the framework bundle; custom modules were not covered.

### Approach — Option 1 (modules ship pre-built migrations)

Chosen for predictability: a custom module ships its own committed `migrations/` folder, following the same per-package convention standard packages already use, and Cloud runs them **after** the framework bundle (additive, priority 1+). "One bundle = the whole standard schema" holds; custom schema is layered on, not generated.

### `@voyant-travel/framework-migrations`

- `loadModuleBundleSource(packageName, { priority, resolveFrom })` — resolves a module package's committed `migrations/` folder by name into a `MigrationSource`, or `null` when it ships none (schema-less modules/plugins are skipped). Ledger source name is the unscoped package name, stable across source and managed modes.
- `collectManagedMigrationSources({ modulePackages, resolveFrom })` — returns `[framework, ...customModules]` deps-first, ready for `runDeploymentMigrations`.

### `@voyant-travel/framework`

- `getVoyantProjectMigrationMetadata(project)` now returns `moduleSources: { packageName, priority }[]` derived from the snapshot's `customSource.modules`, so the platform migrate booter enumerates the custom schema-owning packages to apply after the framework bundle. Adds the `VoyantProfileModuleMigrationSource` type.

### Tests / docs

Adds `module-source.test.ts` (custom module bundle resolution + skip-when-schema-less + deps-first ordering) and `docs/architecture/migration-collector-d2.md`. Changeset: both packages `minor`.
