### PR TITLE
Add operator local graph coverage

### DIFF
--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -1,3 +1,5 @@
+import { readFile } from "node:fs/promises"
+
 import {
   buildDeploymentArtifactManifest,
   buildDeploymentGraphJson,
@@ -11,6 +13,10 @@ import {
   VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY,
 } from "../packages/framework/src/deployment-graph.ts"
 import { defineVoyantProject } from "../packages/framework/src/profile.ts"
+import {
+  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS,
+  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_IDS,
+} from "../starters/operator/deployment-graph.local.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 
 const failures: string[] = []
@@ -114,6 +120,16 @@ async function main(): Promise<void> {
     failures.push("expected managed graph to include selected plugin @voyant-travel/plugin-netopia")
   }
 
+  const operatorGraph = await readOperatorGeneratedGraph()
+  const operatorModuleIds = new Set(operatorGraph.modules.map((unit) => unit.id))
+  const operatorPluginIds = new Set(operatorGraph.plugins.map((unit) => unit.id))
+  for (const id of OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS) {
+    if (!operatorModuleIds.has(id)) failures.push(`expected operator graph to include ${id}`)
+  }
+  for (const id of OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_IDS) {
+    if (!operatorPluginIds.has(id)) failures.push(`expected operator graph to include ${id}`)
+  }
+
   const frameworkRecord = first.packageRecords.find(
     (record) => record.packageName === "@voyant-travel/framework",
   )
@@ -151,6 +167,21 @@ async function main(): Promise<void> {
   console.log(
     `check-deployment-graph: OK (${first.modules.length} modules, ${first.plugins.length} plugins, ${first.contentHash})`,
   )
+}
+
+async function readOperatorGeneratedGraph(): Promise<{
+  modules: Array<{ id: string }>
+  plugins: Array<{ id: string }>
+}> {
+  return JSON.parse(
+    await readFile(
+      new URL("../starters/operator/deployment-graph.generated.json", import.meta.url),
+      "utf8",
+    ),
+  ) as {
+    modules: Array<{ id: string }>
+    plugins: Array<{ id: string }>
+  }
 }
 
 main().catch((error) => {

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -8,7 +8,15 @@ import {
   buildManagedNodeRuntimeEntry,
   buildManagedNodeRuntimeEntryArtifact,
 } from "../packages/framework/src/deployment-artifacts.ts"
-import { resolveManagedProfileDeploymentGraph } from "../packages/framework/src/deployment-graph.ts"
+import {
+  defineDeploymentFromManagedProfile,
+  defineProject,
+  defineProjectFromManagedProfile,
+  type ResolveDeploymentGraphInput,
+  resolveDeploymentGraph,
+} from "../packages/framework/src/deployment-graph.ts"
+import type { VoyantProjectManifest } from "../packages/framework/src/profile-types.ts"
+import { OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST } from "../starters/operator/deployment-graph.local.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 
 interface CliOptions {
@@ -90,13 +98,43 @@ async function main(): Promise<void> {
 }
 
 async function resolveGraph(profilePath: string) {
-  const project = JSON.parse(await readFile(profilePath, "utf8"))
-  const discoveredGraph = await resolveManagedProfileDeploymentGraph(project)
+  const project = JSON.parse(await readFile(profilePath, "utf8")) as VoyantProjectManifest
+  const discoveredGraph = await resolveOperatorDeploymentGraph(project)
   const packageRecords = readPnpmLockfilePackageRecords({
     repoRoot,
-    packageNames: discoveredGraph.packageRecords.map((record) => record.packageName),
+    packageNames: [
+      "@voyant-travel/framework",
+      "@voyant-travel/framework-migrations",
+      ...discoveredGraph.packageRecords.map((record) => record.packageName),
+    ],
   })
-  return resolveManagedProfileDeploymentGraph(project, { packageRecords })
+  return resolveOperatorDeploymentGraph(project, { packageRecords })
+}
+
+function resolveOperatorDeploymentGraph(
+  project: VoyantProjectManifest,
+  options: Omit<ResolveDeploymentGraphInput, "project" | "deployment"> = {},
+) {
+  const graphProject = defineOperatorGraphProject(project)
+  const { project: _managedProject, ...deployment } = defineDeploymentFromManagedProfile(project)
+  return resolveDeploymentGraph({
+    ...options,
+    project: graphProject,
+    deployment,
+    frameworkVersion: options.frameworkVersion ?? project.frameworkVersion,
+    target: options.target ?? deployment.target,
+    mode: options.mode ?? deployment.mode,
+  })
+}
+
+function defineOperatorGraphProject(project: VoyantProjectManifest) {
+  const managedProject = defineProjectFromManagedProfile(project)
+  return defineProject({
+    presetLineage: managedProject.presetLineage,
+    modules: [...managedProject.modules, ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.modules],
+    plugins: [...managedProject.plugins, ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.plugins],
+    meta: managedProject.meta,
+  })
 }
 
 async function writeGeneratedFile(filePath: string, text: string): Promise<void> {

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:963c397abac564cd5aea200269c5492fc9057bc35d1bfb853dbb97a796552130",
+  "graphHash": "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:963c397abac564cd5aea200269c5492fc9057bc35d1bfb853dbb97a796552130",
+      "graphHash": "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:963c397abac564cd5aea200269c5492fc9057bc35d1bfb853dbb97a796552130",
+  "contentHash": "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -750,6 +750,197 @@
       "schema": [],
       "subscribers": [],
       "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/operator#invitations.api.admin",
+          "mount": "operator/invitations",
+          "surface": "admin"
+        },
+        {
+          "anonymous": true,
+          "id": "@voyant-travel/operator#invitations.api.public",
+          "mount": "operator/invitations",
+          "surface": "public"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/operator#invitations",
+      "kind": "module",
+      "links": [],
+      "localId": "operator.invitations",
+      "migrations": [],
+      "order": 26,
+      "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/operator#team.api.admin",
+          "mount": "operator/team",
+          "surface": "admin"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/operator#team",
+      "kind": "module",
+      "links": [],
+      "localId": "operator.team",
+      "migrations": [],
+      "order": 27,
+      "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/operator#cruises.api.admin",
+          "mount": "operator/cruises",
+          "surface": "admin"
+        },
+        {
+          "anonymous": true,
+          "id": "@voyant-travel/operator#cruises.api.public",
+          "mount": "operator/cruises",
+          "surface": "public"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/operator#cruises",
+      "kind": "module",
+      "links": [],
+      "localId": "operator.cruises",
+      "migrations": [],
+      "order": 28,
+      "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/operator#charters.api.admin",
+          "mount": "operator/charters",
+          "surface": "admin"
+        },
+        {
+          "anonymous": true,
+          "id": "@voyant-travel/operator#charters.api.public",
+          "mount": "operator/charters",
+          "surface": "public"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/operator#charters",
+      "kind": "module",
+      "links": [],
+      "localId": "operator.charters",
+      "migrations": [],
+      "order": 29,
+      "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/operator#realtime.api.admin",
+          "mount": "operator/realtime",
+          "surface": "admin"
+        },
+        {
+          "id": "@voyant-travel/operator#realtime.api.public",
+          "mount": "operator/realtime",
+          "surface": "public"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/operator#realtime",
+      "kind": "module",
+      "links": [],
+      "localId": "operator.realtime",
+      "migrations": [],
+      "order": 30,
+      "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/mice#api.admin",
+          "mount": "@voyant-travel/mice",
+          "surface": "admin"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/mice",
+      "kind": "module",
+      "links": [],
+      "localId": "mice",
+      "migrations": [],
+      "order": 31,
+      "packageName": "@voyant-travel/mice",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
     }
   ],
   "packageRecords": [
@@ -856,6 +1047,14 @@
         "reference": "link:../legal"
       },
       "version": "0.149.0"
+    },
+    {
+      "packageName": "@voyant-travel/mice",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../mice"
+      },
+      "version": "0.6.8"
     },
     {
       "packageName": "@voyant-travel/notifications",
@@ -1327,6 +1526,34 @@
       "migrations": [],
       "order": 14,
       "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [
+        {
+          "id": "@voyant-travel/mice#booking-extension.api.admin",
+          "mount": "@voyant-travel/mice/booking-extension",
+          "surface": "admin"
+        }
+      ],
+      "events": [],
+      "id": "@voyant-travel/mice#booking-extension",
+      "kind": "plugin",
+      "links": [],
+      "localId": "mice.booking-extension",
+      "migrations": [],
+      "order": 15,
+      "packageName": "@voyant-travel/mice",
       "provides": {
         "capabilities": [],
         "ports": []

--- a/starters/operator/deployment-graph.local.ts
+++ b/starters/operator/deployment-graph.local.ts
@@ -1,0 +1,91 @@
+import {
+  childGraphEntityId,
+  defineModule,
+  definePlugin,
+  graphIdFromSpecifier,
+  packageNameFromSpecifier,
+  type VoyantGraphRouteSurface,
+  type VoyantGraphUnitManifest,
+} from "../../packages/framework/src/deployment-graph.ts"
+import { moduleIdFromSpecifier } from "../../packages/framework/src/profile-types.ts"
+
+export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS = [
+  "operator/invitations",
+  "operator/team",
+  "operator/cruises",
+  "operator/charters",
+  "operator/realtime",
+  "@voyant-travel/mice",
+] as const
+
+export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_SPECIFIERS = [
+  "@voyant-travel/mice/booking-extension",
+] as const
+
+export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS =
+  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS.map(graphIdFromSpecifier)
+
+export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_IDS =
+  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_SPECIFIERS.map(graphIdFromSpecifier)
+
+export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST = {
+  modules: [
+    localModule("operator/invitations", [
+      { surface: "admin" },
+      { surface: "public", anonymous: true },
+    ]),
+    localModule("operator/team", [{ surface: "admin" }]),
+    localModule("operator/cruises", [{ surface: "admin" }, { surface: "public", anonymous: true }]),
+    localModule("operator/charters", [
+      { surface: "admin" },
+      { surface: "public", anonymous: true },
+    ]),
+    localModule("operator/realtime", [{ surface: "admin" }, { surface: "public" }]),
+    localModule("@voyant-travel/mice", [{ surface: "admin" }]),
+  ],
+  plugins: [localPlugin("@voyant-travel/mice/booking-extension", [{ surface: "admin" }])],
+} satisfies {
+  modules: readonly VoyantGraphUnitManifest[]
+  plugins: readonly VoyantGraphUnitManifest[]
+}
+
+function localModule(
+  specifier: string,
+  api: readonly { surface: VoyantGraphRouteSurface; anonymous?: boolean }[],
+): VoyantGraphUnitManifest {
+  const id = graphIdFromSpecifier(specifier)
+  return defineModule({
+    id,
+    packageName: packageNameFromSpecifier(specifier),
+    localId: moduleIdFromSpecifier(specifier),
+    api: routeBundles(id, specifier, api),
+    meta: { source: "operator-local" },
+  })
+}
+
+function localPlugin(
+  specifier: string,
+  api: readonly { surface: VoyantGraphRouteSurface; anonymous?: boolean }[],
+): VoyantGraphUnitManifest {
+  const id = graphIdFromSpecifier(specifier)
+  return definePlugin({
+    id,
+    packageName: packageNameFromSpecifier(specifier),
+    localId: moduleIdFromSpecifier(specifier),
+    api: routeBundles(id, specifier, api),
+    meta: { source: "operator-local" },
+  })
+}
+
+function routeBundles(
+  graphId: string,
+  specifier: string,
+  api: readonly { surface: VoyantGraphRouteSurface; anonymous?: boolean }[],
+): VoyantGraphUnitManifest["api"] {
+  return api.map((route) => ({
+    id: childGraphEntityId(graphId, `api.${route.surface}`),
+    surface: route.surface,
+    mount: specifier,
+    ...(route.anonymous ? { anonymous: true } : {}),
+  }))
+}

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "node -r ./scripts/env-preload.cjs node_modules/vite/bin/vite.js dev --port 3300",
+    "dev": "pnpm run graph:check && node -r ./scripts/env-preload.cjs node_modules/vite/bin/vite.js dev --port 3300",
     "build": "pnpm run graph:check && vite build && pnpm run copy:deployment-artifacts",
     "copy:deployment-artifacts": "cp managed-profile.json deployment-artifacts.generated.json deployment-graph.generated.json dist/",
     "preview": "pnpm run build && vite preview",

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:963c397abac564cd5aea200269c5492fc9057bc35d1bfb853dbb97a796552130" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const
@@ -39,6 +39,12 @@ export const GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS = [
   "@voyant-travel/operator#media",
   "@voyant-travel/operator#payment-link",
   "@voyant-travel/operator#contract-document",
+  "@voyant-travel/operator#invitations",
+  "@voyant-travel/operator#team",
+  "@voyant-travel/operator#cruises",
+  "@voyant-travel/operator#charters",
+  "@voyant-travel/operator#realtime",
+  "@voyant-travel/mice",
 ] as const
 export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = [
   "@voyant-travel/bookings#booking-supplier-extension",
@@ -56,6 +62,7 @@ export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = [
   "@voyant-travel/operator#proposal-extension",
   "@voyant-travel/operator#catalog-offers-extension",
   "@voyant-travel/operator#catalog-checkout-extension",
+  "@voyant-travel/mice#booking-extension",
 ] as const
 export const GENERATED_DEPLOYMENT_GRAPH_PACKAGE_NAMES = [
   "@voyant-travel/accommodations",
@@ -71,6 +78,7 @@ export const GENERATED_DEPLOYMENT_GRAPH_PACKAGE_NAMES = [
   "@voyant-travel/identity",
   "@voyant-travel/inventory",
   "@voyant-travel/legal",
+  "@voyant-travel/mice",
   "@voyant-travel/notifications",
   "@voyant-travel/operations",
   "@voyant-travel/operator",


### PR DESCRIPTION
## Summary

Adds graph-only declarations for the operator deployment-local runtime families:

- `operator/invitations`
- `operator/team`
- `operator/cruises`
- `operator/charters`
- `operator/realtime`
- `@voyant-travel/mice`
- `@voyant-travel/mice/booking-extension`

The operator graph emitter now appends these starter-local manifests to the managed-profile bridge before resolving the generated artifacts. This keeps them out of managed-profile `customSource`, so route-only starter families are not treated as package migration inputs.

Also makes `operator dev` run `graph:check` before Vite starts, so local dev consumes the same checked graph artifact path as build/deploy.

## Validation

- `pnpm --filter operator graph:emit`
- `pnpm verify:deployment-graph`
- `pnpm --filter operator test src/api/composition.test.ts`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:node-entrypoint`
- `pnpm --filter operator build`

Note: `pnpm --filter operator typecheck` was started in the fresh worktree but interrupted after more than 11 minutes with no diagnostics while the cold server `tsc` pass was still CPU-active.