### PR TITLE
feat: declare operator deployment graph

### DIFF
--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -817,6 +817,13 @@ diagnostic-code registry. The public `voyant doctor --json` command remains the
 CLI follow-up; it should consume this report contract rather than inventing a
 separate diagnostic model.
 
+The reference operator now owns checked-in `voyant.project.ts` and
+`voyant.deployment.ts` declarations. The managed-profile snapshot remains a
+runtime compatibility input for the generated managed Node entry and legacy
+scheduled-job derivation, but it does not select graph units, providers, or the
+deployment target. Phase 2 replaces that remaining compatibility derivation
+with graph-derived requirements and provisioning.
+
 The operator graph also runs an explicit source-admission policy for generated
 artifacts: selected packages must resolve to admitted lockfile/workspace
 provenance, deployment-local operator units get an explicit local workspace

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -20,6 +20,8 @@ import {
   OPERATOR_SCHEMA_ONLY_DEPLOYMENT_GRAPH_MODULE_IDS,
 } from "../starters/operator/deployment-graph.local.ts"
 import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
+import { OPERATOR_VOYANT_DEPLOYMENT } from "../starters/operator/voyant.deployment.ts"
+import { OPERATOR_VOYANT_PROJECT } from "../starters/operator/voyant.project.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 import {
   OPERATOR_GRAPH_ADMISSION_POLICY,
@@ -157,6 +159,36 @@ async function main(): Promise<void> {
   const operatorGraph = await readOperatorGeneratedGraph()
   const operatorModuleIds = new Set(operatorGraph.modules.map((unit) => unit.id))
   const operatorPluginIds = new Set(operatorGraph.plugins.map((unit) => unit.id))
+  const declaredOperatorModuleIds = new Set(OPERATOR_VOYANT_PROJECT.modules.map((unit) => unit.id))
+  const declaredOperatorPluginIds = new Set(OPERATOR_VOYANT_PROJECT.plugins.map((unit) => unit.id))
+  if (OPERATOR_VOYANT_DEPLOYMENT.project !== OPERATOR_VOYANT_PROJECT) {
+    failures.push(
+      "expected operator deployment declaration to bind the operator project declaration",
+    )
+  }
+  if (operatorGraph.project?.presetLineage !== OPERATOR_VOYANT_PROJECT.presetLineage) {
+    failures.push("expected generated operator graph to preserve declared preset lineage")
+  }
+  for (const id of declaredOperatorModuleIds) {
+    if (!operatorModuleIds.has(id)) {
+      failures.push(`expected generated operator graph to include declared module ${id}`)
+    }
+  }
+  for (const id of declaredOperatorPluginIds) {
+    if (!operatorPluginIds.has(id)) {
+      failures.push(`expected generated operator graph to include declared plugin ${id}`)
+    }
+  }
+  for (const id of operatorModuleIds) {
+    if (!declaredOperatorModuleIds.has(id)) {
+      failures.push(`expected generated operator graph module ${id} to come from the declaration`)
+    }
+  }
+  for (const id of operatorPluginIds) {
+    if (!declaredOperatorPluginIds.has(id)) {
+      failures.push(`expected generated operator graph plugin ${id} to come from the declaration`)
+    }
+  }
   const operatorPackageRecords = new Map(
     operatorGraph.packageRecords.map((record) => [record.packageName, record]),
   )
@@ -287,6 +319,7 @@ async function main(): Promise<void> {
 }
 
 async function readOperatorGeneratedGraph(): Promise<{
+  project?: { presetLineage?: string }
   modules: Array<{
     id: string
     workflows?: Array<{ id: string }>

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -10,20 +10,14 @@ import {
   buildManagedNodeRuntimeEntryArtifact,
 } from "../packages/framework/src/deployment-artifacts.ts"
 import {
-  defineDeploymentFromManagedProfile,
-  defineProject,
-  defineProjectFromManagedProfile,
   type ResolveDeploymentGraphInput,
   resolveDeploymentGraph,
 } from "../packages/framework/src/deployment-graph.ts"
 import { getManagedProfileScheduledJobs } from "../packages/framework/src/managed-jobs.ts"
 import type { VoyantProjectManifest } from "../packages/framework/src/profile-types.ts"
-import {
-  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST,
-  OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST,
-} from "../starters/operator/deployment-graph.local.ts"
 import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
 import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "../starters/operator/src/local-scheduled-jobs.ts"
+import { OPERATOR_VOYANT_DEPLOYMENT } from "../starters/operator/voyant.deployment.ts"
 import {
   buildDeploymentGraphDoctorJson,
   buildDeploymentGraphDoctorReport,
@@ -187,8 +181,7 @@ function resolveOperatorDeploymentGraph(
   project: VoyantProjectManifest,
   options: Omit<ResolveDeploymentGraphInput, "project" | "deployment"> = {},
 ) {
-  const graphProject = defineOperatorGraphProject(project)
-  const { project: _managedProject, ...deployment } = defineDeploymentFromManagedProfile(project)
+  const { project: graphProject, ...deployment } = OPERATOR_VOYANT_DEPLOYMENT
   return resolveDeploymentGraph({
     ...options,
     project: graphProject,
@@ -201,20 +194,6 @@ function resolveOperatorDeploymentGraph(
     target: options.target ?? deployment.target,
     mode: options.mode ?? deployment.mode,
     admission: options.admission ?? OPERATOR_GRAPH_ADMISSION_POLICY,
-  })
-}
-
-function defineOperatorGraphProject(project: VoyantProjectManifest) {
-  const managedProject = defineProjectFromManagedProfile(project)
-  return defineProject({
-    presetLineage: managedProject.presetLineage,
-    modules: [
-      ...managedProject.modules,
-      ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.modules,
-      ...OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST.modules,
-    ],
-    plugins: [...managedProject.plugins, ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.plugins],
-    meta: managedProject.meta,
   })
 }
 
@@ -322,12 +301,12 @@ function toPosixRelativePath(fromDir: string, toPath: string, pathModule: typeof
 function printHelp(): void {
   console.log(`Usage: tsx scripts/emit-deployment-graph.ts [--emit]
 
-Resolves the operator managed profile into committed generated graph artifacts.
+Resolves the operator graph declarations into committed generated graph artifacts.
 
 Options:
   --emit                 write generated artifacts instead of checking staleness
   --json                 print the graph doctor report JSON contract
-  --profile <path>       managed profile JSON path
+  --profile <path>       managed-profile compatibility snapshot path
   --manifest-output <path> deployment artifact manifest output path
   --graph-output <path>  resolved graph JSON output path
   --entry-output <path>  runtime entry metadata module output path

--- a/starters/operator/voyant.deployment.ts
+++ b/starters/operator/voyant.deployment.ts
@@ -1,0 +1,33 @@
+import { defineDeployment } from "../../packages/framework/src/deployment-graph.ts"
+import {
+  PROVIDER_ROLES,
+  type VoyantProjectProviders,
+} from "../../packages/framework/src/profile.ts"
+import { resourceRequirementsFor } from "../../packages/framework/src/profile-requirements.ts"
+import { OPERATOR_VOYANT_PROJECT } from "./voyant.project.ts"
+
+export const OPERATOR_VOYANT_DEPLOYMENT_PROVIDERS = {
+  database: "postgres",
+  storage: "memory",
+  cache: "memory",
+  sharedState: "memory",
+  rateLimit: "memory",
+  search: "none",
+  email: "none",
+  sms: "none",
+  auth: "better-auth",
+  scheduledJobs: "none",
+  workflows: "none",
+} as const satisfies VoyantProjectProviders
+
+export const OPERATOR_VOYANT_DEPLOYMENT = defineDeployment({
+  project: OPERATOR_VOYANT_PROJECT,
+  target: "node",
+  mode: "self-hosted",
+  providers: OPERATOR_VOYANT_DEPLOYMENT_PROVIDERS,
+  requirements: {
+    resources: PROVIDER_ROLES.flatMap((role) =>
+      resourceRequirementsFor(role, OPERATOR_VOYANT_DEPLOYMENT_PROVIDERS),
+    ),
+  },
+})

--- a/starters/operator/voyant.project.ts
+++ b/starters/operator/voyant.project.ts
@@ -1,0 +1,34 @@
+import {
+  defineProject,
+  generateFrameworkModuleManifests,
+  generateFrameworkPluginManifests,
+} from "../../packages/framework/src/deployment-graph.ts"
+import { FRAMEWORK_RUNTIME_MANIFEST } from "../../packages/framework/src/manifest.ts"
+import {
+  OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST,
+  OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST,
+} from "./deployment-graph.local.ts"
+
+const CUSTOMER_APP_MODULE_SPECIFIERS = new Set([
+  "@voyant-travel/storefront",
+  "@voyant-travel/storefront/customer-portal",
+  "@voyant-travel/storefront/verification",
+])
+
+export const OPERATOR_STANDARD_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS =
+  FRAMEWORK_RUNTIME_MANIFEST.modules.filter(
+    (specifier) => !CUSTOMER_APP_MODULE_SPECIFIERS.has(specifier),
+  )
+
+export const OPERATOR_VOYANT_PROJECT = defineProject({
+  presetLineage: "operator-standard",
+  modules: [
+    ...generateFrameworkModuleManifests(OPERATOR_STANDARD_DEPLOYMENT_GRAPH_MODULE_SPECIFIERS),
+    ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.modules,
+    ...OPERATOR_SCHEMA_DEPLOYMENT_GRAPH_MANIFEST.modules,
+  ],
+  plugins: [
+    ...generateFrameworkPluginManifests(),
+    ...OPERATOR_LOCAL_DEPLOYMENT_GRAPH_MANIFEST.plugins,
+  ],
+})


### PR DESCRIPTION
## What changed

- add checked-in `voyant.project.ts` and `voyant.deployment.ts` declarations for the reference operator
- resolve generated operator artifacts from those declarations rather than deriving graph closure, providers, or target from `managed-profile.json`
- verify generated graph units all originate from the checked-in declarations

## Why

This advances Phase 1 of the unified deployment graph: the operator starter now has an explicit project/deployment graph while retaining the managed-profile snapshot only for the generated managed Node runtime and legacy scheduled-job compatibility.

## Validation

- `pnpm --filter operator typecheck`
- `pnpm verify:deployment-graph`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `pnpm verify:architecture`
- pre-push full test suite
