### PR TITLE
Refresh operator graph artifacts

### DIFF
--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07",
+  "graphHash": "sha256:36248162ea2a96b48ec42e9aaaf511cc9c1cad47586114a9130e598f8a37801f",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07",
+      "graphHash": "sha256:36248162ea2a96b48ec42e9aaaf511cc9c1cad47586114a9130e598f8a37801f",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07",
+  "contentHash": "sha256:36248162ea2a96b48ec42e9aaaf511cc9c1cad47586114a9130e598f8a37801f",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1385,7 +1385,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.29.2"
+      "version": "0.29.3"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,7 +4,7 @@
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:56062c2d62a4459d273f1bef99cf3abd64ffb7beeef2097e83099181bec18b07" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:36248162ea2a96b48ec42e9aaaf511cc9c1cad47586114a9130e598f8a37801f" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary
- regenerate operator deployment graph artifacts after the framework package version changed
- update the resolved graph hash and runtime entry metadata so `graph:check` passes on `main`

## Verification
- `pnpm verify:deployment-graph`
- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts src/scheduled-crons.test.ts src/api/jobs/workflow-scheduled.test.ts`
- pre-commit affected lint/build/typecheck
- pre-push `pnpm test`