### PR TITLE
Verify operator graph artifact integrity

### DIFF
--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -1,4 +1,5 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { createHash } from "node:crypto"
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -6,7 +7,6 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifacts"
 
-const HASH = `sha256:${"a".repeat(64)}`
 const OTHER_HASH = `sha256:${"b".repeat(64)}`
 
 const roots: string[] = []
@@ -31,6 +31,19 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(() =>
       loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
     ).toThrow(/does not match graph contentHash/)
+  })
+
+  it("fails when the graph content hash does not match the canonical graph body", () => {
+    const root = fixtureRoot()
+    writeFixture(root)
+    const graphPath = join(root, "deployment-graph.generated.json")
+    const graph = JSON.parse(readFileSync(graphPath, "utf8")) as FixtureDeploymentGraph
+    graph.modules.push({ id: "@voyant-travel/catalog" })
+    writeJson(graphPath, graph)
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/does not match canonical graph hash/)
   })
 
   it("fails when generated graph hashes are not sha256 content hashes", () => {
@@ -60,26 +73,26 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
 
   it("resolves source-style artifact paths beside src", () => {
     const root = fixtureRoot()
-    writeFixture(root)
+    const graphHash = writeFixture(root)
 
     const summary = loadOperatorDeploymentGraphArtifacts(
       pathToFileURL(join(root, "src", "server.ts")).href,
     )
 
-    expect(summary.graphHash).toBe(HASH)
+    expect(summary.graphHash).toBe(graphHash)
     expect(summary.moduleIds).toEqual(["@voyant-travel/bookings"])
   })
 
   it("resolves dist-style artifact paths beside dist/server", () => {
     const root = fixtureRoot()
-    writeFixture(join(root, "dist"))
+    const graphHash = writeFixture(join(root, "dist"), { writeRuntimeEntrySource: false })
     mkdirSync(join(root, "dist", "server"), { recursive: true })
 
     const summary = loadOperatorDeploymentGraphArtifacts(
       pathToFileURL(join(root, "dist", "server", "server.js")).href,
     )
 
-    expect(summary.graphHash).toBe(HASH)
+    expect(summary.graphHash).toBe(graphHash)
     expect(summary.pluginIds).toEqual(["@voyant-travel/plugin-smartbill"])
   })
 
@@ -90,6 +103,15 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(() =>
       loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
     ).toThrow(/kind must be managed-profile-node/)
+  })
+
+  it("fails when generated runtime entry constants drift from the graph", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { runtimeEntrySource: { graphHash: OTHER_HASH } })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/GENERATED_DEPLOYMENT_GRAPH_HASH/)
   })
 })
 
@@ -106,11 +128,22 @@ function writeFixture(
     graphHash?: string
     diagnostics?: Array<{ code: string; message: string }>
     runtimeEntry?: Record<string, unknown>
+    runtimeEntrySource?: { graphHash?: string }
+    writeRuntimeEntrySource?: boolean
   } = {},
-): void {
+): string {
   mkdirSync(join(root, "src"), { recursive: true })
   writeFileSync(join(root, "managed-profile.json"), "{}\n")
-  const graphHash = options.graphHash ?? HASH
+  const graphWithoutHash: Omit<FixtureDeploymentGraph, "contentHash"> = {
+    schemaVersion: "voyant.resolved-graph.v1",
+    diagnostics: options.diagnostics ?? [],
+    deployment: { target: "node", mode: "self-hosted" },
+    modules: [{ id: "@voyant-travel/bookings" }],
+    plugins: [{ id: "@voyant-travel/plugin-smartbill" }],
+    packageRecords: [{ packageName: "@voyant-travel/framework" }],
+  }
+  const graphHash = options.graphHash ?? computeGraphContentHash(graphWithoutHash)
+  const graph: FixtureDeploymentGraph = { ...graphWithoutHash, contentHash: graphHash }
   writeJson(join(root, "deployment-artifacts.generated.json"), {
     schemaVersion: "voyant.deployment-artifacts.v1",
     graphHash: options.manifestGraphHash ?? graphHash,
@@ -129,17 +162,83 @@ function writeFixture(
       },
     ],
   })
-  writeJson(join(root, "deployment-graph.generated.json"), {
-    schemaVersion: "voyant.resolved-graph.v1",
-    contentHash: graphHash,
-    diagnostics: options.diagnostics ?? [],
-    deployment: { target: "node", mode: "self-hosted" },
-    modules: [{ id: "@voyant-travel/bookings" }],
-    plugins: [{ id: "@voyant-travel/plugin-smartbill" }],
-    packageRecords: [{ packageName: "@voyant-travel/framework" }],
-  })
+  writeJson(join(root, "deployment-graph.generated.json"), graph)
+  if (options.writeRuntimeEntrySource !== false) {
+    writeGeneratedRuntimeEntrySource(root, graph, {
+      graphHash: options.runtimeEntrySource?.graphHash ?? graphHash,
+    })
+  }
+  return graphHash
 }
 
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`)
+}
+
+interface FixtureDeploymentGraph {
+  schemaVersion: string
+  contentHash: string
+  diagnostics: Array<{ code: string; message: string }>
+  deployment: { target: string; mode: string }
+  modules: Array<{ id: string }>
+  plugins: Array<{ id: string }>
+  packageRecords: Array<{ packageName: string }>
+}
+
+function writeGeneratedRuntimeEntrySource(
+  root: string,
+  graph: FixtureDeploymentGraph,
+  options: { graphHash: string },
+): void {
+  writeFileSync(
+    join(root, "src", "runtime-entry.generated.ts"),
+    [
+      `export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = ${JSON.stringify(
+        graph.schemaVersion,
+      )} as const`,
+      `export const GENERATED_DEPLOYMENT_GRAPH_HASH = ${JSON.stringify(options.graphHash)} as const`,
+      `export const GENERATED_DEPLOYMENT_GRAPH_TARGET = ${JSON.stringify(
+        graph.deployment.target,
+      )} as const`,
+      `export const GENERATED_DEPLOYMENT_GRAPH_MODE = ${JSON.stringify(
+        graph.deployment.mode,
+      )} as const`,
+      'export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const',
+      'export const GENERATED_MANAGED_PROFILE_SNAPSHOT_PATH = "../managed-profile.json" as const',
+      `export const GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS = ${stringArrayLiteral(
+        graph.modules.map((module) => module.id),
+      )} as const`,
+      `export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = ${stringArrayLiteral(
+        graph.plugins.map((plugin) => plugin.id),
+      )} as const`,
+      `export const GENERATED_DEPLOYMENT_GRAPH_PACKAGE_NAMES = ${stringArrayLiteral(
+        graph.packageRecords.map((record) => record.packageName),
+      )} as const`,
+      "",
+    ].join("\n"),
+  )
+}
+
+function stringArrayLiteral(values: readonly string[]): string {
+  return `[${values.map((value) => JSON.stringify(value)).join(", ")}]`
+}
+
+function computeGraphContentHash(graphWithoutHash: Omit<FixtureDeploymentGraph, "contentHash">) {
+  return `sha256:${createHash("sha256").update(canonicalJson(graphWithoutHash)).digest("hex")}`
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === undefined) return null
+  if (value === null || typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map(canonicalize)
+
+  const sorted: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = canonicalize((value as Record<string, unknown>)[key])
+  }
+  return sorted
 }

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { existsSync, readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 
@@ -9,6 +10,8 @@ const EXPECTED_NODE_RUNTIME_ENTRY_ID = "@voyant-travel/framework#runtime.node"
 const EXPECTED_NODE_RUNTIME_ENTRY_FILE = "src/runtime-entry.generated.ts"
 const EXPECTED_NODE_RUNTIME_ENTRY_KIND = "managed-profile-node"
 const EXPECTED_PROFILE_SNAPSHOT = "managed-profile.json"
+const EXPECTED_RUNTIME_ENTRY_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json"
+const EXPECTED_RUNTIME_ENTRY_PROFILE_SNAPSHOT_PATH = "../managed-profile.json"
 const SHA256_CONTENT_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/
 
 export interface OperatorDeploymentGraphArtifactSummary {
@@ -83,11 +86,18 @@ export function loadOperatorDeploymentGraphArtifacts(
       `deployment artifact graphHash ${manifestGraphHash} does not match graph contentHash ${graphHash}`,
     )
   }
+  const canonicalGraphHash = computeGraphContentHash(graph)
+  if (graphHash !== canonicalGraphHash) {
+    throw new Error(
+      `deployment graph contentHash ${graphHash} does not match canonical graph hash ${canonicalGraphHash}`,
+    )
+  }
 
   const target = graphDeploymentTarget(graph)
   if (target !== "node") {
     throw new Error(`operator deployment graph target must be node, got ${String(target)}`)
   }
+  const mode = graphDeploymentMode(graph)
 
   const diagnostics = arrayOfRecords(graph.diagnostics, "deployment graph diagnostics")
   if (diagnostics.length > 0) {
@@ -163,7 +173,7 @@ export function loadOperatorDeploymentGraphArtifacts(
     )
   }
 
-  return {
+  const summary = {
     graphHash,
     moduleIds: collectStringField(graph.modules, "deployment graph modules", "id"),
     pluginIds: collectStringField(graph.plugins, "deployment graph plugins", "id"),
@@ -173,6 +183,10 @@ export function loadOperatorDeploymentGraphArtifacts(
       "packageName",
     ),
   }
+
+  validateGeneratedRuntimeEntrySource({ graphHash, manifestUrl, mode, summary, target })
+
+  return summary
 }
 
 function readJsonFile<T>(url: URL, label: string): T {
@@ -196,6 +210,129 @@ function graphDeploymentTarget(graph: ResolvedDeploymentGraph): string | undefin
   return deployment && typeof deployment === "object"
     ? stringField(deployment as Record<string, unknown>, "target")
     : undefined
+}
+
+function graphDeploymentMode(graph: ResolvedDeploymentGraph): string | undefined {
+  const deployment = graph.deployment
+  return deployment && typeof deployment === "object"
+    ? stringField(deployment as Record<string, unknown>, "mode")
+    : undefined
+}
+
+function computeGraphContentHash(graph: ResolvedDeploymentGraph): string {
+  const { contentHash: _contentHash, ...graphWithoutHash } = graph
+  return `sha256:${createHash("sha256").update(canonicalJson(graphWithoutHash)).digest("hex")}`
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value))
+}
+
+function canonicalize(value: unknown): unknown {
+  if (value === undefined) return null
+  if (value === null || typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map(canonicalize)
+
+  const sorted: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    sorted[key] = canonicalize((value as Record<string, unknown>)[key])
+  }
+  return sorted
+}
+
+function validateGeneratedRuntimeEntrySource(input: {
+  graphHash: string
+  manifestUrl: URL
+  mode: string | undefined
+  summary: OperatorDeploymentGraphArtifactSummary
+  target: string
+}): void {
+  const runtimeEntryUrl = relativeArtifactUrl(EXPECTED_NODE_RUNTIME_ENTRY_FILE, input.manifestUrl)
+  const runtimeEntryFile = fileURLToPath(runtimeEntryUrl)
+  if (!existsSync(runtimeEntryFile)) return
+
+  const source = readFileSync(runtimeEntryFile, "utf8")
+  assertGeneratedStringConst(
+    source,
+    "GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION",
+    RESOLVED_GRAPH_SCHEMA_VERSION,
+  )
+  assertGeneratedStringConst(source, "GENERATED_DEPLOYMENT_GRAPH_HASH", input.graphHash)
+  assertGeneratedStringConst(source, "GENERATED_DEPLOYMENT_GRAPH_TARGET", input.target)
+  assertGeneratedStringConst(source, "GENERATED_DEPLOYMENT_GRAPH_MODE", input.mode)
+  assertGeneratedStringConst(
+    source,
+    "GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH",
+    EXPECTED_RUNTIME_ENTRY_GRAPH_ARTIFACT_PATH,
+  )
+  assertGeneratedStringConst(
+    source,
+    "GENERATED_MANAGED_PROFILE_SNAPSHOT_PATH",
+    EXPECTED_RUNTIME_ENTRY_PROFILE_SNAPSHOT_PATH,
+  )
+  assertGeneratedStringArrayConst(
+    source,
+    "GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS",
+    input.summary.moduleIds,
+  )
+  assertGeneratedStringArrayConst(
+    source,
+    "GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS",
+    input.summary.pluginIds,
+  )
+  assertGeneratedStringArrayConst(
+    source,
+    "GENERATED_DEPLOYMENT_GRAPH_PACKAGE_NAMES",
+    input.summary.packageNames,
+  )
+}
+
+function assertGeneratedStringConst(source: string, name: string, expected: string | undefined) {
+  const actual = parseGeneratedStringConst(source, name)
+  if (actual === expected) return
+  throw new Error(
+    `generated runtime entry ${name} must be ${String(expected)}, got ${String(actual)}`,
+  )
+}
+
+function parseGeneratedStringConst(source: string, name: string): string | undefined {
+  const escapedName = escapeRegExp(name)
+  const match = source.match(
+    new RegExp(`export\\s+const\\s+${escapedName}\\s*=\\s*("(?:[^"\\\\]|\\\\.)*")\\s+as\\s+const`),
+  )
+  if (!match) return undefined
+  return JSON.parse(match[1]) as string
+}
+
+function assertGeneratedStringArrayConst(
+  source: string,
+  name: string,
+  expected: readonly string[],
+): void {
+  const actual = parseGeneratedStringArrayConst(source, name)
+  if (actual && stringArraysEqual(actual, expected)) return
+  throw new Error(`generated runtime entry ${name} must match deployment graph`)
+}
+
+function parseGeneratedStringArrayConst(source: string, name: string): string[] | undefined {
+  const escapedName = escapeRegExp(name)
+  const match = source.match(
+    new RegExp(`export\\s+const\\s+${escapedName}\\s*=\\s*\\[([\\s\\S]*?)\\]\\s+as\\s+const`),
+  )
+  if (!match) return undefined
+  return Array.from(match[1].matchAll(/"((?:[^"\\]|\\.)*)"/g), (entry) =>
+    JSON.parse(`"${entry[1]}"`),
+  )
+}
+
+function stringArraysEqual(actual: readonly string[], expected: readonly string[]): boolean {
+  return (
+    actual.length === expected.length && actual.every((value, index) => value === expected[index])
+  )
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
 function requireString(value: unknown, label: string): string {


### PR DESCRIPTION
## Summary

Hardens the operator deployment artifact boot check so it verifies the resolved graph content hash against the canonical graph body, not only against the manifest value.

Also validates the checked-in generated runtime-entry source when it is present in source layout, so the graph hash, deployment target/mode, artifact paths, module ids, plugin ids, and package names cannot drift from the emitted graph artifacts. Dist layout still allows the generated TypeScript source to be absent.

## Validation

- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:deployment-graph`
- `pnpm verify:node-entrypoint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm --filter operator build`
- commit hook affected Turbo lint/test path passed before push