### PR TITLE
docs: reflect shipped module-subset extension cascade + schema decision

### DIFF
--- a/.changeset/docs-module-subset-cascade.md
+++ b/.changeset/docs-module-subset-cascade.md
@@ -1,0 +1,7 @@
+---
+---
+
+docs: refresh ADR-0007 and the `@voyant-travel/framework` module-subset JSDoc to
+reflect the shipped extension-ownership cascade (voyant#2104/#3074) and the
+decided schema-whole (no bundle partitioning) approach. Comment/doc-only — no
+runtime behavior change, so no package release.

--- a/docs/adr/0007-module-subsetting-and-capability-ports.md
+++ b/docs/adr/0007-module-subsetting-and-capability-ports.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed (2026-06-22)
 - **Relates to:** [consolidated-deployments-rfc](../architecture/consolidated-deployments-rfc.md) (Workstream B / D.1), [ADR-0006](./0006-live-availability-search-contract.md) (capability-gated adapters as precedent), [custom-modules](../architecture/custom-modules.md)
-- **Implemented by:** This PR — `createVoyantApp({ exclude })`, `FRAMEWORK_CAPABILITY_GRAPH` (marking the foundational core, incl. CRM, `isRequired`), and the pure `findCapabilityGaps` / `subsetStandardManifest` validators. A pluggable-implementation port (swap a required module for an external one) was considered and rejected for v1 — see Alternatives. Near-term follow-up: schema-side subsetting + extension cascade.
+- **Implemented by:** This PR — `createVoyantApp({ exclude })`, `FRAMEWORK_CAPABILITY_GRAPH` (marking the foundational core, incl. CRM, `isRequired`), and the pure `findCapabilityGaps` / `subsetStandardManifest` validators. A pluggable-implementation port (swap a required module for an external one) was considered and rejected for v1 — see Alternatives. Extension-ownership cascade shipped as a follow-up (voyant#2104/#3074); the schema side is decided as no-bundle-partitioning (see Phasing).
 
 ## Context
 
@@ -31,9 +31,10 @@ Two facts from the codebase shape the design:
 
 2. **There are two manifests that can drift.** `voyant.config.ts` `modules` drives
    schema/migration/CLI (`db doctor`, drizzle config), while
-   `FRAMEWORK_RUNTIME_MANIFEST` drives runtime mounting. A naive runtime `exclude`
-   would un-mount routes while still migrating the dropped module's tables — hence
-   the schema-side follow-up.
+   `FRAMEWORK_RUNTIME_MANIFEST` drives runtime mounting. A runtime `exclude`
+   un-mounts routes while the monolithic bundle still migrates the dropped module's
+   tables — resolved by keeping schema whole + inert and having `db doctor` treat
+   it as expected (see Phasing), not by partitioning the bundle.
 
 3. **Some modules can't be dropped safely.** Cross-cutting infrastructure (audit
    ledger, identity, commerce primitives) and CRM are reached by many others, so
@@ -112,21 +113,23 @@ goal. See Alternatives.
   `relationshipsService` directly without breaking subsetting — no decoupling debt,
   no port to maintain. If an external-CRM requirement ever appears, the seam is
   override-by-capability (Alternatives); it is not built now.
-- **Schema for excluded modules is not auto-dropped.** Excluding stops *future*
-  migration of those tables; an existing deployment that excludes a module still
-  owns its historical tables and must drop them deliberately. `db doctor` reports
-  orphaned-schema drift.
-- **Excluding a module does not auto-drop its augmenting extensions.** An
-  extension's mount prefix (`HonoExtension.extension.module`) is a *path*, not a
-  foreign key to a mounted module's `name` — the standard set legitimately
-  contains, e.g., a `proposal` extension that mounts under `quote-versions` with
-  no module of that name. So a name-match "orphan" check is unsound (it would
-  reject the full set at boot). `exclude` filters both the module and extension
-  manifest lists, so a deployment dropping a module with augmenting extensions
-  (e.g. `bookings` + `finance/bookings-create-extension`, which mounts under
-  `/v1/admin/bookings`) must list those extension specifiers too, else the
-  excluded module's surface partially leaks. Auto-cascade needs explicit
-  module→extension *ownership* metadata in the graph — a follow-up.
+- **Schema for excluded modules stays whole (by design).** The managed migration
+  bundle is monolithic and version-pinned, so an excluded module's tables are
+  still created but left inert — no routes or admin nav reach them. This keeps the
+  fixed-operator and subset paths on the same single-bundle migration model rather
+  than partitioning the bundle per subset. `voyant db doctor` treats an excluded
+  module's tables as *expected-absent-from-use*, not drift. (Re-selecting the
+  module later "just works" with no migration.)
+- **Excluding a module auto-drops its augmenting extensions** (voyant#2104,
+  shipped). An extension's mount prefix (`HonoExtension.extension.module`) is a
+  *path*, not a foreign key to a mounted module's `name` — the standard set
+  legitimately contains, e.g., a `proposal` extension that mounts under
+  `quote-versions` with no module of that name — so a name-match "orphan" check is
+  unsound. Ownership is therefore *declared* in `FRAMEWORK_EXTENSION_OWNERSHIP`
+  (co-located with the manifest), and `subsetStandardManifest` cascades exclusion
+  from it: dropping `bookings` also drops `finance/bookings-create-extension`
+  (which mounts under `/v1/admin/bookings`) with no need to list it. This runs in
+  the core primitive, so every `exclude` caller is safe, not just the managed path.
 
 ## Phasing
 
@@ -134,10 +137,16 @@ goal. See Alternatives.
 manifest; `FRAMEWORK_CAPABILITY_GRAPH` with `isRequired` (incl. CRM); validated by
 `findCapabilityGaps` + `subsetStandardManifest`.
 
-**Follow-up (near-term, separate issue).** Schema-side subsetting + extension
-cascade: feed `exclude` into drizzle generation so tables drop with routes, and
-declare module→extension *ownership* so excluding a module also drops its
-augmenting extensions (closing the partial-surface-leak above).
+**Extension cascade (shipped, voyant#2104/#3074).** `FRAMEWORK_EXTENSION_OWNERSHIP`
+declares module→extension ownership and `subsetStandardManifest` cascades
+exclusion from it, closing the partial-surface-leak above.
+
+**Schema-side (decided — no bundle partitioning).** Rather than feeding `exclude`
+into drizzle generation to drop tables, the subset leaves the monolithic bundle
+whole and inert (see Consequences); the remaining work is `voyant db doctor`
+knowing a subset's unselected-module tables are expected-absent-from-use rather
+than drift. Admin-UI subsetting + a stable people-picker contract for a substitute
+CRM is a separate, demand-driven follow-up (voyant#2107).
 
 Pluggable-implementation ports (swap a required module — e.g. CRM — for an
 external system) are **not** on the roadmap; see Alternatives.

--- a/packages/framework/src/create-app.ts
+++ b/packages/framework/src/create-app.ts
@@ -62,17 +62,19 @@ export interface CreateVoyantAppConfig<
    * REMOVE (ADR-0007): standard module *and/or extension* specifiers to drop from
    * the framework set entirely — for a deployment that simply doesn't run them
    * (e.g. a non-flights operator excluding `@voyant-travel/flights`). Filters the
-   * runtime manifest (and, once the schema side lands, drizzle generation, so
-   * routes and tables drop together). Naming a specifier absent from the standard
-   * set is a typo and throws; excluding an `isRequired` module throws; excluding a
-   * module another mounted module depends on throws, naming the consumers (drop
-   * those too).
+   * runtime manifest and admin surface. Naming a specifier absent from the
+   * standard set is a typo and throws; excluding an `isRequired` module throws;
+   * excluding a module another mounted module depends on throws, naming the
+   * consumers (drop those too).
    *
-   * Note: an extension's mount prefix (`extension.module`) is a path, not a
-   * foreign key to a mounted module, so excluding a module does NOT auto-drop the
-   * standard extensions that augment its surface — list those extension
-   * specifiers here too. Automatic cascade needs explicit module→extension
-   * ownership metadata (a follow-up; see ADR-0007).
+   * Excluding a module cascades to the standard extensions it owns: an extension's
+   * mount prefix is a path, not a foreign key to a mounted module, so ownership is
+   * declared in `FRAMEWORK_EXTENSION_OWNERSHIP` and its augmenting extensions are
+   * dropped automatically (voyant#2104) — no need to list them here.
+   *
+   * Schema is unaffected: the managed migration bundle is monolithic, so an
+   * excluded module's tables are still created but left inert (no routes/nav
+   * reach them). `voyant db doctor` treats them as expected-absent, not drift.
    *
    * To *replace* a module's capability with a substitute (e.g. HubSpot for CRM)
    * rather than removing it — override-by-capability — is the v2 design and not

--- a/packages/framework/src/manifest.ts
+++ b/packages/framework/src/manifest.ts
@@ -10,10 +10,12 @@
  * The standard set is the DEFAULT, not a fixed profile (ADR-0007). A deployment
  * may pare it down via `createVoyantApp({ exclude })` (remove), validated against
  * `FRAMEWORK_CAPABILITY_GRAPH` (below) so dropping a depended-on module, or an
- * `isRequired` one, fails at boot rather than as a runtime 500. Phase 1 lands the
- * runtime removal mechanism here; aligning schema/migration generation with the
- * same subset is the immediate follow-up. Capability *replacement* (override a
- * module with a substitute) is the v2 design — see ADR-0007 "Deferred to v2".
+ * `isRequired` one, fails at boot rather than as a runtime 500. Excluding a module
+ * cascades to the extensions it owns (`FRAMEWORK_EXTENSION_OWNERSHIP`, voyant#2104).
+ * The subset gates runtime + admin surfaces only; the migration bundle stays
+ * monolithic, so an excluded module's tables are created but inert. Capability
+ * *replacement* (override a module with a substitute) is the v2 design — see
+ * ADR-0007 "Deferred to v2".
  *
  * Workstream B of the consolidated-deployments RFC: the standard registry's
  * factories live in this package alongside the manifest (the "which + order").


### PR DESCRIPTION
## Refresh module-subset docs to match shipped behavior

Follow-up housekeeping after the extension-ownership cascade (#3074, voyant#2104) and the custom-module migration path merged. Several docs still described the cascade + schema-side work as open follow-ups.

- **`create-app.ts` `exclude` JSDoc** — said excluding a module does **not** auto-drop its augmenting extensions and told callers to list them manually. It now cascades from `FRAMEWORK_EXTENSION_OWNERSHIP`, so that guidance was actively misleading. Also corrected the stale "feed `exclude` into drizzle generation so tables drop with routes" line — schema stays whole + inert; `voyant db doctor` treats excluded-module tables as expected-absent.
- **`manifest.ts` header** — same "aligning schema/migration generation is the immediate follow-up" claim refreshed.
- **ADR-0007** — Consequences + Phasing updated: extension cascade marked shipped; the schema side recorded as a *decision* (no bundle partitioning) rather than an open item; admin-UI subsetting pointed at voyant#2107.

Comment/doc-only — no runtime change (empty changeset).
