### PR TITLE
Validate operator graph artifacts at boot

### DIFF
--- a/scripts/check-node-entrypoint.mjs
+++ b/scripts/check-node-entrypoint.mjs
@@ -3,6 +3,8 @@
  *
  *  1. `src/server.ts` (the Node process entry) exists and boots the runtime via
  *     `createNodeServer` from `@voyant-travel/runtime`.
+ *  1b. `src/server.ts` consumes the checked deployment graph artifacts at boot
+ *      so dev/build/deploy share the same graph contract.
  *  2. `src/entry.ts` (the app's `fetch`/`scheduled` handlers) keeps SSR behind a
  *     lazy import so the React + react-dom/server graph isn't pulled into the
  *     module's top-level — imported on first render, not at boot. Heavy API and
@@ -19,6 +21,7 @@ const ROOT = join(__dirname, "..")
 
 const APP_ENTRY = "starters/operator/src/entry.ts"
 const NODE_ENTRY = "starters/operator/src/server.ts"
+const GENERATED_RUNTIME_ENTRY = "runtime-entry.generated"
 
 const FORBIDDEN_IMPORTS = [
   {
@@ -67,16 +70,47 @@ if (!existsSync(join(ROOT, NODE_ENTRY))) {
     check: { id: "missing-node-entry", message: "The Node process entry is missing." },
     text: "",
   })
-} else if (!readFileSync(join(ROOT, NODE_ENTRY), "utf-8").includes("createNodeServer")) {
-  violations.push({
-    file: NODE_ENTRY,
-    line: 0,
-    check: {
-      id: "node-entry-not-wired",
-      message: "The Node entry must boot the runtime via createNodeServer.",
-    },
-    text: "",
-  })
+} else {
+  const nodeEntrySource = readFileSync(join(ROOT, NODE_ENTRY), "utf-8")
+  if (!nodeEntrySource.includes("createNodeServer")) {
+    violations.push({
+      file: NODE_ENTRY,
+      line: 0,
+      check: {
+        id: "node-entry-not-wired",
+        message: "The Node entry must boot the runtime via createNodeServer.",
+      },
+      text: "",
+    })
+  }
+  if (
+    !/^import\s+\{\s*loadOperatorDeploymentGraphArtifacts\s*\}\s+from\s+["']\.\/deployment-graph-artifacts["']/m.test(
+      nodeEntrySource,
+    ) ||
+    !/^const\s+\w+\s*=\s*loadOperatorDeploymentGraphArtifacts\(\s*\)/m.test(nodeEntrySource)
+  ) {
+    violations.push({
+      file: NODE_ENTRY,
+      line: 0,
+      check: {
+        id: "deployment-graph-artifacts-not-consumed",
+        message: "The Node entry must validate deployment graph artifacts at boot.",
+      },
+      text: "",
+    })
+  }
+  if (nodeEntrySource.includes(GENERATED_RUNTIME_ENTRY)) {
+    violations.push({
+      file: NODE_ENTRY,
+      line: 0,
+      check: {
+        id: "deployment-runtime-entry-imported",
+        message:
+          "The Node entry must validate deployment graph artifacts without importing the generated runtime entry.",
+      },
+      text: "",
+    })
+  }
 }
 
 if (violations.length > 0) {
@@ -91,4 +125,6 @@ if (violations.length > 0) {
   process.exit(1)
 }
 
-console.log("check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer)")
+console.log(
+  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts)",
+)

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -1,0 +1,145 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifacts"
+
+const HASH = `sha256:${"a".repeat(64)}`
+const OTHER_HASH = `sha256:${"b".repeat(64)}`
+
+const roots: string[] = []
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
+})
+
+describe("loadOperatorDeploymentGraphArtifacts", () => {
+  it("loads the committed operator graph artifacts", () => {
+    const summary = loadOperatorDeploymentGraphArtifacts()
+
+    expect(summary.graphHash).toMatch(/^sha256:[a-f0-9]{64}$/)
+    expect(summary.moduleIds).toContain("@voyant-travel/bookings")
+    expect(summary.packageNames).toContain("@voyant-travel/framework")
+  })
+
+  it("fails when the artifact graph hash does not match the graph content hash", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { manifestGraphHash: OTHER_HASH })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/does not match graph contentHash/)
+  })
+
+  it("fails when generated graph hashes are not sha256 content hashes", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { graphHash: "not-a-content-hash" })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/must match sha256:<64 lowercase hex chars>/)
+  })
+
+  it("fails when the graph reports diagnostics", () => {
+    const root = fixtureRoot()
+    writeFixture(root, {
+      diagnostics: [
+        {
+          code: "VOYANT_GRAPH_MISSING_CAPABILITY",
+          message: "Required capability acme.crm.people is not provided.",
+        },
+      ],
+    })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/VOYANT_GRAPH_MISSING_CAPABILITY/)
+  })
+
+  it("resolves source-style artifact paths beside src", () => {
+    const root = fixtureRoot()
+    writeFixture(root)
+
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "src", "server.ts")).href,
+    )
+
+    expect(summary.graphHash).toBe(HASH)
+    expect(summary.moduleIds).toEqual(["@voyant-travel/bookings"])
+  })
+
+  it("resolves dist-style artifact paths beside dist/server", () => {
+    const root = fixtureRoot()
+    writeFixture(join(root, "dist"))
+    mkdirSync(join(root, "dist", "server"), { recursive: true })
+
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "dist", "server", "server.js")).href,
+    )
+
+    expect(summary.graphHash).toBe(HASH)
+    expect(summary.pluginIds).toEqual(["@voyant-travel/plugin-smartbill"])
+  })
+
+  it("requires the managed node runtime entry metadata", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { runtimeEntry: { kind: "custom-node" } })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/kind must be managed-profile-node/)
+  })
+})
+
+function fixtureRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "voyant-operator-graph-artifacts-"))
+  roots.push(root)
+  return root
+}
+
+function writeFixture(
+  root: string,
+  options: {
+    manifestGraphHash?: string
+    graphHash?: string
+    diagnostics?: Array<{ code: string; message: string }>
+    runtimeEntry?: Record<string, unknown>
+  } = {},
+): void {
+  mkdirSync(join(root, "src"), { recursive: true })
+  writeFileSync(join(root, "managed-profile.json"), "{}\n")
+  const graphHash = options.graphHash ?? HASH
+  writeJson(join(root, "deployment-artifacts.generated.json"), {
+    schemaVersion: "voyant.deployment-artifacts.v1",
+    graphHash: options.manifestGraphHash ?? graphHash,
+    graph: "deployment-graph.generated.json",
+    runtimeEntries: [
+      {
+        ...{
+          id: "@voyant-travel/framework#runtime.node",
+          target: "node",
+          file: "src/runtime-entry.generated.ts",
+          graphHash,
+          kind: "managed-profile-node",
+          profileSnapshot: "managed-profile.json",
+        },
+        ...options.runtimeEntry,
+      },
+    ],
+  })
+  writeJson(join(root, "deployment-graph.generated.json"), {
+    schemaVersion: "voyant.resolved-graph.v1",
+    contentHash: graphHash,
+    diagnostics: options.diagnostics ?? [],
+    deployment: { target: "node", mode: "self-hosted" },
+    modules: [{ id: "@voyant-travel/bookings" }],
+    plugins: [{ id: "@voyant-travel/plugin-smartbill" }],
+    packageRecords: [{ packageName: "@voyant-travel/framework" }],
+  })
+}
+
+function writeJson(path: string, value: unknown): void {
+  writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`)
+}

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -1,0 +1,233 @@
+import { existsSync, readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+
+const ARTIFACT_MANIFEST_SCHEMA_VERSION = "voyant.deployment-artifacts.v1"
+const RESOLVED_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1"
+const ARTIFACT_MANIFEST_FILENAME = "../deployment-artifacts.generated.json"
+const EXPECTED_GRAPH_ARTIFACT = "deployment-graph.generated.json"
+const EXPECTED_NODE_RUNTIME_ENTRY_ID = "@voyant-travel/framework#runtime.node"
+const EXPECTED_NODE_RUNTIME_ENTRY_FILE = "src/runtime-entry.generated.ts"
+const EXPECTED_NODE_RUNTIME_ENTRY_KIND = "managed-profile-node"
+const EXPECTED_PROFILE_SNAPSHOT = "managed-profile.json"
+const SHA256_CONTENT_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/
+
+export interface OperatorDeploymentGraphArtifactSummary {
+  graphHash: string
+  moduleIds: readonly string[]
+  pluginIds: readonly string[]
+  packageNames: readonly string[]
+}
+
+interface DeploymentArtifactManifest {
+  schemaVersion?: unknown
+  graphHash?: unknown
+  graph?: unknown
+  runtimeEntries?: unknown
+}
+
+interface RuntimeEntryArtifact {
+  id?: unknown
+  target?: unknown
+  file?: unknown
+  graphHash?: unknown
+  kind?: unknown
+  profileSnapshot?: unknown
+}
+
+interface ResolvedDeploymentGraph {
+  schemaVersion?: unknown
+  contentHash?: unknown
+  diagnostics?: unknown
+  deployment?: unknown
+  modules?: unknown
+  plugins?: unknown
+  packageRecords?: unknown
+}
+
+export function loadOperatorDeploymentGraphArtifacts(
+  baseUrl = import.meta.url,
+): OperatorDeploymentGraphArtifactSummary {
+  const manifestUrl = new URL(ARTIFACT_MANIFEST_FILENAME, baseUrl)
+  const manifest = readJsonFile<DeploymentArtifactManifest>(manifestUrl, "deployment artifacts")
+
+  if (manifest.schemaVersion !== ARTIFACT_MANIFEST_SCHEMA_VERSION) {
+    throw new Error(
+      `deployment artifacts schema must be ${ARTIFACT_MANIFEST_SCHEMA_VERSION}, got ${String(
+        manifest.schemaVersion,
+      )}`,
+    )
+  }
+  const manifestGraphHash = requireSha256ContentHash(
+    manifest.graphHash,
+    "deployment artifacts graphHash",
+  )
+  const graphPath = requireString(manifest.graph, "deployment artifacts graph")
+  if (graphPath !== EXPECTED_GRAPH_ARTIFACT) {
+    throw new Error(
+      `deployment artifacts graph must be ${EXPECTED_GRAPH_ARTIFACT}, got ${graphPath}`,
+    )
+  }
+  const graphUrl = relativeArtifactUrl(graphPath, manifestUrl)
+  const graph = readJsonFile<ResolvedDeploymentGraph>(graphUrl, "deployment graph")
+
+  if (graph.schemaVersion !== RESOLVED_GRAPH_SCHEMA_VERSION) {
+    throw new Error(
+      `deployment graph schema must be ${RESOLVED_GRAPH_SCHEMA_VERSION}, got ${String(
+        graph.schemaVersion,
+      )}`,
+    )
+  }
+  const graphHash = requireSha256ContentHash(graph.contentHash, "deployment graph contentHash")
+  if (manifestGraphHash !== graphHash) {
+    throw new Error(
+      `deployment artifact graphHash ${manifestGraphHash} does not match graph contentHash ${graphHash}`,
+    )
+  }
+
+  const target = graphDeploymentTarget(graph)
+  if (target !== "node") {
+    throw new Error(`operator deployment graph target must be node, got ${String(target)}`)
+  }
+
+  const diagnostics = arrayOfRecords(graph.diagnostics, "deployment graph diagnostics")
+  if (diagnostics.length > 0) {
+    const details = diagnostics
+      .map((diagnostic) =>
+        [
+          stringField(diagnostic, "code") ?? "unknown",
+          stringField(diagnostic, "message") ?? "deployment graph diagnostic",
+        ].join(": "),
+      )
+      .join("; ")
+    throw new Error(`deployment graph has diagnostics: ${details}`)
+  }
+
+  const runtimeEntries = arrayOfRecords(
+    manifest.runtimeEntries,
+    "deployment artifacts runtimeEntries",
+  ) as RuntimeEntryArtifact[]
+  if (runtimeEntries.length === 0) {
+    throw new Error("deployment artifacts must include at least one runtime entry")
+  }
+
+  let hasExpectedNodeRuntimeEntry = false
+  for (const entry of runtimeEntries) {
+    const id = requireString(entry.id, "runtime entry id")
+    const entryTarget = requireString(entry.target, `runtime entry ${id} target`)
+    const entryFile = requireString(entry.file, `runtime entry ${id} file`)
+    const entryKind = requireString(entry.kind, `runtime entry ${id} kind`)
+    const entryGraphHash = requireSha256ContentHash(
+      entry.graphHash,
+      `runtime entry ${id} graphHash`,
+    )
+    if (entryGraphHash !== graphHash) {
+      throw new Error(
+        `runtime entry ${id} graphHash ${entryGraphHash} does not match graph contentHash ${graphHash}`,
+      )
+    }
+
+    const profileSnapshot = requireString(
+      entry.profileSnapshot,
+      `runtime entry ${id} profileSnapshot`,
+    )
+    if (id === EXPECTED_NODE_RUNTIME_ENTRY_ID) {
+      if (entryTarget !== "node") {
+        throw new Error(`runtime entry ${id} target must be node, got ${entryTarget}`)
+      }
+      if (entryFile !== EXPECTED_NODE_RUNTIME_ENTRY_FILE) {
+        throw new Error(
+          `runtime entry ${id} file must be ${EXPECTED_NODE_RUNTIME_ENTRY_FILE}, got ${entryFile}`,
+        )
+      }
+      if (entryKind !== EXPECTED_NODE_RUNTIME_ENTRY_KIND) {
+        throw new Error(
+          `runtime entry ${id} kind must be ${EXPECTED_NODE_RUNTIME_ENTRY_KIND}, got ${entryKind}`,
+        )
+      }
+      if (profileSnapshot !== EXPECTED_PROFILE_SNAPSHOT) {
+        throw new Error(
+          `runtime entry ${id} profileSnapshot must be ${EXPECTED_PROFILE_SNAPSHOT}, got ${profileSnapshot}`,
+        )
+      }
+      hasExpectedNodeRuntimeEntry = true
+    }
+
+    const profileUrl = relativeArtifactUrl(profileSnapshot, manifestUrl)
+    if (!existsSync(fileURLToPath(profileUrl))) {
+      throw new Error(`runtime entry ${id} profile snapshot is missing: ${profileSnapshot}`)
+    }
+  }
+  if (!hasExpectedNodeRuntimeEntry) {
+    throw new Error(
+      `deployment artifacts must include the managed node runtime entry ${EXPECTED_NODE_RUNTIME_ENTRY_ID}`,
+    )
+  }
+
+  return {
+    graphHash,
+    moduleIds: collectStringField(graph.modules, "deployment graph modules", "id"),
+    pluginIds: collectStringField(graph.plugins, "deployment graph plugins", "id"),
+    packageNames: collectStringField(
+      graph.packageRecords,
+      "deployment graph packageRecords",
+      "packageName",
+    ),
+  }
+}
+
+function readJsonFile<T>(url: URL, label: string): T {
+  const file = fileURLToPath(url)
+  try {
+    return JSON.parse(readFileSync(file, "utf8")) as T
+  } catch (error) {
+    throw new Error(`could not read ${label} at ${file}: ${reason(error)}`)
+  }
+}
+
+function relativeArtifactUrl(value: string, baseUrl: URL): URL {
+  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\")) {
+    throw new Error(`deployment artifact paths must be relative POSIX paths, got ${value}`)
+  }
+  return new URL(value, baseUrl)
+}
+
+function graphDeploymentTarget(graph: ResolvedDeploymentGraph): string | undefined {
+  const deployment = graph.deployment
+  return deployment && typeof deployment === "object"
+    ? stringField(deployment as Record<string, unknown>, "target")
+    : undefined
+}
+
+function requireString(value: unknown, label: string): string {
+  if (typeof value === "string" && value.length > 0) return value
+  throw new Error(`${label} must be a non-empty string`)
+}
+
+function requireSha256ContentHash(value: unknown, label: string): string {
+  const hash = requireString(value, label)
+  if (SHA256_CONTENT_HASH_PATTERN.test(hash)) return hash
+  throw new Error(`${label} must match sha256:<64 lowercase hex chars>, got ${hash}`)
+}
+
+function arrayOfRecords(value: unknown, label: string): Record<string, unknown>[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`)
+  return value.map((entry, index) => {
+    if (entry && typeof entry === "object") return entry as Record<string, unknown>
+    throw new Error(`${label}[${index}] must be an object`)
+  })
+}
+
+function collectStringField(value: unknown, label: string, field: string): string[] {
+  return arrayOfRecords(value, label).map((entry, index) =>
+    requireString(entry[field], `${label}[${index}].${field}`),
+  )
+}
+
+function stringField(record: Record<string, unknown>, field: string): string | undefined {
+  const value = record[field]
+  return typeof value === "string" ? value : undefined
+}
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/starters/operator/src/server.ts
+++ b/starters/operator/src/server.ts
@@ -21,6 +21,7 @@ import type { KVStore } from "@voyant-travel/utils/cache"
 import { createRedisKvStore } from "@voyant-travel/utils/redis-kv"
 import { createTieredKvStore } from "@voyant-travel/utils/tiered-kv"
 
+import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifacts"
 import { fetch as appFetch, scheduled } from "./entry"
 
 /**
@@ -45,6 +46,7 @@ import { fetch as appFetch, scheduled } from "./entry"
 /** Built client assets (`dist/client`), served for `/assets/*` and public files. */
 const CLIENT_DIR =
   process.env.CLIENT_ASSETS_DIR ?? fileURLToPath(new URL("../client", import.meta.url))
+const deploymentGraphArtifacts = loadOperatorDeploymentGraphArtifacts()
 
 /**
  * Build an object-store binding: S3-backed when R2 credentials are present,
@@ -189,5 +191,7 @@ if (isMainModule) {
       ? { originTrustSecret: process.env.ORIGIN_TRUST_SECRET }
       : {}),
   })
-  console.info(`[operator] Node runtime listening on :${handle.port}`)
+  console.info(
+    `[operator] Node runtime listening on :${handle.port} (${deploymentGraphArtifacts.graphHash})`,
+  )
 }


### PR DESCRIPTION
## Summary

- Add an operator boot-time loader for generated deployment graph artifacts.
- Validate artifact schema versions, sha256 graph hashes, graph diagnostics, node deployment target, and managed node runtime-entry metadata without importing `runtime-entry.generated.ts`.
- Include the graph hash in the operator startup log and extend the node-entrypoint checker to require boot artifact validation.

## Validation

- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:node-entrypoint`
- `pnpm lint:changed`
- `pnpm verify:deployment-graph`
- `pnpm verify:agent-quality:changed`
- `pnpm --filter operator build`
- pre-push `pnpm test`

## Notes

- No changeset: this only changes the private operator starter and repository checker.