### PR TITLE
Derive scheduler provisioning from graph

### DIFF
--- a/.changeset/graph-scheduled-job-provisioning.md
+++ b/.changeset/graph-scheduled-job-provisioning.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Expose graph-derived scheduled-job provisioning metadata on resolved deployment graphs.

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -450,6 +450,41 @@ describe("deployment graph v1", () => {
     expect(graph.diagnostics).toEqual([])
   })
 
+  it("projects managed scheduled jobs into graph provisioning metadata", async () => {
+    const graph = await resolveManagedProfileDeploymentGraph(
+      defineVoyantProject({
+        profile: "operator",
+        frameworkVersion: "0.24.1",
+        modules: ["bookings", "catalog"],
+        plugins: [],
+      }),
+    )
+
+    expect(graph.provisioning.scheduledJobs).toEqual([
+      expect.objectContaining({
+        id: "draft-reaper",
+        cron: "5 * * * *",
+        route: "/__voyant/scheduled",
+        module: "catalog",
+      }),
+      expect.objectContaining({
+        id: "outbox-drain",
+        cron: "*/2 * * * *",
+        route: "/__voyant/scheduled",
+        module: "framework",
+      }),
+      expect.objectContaining({
+        id: "promotion-boundary-scheduler",
+        cron: "*/5 * * * *",
+        route: "/__voyant/scheduled",
+        module: "commerce",
+      }),
+    ])
+    expect(graph.provisioning.scheduledJobs.map((job) => job.id)).not.toEqual(
+      expect.arrayContaining(["channel-push-availability"]),
+    )
+  })
+
   it("validates admission policy against inferred package records", async () => {
     const project = defineProject({
       modules: [

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -1,8 +1,10 @@
 // agent-quality: file-size exception -- reason: first v1 deployment-graph cut keeps schema versions, diagnostics, resolver, managed-profile bridge, and author harness co-located until generated runtime lowering defines stable split points.
 import {
+  getManagedProfileScheduledJobs,
   getStandardProfileEventFiltersForModule,
   getStandardProfileWorkflowManifestForModule,
   type ManagedEventFilterEntry,
+  type ManagedScheduledJob,
   type ManagedWorkflowManifestEntry,
 } from "./managed-jobs.js"
 import {
@@ -147,6 +149,14 @@ export interface VoyantGraphWorkflowSchedule extends VoyantGraphFacetEntity {
   name?: string
 }
 
+export interface VoyantGraphScheduledJob {
+  id: string
+  cron: string
+  description: string
+  route: string
+  module: string
+}
+
 export interface VoyantGraphUnitManifest {
   schemaVersion:
     | typeof VOYANT_GRAPH_MODULE_SCHEMA_VERSION
@@ -252,6 +262,7 @@ export interface ResolveDeploymentGraphInput {
   project: VoyantGraphProject
   deployment?: Omit<VoyantGraphDeployment, "project">
   packageRecords?: readonly VoyantGraphPackageRecord[]
+  scheduledJobs?: readonly (ManagedScheduledJob | VoyantGraphScheduledJob)[]
   frameworkVersion?: string
   target?: string
   mode?: VoyantProjectDeploymentMode
@@ -308,6 +319,9 @@ export interface ResolvedVoyantDeploymentGraph {
     required: readonly string[]
   }
   packageRecords: readonly VoyantGraphPackageRecord[]
+  provisioning: {
+    scheduledJobs: readonly VoyantGraphScheduledJob[]
+  }
   diagnostics: readonly VoyantGraphDiagnostic[]
 }
 
@@ -527,6 +541,7 @@ export async function resolveDeploymentGraph(
   const selectedUnits = [...selectedModules, ...selectedPlugins]
 
   const packageRecords = mergePackageRecords(selectedUnits, input.packageRecords ?? [])
+  const scheduledJobs = normalizeScheduledJobs(input.scheduledJobs ?? [])
   const diagnostics = sortDiagnostics([
     ...selectedUnits.flatMap((unit) => validateGraphUnitManifest(unit.original, unit.kind)),
     ...validateDuplicateGraphIds(selectedUnits),
@@ -560,6 +575,9 @@ export async function resolveDeploymentGraph(
       required: sortedUnique(selectedUnits.flatMap((unit) => unit.requires.capabilities)),
     },
     packageRecords,
+    provisioning: {
+      scheduledJobs,
+    },
     diagnostics,
   }
 
@@ -628,6 +646,7 @@ export async function resolveManagedProfileDeploymentGraph(
     packageRecords:
       options.packageRecords ??
       generateWorkspacePackageRecords(deployment.project, project.frameworkVersion),
+    scheduledJobs: options.scheduledJobs ?? getManagedProfileScheduledJobs(project),
     frameworkVersion: options.frameworkVersion ?? project.frameworkVersion,
     target: options.target ?? deployment.target,
     mode: options.mode ?? deployment.mode,
@@ -836,6 +855,20 @@ function normalizeResourceRequirement(
     })),
     ...(requirement.notes ? { notes: requirement.notes } : {}),
   }
+}
+
+function normalizeScheduledJobs(
+  jobs: readonly (ManagedScheduledJob | VoyantGraphScheduledJob)[],
+): VoyantGraphScheduledJob[] {
+  return jobs
+    .map((job) => ({
+      id: job.id,
+      cron: job.cron,
+      description: job.description,
+      route: job.route,
+      module: job.module,
+    }))
+    .sort((left, right) => left.id.localeCompare(right.id))
 }
 
 function compareEnvRequirements(

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -16,11 +16,13 @@ import {
   type ResolveDeploymentGraphInput,
   resolveDeploymentGraph,
 } from "../packages/framework/src/deployment-graph.ts"
+import { getManagedProfileScheduledJobs } from "../packages/framework/src/managed-jobs.ts"
 import type { VoyantProjectManifest } from "../packages/framework/src/profile-types.ts"
 import {
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST,
   OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST,
 } from "../starters/operator/deployment-graph.local.ts"
+import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "../starters/operator/src/local-scheduled-jobs.ts"
 import {
   buildDeploymentGraphDoctorJson,
   buildDeploymentGraphDoctorReport,
@@ -181,6 +183,10 @@ function resolveOperatorDeploymentGraph(
     ...options,
     project: graphProject,
     deployment,
+    scheduledJobs: [
+      ...(options.scheduledJobs ?? getManagedProfileScheduledJobs(project)),
+      ...OPERATOR_LOCAL_SCHEDULED_JOBS,
+    ],
     frameworkVersion: options.frameworkVersion ?? project.frameworkVersion,
     target: options.target ?? deployment.target,
     mode: options.mode ?? deployment.mode,

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4",
+  "graphHash": "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4",
+      "graphHash": "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4",
+  "contentHash": "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1309,7 +1309,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.27.0"
+      "version": "0.28.1"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",
@@ -1880,6 +1880,59 @@
   ],
   "project": {
     "presetLineage": "operator-standard"
+  },
+  "provisioning": {
+    "scheduledJobs": [
+      {
+        "cron": "0 * * * *",
+        "description": "Channel-push availability reconciler (hourly).",
+        "id": "channel-push-availability",
+        "module": "distribution",
+        "route": "/__voyant/scheduled"
+      },
+      {
+        "cron": "*/15 * * * *",
+        "description": "Channel-push booking-link reconciler (every 15 min).",
+        "id": "channel-push-booking-link",
+        "module": "distribution",
+        "route": "/__voyant/scheduled"
+      },
+      {
+        "cron": "0 3 * * *",
+        "description": "Channel-push content reconciler (nightly at 03:00).",
+        "id": "channel-push-content",
+        "module": "distribution",
+        "route": "/__voyant/scheduled"
+      },
+      {
+        "cron": "5 * * * *",
+        "description": "Drops expired booking drafts (hourly at :05).",
+        "id": "draft-reaper",
+        "module": "catalog",
+        "route": "/__voyant/scheduled"
+      },
+      {
+        "cron": "30 3 * * *",
+        "description": "External cruise catalog refresh (nightly at 03:30).",
+        "id": "external-cruise-catalog-refresh",
+        "module": "@voyant-travel/operator#cruises",
+        "route": "/__voyant/scheduled"
+      },
+      {
+        "cron": "*/2 * * * *",
+        "description": "Redelivers failed/interrupted event-outbox deliveries (every 2 min).",
+        "id": "outbox-drain",
+        "module": "framework",
+        "route": "/__voyant/scheduled"
+      },
+      {
+        "cron": "*/5 * * * *",
+        "description": "Emits promotion.changed at valid_from / valid_until boundaries (every 5 min).",
+        "id": "promotion-boundary-scheduler",
+        "module": "commerce",
+        "route": "/__voyant/scheduled"
+      }
+    ]
   },
   "requirements": {
     "resources": [

--- a/starters/operator/scripts/emit-cloud-scheduler.ts
+++ b/starters/operator/scripts/emit-cloud-scheduler.ts
@@ -2,9 +2,8 @@
  * Emit Cloud Scheduler job definitions for the operator's scheduled work.
  *
  * The operator is a Node deployment (voyant#2966): cron triggers can't run on a
- * timer inside a Cloud Run process, so each stable job id in
- * `src/scheduled-crons.ts` (`OPERATOR_CRON_JOBS` — the single source of truth)
- * becomes a Cloud Scheduler job that POSTs
+ * timer inside a Cloud Run process, so each graph-derived scheduled job becomes
+ * a Cloud Scheduler job that POSTs
  * `/__voyant/scheduled?schedule=<id>&cron=<expr>` with the origin-trust header.
  * The stable schedule id is the dispatch key; the cron expression remains in
  * the URL during rollout so older runtimes can still dispatch the job.
@@ -21,7 +20,7 @@
  * then pipe to a shell or paste into your provisioning tooling. Re-running with
  * `create` fails on existing jobs; switch to `update` in your IaC as needed.
  */
-import { OPERATOR_CRON_JOBS } from "../src/scheduled-crons.js"
+import { loadOperatorDeploymentGraphArtifacts } from "../src/deployment-graph-artifacts.js"
 
 function requireEnv(name: string): string {
   const value = process.env[name]
@@ -38,6 +37,7 @@ const timeZone = process.env.SCHEDULER_TIME_ZONE ?? "Etc/UTC"
 const jobPrefix = process.env.SCHEDULER_JOB_PREFIX ?? "operator"
 const location = process.env.SCHEDULER_LOCATION
 const oidcServiceAccount = process.env.SCHEDULER_OIDC_SERVICE_ACCOUNT
+const deploymentGraphArtifacts = loadOperatorDeploymentGraphArtifacts()
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`
@@ -50,9 +50,9 @@ const lines: string[] = [
   "",
 ]
 
-for (const job of OPERATOR_CRON_JOBS) {
+for (const job of deploymentGraphArtifacts.scheduledJobs) {
   const uri =
-    `${targetUrl}/__voyant/scheduled?schedule=${encodeURIComponent(job.id)}` +
+    `${targetUrl}${job.route}?schedule=${encodeURIComponent(job.id)}` +
     `&cron=${encodeURIComponent(job.cron)}`
   const args = [
     `gcloud scheduler jobs create http ${jobPrefix}-${job.id}`,

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -29,6 +29,7 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(summary.resourceRequirements.map((resource) => resource.resourceKey)).toContain(
       "database:postgres",
     )
+    expect(summary.scheduledJobs.map((job) => job.id)).toContain("external-cruise-catalog-refresh")
   })
 
   it("fails when the artifact graph hash does not match the graph content hash", () => {
@@ -103,6 +104,53 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(() => assertOperatorDeploymentGraphResourceEnv(summary, {})).toThrow(
       /Operator deployment graph resource requirements are not satisfied:\n- secret DATABASE_URL is required for database:postgres/,
     )
+  })
+
+  it("loads graph-derived scheduled jobs for provisioning", () => {
+    const root = fixtureRoot()
+    writeFixture(root)
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "src", "server.ts")).href,
+    )
+
+    expect(summary.scheduledJobs).toEqual([
+      {
+        id: "outbox-drain",
+        cron: "*/2 * * * *",
+        description: "Redelivers failed/interrupted event-outbox deliveries (every 2 min).",
+        route: "/__voyant/scheduled",
+        module: "framework",
+      },
+    ])
+  })
+
+  it("fails when graph-derived scheduler provisioning metadata is missing", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { omitProvisioning: true })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/deployment graph provisioning is missing/)
+  })
+
+  it("fails when graph-derived scheduled jobs are malformed", () => {
+    const root = fixtureRoot()
+    writeFixture(root, {
+      provisioning: {
+        scheduledJobs: [
+          {
+            id: "outbox-drain",
+            cron: "*/2 * * * *",
+            description: "Redelivers failed/interrupted event-outbox deliveries (every 2 min).",
+            module: "framework",
+          },
+        ],
+      },
+    })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/deployment graph provisioning\.scheduledJobs\[0\]\.route/)
   })
 
   it("accepts satisfied required resource environment before boot", () => {
@@ -181,7 +229,9 @@ function writeFixture(
     graphHash?: string
     diagnostics?: Array<{ code: string; message: string }>
     requirements?: FixtureDeploymentGraph["requirements"]
+    provisioning?: FixtureDeploymentGraph["provisioning"]
     omitRequirements?: boolean
+    omitProvisioning?: boolean
     runtimeEntry?: Record<string, unknown>
     runtimeEntrySource?: { graphHash?: string }
     writeRuntimeEntrySource?: boolean
@@ -220,6 +270,21 @@ function writeFixture(
     modules: [{ id: "@voyant-travel/bookings" }],
     plugins: [{ id: "@voyant-travel/plugin-smartbill" }],
     packageRecords: [{ packageName: "@voyant-travel/framework" }],
+    ...(!options.omitProvisioning
+      ? {
+          provisioning: options.provisioning ?? {
+            scheduledJobs: [
+              {
+                id: "outbox-drain",
+                cron: "*/2 * * * *",
+                description: "Redelivers failed/interrupted event-outbox deliveries (every 2 min).",
+                route: "/__voyant/scheduled",
+                module: "framework",
+              },
+            ],
+          },
+        }
+      : {}),
   }
   const graphHash = options.graphHash ?? computeGraphContentHash(graphWithoutHash)
   const graph: FixtureDeploymentGraph = { ...graphWithoutHash, contentHash: graphHash }
@@ -271,6 +336,15 @@ interface FixtureDeploymentGraph {
   modules: Array<{ id: string }>
   plugins: Array<{ id: string }>
   packageRecords: Array<{ packageName: string }>
+  provisioning?: {
+    scheduledJobs: Array<{
+      id: string
+      cron: string
+      description: string
+      route?: string
+      module: string
+    }>
+  }
 }
 
 function writeGeneratedRuntimeEntrySource(

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -20,6 +20,15 @@ export interface OperatorDeploymentGraphArtifactSummary {
   pluginIds: readonly string[]
   packageNames: readonly string[]
   resourceRequirements: readonly OperatorDeploymentGraphResourceRequirement[]
+  scheduledJobs: readonly OperatorDeploymentGraphScheduledJob[]
+}
+
+export interface OperatorDeploymentGraphScheduledJob {
+  id: string
+  cron: string
+  description: string
+  route: string
+  module: string
 }
 
 export interface OperatorDeploymentGraphResourceRequirement {
@@ -62,6 +71,7 @@ interface ResolvedDeploymentGraph {
   diagnostics?: unknown
   deployment?: unknown
   requirements?: unknown
+  provisioning?: unknown
   modules?: unknown
   plugins?: unknown
   packageRecords?: unknown
@@ -203,6 +213,7 @@ export function loadOperatorDeploymentGraphArtifacts(
       "packageName",
     ),
     resourceRequirements: collectResourceRequirements(graph.requirements),
+    scheduledJobs: collectScheduledJobs(graph.provisioning),
   }
 
   validateGeneratedRuntimeEntrySource({ graphHash, manifestUrl, mode, summary, target })
@@ -240,6 +251,34 @@ export function assertOperatorDeploymentGraphResourceEnv(
   throw new Error(
     `Operator deployment graph resource requirements are not satisfied:\n${formatIssues(issues)}`,
   )
+}
+
+function collectScheduledJobs(value: unknown): OperatorDeploymentGraphScheduledJob[] {
+  if (value == null) {
+    throw new Error(
+      "deployment graph provisioning is missing; regenerate deployment graph artifacts",
+    )
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("deployment graph provisioning must be an object")
+  }
+  const jobs = arrayOfRecords(
+    (value as Record<string, unknown>).scheduledJobs,
+    "deployment graph provisioning.scheduledJobs",
+  )
+  return jobs.map((job, index) => ({
+    id: requireString(job.id, `deployment graph provisioning.scheduledJobs[${index}].id`),
+    cron: requireString(job.cron, `deployment graph provisioning.scheduledJobs[${index}].cron`),
+    description: requireString(
+      job.description,
+      `deployment graph provisioning.scheduledJobs[${index}].description`,
+    ),
+    route: requireString(job.route, `deployment graph provisioning.scheduledJobs[${index}].route`),
+    module: requireString(
+      job.module,
+      `deployment graph provisioning.scheduledJobs[${index}].module`,
+    ),
+  }))
 }
 
 function collectResourceRequirements(value: unknown): OperatorDeploymentGraphResourceRequirement[] {

--- a/starters/operator/src/local-scheduled-jobs.ts
+++ b/starters/operator/src/local-scheduled-jobs.ts
@@ -1,0 +1,16 @@
+import {
+  type ManagedScheduledJob,
+  SCHEDULED_JOB_ROUTE,
+} from "@voyant-travel/framework/managed-jobs"
+
+export const EXTERNAL_CRUISE_CATALOG_REFRESH_CRON = "30 3 * * *"
+
+export const OPERATOR_LOCAL_SCHEDULED_JOBS: readonly ManagedScheduledJob[] = [
+  {
+    id: "external-cruise-catalog-refresh",
+    cron: EXTERNAL_CRUISE_CATALOG_REFRESH_CRON,
+    description: "External cruise catalog refresh (nightly at 03:30).",
+    route: SCHEDULED_JOB_ROUTE,
+    module: "@voyant-travel/operator#cruises",
+  },
+]

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,7 +4,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:2bece857d9029971b23d24a23447062bbecbd2a487f375222247204e4ae04de4" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const

--- a/starters/operator/src/scheduled-crons.test.ts
+++ b/starters/operator/src/scheduled-crons.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifacts"
 import {
   CHANNEL_PUSH_AVAILABILITY_CRON,
   OUTBOX_DRAIN_CRON,
@@ -29,5 +30,16 @@ describe("resolveOperatorCronJob", () => {
   it("returns undefined for unknown schedule dispatch keys", () => {
     expect(resolveOperatorCronJob({ scheduleId: "missing-job" })).toBeUndefined()
     expect(resolveOperatorCronJob({ cron: "1 2 3 4 5" })).toBeUndefined()
+  })
+
+  it("can dispatch every graph-derived scheduled job", () => {
+    const graph = loadOperatorDeploymentGraphArtifacts()
+
+    for (const job of graph.scheduledJobs) {
+      expect(resolveOperatorCronJob({ scheduleId: job.id })).toMatchObject({
+        id: job.id,
+        cron: job.cron,
+      })
+    }
   })
 })

--- a/starters/operator/src/scheduled-crons.ts
+++ b/starters/operator/src/scheduled-crons.ts
@@ -11,6 +11,7 @@
 // framework module).
 
 import { STANDARD_OPERATOR_SCHEDULED_JOBS } from "@voyant-travel/framework/managed-jobs"
+import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "./local-scheduled-jobs"
 
 /** One scheduled job: a stable id, its cron expression, and what it does. */
 export interface CronJob {
@@ -40,10 +41,6 @@ export const DRAFT_REAPER_CRON = standardCron("draft-reaper")
 export const PROMOTION_BOUNDARY_SCHEDULER_CRON = standardCron("promotion-boundary-scheduler")
 export const OUTBOX_DRAIN_CRON = standardCron("outbox-drain")
 
-// Deployment-local: `@voyant-travel/cruises` is not part of the standard
-// framework runtime manifest, so the operator owns this cron itself.
-export const EXTERNAL_CRUISE_CATALOG_REFRESH_CRON = "30 3 * * *"
-
 /**
  * The full set of scheduled jobs, in declaration order: the framework's
  * standard set (from the composed module set) plus the operator's
@@ -54,11 +51,9 @@ export const OPERATOR_CRON_JOBS: readonly CronJob[] = [
   ...STANDARD_OPERATOR_SCHEDULED_JOBS.map(
     ({ id, cron, description }): CronJob => ({ id, cron, description }),
   ),
-  {
-    id: "external-cruise-catalog-refresh",
-    cron: EXTERNAL_CRUISE_CATALOG_REFRESH_CRON,
-    description: "External cruise catalog refresh (nightly at 03:30).",
-  },
+  ...OPERATOR_LOCAL_SCHEDULED_JOBS.map(
+    ({ id, cron, description }): CronJob => ({ id, cron, description }),
+  ),
 ]
 
 export interface ScheduledDispatchKey {


### PR DESCRIPTION
## Summary

- Add `provisioning.scheduledJobs` to resolved deployment graphs.
- Populate managed-profile graphs from framework-owned scheduled job metadata.
- Append operator-local scheduled jobs during operator graph generation.
- Make the operator Cloud Scheduler emitter read the generated graph artifact instead of `OPERATOR_CRON_JOBS`.
- Add parity coverage so every graph-derived scheduled job resolves through the runtime dispatch table.

## Validation

- `pnpm --filter @voyant-travel/framework test -- src/deployment-graph.test.ts src/deployment-artifacts.test.ts src/managed-jobs.test.ts`
- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts src/scheduled-crons.test.ts`
- `pnpm --filter operator graph:check`
- `SCHEDULER_TARGET_URL=https://operator.example.run.app ORIGIN_TRUST_SECRET=test-secret pnpm --filter operator emit:cloud-scheduler`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (warning only: existing file-size warning for `starters/operator/src/deployment-graph-artifacts.ts`)
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter operator typecheck`
- `pnpm verify:fast`
- pre-push hook: full cached test lane passed
