### PR TITLE
Represent operator schema migration sources in graph

### DIFF
--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -762,6 +762,16 @@ runtime shapes:
 This validates the manifest against reality before third-party authors depend
 on it, and avoids hand-retrofitting every package up front.
 
+Some first-party schema owners are not active runtime modules in a given
+deployment. Examples include foundational schema packages, additional schema
+packages, and route-deferred verticals whose migrations still apply. The
+resolved graph must still represent those packages as schema-only units with
+stable `schema` and `migrations` entity ids, and its package records must cover
+every package-backed migration source discovered from the generated schema
+manifest. This is the bridge that keeps D.2 package-owned migration discovery
+and deployment-graph lowering from drifting while richer per-migration entity
+generation lands.
+
 ## Implementation Phases
 
 Phases 0-2 are the complete v1 deployment-graph program. Phase 1 is the first

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -16,7 +16,9 @@ import { defineVoyantProject } from "../packages/framework/src/profile.ts"
 import {
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS,
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_IDS,
+  OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_IDS,
 } from "../starters/operator/deployment-graph.local.ts"
+import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 
 const failures: string[] = []
@@ -123,11 +125,26 @@ async function main(): Promise<void> {
   const operatorGraph = await readOperatorGeneratedGraph()
   const operatorModuleIds = new Set(operatorGraph.modules.map((unit) => unit.id))
   const operatorPluginIds = new Set(operatorGraph.plugins.map((unit) => unit.id))
+  const operatorPackageNames = new Set(
+    operatorGraph.packageRecords.map((record) => record.packageName),
+  )
   for (const id of OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS) {
     if (!operatorModuleIds.has(id)) failures.push(`expected operator graph to include ${id}`)
   }
+  for (const id of OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_IDS) {
+    if (!operatorModuleIds.has(id)) {
+      failures.push(`expected operator graph to include schema-only module ${id}`)
+    }
+  }
   for (const id of OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_IDS) {
     if (!operatorPluginIds.has(id)) failures.push(`expected operator graph to include ${id}`)
+  }
+  for (const packageName of operatorMigrationSourcePackageNames()) {
+    if (!operatorPackageNames.has(packageName)) {
+      failures.push(
+        `expected operator graph package records to include migration source ${packageName}`,
+      )
+    }
   }
 
   const frameworkRecord = first.packageRecords.find(
@@ -172,6 +189,7 @@ async function main(): Promise<void> {
 async function readOperatorGeneratedGraph(): Promise<{
   modules: Array<{ id: string }>
   plugins: Array<{ id: string }>
+  packageRecords: Array<{ packageName: string }>
 }> {
   return JSON.parse(
     await readFile(
@@ -181,7 +199,23 @@ async function readOperatorGeneratedGraph(): Promise<{
   ) as {
     modules: Array<{ id: string }>
     plugins: Array<{ id: string }>
+    packageRecords: Array<{ packageName: string }>
   }
+}
+
+function operatorMigrationSourcePackageNames(): string[] {
+  return sortedUnique(
+    operatorSchemaPaths
+      .map((schemaPath) => {
+        const match = schemaPath.match(/(?:^|\/)packages\/([^/]+)\//)
+        return match?.[1] ? `@voyant-travel/${match[1]}` : undefined
+      })
+      .filter((packageName): packageName is string => Boolean(packageName)),
+  )
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort()
 }
 
 main().catch((error) => {

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -17,7 +17,10 @@ import {
   resolveDeploymentGraph,
 } from "../packages/framework/src/deployment-graph.ts"
 import type { VoyantProjectManifest } from "../packages/framework/src/profile-types.ts"
-import { OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST } from "../starters/operator/deployment-graph.local.ts"
+import {
+  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST,
+  OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST,
+} from "../starters/operator/deployment-graph.local.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 
 interface CliOptions {
@@ -138,7 +141,11 @@ function defineOperatorGraphProject(project: VoyantProjectManifest) {
   const managedProject = defineProjectFromManagedProfile(project)
   return defineProject({
     presetLineage: managedProject.presetLineage,
-    modules: [...managedProject.modules, ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.modules],
+    modules: [
+      ...managedProject.modules,
+      ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.modules,
+      ...OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST.modules,
+    ],
     plugins: [...managedProject.plugins, ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.plugins],
     meta: managedProject.meta,
   })

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd",
+  "graphHash": "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd",
+      "graphHash": "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd",
+  "contentHash": "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -941,6 +941,216 @@
       "schema": [],
       "subscribers": [],
       "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/db",
+      "kind": "module",
+      "links": [],
+      "localId": "db",
+      "migrations": [
+        {
+          "id": "@voyant-travel/db#migrations"
+        }
+      ],
+      "order": 32,
+      "packageName": "@voyant-travel/db",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/db#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/availability",
+      "kind": "module",
+      "links": [],
+      "localId": "availability",
+      "migrations": [
+        {
+          "id": "@voyant-travel/availability#migrations"
+        }
+      ],
+      "order": 33,
+      "packageName": "@voyant-travel/availability",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/availability#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/storefront",
+      "kind": "module",
+      "links": [],
+      "localId": "storefront",
+      "migrations": [
+        {
+          "id": "@voyant-travel/storefront#migrations"
+        }
+      ],
+      "order": 34,
+      "packageName": "@voyant-travel/storefront",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/storefront#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/catalog-authoring",
+      "kind": "module",
+      "links": [],
+      "localId": "catalog-authoring",
+      "migrations": [
+        {
+          "id": "@voyant-travel/catalog-authoring#migrations"
+        }
+      ],
+      "order": 35,
+      "packageName": "@voyant-travel/catalog-authoring",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/catalog-authoring#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/workflow-runs",
+      "kind": "module",
+      "links": [],
+      "localId": "workflow-runs",
+      "migrations": [
+        {
+          "id": "@voyant-travel/workflow-runs#migrations"
+        }
+      ],
+      "order": 36,
+      "packageName": "@voyant-travel/workflow-runs",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/workflow-runs#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/charters",
+      "kind": "module",
+      "links": [],
+      "localId": "charters",
+      "migrations": [
+        {
+          "id": "@voyant-travel/charters#migrations"
+        }
+      ],
+      "order": 37,
+      "packageName": "@voyant-travel/charters",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/charters#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
+    },
+    {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/cruises",
+      "kind": "module",
+      "links": [],
+      "localId": "cruises",
+      "migrations": [
+        {
+          "id": "@voyant-travel/cruises#migrations"
+        }
+      ],
+      "order": 38,
+      "packageName": "@voyant-travel/cruises",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [
+        {
+          "id": "@voyant-travel/cruises#schema"
+        }
+      ],
+      "subscribers": [],
+      "workflows": []
     }
   ],
   "packageRecords": [
@@ -961,6 +1171,14 @@
       "version": "0.105.13"
     },
     {
+      "packageName": "@voyant-travel/availability",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../availability"
+      },
+      "version": "0.1.2"
+    },
+    {
       "packageName": "@voyant-travel/bookings",
       "source": {
         "kind": "workspace",
@@ -977,12 +1195,44 @@
       "version": "0.147.0"
     },
     {
+      "packageName": "@voyant-travel/catalog-authoring",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../../packages/catalog-authoring"
+      },
+      "version": "0.106.28"
+    },
+    {
+      "packageName": "@voyant-travel/charters",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../charters"
+      },
+      "version": "0.147.0"
+    },
+    {
       "packageName": "@voyant-travel/commerce",
       "source": {
         "kind": "workspace",
         "reference": "link:../commerce"
       },
       "version": "0.31.0"
+    },
+    {
+      "packageName": "@voyant-travel/cruises",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../cruises"
+      },
+      "version": "0.148.0"
+    },
+    {
+      "packageName": "@voyant-travel/db",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../../packages/db"
+      },
+      "version": "0.110.0"
     },
     {
       "packageName": "@voyant-travel/distribution",
@@ -1109,12 +1359,28 @@
       "version": "0.122.10"
     },
     {
+      "packageName": "@voyant-travel/storefront",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../storefront"
+      },
+      "version": "0.151.0"
+    },
+    {
       "packageName": "@voyant-travel/trips",
       "source": {
         "kind": "workspace",
         "reference": "link:../trips"
       },
       "version": "0.140.0"
+    },
+    {
+      "packageName": "@voyant-travel/workflow-runs",
+      "source": {
+        "kind": "workspace",
+        "reference": "link:../workflow-runs"
+      },
+      "version": "0.111.18"
     }
   ],
   "plugins": [

--- a/starters/operator/deployment-graph.local.ts
+++ b/starters/operator/deployment-graph.local.ts
@@ -22,11 +22,24 @@ export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_SPECIFIERS = [
   "@voyant-travel/mice/booking-extension",
 ] as const
 
+export const OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS = [
+  "@voyant-travel/db",
+  "@voyant-travel/availability",
+  "@voyant-travel/storefront",
+  "@voyant-travel/catalog-authoring",
+  "@voyant-travel/workflow-runs",
+  "@voyant-travel/charters",
+  "@voyant-travel/cruises",
+] as const
+
 export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS =
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS.map(graphIdFromSpecifier)
 
 export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_IDS =
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_PLUGIN_SPECIFIERS.map(graphIdFromSpecifier)
+
+export const OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_IDS =
+  OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS.map(graphIdFromSpecifier)
 
 export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST = {
   modules: [
@@ -47,6 +60,12 @@ export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST = {
 } satisfies {
   modules: readonly VoyantGraphUnitManifest[]
   plugins: readonly VoyantGraphUnitManifest[]
+}
+
+export const OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST = {
+  modules: OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS.map(schemaOnlyModule),
+} satisfies {
+  modules: readonly VoyantGraphUnitManifest[]
 }
 
 function localModule(
@@ -74,6 +93,18 @@ function localPlugin(
     localId: moduleIdFromSpecifier(specifier),
     api: routeBundles(id, specifier, api),
     meta: { source: "operator-local" },
+  })
+}
+
+function schemaOnlyModule(specifier: string): VoyantGraphUnitManifest {
+  const id = graphIdFromSpecifier(specifier)
+  return defineModule({
+    id,
+    packageName: packageNameFromSpecifier(specifier),
+    localId: moduleIdFromSpecifier(specifier),
+    schema: [{ id: childGraphEntityId(id, "schema") }],
+    migrations: [{ id: childGraphEntityId(id, "migrations") }],
+    meta: { source: "operator-schema-only" },
   })
 }
 

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -6,7 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:aa98ef69f10afdcde1a6264f615d28ed0a7c04defa24f7fbd52251f35dda7ccd" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const
@@ -45,6 +45,13 @@ export const GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS = [
   "@voyant-travel/operator#charters",
   "@voyant-travel/operator#realtime",
   "@voyant-travel/mice",
+  "@voyant-travel/db",
+  "@voyant-travel/availability",
+  "@voyant-travel/storefront",
+  "@voyant-travel/catalog-authoring",
+  "@voyant-travel/workflow-runs",
+  "@voyant-travel/charters",
+  "@voyant-travel/cruises",
 ] as const
 export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = [
   "@voyant-travel/bookings#booking-supplier-extension",
@@ -67,9 +74,14 @@ export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = [
 export const GENERATED_DEPLOYMENT_GRAPH_PACKAGE_NAMES = [
   "@voyant-travel/accommodations",
   "@voyant-travel/action-ledger",
+  "@voyant-travel/availability",
   "@voyant-travel/bookings",
   "@voyant-travel/catalog",
+  "@voyant-travel/catalog-authoring",
+  "@voyant-travel/charters",
   "@voyant-travel/commerce",
+  "@voyant-travel/cruises",
+  "@voyant-travel/db",
   "@voyant-travel/distribution",
   "@voyant-travel/finance",
   "@voyant-travel/flights",
@@ -86,7 +98,9 @@ export const GENERATED_DEPLOYMENT_GRAPH_PACKAGE_NAMES = [
   "@voyant-travel/public-document-delivery",
   "@voyant-travel/quotes",
   "@voyant-travel/relationships",
+  "@voyant-travel/storefront",
   "@voyant-travel/trips",
+  "@voyant-travel/workflow-runs",
 ] as const
 
 export function resolveGeneratedProfileSnapshotPath(): string {


### PR DESCRIPTION
## Summary
- Add explicit schema-only graph units for operator package-backed migration sources that are not active runtime modules.
- Include those schema-only units in generated operator graph artifacts and runtime constants so package provenance covers every schema source.
- Extend `check-deployment-graph` to fail when `drizzle.schemas.generated.ts` package sources are missing from generated graph package records.
- Document the schema-only graph unit bridge in `docs/architecture/unified-deployment-graph.md`.

## Validation
- `pnpm verify:deployment-graph`
- `pnpm --filter operator test -- --run src/deployment-graph-artifacts.test.ts` (ran the operator Vitest suite: 48 passed, 1 skipped)
- `pnpm verify:architecture` (`verify:migration-replay-parity` skipped locally because `TEST_DATABASE_URL` is not set)
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- commit hook: changed agent quality + affected lint/typecheck/build
- pre-push hook: `pnpm test`