### PR TITLE
Add graph doctor and workflow facet checks

### DIFF
--- a/.changeset/graph-doctor-workflow-facets.md
+++ b/.changeset/graph-doctor-workflow-facets.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add deployment graph doctor diagnostics for generated artifacts and lower first-party workflow event-filter metadata into resolved graph facets.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -772,6 +772,19 @@ manifest. This is the bridge that keeps D.2 package-owned migration discovery
 and deployment-graph lowering from drifting while richer per-migration entity
 generation lands.
 
+The operator graph now also lowers the first declarative workflow/event-filter
+pair from first-party metadata: commerce contributes
+`promotions.reindex-all-products`, the `promotion.changed` event, and the
+event-filter subscriber that targets that workflow. This is intentionally a
+small facet slice: it proves the graph shape for declarative workflow/event
+routing without pulling runtime workflow bodies into graph discovery.
+
+Product-side tooling exposes the same graph diagnostics in human and JSON form
+through `scripts/emit-deployment-graph.ts --json`, using the checked-in
+diagnostic-code registry. The public `voyant doctor --json` command remains the
+CLI follow-up; it should consume this report contract rather than inventing a
+separate diagnostic model.
+
 ## Implementation Phases
 
 Phases 0-2 are the complete v1 deployment-graph program. Phase 1 is the first

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "verify:raw-minor-unit-labels": "node scripts/check-raw-minor-unit-labels.mjs",
     "verify:lockstep-membership": "node scripts/check-lockstep-membership.mjs",
     "verify:admin-composition-drift": "node scripts/check-admin-composition-drift.mjs",
-    "verify:deployment-graph": "node --test scripts/tests/deployment-graph-provenance.test.mjs && tsx scripts/check-deployment-graph.ts && tsx scripts/emit-deployment-graph.ts",
+    "verify:deployment-graph": "node --test scripts/tests/deployment-graph-provenance.test.mjs && node --import tsx --test scripts/tests/deployment-graph-doctor.test.ts && node --test scripts/tests/check-deployment-graph-import-cheap.test.mjs && node scripts/check-deployment-graph-import-cheap.mjs && tsx scripts/check-deployment-graph.ts && tsx scripts/emit-deployment-graph.ts",
     "verify:framework-bom": "node scripts/generate-framework-bom.mjs",
     "verify:framework-migration-bundle": "node scripts/generate-framework-migration-bundle.mjs",
     "verify:migration-replay-parity": "node scripts/verify-migration-replay-parity.mjs",

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -91,8 +91,8 @@ describe("deployment graph artifacts", () => {
     })
 
     expect(source).toContain(`GENERATED_DEPLOYMENT_GRAPH_HASH = "${graph.contentHash}"`)
-    expect(source).toContain('from "@voyant-travel/framework/managed-runtime"')
     expect(source).toContain('from "node:url"')
+    expect(source).toContain('await import("@voyant-travel/framework/managed-runtime")')
     expect(source).toContain("startManagedProfileRuntime")
     expect(source).not.toContain("starters/")
   })

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -95,8 +95,6 @@ export function buildManagedNodeRuntimeEntry(input: BuildManagedNodeRuntimeEntry
 
 import { fileURLToPath, pathToFileURL } from "node:url"
 
-import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
-
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = ${quote(input.graph.schemaVersion)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_HASH = ${quote(input.graph.contentHash)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = ${quote(input.graph.deployment.target)} as const
@@ -122,6 +120,7 @@ export function resolveGeneratedProfileSnapshotPath(): string {
 
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
+  const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
   })

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1,3 +1,7 @@
+import {
+  bulkReindexProductsWorkflowManifest,
+  promotionAffectedAllFilter,
+} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
 import { describe, expect, it } from "vitest"
 import {
   createTestDeployment,
@@ -317,6 +321,23 @@ describe("deployment graph v1", () => {
       ]),
     )
     expect(graph.modules.map((unit) => unit.id)).not.toContain("@voyant-travel/flights")
+    const commerce = graph.modules.find((unit) => unit.id === "@voyant-travel/commerce")
+    expect(commerce?.workflows).toEqual([bulkReindexProductsWorkflowManifest])
+    expect(commerce?.events).toEqual([
+      {
+        id: "@voyant-travel/commerce#event.promotion.changed",
+        eventType: "promotion.changed",
+      },
+    ])
+    expect(commerce?.subscribers).toEqual([
+      {
+        id: `@voyant-travel/commerce#subscriber.${promotionAffectedAllFilter.id}`,
+        eventType: "promotion.changed",
+        eventFilterId: promotionAffectedAllFilter.id,
+        workflowId: bulkReindexProductsWorkflowManifest.id,
+        filter: promotionAffectedAllFilter.manifest,
+      },
+    ])
     expect(graph.plugins.map((unit) => unit.id)).toEqual(
       expect.arrayContaining(["@voyant-travel/plugin-netopia", "@acme/voyant-loyalty-admin"]),
     )
@@ -432,6 +453,8 @@ describe("deployment graph v1", () => {
 
   it("keeps diagnostic codes checked in and sorted", () => {
     expect(Object.keys(VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY)).toEqual([
+      "VOYANT_GRAPH_ARTIFACT_MISSING",
+      "VOYANT_GRAPH_ARTIFACT_STALE",
       "VOYANT_GRAPH_DUPLICATE_ENTITY_ID",
       "VOYANT_GRAPH_DUPLICATE_ID",
       "VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN",

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -1,5 +1,11 @@
 // agent-quality: file-size exception -- reason: first v1 deployment-graph cut keeps schema versions, diagnostics, resolver, managed-profile bridge, and author harness co-located until generated runtime lowering defines stable split points.
 import {
+  getStandardProfileEventFiltersForModule,
+  getStandardProfileWorkflowManifestForModule,
+  type ManagedEventFilterEntry,
+  type ManagedWorkflowManifestEntry,
+} from "./managed-jobs.js"
+import {
   FRAMEWORK_CAPABILITY_GRAPH,
   FRAMEWORK_RUNTIME_MANIFEST,
   subsetStandardManifest,
@@ -50,6 +56,8 @@ export const VOYANT_GRAPH_RESERVED_FACETS = [
 ] as const
 
 export const VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY = {
+  VOYANT_GRAPH_ARTIFACT_MISSING: "A generated deployment graph artifact is missing.",
+  VOYANT_GRAPH_ARTIFACT_STALE: "A generated deployment graph artifact is stale.",
   VOYANT_GRAPH_DUPLICATE_ENTITY_ID: "Two v1 graph entities resolved to the same stable entity id.",
   VOYANT_GRAPH_DUPLICATE_ID: "Two selected graph units resolved to the same graph id.",
   VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN:
@@ -110,7 +118,19 @@ export interface VoyantGraphFacetEntity {
   source?: string
 }
 
+export interface VoyantGraphEvent extends VoyantGraphFacetEntity {
+  eventType?: string
+}
+
+export interface VoyantGraphSubscriber extends VoyantGraphFacetEntity {
+  eventType?: string
+  eventFilterId?: string
+  workflowId?: string
+  filter?: VoyantGraphJsonObject
+}
+
 export interface VoyantGraphWorkflow extends VoyantGraphFacetEntity {
+  config?: VoyantGraphJsonObject
   schedules?: readonly VoyantGraphWorkflowSchedule[]
 }
 
@@ -131,8 +151,8 @@ export interface VoyantGraphUnitManifest {
   schema?: readonly VoyantGraphFacetEntity[]
   migrations?: readonly VoyantGraphFacetEntity[]
   links?: readonly VoyantGraphFacetEntity[]
-  subscribers?: readonly VoyantGraphFacetEntity[]
-  events?: readonly VoyantGraphFacetEntity[]
+  subscribers?: readonly VoyantGraphSubscriber[]
+  events?: readonly VoyantGraphEvent[]
   workflows?: readonly VoyantGraphWorkflow[]
   meta?: VoyantGraphJsonObject
 }
@@ -255,8 +275,8 @@ export interface ResolvedVoyantGraphUnit {
   schema: readonly VoyantGraphFacetEntity[]
   migrations: readonly VoyantGraphFacetEntity[]
   links: readonly VoyantGraphFacetEntity[]
-  subscribers: readonly VoyantGraphFacetEntity[]
-  events: readonly VoyantGraphFacetEntity[]
+  subscribers: readonly VoyantGraphSubscriber[]
+  events: readonly VoyantGraphEvent[]
   workflows: readonly VoyantGraphWorkflow[]
 }
 
@@ -689,6 +709,9 @@ export function generateFrameworkModuleManifests(
           mount: specifier,
         },
       ],
+      workflows: lowerManagedWorkflowFacets(specifier),
+      events: lowerManagedEventFacets(id, specifier),
+      subscribers: lowerManagedEventFilterFacets(id, specifier),
     })
   })
 }
@@ -757,6 +780,11 @@ export function childGraphEntityId(parentId: string, childId: string): string {
 
 export function canonicalJson(value: unknown): string {
   return JSON.stringify(canonicalize(value))
+}
+
+function toGraphJsonObject(value: unknown): VoyantGraphJsonObject | undefined {
+  if (!isRecord(value)) return undefined
+  return JSON.parse(JSON.stringify(value)) as VoyantGraphJsonObject
 }
 
 export async function sha256(value: unknown): Promise<string> {
@@ -864,9 +892,57 @@ function resolveUnit(
     schema: sortFacetEntities(unit.schema ?? []),
     migrations: sortFacetEntities(unit.migrations ?? []),
     links: sortFacetEntities(unit.links ?? []),
-    subscribers: sortFacetEntities(unit.subscribers ?? []),
-    events: sortFacetEntities(unit.events ?? []),
+    subscribers: sortFacetEntities(unit.subscribers ?? []) as VoyantGraphSubscriber[],
+    events: sortFacetEntities(unit.events ?? []) as VoyantGraphEvent[],
     workflows: sortWorkflows(unit.workflows ?? []),
+  }
+}
+
+function lowerManagedWorkflowFacets(moduleSpecifier: string): VoyantGraphWorkflow[] {
+  return getStandardProfileWorkflowManifestForModule(moduleSpecifier).map((workflow) =>
+    lowerManagedWorkflowFacet(workflow),
+  )
+}
+
+function lowerManagedWorkflowFacet(workflow: ManagedWorkflowManifestEntry): VoyantGraphWorkflow {
+  const config = toGraphJsonObject(workflow.config)
+  return {
+    id: workflow.id,
+    ...(config ? { config } : {}),
+  }
+}
+
+function lowerManagedEventFacets(unitId: string, moduleSpecifier: string): VoyantGraphEvent[] {
+  const eventTypes = sortedUnique(
+    getStandardProfileEventFiltersForModule(moduleSpecifier).map((filter) => filter.eventType),
+  )
+  return eventTypes.map((eventType) => ({
+    id: childGraphEntityId(unitId, `event.${eventType}`),
+    eventType,
+  }))
+}
+
+function lowerManagedEventFilterFacets(
+  unitId: string,
+  moduleSpecifier: string,
+): VoyantGraphSubscriber[] {
+  return getStandardProfileEventFiltersForModule(moduleSpecifier).map((filter) =>
+    lowerManagedEventFilterFacet(unitId, filter),
+  )
+}
+
+function lowerManagedEventFilterFacet(
+  unitId: string,
+  filter: ManagedEventFilterEntry,
+): VoyantGraphSubscriber {
+  const manifest = toGraphJsonObject(filter.manifest)
+  const workflowId = manifest?.targetWorkflowId
+  return {
+    id: childGraphEntityId(unitId, `subscriber.${filter.id}`),
+    eventType: filter.eventType,
+    eventFilterId: filter.id,
+    ...(typeof workflowId === "string" ? { workflowId } : {}),
+    ...(manifest ? { filter: manifest } : {}),
   }
 }
 

--- a/packages/framework/src/managed-jobs.test.ts
+++ b/packages/framework/src/managed-jobs.test.ts
@@ -102,7 +102,13 @@ describe("getManagedProfileEventFilters (voyant#3032)", () => {
 
     // The commerce workflow only fires because this filter routes
     // promotion.changed (kind=all) into it — the workflow manifest alone is inert.
-    expect(filters).toEqual([promotionAffectedAllFilter])
+    expect(filters).toEqual([
+      {
+        id: promotionAffectedAllFilter.id,
+        eventType: promotionAffectedAllFilter.eventType,
+        manifest: promotionAffectedAllFilter.manifest,
+      },
+    ])
     expect(filters[0]?.manifest).toMatchObject({
       targetWorkflowId: bulkReindexProductsWorkflowManifest.id,
     })

--- a/packages/framework/src/managed-jobs.ts
+++ b/packages/framework/src/managed-jobs.ts
@@ -16,11 +16,6 @@
 // modules provisions fewer jobs. `starters/operator` consumes the same set as
 // its single source of truth (plus its own deployment-local jobs).
 
-import {
-  bulkReindexProductsWorkflowManifest,
-  promotionAffectedAllFilter,
-} from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
-
 import { getVoyantProjectRequirements } from "./profile.js"
 import { moduleIdFromSpecifier, type VoyantProjectManifest } from "./profile-types.js"
 
@@ -155,7 +150,14 @@ export const STANDARD_PROFILE_SCHEDULED_JOBS: readonly StandardScheduledJobDefin
 const STANDARD_PROFILE_WORKFLOWS: Readonly<
   Record<string, readonly ManagedWorkflowManifestEntry[]>
 > = {
-  "@voyant-travel/commerce": [bulkReindexProductsWorkflowManifest],
+  "@voyant-travel/commerce": [
+    {
+      id: "promotions.reindex-all-products",
+      config: {
+        defaultRuntime: "node",
+      },
+    },
+  ],
 }
 
 /**
@@ -167,7 +169,27 @@ const STANDARD_PROFILE_WORKFLOWS: Readonly<
  */
 const STANDARD_PROFILE_EVENT_FILTERS: Readonly<Record<string, readonly ManagedEventFilterEntry[]>> =
   {
-    "@voyant-travel/commerce": [promotionAffectedAllFilter],
+    "@voyant-travel/commerce": [
+      {
+        id: "ef_6f8e4b4ce409d04c",
+        eventType: "promotion.changed",
+        manifest: {
+          eventType: "promotion.changed",
+          id: "ef_6f8e4b4ce409d04c",
+          input: {
+            object: {
+              offerId: { path: "data.offerId" },
+              source: { path: "data.source" },
+            },
+          },
+          payloadHash: "6f8e4b4ce409d04c",
+          targetWorkflowId: "promotions.reindex-all-products",
+          where: {
+            eq: [{ path: "data.affected.kind" }, { lit: "all" }],
+          },
+        },
+      },
+    ],
   }
 
 function toManagedScheduledJob(job: StandardScheduledJobDefinition): ManagedScheduledJob {
@@ -236,6 +258,18 @@ export function getManagedProfileEventFilters(
   project: VoyantProjectManifest,
 ): ManagedEventFilterEntry[] {
   return collectActiveModuleEntries(project, STANDARD_PROFILE_EVENT_FILTERS)
+}
+
+export function getStandardProfileWorkflowManifestForModule(
+  moduleSpecifier: string,
+): ManagedWorkflowManifestEntry[] {
+  return [...(STANDARD_PROFILE_WORKFLOWS[moduleSpecifier] ?? [])]
+}
+
+export function getStandardProfileEventFiltersForModule(
+  moduleSpecifier: string,
+): ManagedEventFilterEntry[] {
+  return [...(STANDARD_PROFILE_EVENT_FILTERS[moduleSpecifier] ?? [])]
 }
 
 function collectActiveModuleEntries<T>(

--- a/scripts/check-deployment-graph-import-cheap.mjs
+++ b/scripts/check-deployment-graph-import-cheap.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+/**
+ * Enforces the deployment-graph cold-start invariant from
+ * docs/architecture/unified-deployment-graph.md.
+ *
+ * Graph declaration and generated metadata entrypoints must be cheap to import:
+ * static imports may reach manifest math helpers, but must not pull route,
+ * schema, UI, workflow, runtime, or provider graphs into discovery.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs"
+import path from "node:path"
+
+const DEFAULT_ENTRY_SURFACES = [
+  {
+    id: "framework-deployment-graph",
+    file: "packages/framework/src/deployment-graph.ts",
+  },
+  {
+    id: "framework-deployment-artifacts",
+    file: "packages/framework/src/deployment-artifacts.ts",
+  },
+  {
+    id: "operator-local-deployment-graph",
+    file: "starters/operator/deployment-graph.local.ts",
+  },
+  {
+    id: "operator-generated-runtime-entry",
+    file: "starters/operator/src/runtime-entry.generated.ts",
+  },
+]
+
+const ALLOWED_EXTERNAL_IMPORTS = new Set(["@voyant-travel/hono/composition"])
+
+const ALLOWED_EXTERNAL_IMPORT_PATTERNS = [
+  /\/workflow-[^/]+-manifest$/,
+  /\/[^/]+-workflow-manifest$/,
+]
+
+const FORBIDDEN_EXTERNAL_IMPORTS = new Map([
+  [
+    "@voyant-travel/framework/managed-runtime",
+    "managed runtime route/provider graph must stay behind a dynamic import",
+  ],
+])
+
+const SOURCE_EXTENSIONS = [".ts", ".tsx", ".js", ".mjs", ".cjs"]
+const TEST_PATH_SEGMENTS = new Set(["__tests__", "tests"])
+
+const repoRoot = process.cwd()
+const entrySurfaces = parseArgs(process.argv.slice(2))
+const failures = []
+const checkedFiles = new Set()
+
+for (const entry of entrySurfaces) {
+  const entryPath = path.resolve(repoRoot, entry.file)
+  if (!existsSync(entryPath)) {
+    failures.push({
+      code: "missing-entry",
+      entry,
+      importer: entryPath,
+      message: `entry surface ${entry.file} does not exist`,
+    })
+    continue
+  }
+  walkEntry(entry, entryPath, new Set())
+}
+
+if (failures.length > 0) {
+  console.error("Deployment graph import-cheap check failed.")
+  for (const failure of failures) {
+    console.error(formatFailure(failure))
+  }
+  process.exit(1)
+}
+
+console.log(
+  `check-deployment-graph-import-cheap: OK (${entrySurfaces.length} entry surfaces, ${checkedFiles.size} files)`,
+)
+
+function walkEntry(entry, filePath, activeStack) {
+  const resolved = path.resolve(filePath)
+  if (activeStack.has(resolved)) return
+  checkedFiles.add(resolved)
+
+  const source = readFileSync(resolved, "utf8")
+  for (const edge of staticRuntimeImports(source)) {
+    const violation = forbiddenImport(edge.specifier, resolved)
+    if (violation) {
+      failures.push({
+        code: violation.code,
+        entry,
+        importer: resolved,
+        specifier: edge.specifier,
+        message: violation.reason,
+      })
+      continue
+    }
+
+    if (!isRelativeSpecifier(edge.specifier)) continue
+    const target = resolveSourceImport(path.dirname(resolved), edge.specifier)
+    if (!target) {
+      failures.push({
+        code: "unresolved-import",
+        entry,
+        importer: resolved,
+        specifier: edge.specifier,
+        message: "static relative import could not be resolved",
+      })
+      continue
+    }
+
+    activeStack.add(resolved)
+    walkEntry(entry, target, activeStack)
+    activeStack.delete(resolved)
+  }
+}
+
+function staticRuntimeImports(source) {
+  const imports = []
+  const declarations = /(^|[;\n])\s*(import|export)\s+([^'"();]*?)\s+from\s*["']([^"']+)["']/gs
+  let match = declarations.exec(source)
+  while (match) {
+    const kind = match[2]
+    const clause = match[3].trim()
+    if (!isTypeOnlyImport(kind, clause)) {
+      imports.push({ specifier: match[4] })
+    }
+    match = declarations.exec(source)
+  }
+
+  const sideEffects = /(^|[;\n])\s*import\s*["']([^"']+)["']/gs
+  match = sideEffects.exec(source)
+  while (match) {
+    imports.push({ specifier: match[2] })
+    match = sideEffects.exec(source)
+  }
+
+  return imports
+}
+
+function isTypeOnlyImport(kind, clause) {
+  if (clause.startsWith("type ")) return true
+  if (kind !== "export") return false
+  const named = clause.match(/^\{([^}]*)\}$/s)
+  if (!named) return false
+  const entries = named[1]
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+  return entries.length > 0 && entries.every((entry) => entry.startsWith("type "))
+}
+
+function forbiddenImport(specifier, importer) {
+  if (specifier.startsWith("node:")) return undefined
+  if (ALLOWED_EXTERNAL_IMPORTS.has(specifier)) return undefined
+  if (ALLOWED_EXTERNAL_IMPORT_PATTERNS.some((pattern) => pattern.test(specifier))) {
+    return undefined
+  }
+
+  const exactExternalReason = FORBIDDEN_EXTERNAL_IMPORTS.get(specifier)
+  if (exactExternalReason) {
+    return { code: "runtime-heavy-import", reason: exactExternalReason }
+  }
+
+  const labels = [specifier]
+  if (isRelativeSpecifier(specifier)) {
+    const target = resolveSourceImport(path.dirname(importer), specifier)
+    if (target) labels.push(relativeToRepo(target))
+  }
+
+  for (const label of labels) {
+    const normalized = label.replaceAll("\\", "/")
+    const reason = forbiddenPathReason(normalized)
+    if (reason) return { code: "runtime-heavy-import", reason }
+  }
+
+  return undefined
+}
+
+function forbiddenPathReason(value) {
+  const segments = value.split("/").filter(Boolean)
+  if (segments.some((segment) => TEST_PATH_SEGMENTS.has(segment))) return undefined
+
+  const basename = segments.at(-1) ?? value
+  const basenameWithoutExt = basename.replace(/\.[^.]+$/, "")
+
+  if (value.endsWith(".tsx") || segments.some((segment) => segment.endsWith("-react"))) {
+    return "UI/React graph must not be statically imported by deployment graph discovery"
+  }
+  if (matchesSegment(segments, /^(routes?|api-routes|routes-.+)$/)) {
+    return "route graph must stay behind a lazy runtime import"
+  }
+  if (matchesSegment(segments, /^(schema|schemas|drizzle|migrations)$/)) {
+    return "schema and migration graphs must not be statically imported by manifest discovery"
+  }
+  if (/^(schema|schemas|drizzle|migrations)(\.|$|-)/.test(basenameWithoutExt)) {
+    return "schema and migration graphs must not be statically imported by manifest discovery"
+  }
+  if (matchesSegment(segments, /^(workflows?|workflow-.+)$/)) {
+    return "workflow graph must stay behind a lazy runtime import"
+  }
+  if (matchesSegment(segments, /^(providers?|runtime)$/)) {
+    return "provider/runtime graph must stay behind a lazy runtime import"
+  }
+  if (/^(managed-runtime|runtime|server|service-.+|.*-service)$/.test(basenameWithoutExt)) {
+    return "provider/runtime graph must stay behind a lazy runtime import"
+  }
+
+  return undefined
+}
+
+function matchesSegment(segments, pattern) {
+  return segments.some((segment) => pattern.test(segment))
+}
+
+function resolveSourceImport(fromDir, specifier) {
+  const candidate = path.resolve(fromDir, specifier)
+  const candidates = [candidate]
+  const extension = path.extname(candidate)
+  if ([".js", ".mjs", ".cjs"].includes(extension)) {
+    const withoutExtension = candidate.slice(0, -extension.length)
+    candidates.push(`${withoutExtension}.ts`, `${withoutExtension}.tsx`)
+  }
+  if (!extension) {
+    for (const extension of SOURCE_EXTENSIONS) candidates.push(`${candidate}${extension}`)
+    for (const extension of SOURCE_EXTENSIONS) {
+      candidates.push(path.join(candidate, `index${extension}`))
+    }
+  }
+
+  for (const filePath of candidates) {
+    if (existsSync(filePath) && statSync(filePath).isFile()) return filePath
+  }
+  return undefined
+}
+
+function isRelativeSpecifier(specifier) {
+  return specifier.startsWith(".") || specifier.startsWith("/")
+}
+
+function parseArgs(args) {
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`Usage: node scripts/check-deployment-graph-import-cheap.mjs [--entry id:path]
+
+Checks deployment graph declaration/generated metadata entry surfaces for
+runtime-heavy static imports. Repeat --entry to test custom fixture entries.`)
+    process.exit(0)
+  }
+
+  const entries = []
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg !== "--entry") throw new Error(`Unknown argument: ${arg}`)
+    const value = args[index + 1]
+    if (!value) throw new Error("--entry requires a value")
+    index += 1
+    const separatorIndex = value.indexOf(":")
+    if (separatorIndex === -1) {
+      entries.push({ id: value, file: value })
+      continue
+    }
+    entries.push({
+      id: value.slice(0, separatorIndex),
+      file: value.slice(separatorIndex + 1),
+    })
+  }
+
+  return entries.length > 0 ? entries : DEFAULT_ENTRY_SURFACES
+}
+
+function formatFailure(failure) {
+  const location = failure.specifier
+    ? `${relativeToRepo(failure.importer)} imports ${failure.specifier}`
+    : relativeToRepo(failure.importer)
+  return `  - [deployment-graph-import-cheap:${failure.code}] ${failure.entry.id}: ${location}. ${failure.message}.`
+}
+
+function relativeToRepo(filePath) {
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/")
+}

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -21,10 +21,17 @@ import {
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST,
   OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST,
 } from "../starters/operator/deployment-graph.local.ts"
+import {
+  buildDeploymentGraphDoctorJson,
+  buildDeploymentGraphDoctorReport,
+  checkDeploymentGraphGeneratedArtifacts,
+  formatDeploymentGraphDoctorDiagnostics,
+} from "./lib/deployment-graph-doctor.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 
 interface CliOptions {
   emit: boolean
+  json: boolean
   profilePath: string
   manifestOutputPath: string
   graphOutputPath: string
@@ -79,6 +86,19 @@ async function main(): Promise<void> {
     await writeGeneratedFile(options.manifestOutputPath, manifestText)
     await writeGeneratedFile(options.graphOutputPath, graphText)
     await writeGeneratedFile(options.entryOutputPath, entryText)
+    const report = buildDeploymentGraphDoctorReport({ graph })
+    if (options.json) {
+      process.stdout.write(buildDeploymentGraphDoctorJson(report))
+      if (!report.ok) process.exit(1)
+      return
+    }
+    if (!report.ok) {
+      console.error(
+        "Deployment graph generated artifacts were written, but graph diagnostics remain.",
+      )
+      console.error(formatDeploymentGraphDoctorDiagnostics(report.diagnostics))
+      process.exit(1)
+    }
     console.log(
       `emit-deployment-graph: wrote ${relativeToRepo(
         options.manifestOutputPath,
@@ -89,16 +109,46 @@ async function main(): Promise<void> {
     return
   }
 
-  const failures = await staleGeneratedFiles([
-    { path: options.manifestOutputPath, expected: manifestText },
-    { path: options.graphOutputPath, expected: graphText },
-    { path: options.entryOutputPath, expected: entryText },
-  ])
+  const artifactDiagnostics = await checkDeploymentGraphGeneratedArtifacts(
+    [
+      {
+        path: options.manifestOutputPath,
+        expected: manifestText,
+        facet: "deployment-artifacts",
+        hint: `Run \`${command}\` to refresh generated deployment graph artifacts.`,
+      },
+      {
+        path: options.graphOutputPath,
+        expected: graphText,
+        facet: "deployment-graph",
+        hint: `Run \`${command}\` to refresh generated deployment graph artifacts.`,
+      },
+      {
+        path: options.entryOutputPath,
+        expected: entryText,
+        facet: "runtime-entry",
+        hint: `Run \`${command}\` to refresh generated deployment graph artifacts.`,
+      },
+    ],
+    { repoRoot },
+  )
+  const report = buildDeploymentGraphDoctorReport({ graph, diagnostics: artifactDiagnostics })
 
-  if (failures.length > 0) {
-    console.error("Deployment graph generated artifacts are stale.")
-    for (const failure of failures) console.error(`  - ${failure}`)
-    console.error(`Run \`${command}\` to refresh them.`)
+  if (options.json) {
+    process.stdout.write(buildDeploymentGraphDoctorJson(report))
+    if (!report.ok) process.exit(1)
+    return
+  }
+
+  if (!report.ok) {
+    console.error("Deployment graph doctor failed.")
+    if (artifactDiagnostics.length > 0) {
+      console.error("Generated deployment graph artifacts are stale or missing.")
+    }
+    console.error(formatDeploymentGraphDoctorDiagnostics(report.diagnostics))
+    if (artifactDiagnostics.length > 0) {
+      console.error(`Run \`${command}\` to refresh them.`)
+    }
     process.exit(1)
   }
 
@@ -165,28 +215,10 @@ function formatGeneratedText(filePath: string, text: string): string {
   })
 }
 
-async function staleGeneratedFiles(
-  files: readonly { path: string; expected: string }[],
-): Promise<string[]> {
-  const failures: string[] = []
-  for (const file of files) {
-    let actual: string
-    try {
-      actual = await readFile(file.path, "utf8")
-    } catch {
-      failures.push(`${relativeToRepo(file.path)} is missing`)
-      continue
-    }
-    if (actual !== file.expected) {
-      failures.push(`${relativeToRepo(file.path)} is stale`)
-    }
-  }
-  return failures
-}
-
 function parseArgs(args: readonly string[]): CliOptions {
   const options: CliOptions = {
     emit: false,
+    json: false,
     profilePath: join(defaultOperatorRoot, "managed-profile.json"),
     manifestOutputPath: join(defaultOperatorRoot, "deployment-artifacts.generated.json"),
     graphOutputPath: join(defaultOperatorRoot, "deployment-graph.generated.json"),
@@ -197,6 +229,10 @@ function parseArgs(args: readonly string[]): CliOptions {
     const arg = args[index]
     if (arg === "--emit") {
       options.emit = true
+      continue
+    }
+    if (arg === "--json") {
+      options.json = true
       continue
     }
     if (arg === "--profile") {
@@ -260,6 +296,7 @@ Resolves the operator managed profile into committed generated graph artifacts.
 
 Options:
   --emit                 write generated artifacts instead of checking staleness
+  --json                 print the graph doctor report JSON contract
   --profile <path>       managed profile JSON path
   --manifest-output <path> deployment artifact manifest output path
   --graph-output <path>  resolved graph JSON output path

--- a/scripts/lib/deployment-graph-doctor.ts
+++ b/scripts/lib/deployment-graph-doctor.ts
@@ -1,0 +1,167 @@
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+
+import {
+  canonicalJson,
+  type ResolvedVoyantDeploymentGraph,
+  type VoyantGraphDiagnostic,
+} from "../../packages/framework/src/deployment-graph.ts"
+
+export const VOYANT_GRAPH_DOCTOR_REPORT_SCHEMA_VERSION = "voyant.graph-doctor-report.v1" as const
+
+export interface DeploymentGraphArtifactCheck {
+  path: string
+  expected: string
+  facet: string
+  hint?: string
+}
+
+export interface DeploymentGraphDoctorSummary {
+  schemaVersion: ResolvedVoyantDeploymentGraph["schemaVersion"]
+  contentHash: string
+  target?: string
+  mode?: string
+  modules: {
+    count: number
+    ids: readonly string[]
+  }
+  plugins: {
+    count: number
+    ids: readonly string[]
+  }
+  packageRecords: {
+    count: number
+    packageNames: readonly string[]
+  }
+}
+
+export interface DeploymentGraphDoctorReport {
+  schemaVersion: typeof VOYANT_GRAPH_DOCTOR_REPORT_SCHEMA_VERSION
+  ok: boolean
+  graph: DeploymentGraphDoctorSummary
+  diagnostics: readonly VoyantGraphDiagnostic[]
+}
+
+export interface BuildDeploymentGraphDoctorReportInput {
+  graph: ResolvedVoyantDeploymentGraph
+  diagnostics?: readonly VoyantGraphDiagnostic[]
+}
+
+export interface CheckDeploymentGraphGeneratedArtifactsOptions {
+  repoRoot?: string
+}
+
+export async function checkDeploymentGraphGeneratedArtifacts(
+  files: readonly DeploymentGraphArtifactCheck[],
+  options: CheckDeploymentGraphGeneratedArtifactsOptions = {},
+): Promise<VoyantGraphDiagnostic[]> {
+  const diagnostics: VoyantGraphDiagnostic[] = []
+  for (const file of [...files].sort((left, right) => left.path.localeCompare(right.path))) {
+    const source = relativeDiagnosticPath(file.path, options.repoRoot)
+    let actual: string
+    try {
+      actual = await readFile(file.path, "utf8")
+    } catch {
+      diagnostics.push(
+        sortObjectKeys({
+          code: "VOYANT_GRAPH_ARTIFACT_MISSING",
+          severity: "error",
+          source,
+          facet: file.facet,
+          message: `${source} is missing.`,
+          ...(file.hint ? { hint: file.hint } : {}),
+        }),
+      )
+      continue
+    }
+
+    if (actual !== file.expected) {
+      diagnostics.push(
+        sortObjectKeys({
+          code: "VOYANT_GRAPH_ARTIFACT_STALE",
+          severity: "error",
+          source,
+          facet: file.facet,
+          message: `${source} is stale.`,
+          ...(file.hint ? { hint: file.hint } : {}),
+        }),
+      )
+    }
+  }
+  return sortDiagnostics(diagnostics)
+}
+
+export function buildDeploymentGraphDoctorReport(
+  input: BuildDeploymentGraphDoctorReportInput,
+): DeploymentGraphDoctorReport {
+  const diagnostics = sortDiagnostics([...input.graph.diagnostics, ...(input.diagnostics ?? [])])
+  return {
+    schemaVersion: VOYANT_GRAPH_DOCTOR_REPORT_SCHEMA_VERSION,
+    ok: diagnostics.filter((entry) => entry.severity === "error").length === 0,
+    graph: {
+      schemaVersion: input.graph.schemaVersion,
+      contentHash: input.graph.contentHash,
+      ...(input.graph.deployment.target ? { target: input.graph.deployment.target } : {}),
+      ...(input.graph.deployment.mode ? { mode: input.graph.deployment.mode } : {}),
+      modules: {
+        count: input.graph.modules.length,
+        ids: input.graph.modules.map((unit) => unit.id).sort(),
+      },
+      plugins: {
+        count: input.graph.plugins.length,
+        ids: input.graph.plugins.map((unit) => unit.id).sort(),
+      },
+      packageRecords: {
+        count: input.graph.packageRecords.length,
+        packageNames: input.graph.packageRecords.map((record) => record.packageName).sort(),
+      },
+    },
+    diagnostics,
+  }
+}
+
+export function buildDeploymentGraphDoctorJson(report: DeploymentGraphDoctorReport): string {
+  return `${JSON.stringify(JSON.parse(canonicalJson(report)), null, 2)}\n`
+}
+
+export function formatDeploymentGraphDoctorDiagnostics(
+  diagnostics: readonly VoyantGraphDiagnostic[],
+): string {
+  return sortDiagnostics(diagnostics)
+    .map((entry) => {
+      const suffix = [
+        entry.source ? `source=${entry.source}` : undefined,
+        entry.facet ? `facet=${entry.facet}` : undefined,
+      ]
+        .filter(Boolean)
+        .join(", ")
+      return `  - ${entry.code}: ${entry.message}${suffix ? ` (${suffix})` : ""}`
+    })
+    .join("\n")
+}
+
+export function formatDeploymentGraphDoctorReport(report: DeploymentGraphDoctorReport): string {
+  if (report.ok) {
+    return `deployment graph doctor: OK (${report.graph.modules.count} modules, ${report.graph.plugins.count} plugins, ${report.graph.contentHash})`
+  }
+  return `Deployment graph doctor failed.\n${formatDeploymentGraphDoctorDiagnostics(report.diagnostics)}`
+}
+
+function relativeDiagnosticPath(filePath: string, repoRoot: string | undefined): string {
+  if (!repoRoot) return filePath.replaceAll(path.sep, "/")
+  return path.relative(repoRoot, filePath).replaceAll(path.sep, "/")
+}
+
+function sortDiagnostics(diagnostics: readonly VoyantGraphDiagnostic[]): VoyantGraphDiagnostic[] {
+  return [...diagnostics].sort(
+    (a, b) =>
+      a.code.localeCompare(b.code) ||
+      (a.source ?? "").localeCompare(b.source ?? "") ||
+      (a.facet ?? "").localeCompare(b.facet ?? "") ||
+      a.message.localeCompare(b.message),
+  )
+}
+
+function sortObjectKeys<T extends VoyantGraphDiagnostic>(diagnostic: T): T {
+  return JSON.parse(canonicalJson(diagnostic)) as T
+}

--- a/scripts/tests/check-deployment-graph-import-cheap.test.mjs
+++ b/scripts/tests/check-deployment-graph-import-cheap.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { describe, it } from "node:test"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = path.resolve(fileURLToPath(import.meta.url), "../../..")
+const checkerPath = path.join(repoRoot, "scripts/check-deployment-graph-import-cheap.mjs")
+
+async function createFixture(files) {
+  const root = await mkdtemp(path.join(tmpdir(), "voyant-graph-import-cheap-"))
+  for (const [relativePath, content] of Object.entries(files)) {
+    const filePath = path.join(root, relativePath)
+    await mkdir(path.dirname(filePath), { recursive: true })
+    await writeFile(filePath, content)
+  }
+  return root
+}
+
+async function runChecker(cwd, entry = "manifest:manifest.ts") {
+  return execFileAsync(process.execPath, [checkerPath, "--entry", entry], { cwd })
+}
+
+describe("check-deployment-graph-import-cheap", () => {
+  it("rejects static managed runtime imports from generated metadata entries", async () => {
+    const root = await createFixture({
+      "manifest.ts": `import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
+
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:test" as const
+void startManagedProfileRuntime
+`,
+    })
+
+    await assert.rejects(runChecker(root), (error) => {
+      assert.match(error.stderr, /deployment-graph-import-cheap:runtime-heavy-import/)
+      assert.match(error.stderr, /manifest\.ts imports @voyant-travel\/framework\/managed-runtime/)
+      return true
+    })
+  })
+
+  it("allows managed runtime to stay behind a dynamic import", async () => {
+    const root = await createFixture({
+      "manifest.ts": `export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:test" as const
+
+export async function start() {
+  const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
+  return startManagedProfileRuntime
+}
+`,
+    })
+
+    const result = await runChecker(root)
+
+    assert.match(result.stdout, /check-deployment-graph-import-cheap: OK/)
+  })
+
+  it("allows serializable workflow manifest descriptor imports", async () => {
+    const root = await createFixture({
+      "manifest.ts": `import { workflowManifest } from "@voyant-travel/commerce/promotions/workflow-bulk-reindex-manifest"
+
+export const graph = { workflows: [workflowManifest] }
+`,
+    })
+
+    const result = await runChecker(root)
+
+    assert.match(result.stdout, /check-deployment-graph-import-cheap: OK/)
+  })
+
+  it("rejects transitive route imports from graph declarations", async () => {
+    const root = await createFixture({
+      "manifest.ts": `import { routes } from "./routes"
+
+export const graph = { routes }
+`,
+      "routes.ts": `export const routes = []
+`,
+    })
+
+    await assert.rejects(runChecker(root), (error) => {
+      assert.match(error.stderr, /manifest\.ts imports \.\/routes/)
+      assert.match(error.stderr, /route graph must stay behind a lazy runtime import/)
+      return true
+    })
+  })
+})

--- a/scripts/tests/deployment-graph-doctor.test.ts
+++ b/scripts/tests/deployment-graph-doctor.test.ts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict"
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, it } from "node:test"
+
+import { buildDeploymentGraphJson } from "../../packages/framework/src/deployment-artifacts.ts"
+import {
+  defineModule,
+  defineProject,
+  resolveDeploymentGraph,
+} from "../../packages/framework/src/deployment-graph.ts"
+import {
+  buildDeploymentGraphDoctorJson,
+  buildDeploymentGraphDoctorReport,
+  checkDeploymentGraphGeneratedArtifacts,
+  formatDeploymentGraphDoctorReport,
+} from "../lib/deployment-graph-doctor.ts"
+
+describe("deployment graph doctor report", () => {
+  it("emits deterministic JSON diagnostics for missing and stale generated artifacts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "voyant-graph-doctor-"))
+    const generatedRoot = join(root, "starters", "operator")
+    await mkdir(generatedRoot, { recursive: true })
+
+    const freshPath = join(generatedRoot, "deployment-graph.generated.json")
+    const stalePath = join(generatedRoot, "runtime-entry.generated.ts")
+    const missingPath = join(generatedRoot, "deployment-artifacts.generated.json")
+    await writeFile(freshPath, "fresh\n", "utf8")
+    await writeFile(stalePath, "old\n", "utf8")
+
+    const diagnostics = await checkDeploymentGraphGeneratedArtifacts(
+      [
+        {
+          path: stalePath,
+          expected: "new\n",
+          facet: "runtime-entry",
+          hint: "Run graph:emit.",
+        },
+        {
+          path: freshPath,
+          expected: "fresh\n",
+          facet: "deployment-graph",
+        },
+        {
+          path: missingPath,
+          expected: "{}\n",
+          facet: "deployment-artifacts",
+          hint: "Run graph:emit.",
+        },
+      ],
+      { repoRoot: root },
+    )
+
+    assert.deepEqual(
+      diagnostics.map((entry) => ({
+        code: entry.code,
+        source: entry.source,
+        facet: entry.facet,
+      })),
+      [
+        {
+          code: "VOYANT_GRAPH_ARTIFACT_MISSING",
+          source: "starters/operator/deployment-artifacts.generated.json",
+          facet: "deployment-artifacts",
+        },
+        {
+          code: "VOYANT_GRAPH_ARTIFACT_STALE",
+          source: "starters/operator/runtime-entry.generated.ts",
+          facet: "runtime-entry",
+        },
+      ],
+    )
+
+    const report = buildDeploymentGraphDoctorReport({
+      graph: await cleanGraph(),
+      diagnostics,
+    })
+    const firstJson = buildDeploymentGraphDoctorJson(report)
+    const secondJson = buildDeploymentGraphDoctorJson(report)
+
+    assert.equal(report.ok, false)
+    assert.equal(firstJson, secondJson)
+    assert.match(firstJson, /"schemaVersion": "voyant.graph-doctor-report.v1"/)
+    assert.match(firstJson, /"code": "VOYANT_GRAPH_ARTIFACT_MISSING"/)
+    assert.match(formatDeploymentGraphDoctorReport(report), /VOYANT_GRAPH_ARTIFACT_STALE/)
+  })
+
+  it("uses resolver diagnostics and artifact diagnostics in the same contract", async () => {
+    const project = defineProject({
+      modules: [
+        defineModule({
+          id: "@acme/voyant-loyalty",
+          requires: { capabilities: ["acme.crm.people"] },
+        }),
+      ],
+    })
+    const graph = await resolveDeploymentGraph({ project, target: "node", mode: "self-hosted" })
+    const report = buildDeploymentGraphDoctorReport({
+      graph,
+      diagnostics: [
+        {
+          code: "VOYANT_GRAPH_ARTIFACT_STALE",
+          severity: "error",
+          source: "starters/operator/deployment-graph.generated.json",
+          facet: "deployment-graph",
+          message: "starters/operator/deployment-graph.generated.json is stale.",
+        },
+      ],
+    })
+    const parsed = JSON.parse(buildDeploymentGraphDoctorJson(report)) as {
+      diagnostics: Array<{ code: string }>
+    }
+
+    assert.deepEqual(
+      parsed.diagnostics.map((entry) => entry.code),
+      ["VOYANT_GRAPH_ARTIFACT_STALE", "VOYANT_GRAPH_MISSING_CAPABILITY"],
+    )
+  })
+
+  it("reports clean graphs as ok", async () => {
+    const graph = await cleanGraph()
+    const report = buildDeploymentGraphDoctorReport({ graph })
+
+    assert.equal(report.ok, true)
+    assert.equal(report.diagnostics.length, 0)
+    assert.deepEqual(JSON.parse(buildDeploymentGraphJson(graph)).diagnostics, [])
+    assert.match(formatDeploymentGraphDoctorReport(report), /deployment graph doctor: OK/)
+  })
+})
+
+async function cleanGraph() {
+  const project = defineProject({
+    modules: [
+      defineModule({
+        id: "@acme/voyant-loyalty",
+        provides: { capabilities: ["acme.loyalty.points"] },
+      }),
+    ],
+  })
+  return resolveDeploymentGraph({ project, target: "node", mode: "self-hosted" })
+}

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d",
+  "graphHash": "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d",
+      "graphHash": "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d",
+  "contentHash": "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -255,7 +255,12 @@
           "surface": "admin"
         }
       ],
-      "events": [],
+      "events": [
+        {
+          "eventType": "promotion.changed",
+          "id": "@voyant-travel/commerce#event.promotion.changed"
+        }
+      ],
       "id": "@voyant-travel/commerce",
       "kind": "module",
       "links": [],
@@ -272,8 +277,48 @@
         "ports": []
       },
       "schema": [],
-      "subscribers": [],
-      "workflows": []
+      "subscribers": [
+        {
+          "eventFilterId": "ef_6f8e4b4ce409d04c",
+          "eventType": "promotion.changed",
+          "filter": {
+            "eventType": "promotion.changed",
+            "id": "ef_6f8e4b4ce409d04c",
+            "input": {
+              "object": {
+                "offerId": {
+                  "path": "data.offerId"
+                },
+                "source": {
+                  "path": "data.source"
+                }
+              }
+            },
+            "payloadHash": "6f8e4b4ce409d04c",
+            "targetWorkflowId": "promotions.reindex-all-products",
+            "where": {
+              "eq": [
+                {
+                  "path": "data.affected.kind"
+                },
+                {
+                  "lit": "all"
+                }
+              ]
+            }
+          },
+          "id": "@voyant-travel/commerce#subscriber.ef_6f8e4b4ce409d04c",
+          "workflowId": "promotions.reindex-all-products"
+        }
+      ],
+      "workflows": [
+        {
+          "config": {
+            "defaultRuntime": "node"
+          },
+          "id": "promotions.reindex-all-products"
+        }
+      ]
     },
     {
       "api": [

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -3,10 +3,8 @@
 
 import { fileURLToPath, pathToFileURL } from "node:url"
 
-import { startManagedProfileRuntime } from "@voyant-travel/framework/managed-runtime"
-
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:87a7ee6f21d659b2e2cfecd372ca463df0ed409f3bcd38fdda0c1bec8a73e56d" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const
@@ -111,6 +109,7 @@ export function resolveGeneratedProfileSnapshotPath(): string {
 
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
+  const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
   })


### PR DESCRIPTION
## Summary

- add a product-side deployment graph doctor report contract with stable JSON output and generated-artifact diagnostics
- enforce import-cheap deployment graph entry surfaces and keep the managed runtime behind a dynamic import
- lower the commerce promotions workflow, `promotion.changed` event, and event-filter subscriber into the generated operator graph
- refresh generated operator graph artifacts and add a framework changeset

## Validation

- `pnpm verify:deployment-graph`
- `pnpm --filter @voyant-travel/framework test -- managed-jobs.test.ts deployment-graph.test.ts deployment-artifacts.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter operator graph:check`
- `pnpm --filter operator test -- --run src/deployment-graph-artifacts.test.ts`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (passes with existing file-size warning on `deployment-graph.test.ts`)
- `pnpm verify:architecture` (migration replay parity skipped because `TEST_DATABASE_URL` is not set)
- `pnpm test` (pre-push hook)