### PR TITLE
feat: derive deployment requirements from providers

### DIFF
--- a/.changeset/graph-derived-deployment-requirements.md
+++ b/.changeset/graph-derived-deployment-requirements.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Derive deployment graph resource requirements from declared standard providers.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -821,8 +821,9 @@ The reference operator now owns checked-in `voyant.project.ts` and
 `voyant.deployment.ts` declarations. The managed-profile snapshot remains a
 runtime compatibility input for the generated managed Node entry and legacy
 scheduled-job derivation, but it does not select graph units, providers, or the
-deployment target. Phase 2 replaces that remaining compatibility derivation
-with graph-derived requirements and provisioning.
+deployment target. Deployment requirements derive from the graph's declared
+provider bindings using the existing v1 provider contract; Phase 2 continues
+the remaining runtime compatibility and provisioning migration.
 
 The operator graph also runs an explicit source-admission policy for generated
 artifacts: selected packages must resolve to admitted lockfile/workspace

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -430,6 +430,39 @@ describe("deployment graph v1", () => {
     expect(second.contentHash).toBe(first.contentHash)
   })
 
+  it("derives resource requirements from declared deployment providers", () => {
+    const deployment = defineDeployment({
+      project: defineProject({ modules: [] }),
+      target: "node",
+      mode: "self-hosted",
+      providers: {
+        database: "postgres",
+        cache: "redis",
+        search: "none",
+      },
+    })
+
+    expect(deployment.requirements.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceKey: "database:postgres",
+          provider: "postgres",
+          roles: ["database"],
+        }),
+        expect.objectContaining({
+          resourceKey: "redis",
+          provider: "redis",
+          roles: ["cache"],
+        }),
+        expect.objectContaining({
+          resourceKey: "search:none",
+          provider: "none",
+          required: false,
+        }),
+      ]),
+    )
+  })
+
   it("detects package framework incompatibility from metadata", async () => {
     const project = defineProject({
       modules: [

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -15,7 +15,7 @@ import {
 } from "./manifest.js"
 import {
   getVoyantProjectProviders,
-  getVoyantProjectRequirements,
+  PROVIDER_ROLES,
   toCreateVoyantAppProfileConfig,
   type VoyantProfileEnvRequirement,
   type VoyantProfileResourceRequirement,
@@ -23,6 +23,7 @@ import {
   type VoyantProjectManifest,
   type VoyantProjectProviderRole,
 } from "./profile.js"
+import { resourceRequirementsForProvider } from "./profile-requirements.js"
 import { moduleIdFromSpecifier } from "./profile-types.js"
 
 export const VOYANT_GRAPH_PROJECT_SCHEMA_VERSION = "voyant.project.v1" as const
@@ -429,7 +430,9 @@ export function defineDeployment(input: DefineVoyantGraphDeploymentInput): Voyan
     target: input.target,
     providers: { ...(input.providers ?? {}) },
     ...(input.mode ? { mode: input.mode } : {}),
-    requirements: normalizeDeploymentRequirements(input.requirements),
+    requirements: normalizeDeploymentRequirements(
+      input.requirements ?? deriveDeploymentRequirements(input.providers),
+    ),
     ...(input.meta ? { meta: input.meta } : {}),
   } satisfies VoyantGraphDeployment
 
@@ -439,6 +442,19 @@ export function defineDeployment(input: DefineVoyantGraphDeploymentInput): Voyan
     )
   }
   return deployment
+}
+
+export function deriveDeploymentRequirements(
+  providers: Partial<Record<VoyantProjectProviderRole | string, string>> = {},
+): VoyantGraphDeploymentRequirements {
+  return normalizeDeploymentRequirements({
+    resources: PROVIDER_ROLES.flatMap((role) => {
+      const provider = providers[role]
+      return typeof provider === "string" && provider.trim().length > 0
+        ? resourceRequirementsForProvider(role, provider)
+        : []
+    }),
+  })
 }
 
 export function validateGraphUnitManifest(
@@ -633,17 +649,15 @@ export function defineProjectFromManagedProfile(
 export function defineDeploymentFromManagedProfile(
   project: VoyantProjectManifest,
 ): VoyantGraphDeployment {
-  const requirements = getVoyantProjectRequirements(project)
   const providers = getVoyantProjectProviders(project)
   return defineDeployment({
     project: defineProjectFromManagedProfile(project),
     target: project.mode === "managed-cloud" ? "voyant-cloud" : "node",
     mode: project.mode,
     providers: { ...providers },
-    requirements: { resources: requirements.resources },
     meta: {
-      compatibilityProfile: requirements.profile,
-      frameworkVersion: requirements.frameworkVersion,
+      compatibilityProfile: project.profile,
+      frameworkVersion: project.frameworkVersion,
     },
   })
 }

--- a/packages/framework/src/profile-requirements.ts
+++ b/packages/framework/src/profile-requirements.ts
@@ -14,7 +14,13 @@ export function resourceRequirementsFor(
   role: VoyantProjectProviderRole,
   providers: VoyantProjectProviders,
 ): VoyantProfileResourceRequirement[] {
-  const provider = providers[role]
+  return resourceRequirementsForProvider(role, providers[role])
+}
+
+export function resourceRequirementsForProvider(
+  role: VoyantProjectProviderRole,
+  provider: string,
+): VoyantProfileResourceRequirement[] {
   if (provider === "none") {
     return [
       {

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c",
+  "graphHash": "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c",
+      "graphHash": "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c",
+  "contentHash": "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1290,7 +1290,7 @@
         "kind": "workspace",
         "reference": "link:../accommodations"
       },
-      "version": "0.111.4"
+      "version": "0.111.5"
     },
     {
       "metadata": {
@@ -1307,7 +1307,7 @@
         "kind": "workspace",
         "reference": "link:../action-ledger"
       },
-      "version": "0.105.13"
+      "version": "0.105.14"
     },
     {
       "metadata": {
@@ -1324,7 +1324,7 @@
         "kind": "workspace",
         "reference": "link:../availability"
       },
-      "version": "0.1.2"
+      "version": "0.1.3"
     },
     {
       "metadata": {
@@ -1341,7 +1341,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/bookings"
       },
-      "version": "0.149.0"
+      "version": "0.149.1"
     },
     {
       "metadata": {
@@ -1358,7 +1358,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/catalog"
       },
-      "version": "0.147.0"
+      "version": "0.147.1"
     },
     {
       "metadata": {
@@ -1375,7 +1375,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/catalog-authoring"
       },
-      "version": "0.106.28"
+      "version": "0.106.29"
     },
     {
       "metadata": {
@@ -1392,7 +1392,7 @@
         "kind": "workspace",
         "reference": "link:../charters"
       },
-      "version": "0.147.0"
+      "version": "0.147.1"
     },
     {
       "metadata": {
@@ -1409,7 +1409,7 @@
         "kind": "workspace",
         "reference": "link:../commerce"
       },
-      "version": "0.31.0"
+      "version": "0.31.1"
     },
     {
       "metadata": {
@@ -1426,7 +1426,7 @@
         "kind": "workspace",
         "reference": "link:../cruises"
       },
-      "version": "0.148.0"
+      "version": "0.148.1"
     },
     {
       "metadata": {
@@ -1443,7 +1443,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/db"
       },
-      "version": "0.110.0"
+      "version": "0.110.1"
     },
     {
       "metadata": {
@@ -1460,7 +1460,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/distribution"
       },
-      "version": "0.139.0"
+      "version": "0.139.1"
     },
     {
       "metadata": {
@@ -1477,7 +1477,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/finance"
       },
-      "version": "0.149.0"
+      "version": "0.149.1"
     },
     {
       "metadata": {
@@ -1494,7 +1494,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/flights"
       },
-      "version": "0.149.0"
+      "version": "0.149.1"
     },
     {
       "metadata": {
@@ -1511,7 +1511,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.29.4"
+      "version": "0.29.5"
     },
     {
       "metadata": {
@@ -1528,7 +1528,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/framework-migrations"
       },
-      "version": "0.7.1"
+      "version": "0.7.2"
     },
     {
       "metadata": {
@@ -1545,7 +1545,7 @@
         "kind": "workspace",
         "reference": "link:../hono"
       },
-      "version": "0.122.1"
+      "version": "0.122.2"
     },
     {
       "metadata": {
@@ -1562,7 +1562,7 @@
         "kind": "workspace",
         "reference": "link:../identity"
       },
-      "version": "0.149.0"
+      "version": "0.149.1"
     },
     {
       "metadata": {
@@ -1579,7 +1579,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/inventory"
       },
-      "version": "0.7.9"
+      "version": "0.7.10"
     },
     {
       "metadata": {
@@ -1596,7 +1596,7 @@
         "kind": "workspace",
         "reference": "link:../legal"
       },
-      "version": "0.149.0"
+      "version": "0.149.1"
     },
     {
       "metadata": {
@@ -1613,7 +1613,7 @@
         "kind": "workspace",
         "reference": "link:../mice"
       },
-      "version": "0.6.8"
+      "version": "0.6.9"
     },
     {
       "metadata": {
@@ -1630,7 +1630,7 @@
         "kind": "workspace",
         "reference": "link:../notifications"
       },
-      "version": "0.122.0"
+      "version": "0.122.1"
     },
     {
       "metadata": {
@@ -1647,7 +1647,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/operations"
       },
-      "version": "0.5.21"
+      "version": "0.5.22"
     },
     {
       "metadata": {
@@ -1680,7 +1680,7 @@
         "kind": "workspace",
         "reference": "link:../operator-settings"
       },
-      "version": "0.2.33"
+      "version": "0.2.34"
     },
     {
       "metadata": {
@@ -1715,7 +1715,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/quotes"
       },
-      "version": "0.125.7"
+      "version": "0.125.8"
     },
     {
       "metadata": {
@@ -1732,7 +1732,7 @@
         "kind": "workspace",
         "reference": "link:../../packages/relationships"
       },
-      "version": "0.122.10"
+      "version": "0.122.11"
     },
     {
       "metadata": {
@@ -1749,7 +1749,7 @@
         "kind": "workspace",
         "reference": "link:../storefront"
       },
-      "version": "0.151.0"
+      "version": "0.151.1"
     },
     {
       "metadata": {
@@ -1766,7 +1766,7 @@
         "kind": "workspace",
         "reference": "link:../trips"
       },
-      "version": "0.140.0"
+      "version": "0.140.1"
     },
     {
       "metadata": {
@@ -1783,7 +1783,7 @@
         "kind": "workspace",
         "reference": "link:../workflow-runs"
       },
-      "version": "0.111.18"
+      "version": "0.111.19"
     }
   ],
   "plugins": [

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:e70d753f1be58f1f98154f01bd4984817ffcfbaaf323d7d89b1ec6a3dc90af9c" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const

--- a/starters/operator/voyant.deployment.ts
+++ b/starters/operator/voyant.deployment.ts
@@ -1,9 +1,5 @@
 import { defineDeployment } from "../../packages/framework/src/deployment-graph.ts"
-import {
-  PROVIDER_ROLES,
-  type VoyantProjectProviders,
-} from "../../packages/framework/src/profile.ts"
-import { resourceRequirementsFor } from "../../packages/framework/src/profile-requirements.ts"
+import type { VoyantProjectProviders } from "../../packages/framework/src/profile.ts"
 import { OPERATOR_VOYANT_PROJECT } from "./voyant.project.ts"
 
 export const OPERATOR_VOYANT_DEPLOYMENT_PROVIDERS = {
@@ -25,9 +21,4 @@ export const OPERATOR_VOYANT_DEPLOYMENT = defineDeployment({
   target: "node",
   mode: "self-hosted",
   providers: OPERATOR_VOYANT_DEPLOYMENT_PROVIDERS,
-  requirements: {
-    resources: PROVIDER_ROLES.flatMap((role) =>
-      resourceRequirementsFor(role, OPERATOR_VOYANT_DEPLOYMENT_PROVIDERS),
-    ),
-  },
 })


### PR DESCRIPTION
## What changed

- make `defineDeployment` derive standard resource requirements directly from declared providers
- retain explicit requirement declarations for future extension-defined providers
- remove the operator declaration's dependency on the managed-profile requirement bridge
- refresh generated operator graph artifacts and add the framework changeset

## Why

The deployment declaration is now the source of truth for provider requirements. The managed-profile bridge remains compatibility-only, advancing Phase 2 of the unified deployment graph.

## Validation

- `pnpm --filter @voyant-travel/framework test -- src/deployment-graph.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- `pnpm verify:architecture`
- pre-push full test suite
