### PR TITLE
Preflight operator migrations with graph env

### DIFF
--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -48,10 +48,11 @@ workload class well. On Node none of it is necessary.
 - **Build:** `pnpm --filter operator build` (Vite, no `@cloudflare/vite-plugin`)
   emits `dist/client` + `dist/server/server.js`. **Run:** `pnpm --filter operator
   start` (`node dist/server/server.js`).
-- **Graph contract:** `pnpm --filter operator dev` and standalone Node boot both
-  load the generated deployment graph artifacts and fail before serving traffic
-  when graph-declared required resource env is missing. Local `.env` loading is
-  only a source for satisfying the same graph contract; it is not a parallel
+- **Graph contract:** `pnpm --filter operator dev`, `pnpm --filter operator
+  db:migrate`, and standalone Node boot all load the generated deployment graph
+  artifacts and fail before serving traffic or touching the database when
+  graph-declared required resource env is missing. Local `.env` loading is only
+  a source for satisfying the same graph contract; it is not a parallel
   deployment shape.
 - **Database:** the pooled node-postgres lane (`DATABASE_URL_DIRECT`, `adapter:
   "node"`) is the production default — one resident pool per process. neon-http/WS
@@ -102,8 +103,9 @@ Avoid:
 
 The mechanical check lives in `scripts/check-node-entrypoint.mjs` and is part of
 `pnpm verify:architecture`: it asserts `src/server.ts` wires `createNodeServer`
-and graph artifact/resource validation, that `pnpm --filter operator dev`
-preflights graph resource env, and that the app entry keeps those graphs lazy.
+and graph artifact/resource validation, that `pnpm --filter operator dev` and
+`pnpm --filter operator db:migrate` preflight graph resource env, and that the
+app entry keeps those graphs lazy.
 
 ## Stop-the-bleed policy
 

--- a/scripts/check-node-entrypoint.mjs
+++ b/scripts/check-node-entrypoint.mjs
@@ -6,6 +6,8 @@
  *  1b. `src/server.ts` consumes the checked deployment graph artifacts and
  *      asserts graph resource env before standalone boot so dev/build/deploy
  *      share the same graph contract.
+ *  1c. the operator dev and migration lanes preflight the same graph contract
+ *      before serving traffic or touching the database.
  *  2. `src/entry.ts` (the app's `fetch`/`scheduled` handlers) keeps SSR behind a
  *     lazy import so the React + react-dom/server graph isn't pulled into the
  *     module's top-level — imported on first render, not at boot. Heavy API and
@@ -22,6 +24,7 @@ const ROOT = join(__dirname, "..")
 
 const APP_ENTRY = "starters/operator/src/entry.ts"
 const NODE_ENTRY = "starters/operator/src/server.ts"
+const OPERATOR_MIGRATE_SCRIPT = "starters/operator/scripts/migrate.ts"
 const OPERATOR_PACKAGE_JSON = "starters/operator/package.json"
 const OPERATOR_GRAPH_ENV_CHECK = "starters/operator/scripts/check-deployment-graph-env.ts"
 const GENERATED_RUNTIME_ENTRY = "runtime-entry.generated"
@@ -148,6 +151,7 @@ if (!existsSync(join(ROOT, OPERATOR_PACKAGE_JSON))) {
     packageJson.scripts && typeof packageJson.scripts === "object" ? packageJson.scripts : {}
   const graphEnvScript = typeof scripts["graph:env"] === "string" ? scripts["graph:env"] : ""
   const devScript = typeof scripts.dev === "string" ? scripts.dev : ""
+  const migrateScript = typeof scripts["db:migrate"] === "string" ? scripts["db:migrate"] : ""
   const graphEnvIndex = devScript.indexOf("pnpm run graph:env")
   const viteIndex = devScript.indexOf("node_modules/vite/bin/vite.js")
 
@@ -184,6 +188,17 @@ if (!existsSync(join(ROOT, OPERATOR_PACKAGE_JSON))) {
       text: devScript,
     })
   }
+  if (!migrateScript.includes("pnpm run graph:check")) {
+    violations.push({
+      file: OPERATOR_PACKAGE_JSON,
+      line: 0,
+      check: {
+        id: "operator-migrate-graph-check-missing",
+        message: "The operator db:migrate script must run graph:check before migration.",
+      },
+      text: migrateScript,
+    })
+  }
 }
 
 if (!existsSync(join(ROOT, OPERATOR_GRAPH_ENV_CHECK))) {
@@ -215,6 +230,35 @@ if (!existsSync(join(ROOT, OPERATOR_GRAPH_ENV_CHECK))) {
   }
 }
 
+if (!existsSync(join(ROOT, OPERATOR_MIGRATE_SCRIPT))) {
+  violations.push({
+    file: OPERATOR_MIGRATE_SCRIPT,
+    line: 0,
+    check: {
+      id: "missing-operator-migrate-script",
+      message: "The operator migration script is missing.",
+    },
+    text: "",
+  })
+} else {
+  const migrateSource = readFileSync(join(ROOT, OPERATOR_MIGRATE_SCRIPT), "utf-8")
+  if (
+    !migrateSource.includes("loadOperatorDeploymentGraphArtifacts") ||
+    !migrateSource.includes("assertOperatorDeploymentGraphResourceEnv") ||
+    !/assertOperatorDeploymentGraphResourceEnv\(\s*\w+\s*,\s*process\.env\s*\)/m.test(migrateSource)
+  ) {
+    violations.push({
+      file: OPERATOR_MIGRATE_SCRIPT,
+      line: 0,
+      check: {
+        id: "operator-migrate-graph-env-not-asserted",
+        message: "The operator migration script must assert graph resource env before connecting.",
+      },
+      text: "",
+    })
+  }
+}
+
 if (violations.length > 0) {
   console.error("Node entrypoint violation.")
   console.error("See docs/architecture/deployment-targets.md for the rule.\n")
@@ -228,5 +272,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts + resource env; dev preflights graph env)",
+  "check-node-entrypoint: OK (app entry lazy; server.ts wires createNodeServer + graph artifacts + resource env; dev/migrate preflight graph env)",
 )

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -22,7 +22,7 @@
     "workflows:doctor": "voyant workflows doctor --target entry --file src/workflows.ts",
     "db:generate": "drizzle-kit generate --config=drizzle.deployment-migrations.config.ts",
     "db:generate:deployment": "drizzle-kit generate --config=drizzle.deployment-migrations.config.ts",
-    "db:migrate": "tsx scripts/migrate.ts",
+    "db:migrate": "pnpm run graph:check && tsx scripts/migrate.ts",
     "db:push": "drizzle-kit push",
     "db:check": "drizzle-kit check --config=drizzle.deployment-migrations.config.ts",
     "db:studio": "drizzle-kit studio",

--- a/starters/operator/scripts/migrate.ts
+++ b/starters/operator/scripts/migrate.ts
@@ -34,6 +34,10 @@ import {
 import { config } from "dotenv"
 import { Client } from "pg"
 import { schema } from "../drizzle.schemas.generated.ts"
+import {
+  assertOperatorDeploymentGraphResourceEnv,
+  loadOperatorDeploymentGraphArtifacts,
+} from "../src/deployment-graph-artifacts"
 
 const explicitDatabaseUrl = process.env.DATABASE_URL
 config({ path: ".env" })
@@ -44,6 +48,14 @@ config({ path: ".env", override: true })
 // runs) must WIN over `.env` (loaded with `override: true` for local-dev
 // ergonomics), which would otherwise redirect every run at the local dev DB.
 if (explicitDatabaseUrl) process.env.DATABASE_URL = explicitDatabaseUrl
+
+const deploymentGraphArtifacts = loadOperatorDeploymentGraphArtifacts()
+try {
+  assertOperatorDeploymentGraphResourceEnv(deploymentGraphArtifacts, process.env)
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+}
 
 const databaseUrl = process.env.DATABASE_URL
 if (!databaseUrl) {


### PR DESCRIPTION
## Summary

- Run `graph:check` before the operator `db:migrate` command.
- Have `scripts/migrate.ts` load generated deployment graph artifacts and assert graph-declared required resource env after its existing `.env` loading, before opening a Postgres connection.
- Extend the architecture guard and Node deployment-targets doc so the migrate lane stays aligned with the same graph contract as dev and standalone boot.

## Notes

This covers graph artifact/resource preflight for migration. It does not yet move migration source discovery to graph migration facets; the script still discovers sources from `drizzle.schemas.generated.ts`.

## Validation

- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:node-entrypoint`
- `pnpm verify:deployment-graph`
- `pnpm verify:architecture`
- `pnpm --filter operator graph:env`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts`
- `DATABASE_URL='   ' pnpm --filter operator db:migrate` fails before DB connection with the expected missing `DATABASE_URL` graph-resource error
- pre-push hook: `pnpm test`