### PR TITLE
feat: validate runtime requirements from graph

### DIFF
--- a/.changeset/graph-runtime-requirements.md
+++ b/.changeset/graph-runtime-requirements.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Allow managed runtime startup to validate requirements supplied by a resolved deployment graph.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -822,8 +822,9 @@ The reference operator now owns checked-in `voyant.project.ts` and
 runtime compatibility input for the generated managed Node entry and legacy
 scheduled-job derivation, but it does not select graph units, providers, or the
 deployment target. Deployment requirements derive from the graph's declared
-provider bindings using the existing v1 provider contract; Phase 2 continues
-the remaining runtime compatibility and provisioning migration.
+provider bindings using the existing v1 provider contract, and generated Node
+runtime entries pass those resolved requirements into boot validation. Phase 2
+continues the remaining runtime compatibility and provisioning migration.
 
 The operator graph also runs an explicit source-admission policy for generated
 artifacts: selected packages must resolve to admitted lockfile/workspace

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -106,11 +106,13 @@ describe("deployment graph artifacts", () => {
     expect(source).toContain('import { readFileSync } from "node:fs"')
     expect(source).toContain('from "node:url"')
     expect(source).toContain("assertGeneratedDeploymentGraphArtifact()")
+    expect(source).toContain("resolveGeneratedDeploymentRequirements")
     expect(source).toContain('await import("@voyant-travel/framework/managed-runtime")')
     expect(
       source.indexOf("if (isMainModule) {\n  assertGeneratedDeploymentGraphArtifact()"),
     ).toBeLessThan(source.indexOf('await import("@voyant-travel/framework/managed-runtime")'))
     expect(source).toContain("startManagedProfileRuntime")
+    expect(source).toContain("deploymentRequirements: resolveGeneratedDeploymentRequirements()")
     expect(source).not.toContain("starters/")
   })
 

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -104,6 +104,8 @@ export function buildManagedNodeRuntimeEntry(input: BuildManagedNodeRuntimeEntry
 import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
+import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework/deployment-graph"
+
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = ${quote(input.graph.schemaVersion)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_HASH = ${quote(input.graph.contentHash)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = ${quote(input.graph.deployment.target)} as const
@@ -128,17 +130,7 @@ export function resolveGeneratedProfileSnapshotPath(): string {
 }
 
 export function assertGeneratedDeploymentGraphArtifact(): void {
-  const graph = JSON.parse(
-    readFileSync(
-      fileURLToPath(new URL(GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH, import.meta.url)),
-      "utf8",
-    ),
-  ) as {
-    schemaVersion?: unknown
-    contentHash?: unknown
-    deployment?: { target?: unknown; mode?: unknown }
-    diagnostics?: unknown
-  }
+  const graph = readGeneratedDeploymentGraph()
   if (graph.schemaVersion !== GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION) {
     throw new Error(
       \`Generated deployment graph schemaVersion \${String(
@@ -179,12 +171,46 @@ export function assertGeneratedDeploymentGraphArtifact(): void {
   }
 }
 
+export function resolveGeneratedDeploymentRequirements(): VoyantGraphDeploymentRequirements {
+  const requirements = readGeneratedDeploymentGraph().requirements
+  if (!requirements || typeof requirements !== "object" || Array.isArray(requirements)) {
+    throw new Error("Generated deployment graph requirements are missing or invalid")
+  }
+  const candidate = requirements as { resources?: unknown }
+  if (!Array.isArray(candidate.resources)) {
+    throw new Error("Generated deployment graph requirements.resources must be an array")
+  }
+  return candidate as VoyantGraphDeploymentRequirements
+}
+
+function readGeneratedDeploymentGraph(): {
+  schemaVersion?: unknown
+  contentHash?: unknown
+  deployment?: { target?: unknown; mode?: unknown }
+  requirements?: unknown
+  diagnostics?: unknown
+} {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH, import.meta.url)),
+      "utf8",
+    ),
+  ) as {
+    schemaVersion?: unknown
+    contentHash?: unknown
+    deployment?: { target?: unknown; mode?: unknown }
+    requirements?: unknown
+    diagnostics?: unknown
+  }
+}
+
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
   assertGeneratedDeploymentGraphArtifact()
   const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
+    deploymentRequirements: resolveGeneratedDeploymentRequirements(),
   })
   console.info(
     \`[managed-runtime] Node runtime listening on :\${handle.port} (\${GENERATED_DEPLOYMENT_GRAPH_HASH})\`,

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -138,6 +138,48 @@ describe("managed profile runtime entry", () => {
     expect(runtime.app.fetch).toEqual(expect.any(Function))
   })
 
+  it("validates the graph-supplied deployment requirements at startup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    await expect(
+      loadManagedProfileRuntime({
+        profileSnapshotPath: snapshotPath,
+        env: { DATABASE_URL: "managed-profile-test-db" },
+        deploymentRequirements: {
+          resources: [
+            {
+              resourceKey: "graph:runtime",
+              roles: ["database"],
+              provider: "postgres",
+              required: true,
+              env: [
+                {
+                  name: "GRAPH_RUNTIME_SECRET",
+                  kind: "secret",
+                  required: true,
+                  description: "Required by the resolved deployment graph.",
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ).rejects.toThrow(/GRAPH_RUNTIME_SECRET is required for graph:runtime/)
+  })
+
   it("fails fast when a managed-cloud profile is missing required runtime substrate", async () => {
     const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
     const snapshotPath = join(dir, "managed-profile.json")

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -160,6 +160,7 @@ import {
   resolveManagedCustomExtensions,
   resolveManagedCustomModules,
 } from "./custom-source-resolution.js"
+import type { VoyantGraphDeploymentRequirements } from "./deployment-graph.js"
 import { type ManagedPlugin, resolveManagedPlugins } from "./plugin-resolution.js"
 import {
   getVoyantProjectRequirements,
@@ -242,6 +243,11 @@ type ManagedProfileAppExtensions = Record<string, ExtensionFactory<FrameworkProv
 
 export interface ManagedProfileRuntimeOptions {
   profileSnapshotPath: string
+  /**
+   * Resolved deployment requirements supplied by a checked graph artifact.
+   * Omit this only for legacy snapshot-only callers.
+   */
+  deploymentRequirements?: VoyantGraphDeploymentRequirements
   env?: Record<string, unknown> | ManagedProfileRuntimeEnv
   auth?: VoyantAuthIntegration<ManagedProfileRuntimeEnv>
   providers?: Partial<FrameworkProviders>
@@ -323,7 +329,13 @@ export async function loadManagedProfileRuntime(
 ): Promise<ManagedProfileRuntime> {
   const project = await loadManagedProfileSnapshot(options.profileSnapshotPath)
   const env = createManagedProfileNodeEnv(options.env ?? process.env)
-  const requirements = getVoyantProjectRequirements(project)
+  const profileRequirements = getVoyantProjectRequirements(project)
+  const requirements: VoyantProfileRequirements = {
+    ...profileRequirements,
+    ...(options.deploymentRequirements
+      ? { resources: options.deploymentRequirements.resources }
+      : {}),
+  }
   const auth = resolveManagedProfileAuthIntegration({
     env,
     auth: options.app?.auth ?? options.auth,

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -4,6 +4,8 @@
 import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
+import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework/deployment-graph"
+
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
 export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
@@ -112,17 +114,7 @@ export function resolveGeneratedProfileSnapshotPath(): string {
 }
 
 export function assertGeneratedDeploymentGraphArtifact(): void {
-  const graph = JSON.parse(
-    readFileSync(
-      fileURLToPath(new URL(GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH, import.meta.url)),
-      "utf8",
-    ),
-  ) as {
-    schemaVersion?: unknown
-    contentHash?: unknown
-    deployment?: { target?: unknown; mode?: unknown }
-    diagnostics?: unknown
-  }
+  const graph = readGeneratedDeploymentGraph()
   if (graph.schemaVersion !== GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION) {
     throw new Error(
       `Generated deployment graph schemaVersion ${String(
@@ -163,12 +155,46 @@ export function assertGeneratedDeploymentGraphArtifact(): void {
   }
 }
 
+export function resolveGeneratedDeploymentRequirements(): VoyantGraphDeploymentRequirements {
+  const requirements = readGeneratedDeploymentGraph().requirements
+  if (!requirements || typeof requirements !== "object" || Array.isArray(requirements)) {
+    throw new Error("Generated deployment graph requirements are missing or invalid")
+  }
+  const candidate = requirements as { resources?: unknown }
+  if (!Array.isArray(candidate.resources)) {
+    throw new Error("Generated deployment graph requirements.resources must be an array")
+  }
+  return candidate as VoyantGraphDeploymentRequirements
+}
+
+function readGeneratedDeploymentGraph(): {
+  schemaVersion?: unknown
+  contentHash?: unknown
+  deployment?: { target?: unknown; mode?: unknown }
+  requirements?: unknown
+  diagnostics?: unknown
+} {
+  return JSON.parse(
+    readFileSync(
+      fileURLToPath(new URL(GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH, import.meta.url)),
+      "utf8",
+    ),
+  ) as {
+    schemaVersion?: unknown
+    contentHash?: unknown
+    deployment?: { target?: unknown; mode?: unknown }
+    requirements?: unknown
+    diagnostics?: unknown
+  }
+}
+
 const isMainModule = import.meta.url === pathToFileURL(process.argv[1] ?? "").href
 if (isMainModule) {
   assertGeneratedDeploymentGraphArtifact()
   const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
+    deploymentRequirements: resolveGeneratedDeploymentRequirements(),
   })
   console.info(
     `[managed-runtime] Node runtime listening on :${handle.port} (${GENERATED_DEPLOYMENT_GRAPH_HASH})`,


### PR DESCRIPTION
## What changed

- let managed runtime startup accept requirements from a resolved deployment graph
- make generated Node runtime entries read and pass their checked graph requirements into boot validation
- preserve snapshot-derived requirements for legacy callers that do not supply a graph
- add runtime and generated-entry coverage, documentation, and a framework changeset

## Why

The generated Node runtime now validates the same graph-derived requirements used by doctor, build, and deployment artifacts. This removes another managed-profile compatibility dependency from the Phase 2 runtime path.

## Validation

- `pnpm --filter @voyant-travel/framework test -- src/deployment-artifacts.test.ts src/managed-runtime.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter operator typecheck`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- `pnpm verify:architecture`
- pre-push full test suite
