### PR TITLE
Use schedule ids for scheduler dispatch

### DIFF
--- a/.changeset/schedule-id-dispatch.md
+++ b/.changeset/schedule-id-dispatch.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/runtime": minor
+"@voyant-travel/framework": patch
+---
+
+Support stable schedule-id dispatch for scheduled Node runtime hooks.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -68,7 +68,9 @@ workload class well. On Node none of it is necessary.
 - **Crons:** declared runtime-neutrally in `src/scheduled-crons.ts`
   (`OPERATOR_CRON_JOBS`). On Node they can't run on a timer inside the process, so
   `pnpm --filter operator emit:cloud-scheduler` fans them out to Cloud Scheduler
-  jobs that POST `/__voyant/scheduled?cron=<expr>` with the origin-trust header.
+  jobs that POST `/__voyant/scheduled?schedule=<stable-id>` with the
+  origin-trust header. During rollout the emitted URL also carries `cron` as a
+  compatibility fallback for older runtimes.
 - **CI:** the `node-smoke` job builds the operator, boots it under Node, and
   asserts `/healthz` + API dispatch — so the first-class target is gated.
 

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -661,6 +661,11 @@ stable graph entity ids. Existing Cloud Scheduler cron callbacks are not modeled
 as workflow schedules; they remain runtime maintenance/provisioning metadata
 until the scheduler dispatch migration has a stable schedule-id contract.
 
+Implementation note: Node scheduler dispatch now accepts `?schedule=<stable-id>`
+and the operator Cloud Scheduler emitter uses that stable id as the runtime
+dispatch key. Legacy `?cron=<expr>` URLs remain accepted as a compatibility
+fallback for already-provisioned scheduler jobs.
+
 ## Events And Webhooks
 
 V1 should include subscribers and workflow event filters that already map to

--- a/packages/framework/src/managed-jobs.ts
+++ b/packages/framework/src/managed-jobs.ts
@@ -21,7 +21,7 @@ import { moduleIdFromSpecifier, type VoyantProjectManifest } from "./profile-typ
 
 /**
  * The Node runtime path a Cloud Scheduler job POSTs to trigger scheduled work.
- * The cron expression is passed as `?cron=<expr>` and the request carries the
+ * The stable job id is passed as `?schedule=<id>` and the request carries the
  * origin-trust header — see `packages/runtime`'s `SCHEDULED_PATH`.
  */
 export const SCHEDULED_JOB_ROUTE = "/__voyant/scheduled"
@@ -34,7 +34,7 @@ export interface ManagedScheduledJob {
   readonly cron: string
   /** Human-readable description of the work this trigger drives. */
   readonly description: string
-  /** The runtime route the job POSTs (`?cron=<expr>` selects the handler). */
+  /** The runtime route the job POSTs (`?schedule=<id>` selects the handler). */
   readonly route: string
   /**
    * The module this job belongs to — a `moduleId` (e.g. `distribution`) for
@@ -224,7 +224,7 @@ function resolveActiveModuleSpecifiers(project: VoyantProjectManifest): Readonly
  * Given only a valid `voyant.managed-profile.v1` snapshot and the installed
  * framework version, Cloud can compute exactly which scheduler jobs to create:
  * always-on framework jobs plus one job per active module that owns scheduled
- * work. Every job POSTs {@link SCHEDULED_JOB_ROUTE} with `?cron=<expr>`.
+ * work. Every job POSTs {@link SCHEDULED_JOB_ROUTE} with `?schedule=<id>`.
  */
 export function getManagedProfileScheduledJobs(
   project: VoyantProjectManifest,

--- a/packages/framework/src/profile-requirements.ts
+++ b/packages/framework/src/profile-requirements.ts
@@ -153,7 +153,7 @@ function envForProvider(
 
 function notesForProvider(role: VoyantProjectProviderRole, provider: string): string | undefined {
   if (role === "scheduledJobs" && provider === "cloud-scheduler") {
-    return "Cloud Scheduler should POST /__voyant/scheduled?cron=<expr> with x-voyant-origin-trust."
+    return "Cloud Scheduler should POST /__voyant/scheduled?schedule=<stable-id> with x-voyant-origin-trust."
   }
   if (role === "workflows" && provider === "voyant-cloud") {
     return "App code forwards workflow trigger/event calls to the hosted Voyant Cloud workflow runtime."

--- a/packages/runtime/src/node-server.test.ts
+++ b/packages/runtime/src/node-server.test.ts
@@ -96,6 +96,52 @@ describe("createNodeServer", () => {
     expect(seenCron).toBe("*/2 * * * *")
   })
 
+  it("dispatches the scheduled handler over HTTP with the stable schedule id", async () => {
+    let seenScheduleId: string | undefined
+    let seenCron: string | undefined
+    const handle = boot({
+      env: {},
+      originTrustSecret: "top-secret",
+      fetch: () => new Response("app"),
+      scheduled: (event) => {
+        seenScheduleId = event.scheduleId
+        seenCron = event.cron
+      },
+    })
+    const port = await ready(handle)
+
+    const res = await fetch(`http://127.0.0.1:${port}/__voyant/scheduled?schedule=outbox-drain`, {
+      method: "POST",
+      headers: { [ORIGIN_TRUST_HEADER]: "top-secret" },
+    })
+    expect(res.status).toBe(202)
+    expect(seenScheduleId).toBe("outbox-drain")
+    expect(seenCron).toBeUndefined()
+  })
+
+  it("dispatches both stable schedule id and legacy cron when both are present", async () => {
+    let seenScheduleId: string | undefined
+    let seenCron: string | undefined
+    const handle = boot({
+      env: {},
+      originTrustSecret: "top-secret",
+      fetch: () => new Response("app"),
+      scheduled: (event) => {
+        seenScheduleId = event.scheduleId
+        seenCron = event.cron
+      },
+    })
+    const port = await ready(handle)
+
+    const res = await fetch(
+      `http://127.0.0.1:${port}/__voyant/scheduled?schedule=outbox-drain&cron=${encodeURIComponent("*/2 * * * *")}`,
+      { method: "POST", headers: { [ORIGIN_TRUST_HEADER]: "top-secret" } },
+    )
+    expect(res.status).toBe(202)
+    expect(seenScheduleId).toBe("outbox-drain")
+    expect(seenCron).toBe("*/2 * * * *")
+  })
+
   it("requires trust for the scheduled hook", async () => {
     const handle = boot({
       env: {},

--- a/packages/runtime/src/node-server.ts
+++ b/packages/runtime/src/node-server.ts
@@ -18,17 +18,28 @@ export interface ScheduledHandlerArgs<Env> {
 
 /**
  * Invoke a Worker-style `scheduled()` handler from an HTTP request. Reads the
- * cron expression from the `cron` query param. Returns `202` on success, `500`
- * on handler error, `400` when `cron` is missing. Exported standalone so it can
- * be mounted into any server loop, not just {@link createNodeServer}.
+ * stable schedule id from the `schedule` query param; legacy callers may still
+ * send `cron`. Returns `202` on success, `500` on handler error, `400` when
+ * neither dispatch key is present. Exported standalone so it can be mounted
+ * into any server loop, not just {@link createNodeServer}.
  */
 export async function scheduledHandler<Env>(args: ScheduledHandlerArgs<Env>): Promise<Response> {
-  const cron = new URL(args.request.url).searchParams.get("cron")
-  if (!cron) {
-    return new Response("Missing `cron` query param", { status: 400 })
+  const params = new URL(args.request.url).searchParams
+  const scheduleId = params.get("schedule") ?? undefined
+  const cron = params.get("cron") ?? undefined
+  if (!scheduleId && !cron) {
+    return new Response("Missing `schedule` or `cron` query param", { status: 400 })
   }
   try {
-    await args.scheduled({ cron, scheduledTime: Date.now() }, args.env, args.ctx)
+    await args.scheduled(
+      {
+        ...(scheduleId ? { scheduleId } : {}),
+        ...(cron ? { cron } : {}),
+        scheduledTime: Date.now(),
+      },
+      args.env,
+      args.ctx,
+    )
     return new Response(null, { status: 202 })
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -51,12 +51,14 @@ export type FetchHandler<Env> = (
 ) => Response | Promise<Response>
 
 /**
- * The event object passed to a Worker `scheduled()` handler. On Cloud Run the
- * cron triggers arrive over HTTP (Cloud Scheduler), so `scheduledTime` is the
- * dispatch time and `cron` is echoed from the request.
+ * The event object passed to a Worker `scheduled()` handler. On Node targets the
+ * scheduler dispatch arrives over HTTP, so `scheduledTime` is the dispatch time.
+ * New dispatchers identify jobs by stable `scheduleId`; `cron` remains optional
+ * for Workers compatibility and legacy Cloud Scheduler URLs.
  */
 export interface ScheduledEventLike {
-  cron: string
+  scheduleId?: string
+  cron?: string
   scheduledTime: number
 }
 

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -43,9 +43,9 @@ pnpm -F operator build        # emits dist/client + dist/server/server.js
 pnpm -F operator start        # node dist/server/server.js (PORT, default 8080)
 ```
 
-The server exposes `/healthz` (probe), `/__voyant/scheduled?cron=<expr>` (the
+The server exposes `/healthz` (probe), `/__voyant/scheduled?schedule=<id>` (the
 Cloud Scheduler hook, origin-trust gated), and serves the client build. Generate
-Cloud Scheduler jobs for the crons in `src/scheduled-crons.ts` with
+Cloud Scheduler jobs for the jobs in `src/scheduled-crons.ts` with
 `pnpm -F operator emit:cloud-scheduler` (see the script header for env).
 
 ## Optional Cloud Services
@@ -148,7 +148,7 @@ gcloud run deploy operator \
 `/healthz` is the container/liveness probe. Set `ORIGIN_TRUST_SECRET` when a
 dispatcher fronts the service (it stamps `x-voyant-origin-trust`; `/healthz` is
 exempt). Crons don't run in-process — wire Cloud Scheduler with
-`pnpm -F operator emit:cloud-scheduler` (POSTs `/__voyant/scheduled?cron=…`). See
+`pnpm -F operator emit:cloud-scheduler` (POSTs `/__voyant/scheduled?schedule=…`). See
 [docs/architecture/deployment-targets.md](../../docs/architecture/deployment-targets.md).
 
 ## Routes
@@ -158,7 +158,7 @@ exempt). Crons don't run in-process — wire Cloud Scheduler with
 - `/api/auth/*` — Better Auth handler
 - `/*` — TanStack Start SSR dashboard
 - `/healthz` — liveness probe (Node runtime)
-- `/__voyant/scheduled?cron=<expr>` — Cloud Scheduler hook (origin-trust gated)
+- `/__voyant/scheduled?schedule=<id>` — Cloud Scheduler hook (origin-trust gated)
 
 ## External cruise adapters
 

--- a/starters/operator/scripts/emit-cloud-scheduler.ts
+++ b/starters/operator/scripts/emit-cloud-scheduler.ts
@@ -2,9 +2,12 @@
  * Emit Cloud Scheduler job definitions for the operator's scheduled work.
  *
  * The operator is a Node deployment (voyant#2966): cron triggers can't run on a
- * timer inside a Cloud Run process, so each cron in `src/scheduled-crons.ts`
- * (`OPERATOR_CRON_JOBS` — the single source of truth) becomes a Cloud Scheduler
- * job that POSTs `/__voyant/scheduled?cron=<expr>` with the origin-trust header.
+ * timer inside a Cloud Run process, so each stable job id in
+ * `src/scheduled-crons.ts` (`OPERATOR_CRON_JOBS` — the single source of truth)
+ * becomes a Cloud Scheduler job that POSTs
+ * `/__voyant/scheduled?schedule=<id>&cron=<expr>` with the origin-trust header.
+ * The stable schedule id is the dispatch key; the cron expression remains in
+ * the URL during rollout so older runtimes can still dispatch the job.
  * This mirrors what `wrangler.jsonc` `triggers.crons` did on Workers.
  *
  * Usage:
@@ -48,7 +51,9 @@ const lines: string[] = [
 ]
 
 for (const job of OPERATOR_CRON_JOBS) {
-  const uri = `${targetUrl}/__voyant/scheduled?cron=${encodeURIComponent(job.cron)}`
+  const uri =
+    `${targetUrl}/__voyant/scheduled?schedule=${encodeURIComponent(job.id)}` +
+    `&cron=${encodeURIComponent(job.cron)}`
   const args = [
     `gcloud scheduler jobs create http ${jobPrefix}-${job.id}`,
     location ? `--location=${location}` : undefined,

--- a/starters/operator/src/entry.ts
+++ b/starters/operator/src/entry.ts
@@ -5,10 +5,7 @@ import {
   CHANNEL_PUSH_AVAILABILITY_CRON,
   CHANNEL_PUSH_BOOKING_LINK_CRON,
   CHANNEL_PUSH_CONTENT_CRON,
-  DRAFT_REAPER_CRON,
-  EXTERNAL_CRUISE_CATALOG_REFRESH_CRON,
-  OUTBOX_DRAIN_CRON,
-  PROMOTION_BOUNDARY_SCHEDULER_CRON,
+  resolveOperatorCronJob,
 } from "./scheduled-crons"
 
 // SSR is loaded lazily behind the non-API branch so the React + react-dom/server
@@ -20,20 +17,30 @@ export const fetch = createWorkerFetch<AppBindings, ExecutionContext>({
   ssr: lazySsr(() => import("./ssr-handler").then((mod) => mod.handleSsrRequest)),
 })
 
-// Scheduled entrypoint. On Node the platform's Cloud Scheduler POSTs each cron
-// expression to `/__voyant/scheduled?cron=<expr>` (see createNodeServer); the
-// reconciler picks the right scanner based on `event.cron`. Cron expressions are
-// the single source of truth in `./scheduled-crons` (`OPERATOR_CRON_JOBS`), fanned
-// out to Cloud Scheduler by `scripts/emit-cloud-scheduler.mjs`.
+// Scheduled entrypoint. On Node the platform's Cloud Scheduler POSTs each stable
+// job id to `/__voyant/scheduled?schedule=<id>` (see createNodeServer). Legacy
+// `?cron=<expr>` dispatch still resolves through `./scheduled-crons` so already
+// provisioned scheduler jobs do not break while provisioning migrates.
 export async function scheduled(
   event: ScheduledController,
   env: AppBindings,
   ctx: ExecutionContext,
 ): Promise<void> {
-  if (event.cron === OUTBOX_DRAIN_CRON) {
+  const dispatchKey = event as ScheduledController & { scheduleId?: string }
+  const job = resolveOperatorCronJob(dispatchKey)
+  if (!job) {
+    console.warn("[scheduled] unknown schedule", {
+      scheduleId: dispatchKey.scheduleId,
+      cron: dispatchKey.cron,
+    })
+    return
+  }
+  const scheduledEvent = { ...dispatchKey, cron: job.cron }
+
+  if (job.id === "outbox-drain") {
     ctx.waitUntil(
       import("./api/jobs/outbox-drain-scheduled")
-        .then((mod) => mod.runScheduledOutboxDrain(event, env))
+        .then((mod) => mod.runScheduledOutboxDrain(scheduledEvent, env))
         .then((result) => {
           if (result.claimed > 0 || result.deadLettered > 0) {
             console.info("[outbox-drain] result", result)
@@ -43,10 +50,10 @@ export async function scheduled(
     )
     return
   }
-  if (event.cron === DRAFT_REAPER_CRON) {
+  if (job.id === "draft-reaper") {
     ctx.waitUntil(
       import("./api/jobs/draft-reaper-scheduled")
-        .then((mod) => mod.runScheduledDraftReaper(event, env))
+        .then((mod) => mod.runScheduledDraftReaper(scheduledEvent, env))
         .then((result) => {
           console.info("[draft-reaper] result", result)
         })
@@ -54,10 +61,10 @@ export async function scheduled(
     )
     return
   }
-  if (event.cron === PROMOTION_BOUNDARY_SCHEDULER_CRON) {
+  if (job.id === "promotion-boundary-scheduler") {
     ctx.waitUntil(
       import("./api/jobs/promotion-scheduled")
-        .then((mod) => mod.runScheduledPromotionBoundary(event, env))
+        .then((mod) => mod.runScheduledPromotionBoundary(scheduledEvent, env))
         .then((result) => {
           console.info("[promotion-scheduler] result", result)
         })
@@ -66,21 +73,21 @@ export async function scheduled(
     return
   }
   if (
-    event.cron === CHANNEL_PUSH_BOOKING_LINK_CRON ||
-    event.cron === CHANNEL_PUSH_AVAILABILITY_CRON ||
-    event.cron === CHANNEL_PUSH_CONTENT_CRON
+    job.cron === CHANNEL_PUSH_BOOKING_LINK_CRON ||
+    job.cron === CHANNEL_PUSH_AVAILABILITY_CRON ||
+    job.cron === CHANNEL_PUSH_CONTENT_CRON
   ) {
     ctx.waitUntil(
       import("./api/jobs/channel-push-scheduled")
-        .then((mod) => mod.runScheduledChannelPushReconciler(event, env))
+        .then((mod) => mod.runScheduledChannelPushReconciler(scheduledEvent, env))
         .catch((err) => reportBackgroundFailure("channel-push", err)),
     )
     return
   }
-  if (event.cron === EXTERNAL_CRUISE_CATALOG_REFRESH_CRON) {
+  if (job.id === "external-cruise-catalog-refresh") {
     ctx.waitUntil(
       import("./api/jobs/external-cruise-refresh-scheduled")
-        .then((mod) => mod.runScheduledExternalCruiseCatalogRefresh(event, env))
+        .then((mod) => mod.runScheduledExternalCruiseCatalogRefresh(scheduledEvent, env))
         .then((result) => {
           console.info("[external-cruise-refresh] result", result)
         })
@@ -88,5 +95,5 @@ export async function scheduled(
     )
     return
   }
-  console.warn("[scheduled] unknown cron expression", { cron: event.cron })
+  console.warn("[scheduled] unhandled schedule", { scheduleId: job.id, cron: job.cron })
 }

--- a/starters/operator/src/scheduled-crons.test.ts
+++ b/starters/operator/src/scheduled-crons.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  CHANNEL_PUSH_AVAILABILITY_CRON,
+  OUTBOX_DRAIN_CRON,
+  resolveOperatorCronJob,
+} from "./scheduled-crons"
+
+describe("resolveOperatorCronJob", () => {
+  it("resolves stable schedule ids before cron expressions", () => {
+    expect(
+      resolveOperatorCronJob({
+        scheduleId: "channel-push-availability",
+        cron: OUTBOX_DRAIN_CRON,
+      }),
+    ).toMatchObject({
+      id: "channel-push-availability",
+      cron: CHANNEL_PUSH_AVAILABILITY_CRON,
+    })
+  })
+
+  it("keeps legacy cron dispatch working", () => {
+    expect(resolveOperatorCronJob({ cron: OUTBOX_DRAIN_CRON })).toMatchObject({
+      id: "outbox-drain",
+      cron: OUTBOX_DRAIN_CRON,
+    })
+  })
+
+  it("returns undefined for unknown schedule dispatch keys", () => {
+    expect(resolveOperatorCronJob({ scheduleId: "missing-job" })).toBeUndefined()
+    expect(resolveOperatorCronJob({ cron: "1 2 3 4 5" })).toBeUndefined()
+  })
+})

--- a/starters/operator/src/scheduled-crons.ts
+++ b/starters/operator/src/scheduled-crons.ts
@@ -1,7 +1,7 @@
-// Runtime-neutral cron declarations. These expressions are the single source of
-// truth for the operator's scheduled work: `entry.ts` `scheduled()` dispatches
-// off them, and `scripts/emit-cloud-scheduler.ts` fans them out to Cloud
-// Scheduler jobs that POST `/__voyant/scheduled?cron=<expr>` on the Node runtime.
+// Runtime-neutral scheduled job declarations. Stable ids are the dispatch keys
+// for the operator's scheduled work: `entry.ts` `scheduled()` resolves them, and
+// `scripts/emit-cloud-scheduler.ts` fans them out to Cloud Scheduler jobs that
+// POST `/__voyant/scheduled?schedule=<id>&cron=<expr>` on the Node runtime.
 //
 // The STANDARD job set is now owned by the framework and derived from the
 // composed module set (voyant#3032) — `@voyant-travel/framework/managed-jobs` —
@@ -60,3 +60,18 @@ export const OPERATOR_CRON_JOBS: readonly CronJob[] = [
     description: "External cruise catalog refresh (nightly at 03:30).",
   },
 ]
+
+export interface ScheduledDispatchKey {
+  cron?: string
+  scheduleId?: string
+}
+
+export function resolveOperatorCronJob(event: ScheduledDispatchKey) {
+  if (event.scheduleId) {
+    return OPERATOR_CRON_JOBS.find((job) => job.id === event.scheduleId)
+  }
+  if (event.cron) {
+    return OPERATOR_CRON_JOBS.find((job) => job.cron === event.cron)
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary

- Teach the Node scheduled hook to accept stable `schedule` ids while preserving legacy `cron` query dispatch.
- Switch operator Cloud Scheduler emission to `schedule=<id>&cron=<expr>` for rolling compatibility.
- Resolve operator scheduled jobs by id first, with cron fallback for already-provisioned jobs.
- Update scheduler docs and framework managed-job notes to point new provisioning at stable schedule ids.

## Validation

- `pnpm --filter @voyant-travel/runtime test`
- `pnpm --filter @voyant-travel/runtime typecheck`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator test`
- `SCHEDULER_TARGET_URL=https://operator.example.test ORIGIN_TRUST_SECRET=test pnpm --filter operator emit:cloud-scheduler`
- `pnpm --filter operator graph:emit`
- `pnpm --filter operator graph:check`
- `pnpm --filter @voyant-travel/framework test -- managed-jobs.test.ts profile.test.ts deployment-graph.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm verify:deployment-graph`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit hook: 191 tasks passed
- pre-push hook: 100 tasks passed