### PR TITLE
Carry migration sources in graph artifacts

### DIFF
--- a/.changeset/graph-migration-source-artifacts.md
+++ b/.changeset/graph-migration-source-artifacts.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Add package-backed migration source metadata to deployment artifact manifests so
+deployment graph artifact consumers can validate the schema-manifest migration
+closure against graph package records.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -796,6 +796,14 @@ manifest. This is the bridge that keeps D.2 package-owned migration discovery
 and deployment-graph lowering from drifting while richer per-migration entity
 generation lands.
 
+The source-backed operator deployment artifact manifest also records the
+package-backed migration source list derived from
+`drizzle.schemas.generated.ts`. Runtime migration execution consumes that
+validated artifact list, then still uses the D.2 collector to resolve package
+migration folders and apply the deployment-local migration source last. Graph
+artifact validation rejects sources that are not represented in graph package
+records.
+
 The operator graph now also lowers the first declarative workflow/event-filter
 pair from first-party metadata: commerce contributes
 `promotions.reindex-all-products`, the `promotion.changed` event, and the

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -63,6 +63,12 @@ describe("deployment graph artifacts", () => {
         graph,
         graphArtifactPath: "deployment-graph.generated.json",
         runtimeEntries: [entry],
+        migrationSources: [
+          {
+            packageName: "@acme/voyant-loyalty",
+            schema: "../../node_modules/@acme/voyant-loyalty/dist/schema.js",
+          },
+        ],
       }),
     ).toEqual({
       schemaVersion: VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION,
@@ -76,6 +82,12 @@ describe("deployment graph artifacts", () => {
           graphHash: graph.contentHash,
           kind: "managed-profile-node",
           profileSnapshot: "managed-profile.json",
+        },
+      ],
+      migrationSources: [
+        {
+          packageName: "@acme/voyant-loyalty",
+          schema: "../../node_modules/@acme/voyant-loyalty/dist/schema.js",
         },
       ],
     })

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -15,17 +15,24 @@ export interface VoyantDeploymentRuntimeEntryArtifact {
   profileSnapshot: string
 }
 
+export interface VoyantDeploymentMigrationSourceArtifact {
+  packageName: string
+  schema: string
+}
+
 export interface VoyantDeploymentArtifactManifest {
   schemaVersion: typeof VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION
   graphHash: string
   graph: string
   runtimeEntries: readonly VoyantDeploymentRuntimeEntryArtifact[]
+  migrationSources: readonly VoyantDeploymentMigrationSourceArtifact[]
 }
 
 export interface BuildDeploymentArtifactManifestInput {
   graph: ResolvedVoyantDeploymentGraph
   graphArtifactPath: string
   runtimeEntries: readonly VoyantDeploymentRuntimeEntryArtifact[]
+  migrationSources?: readonly VoyantDeploymentMigrationSourceArtifact[]
 }
 
 export interface BuildManagedNodeRuntimeEntryArtifactInput {
@@ -67,6 +74,7 @@ export function buildDeploymentArtifactManifest(
     runtimeEntries: [...input.runtimeEntries].sort((left, right) =>
       left.id.localeCompare(right.id),
     ),
+    migrationSources: normalizeMigrationSources(input.migrationSources ?? []),
   }
 }
 
@@ -138,6 +146,15 @@ function formatConstArray(values: readonly string[]): string {
 
 function quote(value: string | VoyantProjectDeploymentMode | undefined): string {
   return JSON.stringify(value ?? null)
+}
+
+function normalizeMigrationSources(
+  migrationSources: readonly VoyantDeploymentMigrationSourceArtifact[],
+): VoyantDeploymentMigrationSourceArtifact[] {
+  return migrationSources.map((source) => {
+    assertRelativeArtifactPath(source.schema, `migration source "${source.packageName}" schema`)
+    return { packageName: source.packageName, schema: source.schema }
+  })
 }
 
 function assertRelativeArtifactPath(value: string, label: string): void {

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -85,6 +85,7 @@ async function main(): Promise<void> {
         profileSnapshot: "managed-profile.json",
       }),
     ],
+    migrationSources: operatorMigrationSources(),
   })
   if (artifactManifest.schemaVersion !== VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION) {
     failures.push("expected deployment artifact manifest schema version v1")
@@ -94,6 +95,15 @@ async function main(): Promise<void> {
   }
   if (artifactManifest.runtimeEntries[0]?.graphHash !== first.contentHash) {
     failures.push("expected runtime entry artifact to reference the resolved graph hash")
+  }
+  const artifactMigrationSourcePackageNames = artifactManifest.migrationSources.map(
+    (source) => source.packageName,
+  )
+  if (
+    JSON.stringify(artifactMigrationSourcePackageNames) !==
+    JSON.stringify(operatorMigrationSourcePackageNames())
+  ) {
+    failures.push("expected deployment artifacts to preserve operator migration source packages")
   }
 
   if (first.diagnostics.length > 0) {
@@ -161,6 +171,17 @@ async function main(): Promise<void> {
         `expected operator graph package records to include migration source ${packageName}`,
       )
     }
+  }
+
+  const operatorMigrateSource = await readFile(
+    new URL("../starters/operator/scripts/migrate.ts", import.meta.url),
+    "utf8",
+  )
+  if (operatorMigrateSource.includes("drizzle.schemas.generated")) {
+    failures.push("expected operator db:migrate to avoid importing drizzle.schemas.generated.ts")
+  }
+  if (!operatorMigrateSource.includes("deploymentGraphArtifacts.migrationSources")) {
+    failures.push("expected operator db:migrate to consume graph artifact migration sources")
   }
 
   const frameworkRecord = first.packageRecords.find(
@@ -232,18 +253,21 @@ async function readOperatorGeneratedGraph(): Promise<{
 }
 
 function operatorMigrationSourcePackageNames(): string[] {
-  return sortedUnique(
-    operatorSchemaPaths
-      .map((schemaPath) => {
-        const match = schemaPath.match(/(?:^|\/)packages\/([^/]+)\//)
-        return match?.[1] ? `@voyant-travel/${match[1]}` : undefined
-      })
-      .filter((packageName): packageName is string => Boolean(packageName)),
-  )
+  return operatorMigrationSources().map((source) => source.packageName)
 }
 
-function sortedUnique(values: readonly string[]): string[] {
-  return [...new Set(values)].sort()
+function operatorMigrationSources(): Array<{ packageName: string; schema: string }> {
+  const seen = new Set<string>()
+  const sources: Array<{ packageName: string; schema: string }> = []
+  for (const schemaPath of operatorSchemaPaths) {
+    const match = schemaPath.match(/(?:^|\/)packages\/([^/]+)\//)
+    if (!match?.[1]) continue
+    const packageName = `@voyant-travel/${match[1]}`
+    if (seen.has(packageName)) continue
+    seen.add(packageName)
+    sources.push({ packageName, schema: schemaPath })
+  }
+  return sources
 }
 
 main().catch((error) => {

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -22,6 +22,7 @@ import {
   OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST,
   OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST,
 } from "../starters/operator/deployment-graph.local.ts"
+import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
 import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "../starters/operator/src/local-scheduled-jobs.ts"
 import {
   buildDeploymentGraphDoctorJson,
@@ -78,6 +79,7 @@ async function main(): Promise<void> {
         profileSnapshot: relativeToOperator(options.profilePath),
       }),
     ],
+    migrationSources: operatorMigrationSources(),
   })
   const manifestText = formatGeneratedText(
     options.manifestOutputPath,
@@ -205,6 +207,19 @@ function defineOperatorGraphProject(project: VoyantProjectManifest) {
     plugins: [...managedProject.plugins, ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.plugins],
     meta: managedProject.meta,
   })
+}
+
+function operatorMigrationSources() {
+  return operatorSchemaPaths
+    .map((schemaPath) => {
+      const match = schemaPath.match(/(?:^|\/)packages\/([^/]+)\//)
+      if (!match?.[1]) return undefined
+      return {
+        packageName: `@voyant-travel/${match[1]}`,
+        schema: schemaPath,
+      }
+    })
+    .filter((source): source is { packageName: string; schema: string } => Boolean(source))
 }
 
 async function writeGeneratedFile(filePath: string, text: string): Promise<void> {

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -11,5 +11,107 @@
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }
+  ],
+  "migrationSources": [
+    {
+      "packageName": "@voyant-travel/db",
+      "schema": "../../packages/db/src/schema/index.ts"
+    },
+    {
+      "packageName": "@voyant-travel/action-ledger",
+      "schema": "../../packages/action-ledger/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/relationships",
+      "schema": "../../packages/relationships/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/quotes",
+      "schema": "../../packages/quotes/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/identity",
+      "schema": "../../packages/identity/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/bookings",
+      "schema": "../../packages/bookings/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/distribution",
+      "schema": "../../packages/distribution/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/inventory",
+      "schema": "../../packages/inventory/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/commerce",
+      "schema": "../../packages/commerce/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/catalog",
+      "schema": "../../packages/catalog/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/finance",
+      "schema": "../../packages/finance/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/availability",
+      "schema": "../../packages/availability/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/operations",
+      "schema": "../../packages/operations/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/notifications",
+      "schema": "../../packages/notifications/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/flights",
+      "schema": "../../packages/flights/src/reference/local-postgres.ts"
+    },
+    {
+      "packageName": "@voyant-travel/legal",
+      "schema": "../../packages/legal/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/storefront",
+      "schema": "../../packages/storefront/src/verification/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/trips",
+      "schema": "../../packages/trips/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/operator-settings",
+      "schema": "../../packages/operator-settings/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/accommodations",
+      "schema": "../../packages/accommodations/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/mice",
+      "schema": "../../packages/mice/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/catalog-authoring",
+      "schema": "../../packages/catalog-authoring/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/workflow-runs",
+      "schema": "../../packages/workflow-runs/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/charters",
+      "schema": "../../packages/charters/src/schema.ts"
+    },
+    {
+      "packageName": "@voyant-travel/cruises",
+      "schema": "../../packages/cruises/src/schema.ts"
+    }
   ]
 }

--- a/starters/operator/scripts/migrate.ts
+++ b/starters/operator/scripts/migrate.ts
@@ -2,9 +2,8 @@
  * Deployment migration runner — D.2 package-owned migrations + topological
  * collector (`@voyant-travel/framework-migrations`). Each schema-owning package
  * SHIPS its own drizzle `migrations/` folder; this runner discovers them from
- * the same generated list `drizzle.config.ts` consumes
- * (`drizzle.schemas.generated.ts` ← `voyant.config.ts`), orders them deps-first
- * by `voyant.requiresSchemas`, and applies:
+ * the validated deployment graph artifact's migration source list, orders them
+ * deps-first by `voyant.requiresSchemas`, and applies:
  *
  *   1. each package source (topological order — a package's deps migrate first)
  *   2. this deployment's own `./migrations` (cross-module link tables + any
@@ -33,7 +32,6 @@ import {
 } from "@voyant-travel/framework-migrations"
 import { config } from "dotenv"
 import { Client } from "pg"
-import { schema } from "../drizzle.schemas.generated.ts"
 import {
   assertOperatorDeploymentGraphResourceEnv,
   loadOperatorDeploymentGraphArtifacts,
@@ -63,8 +61,9 @@ if (!databaseUrl) {
 }
 
 const scriptsDir = path.dirname(fileURLToPath(import.meta.url))
-// The generated schema paths (`../../packages/…`) resolve from the deployment
-// root, where `drizzle.config` lives; the deployment's own migrations are `./migrations`.
+// The graph artifact's schema paths (`../../packages/…`) resolve from the
+// deployment root, where `drizzle.config` lives; the deployment's own migrations
+// are `./migrations`.
 const baseDir = path.resolve(scriptsDir, "..")
 const client = new Client({ connectionString: databaseUrl })
 
@@ -72,18 +71,21 @@ try {
   await client.connect()
 
   // Discover package sources (deps-first) + the deployment's ./migrations (last).
-  const discovered = discoverMigrationSources(schema, {
-    baseDir,
-    deploymentMigrationsDir: path.join(baseDir, "migrations"),
-  })
+  const discovered = discoverMigrationSources(
+    deploymentGraphArtifacts.migrationSources.map((source) => source.schema),
+    {
+      baseDir,
+      deploymentMigrationsDir: path.join(baseDir, "migrations"),
+    },
+  )
   const sources: MigrationSource[] = []
   for (let i = 0; i < discovered.length; i++) {
     const d = discovered[i] as (typeof discovered)[number]
     if (!d.hasMigrations) {
       throw new Error(
         `migration source '${d.name}' has no migrations folder at ${d.migrationsDir}. ` +
-          "Regenerate the schema list and verify the owning package publishes migrations/*.sql " +
-          "and migrations/meta/_journal.json.",
+          "Regenerate deployment graph artifacts and verify the owning package publishes " +
+          "migrations/*.sql and migrations/meta/_journal.json.",
       )
     }
     sources.push({

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -26,6 +26,12 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(summary.graphHash).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(summary.moduleIds).toContain("@voyant-travel/bookings")
     expect(summary.packageNames).toContain("@voyant-travel/framework")
+    expect(summary.migrationSources.map((source) => source.packageName)).toEqual(
+      expect.arrayContaining(["@voyant-travel/db", "@voyant-travel/bookings"]),
+    )
+    expect(summary.migrationSources.map((source) => source.schema)).toContain(
+      "../../packages/db/src/schema/index.ts",
+    )
     expect(summary.providers).toMatchObject({
       database: "postgres",
       storage: "memory",
@@ -256,6 +262,22 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     ).toThrow(/deployment graph provisioning\.scheduledJobs\[0\]\.route/)
   })
 
+  it("fails when artifact migration sources are not graph package records", () => {
+    const root = fixtureRoot()
+    writeFixture(root, {
+      migrationSources: [
+        {
+          packageName: "@voyant-travel/missing",
+          schema: "../../packages/missing/src/schema.ts",
+        },
+      ],
+    })
+
+    expect(() =>
+      loadOperatorDeploymentGraphArtifacts(pathToFileURL(join(root, "src", "server.ts")).href),
+    ).toThrow(/is not present in deployment graph packageRecords/)
+  })
+
   it("accepts satisfied required resource environment before boot", () => {
     const root = fixtureRoot()
     writeFixture(root)
@@ -339,6 +361,7 @@ function writeFixture(
     runtimeEntry?: Record<string, unknown>
     runtimeEntrySource?: { graphHash?: string }
     writeRuntimeEntrySource?: boolean
+    migrationSources?: Array<{ packageName: string; schema: string }>
   } = {},
 ): string {
   mkdirSync(join(root, "src"), { recursive: true })
@@ -423,6 +446,12 @@ function writeFixture(
           profileSnapshot: "managed-profile.json",
         },
         ...options.runtimeEntry,
+      },
+    ],
+    migrationSources: options.migrationSources ?? [
+      {
+        packageName: "@voyant-travel/framework",
+        schema: "../../packages/framework/src/schema.ts",
       },
     ],
   })

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -22,6 +22,7 @@ export interface OperatorDeploymentGraphArtifactSummary {
   providers: Readonly<Record<string, string>>
   resourceRequirements: readonly OperatorDeploymentGraphResourceRequirement[]
   scheduledJobs: readonly OperatorDeploymentGraphScheduledJob[]
+  migrationSources: readonly OperatorDeploymentGraphMigrationSource[]
 }
 
 export interface OperatorDeploymentGraphScheduledJob {
@@ -43,6 +44,11 @@ export interface OperatorDeploymentGraphResourceRequirement {
   notes?: string
 }
 
+export interface OperatorDeploymentGraphMigrationSource {
+  packageName: string
+  schema: string
+}
+
 export interface OperatorDeploymentGraphEnvRequirement {
   name: string
   kind: string
@@ -57,6 +63,7 @@ interface DeploymentArtifactManifest {
   graphHash?: unknown
   graph?: unknown
   runtimeEntries?: unknown
+  migrationSources?: unknown
 }
 
 interface RuntimeEntryArtifact {
@@ -206,18 +213,22 @@ export function loadOperatorDeploymentGraphArtifacts(
     )
   }
 
+  const packageNames = collectStringField(
+    graph.packageRecords,
+    "deployment graph packageRecords",
+    "packageName",
+  )
+  const migrationSources = collectMigrationSources(manifest.migrationSources, packageNames)
+
   const summary = {
     graphHash,
     moduleIds: collectStringField(graph.modules, "deployment graph modules", "id"),
     pluginIds: collectStringField(graph.plugins, "deployment graph plugins", "id"),
-    packageNames: collectStringField(
-      graph.packageRecords,
-      "deployment graph packageRecords",
-      "packageName",
-    ),
+    packageNames,
     providers: collectDeploymentProviders(graph.deployment),
     resourceRequirements: collectResourceRequirements(graph.requirements),
     scheduledJobs: collectScheduledJobs(graph.provisioning),
+    migrationSources,
   }
 
   validateGeneratedRuntimeEntrySource({ graphHash, manifestUrl, mode, summary, target })
@@ -285,6 +296,30 @@ function collectScheduledJobs(value: unknown): OperatorDeploymentGraphScheduledJ
     ...(typeof job.workflowId === "string" ? { workflowId: job.workflowId } : {}),
     ...(Object.hasOwn(job, "input") ? { input: job.input } : {}),
   }))
+}
+
+function collectMigrationSources(
+  value: unknown,
+  packageNames: readonly string[],
+): OperatorDeploymentGraphMigrationSource[] {
+  const knownPackages = new Set(packageNames)
+  return arrayOfRecords(value, "deployment artifacts migrationSources").map((source, index) => {
+    const packageName = requireString(
+      source.packageName,
+      `deployment artifacts migrationSources[${index}].packageName`,
+    )
+    if (!knownPackages.has(packageName)) {
+      throw new Error(
+        `deployment artifacts migrationSources[${index}].packageName ${packageName} is not present in deployment graph packageRecords`,
+      )
+    }
+    const schema = requireString(
+      source.schema,
+      `deployment artifacts migrationSources[${index}].schema`,
+    )
+    assertRelativePosixPath(schema, `deployment artifacts migrationSources[${index}].schema`)
+    return { packageName, schema }
+  })
 }
 
 function collectResourceRequirements(value: unknown): OperatorDeploymentGraphResourceRequirement[] {
@@ -374,10 +409,14 @@ function readJsonFile<T>(url: URL, label: string): T {
 }
 
 function relativeArtifactUrl(value: string, baseUrl: URL): URL {
-  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\")) {
-    throw new Error(`deployment artifact paths must be relative POSIX paths, got ${value}`)
-  }
+  assertRelativePosixPath(value, "deployment artifact paths")
   return new URL(value, baseUrl)
+}
+
+function assertRelativePosixPath(value: string, label: string): void {
+  if (value.startsWith("/") || /^[A-Za-z]:[\\/]/.test(value) || value.includes("\\")) {
+    throw new Error(`${label} must be relative POSIX paths, got ${value}`)
+  }
 }
 
 function graphDeploymentTarget(graph: ResolvedDeploymentGraph): string | undefined {


### PR DESCRIPTION
## Summary
- add package-backed migration source metadata to deployment artifact manifests
- emit the operator migration source list from `drizzle.schemas.generated.ts` into committed graph artifacts
- make operator artifact loading validate migration sources against graph package records and make `db:migrate` consume the validated artifact list
- pin the handoff with graph checks, docs, and tests

## Verification
- `pnpm --filter @voyant-travel/framework test -- src/deployment-artifacts.test.ts`
- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts`
- `pnpm verify:deployment-graph`
- `pnpm --filter operator typecheck`
- `pnpm --filter @voyant-travel/framework typecheck`
- `node scripts/check-node-entrypoint.mjs && node scripts/check-operator-docker-target.mjs`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- pre-commit affected lint/build/typecheck