### PR TITLE
feat: read graph package metadata from package json

### DIFF
--- a/scripts/lib/deployment-graph-provenance.mjs
+++ b/scripts/lib/deployment-graph-provenance.mjs
@@ -5,15 +5,19 @@ import { parse } from "yaml"
 
 const dependencySections = ["dependencies", "optionalDependencies", "devDependencies"]
 const ignoredWorkspaceDirs = new Set([".git", ".turbo", "build", "dist", "node_modules"])
+const voyantPackageMetadataSchemaVersion = "voyant.package.v1"
+const voyantPackageKinds = new Set(["module", "plugin"])
+const voyantDeploymentModes = new Set(["managed-cloud", "self-hosted", "local"])
 
 export function readPnpmLockfilePackageRecords(options) {
   const repoRoot = options.repoRoot ?? process.cwd()
   const lockfilePath = options.lockfilePath ?? path.join(repoRoot, "pnpm-lock.yaml")
+  const workspacePackageInfo = readWorkspacePackageInfo(repoRoot)
   return packageRecordsFromPnpmLockfile(readFileSync(lockfilePath, "utf8"), {
     packageNames: options.packageNames,
     importerPaths: options.importerPaths,
-    workspacePackageVersions:
-      options.workspacePackageVersions ?? readWorkspacePackageVersions(repoRoot),
+    workspacePackageVersions: options.workspacePackageVersions ?? workspacePackageInfo.versions,
+    workspacePackageMetadata: options.workspacePackageMetadata ?? workspacePackageInfo.metadata,
   })
 }
 
@@ -25,6 +29,11 @@ export function packageRecordsFromPnpmLockfile(lockfileText, options) {
       left.localeCompare(right),
     ),
   )
+  const workspacePackageMetadata = new Map(
+    Object.entries(options.workspacePackageMetadata ?? {})
+      .map(([packageName, metadata]) => [packageName, normalizeVoyantPackageMetadata(metadata)])
+      .filter(([, metadata]) => metadata),
+  )
 
   return [...new Set(options.packageNames)]
     .sort((left, right) => left.localeCompare(right))
@@ -33,18 +42,34 @@ export function packageRecordsFromPnpmLockfile(lockfileText, options) {
         lockfile,
         dependencies: dependencies.get(packageName) ?? [],
         workspacePackageVersions,
+        workspacePackageMetadata,
       }),
     )
 }
 
 export function readWorkspacePackageVersions(repoRoot) {
+  return readWorkspacePackageInfo(repoRoot).versions
+}
+
+export function readWorkspacePackageMetadata(repoRoot) {
+  return readWorkspacePackageInfo(repoRoot).metadata
+}
+
+function readWorkspacePackageInfo(repoRoot) {
   const versions = {}
+  const metadata = {}
   for (const packageJsonPath of listPackageJsonFiles(repoRoot)) {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
-    if (typeof packageJson.name !== "string" || typeof packageJson.version !== "string") continue
-    versions[packageJson.name] = packageJson.version
+    if (typeof packageJson.name !== "string") continue
+    if (typeof packageJson.version === "string") {
+      versions[packageJson.name] = packageJson.version
+    }
+    const packageMetadata = normalizeVoyantPackageMetadata(packageJson.voyant)
+    if (packageMetadata) {
+      metadata[packageJson.name] = packageMetadata
+    }
   }
-  return versions
+  return { versions, metadata }
 }
 
 function packageRecordForPackage(packageName, context) {
@@ -54,44 +79,73 @@ function packageRecordForPackage(packageName, context) {
     context.workspacePackageVersions,
   )
   if (!dependency) {
-    return unknownPackageRecord(packageName, context.workspacePackageVersions.get(packageName))
+    return withPackageMetadata(
+      unknownPackageRecord(packageName, context.workspacePackageVersions.get(packageName)),
+      packageName,
+      context,
+    )
   }
 
   if (isWorkspaceDependency(dependency)) {
-    return {
-      packageName,
-      ...versionField(context.workspacePackageVersions.get(packageName)),
-      source: {
-        kind: "workspace",
-        reference: dependency.version,
+    return withPackageMetadata(
+      {
+        packageName,
+        ...versionField(context.workspacePackageVersions.get(packageName)),
+        source: {
+          kind: "workspace",
+          reference: dependency.version,
+        },
       },
-    }
+      packageName,
+      context,
+    )
   }
 
   if (dependency.version.startsWith("file:")) {
-    return {
+    return withPackageMetadata(
+      {
+        packageName,
+        source: { kind: "file", reference: dependency.version },
+      },
       packageName,
-      source: { kind: "file", reference: dependency.version },
-    }
+      context,
+    )
   }
 
   if (isGitReference(dependency.version)) {
-    return {
+    return withPackageMetadata(
+      {
+        packageName,
+        source: { kind: "git", reference: dependency.version },
+      },
       packageName,
-      source: { kind: "git", reference: dependency.version },
-    }
+      context,
+    )
   }
 
   const version = basePnpmVersion(dependency.version)
   const integrity = context.lockfile?.packages?.[`${packageName}@${version}`]?.resolution?.integrity
-  return {
-    packageName,
-    ...versionField(version),
-    source: {
-      kind: "registry",
-      reference: `pnpm-lock:${packageName}@${dependency.version}`,
-      ...(typeof integrity === "string" ? { integrity } : {}),
+  return withPackageMetadata(
+    {
+      packageName,
+      ...versionField(version),
+      source: {
+        kind: "registry",
+        reference: `pnpm-lock:${packageName}@${dependency.version}`,
+        ...(typeof integrity === "string" ? { integrity } : {}),
+      },
     },
+    packageName,
+    context,
+  )
+}
+
+function withPackageMetadata(record, packageName, context) {
+  const metadata = context.workspacePackageMetadata.get(packageName)
+  if (!metadata) return record
+  return {
+    ...record,
+    metadata,
   }
 }
 
@@ -165,6 +219,104 @@ function isGitReference(value) {
 
 function basePnpmVersion(value) {
   return value.split("(")[0] ?? value
+}
+
+function normalizeVoyantPackageMetadata(value) {
+  if (!isRecord(value)) return undefined
+  if (value.schemaVersion !== voyantPackageMetadataSchemaVersion) return undefined
+  if (!voyantPackageKinds.has(value.kind)) return undefined
+
+  const compatibleWith = normalizeCompatibleWith(value.compatibleWith)
+  const requires = normalizeCapabilityDeclaration(value.requires)
+  return {
+    schemaVersion: voyantPackageMetadataSchemaVersion,
+    kind: value.kind,
+    ...(compatibleWith ? { compatibleWith } : {}),
+    ...(requires ? { requires } : {}),
+  }
+}
+
+function normalizeCompatibleWith(value) {
+  if (!isRecord(value)) return undefined
+
+  const framework = normalizeString(value.framework)
+  const targets = normalizeStringList(value.targets)
+  const modes = normalizeStringList(value.modes, { allowedValues: voyantDeploymentModes })
+  const compatibleWith = {
+    ...(framework ? { framework } : {}),
+    ...(targets ? { targets } : {}),
+    ...(modes ? { modes } : {}),
+  }
+  return Object.keys(compatibleWith).length > 0 ? compatibleWith : undefined
+}
+
+function normalizeCapabilityDeclaration(value) {
+  if (!isRecord(value)) return undefined
+
+  const capabilities = normalizeStringList(value.capabilities)
+  const ports = normalizePorts(value.ports)
+  const declaration = {
+    ...(capabilities ? { capabilities } : {}),
+    ...(ports ? { ports } : {}),
+  }
+  return Object.keys(declaration).length > 0 ? declaration : undefined
+}
+
+function normalizePorts(value) {
+  const entries = Array.isArray(value) ? value : typeof value === "string" ? [value] : []
+  const ports = []
+  const seen = new Set()
+
+  for (const entry of entries) {
+    const port = normalizePort(entry)
+    if (!port || seen.has(port.id)) continue
+    seen.add(port.id)
+    ports.push(port)
+  }
+
+  return ports.length > 0 ? ports : undefined
+}
+
+function normalizePort(value) {
+  if (typeof value === "string") {
+    const id = normalizeString(value)
+    return id ? { id } : undefined
+  }
+
+  if (!isRecord(value)) return undefined
+  const id = normalizeString(value.id)
+  if (!id) return undefined
+  return {
+    id,
+    ...(typeof value.optional === "boolean" ? { optional: value.optional } : {}),
+  }
+}
+
+function normalizeStringList(value, options = {}) {
+  const entries = Array.isArray(value) ? value : typeof value === "string" ? [value] : []
+  const values = []
+  const seen = new Set()
+
+  for (const entry of entries) {
+    const normalized = normalizeString(entry)
+    if (!normalized || options.allowedValues?.has(normalized) === false || seen.has(normalized)) {
+      continue
+    }
+    seen.add(normalized)
+    values.push(normalized)
+  }
+
+  return values.length > 0 ? values : undefined
+}
+
+function normalizeString(value) {
+  if (typeof value !== "string") return undefined
+  const normalized = value.trim()
+  return normalized.length > 0 ? normalized : undefined
+}
+
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
 }
 
 function listPackageJsonFiles(rootDir) {

--- a/scripts/tests/deployment-graph-provenance.test.mjs
+++ b/scripts/tests/deployment-graph-provenance.test.mjs
@@ -1,7 +1,13 @@
 import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
 import { describe, it } from "node:test"
 
-import { packageRecordsFromPnpmLockfile } from "../lib/deployment-graph-provenance.mjs"
+import {
+  packageRecordsFromPnpmLockfile,
+  readPnpmLockfilePackageRecords,
+} from "../lib/deployment-graph-provenance.mjs"
 
 const lockfile = `
 lockfileVersion: '9.0'
@@ -74,6 +80,177 @@ describe("deployment graph package provenance", () => {
       {
         packageName: "@voyant-travel/plugin-netopia",
         source: { kind: "unknown" },
+      },
+    ])
+  })
+
+  it("attaches normalized v1 workspace package metadata and ignores legacy voyant blocks", () => {
+    const records = packageRecordsFromPnpmLockfile(lockfile, {
+      packageNames: [
+        "@voyant-travel/bookings",
+        "@voyant-travel/legacy",
+        "@voyant-travel/plugin-netopia",
+      ],
+      workspacePackageVersions: {
+        "@voyant-travel/bookings": "0.149.0",
+        "@voyant-travel/legacy": "0.1.0",
+      },
+      workspacePackageMetadata: {
+        "@voyant-travel/bookings": {
+          schemaVersion: "voyant.package.v1",
+          kind: "module",
+          compatibleWith: {
+            framework: " ^0.24.0 ",
+            targets: " node ",
+            modes: ["self-hosted", "invalid", 42, "managed-cloud", "self-hosted"],
+          },
+          requires: {
+            capabilities: ["booking.records", "", "booking.records", 42],
+            ports: [
+              "db.transaction",
+              { id: "payment.provider", optional: true },
+              { id: "ignored.optional", optional: "yes" },
+              { id: "" },
+            ],
+          },
+        },
+        "@voyant-travel/legacy": {
+          schema: "./schema",
+          requiresSchemas: ["@voyant-travel/db"],
+        },
+        "@voyant-travel/plugin-netopia": {
+          schemaVersion: "voyant.package.v1",
+          kind: "adapter",
+          compatibleWith: { targets: ["node"] },
+        },
+      },
+    })
+
+    assert.deepEqual(records, [
+      {
+        packageName: "@voyant-travel/bookings",
+        version: "0.149.0",
+        source: { kind: "workspace", reference: "link:../bookings" },
+        metadata: {
+          schemaVersion: "voyant.package.v1",
+          kind: "module",
+          compatibleWith: {
+            framework: "^0.24.0",
+            targets: ["node"],
+            modes: ["self-hosted", "managed-cloud"],
+          },
+          requires: {
+            capabilities: ["booking.records"],
+            ports: [
+              { id: "db.transaction" },
+              { id: "payment.provider", optional: true },
+              { id: "ignored.optional" },
+            ],
+          },
+        },
+      },
+      {
+        packageName: "@voyant-travel/legacy",
+        version: "0.1.0",
+        source: { kind: "unknown" },
+      },
+      {
+        packageName: "@voyant-travel/plugin-netopia",
+        version: "0.105.18",
+        source: {
+          kind: "registry",
+          reference:
+            "pnpm-lock:@voyant-travel/plugin-netopia@0.105.18(@types/pg@8.20.0)(postgres@3.4.9)",
+          integrity: "sha512-netopia",
+        },
+      },
+    ])
+  })
+
+  it("reads v1 voyant package metadata from package.json files", () => {
+    const repoRoot = mkdtempSync(path.join(tmpdir(), "voyant-provenance-"))
+    mkdirSync(path.join(repoRoot, "packages", "v1-module"), { recursive: true })
+    mkdirSync(path.join(repoRoot, "packages", "legacy-module"), { recursive: true })
+    writeFileSync(
+      path.join(repoRoot, "pnpm-lock.yaml"),
+      `
+lockfileVersion: '9.0'
+
+importers:
+  starters/operator:
+    dependencies:
+      '@acme/voyant-loyalty':
+        specifier: workspace:*
+        version: link:../../packages/v1-module
+      '@acme/legacy':
+        specifier: workspace:*
+        version: link:../../packages/legacy-module
+`,
+    )
+    writeFileSync(
+      path.join(repoRoot, "packages", "v1-module", "package.json"),
+      JSON.stringify(
+        {
+          name: "@acme/voyant-loyalty",
+          version: "1.2.3",
+          voyant: {
+            schemaVersion: "voyant.package.v1",
+            kind: "plugin",
+            compatibleWith: {
+              targets: ["node", "voyant-cloud"],
+              modes: "self-hosted",
+            },
+            requires: {
+              capabilities: "identity.people",
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    )
+    writeFileSync(
+      path.join(repoRoot, "packages", "legacy-module", "package.json"),
+      JSON.stringify(
+        {
+          name: "@acme/legacy",
+          version: "0.1.0",
+          voyant: {
+            schema: "./schema",
+            requiresSchemas: ["@voyant-travel/db"],
+          },
+        },
+        null,
+        2,
+      ),
+    )
+
+    const records = readPnpmLockfilePackageRecords({
+      repoRoot,
+      packageNames: ["@acme/legacy", "@acme/voyant-loyalty"],
+    })
+
+    assert.deepEqual(records, [
+      {
+        packageName: "@acme/legacy",
+        version: "0.1.0",
+        source: { kind: "workspace", reference: "link:../../packages/legacy-module" },
+      },
+      {
+        packageName: "@acme/voyant-loyalty",
+        version: "1.2.3",
+        source: { kind: "workspace", reference: "link:../../packages/v1-module" },
+        metadata: {
+          schemaVersion: "voyant.package.v1",
+          kind: "plugin",
+          compatibleWith: {
+            targets: ["node", "voyant-cloud"],
+            modes: ["self-hosted"],
+          },
+          requires: {
+            capabilities: ["identity.people"],
+          },
+        },
       },
     ])
   })


### PR DESCRIPTION
## Summary

- read workspace package `voyant.package.v1` metadata from package.json during deployment graph provenance collection
- ignore legacy `voyant` schema metadata blocks so existing packages do not become graph package metadata accidentally
- normalize compatible targets/modes, required capabilities, and simple port declarations before attaching metadata to package records

## Validation

- `node --test scripts/tests/deployment-graph-provenance.test.mjs`
- `pnpm exec biome check scripts/lib/deployment-graph-provenance.mjs scripts/tests/deployment-graph-provenance.test.mjs`
- `pnpm verify:deployment-graph`
- `pnpm lint:changed`
- `git diff --check`
