### PR TITLE
Publish substrate graph package metadata

### DIFF
--- a/.changeset/substrate-package-metadata.md
+++ b/.changeset/substrate-package-metadata.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/framework-migrations": patch
+"@voyant-travel/hono": patch
+---
+
+Publish `voyant.package.v1` compatibility metadata from graph substrate packages
+and allow package metadata records to distinguish framework and library packages
+from selectable modules and plugins.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -830,6 +830,15 @@ compatibility metadata alongside the existing migration-facing `schema` and
 operator migration source to expose that normalized module metadata before the
 package can remain in generated operator graph artifacts.
 
+Substrate package records use the same metadata contract without becoming graph
+units: `@voyant-travel/framework` publishes `kind: "framework"`, while
+supporting packages such as `@voyant-travel/framework-migrations` and
+`@voyant-travel/hono` publish `kind: "library"`. Released first-party registry
+plugins that predate package-owned v1 metadata may be admitted through an
+explicit operator metadata bridge, but generated operator graph checks still
+require the final package record to carry normalized `voyant.package.v1`
+compatibility metadata before runtime imports are emitted.
+
 ## Implementation Phases
 
 Phases 0-2 are the complete v1 deployment-graph program. Phase 1 is the first

--- a/packages/framework-migrations/package.json
+++ b/packages/framework-migrations/package.json
@@ -29,6 +29,22 @@
     "migrations/meta/_journal.json",
     "cutline.generated.json"
   ],
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "library",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public",
     "exports": {

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -15,6 +15,22 @@
   "files": [
     "dist"
   ],
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "framework",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    }
+  },
   "scripts": {
     "build": "NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.build.json",
     "typecheck": "NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.typecheck.json",

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -33,6 +33,7 @@ export const VOYANT_GRAPH_PACKAGE_SCHEMA_VERSION = "voyant.package.v1" as const
 export const VOYANT_RESOLVED_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
 
 export type VoyantGraphUnitKind = "module" | "plugin"
+export type VoyantGraphPackageKind = VoyantGraphUnitKind | "framework" | "library"
 export type VoyantGraphDiagnosticSeverity = "info" | "warning" | "error"
 export type VoyantGraphRouteSurface = "admin" | "public" | "webhook" | "internal"
 export type VoyantGraphPackageSourceKind = "registry" | "workspace" | "file" | "git" | "unknown"
@@ -239,7 +240,7 @@ export interface VoyantGraphDeployment {
 
 export interface VoyantGraphPackageMetadata {
   schemaVersion: typeof VOYANT_GRAPH_PACKAGE_SCHEMA_VERSION
-  kind: VoyantGraphUnitKind
+  kind: VoyantGraphPackageKind
   compatibleWith?: {
     framework?: string
     targets?: readonly string[]

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -60,6 +60,22 @@
   "files": [
     "dist"
   ],
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "library",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node",
+        "voyant-cloud"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    }
+  },
   "publishConfig": {
     "access": "public",
     "exports": {

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -23,6 +23,7 @@ import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.sche
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 import {
   OPERATOR_GRAPH_ADMISSION_POLICY,
+  OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
   withOperatorDeploymentLocalPackageRecords,
 } from "./lib/operator-deployment-graph-package-records.ts"
 
@@ -35,11 +36,19 @@ const project = defineVoyantProject({
   plugins: ["@voyant-travel/plugin-netopia"],
 })
 
+const OPERATOR_PACKAGE_METADATA_KIND_EXPECTATIONS = new Map<string, string>([
+  ["@voyant-travel/framework", "framework"],
+  ["@voyant-travel/framework-migrations", "library"],
+  ["@voyant-travel/hono", "library"],
+  ["@voyant-travel/plugin-netopia", "plugin"],
+])
+
 async function main(): Promise<void> {
   const discoveredGraph = await resolveManagedProfileDeploymentGraph(project)
   const packageRecords = withOperatorDeploymentLocalPackageRecords(
     readPnpmLockfilePackageRecords({
       packageNames: discoveredGraph.packageRecords.map((record) => record.packageName),
+      packageMetadata: OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
     }),
   )
   const first = await resolveManagedProfileDeploymentGraph(project, {
@@ -158,6 +167,23 @@ async function main(): Promise<void> {
     if (record.source?.kind === "unknown") {
       failures.push(`expected operator graph package record ${record.packageName} to be admitted`)
     }
+    const expectedKind =
+      OPERATOR_PACKAGE_METADATA_KIND_EXPECTATIONS.get(record.packageName) ?? "module"
+    const metadata = record.metadata
+    if (
+      metadata?.schemaVersion !== "voyant.package.v1" ||
+      metadata.kind !== expectedKind ||
+      typeof metadata.compatibleWith?.framework !== "string" ||
+      !metadata.compatibleWith.targets?.includes("node") ||
+      !metadata.compatibleWith.targets?.includes("voyant-cloud") ||
+      !metadata.compatibleWith.modes?.includes("local") ||
+      !metadata.compatibleWith.modes?.includes("managed-cloud") ||
+      !metadata.compatibleWith.modes?.includes("self-hosted")
+    ) {
+      failures.push(
+        `expected operator graph package record ${record.packageName} to include voyant.package.v1 ${expectedKind} compatibility metadata`,
+      )
+    }
   }
   if (!operatorPackageNames.has("@voyant-travel/hono")) {
     failures.push("expected operator graph package records to include @voyant-travel/hono")
@@ -203,26 +229,9 @@ async function main(): Promise<void> {
     if (!operatorPluginIds.has(id)) failures.push(`expected operator graph to include ${id}`)
   }
   for (const packageName of operatorMigrationSourcePackageNames()) {
-    const record = operatorPackageRecords.get(packageName)
-    if (!record) {
+    if (!operatorPackageRecords.has(packageName)) {
       failures.push(
         `expected operator graph package records to include migration source ${packageName}`,
-      )
-      continue
-    }
-    const metadata = record.metadata
-    if (
-      metadata?.schemaVersion !== "voyant.package.v1" ||
-      metadata.kind !== "module" ||
-      typeof metadata.compatibleWith?.framework !== "string" ||
-      !metadata.compatibleWith.targets?.includes("node") ||
-      !metadata.compatibleWith.targets?.includes("voyant-cloud") ||
-      !metadata.compatibleWith.modes?.includes("local") ||
-      !metadata.compatibleWith.modes?.includes("managed-cloud") ||
-      !metadata.compatibleWith.modes?.includes("self-hosted")
-    ) {
-      failures.push(
-        `expected migration source package ${packageName} to include voyant.package.v1 module compatibility metadata`,
       )
     }
   }

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -33,6 +33,7 @@ import {
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 import {
   OPERATOR_GRAPH_ADMISSION_POLICY,
+  OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
   withOperatorDeploymentLocalPackageRecords,
 } from "./lib/operator-deployment-graph-package-records.ts"
 
@@ -176,6 +177,7 @@ async function resolveGraph(profilePath: string) {
         "@voyant-travel/framework-migrations",
         ...discoveredGraph.packageRecords.map((record) => record.packageName),
       ],
+      packageMetadata: OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
     }),
   )
   return resolveOperatorDeploymentGraph(project, { packageRecords })

--- a/scripts/lib/deployment-graph-provenance.mjs
+++ b/scripts/lib/deployment-graph-provenance.mjs
@@ -6,7 +6,7 @@ import { parse } from "yaml"
 const dependencySections = ["dependencies", "optionalDependencies", "devDependencies"]
 const ignoredWorkspaceDirs = new Set([".audit", ".git", ".turbo", "build", "dist", "node_modules"])
 const voyantPackageMetadataSchemaVersion = "voyant.package.v1"
-const voyantPackageKinds = new Set(["module", "plugin"])
+const voyantPackageKinds = new Set(["framework", "library", "module", "plugin"])
 const voyantDeploymentModes = new Set(["managed-cloud", "self-hosted", "local"])
 
 export function readPnpmLockfilePackageRecords(options) {
@@ -18,6 +18,7 @@ export function readPnpmLockfilePackageRecords(options) {
     importerPaths: options.importerPaths,
     workspacePackageVersions: options.workspacePackageVersions ?? workspacePackageInfo.versions,
     workspacePackageMetadata: options.workspacePackageMetadata ?? workspacePackageInfo.metadata,
+    packageMetadata: options.packageMetadata,
   })
 }
 
@@ -29,8 +30,11 @@ export function packageRecordsFromPnpmLockfile(lockfileText, options) {
       left.localeCompare(right),
     ),
   )
-  const workspacePackageMetadata = new Map(
-    Object.entries(options.workspacePackageMetadata ?? {})
+  const packageMetadata = new Map(
+    Object.entries({
+      ...(options.workspacePackageMetadata ?? {}),
+      ...(options.packageMetadata ?? {}),
+    })
       .map(([packageName, metadata]) => [packageName, normalizeVoyantPackageMetadata(metadata)])
       .filter(([, metadata]) => metadata),
   )
@@ -42,7 +46,7 @@ export function packageRecordsFromPnpmLockfile(lockfileText, options) {
         lockfile,
         dependencies: dependencies.get(packageName) ?? [],
         workspacePackageVersions,
-        workspacePackageMetadata,
+        packageMetadata,
       }),
     )
 }
@@ -141,7 +145,7 @@ function packageRecordForPackage(packageName, context) {
 }
 
 function withPackageMetadata(record, packageName, context) {
-  const metadata = context.workspacePackageMetadata.get(packageName)
+  const metadata = context.packageMetadata.get(packageName)
   if (!metadata) return record
   return {
     ...record,

--- a/scripts/lib/operator-deployment-graph-package-records.ts
+++ b/scripts/lib/operator-deployment-graph-package-records.ts
@@ -2,11 +2,26 @@ import {
   VOYANT_GRAPH_PACKAGE_SCHEMA_VERSION,
   type VoyantGraphAdmissionPolicy,
   type VoyantGraphPackageRecord,
+  type VoyantPackageMetadata,
 } from "../../packages/framework/src/deployment-graph.ts"
 
 export const OPERATOR_GRAPH_ADMISSION_POLICY = {
   allowedSourceKinds: ["registry", "workspace"],
 } as const satisfies VoyantGraphAdmissionPolicy
+
+const OPERATOR_GRAPH_COMPATIBILITY = {
+  framework: ">=0.26.0",
+  targets: ["node", "voyant-cloud"],
+  modes: ["local", "managed-cloud", "self-hosted"],
+} as const
+
+export const OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES = {
+  "@voyant-travel/plugin-netopia": {
+    schemaVersion: VOYANT_GRAPH_PACKAGE_SCHEMA_VERSION,
+    kind: "plugin",
+    compatibleWith: OPERATOR_GRAPH_COMPATIBILITY,
+  },
+} as const satisfies Record<string, VoyantPackageMetadata>
 
 const OPERATOR_LOCAL_PACKAGE_RECORDS = [
   {
@@ -18,10 +33,7 @@ const OPERATOR_LOCAL_PACKAGE_RECORDS = [
     metadata: {
       schemaVersion: VOYANT_GRAPH_PACKAGE_SCHEMA_VERSION,
       kind: "module",
-      compatibleWith: {
-        targets: ["node", "voyant-cloud"],
-        modes: ["local", "managed-cloud", "self-hosted"],
-      },
+      compatibleWith: OPERATOR_GRAPH_COMPATIBILITY,
     },
   },
 ] as const satisfies readonly VoyantGraphPackageRecord[]

--- a/scripts/tests/deployment-graph-provenance.test.mjs
+++ b/scripts/tests/deployment-graph-provenance.test.mjs
@@ -167,6 +167,45 @@ describe("deployment graph package provenance", () => {
     ])
   })
 
+  it("attaches explicit v1 metadata overrides to registry package records", () => {
+    const records = packageRecordsFromPnpmLockfile(lockfile, {
+      packageNames: ["@voyant-travel/plugin-netopia"],
+      packageMetadata: {
+        "@voyant-travel/plugin-netopia": {
+          schemaVersion: "voyant.package.v1",
+          kind: "plugin",
+          compatibleWith: {
+            framework: ">=0.26.0",
+            targets: ["node", "voyant-cloud"],
+            modes: ["local", "managed-cloud", "self-hosted"],
+          },
+        },
+      },
+    })
+
+    assert.deepEqual(records, [
+      {
+        packageName: "@voyant-travel/plugin-netopia",
+        version: "0.105.18",
+        source: {
+          kind: "registry",
+          reference:
+            "pnpm-lock:@voyant-travel/plugin-netopia@0.105.18(@types/pg@8.20.0)(postgres@3.4.9)",
+          integrity: "sha512-netopia",
+        },
+        metadata: {
+          schemaVersion: "voyant.package.v1",
+          kind: "plugin",
+          compatibleWith: {
+            framework: ">=0.26.0",
+            targets: ["node", "voyant-cloud"],
+            modes: ["local", "managed-cloud", "self-hosted"],
+          },
+        },
+      },
+    ])
+  })
+
   it("reads v1 voyant package metadata from package.json files", () => {
     const repoRoot = mkdtempSync(path.join(tmpdir(), "voyant-provenance-"))
     mkdirSync(path.join(repoRoot, "packages", "v1-module"), { recursive: true })
@@ -249,6 +288,66 @@ importers:
           },
           requires: {
             capabilities: ["identity.people"],
+          },
+        },
+      },
+    ])
+  })
+
+  it("reads substrate package metadata kinds from package.json files", () => {
+    const repoRoot = mkdtempSync(path.join(tmpdir(), "voyant-provenance-"))
+    mkdirSync(path.join(repoRoot, "packages", "framework"), { recursive: true })
+    writeFileSync(
+      path.join(repoRoot, "pnpm-lock.yaml"),
+      `
+lockfileVersion: '9.0'
+
+importers:
+  starters/operator:
+    dependencies:
+      '@voyant-travel/framework':
+        specifier: workspace:*
+        version: link:../../packages/framework
+`,
+    )
+    writeFileSync(
+      path.join(repoRoot, "packages", "framework", "package.json"),
+      JSON.stringify(
+        {
+          name: "@voyant-travel/framework",
+          version: "0.29.4",
+          voyant: {
+            schemaVersion: "voyant.package.v1",
+            kind: "framework",
+            compatibleWith: {
+              framework: ">=0.26.0",
+              targets: ["node"],
+              modes: ["local"],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+    )
+
+    const records = readPnpmLockfilePackageRecords({
+      repoRoot,
+      packageNames: ["@voyant-travel/framework"],
+    })
+
+    assert.deepEqual(records, [
+      {
+        packageName: "@voyant-travel/framework",
+        version: "0.29.4",
+        source: { kind: "workspace", reference: "link:../../packages/framework" },
+        metadata: {
+          schemaVersion: "voyant.package.v1",
+          kind: "framework",
+          compatibleWith: {
+            framework: ">=0.26.0",
+            targets: ["node"],
+            modes: ["local"],
           },
         },
       },

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659",
+  "graphHash": "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659",
+      "graphHash": "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659",
+  "contentHash": "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1497,6 +1497,15 @@
       "version": "0.149.0"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "framework",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/framework",
       "source": {
         "kind": "workspace",
@@ -1505,6 +1514,15 @@
       "version": "0.29.4"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "library",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/framework-migrations",
       "source": {
         "kind": "workspace",
@@ -1513,6 +1531,15 @@
       "version": "0.7.1"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "library",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/hono",
       "source": {
         "kind": "workspace",
@@ -1625,6 +1652,7 @@
     {
       "metadata": {
         "compatibleWith": {
+          "framework": ">=0.26.0",
           "modes": ["local", "managed-cloud", "self-hosted"],
           "targets": ["node", "voyant-cloud"]
         },
@@ -1655,6 +1683,15 @@
       "version": "0.2.33"
     },
     {
+      "metadata": {
+        "compatibleWith": {
+          "framework": ">=0.26.0",
+          "modes": ["local", "managed-cloud", "self-hosted"],
+          "targets": ["node", "voyant-cloud"]
+        },
+        "kind": "plugin",
+        "schemaVersion": "voyant.package.v1"
+      },
       "packageName": "@voyant-travel/plugin-netopia",
       "source": {
         "integrity": "sha512-HlchshFZnOWJtn8OXh9bjs+VM9QHMD925SuLL3fTuazbaV/e2ZU8PeCAeclKlXSI4ujBAfsZzNAi2Ucz46/6JQ==",

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:0ab105edd445671dca7c1afd0db9b3ec3a3b6cf60e870491b46d4d2dd8887659" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary
- allow `voyant.package.v1` metadata to classify substrate packages as `framework` or `library` without treating them as selectable graph units
- publish v1 compatibility metadata from `@voyant-travel/framework`, `@voyant-travel/framework-migrations`, and `@voyant-travel/hono`
- add an explicit operator metadata bridge for the currently released registry `@voyant-travel/plugin-netopia` while preserving registry provenance and integrity
- regenerate operator graph artifacts and make the architecture check require normalized compatibility metadata on every generated operator package record

## Verification
- `node --test scripts/tests/deployment-graph-provenance.test.mjs`
- `pnpm --filter @voyant-travel/framework test -- src/deployment-graph.test.ts`
- `pnpm --filter operator graph:emit`
- `pnpm verify:deployment-graph`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/hono typecheck`
- `pnpm --filter @voyant-travel/framework-migrations typecheck`
- `pnpm --filter operator test -- src/deployment-graph-artifacts.test.ts`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`
- `node scripts/check-node-entrypoint.mjs && node scripts/check-operator-docker-target.mjs`
- commit hook affected lint/build/typecheck: 191/191 tasks passed