### PR TITLE
Mount managed customSource modules/extensions at runtime (#3079)

### DIFF
--- a/.changeset/managed-custom-source-runtime-mounting.md
+++ b/.changeset/managed-custom-source-runtime-mounting.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Mount managed `customSource` modules/extensions at runtime (voyant#3079,
+follow-up to #3069).
+
+`framework@0.22.0` derived `customSource.modules` into migration sources, so a
+bring-your-own schema-owning module's tables migrated in a managed deployment —
+but the managed runtime never wired `customSource`, so those modules' API routes
+404'd and their admin extensions never composed.
+
+`loadManagedProfileRuntime` now resolves each `customSource.modules` and
+`customSource.extensions` specifier — the analog of `resolveManagedPlugins` for
+schema-owning modules — and merges the resulting factories into
+`createManagedProfileApp` → `createVoyantApp`'s `modules`/`extensions` channel,
+so routes mount and admin extensions compose against the deployment's installed
+dependency tree. A declared-but-unresolved `customSource` entry fails loud at
+boot, mirroring the existing `plugins` check. New `resolveManagedCustomModules`
+/ `resolveManagedCustomExtensions` APIs are exported, with an injectable
+`importCustomSourceModule` loader for pre-bundled registries and tests.

--- a/packages/framework/src/custom-source-resolution.test.ts
+++ b/packages/framework/src/custom-source-resolution.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  resolveManagedCustomExtensions,
+  resolveManagedCustomModules,
+} from "./custom-source-resolution.js"
+
+function project(customSource: { modules?: string[]; extensions?: string[] } = {}) {
+  return { customSource } as Parameters<typeof resolveManagedCustomModules>[0]
+}
+
+describe("resolveManagedCustomModules", () => {
+  it("returns an empty record when the profile declares no custom modules", async () => {
+    const importModule = vi.fn()
+    const resolved = await resolveManagedCustomModules(project(), {}, { importModule })
+    expect(resolved).toEqual({})
+    expect(importModule).not.toHaveBeenCalled()
+  })
+
+  it("uses a `voyantModule` factory keyed by the package specifier", async () => {
+    const factory = vi.fn(() => ({ module: { name: "loyalty" } }))
+    const resolved = await resolveManagedCustomModules(
+      project({ modules: ["@acme/loyalty"] }),
+      { DATABASE_URL: "postgres://test" },
+      { importModule: async () => ({ voyantModule: factory }) },
+    )
+
+    expect(Object.keys(resolved)).toEqual(["@acme/loyalty"])
+    expect(resolved["@acme/loyalty"]?.({ capabilities: {} as never, options: {} })).toEqual({
+      module: { name: "loyalty" },
+    })
+    expect(factory).toHaveBeenCalledWith({ capabilities: {}, options: {} })
+  })
+
+  it("accepts a `default` export that is already a Hono module object", async () => {
+    const resolved = await resolveManagedCustomModules(
+      project({ modules: ["@acme/cases"] }),
+      {},
+      {
+        importModule: async () => ({ default: { module: { name: "cases" } } }),
+      },
+    )
+    expect(resolved["@acme/cases"]?.({ capabilities: {} as never, options: {} })).toEqual({
+      module: { name: "cases" },
+    })
+  })
+
+  it("throws a specifier-named error when no managed-module entry is exported", async () => {
+    await expect(
+      resolveManagedCustomModules(
+        project({ modules: ["@bad/module"] }),
+        {},
+        {
+          importModule: async () => ({ somethingElse: true }),
+        },
+      ),
+    ).rejects.toThrow(/@bad\/module.*does not export a managed-module entry/)
+  })
+
+  it("wraps an import failure with the specifier", async () => {
+    await expect(
+      resolveManagedCustomModules(
+        project({ modules: ["@missing/module"] }),
+        {},
+        {
+          importModule: async () => {
+            throw new Error("Cannot find module")
+          },
+        },
+      ),
+    ).rejects.toThrow(/Failed to import custom module "@missing\/module": Cannot find module/)
+  })
+})
+
+describe("resolveManagedCustomExtensions", () => {
+  it("uses a `voyantExtension` factory keyed by the package specifier", async () => {
+    const factory = vi.fn(() => ({ extension: { name: "source-health", module: "products" } }))
+    const resolved = await resolveManagedCustomExtensions(
+      project({ extensions: ["@acme/source-health"] }),
+      {},
+      { importModule: async () => ({ voyantExtension: factory }) },
+    )
+
+    expect(Object.keys(resolved)).toEqual(["@acme/source-health"])
+    expect(resolved["@acme/source-health"]?.({ capabilities: {} as never, options: {} })).toEqual({
+      extension: { name: "source-health", module: "products" },
+    })
+  })
+
+  it("accepts a `default` export that is already a Hono extension object", async () => {
+    const resolved = await resolveManagedCustomExtensions(
+      project({ extensions: ["@acme/product-sync"] }),
+      {},
+      {
+        importModule: async () => ({
+          default: { extension: { name: "product-sync", module: "products" } },
+        }),
+      },
+    )
+    expect(resolved["@acme/product-sync"]?.({ capabilities: {} as never, options: {} })).toEqual({
+      extension: { name: "product-sync", module: "products" },
+    })
+  })
+
+  it("throws a specifier-named error when no managed-extension entry is exported", async () => {
+    await expect(
+      resolveManagedCustomExtensions(
+        project({ extensions: ["@bad/extension"] }),
+        {},
+        {
+          importModule: async () => ({ somethingElse: true }),
+        },
+      ),
+    ).rejects.toThrow(/@bad\/extension.*does not export a managed-extension entry/)
+  })
+
+  it("wraps an import failure with the specifier", async () => {
+    await expect(
+      resolveManagedCustomExtensions(
+        project({ extensions: ["@missing/extension"] }),
+        {},
+        {
+          importModule: async () => {
+            throw new Error("Cannot find module")
+          },
+        },
+      ),
+    ).rejects.toThrow(/Failed to import custom extension "@missing\/extension": Cannot find module/)
+  })
+})

--- a/packages/framework/src/custom-source-resolution.ts
+++ b/packages/framework/src/custom-source-resolution.ts
@@ -1,0 +1,165 @@
+/**
+ * Resolve a managed profile's `customSource` module/extension lists into
+ * composition factories.
+ *
+ * Managed custom source is the source-free path for bring-your-own packages
+ * that are modules or extensions in Voyant's runtime vocabulary, rather than
+ * plugin distribution bundles. The profile snapshot records npm specifier
+ * strings under `customSource.modules` and `customSource.extensions`; this
+ * resolver imports each package, finds the managed module/extension entry, and
+ * returns a composition registry fragment keyed by the original specifier.
+ *
+ * The resulting records are passed to `createVoyantApp({ modules, extensions })`
+ * so schema-owning custom modules get the same Hono route/admin-extension
+ * treatment as deployment-local factories in a starter.
+ */
+
+import type { ExtensionFactory, ModuleFactory } from "@voyant-travel/hono/composition"
+import type { HonoExtension, HonoModule } from "@voyant-travel/hono/module"
+
+import type { FrameworkProviders } from "./composition-lazy.js"
+import type { VoyantProjectManifest } from "./profile-types.js"
+
+export interface ResolveManagedCustomSourceOptions {
+  /**
+   * Module loader, injectable for tests. Defaults to dynamic `import()`, which a
+   * Node-first managed runtime supports for published custom module packages.
+   */
+  importModule?: (specifier: string) => Promise<Record<string, unknown>>
+}
+
+const MODULE_EXPORT_NAMES = [
+  "voyantModule",
+  "createVoyantModule",
+  "createModule",
+  "default",
+] as const
+
+const EXTENSION_EXPORT_NAMES = [
+  "voyantExtension",
+  "createVoyantExtension",
+  "createExtension",
+  "default",
+] as const
+
+/**
+ * Resolve every specifier in `project.customSource.modules` to a module factory
+ * keyed by the specifier. Throws a specifier-named error when a package exposes
+ * no managed-module entry; managed profiles must fail loud at boot, never
+ * silently drop a schema-owning route bundle.
+ */
+export async function resolveManagedCustomModules(
+  project: Pick<VoyantProjectManifest, "customSource">,
+  env: Record<string, unknown>,
+  options: ResolveManagedCustomSourceOptions = {},
+): Promise<Record<string, ModuleFactory<FrameworkProviders>>> {
+  void env
+  return resolveManagedCustomEntries<HonoModule, ModuleFactory<FrameworkProviders>>({
+    specifiers: project.customSource?.modules ?? [],
+    kind: "module",
+    entryLabel: "managed-module",
+    exportNames: MODULE_EXPORT_NAMES,
+    isBareObject: isHonoModule,
+    wrapBareObject: (value) => () => value,
+    options,
+  })
+}
+
+/**
+ * Resolve every specifier in `project.customSource.extensions` to an extension
+ * factory keyed by the specifier. Throws a specifier-named error when a package
+ * exposes no managed-extension entry; managed profiles must fail loud at boot,
+ * never silently drop admin/public extension routes.
+ */
+export async function resolveManagedCustomExtensions(
+  project: Pick<VoyantProjectManifest, "customSource">,
+  env: Record<string, unknown>,
+  options: ResolveManagedCustomSourceOptions = {},
+): Promise<Record<string, ExtensionFactory<FrameworkProviders>>> {
+  void env
+  return resolveManagedCustomEntries<HonoExtension, ExtensionFactory<FrameworkProviders>>({
+    specifiers: project.customSource?.extensions ?? [],
+    kind: "extension",
+    entryLabel: "managed-extension",
+    exportNames: EXTENSION_EXPORT_NAMES,
+    isBareObject: isHonoExtension,
+    wrapBareObject: (value) => () => value,
+    options,
+  })
+}
+
+async function resolveManagedCustomEntries<TBareObject, TFactory>(config: {
+  specifiers: readonly string[]
+  kind: "module" | "extension"
+  entryLabel: "managed-module" | "managed-extension"
+  exportNames: readonly string[]
+  isBareObject: (value: unknown) => value is TBareObject
+  wrapBareObject: (value: TBareObject) => TFactory
+  options: ResolveManagedCustomSourceOptions
+}): Promise<Record<string, TFactory>> {
+  const importModule = config.options.importModule ?? defaultImportModule
+  const resolved: Record<string, TFactory> = {}
+  for (const specifier of config.specifiers) {
+    let mod: Record<string, unknown>
+    try {
+      mod = await importModule(specifier)
+    } catch (error) {
+      throw new Error(
+        `Failed to import custom ${config.kind} "${specifier}": ${errorMessage(error)}`,
+      )
+    }
+    resolved[specifier] = pickManagedCustomEntry(mod, specifier, config)
+  }
+  return resolved
+}
+
+function pickManagedCustomEntry<TBareObject, TFactory>(
+  mod: Record<string, unknown>,
+  specifier: string,
+  config: {
+    entryLabel: "managed-module" | "managed-extension"
+    exportNames: readonly string[]
+    isBareObject: (value: unknown) => value is TBareObject
+    wrapBareObject: (value: TBareObject) => TFactory
+  },
+): TFactory {
+  for (const name of config.exportNames) {
+    const candidate = mod[name]
+    if (typeof candidate === "function") {
+      return candidate as TFactory
+    }
+    if (config.isBareObject(candidate)) {
+      return config.wrapBareObject(candidate)
+    }
+  }
+  throw new Error(
+    `Custom source "${specifier}" does not export a ${config.entryLabel} entry. ` +
+      `Export one of: ${config.exportNames.join(", ")}`,
+  )
+}
+
+function isHonoModule(value: unknown): value is HonoModule {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { module?: { name?: unknown } }).module?.name === "string"
+  )
+}
+
+function isHonoExtension(value: unknown): value is HonoExtension {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { extension?: { module?: unknown; name?: unknown } }).extension?.module ===
+      "string" &&
+    typeof (value as { extension?: { name?: unknown } }).extension?.name === "string"
+  )
+}
+
+function defaultImportModule(specifier: string): Promise<Record<string, unknown>> {
+  return import(specifier) as Promise<Record<string, unknown>>
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -350,6 +350,82 @@ describe("managed profile runtime entry", () => {
     ).rejects.toThrow(/does not export a managed-plugin entry/)
   })
 
+  it("resolves snapshot custom source modules/extensions and boots source-free", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          customSource: {
+            modules: ["@third-party/custom-module"],
+            extensions: ["@third-party/custom-ext"],
+          },
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    const moduleFactory = vi.fn(() => ({
+      module: { name: "custom-module" },
+    }))
+    const extensionFactory = vi.fn(() => ({
+      extension: { name: "custom-ext", module: "custom-module" },
+    }))
+
+    const importCustomSourceModule = vi.fn(async (specifier: string) => {
+      if (specifier === "@third-party/custom-module") {
+        return { voyantModule: moduleFactory }
+      }
+      if (specifier === "@third-party/custom-ext") {
+        return { voyantExtension: extensionFactory }
+      }
+      throw new Error(`Unexpected specifier ${specifier}`)
+    })
+
+    const runtime = await loadManagedProfileRuntime({
+      profileSnapshotPath: snapshotPath,
+      env: { DATABASE_URL: "managed-profile-test-db" },
+      importCustomSourceModule,
+    })
+
+    expect(runtime.app.fetch).toEqual(expect.any(Function))
+    expect(importCustomSourceModule).toHaveBeenCalledWith("@third-party/custom-module")
+    expect(importCustomSourceModule).toHaveBeenCalledWith("@third-party/custom-ext")
+    expect(moduleFactory).toHaveBeenCalled()
+    expect(extensionFactory).toHaveBeenCalled()
+  })
+
+  it("fails fast when a snapshot custom module exposes no managed-module entry", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          customSource: { modules: ["@third-party/custom-module"] },
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    await expect(
+      loadManagedProfileRuntime({
+        profileSnapshotPath: snapshotPath,
+        env: { DATABASE_URL: "managed-profile-test-db" },
+        importCustomSourceModule: async () => ({ notAFactory: 42 }),
+      }),
+    ).rejects.toThrow(/does not export a managed-module entry/)
+  })
+
   it("builds managed Node bindings from plain env/secrets", () => {
     const env = createManagedProfileNodeEnv({
       DATABASE_URL: "managed-profile-test-db",

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -74,6 +74,7 @@ import {
   type VoyantBindings,
   type VoyantDb,
 } from "@voyant-travel/hono"
+import type { ExtensionFactory, ModuleFactory } from "@voyant-travel/hono/composition"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import { productsService } from "@voyant-travel/inventory"
 import { createProductContentRoutes } from "@voyant-travel/inventory/routes-content"
@@ -155,6 +156,10 @@ import { type Context, Hono } from "hono"
 
 import type { FrameworkProviders } from "./composition-lazy.js"
 import { type CreateVoyantAppConfig, createVoyantApp } from "./create-app.js"
+import {
+  resolveManagedCustomExtensions,
+  resolveManagedCustomModules,
+} from "./custom-source-resolution.js"
 import { type ManagedPlugin, resolveManagedPlugins } from "./plugin-resolution.js"
 import {
   getVoyantProjectRequirements,
@@ -164,6 +169,12 @@ import {
   type VoyantProjectManifest,
   validateVoyantProject,
 } from "./profile.js"
+
+export {
+  type ResolveManagedCustomSourceOptions,
+  resolveManagedCustomExtensions,
+  resolveManagedCustomModules,
+} from "./custom-source-resolution.js"
 
 export {
   type ManagedPlugin,
@@ -226,6 +237,9 @@ export interface ManagedProfileRuntimeEnv extends VoyantBindings {
   PORT?: string
 }
 
+type ManagedProfileAppModules = Record<string, ModuleFactory<FrameworkProviders>>
+type ManagedProfileAppExtensions = Record<string, ExtensionFactory<FrameworkProviders>>
+
 export interface ManagedProfileRuntimeOptions {
   profileSnapshotPath: string
   env?: Record<string, unknown> | ManagedProfileRuntimeEnv
@@ -243,6 +257,13 @@ export interface ManagedProfileRuntimeOptions {
    * pre-bundled registry instead of node resolution.
    */
   importPluginModule?: (specifier: string) => Promise<Record<string, unknown>>
+  /**
+   * Override how snapshot `customSource.modules` and `customSource.extensions`
+   * specifiers are imported. Defaults to dynamic `import()`; injectable so Cloud
+   * (or tests) can resolve custom source packages from a pre-bundled registry
+   * instead of node resolution.
+   */
+  importCustomSourceModule?: (specifier: string) => Promise<Record<string, unknown>>
 }
 
 export interface ManagedProfileRuntime {
@@ -313,12 +334,27 @@ export async function loadManagedProfileRuntime(
     toPluginEnvRecord(env),
     options.importPluginModule ? { importModule: options.importPluginModule } : {},
   )
+  const customSourceOptions = options.importCustomSourceModule
+    ? { importModule: options.importCustomSourceModule }
+    : {}
+  const customModules = await resolveManagedCustomModules(
+    project,
+    toPluginEnvRecord(env),
+    customSourceOptions,
+  )
+  const customExtensions = await resolveManagedCustomExtensions(
+    project,
+    toPluginEnvRecord(env),
+    customSourceOptions,
+  )
   assertManagedProfileRuntimeSupport({
     project,
     requirements,
     env,
     hasAuthIntegration: Boolean(auth),
     hasResolvedPlugins: plugins.length > 0,
+    hasResolvedCustomModules: Object.keys(customModules).length > 0,
+    hasResolvedCustomExtensions: Object.keys(customExtensions).length > 0,
   })
   const app = createManagedProfileApp({
     project,
@@ -327,6 +363,8 @@ export async function loadManagedProfileRuntime(
     providers: options.providers,
     app: options.app,
     plugins,
+    modules: customModules,
+    extensions: customExtensions,
   })
 
   return {
@@ -390,6 +428,20 @@ export function createManagedProfileApp(options: {
    * snapshot declares plugins, either these or `app.plugins` must be non-empty.
    */
   plugins?: ManagedPlugin[]
+  /**
+   * Module factories resolved from the snapshot's `customSource.modules` list
+   * (see {@link resolveManagedCustomModules}), merged after any `app.modules`.
+   * When the snapshot declares custom modules, either these or `app.modules`
+   * must be non-empty.
+   */
+  modules?: ManagedProfileAppModules
+  /**
+   * Extension factories resolved from the snapshot's `customSource.extensions`
+   * list (see {@link resolveManagedCustomExtensions}), merged after any
+   * `app.extensions`. When the snapshot declares custom extensions, either these
+   * or `app.extensions` must be non-empty.
+   */
+  extensions?: ManagedProfileAppExtensions
 }) {
   const auth = resolveManagedProfileAuthIntegration({
     env: options.env,
@@ -397,10 +449,20 @@ export function createManagedProfileApp(options: {
     activeModules: resolveActiveModuleIds(options.project),
   })
   const mergedPlugins = [...(options.app?.plugins ?? []), ...(options.plugins ?? [])]
+  const mergedModules: ManagedProfileAppModules = {
+    ...(options.app?.modules ?? {}),
+    ...(options.modules ?? {}),
+  }
+  const mergedExtensions: ManagedProfileAppExtensions = {
+    ...(options.app?.extensions ?? {}),
+    ...(options.extensions ?? {}),
+  }
   assertManagedProfileAppSupport({
     project: options.project,
     hasAuthIntegration: Boolean(auth),
     hasResolvedPlugins: mergedPlugins.length > 0,
+    hasResolvedCustomModules: Object.keys(mergedModules).length > 0,
+    hasResolvedCustomExtensions: Object.keys(mergedExtensions).length > 0,
   })
   const bridge = toCreateVoyantAppProfileConfig(options.project)
   return createVoyantApp<ManagedProfileRuntimeEnv, FrameworkProviders>({
@@ -424,6 +486,8 @@ export function createManagedProfileApp(options: {
       ManagedProfileRuntimeEnv,
       FrameworkProviders
     >["plugins"],
+    modules: mergedModules,
+    extensions: mergedExtensions,
     basePath: options.app?.basePath ?? "/api",
     auth,
     exclude: bridge.exclude,
@@ -1027,13 +1091,17 @@ function assertManagedProfileRuntimeSupport(options: {
   env: ManagedProfileRuntimeEnv
   hasAuthIntegration: boolean
   hasResolvedPlugins: boolean
+  hasResolvedCustomModules: boolean
+  hasResolvedCustomExtensions: boolean
 }) {
   const issues = [
-    ...managedProfileAppSupportIssues(
-      options.project,
-      options.hasAuthIntegration,
-      options.hasResolvedPlugins,
-    ),
+    ...managedProfileAppSupportIssues({
+      project: options.project,
+      hasAuthIntegration: options.hasAuthIntegration,
+      hasResolvedPlugins: options.hasResolvedPlugins,
+      hasResolvedCustomModules: options.hasResolvedCustomModules,
+      hasResolvedCustomExtensions: options.hasResolvedCustomExtensions,
+    }),
     ...managedProfileEnvIssues(options.requirements, options.env),
   ]
   if (issues.length > 0) {
@@ -1045,31 +1113,46 @@ function assertManagedProfileAppSupport(options: {
   project: VoyantProjectManifest
   hasAuthIntegration: boolean
   hasResolvedPlugins: boolean
+  hasResolvedCustomModules: boolean
+  hasResolvedCustomExtensions: boolean
 }) {
-  const issues = managedProfileAppSupportIssues(
-    options.project,
-    options.hasAuthIntegration,
-    options.hasResolvedPlugins,
-  )
+  const issues = managedProfileAppSupportIssues(options)
   if (issues.length > 0) {
     throw new Error(`Managed profile app is not ready to start:\n${formatIssues(issues)}`)
   }
 }
 
-function managedProfileAppSupportIssues(
-  project: VoyantProjectManifest,
-  hasAuthIntegration: boolean,
-  hasResolvedPlugins: boolean,
-): string[] {
+function managedProfileAppSupportIssues(options: {
+  project: VoyantProjectManifest
+  hasAuthIntegration: boolean
+  hasResolvedPlugins: boolean
+  hasResolvedCustomModules: boolean
+  hasResolvedCustomExtensions: boolean
+}): string[] {
+  const { project } = options
   const issues: string[] = []
-  if (project.plugins.length > 0 && !hasResolvedPlugins) {
+  if (project.plugins.length > 0 && !options.hasResolvedPlugins) {
     issues.push(
       `snapshot plugins were declared but not resolved by @voyant-travel/framework/managed-runtime: ${project.plugins.join(
         ", ",
       )}`,
     )
   }
-  if (project.mode === "managed-cloud" && !hasAuthIntegration) {
+  if ((project.customSource?.modules?.length ?? 0) > 0 && !options.hasResolvedCustomModules) {
+    issues.push(
+      `snapshot customSource.modules were declared but not resolved by @voyant-travel/framework/managed-runtime: ${project.customSource?.modules?.join(
+        ", ",
+      )}`,
+    )
+  }
+  if ((project.customSource?.extensions?.length ?? 0) > 0 && !options.hasResolvedCustomExtensions) {
+    issues.push(
+      `snapshot customSource.extensions were declared but not resolved by @voyant-travel/framework/managed-runtime: ${project.customSource?.extensions?.join(
+        ", ",
+      )}`,
+    )
+  }
+  if (project.mode === "managed-cloud" && !options.hasAuthIntegration) {
     issues.push(
       "managed-cloud profiles require VOYANT_ADMIN_AUTH_MODE=voyant-cloud with Cloud admin auth env, or an injected admin auth integration",
     )

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -399,4 +399,19 @@ describe("resolveActiveModuleIds (admin gating signal, voyant#3063)", () => {
     expect(active).not.toContain("flights")
     expect(active).not.toContain("legal")
   })
+
+  it("includes custom source modules the runtime mounts (voyant#3079)", () => {
+    const project = validProject({
+      modules: ["catalog", "bookings"],
+      customSource: { modules: ["@acme/loyalty", "@acme/gift-cards"] },
+    })
+
+    const active = resolveActiveModuleIds(project)
+
+    // Custom schema-owning modules are now mounted, so the admin gating signal
+    // must report them alongside the standard subset — otherwise a source-free
+    // admin hides a UI whose API routes are live.
+    expect(active).toEqual(expect.arrayContaining(["@acme.loyalty", "@acme.gift-cards"]))
+    expect(active).toEqual(expect.arrayContaining(["catalog", "bookings"]))
+  })
 })

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -124,10 +124,22 @@ export function validateVoyantProject(input: unknown): VoyantProfileValidationRe
  * matching module extensions.
  *
  * Derived from the same `include` set that drives `createVoyantApp({ exclude })`,
- * so the admin nav can never drift from what the API mounts.
+ * plus the snapshot's `customSource.modules` — which the managed runtime now
+ * mounts (voyant#3079) — so the admin nav can never drift from what the API
+ * mounts. The custom specifiers are guarded the same way as the migration-source
+ * derivation: a malformed snapshot value is ignored, not iterated per character.
  */
 export function resolveActiveModuleIds(project: VoyantProjectManifest): string[] {
-  return getVoyantProjectRequirements(project).modules.include.map(moduleIdFromSpecifier)
+  const standard = getVoyantProjectRequirements(project).modules.include.map(moduleIdFromSpecifier)
+  const custom = Array.isArray(project.customSource?.modules)
+    ? project.customSource.modules
+        .filter(
+          (specifier): specifier is string =>
+            typeof specifier === "string" && specifier.trim().length > 0,
+        )
+        .map(moduleIdFromSpecifier)
+    : []
+  return unique([...standard, ...custom])
 }
 
 export function getVoyantProjectRequirements(


### PR DESCRIPTION
## Summary

Closes #3079 (follow-up to #3069).

`framework@0.22.0` derived `customSource.modules` into **migration** sources, so a bring-your-own schema-owning module's tables migrate in a managed deployment — but the managed **runtime** never wired `customSource`, so those modules' API routes 404'd and their admin extensions never composed. Net: tables created, endpoints absent.

This mounts them — the exact analog of how `plugins` are already resolved and mounted via `resolveManagedPlugins`.

## Changes (`packages/framework`)

- **`custom-source-resolution.ts`** (new) — `resolveManagedCustomModules` / `resolveManagedCustomExtensions`: dynamic-`import()` each `customSource.modules` / `customSource.extensions` specifier, pick the factory export (`voyantModule` / `createVoyantModule` / `createModule` / `default`, or a bare `HonoModule` / `HonoExtension` object wrapped as a factory), keyed by specifier. Fails loud on a missing entry — a managed profile never silently drops a configured integration. Injectable `importModule` loader for pre-bundled registries and tests.
- **`managed-runtime.ts`** — `loadManagedProfileRuntime` resolves both and merges the resulting factories into `createManagedProfileApp` → `createVoyantApp`'s `modules` / `extensions` channel, so routes mount and admin extensions compose against the deployment's installed dependency tree (the same tree `loadModuleBundleSource` uses). Added a declared-but-unresolved fail-loud check mirroring the existing `plugins` one, an injectable `importCustomSourceModule` option, and re-exported the new APIs.
- **Tests** — source-free boot with a custom module + extension (asserts both factories are actually invoked), fail-fast on a package with no managed-module entry, plus resolver unit tests.
- **Changeset** — `@voyant-travel/framework` patch (0.23.1 → 0.23.2).

## Verification

- `pnpm --filter @voyant-travel/framework typecheck` — clean
- `pnpm --filter @voyant-travel/framework test` — 114 passed
- `pnpm --filter @voyant-travel/framework lint` — clean
- `pnpm release:plan` — single `@voyant-travel/framework` patch, no mixed-changeset

Closes the last runtime gap for the "bring-your-own custom module" tier (#2983 tier 2); platform side (per-operator build installs the packages, managed booter runs their migrations) is already ready.
