### PR TITLE
Lower workflow schedules into deployment graph

### DIFF
--- a/.changeset/workflow-schedule-graph.md
+++ b/.changeset/workflow-schedule-graph.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Lower workflow schedule descriptors into deployment graph workflow facets.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -655,6 +655,12 @@ Existing `?cron=<expr>` dispatch should be migrated toward
 Low-level runtime maintenance can keep an internal scheduler escape hatch, but
 it should not become the module/plugin authoring surface.
 
+Implementation note: v1 graph units lower workflow descriptor
+`config.schedule` declarations into nested `workflows[].schedules` entries with
+stable graph entity ids. Existing Cloud Scheduler cron callbacks are not modeled
+as workflow schedules; they remain runtime maintenance/provisioning metadata
+until the scheduler dispatch migration has a stable schedule-id contract.
+
 ## Events And Webhooks
 
 V1 should include subscribers and workflow event filters that already map to

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework; deployment graph v1 tests stay co-located while the resolver, diagnostics, hashing, and managed-profile bridge share one contract harness.
 import {
   bulkReindexProductsWorkflowManifest,
   promotionAffectedAllFilter,
@@ -51,6 +52,7 @@ describe("deployment graph v1", () => {
         }),
       ]),
     )
+    expect(validateGraphUnitManifest(module)).toEqual([])
   })
 
   it("rejects bare legacy aliases as canonical graph ids", () => {
@@ -88,6 +90,89 @@ describe("deployment graph v1", () => {
         expect.objectContaining({ code: "VOYANT_GRAPH_MISSING_CAPABILITY" }),
       ]),
     )
+  })
+
+  it("lowers workflow schedule descriptors into nested stable graph entities", async () => {
+    const project = defineProject({
+      modules: [
+        defineModule({
+          id: "@acme/voyant-automation",
+          workflows: [
+            {
+              id: "daily-rollup",
+              config: {
+                defaultRuntime: "node",
+                schedule: [
+                  {
+                    cron: "0 * * * *",
+                    timezone: "UTC",
+                    environments: ["production"],
+                    input: { kind: "hourly" },
+                    overlap: "skip",
+                    name: "hourly",
+                  },
+                  {
+                    at: "2026-01-01T12:00:00.000Z",
+                    enabled: false,
+                  },
+                ],
+              },
+            },
+          ],
+        }),
+      ],
+    })
+
+    const graph = await resolveDeploymentGraph({ project, target: "node", mode: "self-hosted" })
+    const [unit] = graph.modules
+
+    expect(unit?.workflows[0]?.schedules).toEqual([
+      {
+        id: "@acme/voyant-automation#schedule.daily-rollup.hourly",
+        workflowId: "daily-rollup",
+        cron: "0 * * * *",
+        timezone: "UTC",
+        environments: ["production"],
+        input: { kind: "hourly" },
+        overlap: "skip",
+        name: "hourly",
+      },
+      {
+        id: "@acme/voyant-automation#schedule.daily-rollup.schedule-2",
+        workflowId: "daily-rollup",
+        at: "2026-01-01T12:00:00.000Z",
+        enabled: false,
+      },
+    ])
+    expect(graph.diagnostics).toEqual([])
+  })
+
+  it("detects duplicate workflow schedule entity ids after descriptor lowering", async () => {
+    const project = defineProject({
+      modules: [
+        defineModule({
+          id: "@acme/voyant-automation",
+          workflows: [
+            {
+              id: "daily-rollup",
+              schedules: [{ id: "@acme/voyant-automation#schedule.daily-rollup.hourly" }],
+              config: {
+                schedule: { cron: "0 * * * *", name: "hourly" },
+              },
+            },
+          ],
+        }),
+      ],
+    })
+
+    const graph = await resolveDeploymentGraph({ project, target: "node", mode: "self-hosted" })
+
+    expect(graph.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "VOYANT_GRAPH_DUPLICATE_ENTITY_ID",
+        source: "@acme/voyant-automation",
+      }),
+    ])
   })
 
   it("hashes deterministic canonical graph content", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -136,6 +136,15 @@ export interface VoyantGraphWorkflow extends VoyantGraphFacetEntity {
 
 export interface VoyantGraphWorkflowSchedule extends VoyantGraphFacetEntity {
   workflowId?: string
+  cron?: string
+  every?: string | number
+  at?: string
+  timezone?: string
+  input?: VoyantGraphJsonValue
+  enabled?: boolean
+  overlap?: "skip" | "queue" | "allow"
+  environments?: readonly ("production" | "preview" | "development")[]
+  name?: string
 }
 
 export interface VoyantGraphUnitManifest {
@@ -787,6 +796,13 @@ function toGraphJsonObject(value: unknown): VoyantGraphJsonObject | undefined {
   return JSON.parse(JSON.stringify(value)) as VoyantGraphJsonObject
 }
 
+function toGraphJsonValue(value: unknown): VoyantGraphJsonValue | undefined {
+  if (value === undefined || typeof value === "function") return undefined
+  const text = JSON.stringify(value)
+  if (text === undefined) return undefined
+  return JSON.parse(text) as VoyantGraphJsonValue
+}
+
 export async function sha256(value: unknown): Promise<string> {
   const text = canonicalJson(value)
   const bytes = new TextEncoder().encode(text)
@@ -894,7 +910,7 @@ function resolveUnit(
     links: sortFacetEntities(unit.links ?? []),
     subscribers: sortFacetEntities(unit.subscribers ?? []) as VoyantGraphSubscriber[],
     events: sortFacetEntities(unit.events ?? []) as VoyantGraphEvent[],
-    workflows: sortWorkflows(unit.workflows ?? []),
+    workflows: sortWorkflows(normalizeWorkflowScheduleFacets(unit.id, unit.workflows ?? [])),
   }
 }
 
@@ -910,6 +926,79 @@ function lowerManagedWorkflowFacet(workflow: ManagedWorkflowManifestEntry): Voya
     id: workflow.id,
     ...(config ? { config } : {}),
   }
+}
+
+function normalizeWorkflowScheduleFacets(
+  unitId: string,
+  workflows: readonly VoyantGraphWorkflow[],
+): VoyantGraphWorkflow[] {
+  return workflows.map((workflow) => {
+    const declared = workflow.schedules ?? []
+    const lowered =
+      isRecord(workflow.config) && workflow.config.schedule !== undefined
+        ? lowerWorkflowScheduleFacets(unitId, workflow.id, workflow.config.schedule)
+        : []
+    return lowered.length > 0 ? { ...workflow, schedules: [...declared, ...lowered] } : workflow
+  })
+}
+
+function lowerWorkflowScheduleFacets(
+  unitId: string,
+  workflowId: string,
+  value: unknown,
+): VoyantGraphWorkflowSchedule[] {
+  const schedules = Array.isArray(value) ? value : [value]
+  return schedules.flatMap((schedule, index) => {
+    const lowered = lowerWorkflowScheduleFacet(unitId, workflowId, schedule, index)
+    return lowered ? [lowered] : []
+  })
+}
+
+function lowerWorkflowScheduleFacet(
+  unitId: string,
+  workflowId: string,
+  value: unknown,
+  index: number,
+): VoyantGraphWorkflowSchedule | undefined {
+  if (!isRecord(value)) return undefined
+  const input = typeof value.input === "function" ? undefined : toGraphJsonValue(value.input)
+  const environments = normalizeScheduleEnvironments(value.environments)
+  return {
+    id: childGraphEntityId(unitId, `schedule.${workflowId}.${scheduleEntityKey(value, index)}`),
+    workflowId,
+    ...(typeof value.cron === "string" ? { cron: value.cron } : {}),
+    ...(typeof value.every === "string" || typeof value.every === "number"
+      ? { every: value.every }
+      : {}),
+    ...(typeof value.at === "string"
+      ? { at: value.at }
+      : value.at instanceof Date
+        ? { at: value.at.toISOString() }
+        : {}),
+    ...(typeof value.timezone === "string" ? { timezone: value.timezone } : {}),
+    ...(input !== undefined ? { input } : {}),
+    ...(typeof value.enabled === "boolean" ? { enabled: value.enabled } : {}),
+    ...(value.overlap === "skip" || value.overlap === "queue" || value.overlap === "allow"
+      ? { overlap: value.overlap }
+      : {}),
+    ...(environments.length > 0 ? { environments } : {}),
+    ...(typeof value.name === "string" ? { name: value.name } : {}),
+  }
+}
+
+function scheduleEntityKey(value: Record<string, unknown>, index: number): string {
+  if (typeof value.name === "string" && isGraphEntityIdSegment(value.name)) return value.name
+  return `schedule-${index + 1}`
+}
+
+function normalizeScheduleEnvironments(
+  value: unknown,
+): Array<"production" | "preview" | "development"> {
+  if (!Array.isArray(value)) return []
+  return value.filter(
+    (entry): entry is "production" | "preview" | "development" =>
+      entry === "production" || entry === "preview" || entry === "development",
+  )
 }
 
 function lowerManagedEventFacets(unitId: string, moduleSpecifier: string): VoyantGraphEvent[] {
@@ -1412,6 +1501,10 @@ function packageNameFromGraphId(id: string): string {
 
 function isCanonicalGraphId(id: string): boolean {
   return GRAPH_ID_PATTERN.test(id)
+}
+
+function isGraphEntityIdSegment(value: string): boolean {
+  return /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(value)
 }
 
 function usesReservedCapabilityNamespace(token: string): boolean {

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8",
+  "graphHash": "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8",
+      "graphHash": "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8",
+  "contentHash": "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1309,7 +1309,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.26.1"
+      "version": "0.27.0"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,7 +4,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:fa12612d273b8c480a798266dd55fe5a92ad5955a1aa7c9d5d4e14dd1da0efe8" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary

- Extend deployment graph workflow schedule facets with the existing workflow schedule descriptor fields.
- Lower `workflow.config.schedule` into nested `workflows[].schedules` entries with stable graph entity ids during graph resolution.
- Document that Cloud Scheduler cron callbacks remain runtime maintenance metadata until the schedule-id dispatch contract lands.
- Refresh operator generated graph artifacts for the current framework package record/hash.

## Validation

- `pnpm --filter @voyant-travel/framework test -- deployment-graph.test.ts managed-jobs.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter operator graph:emit`
- `pnpm verify:deployment-graph`
- `pnpm --filter operator graph:check`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: 191 tasks passed
- pre-push hook: 100 tasks passed