### PR TITLE
Declare operator workflow schedules in graph

### DIFF
--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -672,6 +672,13 @@ operator scheduled entrypoint can route them through the workflow runtime by
 stable schedule id. Runtime maintenance jobs remain explicit scheduled-job
 metadata.
 
+Implementation note: the source-backed operator starter declares its local
+workflow bundle as `@voyant-travel/operator#workflows`, including scheduled
+workflow descriptors for booking hold expiry and due notification reminders.
+Those schedules are provisioned from the graph like package-owned workflow
+schedules, while the workflow handler bodies remain in the operator workflow
+bundle.
+
 ## Events And Webhooks
 
 V1 should include subscribers and workflow event filters that already map to

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -131,6 +131,22 @@ async function main(): Promise<void> {
   for (const id of OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_IDS) {
     if (!operatorModuleIds.has(id)) failures.push(`expected operator graph to include ${id}`)
   }
+  const operatorWorkflowModule = operatorGraph.modules.find(
+    (unit) => unit.id === "@voyant-travel/operator#workflows",
+  )
+  const operatorWorkflowIds = new Set(operatorWorkflowModule?.workflows?.map((entry) => entry.id))
+  for (const workflowId of ["bookings.expire-stale-holds", "notifications.send-due-reminders"]) {
+    if (!operatorWorkflowIds.has(workflowId)) {
+      failures.push(`expected operator workflow graph module to include ${workflowId}`)
+    }
+    if (
+      !operatorGraph.provisioning?.scheduledJobs?.some(
+        (job) => job.workflowId === workflowId && job.id.includes(`#workflows.schedule.`),
+      )
+    ) {
+      failures.push(`expected operator graph provisioning to schedule ${workflowId}`)
+    }
+  }
   for (const id of OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_IDS) {
     if (!operatorModuleIds.has(id)) {
       failures.push(`expected operator graph to include schema-only module ${id}`)
@@ -187,9 +203,15 @@ async function main(): Promise<void> {
 }
 
 async function readOperatorGeneratedGraph(): Promise<{
-  modules: Array<{ id: string }>
+  modules: Array<{
+    id: string
+    workflows?: Array<{ id: string }>
+  }>
   plugins: Array<{ id: string }>
   packageRecords: Array<{ packageName: string }>
+  provisioning?: {
+    scheduledJobs?: Array<{ id: string; workflowId?: string }>
+  }
 }> {
   return JSON.parse(
     await readFile(
@@ -197,9 +219,15 @@ async function readOperatorGeneratedGraph(): Promise<{
       "utf8",
     ),
   ) as {
-    modules: Array<{ id: string }>
+    modules: Array<{
+      id: string
+      workflows?: Array<{ id: string }>
+    }>
     plugins: Array<{ id: string }>
     packageRecords: Array<{ packageName: string }>
+    provisioning?: {
+      scheduledJobs?: Array<{ id: string; workflowId?: string }>
+    }
   }
 }
 

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0",
+  "graphHash": "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0",
+      "graphHash": "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0",
+  "contentHash": "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1026,6 +1026,82 @@
       "workflows": []
     },
     {
+      "api": [],
+      "events": [],
+      "id": "@voyant-travel/operator#workflows",
+      "kind": "module",
+      "links": [],
+      "localId": "operator.workflows",
+      "migrations": [],
+      "order": 33,
+      "packageName": "@voyant-travel/operator",
+      "provides": {
+        "capabilities": [],
+        "ports": []
+      },
+      "requires": {
+        "capabilities": [],
+        "ports": []
+      },
+      "schema": [],
+      "subscribers": [],
+      "workflows": [
+        {
+          "config": {
+            "defaultRuntime": "node",
+            "schedule": {
+              "cron": "*/5 * * * *",
+              "name": "every-5-minutes"
+            }
+          },
+          "id": "bookings.expire-stale-holds",
+          "schedules": [
+            {
+              "cron": "*/5 * * * *",
+              "id": "@voyant-travel/operator#workflows.schedule.bookings.expire-stale-holds.every-5-minutes",
+              "name": "every-5-minutes",
+              "workflowId": "bookings.expire-stale-holds"
+            }
+          ]
+        },
+        {
+          "config": {
+            "defaultRuntime": "node",
+            "retry": {
+              "backoff": "exponential",
+              "max": 3,
+              "maxDelay": "300s"
+            }
+          },
+          "id": "notifications.deliver-reminder"
+        },
+        {
+          "config": {
+            "defaultRuntime": "node",
+            "schedule": {
+              "cron": "0 * * * *",
+              "name": "hourly"
+            }
+          },
+          "id": "notifications.send-due-reminders",
+          "schedules": [
+            {
+              "cron": "0 * * * *",
+              "id": "@voyant-travel/operator#workflows.schedule.notifications.send-due-reminders.hourly",
+              "name": "hourly",
+              "workflowId": "notifications.send-due-reminders"
+            }
+          ]
+        },
+        {
+          "config": {
+            "defaultRuntime": "node"
+          },
+          "id": "products.generate-pdf"
+        }
+      ]
+    },
+    {
       "api": [
         {
           "id": "@voyant-travel/public-document-delivery#api",
@@ -1039,7 +1115,7 @@
       "links": [],
       "localId": "public-document-delivery",
       "migrations": [],
-      "order": 33,
+      "order": 34,
       "packageName": "@voyant-travel/public-document-delivery",
       "provides": {
         "capabilities": [],
@@ -1067,7 +1143,7 @@
       "links": [],
       "localId": "quotes",
       "migrations": [],
-      "order": 34,
+      "order": 35,
       "packageName": "@voyant-travel/quotes",
       "provides": {
         "capabilities": [],
@@ -1095,7 +1171,7 @@
       "links": [],
       "localId": "relationships",
       "migrations": [],
-      "order": 35,
+      "order": 36,
       "packageName": "@voyant-travel/relationships",
       "provides": {
         "capabilities": [],
@@ -1121,7 +1197,7 @@
           "id": "@voyant-travel/storefront#migrations"
         }
       ],
-      "order": 36,
+      "order": 37,
       "packageName": "@voyant-travel/storefront",
       "provides": {
         "capabilities": [],
@@ -1153,7 +1229,7 @@
       "links": [],
       "localId": "trips",
       "migrations": [],
-      "order": 37,
+      "order": 38,
       "packageName": "@voyant-travel/trips",
       "provides": {
         "capabilities": [],
@@ -1179,7 +1255,7 @@
           "id": "@voyant-travel/workflow-runs#migrations"
         }
       ],
-      "order": 38,
+      "order": 39,
       "packageName": "@voyant-travel/workflow-runs",
       "provides": {
         "capabilities": [],
@@ -1883,6 +1959,22 @@
   },
   "provisioning": {
     "scheduledJobs": [
+      {
+        "cron": "*/5 * * * *",
+        "description": "Triggers workflow bookings.expire-stale-holds from graph schedule @voyant-travel/operator#workflows.schedule.bookings.expire-stale-holds.every-5-minutes.",
+        "id": "@voyant-travel/operator#workflows.schedule.bookings.expire-stale-holds.every-5-minutes",
+        "module": "operator.workflows",
+        "route": "/__voyant/scheduled",
+        "workflowId": "bookings.expire-stale-holds"
+      },
+      {
+        "cron": "0 * * * *",
+        "description": "Triggers workflow notifications.send-due-reminders from graph schedule @voyant-travel/operator#workflows.schedule.notifications.send-due-reminders.hourly.",
+        "id": "@voyant-travel/operator#workflows.schedule.notifications.send-due-reminders.hourly",
+        "module": "operator.workflows",
+        "route": "/__voyant/scheduled",
+        "workflowId": "notifications.send-due-reminders"
+      },
       {
         "cron": "0 * * * *",
         "description": "Channel-push availability reconciler (hourly).",

--- a/starters/operator/deployment-graph.local.ts
+++ b/starters/operator/deployment-graph.local.ts
@@ -10,6 +10,7 @@ import {
 import { moduleIdFromSpecifier } from "../../packages/framework/src/profile-types.ts"
 
 export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS = [
+  "operator/workflows",
   "operator/invitations",
   "operator/team",
   "operator/cruises",
@@ -43,6 +44,7 @@ export const OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_IDS =
 
 export const OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST = {
   modules: [
+    operatorWorkflowBundleModule(),
     localModule("operator/invitations", [
       { surface: "admin" },
       { surface: "public", anonymous: true },
@@ -92,6 +94,50 @@ function localPlugin(
     packageName: packageNameFromSpecifier(specifier),
     localId: moduleIdFromSpecifier(specifier),
     api: routeBundles(id, specifier, api),
+    meta: { source: "operator-local" },
+  })
+}
+
+function operatorWorkflowBundleModule(): VoyantGraphUnitManifest {
+  const specifier = "operator/workflows"
+  const id = graphIdFromSpecifier(specifier)
+  return defineModule({
+    id,
+    packageName: packageNameFromSpecifier(specifier),
+    localId: moduleIdFromSpecifier(specifier),
+    workflows: [
+      {
+        id: "products.generate-pdf",
+        config: {
+          defaultRuntime: "node",
+        },
+      },
+      {
+        id: "bookings.expire-stale-holds",
+        config: {
+          defaultRuntime: "node",
+          schedule: { cron: "*/5 * * * *", name: "every-5-minutes" },
+        },
+      },
+      {
+        id: "notifications.deliver-reminder",
+        config: {
+          defaultRuntime: "node",
+          retry: {
+            max: 3,
+            backoff: "exponential",
+            maxDelay: "300s",
+          },
+        },
+      },
+      {
+        id: "notifications.send-due-reminders",
+        config: {
+          defaultRuntime: "node",
+          schedule: { cron: "0 * * * *", name: "hourly" },
+        },
+      },
+    ],
     meta: { source: "operator-local" },
   })
 }

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -36,6 +36,20 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
       "database:postgres",
     )
     expect(summary.scheduledJobs.map((job) => job.id)).toContain("external-cruise-catalog-refresh")
+    expect(summary.scheduledJobs).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "@voyant-travel/operator#workflows.schedule.bookings.expire-stale-holds.every-5-minutes",
+          cron: "*/5 * * * *",
+          workflowId: "bookings.expire-stale-holds",
+        }),
+        expect.objectContaining({
+          id: "@voyant-travel/operator#workflows.schedule.notifications.send-due-reminders.hourly",
+          cron: "0 * * * *",
+          workflowId: "notifications.send-due-reminders",
+        }),
+      ]),
+    )
   })
 
   it("fails when the artifact graph hash does not match the graph content hash", () => {

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,7 +4,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:339550f7938d98d5a93aef8be863cd33c521a22980f8dbf86fa61f4cda66a7d0" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const
@@ -44,6 +44,7 @@ export const GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS = [
   "@voyant-travel/operator#payment-link",
   "@voyant-travel/operator#realtime",
   "@voyant-travel/operator#team",
+  "@voyant-travel/operator#workflows",
   "@voyant-travel/public-document-delivery",
   "@voyant-travel/quotes",
   "@voyant-travel/relationships",


### PR DESCRIPTION
## Summary
- declare the operator workflow bundle as the operator-local graph module `@voyant-travel/operator#workflows`
- add manifest-only workflow descriptors for operator workflows, with stable schedule names for booking hold expiry and due notification reminders
- regenerate operator deployment graph artifacts and pin the workflow schedule provisioning in graph checks/tests

## Verification
- `pnpm verify:deployment-graph`
- `pnpm --filter operator test -- src/scheduled-crons.test.ts src/api/jobs/workflow-scheduled.test.ts src/deployment-graph-artifacts.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator graph:check`
- `pnpm lint:changed`
- `git diff --check`
- pre-commit affected lint/build/typecheck
- pre-push `pnpm test`