### PR TITLE
Dispatch graph workflow schedules

### DIFF
--- a/.changeset/graph-workflow-schedule-dispatch.md
+++ b/.changeset/graph-workflow-schedule-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Carry workflow schedule dispatch metadata through deployment graph scheduled jobs.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -666,6 +666,12 @@ and the operator Cloud Scheduler emitter uses that stable id as the runtime
 dispatch key. Legacy `?cron=<expr>` URLs remain accepted as a compatibility
 fallback for already-provisioned scheduler jobs.
 
+Implementation note: graph-derived workflow schedules carry their `workflowId`
+and optional schedule `input` through `provisioning.scheduledJobs`, so the
+operator scheduled entrypoint can route them through the workflow runtime by
+stable schedule id. Runtime maintenance jobs remain explicit scheduled-job
+metadata.
+
 ## Events And Webhooks
 
 V1 should include subscribers and workflow event filters that already map to

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -215,6 +215,8 @@ describe("deployment graph v1", () => {
           "Triggers workflow daily-rollup from graph schedule @acme/voyant-automation#schedule.daily-rollup.hourly.",
         route: "/__voyant/scheduled",
         module: "@acme/voyant-automation",
+        workflowId: "daily-rollup",
+        input: { kind: "hourly" },
       },
     ])
     expect(graph.diagnostics).toEqual([])

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -160,6 +160,8 @@ export interface VoyantGraphScheduledJob {
   description: string
   route: string
   module: string
+  workflowId?: string
+  input?: VoyantGraphJsonValue
 }
 
 export interface VoyantGraphUnitManifest {
@@ -878,6 +880,8 @@ function normalizeScheduledJobs(
       description: job.description,
       route: job.route,
       module: job.module,
+      ...("workflowId" in job && job.workflowId ? { workflowId: job.workflowId } : {}),
+      ...("input" in job && job.input !== undefined ? { input: job.input } : {}),
     }))
     .sort((left, right) => left.id.localeCompare(right.id))
 }
@@ -896,6 +900,8 @@ function deriveWorkflowScheduledJobs(
             description: `Triggers workflow ${workflow.id} from graph schedule ${schedule.id}.`,
             route: SCHEDULED_JOB_ROUTE,
             module: unit.localId ?? unit.id,
+            workflowId: workflow.id,
+            ...(schedule.input !== undefined ? { input: schedule.input } : {}),
           },
         ]
       }),

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:bd86286a51bcf268a026cd5d19af5770b6560ff0388f92b5106649d7bd5012ae",
+  "graphHash": "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:bd86286a51bcf268a026cd5d19af5770b6560ff0388f92b5106649d7bd5012ae",
+      "graphHash": "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:bd86286a51bcf268a026cd5d19af5770b6560ff0388f92b5106649d7bd5012ae",
+  "contentHash": "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1309,7 +1309,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.29.1"
+      "version": "0.29.2"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",

--- a/starters/operator/src/api/jobs/workflow-scheduled.test.ts
+++ b/starters/operator/src/api/jobs/workflow-scheduled.test.ts
@@ -1,0 +1,128 @@
+import type { WorkflowDriver } from "@voyant-travel/workflows/driver"
+import { describe, expect, it, vi } from "vitest"
+import {
+  type GraphWorkflowScheduledJob,
+  isGraphWorkflowScheduledJob,
+  runScheduledWorkflow,
+} from "./workflow-scheduled"
+
+describe("runScheduledWorkflow", () => {
+  it("triggers graph workflow schedules through the operator workflow driver", async () => {
+    const bootstrapWorkflowBundle = vi.fn()
+    const registerManifestCalls: Parameters<WorkflowDriver["registerManifest"]>[] = []
+    const triggerCalls: unknown[][] = []
+    const driver = {
+      async registerManifest(...args) {
+        registerManifestCalls.push(args)
+        return { versionId: args[0].manifest.versionId }
+      },
+      async trigger(workflowId, ...args) {
+        triggerCalls.push([workflowId, ...args])
+        return {
+          id: "run_1",
+          workflowId: String(workflowId),
+          status: "queued",
+          startedAt: 1,
+        }
+      },
+      ingestEvent: vi.fn(),
+      getManifest: vi.fn(),
+    } satisfies WorkflowDriver
+    const job: GraphWorkflowScheduledJob = {
+      id: "@voyant-travel/operator#schedule.notifications.send-due-reminders.hourly",
+      cron: "0 * * * *",
+      description: "Triggers due reminders.",
+      route: "/__voyant/scheduled",
+      module: "operator",
+      workflowId: "notifications.send-due-reminders",
+      input: { now: "2026-07-10T05:30:00.000Z" },
+    }
+
+    await runScheduledWorkflow(
+      job,
+      {
+        scheduleId: job.id,
+        cron: job.cron,
+        scheduledTime: Date.parse("2026-07-10T05:30:45.000Z"),
+      },
+      {
+        VOYANT_CLOUD_APP_SLUG: "operator",
+        VOYANT_CLOUD_ENVIRONMENT: "production",
+      } as AppBindings,
+      {
+        importWorkflowBundle: async () => ({ bootstrapWorkflowBundle }),
+        createWorkflowDriver: () => () => driver,
+        listRegisteredWorkflows: () => [
+          {
+            id: "notifications.send-due-reminders",
+            config: {
+              id: "notifications.send-due-reminders",
+              defaultRuntime: "node",
+              schedule: { cron: "0 * * * *" },
+              async run() {
+                return {}
+              },
+            },
+          },
+        ],
+        listEventFilters: () => [],
+      },
+    )
+
+    expect(bootstrapWorkflowBundle).toHaveBeenCalledWith({
+      env: expect.objectContaining({ VOYANT_CLOUD_APP_SLUG: "operator" }),
+    })
+    expect(registerManifestCalls).toEqual([
+      [
+        {
+          environment: "production",
+          manifest: expect.objectContaining({
+            projectId: "operator",
+            workflows: [
+              expect.objectContaining({
+                id: "notifications.send-due-reminders",
+              }),
+            ],
+          }),
+        },
+      ],
+    ])
+    expect(triggerCalls).toEqual([
+      [
+        "notifications.send-due-reminders",
+        { now: "2026-07-10T05:30:00.000Z" },
+        {
+          environment: "production",
+          idempotencyKey:
+            "scheduled:@voyant-travel/operator#schedule.notifications.send-due-reminders.hourly:1783661445000",
+          tags: [
+            "scheduled",
+            "schedule:@voyant-travel/operator#schedule.notifications.send-due-reminders.hourly",
+          ],
+        },
+      ],
+    ])
+  })
+
+  it("detects graph workflow schedule jobs by workflowId", () => {
+    expect(
+      isGraphWorkflowScheduledJob({
+        id: "hourly",
+        cron: "0 * * * *",
+        description: "Hourly",
+        route: "/__voyant/scheduled",
+        module: "operator",
+        workflowId: "workflow.hourly",
+      }),
+    ).toBe(true)
+    expect(
+      isGraphWorkflowScheduledJob({
+        id: "outbox-drain",
+        cron: "*/2 * * * *",
+        description: "Outbox",
+        route: "/__voyant/scheduled",
+        module: "framework",
+      }),
+    ).toBe(false)
+  })
+})

--- a/starters/operator/src/api/jobs/workflow-scheduled.ts
+++ b/starters/operator/src/api/jobs/workflow-scheduled.ts
@@ -1,0 +1,116 @@
+import { __listRegisteredWorkflows } from "@voyant-travel/workflows"
+import type { DriverFactoryDeps, WorkflowDriver } from "@voyant-travel/workflows/driver"
+import { buildManifest, getEventFilterRegistry } from "@voyant-travel/workflows/events"
+import type { CronJob } from "../../scheduled-crons"
+import { createOperatorWorkflowDriver } from "../runtime/operator-runtime-adapter"
+
+type WorkflowEnvironment = "production" | "preview" | "development"
+type RegisteredWorkflow = ReturnType<typeof __listRegisteredWorkflows>[number]
+
+interface WorkflowBundleModule {
+  bootstrapWorkflowBundle?: (ctx?: { env?: NodeJS.ProcessEnv }) => Promise<void> | void
+}
+
+interface ScheduledWorkflowRuntimeDeps {
+  importWorkflowBundle?: () => Promise<WorkflowBundleModule>
+  createWorkflowDriver?: typeof createOperatorWorkflowDriver
+  listRegisteredWorkflows?: () => readonly RegisteredWorkflow[]
+  listEventFilters?: () => ReturnType<typeof getEventFilterRegistry>["list"] extends () => infer T
+    ? T
+    : never
+  buildWorkflowManifest?: typeof buildManifest
+  factoryDeps?: DriverFactoryDeps
+  now?: () => number
+}
+
+export type GraphWorkflowScheduledJob = CronJob & { workflowId: string }
+
+export function isGraphWorkflowScheduledJob(job: CronJob): job is GraphWorkflowScheduledJob {
+  return typeof job.workflowId === "string" && job.workflowId.length > 0
+}
+
+export async function runScheduledWorkflow(
+  job: GraphWorkflowScheduledJob,
+  event: ScheduledController,
+  env: AppBindings,
+  deps: ScheduledWorkflowRuntimeDeps = {},
+): Promise<void> {
+  const importWorkflowBundle = deps.importWorkflowBundle ?? (() => import("../../workflows"))
+  const workflowBundle = await importWorkflowBundle()
+  await workflowBundle.bootstrapWorkflowBundle?.({ env: workflowBundleEnv(env) })
+
+  const environment = resolveWorkflowEnvironment(env)
+  const driver = createWorkflowDriver(env, deps)
+  const workflows = (deps.listRegisteredWorkflows ?? __listRegisteredWorkflows)().map(
+    (workflow) => ({
+      id: workflow.id,
+      config: workflow.config,
+    }),
+  )
+  const eventFilters = deps.listEventFilters?.() ?? getEventFilterRegistry().list()
+  const manifest = await (deps.buildWorkflowManifest ?? buildManifest)({
+    projectId: env.VOYANT_CLOUD_APP_SLUG ?? "operator",
+    environment,
+    workflows,
+    eventFilters,
+  })
+
+  await driver.registerManifest({ environment, manifest })
+  await driver.trigger(job.workflowId, job.input ?? {}, {
+    environment,
+    idempotencyKey: scheduledWorkflowIdempotencyKey(job, event, deps.now),
+    tags: ["scheduled", `schedule:${job.id}`],
+  })
+}
+
+function createWorkflowDriver(
+  env: AppBindings,
+  deps: ScheduledWorkflowRuntimeDeps,
+): WorkflowDriver {
+  const factory = (deps.createWorkflowDriver ?? createOperatorWorkflowDriver)(env)
+  return factory(deps.factoryDeps ?? DEFAULT_DRIVER_FACTORY_DEPS)
+}
+
+const EMPTY_SERVICE_RESOLVER: DriverFactoryDeps["services"] = {
+  resolve(name) {
+    throw new Error(
+      `[scheduled-workflow] service "${name}" is unavailable outside the API app runtime`,
+    )
+  },
+  has() {
+    return false
+  },
+}
+
+const DEFAULT_DRIVER_FACTORY_DEPS: DriverFactoryDeps = {
+  services: EMPTY_SERVICE_RESOLVER,
+  logger(level, msg, data) {
+    const method =
+      level === "error" ? console.error : level === "warn" ? console.warn : console.info
+    if (data !== undefined) method(`[scheduled-workflow] ${msg}`, data)
+    else method(`[scheduled-workflow] ${msg}`)
+  },
+}
+
+function resolveWorkflowEnvironment(env: AppBindings): WorkflowEnvironment {
+  const value = env.VOYANT_CLOUD_ENVIRONMENT
+  if (value === "production" || value === "preview" || value === "development") return value
+  return "development"
+}
+
+function workflowBundleEnv(env: AppBindings): NodeJS.ProcessEnv {
+  const out: NodeJS.ProcessEnv = { ...process.env }
+  for (const [key, value] of Object.entries(env)) {
+    if (typeof value === "string") out[key] = value
+  }
+  return out
+}
+
+function scheduledWorkflowIdempotencyKey(
+  job: GraphWorkflowScheduledJob,
+  event: ScheduledController,
+  now: (() => number) | undefined,
+): string {
+  const scheduledTime = event.scheduledTime ?? now?.() ?? Date.now()
+  return `scheduled:${job.id}:${scheduledTime}`
+}

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -130,6 +130,40 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     ])
   })
 
+  it("loads graph-derived workflow schedule metadata for dispatch", () => {
+    const root = fixtureRoot()
+    writeFixture(root, {
+      provisioning: {
+        scheduledJobs: [
+          {
+            id: "@voyant-travel/operator#schedule.notifications.send-due-reminders.hourly",
+            cron: "0 * * * *",
+            description: "Triggers due reminders.",
+            route: "/__voyant/scheduled",
+            module: "operator",
+            workflowId: "notifications.send-due-reminders",
+            input: { now: "2026-07-10T05:30:00.000Z" },
+          },
+        ],
+      },
+    })
+    const summary = loadOperatorDeploymentGraphArtifacts(
+      pathToFileURL(join(root, "src", "server.ts")).href,
+    )
+
+    expect(summary.scheduledJobs).toEqual([
+      {
+        id: "@voyant-travel/operator#schedule.notifications.send-due-reminders.hourly",
+        cron: "0 * * * *",
+        description: "Triggers due reminders.",
+        route: "/__voyant/scheduled",
+        module: "operator",
+        workflowId: "notifications.send-due-reminders",
+        input: { now: "2026-07-10T05:30:00.000Z" },
+      },
+    ])
+  })
+
   it("loads graph-derived deployment providers for runtime binding selection", () => {
     const root = fixtureRoot()
     writeFixture(root, {
@@ -419,6 +453,8 @@ interface FixtureDeploymentGraph {
       description: string
       route?: string
       module: string
+      workflowId?: string
+      input?: unknown
     }>
   }
 }

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -30,6 +30,8 @@ export interface OperatorDeploymentGraphScheduledJob {
   description: string
   route: string
   module: string
+  workflowId?: string
+  input?: unknown
 }
 
 export interface OperatorDeploymentGraphResourceRequirement {
@@ -280,6 +282,8 @@ function collectScheduledJobs(value: unknown): OperatorDeploymentGraphScheduledJ
       job.module,
       `deployment graph provisioning.scheduledJobs[${index}].module`,
     ),
+    ...(typeof job.workflowId === "string" ? { workflowId: job.workflowId } : {}),
+    ...(Object.hasOwn(job, "input") ? { input: job.input } : {}),
   }))
 }
 

--- a/starters/operator/src/entry.ts
+++ b/starters/operator/src/entry.ts
@@ -37,6 +37,27 @@ export async function scheduled(
   }
   const scheduledEvent = { ...dispatchKey, cron: job.cron }
 
+  if (job.workflowId) {
+    ctx.waitUntil(
+      import("./api/jobs/workflow-scheduled")
+        .then((mod) => {
+          if (!mod.isGraphWorkflowScheduledJob(job)) {
+            throw new Error(`[scheduled] invalid workflow schedule ${job.id}`)
+          }
+          return mod.runScheduledWorkflow(job, scheduledEvent, env)
+        })
+        .then((result) => {
+          console.info("[scheduled-workflow] triggered", {
+            scheduleId: job.id,
+            workflowId: job.workflowId,
+          })
+          return result
+        })
+        .catch((err) => reportBackgroundFailure("scheduled-workflow", err)),
+    )
+    return
+  }
+
   if (job.id === "outbox-drain") {
     ctx.waitUntil(
       import("./api/jobs/outbox-drain-scheduled")

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,7 +4,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:bd86286a51bcf268a026cd5d19af5770b6560ff0388f92b5106649d7bd5012ae" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const

--- a/starters/operator/src/scheduled-crons.test.ts
+++ b/starters/operator/src/scheduled-crons.test.ts
@@ -4,6 +4,7 @@ import { loadOperatorDeploymentGraphArtifacts } from "./deployment-graph-artifac
 import {
   CHANNEL_PUSH_AVAILABILITY_CRON,
   OUTBOX_DRAIN_CRON,
+  resolveCronJobFromJobs,
   resolveOperatorCronJob,
 } from "./scheduled-crons"
 
@@ -30,6 +31,33 @@ describe("resolveOperatorCronJob", () => {
   it("returns undefined for unknown schedule dispatch keys", () => {
     expect(resolveOperatorCronJob({ scheduleId: "missing-job" })).toBeUndefined()
     expect(resolveOperatorCronJob({ cron: "1 2 3 4 5" })).toBeUndefined()
+  })
+
+  it("preserves graph workflow schedule dispatch metadata", () => {
+    expect(
+      resolveCronJobFromJobs(
+        { scheduleId: "@voyant-travel/operator#schedule.notifications.hourly" },
+        [
+          {
+            id: "@voyant-travel/operator#schedule.notifications.hourly",
+            cron: "0 * * * *",
+            description: "Triggers notifications.",
+            route: "/__voyant/scheduled",
+            module: "operator",
+            workflowId: "notifications.send-due-reminders",
+            input: { now: "2026-07-10T05:30:00.000Z" },
+          },
+        ],
+      ),
+    ).toEqual({
+      id: "@voyant-travel/operator#schedule.notifications.hourly",
+      cron: "0 * * * *",
+      description: "Triggers notifications.",
+      route: "/__voyant/scheduled",
+      module: "operator",
+      workflowId: "notifications.send-due-reminders",
+      input: { now: "2026-07-10T05:30:00.000Z" },
+    })
   })
 
   it("can dispatch every graph-derived scheduled job", () => {

--- a/starters/operator/src/scheduled-crons.ts
+++ b/starters/operator/src/scheduled-crons.ts
@@ -2,16 +2,11 @@
 // for the operator's scheduled work: `entry.ts` `scheduled()` resolves them, and
 // `scripts/emit-cloud-scheduler.ts` fans them out to Cloud Scheduler jobs that
 // POST `/__voyant/scheduled?schedule=<id>&cron=<expr>` on the Node runtime.
-//
-// The STANDARD job set is now owned by the framework and derived from the
-// composed module set (voyant#3032) — `@voyant-travel/framework/managed-jobs` —
-// so the operator and a source-free managed deployment provision the same jobs
-// from one source. The operator appends only its deployment-local jobs (the
-// external cruise refresh, since `@voyant-travel/cruises` is not a standard
-// framework module).
 
-import { STANDARD_OPERATOR_SCHEDULED_JOBS } from "@voyant-travel/framework/managed-jobs"
-import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "./local-scheduled-jobs"
+import {
+  loadOperatorDeploymentGraphArtifacts,
+  type OperatorDeploymentGraphScheduledJob,
+} from "./deployment-graph-artifacts"
 
 /** One scheduled job: a stable id, its cron expression, and what it does. */
 export interface CronJob {
@@ -21,18 +16,24 @@ export interface CronJob {
   cron: string
   /** Human-readable description of the work this trigger drives. */
   description: string
+  route: string
+  module: string
+  workflowId?: string
+  input?: unknown
 }
 
+const GRAPH_OPERATOR_CRON_JOBS = loadOperatorDeploymentGraphArtifacts().scheduledJobs
+
 function standardCron(id: string): string {
-  const job = STANDARD_OPERATOR_SCHEDULED_JOBS.find((entry) => entry.id === id)
+  const job = GRAPH_OPERATOR_CRON_JOBS.find((entry) => entry.id === id)
   if (!job) {
-    throw new Error(`[scheduled-crons] unknown standard framework scheduled job "${id}".`)
+    throw new Error(`[scheduled-crons] unknown graph scheduled job "${id}".`)
   }
   return job.cron
 }
 
 // The cron expressions `entry.ts` `scheduled()` dispatches on. Sourced from the
-// framework's standard job set so the dispatch and the emitted Cloud Scheduler
+// generated deployment graph so the dispatch and the emitted Cloud Scheduler
 // jobs can never drift.
 export const CHANNEL_PUSH_BOOKING_LINK_CRON = standardCron("channel-push-booking-link")
 export const CHANNEL_PUSH_AVAILABILITY_CRON = standardCron("channel-push-availability")
@@ -42,19 +43,22 @@ export const PROMOTION_BOUNDARY_SCHEDULER_CRON = standardCron("promotion-boundar
 export const OUTBOX_DRAIN_CRON = standardCron("outbox-drain")
 
 /**
- * The full set of scheduled jobs, in declaration order: the framework's
- * standard set (from the composed module set) plus the operator's
- * deployment-local jobs. Consumed by the Cloud Scheduler emitter; kept in sync
- * with `entry.ts` `scheduled()` dispatch by the shared cron constants above.
+ * The full set of scheduled jobs, in generated graph order. Consumed by the
+ * Cloud Scheduler emitter and by `entry.ts` `scheduled()` dispatch.
  */
-export const OPERATOR_CRON_JOBS: readonly CronJob[] = [
-  ...STANDARD_OPERATOR_SCHEDULED_JOBS.map(
-    ({ id, cron, description }): CronJob => ({ id, cron, description }),
-  ),
-  ...OPERATOR_LOCAL_SCHEDULED_JOBS.map(
-    ({ id, cron, description }): CronJob => ({ id, cron, description }),
-  ),
-]
+export const OPERATOR_CRON_JOBS: readonly CronJob[] = GRAPH_OPERATOR_CRON_JOBS.map(toCronJob)
+
+function toCronJob(job: OperatorDeploymentGraphScheduledJob): CronJob {
+  return {
+    id: job.id,
+    cron: job.cron,
+    description: job.description,
+    route: job.route,
+    module: job.module,
+    ...(job.workflowId ? { workflowId: job.workflowId } : {}),
+    ...(Object.hasOwn(job, "input") ? { input: job.input } : {}),
+  }
+}
 
 export interface ScheduledDispatchKey {
   cron?: string
@@ -62,11 +66,15 @@ export interface ScheduledDispatchKey {
 }
 
 export function resolveOperatorCronJob(event: ScheduledDispatchKey) {
+  return resolveCronJobFromJobs(event, OPERATOR_CRON_JOBS)
+}
+
+export function resolveCronJobFromJobs(event: ScheduledDispatchKey, jobs: readonly CronJob[]) {
   if (event.scheduleId) {
-    return OPERATOR_CRON_JOBS.find((job) => job.id === event.scheduleId)
+    return jobs.find((job) => job.id === event.scheduleId)
   }
   if (event.cron) {
-    return OPERATOR_CRON_JOBS.find((job) => job.cron === event.cron)
+    return jobs.find((job) => job.cron === event.cron)
   }
   return undefined
 }


### PR DESCRIPTION
## Summary

- carry `workflowId` and optional schedule `input` from graph workflow schedules into `provisioning.scheduledJobs`
- make the operator scheduled dispatch table read generated graph artifacts instead of static scheduled-job lists
- route graph-derived workflow schedule jobs through the operator workflow driver by stable schedule id

## Verification

- `pnpm --filter @voyant-travel/framework test -- src/deployment-graph.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts src/scheduled-crons.test.ts src/api/jobs/workflow-scheduled.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:deployment-graph`
- `pnpm lint:changed`
- `git diff --check`
- pre-push `pnpm test`
