### PR TITLE
Consume deployment graph artifacts in managed operator

### DIFF
--- a/.changeset/managed-operator-graph-consumption.md
+++ b/.changeset/managed-operator-graph-consumption.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Keep generated deployment graph runtime entry metadata import-safe by loading the managed runtime only when the entry module is executed directly.

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -91,7 +91,7 @@ describe("deployment graph artifacts", () => {
     })
 
     expect(source).toContain(`GENERATED_DEPLOYMENT_GRAPH_HASH = "${graph.contentHash}"`)
-    expect(source).toContain('from "@voyant-travel/framework/managed-runtime"')
+    expect(source).toContain('await import(\n    "@voyant-travel/framework/managed-runtime"')
     expect(source).toContain('from "node:url"')
     expect(source).toContain("startManagedProfileRuntime")
     expect(source).not.toContain("starters/")

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -95,8 +95,6 @@ export function buildManagedNodeRuntimeEntry(input: BuildManagedNodeRuntimeEntry
 
 import { fileURLToPath, pathToFileURL } from "node:url"
 
-import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
-
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = ${quote(input.graph.schemaVersion)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_HASH = ${quote(input.graph.contentHash)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = ${quote(input.graph.deployment.target)} as const
@@ -122,6 +120,9 @@ export function resolveGeneratedProfileSnapshotPath(): string {
 
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
+  const { startManagedProfileRuntime } = await import(
+    "@voyant-travel/framework/managed-runtime"
+  )
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
   })

--- a/starters/managed-operator/package.json
+++ b/starters/managed-operator/package.json
@@ -4,9 +4,10 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "vite dev --port 3400",
-    "build": "vite build && pnpm run copy:snapshot",
-    "copy:snapshot": "cp managed-profile.json dist/managed-profile.json",
+    "dev": "pnpm run graph:check && vite dev --port 3400",
+    "build": "pnpm run graph:check && vite build && pnpm run copy:deployment-artifacts",
+    "copy:deployment-artifacts": "cp managed-profile.json deployment-artifacts.generated.json deployment-graph.generated.json dist/",
+    "doctor": "pnpm run graph:check",
     "graph:check": "tsx ../../scripts/emit-deployment-graph.ts",
     "graph:emit": "tsx ../../scripts/emit-deployment-graph.ts --emit",
     "generate:snapshot": "tsx scripts/generate-snapshot.ts",

--- a/starters/managed-operator/src/entry.ts
+++ b/starters/managed-operator/src/entry.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath } from "node:url"
-
 import {
   type AppLoader,
   createApiDispatch,
@@ -7,6 +5,11 @@ import {
   lazyApp,
   lazySsr,
 } from "@voyant-travel/runtime"
+
+import {
+  GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS,
+  resolveGeneratedProfileSnapshotPath,
+} from "./runtime-entry.generated"
 
 /**
  * The managed-operator reference serves the SSR admin UI AND the REAL managed
@@ -22,25 +25,11 @@ import {
  * store) end-to-end.
  */
 
-/**
- * Resolve the managed-profile snapshot the runtime composes from.
- *
- * `MANAGED_PROFILE_SNAPSHOT` wins when set (the robust deployment path — the
- * orchestrator passes an absolute path at boot). Otherwise we resolve
- * `managed-profile.json` relative to this module. At runtime this module is
- * `dist/server/server.js`, so `../managed-profile.json` points at `dist/` — the
- * `build` script copies `managed-profile.json` into `dist/` (see
- * `copy:snapshot`) precisely so this relative resolution lands on a real file.
- */
-function resolveSnapshotPath(): string {
-  const fromEnv = process.env.MANAGED_PROFILE_SNAPSHOT?.trim()
-  if (fromEnv) return fromEnv
-  return fileURLToPath(new URL("../managed-profile.json", import.meta.url))
-}
-
 const loadManagedApi: AppLoader<AppBindings, ExecutionContext> = lazyApp(async () => {
   const { loadManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
-  const runtime = await loadManagedProfileRuntime({ profileSnapshotPath: resolveSnapshotPath() })
+  const runtime = await loadManagedProfileRuntime({
+    profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
+  })
   // The runtime serves the API from its own composed env (process.env), so we
   // drop the dispatch-supplied env/ctx and defer entirely to `runtime.fetch`.
   return { fetch: (request) => runtime.fetch(request) }
@@ -84,25 +73,12 @@ function devAuthJson(body: unknown): Response {
 }
 
 /**
- * The active module ids for this snapshot, so the DEV `/auth/bootstrap-status`
- * reports the same module set a managed-cloud deployment's real handler would —
- * letting the source-free admin's module gating (voyant#3063) be exercised
- * locally (set `modules` to a subset in `managed-profile.json` and the nav
- * follows). Uses the LIGHT `@voyant-travel/framework/profile` export (pure
- * composition math), not the full API runtime. Fails open (returns `undefined`)
- * so a malformed/absent snapshot leaves the admin composing everything.
+ * The active module ids for this graph, so the DEV `/auth/bootstrap-status`
+ * reports the same module set doctor/build/deploy validated. `graph:check`
+ * keeps this generated module in lockstep with `managed-profile.json`.
  */
-async function resolveDevActiveModuleIds(): Promise<string[] | undefined> {
-  try {
-    const [{ readFile }, { resolveActiveModuleIds }] = await Promise.all([
-      import("node:fs/promises"),
-      import("@voyant-travel/framework/profile"),
-    ])
-    const raw = await readFile(resolveSnapshotPath(), "utf8")
-    return resolveActiveModuleIds(JSON.parse(raw))
-  } catch {
-    return undefined
-  }
+async function resolveDevActiveModuleIds(): Promise<string[]> {
+  return [...GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS]
 }
 
 const loadDevAuth: AppLoader<AppBindings, ExecutionContext> = lazyApp(async () => {

--- a/starters/managed-operator/src/runtime-entry.generated.ts
+++ b/starters/managed-operator/src/runtime-entry.generated.ts
@@ -3,8 +3,6 @@
 
 import { fileURLToPath, pathToFileURL } from "node:url"
 
-import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
-
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
 export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:4c24f95cc808dfeed36da312ce30a9d764a4a630d56c014d94798df96319f724" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
@@ -89,6 +87,9 @@ export function resolveGeneratedProfileSnapshotPath(): string {
 
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
+  const { startManagedProfileRuntime } = await import(
+    "@voyant-travel/framework/managed-runtime"
+  )
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
   })

--- a/starters/managed-operator/src/server.ts
+++ b/starters/managed-operator/src/server.ts
@@ -10,6 +10,7 @@ import {
 } from "@voyant-travel/runtime"
 
 import { fetch as appFetch, scheduled } from "./entry"
+import { GENERATED_DEPLOYMENT_GRAPH_HASH } from "./runtime-entry.generated"
 
 /**
  * Node entry for the managed-operator reference (voyant#3044). This file is also
@@ -90,5 +91,7 @@ if (isMainModule) {
       ? { originTrustSecret: process.env.ORIGIN_TRUST_SECRET }
       : {}),
   })
-  console.info(`[managed-operator] Node runtime listening on :${handle.port}`)
+  console.info(
+    `[managed-operator] Node runtime listening on :${handle.port} (${GENERATED_DEPLOYMENT_GRAPH_HASH})`,
+  )
 }


### PR DESCRIPTION
## Summary
- Make the generated runtime entry metadata import-safe by loading `managed-runtime` only when the entry is executed directly.
- Wire the managed operator API/dev auth path and startup log to generated graph metadata.
- Run `graph:check` before `dev`/`build`, add a starter-local `doctor` script, and copy generated graph artifacts into `dist` with the managed profile snapshot.

## Validation
- `pnpm verify:deployment-graph`
- `pnpm --filter managed-operator run doctor`
- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter managed-operator typecheck`
- `pnpm --filter managed-operator build`
- `pnpm --filter managed-operator lint`
- `pnpm --filter @voyant-travel/framework lint`
- pre-commit affected lane: 192 tasks passed
- pre-push test lane: 101 tasks passed