### PR TITLE
Add graph resource requirements

### DIFF
--- a/.changeset/graph-resource-requirements.md
+++ b/.changeset/graph-resource-requirements.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Expose graph resource requirements from resolved deployment graphs.

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 import {
   createTestDeployment,
+  defineDeployment,
   defineModule,
   definePlugin,
   defineProject,
@@ -137,6 +138,85 @@ describe("deployment graph v1", () => {
     expect(second.contentHash).toBe(first.contentHash)
   })
 
+  it("normalizes deployment resource requirements before hashing", async () => {
+    const project = defineProject({
+      modules: [],
+    })
+    const firstDeployment = defineDeployment({
+      project,
+      target: "node",
+      mode: "self-hosted",
+      requirements: {
+        resources: [
+          {
+            resourceKey: "database:postgres",
+            roles: ["database", "cache"],
+            provider: "postgres",
+            required: true,
+            env: [
+              {
+                name: "DATABASE_URL_REPLICAS",
+                kind: "secret",
+                required: false,
+                description: "Read replicas.",
+              },
+              {
+                name: "DATABASE_URL",
+                kind: "secret",
+                required: true,
+                description: "Primary database.",
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const secondDeployment = defineDeployment({
+      project,
+      target: "node",
+      mode: "self-hosted",
+      requirements: {
+        resources: [
+          {
+            resourceKey: "database:postgres",
+            roles: ["cache", "database"],
+            provider: "postgres",
+            required: true,
+            env: [
+              {
+                name: "DATABASE_URL",
+                kind: "secret",
+                required: true,
+                description: "Primary database.",
+              },
+              {
+                name: "DATABASE_URL_REPLICAS",
+                kind: "secret",
+                required: false,
+                description: "Read replicas.",
+              },
+            ],
+          },
+        ],
+      },
+    })
+    const { project: _firstProject, ...firstDeploymentInput } = firstDeployment
+    const { project: _secondProject, ...secondDeploymentInput } = secondDeployment
+
+    const first = await resolveDeploymentGraph({
+      project,
+      deployment: firstDeploymentInput,
+    })
+    const second = await resolveDeploymentGraph({
+      project,
+      deployment: secondDeploymentInput,
+    })
+
+    expect(first.requirements.resources).toEqual(second.requirements.resources)
+    expect(JSON.stringify(first.requirements)).not.toContain('"notes":null')
+    expect(second.contentHash).toBe(first.contentHash)
+  })
+
   it("detects package framework incompatibility from metadata", async () => {
     const project = defineProject({
       modules: [
@@ -206,6 +286,28 @@ describe("deployment graph v1", () => {
     expect(graph.schemaVersion).toBe("voyant.resolved-graph.v1")
     expect(graph.project.presetLineage).toBe("operator-standard")
     expect(graph.deployment.target).toBe("voyant-cloud")
+    expect(graph.deployment.providers).toEqual(
+      expect.objectContaining({
+        database: "postgres",
+        storage: "s3",
+        cache: "redis",
+        sharedState: "redis",
+        rateLimit: "redis",
+        auth: "voyant-cloud",
+        workflows: "voyant-cloud",
+      }),
+    )
+    expect(graph.requirements.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ resourceKey: "redis", provider: "redis" }),
+        expect.objectContaining({ resourceKey: "object-storage", provider: "s3" }),
+        expect.objectContaining({ resourceKey: "auth:voyant-cloud", provider: "voyant-cloud" }),
+        expect.objectContaining({
+          resourceKey: "workflows:voyant-cloud",
+          provider: "voyant-cloud",
+        }),
+      ]),
+    )
     expect(graph.modules.map((unit) => unit.id)).toEqual(
       expect.arrayContaining([
         "@voyant-travel/bookings",

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -5,8 +5,11 @@ import {
   subsetStandardManifest,
 } from "./manifest.js"
 import {
+  getVoyantProjectProviders,
   getVoyantProjectRequirements,
   toCreateVoyantAppProfileConfig,
+  type VoyantProfileEnvRequirement,
+  type VoyantProfileResourceRequirement,
   type VoyantProjectDeploymentMode,
   type VoyantProjectManifest,
   type VoyantProjectProviderRole,
@@ -170,7 +173,12 @@ export interface DefineVoyantGraphDeploymentInput {
   target: string
   providers?: Partial<Record<VoyantProjectProviderRole | string, string>>
   mode?: VoyantProjectDeploymentMode
+  requirements?: VoyantGraphDeploymentRequirements
   meta?: VoyantGraphJsonObject
+}
+
+export interface VoyantGraphDeploymentRequirements {
+  resources: readonly VoyantProfileResourceRequirement[]
 }
 
 export interface VoyantGraphDeployment {
@@ -179,6 +187,7 @@ export interface VoyantGraphDeployment {
   target: string
   providers: Partial<Record<VoyantProjectProviderRole | string, string>>
   mode?: VoyantProjectDeploymentMode
+  requirements: VoyantGraphDeploymentRequirements
   meta?: VoyantGraphJsonObject
 }
 
@@ -262,6 +271,7 @@ export interface ResolvedVoyantDeploymentGraph {
     mode?: VoyantProjectDeploymentMode
     providers: Partial<Record<VoyantProjectProviderRole | string, string>>
   }
+  requirements: VoyantGraphDeploymentRequirements
   modules: readonly ResolvedVoyantGraphUnit[]
   plugins: readonly ResolvedVoyantGraphUnit[]
   capabilities: {
@@ -365,6 +375,7 @@ export function defineDeployment(input: DefineVoyantGraphDeploymentInput): Voyan
     target: input.target,
     providers: { ...(input.providers ?? {}) },
     ...(input.mode ? { mode: input.mode } : {}),
+    requirements: normalizeDeploymentRequirements(input.requirements),
     ...(input.meta ? { meta: input.meta } : {}),
   } satisfies VoyantGraphDeployment
 
@@ -477,6 +488,7 @@ export async function resolveDeploymentGraph(
   const target = input.target ?? input.deployment?.target
   const mode = input.mode ?? input.deployment?.mode
   const providers = { ...(input.deployment?.providers ?? {}) }
+  const requirements = normalizeDeploymentRequirements(input.deployment?.requirements)
   const selectedModules = input.project.modules.map((unit, index) =>
     resolveUnit(unit, "module", index),
   )
@@ -511,6 +523,7 @@ export async function resolveDeploymentGraph(
       ...(mode ? { mode } : {}),
       providers,
     },
+    requirements,
     modules,
     plugins,
     capabilities: {
@@ -560,11 +573,13 @@ export function defineDeploymentFromManagedProfile(
   project: VoyantProjectManifest,
 ): VoyantGraphDeployment {
   const requirements = getVoyantProjectRequirements(project)
+  const providers = getVoyantProjectProviders(project)
   return defineDeployment({
     project: defineProjectFromManagedProfile(project),
     target: project.mode === "managed-cloud" ? "voyant-cloud" : "node",
     mode: project.mode,
-    providers: project.providers ? { ...project.providers } : undefined,
+    providers: { ...providers },
+    requirements: { resources: requirements.resources },
     meta: {
       compatibilityProfile: requirements.profile,
       frameworkVersion: requirements.frameworkVersion,
@@ -749,6 +764,58 @@ export async function sha256(value: unknown): Promise<string> {
   const bytes = new TextEncoder().encode(text)
   const digest = await getCrypto().subtle.digest("SHA-256", bytes)
   return bytesToHex(new Uint8Array(digest))
+}
+
+function normalizeDeploymentRequirements(
+  requirements: VoyantGraphDeploymentRequirements | undefined,
+): VoyantGraphDeploymentRequirements {
+  return {
+    resources: [...(requirements?.resources ?? [])]
+      .map(normalizeResourceRequirement)
+      .sort(compareResourceRequirements),
+  }
+}
+
+function normalizeResourceRequirement(
+  requirement: VoyantProfileResourceRequirement,
+): VoyantProfileResourceRequirement {
+  return {
+    resourceKey: requirement.resourceKey,
+    roles: [...requirement.roles].sort(),
+    provider: requirement.provider,
+    required: requirement.required,
+    env: [...requirement.env].sort(compareEnvRequirements).map((env) => ({
+      name: env.name,
+      kind: env.kind,
+      required: env.required,
+      description: env.description,
+    })),
+    ...(requirement.notes ? { notes: requirement.notes } : {}),
+  }
+}
+
+function compareEnvRequirements(
+  left: VoyantProfileEnvRequirement,
+  right: VoyantProfileEnvRequirement,
+): number {
+  return (
+    left.name.localeCompare(right.name) ||
+    left.kind.localeCompare(right.kind) ||
+    Number(left.required) - Number(right.required) ||
+    left.description.localeCompare(right.description)
+  )
+}
+
+function compareResourceRequirements(
+  left: VoyantProfileResourceRequirement,
+  right: VoyantProfileResourceRequirement,
+): number {
+  return (
+    left.resourceKey.localeCompare(right.resourceKey) ||
+    left.provider.localeCompare(right.provider) ||
+    Number(left.required) - Number(right.required) ||
+    left.roles.join(",").localeCompare(right.roles.join(","))
+  )
 }
 
 function defineGraphUnit(

--- a/packages/framework/src/profile-requirements.ts
+++ b/packages/framework/src/profile-requirements.ts
@@ -27,6 +27,7 @@ export function resourceRequirementsFor(
     ]
   }
 
+  const notes = notesForProvider(role, provider)
   return [
     {
       resourceKey: resourceKeyFor(role, provider),
@@ -34,7 +35,7 @@ export function resourceRequirementsFor(
       provider,
       required: true,
       env: envForProvider(role, provider),
-      notes: notesForProvider(role, provider),
+      ...(notes ? { notes } : {}),
     },
   ]
 }

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -6,6 +6,7 @@ import {
 import {
   defineVoyantProject,
   getVoyantProjectMigrationMetadata,
+  getVoyantProjectProviders,
   getVoyantProjectRequirements,
   MANAGED_OPERATOR_DEFAULT_PROVIDERS,
   resolveActiveModuleIds,
@@ -95,6 +96,33 @@ describe("managed profile contract", () => {
     })
 
     expect(validateVoyantProject(project)).toEqual({ ok: true, issues: [] })
+  })
+
+  it("normalizes providers for managed-cloud and self-hosted profiles", () => {
+    expect(getVoyantProjectProviders(validProject())).toEqual(MANAGED_OPERATOR_DEFAULT_PROVIDERS)
+
+    const selfHostedProviders = {
+      ...MANAGED_OPERATOR_DEFAULT_PROVIDERS,
+      storage: "memory",
+      cache: "postgres",
+      sharedState: "postgres",
+      rateLimit: "postgres",
+      search: "none",
+      email: "none",
+      sms: "none",
+      auth: "better-auth",
+      scheduledJobs: "none",
+      workflows: "self-hosted",
+    } as const
+    const selfHostedProject = defineVoyantProject({
+      profile: "operator",
+      frameworkVersion: "0.12.22",
+      mode: "self-hosted",
+      modules: ["catalog", "bookings", "finance", "relationships"],
+      providers: selfHostedProviders,
+    })
+
+    expect(getVoyantProjectProviders(selfHostedProject)).toEqual(selfHostedProviders)
   })
 
   it("exports resource requirements before app boot", () => {

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -147,7 +147,7 @@ export function getVoyantProjectRequirements(
 ): VoyantProfileRequirements {
   assertValidVoyantProject(project)
   const bridge = toCreateVoyantAppProfileConfig(project)
-  const providers = providersForProject(project)
+  const providers = getVoyantProjectProviders(project)
 
   return {
     schemaVersion: project.schemaVersion,
@@ -165,6 +165,13 @@ export function getVoyantProjectRequirements(
     ),
     migration: getVoyantProjectMigrationMetadata(project),
   }
+}
+
+export function getVoyantProjectProviders(project: VoyantProjectManifest): VoyantProjectProviders {
+  assertValidVoyantProject(project)
+  if (project.mode === "managed-cloud") return MANAGED_OPERATOR_DEFAULT_PROVIDERS
+  if (!project.providers) throw new Error(`${project.mode} profiles must declare providers.`)
+  return project.providers
 }
 
 export function getVoyantProjectMigrationMetadata(
@@ -324,12 +331,6 @@ function computeCreateVoyantAppExclude(project: VoyantProjectManifest): string[]
 
 function resolvedExcludedModuleIds(project: VoyantProjectManifest): string[] {
   return computeCreateVoyantAppExclude(project).map(moduleIdFromSpecifier)
-}
-
-function providersForProject(project: VoyantProjectManifest): VoyantProjectProviders {
-  if (project.mode === "managed-cloud") return MANAGED_OPERATOR_DEFAULT_PROVIDERS
-  if (!project.providers) throw new Error(`${project.mode} profiles must declare providers.`)
-  return project.providers
 }
 
 function mergeResourceRequirements(

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import path, { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -35,7 +36,7 @@ const command = "pnpm --filter operator graph:emit"
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2))
   const graph = await resolveGraph(options.profilePath)
-  const graphText = buildDeploymentGraphJson(graph)
+  const graphText = formatGeneratedText(options.graphOutputPath, buildDeploymentGraphJson(graph))
   const graphArtifactPath = toPosixRelativePath(
     dirname(options.entryOutputPath),
     options.graphOutputPath,
@@ -46,12 +47,15 @@ async function main(): Promise<void> {
     options.profilePath,
     path,
   )
-  const entryText = buildManagedNodeRuntimeEntry({
-    graph,
-    graphArtifactPath,
-    profileSnapshotPath,
-    command,
-  })
+  const entryText = formatGeneratedText(
+    options.entryOutputPath,
+    buildManagedNodeRuntimeEntry({
+      graph,
+      graphArtifactPath,
+      profileSnapshotPath,
+      command,
+    }),
+  )
   const manifest = buildDeploymentArtifactManifest({
     graph,
     graphArtifactPath: relativeToOperator(options.graphOutputPath),
@@ -63,7 +67,10 @@ async function main(): Promise<void> {
       }),
     ],
   })
-  const manifestText = `${JSON.stringify(manifest, null, 2)}\n`
+  const manifestText = formatGeneratedText(
+    options.manifestOutputPath,
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  )
 
   if (options.emit) {
     await writeGeneratedFile(options.manifestOutputPath, manifestText)
@@ -140,6 +147,15 @@ function defineOperatorGraphProject(project: VoyantProjectManifest) {
 async function writeGeneratedFile(filePath: string, text: string): Promise<void> {
   await mkdir(dirname(filePath), { recursive: true })
   await writeFile(filePath, text, "utf8")
+}
+
+function formatGeneratedText(filePath: string, text: string): string {
+  return execFileSync("pnpm", ["exec", "biome", "format", "--stdin-file-path", filePath], {
+    cwd: repoRoot,
+    encoding: "utf8",
+    input: text,
+    maxBuffer: 1024 * 1024 * 16,
+  })
 }
 
 async function staleGeneratedFiles(

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c",
+  "graphHash": "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c",
+      "graphHash": "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c",
+  "contentHash": "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1569,6 +1569,106 @@
   ],
   "project": {
     "presetLineage": "operator-standard"
+  },
+  "requirements": {
+    "resources": [
+      {
+        "env": [],
+        "provider": "better-auth",
+        "required": true,
+        "resourceKey": "auth:better-auth",
+        "roles": ["auth"]
+      },
+      {
+        "env": [],
+        "provider": "memory",
+        "required": true,
+        "resourceKey": "cache:memory",
+        "roles": ["cache"]
+      },
+      {
+        "env": [
+          {
+            "description": "Primary Postgres connection URL used by migrations and fallback DB clients.",
+            "kind": "secret",
+            "name": "DATABASE_URL",
+            "required": true
+          },
+          {
+            "description": "Direct Postgres URL for the resident Node pool.",
+            "kind": "secret",
+            "name": "DATABASE_URL_DIRECT",
+            "required": false
+          },
+          {
+            "description": "Comma-separated read replica URLs for the HTTP data plane.",
+            "kind": "secret",
+            "name": "DATABASE_URL_REPLICAS",
+            "required": false
+          }
+        ],
+        "provider": "postgres",
+        "required": true,
+        "resourceKey": "database:postgres",
+        "roles": ["database"]
+      },
+      {
+        "env": [],
+        "provider": "none",
+        "required": false,
+        "resourceKey": "email:none",
+        "roles": ["email"]
+      },
+      {
+        "env": [],
+        "provider": "memory",
+        "required": true,
+        "resourceKey": "rateLimit:memory",
+        "roles": ["rateLimit"]
+      },
+      {
+        "env": [],
+        "provider": "none",
+        "required": false,
+        "resourceKey": "scheduledJobs:none",
+        "roles": ["scheduledJobs"]
+      },
+      {
+        "env": [],
+        "provider": "none",
+        "required": false,
+        "resourceKey": "search:none",
+        "roles": ["search"]
+      },
+      {
+        "env": [],
+        "provider": "memory",
+        "required": true,
+        "resourceKey": "sharedState:memory",
+        "roles": ["sharedState"]
+      },
+      {
+        "env": [],
+        "provider": "none",
+        "required": false,
+        "resourceKey": "sms:none",
+        "roles": ["sms"]
+      },
+      {
+        "env": [],
+        "provider": "memory",
+        "required": true,
+        "resourceKey": "storage:memory",
+        "roles": ["storage"]
+      },
+      {
+        "env": [],
+        "provider": "none",
+        "required": false,
+        "resourceKey": "workflows:none",
+        "roles": ["workflows"]
+      }
+    ]
   },
   "schemaVersion": "voyant.resolved-graph.v1"
 }

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -22,6 +22,9 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(summary.graphHash).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(summary.moduleIds).toContain("@voyant-travel/bookings")
     expect(summary.packageNames).toContain("@voyant-travel/framework")
+    expect(summary.resourceRequirements.map((resource) => resource.resourceKey)).toContain(
+      "database:postgres",
+    )
   })
 
   it("fails when the artifact graph hash does not match the graph content hash", () => {
@@ -69,6 +72,15 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(() =>
       loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
     ).toThrow(/VOYANT_GRAPH_MISSING_CAPABILITY/)
+  })
+
+  it("fails when the graph omits resource requirements", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { omitRequirements: true })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/deployment graph requirements must be an object/)
   })
 
   it("resolves source-style artifact paths beside src", () => {
@@ -127,6 +139,8 @@ function writeFixture(
     manifestGraphHash?: string
     graphHash?: string
     diagnostics?: Array<{ code: string; message: string }>
+    requirements?: FixtureDeploymentGraph["requirements"]
+    omitRequirements?: boolean
     runtimeEntry?: Record<string, unknown>
     runtimeEntrySource?: { graphHash?: string }
     writeRuntimeEntrySource?: boolean
@@ -138,6 +152,30 @@ function writeFixture(
     schemaVersion: "voyant.resolved-graph.v1",
     diagnostics: options.diagnostics ?? [],
     deployment: { target: "node", mode: "self-hosted" },
+    ...(!options.omitRequirements && options.requirements !== undefined
+      ? { requirements: options.requirements }
+      : !options.omitRequirements
+        ? {
+            requirements: {
+              resources: [
+                {
+                  resourceKey: "database:postgres",
+                  roles: ["database"],
+                  provider: "postgres",
+                  required: true,
+                  env: [
+                    {
+                      name: "DATABASE_URL",
+                      kind: "secret",
+                      required: true,
+                      description: "Primary Postgres connection URL.",
+                    },
+                  ],
+                },
+              ],
+            },
+          }
+        : {}),
     modules: [{ id: "@voyant-travel/bookings" }],
     plugins: [{ id: "@voyant-travel/plugin-smartbill" }],
     packageRecords: [{ packageName: "@voyant-travel/framework" }],
@@ -180,6 +218,15 @@ interface FixtureDeploymentGraph {
   contentHash: string
   diagnostics: Array<{ code: string; message: string }>
   deployment: { target: string; mode: string }
+  requirements?: {
+    resources: Array<{
+      resourceKey: string
+      roles: string[]
+      provider: string
+      required: boolean
+      env: Array<{ name: string; kind: string; required: boolean; description: string }>
+    }>
+  }
   modules: Array<{ id: string }>
   plugins: Array<{ id: string }>
   packageRecords: Array<{ packageName: string }>

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -19,6 +19,23 @@ export interface OperatorDeploymentGraphArtifactSummary {
   moduleIds: readonly string[]
   pluginIds: readonly string[]
   packageNames: readonly string[]
+  resourceRequirements: readonly OperatorDeploymentGraphResourceRequirement[]
+}
+
+export interface OperatorDeploymentGraphResourceRequirement {
+  resourceKey: string
+  roles: readonly string[]
+  provider: string
+  required: boolean
+  env: readonly OperatorDeploymentGraphEnvRequirement[]
+  notes?: string
+}
+
+export interface OperatorDeploymentGraphEnvRequirement {
+  name: string
+  kind: string
+  required: boolean
+  description: string
 }
 
 interface DeploymentArtifactManifest {
@@ -42,6 +59,7 @@ interface ResolvedDeploymentGraph {
   contentHash?: unknown
   diagnostics?: unknown
   deployment?: unknown
+  requirements?: unknown
   modules?: unknown
   plugins?: unknown
   packageRecords?: unknown
@@ -182,11 +200,70 @@ export function loadOperatorDeploymentGraphArtifacts(
       "deployment graph packageRecords",
       "packageName",
     ),
+    resourceRequirements: collectResourceRequirements(graph.requirements),
   }
 
   validateGeneratedRuntimeEntrySource({ graphHash, manifestUrl, mode, summary, target })
 
   return summary
+}
+
+function collectResourceRequirements(value: unknown): OperatorDeploymentGraphResourceRequirement[] {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("deployment graph requirements must be an object")
+  }
+  const resources = arrayOfRecords(
+    (value as Record<string, unknown>).resources,
+    "deployment graph requirements.resources",
+  )
+  return resources.map((resource, index) => {
+    const resourceKey = requireString(
+      resource.resourceKey,
+      `deployment graph requirements.resources[${index}].resourceKey`,
+    )
+    const provider = requireString(
+      resource.provider,
+      `deployment graph requirements.resources[${index}].provider`,
+    )
+    const required = requireBoolean(
+      resource.required,
+      `deployment graph requirements.resources[${index}].required`,
+    )
+    const roles = collectStringArray(
+      resource.roles,
+      `deployment graph requirements.resources[${index}].roles`,
+    )
+    const env = arrayOfRecords(
+      resource.env,
+      `deployment graph requirements.resources[${index}].env`,
+    ).map((entry, envIndex) => ({
+      name: requireString(
+        entry.name,
+        `deployment graph requirements.resources[${index}].env[${envIndex}].name`,
+      ),
+      kind: requireString(
+        entry.kind,
+        `deployment graph requirements.resources[${index}].env[${envIndex}].kind`,
+      ),
+      required: requireBoolean(
+        entry.required,
+        `deployment graph requirements.resources[${index}].env[${envIndex}].required`,
+      ),
+      description: requireString(
+        entry.description,
+        `deployment graph requirements.resources[${index}].env[${envIndex}].description`,
+      ),
+    }))
+    const notes = stringField(resource, "notes")
+    return {
+      resourceKey,
+      roles,
+      provider,
+      required,
+      env,
+      ...(notes ? { notes } : {}),
+    }
+  })
 }
 
 function readJsonFile<T>(url: URL, label: string): T {
@@ -338,6 +415,16 @@ function escapeRegExp(value: string): string {
 function requireString(value: unknown, label: string): string {
   if (typeof value === "string" && value.length > 0) return value
   throw new Error(`${label} must be a non-empty string`)
+}
+
+function requireBoolean(value: unknown, label: string): boolean {
+  if (typeof value === "boolean") return value
+  throw new Error(`${label} must be a boolean`)
+}
+
+function collectStringArray(value: unknown, label: string): string[] {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`)
+  return value.map((entry, index) => requireString(entry, `${label}[${index}]`))
 }
 
 function requireSha256ContentHash(value: unknown, label: string): string {

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:4e90fce9c92fa2a651ae591bab8c7c2fbabafdc711e68732b274d687ca17af2c" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary

- add resolved deployment graph `requirements.resources` derived from managed profile providers
- expose normalized profile providers from `@voyant-travel/framework` and add a patch changeset
- validate and surface operator artifact resource requirements
- make deployment graph artifact emission formatter-stable so `graph:emit`, `graph:check`, and lint agree

## Verification

- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter operator test`
- `pnpm --filter operator typecheck`
- `pnpm verify:deployment-graph`
- `pnpm --filter operator graph:check`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`

Pre-push also ran the repo test lane successfully.