### PR TITLE
Preflight operator dev graph env

### DIFF
--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -48,6 +48,11 @@ workload class well. On Node none of it is necessary.
 - **Build:** `pnpm --filter operator build` (Vite, no `@cloudflare/vite-plugin`)
   emits `dist/client` + `dist/server/server.js`. **Run:** `pnpm --filter operator
   start` (`node dist/server/server.js`).
+- **Graph contract:** `pnpm --filter operator dev` and standalone Node boot both
+  load the generated deployment graph artifacts and fail before serving traffic
+  when graph-declared required resource env is missing. Local `.env` loading is
+  only a source for satisfying the same graph contract; it is not a parallel
+  deployment shape.
 - **Database:** the pooled node-postgres lane (`DATABASE_URL_DIRECT`, `adapter:
   "node"`) is the production default — one resident pool per process. neon-http/WS
   remain the fallback adapters. See
@@ -97,7 +102,8 @@ Avoid:
 
 The mechanical check lives in `scripts/check-node-entrypoint.mjs` and is part of
 `pnpm verify:architecture`: it asserts `src/server.ts` wires `createNodeServer`
-and that the app entry keeps those graphs lazy.
+and graph artifact/resource validation, that `pnpm --filter operator dev`
+preflights graph resource env, and that the app entry keeps those graphs lazy.
 
 ## Stop-the-bleed policy
 

--- a/scripts/check-node-entrypoint.mjs
+++ b/scripts/check-node-entrypoint.mjs
@@ -22,6 +22,8 @@ const ROOT = join(__dirname, "..")
 
 const APP_ENTRY = "starters/operator/src/entry.ts"
 const NODE_ENTRY = "starters/operator/src/server.ts"
+const OPERATOR_PACKAGE_JSON = "starters/operator/package.json"
+const OPERATOR_GRAPH_ENV_CHECK = "starters/operator/scripts/check-deployment-graph-env.ts"
 const GENERATED_RUNTIME_ENTRY = "runtime-entry.generated"
 
 const FORBIDDEN_IMPORTS = [
@@ -129,6 +131,90 @@ if (!existsSync(join(ROOT, NODE_ENTRY))) {
   }
 }
 
+// 3. Dev lane: must preflight the same graph resource env before Vite boots.
+if (!existsSync(join(ROOT, OPERATOR_PACKAGE_JSON))) {
+  violations.push({
+    file: OPERATOR_PACKAGE_JSON,
+    line: 0,
+    check: {
+      id: "missing-operator-package-json",
+      message: "The operator package manifest is missing.",
+    },
+    text: "",
+  })
+} else {
+  const packageJson = JSON.parse(readFileSync(join(ROOT, OPERATOR_PACKAGE_JSON), "utf-8"))
+  const scripts =
+    packageJson.scripts && typeof packageJson.scripts === "object" ? packageJson.scripts : {}
+  const graphEnvScript = typeof scripts["graph:env"] === "string" ? scripts["graph:env"] : ""
+  const devScript = typeof scripts.dev === "string" ? scripts.dev : ""
+  const graphEnvIndex = devScript.indexOf("pnpm run graph:env")
+  const viteIndex = devScript.indexOf("node_modules/vite/bin/vite.js")
+
+  if (!graphEnvScript.includes("scripts/check-deployment-graph-env.ts")) {
+    violations.push({
+      file: OPERATOR_PACKAGE_JSON,
+      line: 0,
+      check: {
+        id: "operator-graph-env-script-missing",
+        message: "The operator package must expose graph:env for graph resource env preflight.",
+      },
+      text: graphEnvScript,
+    })
+  }
+  if (graphEnvIndex === -1) {
+    violations.push({
+      file: OPERATOR_PACKAGE_JSON,
+      line: 0,
+      check: {
+        id: "operator-dev-graph-env-missing",
+        message: "The operator dev script must run graph:env before Vite boots.",
+      },
+      text: devScript,
+    })
+  }
+  if (viteIndex !== -1 && graphEnvIndex > viteIndex) {
+    violations.push({
+      file: OPERATOR_PACKAGE_JSON,
+      line: 0,
+      check: {
+        id: "operator-dev-graph-env-after-vite",
+        message: "The operator dev script must run graph:env before Vite boots.",
+      },
+      text: devScript,
+    })
+  }
+}
+
+if (!existsSync(join(ROOT, OPERATOR_GRAPH_ENV_CHECK))) {
+  violations.push({
+    file: OPERATOR_GRAPH_ENV_CHECK,
+    line: 0,
+    check: {
+      id: "missing-operator-graph-env-check",
+      message: "The operator graph resource env preflight script is missing.",
+    },
+    text: "",
+  })
+} else {
+  const graphEnvSource = readFileSync(join(ROOT, OPERATOR_GRAPH_ENV_CHECK), "utf-8")
+  if (
+    !graphEnvSource.includes("loadOperatorDeploymentGraphArtifacts") ||
+    !graphEnvSource.includes("assertOperatorDeploymentGraphResourceEnv") ||
+    !graphEnvSource.includes("process.env")
+  ) {
+    violations.push({
+      file: OPERATOR_GRAPH_ENV_CHECK,
+      line: 0,
+      check: {
+        id: "operator-graph-env-check-not-wired",
+        message: "The operator graph env script must load graph artifacts and assert resource env.",
+      },
+      text: "",
+    })
+  }
+}
+
 if (violations.length > 0) {
   console.error("Node entrypoint violation.")
   console.error("See docs/architecture/deployment-targets.md for the rule.\n")
@@ -142,5 +228,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts + resource env)",
+  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts + resource env; dev preflights graph env)",
 )

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9",
+  "graphHash": "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9",
+      "graphHash": "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9",
+  "contentHash": "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1014,7 +1014,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.26.0"
+      "version": "0.26.1"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "pnpm run graph:check && node -r ./scripts/env-preload.cjs node_modules/vite/bin/vite.js dev --port 3300",
+    "dev": "pnpm run graph:check && pnpm run graph:env && node -r ./scripts/env-preload.cjs node_modules/vite/bin/vite.js dev --port 3300",
     "build": "pnpm run graph:check && vite build && pnpm run copy:deployment-artifacts",
     "copy:deployment-artifacts": "cp managed-profile.json deployment-artifacts.generated.json deployment-graph.generated.json dist/",
     "preview": "pnpm run build && vite preview",
@@ -14,6 +14,7 @@
     "generate:openapi": "UPDATE_OPENAPI=1 vitest run src/api/openapi.test.ts",
     "generate:managed-profile": "tsx scripts/generate-managed-profile.ts",
     "graph:check": "tsx ../../scripts/emit-deployment-graph.ts",
+    "graph:env": "tsx scripts/check-deployment-graph-env.ts",
     "graph:emit": "tsx ../../scripts/emit-deployment-graph.ts --emit",
     "dev:worker": "voyant dev --file src/workflows.ts --port 3310",
     "emit:cloud-scheduler": "tsx scripts/emit-cloud-scheduler.ts",

--- a/starters/operator/scripts/check-deployment-graph-env.ts
+++ b/starters/operator/scripts/check-deployment-graph-env.ts
@@ -1,0 +1,43 @@
+import {
+  assertOperatorDeploymentGraphResourceEnv,
+  loadOperatorDeploymentGraphArtifacts,
+} from "../src/deployment-graph-artifacts"
+
+function loadLocalEnv(): void {
+  try {
+    const processWithEnvFile = process as typeof process & {
+      loadEnvFile?: (path?: string) => void
+    }
+    processWithEnvFile.loadEnvFile?.(".env")
+  } catch {
+    // No local .env file. Real deployments rely on ambient platform env.
+  }
+}
+
+function main(): void {
+  loadLocalEnv()
+
+  const summary = loadOperatorDeploymentGraphArtifacts()
+  assertOperatorDeploymentGraphResourceEnv(summary, process.env)
+
+  const requiredEnvNames = new Set(
+    summary.resourceRequirements.flatMap((resource) =>
+      resource.env
+        .filter((requirement) => requirement.required)
+        .map((requirement) => requirement.name),
+    ),
+  )
+
+  console.log(`operator deployment graph env: OK (${requiredEnvNames.size} required resource env)`)
+}
+
+function reason(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(reason(error))
+  process.exitCode = 1
+}

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:8ab9e3ee54d6b743c3072cdcae9a2174c9aa0dca369ee43d4b77f383ed6a62a9" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary

- Add an operator `graph:env` preflight that loads local `.env`, reads generated deployment graph artifacts, and asserts graph-declared required resource env before dev boots.
- Wire `pnpm --filter operator dev` to run the preflight after `graph:check` and before Vite.
- Extend the Node entrypoint architecture checker and deployment-targets doc to keep the dev lane aligned with the same graph resource contract.
- Refresh operator generated deployment graph artifacts after the framework package release bump.

## Validation

- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:node-entrypoint`
- `pnpm verify:deployment-graph`
- `pnpm verify:architecture`
- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts`
- `pnpm --filter operator test`
- `pnpm --filter operator typecheck`
- `DATABASE_URL=postgres://user:pass@example.test:5432/voyant pnpm --filter operator graph:env`
- `DATABASE_URL='   ' pnpm --filter operator graph:env` fails with the expected missing `DATABASE_URL` graph-resource error
- pre-push hook: `pnpm test`