### PR TITLE
fix: derive operator providers from graph

### DIFF
--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -40,11 +40,13 @@ workload class well. On Node none of it is necessary.
   provisioned env/secrets; storefront/site artifacts remain separate apps that
   consume the managed API for the selected profile. Today that profile is the
   standard managed `operator` profile, but the entry is not named after it.
-- **Bindings are real Node providers, not Cloudflare emulation.** In-process KV
-  (`createMemoryKvNamespace`) backs `CACHE`/`RATE_LIMIT`; object storage is
-  S3-backed in prod (`createR2BucketShim`) or in-process in dev
-  (`createMemoryR2Bucket`); there is no `caches.default` shim (the public-cache
-  middleware reads `env.CACHE` directly).
+- **Bindings are real Node providers, not Cloudflare emulation.** The resolved
+  deployment graph's `deployment.providers` map selects the concrete Node
+  providers. `memory` uses in-process KV/object storage, `redis`/`postgres`
+  back selected KV and rate-limit stores, and `r2`/`s3` backs object storage via
+  `createR2BucketShim`. Env vars configure the graph-selected provider; their
+  mere presence must not change provider choice. There is no `caches.default`
+  shim (the public-cache middleware reads `env.CACHE` directly).
 - **Build:** `pnpm --filter operator build` (Vite, no `@cloudflare/vite-plugin`)
   emits `dist/client` + `dist/server/server.js`. **Run:** `pnpm --filter operator
   start` (`node dist/server/server.js`).
@@ -57,9 +59,9 @@ workload class well. On Node none of it is necessary.
 - **Graph contract:** `pnpm --filter operator dev`, `pnpm --filter operator
   db:migrate`, and standalone Node boot all load the generated deployment graph
   artifacts and fail before serving traffic or touching the database when
-  graph-declared required resource env is missing. Local `.env` loading is only
-  a source for satisfying the same graph contract; it is not a parallel
-  deployment shape.
+  graph-declared required resource env or graph-selected provider env is
+  missing. Local `.env` loading is only a source for satisfying the same graph
+  contract; it is not a parallel deployment shape.
 - **Database:** the pooled node-postgres lane (`DATABASE_URL_DIRECT`, `adapter:
   "node"`) is the production default — one resident pool per process. neon-http/WS
   remain the fallback adapters. See
@@ -115,7 +117,10 @@ The mechanical checks live in `scripts/check-node-entrypoint.mjs` and
 and graph artifact/resource validation, that `pnpm --filter operator dev` and
 `pnpm --filter operator db:migrate` preflight graph resource env, that the Docker
 target consumes the graph-checked build artifacts, and that the app entry keeps
-those graphs lazy.
+those graphs lazy. The Node entrypoint check also asserts provider bindings are
+selected from `deployment.providers`, so adding `REDIS_URL`, `DATABASE_URL`, or
+R2 env cannot silently alter runtime providers unless the graph selects those
+providers.
 
 ## Stop-the-bleed policy
 

--- a/scripts/check-node-entrypoint.mjs
+++ b/scripts/check-node-entrypoint.mjs
@@ -8,6 +8,8 @@
  *      share the same graph contract.
  *  1c. the operator dev and migration lanes preflight the same graph contract
  *      before serving traffic or touching the database.
+ *  1d. provider bindings are selected from graph-declared providers, not
+ *      incidental env var presence.
  *  2. `src/entry.ts` (the app's `fetch`/`scheduled` handlers) keeps SSR behind a
  *     lazy import so the React + react-dom/server graph isn't pulled into the
  *     module's top-level — imported on first render, not at boot. Heavy API and
@@ -132,6 +134,37 @@ if (!existsSync(join(ROOT, NODE_ENTRY))) {
       text: "",
     })
   }
+  if (
+    !nodeEntrySource.includes("resolveOperatorNodeProviderPlan") ||
+    !nodeEntrySource.includes("deploymentGraphArtifacts.providers") ||
+    !/^const\s+\w+\s*=\s*resolveOperatorNodeProviderPlan\(\s*deploymentGraphArtifacts\.providers\s*\)/m.test(
+      nodeEntrySource,
+    )
+  ) {
+    violations.push({
+      file: NODE_ENTRY,
+      line: 0,
+      check: {
+        id: "deployment-graph-providers-not-consumed",
+        message: "The Node entry must select runtime providers from deployment graph providers.",
+      },
+      text: "",
+    })
+  }
+  if (
+    !nodeEntrySource.includes("validateOperatorNodeProviderPlanEnv") ||
+    !nodeEntrySource.includes("assertOperatorNodeProviderPlanEnv")
+  ) {
+    violations.push({
+      file: NODE_ENTRY,
+      line: 0,
+      check: {
+        id: "deployment-provider-plan-env-not-asserted",
+        message: "The Node entry must assert graph-selected provider env before binding providers.",
+      },
+      text: "",
+    })
+  }
 }
 
 // 3. Dev lane: must preflight the same graph resource env before Vite boots.
@@ -224,6 +257,20 @@ if (!existsSync(join(ROOT, OPERATOR_GRAPH_ENV_CHECK))) {
       check: {
         id: "operator-graph-env-check-not-wired",
         message: "The operator graph env script must load graph artifacts and assert resource env.",
+      },
+      text: "",
+    })
+  }
+  if (
+    !graphEnvSource.includes("resolveOperatorNodeProviderPlan") ||
+    !graphEnvSource.includes("validateOperatorNodeProviderPlanEnv")
+  ) {
+    violations.push({
+      file: OPERATOR_GRAPH_ENV_CHECK,
+      line: 0,
+      check: {
+        id: "operator-graph-env-provider-plan-not-wired",
+        message: "The operator graph env script must validate graph-selected provider env.",
       },
       text: "",
     })

--- a/starters/operator/scripts/check-deployment-graph-env.ts
+++ b/starters/operator/scripts/check-deployment-graph-env.ts
@@ -2,6 +2,10 @@ import {
   assertOperatorDeploymentGraphResourceEnv,
   loadOperatorDeploymentGraphArtifacts,
 } from "../src/deployment-graph-artifacts"
+import {
+  resolveOperatorNodeProviderPlan,
+  validateOperatorNodeProviderPlanEnv,
+} from "../src/operator-node-provider-plan"
 
 function loadLocalEnv(): void {
   try {
@@ -19,6 +23,15 @@ function main(): void {
 
   const summary = loadOperatorDeploymentGraphArtifacts()
   assertOperatorDeploymentGraphResourceEnv(summary, process.env)
+  const providerPlan = resolveOperatorNodeProviderPlan(summary.providers)
+  const providerPlanIssues = validateOperatorNodeProviderPlanEnv(providerPlan, process.env)
+  if (providerPlanIssues.length > 0) {
+    throw new Error(
+      `Operator deployment graph provider plan requirements are not satisfied:\n${formatIssues(
+        providerPlanIssues,
+      )}`,
+    )
+  }
 
   const requiredEnvNames = new Set(
     summary.resourceRequirements.flatMap((resource) =>
@@ -29,6 +42,10 @@ function main(): void {
   )
 
   console.log(`operator deployment graph env: OK (${requiredEnvNames.size} required resource env)`)
+}
+
+function formatIssues(issues: readonly string[]): string {
+  return issues.map((issue) => `- ${issue}`).join("\n")
 }
 
 function reason(error: unknown): string {

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -26,6 +26,12 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(summary.graphHash).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(summary.moduleIds).toContain("@voyant-travel/bookings")
     expect(summary.packageNames).toContain("@voyant-travel/framework")
+    expect(summary.providers).toMatchObject({
+      database: "postgres",
+      storage: "memory",
+      cache: "memory",
+      rateLimit: "memory",
+    })
     expect(summary.resourceRequirements.map((resource) => resource.resourceKey)).toContain(
       "database:postgres",
     )
@@ -122,6 +128,55 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
         module: "framework",
       },
     ])
+  })
+
+  it("loads graph-derived deployment providers for runtime binding selection", () => {
+    const root = fixtureRoot()
+    writeFixture(root, {
+      deployment: {
+        target: "node",
+        mode: "self-hosted",
+        providers: {
+          database: "postgres",
+          storage: "s3",
+          cache: "redis",
+          sharedState: "redis",
+          rateLimit: "postgres",
+          search: "none",
+          email: "none",
+          sms: "none",
+          auth: "better-auth",
+          scheduledJobs: "cloud-scheduler",
+          workflows: "none",
+        },
+      },
+    })
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "src", "server.ts")).href,
+    )
+
+    expect(summary.providers).toEqual({
+      database: "postgres",
+      storage: "s3",
+      cache: "redis",
+      sharedState: "redis",
+      rateLimit: "postgres",
+      search: "none",
+      email: "none",
+      sms: "none",
+      auth: "better-auth",
+      scheduledJobs: "cloud-scheduler",
+      workflows: "none",
+    })
+  })
+
+  it("fails when graph-derived deployment providers are missing", () => {
+    const root = fixtureRoot()
+    writeFixture(root, { deployment: { target: "node", mode: "self-hosted" } })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/deployment graph deployment\.providers must be an object/)
   })
 
   it("fails when graph-derived scheduler provisioning metadata is missing", () => {
@@ -228,6 +283,7 @@ function writeFixture(
     manifestGraphHash?: string
     graphHash?: string
     diagnostics?: Array<{ code: string; message: string }>
+    deployment?: FixtureDeploymentGraph["deployment"]
     requirements?: FixtureDeploymentGraph["requirements"]
     provisioning?: FixtureDeploymentGraph["provisioning"]
     omitRequirements?: boolean
@@ -242,7 +298,23 @@ function writeFixture(
   const graphWithoutHash: Omit<FixtureDeploymentGraph, "contentHash"> = {
     schemaVersion: "voyant.resolved-graph.v1",
     diagnostics: options.diagnostics ?? [],
-    deployment: { target: "node", mode: "self-hosted" },
+    deployment: options.deployment ?? {
+      target: "node",
+      mode: "self-hosted",
+      providers: {
+        database: "postgres",
+        storage: "memory",
+        cache: "memory",
+        sharedState: "memory",
+        rateLimit: "memory",
+        search: "none",
+        email: "none",
+        sms: "none",
+        auth: "better-auth",
+        scheduledJobs: "none",
+        workflows: "none",
+      },
+    },
     ...(!options.omitRequirements && options.requirements !== undefined
       ? { requirements: options.requirements }
       : !options.omitRequirements
@@ -323,7 +395,11 @@ interface FixtureDeploymentGraph {
   schemaVersion: string
   contentHash: string
   diagnostics: Array<{ code: string; message: string }>
-  deployment: { target: string; mode: string }
+  deployment: {
+    target: string
+    mode: string
+    providers?: Record<string, string>
+  }
   requirements?: {
     resources: Array<{
       resourceKey: string

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -19,6 +19,7 @@ export interface OperatorDeploymentGraphArtifactSummary {
   moduleIds: readonly string[]
   pluginIds: readonly string[]
   packageNames: readonly string[]
+  providers: Readonly<Record<string, string>>
   resourceRequirements: readonly OperatorDeploymentGraphResourceRequirement[]
   scheduledJobs: readonly OperatorDeploymentGraphScheduledJob[]
 }
@@ -212,6 +213,7 @@ export function loadOperatorDeploymentGraphArtifacts(
       "deployment graph packageRecords",
       "packageName",
     ),
+    providers: collectDeploymentProviders(graph.deployment),
     resourceRequirements: collectResourceRequirements(graph.requirements),
     scheduledJobs: collectScheduledJobs(graph.provisioning),
   }
@@ -337,6 +339,25 @@ function collectResourceRequirements(value: unknown): OperatorDeploymentGraphRes
       ...(notes ? { notes } : {}),
     }
   })
+}
+
+function collectDeploymentProviders(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("deployment graph deployment must be an object")
+  }
+  const providers = (value as Record<string, unknown>).providers
+  if (!providers || typeof providers !== "object" || Array.isArray(providers)) {
+    throw new Error("deployment graph deployment.providers must be an object")
+  }
+
+  const collected: Record<string, string> = {}
+  for (const [role, provider] of Object.entries(providers)) {
+    if (typeof provider !== "string" || provider.length === 0) {
+      throw new Error(`deployment graph deployment.providers.${role} must be a non-empty string`)
+    }
+    collected[role] = provider
+  }
+  return collected
 }
 
 function readJsonFile<T>(url: URL, label: string): T {

--- a/starters/operator/src/operator-node-provider-plan.test.ts
+++ b/starters/operator/src/operator-node-provider-plan.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  resolveOperatorNodeProviderPlan,
+  validateOperatorNodeProviderPlanEnv,
+} from "./operator-node-provider-plan"
+
+describe("resolveOperatorNodeProviderPlan", () => {
+  it("keeps memory providers even when external provider env is present", () => {
+    const plan = resolveOperatorNodeProviderPlan({
+      storage: "memory",
+      cache: "memory",
+      sharedState: "memory",
+      rateLimit: "memory",
+    })
+
+    expect(plan).toEqual({
+      storage: "memory",
+      cache: "memory",
+      sharedState: "memory",
+      rateLimit: "memory",
+    })
+    expect(
+      validateOperatorNodeProviderPlanEnv(plan, {
+        REDIS_URL: "redis://example.test:6379",
+        DATABASE_URL: "postgres://user:pass@example.test:5432/voyant",
+        R2_S3_ENDPOINT: "https://r2.example.test",
+        R2_ACCESS_KEY_ID: "key",
+        R2_SECRET_ACCESS_KEY: "secret",
+        R2_BUCKET_MEDIA: "media",
+        R2_BUCKET_DOCUMENTS: "documents",
+      }),
+    ).toEqual([])
+  })
+
+  it("maps redis, postgres, and object storage graph providers to the Node plan", () => {
+    const plan = resolveOperatorNodeProviderPlan({
+      storage: "r2",
+      cache: "redis",
+      sharedState: "redis",
+      rateLimit: "postgres",
+    })
+
+    expect(plan).toEqual({
+      storage: "r2",
+      cache: "redis",
+      sharedState: "redis",
+      rateLimit: "postgres",
+    })
+  })
+
+  it("validates env required by the selected graph providers", () => {
+    const plan = resolveOperatorNodeProviderPlan({
+      storage: "s3",
+      cache: "redis",
+      sharedState: "redis",
+      rateLimit: "postgres",
+    })
+
+    expect(validateOperatorNodeProviderPlanEnv(plan, {})).toEqual([
+      "env R2_S3_ENDPOINT is required by the operator Node provider plan",
+      "env R2_ACCESS_KEY_ID is required by the operator Node provider plan",
+      "env R2_SECRET_ACCESS_KEY is required by the operator Node provider plan",
+      "env R2_BUCKET_MEDIA is required by the operator Node provider plan",
+      "env R2_BUCKET_DOCUMENTS is required by the operator Node provider plan",
+      "env REDIS_URL is required by the operator Node provider plan",
+      "env DATABASE_URL is required by the operator Node provider plan",
+    ])
+  })
+
+  it("rejects unsupported graph providers", () => {
+    expect(() =>
+      resolveOperatorNodeProviderPlan({
+        storage: "local-disk",
+        cache: "memory",
+        sharedState: "memory",
+        rateLimit: "memory",
+      }),
+    ).toThrow(/providers\.storage=local-disk/)
+    expect(() =>
+      resolveOperatorNodeProviderPlan({
+        storage: "memory",
+        cache: "memcached",
+        sharedState: "memory",
+        rateLimit: "memory",
+      }),
+    ).toThrow(/providers\.cache=memcached/)
+  })
+
+  it("requires explicit graph provider roles used by the Node runtime", () => {
+    expect(() =>
+      resolveOperatorNodeProviderPlan({
+        storage: "memory",
+        cache: "memory",
+        rateLimit: "memory",
+      }),
+    ).toThrow(/providers\.sharedState/)
+  })
+})

--- a/starters/operator/src/operator-node-provider-plan.ts
+++ b/starters/operator/src/operator-node-provider-plan.ts
@@ -1,0 +1,79 @@
+export type OperatorNodeObjectStorageProvider = "memory" | "r2" | "s3"
+export type OperatorNodeKvProvider = "memory" | "postgres" | "redis"
+
+export interface OperatorNodeProviderPlan {
+  storage: OperatorNodeObjectStorageProvider
+  cache: OperatorNodeKvProvider
+  sharedState: OperatorNodeKvProvider
+  rateLimit: OperatorNodeKvProvider
+}
+
+const KV_PROVIDER_ROLES = ["cache", "sharedState", "rateLimit"] as const
+
+export function resolveOperatorNodeProviderPlan(
+  providers: Readonly<Record<string, string>>,
+): OperatorNodeProviderPlan {
+  return {
+    storage: objectStorageProvider(providers, "storage"),
+    cache: kvProvider(providers, "cache"),
+    sharedState: kvProvider(providers, "sharedState"),
+    rateLimit: kvProvider(providers, "rateLimit"),
+  }
+}
+
+export function validateOperatorNodeProviderPlanEnv(
+  plan: OperatorNodeProviderPlan,
+  env: Record<string, unknown>,
+): string[] {
+  const required = new Set<string>()
+  if (plan.storage === "r2" || plan.storage === "s3") {
+    required.add("R2_S3_ENDPOINT")
+    required.add("R2_ACCESS_KEY_ID")
+    required.add("R2_SECRET_ACCESS_KEY")
+    required.add("R2_BUCKET_MEDIA")
+    required.add("R2_BUCKET_DOCUMENTS")
+  }
+
+  for (const role of KV_PROVIDER_ROLES) {
+    if (plan[role] === "redis") required.add("REDIS_URL")
+    if (plan[role] === "postgres") required.add("DATABASE_URL")
+  }
+
+  return Array.from(required)
+    .filter((name) => !present(env[name]))
+    .map((name) => `env ${name} is required by the operator Node provider plan`)
+}
+
+function objectStorageProvider(
+  providers: Readonly<Record<string, string>>,
+  role: "storage",
+): OperatorNodeObjectStorageProvider {
+  const provider = requireProvider(providers, role)
+  if (provider === "none" || provider === "memory") return "memory"
+  if (provider === "r2" || provider === "s3") return provider
+  throw new Error(
+    `deployment graph providers.${role}=${provider} is not supported by the operator Node runtime`,
+  )
+}
+
+function kvProvider(
+  providers: Readonly<Record<string, string>>,
+  role: (typeof KV_PROVIDER_ROLES)[number],
+): OperatorNodeKvProvider {
+  const provider = requireProvider(providers, role)
+  if (provider === "none" || provider === "memory") return "memory"
+  if (provider === "redis" || provider === "postgres") return provider
+  throw new Error(
+    `deployment graph providers.${role}=${provider} is not supported by the operator Node runtime`,
+  )
+}
+
+function requireProvider(providers: Readonly<Record<string, string>>, role: string): string {
+  const provider = providers[role]
+  if (typeof provider === "string" && provider.length > 0) return provider
+  throw new Error(`deployment graph providers.${role} must be a non-empty string`)
+}
+
+function present(value: unknown): boolean {
+  return typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+}

--- a/starters/operator/src/server.ts
+++ b/starters/operator/src/server.ts
@@ -26,6 +26,13 @@ import {
   loadOperatorDeploymentGraphArtifacts,
 } from "./deployment-graph-artifacts"
 import { fetch as appFetch, scheduled } from "./entry"
+import {
+  type OperatorNodeKvProvider,
+  type OperatorNodeObjectStorageProvider,
+  type OperatorNodeProviderPlan,
+  resolveOperatorNodeProviderPlan,
+  validateOperatorNodeProviderPlanEnv,
+} from "./operator-node-provider-plan"
 
 /**
  * Node entry for the operator (voyant#2966). This file is also TanStack Start's
@@ -41,35 +48,36 @@ import { fetch as appFetch, scheduled } from "./entry"
  *      `scheduled()` hook for Cloud Scheduler, graceful drain, and static asset
  *      serving for the client build.
  *
- * Bindings are real Node providers, not Cloudflare emulation: in-process KV for
- * `CACHE`/`RATE_LIMIT`, and an S3-backed (or, offline, in-process) object store
- * for `MEDIA_BUCKET`/`DOCUMENTS_BUCKET`.
+ * Bindings are real Node providers selected by the deployment graph, not
+ * Cloudflare emulation: in-process KV for memory `CACHE`/`RATE_LIMIT`,
+ * Postgres/Redis when the graph selects them, and S3/R2-backed object storage
+ * only when graph providers require it.
  */
 
 /** Built client assets (`dist/client`), served for `/assets/*` and public files. */
 const CLIENT_DIR =
   process.env.CLIENT_ASSETS_DIR ?? fileURLToPath(new URL("../client", import.meta.url))
 const deploymentGraphArtifacts = loadOperatorDeploymentGraphArtifacts()
+const deploymentProviderPlan = resolveOperatorNodeProviderPlan(deploymentGraphArtifacts.providers)
+assertOperatorNodeProviderPlanEnv(deploymentProviderPlan, process.env)
 
-/**
- * Build an object-store binding: S3-backed when R2 credentials are present,
- * otherwise an in-process store so local/dev/self-host runs work offline.
- */
-function objectStore(bucketEnv: string | undefined): R2BucketShim {
-  if (
-    process.env.R2_S3_ENDPOINT &&
-    process.env.R2_ACCESS_KEY_ID &&
-    process.env.R2_SECRET_ACCESS_KEY &&
-    bucketEnv
-  ) {
-    return createR2BucketShim({
-      endpoint: process.env.R2_S3_ENDPOINT,
-      bucket: bucketEnv,
-      accessKeyId: process.env.R2_ACCESS_KEY_ID,
-      secretAccessKey: process.env.R2_SECRET_ACCESS_KEY,
-    })
+function objectStore(
+  bucketEnvName: string,
+  bucketEnv: string | undefined,
+  provider: OperatorNodeObjectStorageProvider = deploymentProviderPlan.storage,
+): R2BucketShim {
+  switch (provider) {
+    case "memory":
+      return createMemoryR2Bucket()
+    case "r2":
+    case "s3":
+      return createR2BucketShim({
+        endpoint: requiredStringEnv("R2_S3_ENDPOINT", `storage provider ${provider}`),
+        bucket: requiredStringValue(bucketEnvName, bucketEnv, `storage provider ${provider}`),
+        accessKeyId: requiredStringEnv("R2_ACCESS_KEY_ID", `storage provider ${provider}`),
+        secretAccessKey: requiredStringEnv("R2_SECRET_ACCESS_KEY", `storage provider ${provider}`),
+      })
   }
-  return createMemoryR2Bucket()
 }
 
 function dbUrl(): string | undefined {
@@ -88,44 +96,76 @@ function isPostgresConnectionUrl(value: string): boolean {
 
 let sharedStoreDb: ReturnType<typeof createDbClient> | undefined
 
-function resolveSharedStoreDb() {
+function resolveSharedStoreDb(role: string) {
   const url = dbUrl()
-  if (!url) return undefined
+  if (!url) {
+    throw new Error(
+      `DATABASE_URL or DATABASE_URL_DIRECT must be a postgres URL for graph-selected ${role}`,
+    )
+  }
   sharedStoreDb ??= createDbClient(url, { adapter: "node" })
   return sharedStoreDb
 }
 
-function createRuntimeStores(): {
+function createRuntimeStores(plan: OperatorNodeProviderPlan = deploymentProviderPlan): {
   CACHE: KVStore
   RATE_LIMIT: KVStore
   RATE_LIMIT_STORE: NonNullable<AppBindings["RATE_LIMIT_STORE"]>
 } {
   const l1Cache = createMemoryKvNamespace()
   const l1RateLimit = createMemoryKvNamespace()
-  const redisUrl = process.env.REDIS_URL?.trim()
-
-  if (redisUrl) {
-    return {
-      CACHE: createTieredKvStore(l1Cache, createRedisKvStore(redisUrl)),
-      RATE_LIMIT: createTieredKvStore(l1RateLimit, createRedisKvStore(redisUrl)),
-      RATE_LIMIT_STORE: createRedisRateLimitStore(redisUrl),
-    }
-  }
-
-  const db = resolveSharedStoreDb()
-  if (db) {
-    return {
-      CACHE: createTieredKvStore(l1Cache, createPostgresKvStore(db)),
-      RATE_LIMIT: createTieredKvStore(l1RateLimit, createPostgresKvStore(db)),
-      RATE_LIMIT_STORE: createPostgresFixedWindowRateLimitStore(db),
-    }
-  }
 
   return {
-    CACHE: l1Cache,
-    RATE_LIMIT: l1RateLimit,
-    RATE_LIMIT_STORE: createMemoryRateLimitStore(),
+    CACHE: createKvStoreForProvider("cache", plan.cache, l1Cache),
+    RATE_LIMIT: createKvStoreForProvider("rateLimit", plan.rateLimit, l1RateLimit),
+    RATE_LIMIT_STORE: createRateLimitStoreForProvider(plan.rateLimit),
   }
+}
+
+function createKvStoreForProvider(
+  role: "cache" | "rateLimit",
+  provider: OperatorNodeKvProvider,
+  l1Store: KVStore,
+): KVStore {
+  switch (provider) {
+    case "memory":
+      return l1Store
+    case "redis":
+      return createTieredKvStore(
+        l1Store,
+        createRedisKvStore(requiredStringEnv("REDIS_URL", `${role} provider redis`)),
+      )
+    case "postgres":
+      return createTieredKvStore(
+        l1Store,
+        createPostgresKvStore(resolveSharedStoreDb(`${role} provider postgres`)),
+      )
+  }
+}
+
+function createRateLimitStoreForProvider(
+  provider: OperatorNodeKvProvider,
+): NonNullable<AppBindings["RATE_LIMIT_STORE"]> {
+  switch (provider) {
+    case "memory":
+      return createMemoryRateLimitStore()
+    case "redis":
+      return createRedisRateLimitStore(requiredStringEnv("REDIS_URL", "rateLimit provider redis"))
+    case "postgres":
+      return createPostgresFixedWindowRateLimitStore(
+        resolveSharedStoreDb("rateLimit provider postgres"),
+      )
+  }
+}
+
+function requiredStringEnv(name: string, context: string): string {
+  return requiredStringValue(name, process.env[name], context)
+}
+
+function requiredStringValue(name: string, value: string | undefined, context: string): string {
+  const trimmed = value?.trim()
+  if (trimmed) return trimmed
+  throw new Error(`${name} is required for graph-selected ${context}`)
 }
 
 const stores = createRuntimeStores()
@@ -137,8 +177,8 @@ const env = composeNodeEnv<AppBindings>(process.env, {
     RATE_LIMIT: stores.RATE_LIMIT,
   },
   r2: {
-    MEDIA_BUCKET: objectStore(process.env.R2_BUCKET_MEDIA),
-    DOCUMENTS_BUCKET: objectStore(process.env.R2_BUCKET_DOCUMENTS),
+    MEDIA_BUCKET: objectStore("R2_BUCKET_MEDIA", process.env.R2_BUCKET_MEDIA),
+    DOCUMENTS_BUCKET: objectStore("R2_BUCKET_DOCUMENTS", process.env.R2_BUCKET_DOCUMENTS),
   },
   extra: {
     RATE_LIMIT_STORE: stores.RATE_LIMIT_STORE,
@@ -199,4 +239,21 @@ if (isMainModule) {
   console.info(
     `[operator] Node runtime listening on :${handle.port} (${deploymentGraphArtifacts.graphHash})`,
   )
+}
+
+function assertOperatorNodeProviderPlanEnv(
+  plan: OperatorNodeProviderPlan,
+  envValues: Record<string, unknown>,
+): void {
+  const issues = validateOperatorNodeProviderPlanEnv(plan, envValues)
+  if (issues.length === 0) return
+  throw new Error(
+    `Operator deployment graph provider plan requirements are not satisfied:\n${formatIssues(
+      issues,
+    )}`,
+  )
+}
+
+function formatIssues(issues: readonly string[]): string {
+  return issues.map((issue) => `- ${issue}`).join("\n")
 }


### PR DESCRIPTION
## Summary

- expose `deployment.providers` from checked operator deployment graph artifacts
- add an operator Node provider plan so storage/cache/rate-limit bindings follow graph-selected providers instead of incidental env presence
- preflight graph-selected provider env in `graph:env` and the Node entrypoint, and enforce the rule in `check-node-entrypoint`
- update deployment target docs and add focused provider-plan/artifact tests

## Validation

- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts src/operator-node-provider-plan.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:node-entrypoint`
- `pnpm verify:operator-docker-target`
- `pnpm verify:deployment-graph`
- `pnpm lint:changed`
- `git diff --check`
- pre-push `pnpm test` hook passed
