### PR TITLE
Publish first-party graph package metadata

### DIFF
--- a/.changeset/first-party-package-metadata.md
+++ b/.changeset/first-party-package-metadata.md
@@ -1,0 +1,31 @@
+---
+"@voyant-travel/accommodations": patch
+"@voyant-travel/action-ledger": patch
+"@voyant-travel/availability": patch
+"@voyant-travel/bookings": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/catalog-authoring": patch
+"@voyant-travel/charters": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/cruises": patch
+"@voyant-travel/db": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/flights": patch
+"@voyant-travel/identity": patch
+"@voyant-travel/inventory": patch
+"@voyant-travel/legal": patch
+"@voyant-travel/mice": patch
+"@voyant-travel/notifications": patch
+"@voyant-travel/operations": patch
+"@voyant-travel/operator-settings": patch
+"@voyant-travel/quotes": patch
+"@voyant-travel/relationships": patch
+"@voyant-travel/storefront": patch
+"@voyant-travel/trips": patch
+"@voyant-travel/workflow-runs": patch
+---
+
+Publish `voyant.package.v1` compatibility metadata from first-party
+schema-owning packages so deployment graph package admission can validate their
+framework, target, and deployment-mode compatibility before runtime imports.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -824,6 +824,12 @@ record, and virtual graph units point package provenance at the real package
 that ships them. Generated managed runtime entries validate graph artifacts and
 graph diagnostics before importing the managed runtime package.
 
+Schema-owning first-party package manifests publish `voyant.package.v1`
+compatibility metadata alongside the existing migration-facing `schema` and
+`requiresSchemas` declarations. Graph checks require every package-backed
+operator migration source to expose that normalized module metadata before the
+package can remain in generated operator graph artifacts.
+
 ## Implementation Phases
 
 Phases 0-2 are the complete v1 deployment-graph program. Phase 1 is the first

--- a/packages/accommodations/package.json
+++ b/packages/accommodations/package.json
@@ -130,6 +130,20 @@
     "directory": "packages/accommodations"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db",

--- a/packages/action-ledger/package.json
+++ b/packages/action-ledger/package.json
@@ -108,6 +108,20 @@
     "directory": "packages/action-ledger"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/availability/package.json
+++ b/packages/availability/package.json
@@ -9,6 +9,20 @@
     "./schema": "./src/schema.ts"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -201,6 +201,20 @@
     "directory": "packages/bookings"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/catalog-authoring/package.json
+++ b/packages/catalog-authoring/package.json
@@ -75,6 +75,20 @@
     "directory": "packages/catalog-authoring"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db",

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -40,6 +40,20 @@
     "./offers": "./src/offers/operator-routes.ts"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/charters/package.json
+++ b/packages/charters/package.json
@@ -130,6 +130,20 @@
     "directory": "packages/charters"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -118,6 +118,20 @@
     "directory": "packages/commerce"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/cruises/package.json
+++ b/packages/cruises/package.json
@@ -166,6 +166,20 @@
     "directory": "packages/cruises"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -370,6 +370,20 @@
     "vitest": "catalog:"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": []
   }

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -94,6 +94,20 @@
     "directory": "packages/distribution"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/bookings",

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -170,6 +170,20 @@
     "directory": "packages/finance"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -18,6 +18,20 @@
     "./payment-integration": "./src/payment-integration.ts"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./reference/local-postgres",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/identity/package.json
+++ b/packages/identity/package.json
@@ -78,6 +78,20 @@
     "directory": "packages/identity"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -265,6 +265,20 @@
     "directory": "packages/inventory"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -189,6 +189,20 @@
     "directory": "packages/legal"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/mice/package.json
+++ b/packages/mice/package.json
@@ -85,6 +85,20 @@
     "directory": "packages/mice"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/accommodations",

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -126,6 +126,20 @@
     "directory": "packages/notifications"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -112,6 +112,20 @@
     "directory": "packages/operations"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/availability",

--- a/packages/operator-settings/package.json
+++ b/packages/operator-settings/package.json
@@ -77,6 +77,20 @@
     "directory": "packages/operator-settings"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/quotes/package.json
+++ b/packages/quotes/package.json
@@ -98,6 +98,20 @@
     "directory": "packages/quotes"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/relationships/package.json
+++ b/packages/relationships/package.json
@@ -106,6 +106,20 @@
     "directory": "packages/relationships"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -22,6 +22,20 @@
     "./verification/validation": "./src/verification/validation.ts"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./verification/schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/storefront/tests/verification/unit/module.test.ts
+++ b/packages/storefront/tests/verification/unit/module.test.ts
@@ -61,7 +61,13 @@ describe("createStorefrontVerificationHonoModule.bootstrap", () => {
     ) as {
       exports: Record<string, string>
       publishConfig: { exports: Record<string, unknown> }
-      voyant: { schema: string; requiresSchemas: string[] }
+      voyant: {
+        schemaVersion: string
+        kind: string
+        compatibleWith: { framework: string; targets: string[]; modes: string[] }
+        schema: string
+        requiresSchemas: string[]
+      }
     }
 
     expect(getTableName(storefrontVerificationChallenges)).toBe(
@@ -72,9 +78,16 @@ describe("createStorefrontVerificationHonoModule.bootstrap", () => {
       import: "./dist/verification/schema.js",
       types: "./dist/verification/schema.d.ts",
     })
-    expect(packageJson.voyant).toEqual({
-      schema: "./verification/schema",
-      requiresSchemas: ["@voyant-travel/db"],
-    })
+    expect(packageJson.voyant.schemaVersion).toBe("voyant.package.v1")
+    expect(packageJson.voyant.kind).toBe("module")
+    expect(packageJson.voyant.compatibleWith.framework).toBe(">=0.26.0")
+    expect(packageJson.voyant.compatibleWith.targets).toEqual(["node", "voyant-cloud"])
+    expect(packageJson.voyant.compatibleWith.modes).toEqual([
+      "local",
+      "managed-cloud",
+      "self-hosted",
+    ])
+    expect(packageJson.voyant.schema).toBe("./verification/schema")
+    expect(packageJson.voyant.requiresSchemas).toEqual(["@voyant-travel/db"])
   })
 })

--- a/packages/trips/package.json
+++ b/packages/trips/package.json
@@ -16,6 +16,20 @@
     "./routes": "./src/routes.ts"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/packages/workflow-runs/package.json
+++ b/packages/workflow-runs/package.json
@@ -13,6 +13,20 @@
     "./workflows": "./src/workflows.ts"
   },
   "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
     "schema": "./schema",
     "requiresSchemas": [
       "@voyant-travel/db"

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -30,7 +30,7 @@ const failures: string[] = []
 
 const project = defineVoyantProject({
   profile: "operator",
-  frameworkVersion: "0.0.0-check",
+  frameworkVersion: "0.26.0",
   modules: ["bookings", "finance", "relationships"],
   plugins: ["@voyant-travel/plugin-netopia"],
 })
@@ -148,6 +148,9 @@ async function main(): Promise<void> {
   const operatorGraph = await readOperatorGeneratedGraph()
   const operatorModuleIds = new Set(operatorGraph.modules.map((unit) => unit.id))
   const operatorPluginIds = new Set(operatorGraph.plugins.map((unit) => unit.id))
+  const operatorPackageRecords = new Map(
+    operatorGraph.packageRecords.map((record) => [record.packageName, record]),
+  )
   const operatorPackageNames = new Set(
     operatorGraph.packageRecords.map((record) => record.packageName),
   )
@@ -200,9 +203,26 @@ async function main(): Promise<void> {
     if (!operatorPluginIds.has(id)) failures.push(`expected operator graph to include ${id}`)
   }
   for (const packageName of operatorMigrationSourcePackageNames()) {
-    if (!operatorPackageNames.has(packageName)) {
+    const record = operatorPackageRecords.get(packageName)
+    if (!record) {
       failures.push(
         `expected operator graph package records to include migration source ${packageName}`,
+      )
+      continue
+    }
+    const metadata = record.metadata
+    if (
+      metadata?.schemaVersion !== "voyant.package.v1" ||
+      metadata.kind !== "module" ||
+      typeof metadata.compatibleWith?.framework !== "string" ||
+      !metadata.compatibleWith.targets?.includes("node") ||
+      !metadata.compatibleWith.targets?.includes("voyant-cloud") ||
+      !metadata.compatibleWith.modes?.includes("local") ||
+      !metadata.compatibleWith.modes?.includes("managed-cloud") ||
+      !metadata.compatibleWith.modes?.includes("self-hosted")
+    ) {
+      failures.push(
+        `expected migration source package ${packageName} to include voyant.package.v1 module compatibility metadata`,
       )
     }
   }
@@ -263,7 +283,19 @@ async function readOperatorGeneratedGraph(): Promise<{
     workflows?: Array<{ id: string }>
   }>
   plugins: Array<{ id: string }>
-  packageRecords: Array<{ packageName: string; source?: { kind?: string } }>
+  packageRecords: Array<{
+    packageName: string
+    source?: { kind?: string }
+    metadata?: {
+      schemaVersion?: string
+      kind?: string
+      compatibleWith?: {
+        framework?: string
+        targets?: string[]
+        modes?: string[]
+      }
+    }
+  }>
   provisioning?: {
     scheduledJobs?: Array<{ id: string; workflowId?: string }>
   }
@@ -279,7 +311,19 @@ async function readOperatorGeneratedGraph(): Promise<{
       workflows?: Array<{ id: string }>
     }>
     plugins: Array<{ id: string }>
-    packageRecords: Array<{ packageName: string; source?: { kind?: string } }>
+    packageRecords: Array<{
+      packageName: string
+      source?: { kind?: string }
+      metadata?: {
+        schemaVersion?: string
+        kind?: string
+        compatibleWith?: {
+          framework?: string
+          targets?: string[]
+          modes?: string[]
+        }
+      }
+    }>
     provisioning?: {
       scheduledJobs?: Array<{ id: string; workflowId?: string }>
     }

--- a/scripts/lib/deployment-graph-provenance.mjs
+++ b/scripts/lib/deployment-graph-provenance.mjs
@@ -4,7 +4,7 @@ import path from "node:path"
 import { parse } from "yaml"
 
 const dependencySections = ["dependencies", "optionalDependencies", "devDependencies"]
-const ignoredWorkspaceDirs = new Set([".git", ".turbo", "build", "dist", "node_modules"])
+const ignoredWorkspaceDirs = new Set([".audit", ".git", ".turbo", "build", "dist", "node_modules"])
 const voyantPackageMetadataSchemaVersion = "voyant.package.v1"
 const voyantPackageKinds = new Set(["module", "plugin"])
 const voyantDeploymentModes = new Set(["managed-cloud", "self-hosted", "local"])

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:561dbc3b80b539d4b21d31492fbf574961b7e2a1a957b96ec2109ecfbe73f260",
+  "graphHash": "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:561dbc3b80b539d4b21d31492fbf574961b7e2a1a957b96ec2109ecfbe73f260",
+      "graphHash": "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:561dbc3b80b539d4b21d31492fbf574961b7e2a1a957b96ec2109ecfbe73f260",
+  "contentHash": "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1276,6 +1276,15 @@
   ],
   "packageRecords": [
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/accommodations",
       "source": {
         "kind": "workspace",
@@ -1284,6 +1293,15 @@
       "version": "0.111.4"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/action-ledger",
       "source": {
         "kind": "workspace",
@@ -1292,6 +1310,15 @@
       "version": "0.105.13"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/availability",
       "source": {
         "kind": "workspace",
@@ -1300,6 +1327,15 @@
       "version": "0.1.2"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/bookings",
       "source": {
         "kind": "workspace",
@@ -1308,6 +1344,15 @@
       "version": "0.149.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/catalog",
       "source": {
         "kind": "workspace",
@@ -1316,6 +1361,15 @@
       "version": "0.147.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/catalog-authoring",
       "source": {
         "kind": "workspace",
@@ -1324,6 +1378,15 @@
       "version": "0.106.28"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/charters",
       "source": {
         "kind": "workspace",
@@ -1332,6 +1395,15 @@
       "version": "0.147.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/commerce",
       "source": {
         "kind": "workspace",
@@ -1340,6 +1412,15 @@
       "version": "0.31.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/cruises",
       "source": {
         "kind": "workspace",
@@ -1348,6 +1429,15 @@
       "version": "0.148.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/db",
       "source": {
         "kind": "workspace",
@@ -1356,6 +1446,15 @@
       "version": "0.110.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/distribution",
       "source": {
         "kind": "workspace",
@@ -1364,6 +1463,15 @@
       "version": "0.139.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/finance",
       "source": {
         "kind": "workspace",
@@ -1372,6 +1480,15 @@
       "version": "0.149.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/flights",
       "source": {
         "kind": "workspace",
@@ -1385,7 +1502,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.29.3"
+      "version": "0.29.4"
     },
     {
       "packageName": "@voyant-travel/framework-migrations",
@@ -1404,6 +1521,15 @@
       "version": "0.122.1"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/identity",
       "source": {
         "kind": "workspace",
@@ -1412,6 +1538,15 @@
       "version": "0.149.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/inventory",
       "source": {
         "kind": "workspace",
@@ -1420,6 +1555,15 @@
       "version": "0.7.9"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/legal",
       "source": {
         "kind": "workspace",
@@ -1428,6 +1572,15 @@
       "version": "0.149.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/mice",
       "source": {
         "kind": "workspace",
@@ -1436,6 +1589,15 @@
       "version": "0.6.8"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/notifications",
       "source": {
         "kind": "workspace",
@@ -1444,6 +1606,15 @@
       "version": "0.122.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/operations",
       "source": {
         "kind": "workspace",
@@ -1467,6 +1638,15 @@
       }
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/operator-settings",
       "source": {
         "kind": "workspace",
@@ -1484,6 +1664,15 @@
       "version": "0.105.18"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/quotes",
       "source": {
         "kind": "workspace",
@@ -1492,6 +1681,15 @@
       "version": "0.125.7"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/relationships",
       "source": {
         "kind": "workspace",
@@ -1500,6 +1698,15 @@
       "version": "0.122.10"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/storefront",
       "source": {
         "kind": "workspace",
@@ -1508,6 +1715,15 @@
       "version": "0.151.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/trips",
       "source": {
         "kind": "workspace",
@@ -1516,6 +1732,15 @@
       "version": "0.140.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "module",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/workflow-runs",
       "source": {
         "kind": "workspace",

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:561dbc3b80b539d4b21d31492fbf574961b7e2a1a957b96ec2109ecfbe73f260" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary
- add `voyant.package.v1` module compatibility metadata to the 25 first-party schema-owning package manifests while preserving `schema` / `requiresSchemas`
- regenerate operator graph artifacts so package-backed migration sources carry normalized compatibility metadata
- make deployment graph checks require package-backed migration source records to expose v1 module compatibility metadata
- keep the provenance walker out of the untracked `.audit/` workspace
- update the storefront manifest verification test for the new v1 metadata contract

## Verification
- `pnpm --filter operator graph:emit`
- `pnpm --filter @voyant-travel/framework test -- src/deployment-graph.test.ts`
- `node --test scripts/tests/deployment-graph-provenance.test.mjs`
- `pnpm verify:deployment-graph`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- `node scripts/check-node-entrypoint.mjs && node scripts/check-operator-docker-target.mjs`
- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/storefront test`
- commit hook affected lint/build/typecheck: 191/191 tasks passed
- pre-push `pnpm test`: 100/100 tasks passed