### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/graph-scheduled-job-provisioning.md
+++ b/.changeset/graph-scheduled-job-provisioning.md
@@ -1,5 +1,0 @@
----
-"@voyant-travel/framework": minor
----
-
-Expose graph-derived scheduled-job provisioning metadata on resolved deployment graphs.

--- a/packages/framework/CHANGELOG.md
+++ b/packages/framework/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @voyant-travel/framework
 
+## 0.29.0
+
+### Minor Changes
+
+- 0049ba7: Expose graph-derived scheduled-job provisioning metadata on resolved deployment graphs.
+
 ## 0.28.1
 
 ### Patch Changes

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/framework",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "description": "Voyant framework BOM — pins the tested runtime-module set so a deployment tracks one framework version and upgrades atomically (no per-package compatibility matrix, no per-package republish/email spam).",
   "license": "Apache-2.0",
   "type": "module",

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd",
+  "graphHash": "sha256:835e7c114ca7a4a499ee0afe031f930779db8a1881d2f1e286fe72095919d253",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd",
+      "graphHash": "sha256:835e7c114ca7a4a499ee0afe031f930779db8a1881d2f1e286fe72095919d253",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd",
+  "contentHash": "sha256:835e7c114ca7a4a499ee0afe031f930779db8a1881d2f1e286fe72095919d253",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1309,7 +1309,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.28.1"
+      "version": "0.29.0"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,7 +4,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:b5edbb4e5b4bba529cd91f4d9e8eb84551df90e2f00468d4d5b40f03f39020fd" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:835e7c114ca7a4a499ee0afe031f930779db8a1881d2f1e286fe72095919d253" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary

- Release the graph-derived scheduler provisioning framework update.
- Bump `@voyant-travel/framework` to `0.29.0`.
- Consume `.changeset/graph-scheduled-job-provisioning.md`.

## Validation

- `pnpm version-packages`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed` (expected release warning: changeset consumed)
- `pnpm verify:release-config`
- `pnpm release:plan`
- `git diff --check`
- pre-commit hook passed
- pre-push hook: full cached test lane passed
