### PR TITLE
Validate operator graph resource env

### DIFF
--- a/scripts/check-node-entrypoint.mjs
+++ b/scripts/check-node-entrypoint.mjs
@@ -3,8 +3,9 @@
  *
  *  1. `src/server.ts` (the Node process entry) exists and boots the runtime via
  *     `createNodeServer` from `@voyant-travel/runtime`.
- *  1b. `src/server.ts` consumes the checked deployment graph artifacts at boot
- *      so dev/build/deploy share the same graph contract.
+ *  1b. `src/server.ts` consumes the checked deployment graph artifacts and
+ *      asserts graph resource env before standalone boot so dev/build/deploy
+ *      share the same graph contract.
  *  2. `src/entry.ts` (the app's `fetch`/`scheduled` handlers) keeps SSR behind a
  *     lazy import so the React + react-dom/server graph isn't pulled into the
  *     module's top-level — imported on first render, not at boot. Heavy API and
@@ -84,9 +85,8 @@ if (!existsSync(join(ROOT, NODE_ENTRY))) {
     })
   }
   if (
-    !/^import\s+\{\s*loadOperatorDeploymentGraphArtifacts\s*\}\s+from\s+["']\.\/deployment-graph-artifacts["']/m.test(
-      nodeEntrySource,
-    ) ||
+    !nodeEntrySource.includes('from "./deployment-graph-artifacts"') ||
+    !nodeEntrySource.includes("loadOperatorDeploymentGraphArtifacts") ||
     !/^const\s+\w+\s*=\s*loadOperatorDeploymentGraphArtifacts\(\s*\)/m.test(nodeEntrySource)
   ) {
     violations.push({
@@ -95,6 +95,22 @@ if (!existsSync(join(ROOT, NODE_ENTRY))) {
       check: {
         id: "deployment-graph-artifacts-not-consumed",
         message: "The Node entry must validate deployment graph artifacts at boot.",
+      },
+      text: "",
+    })
+  }
+  if (
+    !nodeEntrySource.includes("assertOperatorDeploymentGraphResourceEnv") ||
+    !/assertOperatorDeploymentGraphResourceEnv\(\s*\w+\s*,\s*process\.env\s*\)/m.test(
+      nodeEntrySource,
+    )
+  ) {
+    violations.push({
+      file: NODE_ENTRY,
+      line: 0,
+      check: {
+        id: "deployment-graph-resource-env-not-asserted",
+        message: "The Node entry must assert graph resource env before standalone boot.",
       },
       text: "",
     })
@@ -126,5 +142,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts)",
+  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts + resource env)",
 )

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { afterEach, describe, expect, it } from "vitest"
 
-import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifacts"
+import {
+  assertOperatorDeploymentGraphResourceEnv,
+  loadOperatorDeploymentGraphArtifacts,
+  validateOperatorDeploymentGraphResourceEnv,
+} from "./deployment-graph-artifacts"
 
 const OTHER_HASH = `sha256:${"b".repeat(64)}`
 
@@ -81,6 +85,43 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(() =>
       loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
     ).toThrow(/deployment graph requirements must be an object/)
+  })
+
+  it("reports missing required resource environment before boot", () => {
+    const root = fixtureRoot()
+    writeFixture(root)
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "src", "server.ts")).href,
+    )
+
+    expect(validateOperatorDeploymentGraphResourceEnv(summary, {})).toEqual([
+      "secret DATABASE_URL is required for database:postgres",
+    ])
+    expect(validateOperatorDeploymentGraphResourceEnv(summary, { DATABASE_URL: "   " })).toEqual([
+      "secret DATABASE_URL is required for database:postgres",
+    ])
+    expect(() => assertOperatorDeploymentGraphResourceEnv(summary, {})).toThrow(
+      /Operator deployment graph resource requirements are not satisfied:\n- secret DATABASE_URL is required for database:postgres/,
+    )
+  })
+
+  it("accepts satisfied required resource environment before boot", () => {
+    const root = fixtureRoot()
+    writeFixture(root)
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "src", "server.ts")).href,
+    )
+
+    expect(
+      validateOperatorDeploymentGraphResourceEnv(summary, {
+        DATABASE_URL: "postgres://user:pass@example.test:5432/voyant",
+      }),
+    ).toEqual([])
+    expect(() =>
+      assertOperatorDeploymentGraphResourceEnv(summary, {
+        DATABASE_URL: "postgres://user:pass@example.test:5432/voyant",
+      }),
+    ).not.toThrow()
   })
 
   it("resolves source-style artifact paths beside src", () => {

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -38,6 +38,8 @@ export interface OperatorDeploymentGraphEnvRequirement {
   description: string
 }
 
+export type OperatorDeploymentGraphEnv = Record<string, unknown>
+
 interface DeploymentArtifactManifest {
   schemaVersion?: unknown
   graphHash?: unknown
@@ -206,6 +208,38 @@ export function loadOperatorDeploymentGraphArtifacts(
   validateGeneratedRuntimeEntrySource({ graphHash, manifestUrl, mode, summary, target })
 
   return summary
+}
+
+export function validateOperatorDeploymentGraphResourceEnv(
+  summary: Pick<OperatorDeploymentGraphArtifactSummary, "resourceRequirements">,
+  env: OperatorDeploymentGraphEnv,
+): string[] {
+  const issues: string[] = []
+  for (const resource of summary.resourceRequirements) {
+    for (const requirement of resource.env) {
+      if (!requirement.required) continue
+      const value = env[requirement.name]
+      const present =
+        typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+      if (!present) {
+        issues.push(
+          `${requirement.kind} ${requirement.name} is required for ${resource.resourceKey}`,
+        )
+      }
+    }
+  }
+  return [...new Set(issues)]
+}
+
+export function assertOperatorDeploymentGraphResourceEnv(
+  summary: Pick<OperatorDeploymentGraphArtifactSummary, "resourceRequirements">,
+  env: OperatorDeploymentGraphEnv,
+): void {
+  const issues = validateOperatorDeploymentGraphResourceEnv(summary, env)
+  if (issues.length === 0) return
+  throw new Error(
+    `Operator deployment graph resource requirements are not satisfied:\n${formatIssues(issues)}`,
+  )
 }
 
 function collectResourceRequirements(value: unknown): OperatorDeploymentGraphResourceRequirement[] {
@@ -406,6 +440,10 @@ function stringArraysEqual(actual: readonly string[], expected: readonly string[
   return (
     actual.length === expected.length && actual.every((value, index) => value === expected[index])
   )
+}
+
+function formatIssues(issues: readonly string[]): string {
+  return issues.map((issue) => `- ${issue}`).join("\n")
 }
 
 function escapeRegExp(value: string): string {

--- a/starters/operator/src/server.ts
+++ b/starters/operator/src/server.ts
@@ -21,7 +21,10 @@ import type { KVStore } from "@voyant-travel/utils/cache"
 import { createRedisKvStore } from "@voyant-travel/utils/redis-kv"
 import { createTieredKvStore } from "@voyant-travel/utils/tiered-kv"
 
-import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifacts"
+import {
+  assertOperatorDeploymentGraphResourceEnv,
+  loadOperatorDeploymentGraphArtifacts,
+} from "./deployment-graph-artifacts"
 import { fetch as appFetch, scheduled } from "./entry"
 
 /**
@@ -182,6 +185,8 @@ export default {
 // spawn a second listener — only a direct `node dist/server/server.js` run does.
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
+  assertOperatorDeploymentGraphResourceEnv(deploymentGraphArtifacts, process.env)
+
   const handle = createNodeServer<AppBindings>({
     fetch: (request, bindings, ctx) => web.fetch(request, bindings, toExecutionContext(ctx)),
     scheduled: (event, bindings, ctx) => scheduled(event, bindings, toExecutionContext(ctx)),


### PR DESCRIPTION
## Summary

- add reusable operator artifact helpers to validate required resource env from the resolved deployment graph
- assert graph resource env before the standalone Node server opens its listener
- extend the node-entrypoint architecture check so graph artifact loading and resource-env assertion stay wired

## Behavior note

This fails standalone operator Node boot early when required graph resource env is missing, for example `DATABASE_URL` for the committed `database:postgres` resource. Vite/dev imports still avoid opening the listener and do not run the standalone boot assertion.

## Verification

- `pnpm verify:node-entrypoint`
- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator graph:check`
- `pnpm verify:deployment-graph`
- `pnpm --filter operator test`

Pre-push also ran the repo test lane successfully.