### PR TITLE
Make demo-backed families optional: auto-exclude flights when unwired

### DIFF
--- a/.changeset/optional-demo-family-loaders.md
+++ b/.changeset/optional-demo-family-loaders.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Make demo-backed standard families optional so a deployment never has to wire (or
+install a data source for) a family it doesn't run.
+
+`FrameworkProviders.loadFlightAdminRoutes` is now **optional**. When it isn't
+provided, `createVoyantApp` auto-excludes `@voyant-travel/flights` (no routes, no
+admin nav) via the ADR-0007 subsetting path — "not wired" is treated as "not run"
+— instead of forcing the deployment to stub it. The flights family has no
+first-party real connector yet (only the demo adapter), so an operator that
+doesn't sell flights should not need one.
+
+The mechanism is a small `OPTIONAL_FAMILY_LOADERS` map (specifier → the
+`FrameworkProviders` field that mounts it) plus the exported
+`optionalFamiliesToExclude(providers)` helper; more families can opt in as they
+gain deployment-injected, optional loaders. Deployments that DO provide the loader
+(the operator starter, the managed runtime) are unaffected.

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -79,7 +79,14 @@ export interface FrameworkProviders {
   ) => import("@voyant-travel/finance/card-payment").CardPaymentStarter | null
   notificationsAutoConfirmAndDispatch?: CreateNotificationsHonoModuleOptions["autoConfirmAndDispatch"]
   createChannelPushExtension: () => HonoExtension
-  loadFlightAdminRoutes: LazyRoutesLoader
+  /**
+   * OPTIONAL: the `@voyant-travel/flights` family has no first-party real
+   * connector yet (only the demo adapter), so a deployment that doesn't run
+   * flights should not have to wire or install one. When this loader is omitted,
+   * `createVoyantApp` auto-excludes the flights module (see
+   * `OPTIONAL_FAMILY_LOADERS`) rather than forcing a stub.
+   */
+  loadFlightAdminRoutes?: LazyRoutesLoader
   loadMcpAdminRoutes: LazyRoutesLoader
   loadCatalogBookingRoutes: LazyRoutesLoader
   loadCatalogContentRoutes: LazyRoutesLoader

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -783,10 +783,23 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
         },
       }
     },
-    "@voyant-travel/flights": ({ capabilities }) => ({
-      module: { name: "flights" },
-      lazyAdminRoutes: capabilities.loadFlightAdminRoutes,
-    }),
+    "@voyant-travel/flights": ({ capabilities }) => {
+      // `loadFlightAdminRoutes` is optional so `createVoyantApp` can auto-exclude
+      // flights when it's unwired. If flights IS in the manifest (e.g. a direct
+      // `frameworkComposition` mount) the loader must be present — fail fast here
+      // rather than mounting a flights module in admin metadata with no routes.
+      if (!capabilities.loadFlightAdminRoutes) {
+        throw new Error(
+          "frameworkComposition: @voyant-travel/flights is in the manifest but " +
+            "loadFlightAdminRoutes was not provided. Provide the loader, or drop the " +
+            "specifier (createVoyantApp auto-excludes it when the loader is absent).",
+        )
+      }
+      return {
+        module: { name: "flights" },
+        lazyAdminRoutes: capabilities.loadFlightAdminRoutes,
+      }
+    },
     "operator/mcp": ({ capabilities }) => ({
       module: { name: "mcp" },
       lazyAdminRoutes: capabilities.loadMcpAdminRoutes,

--- a/packages/framework/src/create-app.test.ts
+++ b/packages/framework/src/create-app.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+import type { FrameworkProviders } from "./composition-lazy.js"
+import { optionalFamiliesToExclude } from "./create-app.js"
+
+/** Cast a loose record to the providers slice the helper reads (avoids stubbing every field). */
+function providersWith(fields: Record<string, unknown>): Partial<FrameworkProviders> {
+  return fields as Partial<FrameworkProviders>
+}
+
+describe("optionalFamiliesToExclude (auto-exclude unwired optional families)", () => {
+  it("excludes @voyant-travel/flights when loadFlightAdminRoutes is not provided", () => {
+    expect(optionalFamiliesToExclude({})).toContain("@voyant-travel/flights")
+  })
+
+  it("keeps flights when the loader is provided", () => {
+    const excluded = optionalFamiliesToExclude(providersWith({ loadFlightAdminRoutes: () => {} }))
+    expect(excluded).not.toContain("@voyant-travel/flights")
+  })
+
+  it("does not exclude required (non-optional) families", () => {
+    // Only families in OPTIONAL_FAMILY_LOADERS can be auto-excluded; an empty
+    // providers object must not drop the core standard set.
+    expect(optionalFamiliesToExclude({})).toEqual(["@voyant-travel/flights"])
+  })
+})

--- a/packages/framework/src/create-app.test.ts
+++ b/packages/framework/src/create-app.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import type { FrameworkProviders } from "./composition-lazy.js"
+import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
 import { optionalFamiliesToExclude } from "./create-app.js"
 
 /** Cast a loose record to the providers slice the helper reads (avoids stubbing every field). */
@@ -21,5 +21,14 @@ describe("optionalFamiliesToExclude (auto-exclude unwired optional families)", (
     // Only families in OPTIONAL_FAMILY_LOADERS can be auto-excluded; an empty
     // providers object must not drop the core standard set.
     expect(optionalFamiliesToExclude({})).toEqual(["@voyant-travel/flights"])
+  })
+
+  it("flights factory fails fast in direct composition when the loader is absent", () => {
+    // `createVoyantApp` excludes flights before the factory runs; a direct
+    // `frameworkComposition` mount that keeps flights but omits the loader must
+    // fail loudly rather than mount a routeless module in admin metadata.
+    const factory = frameworkComposition.modules["@voyant-travel/flights"]
+    if (!factory) throw new Error("expected a flights module factory")
+    expect(() => factory({ capabilities: {} } as never)).toThrow(/loadFlightAdminRoutes/)
   })
 })

--- a/packages/framework/src/create-app.ts
+++ b/packages/framework/src/create-app.ts
@@ -43,6 +43,32 @@ import { type FrameworkProviders, frameworkComposition } from "./composition-laz
 import { subsetStandardManifest } from "./manifest.js"
 
 /**
+ * Standard families whose route loader is deployment-injected AND optional: when
+ * the loader isn't provided, `createVoyantApp` auto-excludes the family (no
+ * routes, no admin nav) instead of forcing the deployment to stub it or install
+ * a data source it doesn't run. Keyed by manifest specifier → the
+ * {@link FrameworkProviders} field that mounts it.
+ *
+ * `@voyant-travel/flights` has no first-party real connector yet — only the demo
+ * adapter — so an operator that doesn't sell flights should never need to wire or
+ * install one. "Not wired" is treated as "not run" (ADR-0007 subsetting).
+ */
+const OPTIONAL_FAMILY_LOADERS = {
+  "@voyant-travel/flights": "loadFlightAdminRoutes",
+} as const satisfies Record<string, keyof FrameworkProviders>
+
+/**
+ * The optional standard families whose injected loader is absent from
+ * `providers` — auto-excluded so a deployment never has to stub a family (or
+ * install its demo/data source) it doesn't run. Exported for tests.
+ */
+export function optionalFamiliesToExclude(providers: Partial<FrameworkProviders>): string[] {
+  return Object.entries(OPTIONAL_FAMILY_LOADERS)
+    .filter(([, field]) => providers[field] == null)
+    .map(([specifier]) => specifier)
+}
+
+/**
  * Config for {@link createVoyantApp}: the injected providers + deployment-local
  * additions, plus everything else `createApp` takes (db, auth, workflows,
  * outbox, publicPaths, …) — minus the `manifest`/`registry`/`capabilities` the
@@ -93,8 +119,13 @@ export function createVoyantApp<
 >(config: CreateVoyantAppConfig<TBindings, TProviders>) {
   const { providers, modules = {}, extensions = {}, exclude, ...rest } = config
 
+  // Auto-exclude optional standard families whose injected loader wasn't provided
+  // (e.g. flights on a deployment that doesn't sell them) — merged with the
+  // explicit `exclude`, then cascaded to owned extensions by subsetStandardManifest.
+  const resolvedExclude = [...(exclude ?? []), ...optionalFamiliesToExclude(providers)]
+
   const { modules: standardModules, extensions: standardExtensions } = subsetStandardManifest({
-    exclude,
+    exclude: resolvedExclude,
   })
 
   const registry: CompositionRegistry<TProviders> = {

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -554,7 +554,9 @@ describe("managed profile runtime entry", () => {
   }, 10000)
 
   it("wires package-owned flights routes in the default managed providers", async () => {
-    const app = await createManagedProfileProviders().loadFlightAdminRoutes()
+    const loadFlightAdminRoutes = createManagedProfileProviders().loadFlightAdminRoutes
+    if (!loadFlightAdminRoutes) throw new Error("managed providers must wire flights")
+    const app = await loadFlightAdminRoutes()
     const response = await app.request("/search", {
       method: "POST",
       body: JSON.stringify({


### PR DESCRIPTION
## Make demo-backed families optional — never force installing/wiring a demo

Principle: a deployment must never be required to install or wire a **demo** data source (or any data source) for a standard family it doesn't run. Framework-level enabler for that; re-scopes #2170.

### Change

`FrameworkProviders.loadFlightAdminRoutes` is now **optional**. When it isn't provided, `createVoyantApp` **auto-excludes** `@voyant-travel/flights` (no routes, no admin nav) through the existing ADR-0007 subsetting/cascade path — "not wired" is treated as "not run" — instead of forcing the deployment to stub it.

The flights family has no first-party real connector yet (only the demo adapter via `@voyant-travel/plugin-flights-demo`), so an operator that doesn't sell flights should not need one.

- `OPTIONAL_FAMILY_LOADERS` — a small map (manifest specifier → the `FrameworkProviders` field that mounts it), co-located with `createVoyantApp`. More families can opt in as they gain deployment-injected optional loaders.
- `optionalFamiliesToExclude(providers)` — exported helper returning the unwired optional families; `createVoyantApp` merges them into `exclude`.

Backward compatible: deployments that provide the loader (the operator starter, the managed runtime) are unaffected — flights mounts exactly as before.

### Tests

`create-app.test.ts` covers: flights auto-excluded when `loadFlightAdminRoutes` absent; kept when provided; no over-exclusion of required families. Framework: typecheck + lint clean, 106 tests pass; affected operator/managed-operator typecheck green.

### Follow-up (operator starter adoption)

This makes the *contract* honor the principle. Making the **reference operator itself** demo-free out-of-the-box is a separate change: `starters/operator` still lists the demo plugins as hard `dependencies` and statically imports them in three sync per-request paths (`flights-runtime.ts`, `trips-flight-runtime.ts`, `booking-engine-runtime.ts`). Adopting this requires gating each demo-backed wiring point on demo availability (so `buildOperatorProviders` omits `loadFlightAdminRoutes` → auto-exclude, and trips/catalog skip their demo adapters) and moving the demo plugins to `optionalDependencies`. Tracked for a focused follow-up.
