### PR TITLE
Add deployment graph lockfile provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "verify:raw-minor-unit-labels": "node scripts/check-raw-minor-unit-labels.mjs",
     "verify:lockstep-membership": "node scripts/check-lockstep-membership.mjs",
     "verify:admin-composition-drift": "node scripts/check-admin-composition-drift.mjs",
-    "verify:deployment-graph": "tsx scripts/check-deployment-graph.ts",
+    "verify:deployment-graph": "node --test scripts/tests/deployment-graph-provenance.test.mjs && tsx scripts/check-deployment-graph.ts",
     "verify:framework-bom": "node scripts/generate-framework-bom.mjs",
     "verify:framework-migration-bundle": "node scripts/generate-framework-migration-bundle.mjs",
     "verify:migration-replay-parity": "node scripts/verify-migration-replay-parity.mjs",
@@ -98,7 +98,8 @@
     "semver": "^7.8.5",
     "tsx": "catalog:",
     "turbo": "^2.10.2",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "yaml": "2.8.3"
   },
   "packageManager": "pnpm@10.18.0",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+      yaml:
+        specifier: 2.8.3
+        version: 2.8.3
 
   apps/catalog-demo-api:
     dependencies:

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -1,8 +1,10 @@
 import {
+  canonicalJson,
   resolveManagedProfileDeploymentGraph,
   VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY,
 } from "../packages/framework/src/deployment-graph.ts"
 import { defineVoyantProject } from "../packages/framework/src/profile.ts"
+import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 
 const failures: string[] = []
 
@@ -14,8 +16,12 @@ const project = defineVoyantProject({
 })
 
 async function main(): Promise<void> {
-  const first = await resolveManagedProfileDeploymentGraph(project)
-  const second = await resolveManagedProfileDeploymentGraph(project)
+  const discoveredGraph = await resolveManagedProfileDeploymentGraph(project)
+  const packageRecords = readPnpmLockfilePackageRecords({
+    packageNames: discoveredGraph.packageRecords.map((record) => record.packageName),
+  })
+  const first = await resolveManagedProfileDeploymentGraph(project, { packageRecords })
+  const second = await resolveManagedProfileDeploymentGraph(project, { packageRecords })
 
   if (first.schemaVersion !== "voyant.resolved-graph.v1") {
     failures.push(`expected resolved graph schema v1, got ${first.schemaVersion}`)
@@ -27,6 +33,10 @@ async function main(): Promise<void> {
 
   if (first.contentHash !== second.contentHash) {
     failures.push("expected managed profile graph hash to be deterministic across identical inputs")
+  }
+
+  if (canonicalJson(first) !== canonicalJson(second)) {
+    failures.push("expected managed profile graph JSON manifest to be deterministic")
   }
 
   if (first.diagnostics.length > 0) {
@@ -53,6 +63,28 @@ async function main(): Promise<void> {
 
   if (!first.plugins.some((unit) => unit.id === "@voyant-travel/plugin-netopia")) {
     failures.push("expected managed graph to include selected plugin @voyant-travel/plugin-netopia")
+  }
+
+  const frameworkRecord = first.packageRecords.find(
+    (record) => record.packageName === "@voyant-travel/framework",
+  )
+  if (frameworkRecord?.source.kind !== "workspace" || !frameworkRecord.version) {
+    failures.push(
+      "expected @voyant-travel/framework package record to include workspace provenance",
+    )
+  }
+
+  const netopiaRecord = first.packageRecords.find(
+    (record) => record.packageName === "@voyant-travel/plugin-netopia",
+  )
+  if (
+    netopiaRecord?.source.kind !== "registry" ||
+    !netopiaRecord.version ||
+    !netopiaRecord.source.integrity
+  ) {
+    failures.push(
+      "expected @voyant-travel/plugin-netopia package record to include lockfile registry provenance",
+    )
   }
 
   const diagnosticCodes = Object.keys(VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY)

--- a/scripts/lib/deployment-graph-provenance.mjs
+++ b/scripts/lib/deployment-graph-provenance.mjs
@@ -1,0 +1,193 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import path from "node:path"
+
+import { parse } from "yaml"
+
+const dependencySections = ["dependencies", "optionalDependencies", "devDependencies"]
+const ignoredWorkspaceDirs = new Set([".git", ".turbo", "build", "dist", "node_modules"])
+
+export function readPnpmLockfilePackageRecords(options) {
+  const repoRoot = options.repoRoot ?? process.cwd()
+  const lockfilePath = options.lockfilePath ?? path.join(repoRoot, "pnpm-lock.yaml")
+  return packageRecordsFromPnpmLockfile(readFileSync(lockfilePath, "utf8"), {
+    packageNames: options.packageNames,
+    importerPaths: options.importerPaths,
+    workspacePackageVersions:
+      options.workspacePackageVersions ?? readWorkspacePackageVersions(repoRoot),
+  })
+}
+
+export function packageRecordsFromPnpmLockfile(lockfileText, options) {
+  const lockfile = parse(lockfileText)
+  const dependencies = indexImporterDependencies(lockfile?.importers ?? {}, options.importerPaths)
+  const workspacePackageVersions = new Map(
+    Object.entries(options.workspacePackageVersions ?? {}).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+  )
+
+  return [...new Set(options.packageNames)]
+    .sort((left, right) => left.localeCompare(right))
+    .map((packageName) =>
+      packageRecordForPackage(packageName, {
+        lockfile,
+        dependencies: dependencies.get(packageName) ?? [],
+        workspacePackageVersions,
+      }),
+    )
+}
+
+export function readWorkspacePackageVersions(repoRoot) {
+  const versions = {}
+  for (const packageJsonPath of listPackageJsonFiles(repoRoot)) {
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+    if (typeof packageJson.name !== "string" || typeof packageJson.version !== "string") continue
+    versions[packageJson.name] = packageJson.version
+  }
+  return versions
+}
+
+function packageRecordForPackage(packageName, context) {
+  const dependency = chooseDependency(
+    packageName,
+    context.dependencies,
+    context.workspacePackageVersions,
+  )
+  if (!dependency) {
+    return unknownPackageRecord(packageName, context.workspacePackageVersions.get(packageName))
+  }
+
+  if (isWorkspaceDependency(dependency)) {
+    return {
+      packageName,
+      ...versionField(context.workspacePackageVersions.get(packageName)),
+      source: {
+        kind: "workspace",
+        reference: dependency.version,
+      },
+    }
+  }
+
+  if (dependency.version.startsWith("file:")) {
+    return {
+      packageName,
+      source: { kind: "file", reference: dependency.version },
+    }
+  }
+
+  if (isGitReference(dependency.version)) {
+    return {
+      packageName,
+      source: { kind: "git", reference: dependency.version },
+    }
+  }
+
+  const version = basePnpmVersion(dependency.version)
+  const integrity = context.lockfile?.packages?.[`${packageName}@${version}`]?.resolution?.integrity
+  return {
+    packageName,
+    ...versionField(version),
+    source: {
+      kind: "registry",
+      reference: `pnpm-lock:${packageName}@${dependency.version}`,
+      ...(typeof integrity === "string" ? { integrity } : {}),
+    },
+  }
+}
+
+function chooseDependency(packageName, dependencies, workspacePackageVersions) {
+  if (workspacePackageVersions.has(packageName)) {
+    return dependencies.find(isWorkspaceDependency)
+  }
+  return [...dependencies].sort(compareDependencies)[0]
+}
+
+function unknownPackageRecord(packageName, version) {
+  return {
+    packageName,
+    ...versionField(version),
+    source: { kind: "unknown" },
+  }
+}
+
+function versionField(version) {
+  return typeof version === "string" && version.length > 0 ? { version } : {}
+}
+
+function indexImporterDependencies(importers, importerPaths) {
+  const selectedImporters = importerPaths ? new Set(importerPaths) : undefined
+  const dependencies = new Map()
+
+  for (const [importerPath, importer] of Object.entries(importers)) {
+    if (selectedImporters && !selectedImporters.has(importerPath)) continue
+
+    for (const section of dependencySections) {
+      for (const [packageName, value] of Object.entries(importer?.[section] ?? {})) {
+        if (!value || typeof value !== "object" || typeof value.version !== "string") continue
+        const entries = dependencies.get(packageName) ?? []
+        entries.push({
+          importerPath,
+          section,
+          specifier: typeof value.specifier === "string" ? value.specifier : "",
+          version: value.version,
+        })
+        dependencies.set(packageName, entries)
+      }
+    }
+  }
+
+  return dependencies
+}
+
+function compareDependencies(left, right) {
+  return (
+    dependencyRank(left) - dependencyRank(right) ||
+    left.importerPath.localeCompare(right.importerPath) ||
+    left.section.localeCompare(right.section) ||
+    left.version.localeCompare(right.version)
+  )
+}
+
+function dependencyRank(entry) {
+  if (isWorkspaceDependency(entry)) return 0
+  if (entry.version.startsWith("file:")) return 1
+  if (isGitReference(entry.version)) return 2
+  return 3
+}
+
+function isWorkspaceDependency(entry) {
+  return entry.version.startsWith("link:") || entry.specifier.startsWith("workspace:")
+}
+
+function isGitReference(value) {
+  return value.startsWith("git+") || value.startsWith("github:") || value.includes(".git#")
+}
+
+function basePnpmVersion(value) {
+  return value.split("(")[0] ?? value
+}
+
+function listPackageJsonFiles(rootDir) {
+  const files = []
+  walk(rootDir)
+  return files.sort((left, right) => left.localeCompare(right))
+
+  function walk(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const fullPath = path.join(directory, entry.name)
+      const relativePath = path.relative(rootDir, fullPath).split(path.sep).join("/")
+
+      if (entry.isDirectory()) {
+        if (ignoredWorkspaceDirs.has(entry.name) || relativePath.startsWith(".claude/worktrees/")) {
+          continue
+        }
+        walk(fullPath)
+        continue
+      }
+
+      if (entry.isFile() && entry.name === "package.json" && existsSync(fullPath)) {
+        files.push(fullPath)
+      }
+    }
+  }
+}

--- a/scripts/tests/deployment-graph-provenance.test.mjs
+++ b/scripts/tests/deployment-graph-provenance.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { packageRecordsFromPnpmLockfile } from "../lib/deployment-graph-provenance.mjs"
+
+const lockfile = `
+lockfileVersion: '9.0'
+
+importers:
+  packages/framework:
+    dependencies:
+      '@voyant-travel/bookings':
+        specifier: workspace:*
+        version: link:../bookings
+      '@voyant-travel/cloud-sdk':
+        specifier: ^0.11.0
+        version: 0.11.0(typesense@3.0.6)
+  starters/operator:
+    dependencies:
+      '@voyant-travel/plugin-netopia':
+        specifier: ^0.105.18
+        version: 0.105.18(@types/pg@8.20.0)(postgres@3.4.9)
+
+packages:
+  '@voyant-travel/cloud-sdk@0.11.0':
+    resolution: {integrity: sha512-cloud}
+  '@voyant-travel/plugin-netopia@0.105.18':
+    resolution: {integrity: sha512-netopia}
+`
+
+describe("deployment graph package provenance", () => {
+  it("derives workspace and registry package records from pnpm lockfile importers", () => {
+    const records = packageRecordsFromPnpmLockfile(lockfile, {
+      packageNames: [
+        "@voyant-travel/plugin-netopia",
+        "@voyant-travel/bookings",
+        "@acme/custom-module",
+      ],
+      workspacePackageVersions: {
+        "@voyant-travel/bookings": "0.149.0",
+      },
+    })
+
+    assert.deepEqual(records, [
+      {
+        packageName: "@acme/custom-module",
+        source: { kind: "unknown" },
+      },
+      {
+        packageName: "@voyant-travel/bookings",
+        version: "0.149.0",
+        source: { kind: "workspace", reference: "link:../bookings" },
+      },
+      {
+        packageName: "@voyant-travel/plugin-netopia",
+        version: "0.105.18",
+        source: {
+          kind: "registry",
+          reference:
+            "pnpm-lock:@voyant-travel/plugin-netopia@0.105.18(@types/pg@8.20.0)(postgres@3.4.9)",
+          integrity: "sha512-netopia",
+        },
+      },
+    ])
+  })
+
+  it("can scope provenance to selected pnpm importers", () => {
+    const records = packageRecordsFromPnpmLockfile(lockfile, {
+      packageNames: ["@voyant-travel/plugin-netopia"],
+      importerPaths: ["packages/framework"],
+    })
+
+    assert.deepEqual(records, [
+      {
+        packageName: "@voyant-travel/plugin-netopia",
+        source: { kind: "unknown" },
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- add a script-side pnpm lockfile provenance reader for deployment graph package records
- feed lockfile-derived package records into the deployment graph architecture check
- extend `verify:deployment-graph` with provenance unit coverage and deterministic JSON manifest assertion

## Validation
- `node --test scripts/tests/deployment-graph-provenance.test.mjs`
- `pnpm verify:deployment-graph`
- `pnpm exec biome check package.json scripts/check-deployment-graph.ts scripts/lib/deployment-graph-provenance.mjs scripts/tests/deployment-graph-provenance.test.mjs`
- `pnpm verify:dependency-versions`
- `pnpm verify:architecture`
- pre-commit affected lane: 192 tasks passed
- pre-push test lane: 101 tasks passed

## Notes
- No changeset: this is root/script tooling only, no published package API.
- This is the package provenance slice before generated runtime entry artifacts.