### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/schedule-id-dispatch.md
+++ b/.changeset/schedule-id-dispatch.md
@@ -1,6 +1,0 @@
----
-"@voyant-travel/runtime": minor
-"@voyant-travel/framework": patch
----
-
-Support stable schedule-id dispatch for scheduled Node runtime hooks.

--- a/packages/admin-host/CHANGELOG.md
+++ b/packages/admin-host/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @voyant-travel/admin-host
 
+## 0.2.1
+
+### Patch Changes
+
+- Updated dependencies [e232b21]
+  - @voyant-travel/runtime@0.5.0
+
 ## 0.2.0
 
 ### Minor Changes

--- a/packages/admin-host/package.json
+++ b/packages/admin-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/admin-host",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,

--- a/packages/framework/CHANGELOG.md
+++ b/packages/framework/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @voyant-travel/framework
 
+## 0.28.1
+
+### Patch Changes
+
+- e232b21: Support stable schedule-id dispatch for scheduled Node runtime hooks.
+- Updated dependencies [e232b21]
+  - @voyant-travel/runtime@0.5.0
+
 ## 0.28.0
 
 ### Minor Changes

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/framework",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "Voyant framework BOM — pins the tested runtime-module set so a deployment tracks one framework version and upgrades atomically (no per-package compatibility matrix, no per-package republish/email spam).",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/runtime/CHANGELOG.md
+++ b/packages/runtime/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @voyant-travel/worker-runtime
 
+## 0.5.0
+
+### Minor Changes
+
+- e232b21: Support stable schedule-id dispatch for scheduled Node runtime hooks.
+
 ## 0.4.2
 
 ### Patch Changes

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/runtime",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary

- Release pending schedule-id dispatch package updates.
- Bump `@voyant-travel/runtime` to `0.5.0`.
- Bump `@voyant-travel/framework` to `0.28.1`.
- Bump `@voyant-travel/admin-host` to `0.2.1` through runtime dependency propagation.

## Validation

- `pnpm version-packages`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (expected release warning: changeset consumed)
- `pnpm verify:release-config`
- `pnpm release:plan`
- `git diff --check`
- pre-commit hook: 191 tasks passed
