### PR TITLE
feat: preserve graph environment aliases

### DIFF
--- a/.changeset/graph-env-alias-compatibility.md
+++ b/.changeset/graph-env-alias-compatibility.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Allow graph resource requirements to declare compatible environment aliases, including `DATABASE_URL_DIRECT` for Postgres runtime validation.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -67,6 +67,8 @@ workload class well. On Node none of it is necessary.
   remain the fallback adapters. See
   [performance-enterprise-scale-assessment.md](./performance-enterprise-scale-assessment.md)
   §2.6.
+  The canonical graph `DATABASE_URL` requirement accepts `DATABASE_URL_DIRECT`
+  as a compatible alias, so either value satisfies pre-boot validation.
 - **Crons:** declared runtime-neutrally in `src/scheduled-crons.ts`
   (`OPERATOR_CRON_JOBS`). On Node they can't run on a timer inside the process, so
   `pnpm --filter operator emit:cloud-scheduler` fans them out to Cloud Scheduler

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -824,7 +824,10 @@ scheduled-job derivation, but it does not select graph units, providers, or the
 deployment target. Deployment requirements derive from the graph's declared
 provider bindings using the existing v1 provider contract, and generated Node
 runtime entries pass those resolved requirements into boot validation. Phase 2
-continues the remaining runtime compatibility and provisioning migration.
+also models compatible environment aliases on canonical resource requirements:
+for example, either `DATABASE_URL` or the Node-pool `DATABASE_URL_DIRECT`
+satisfies the graph's Postgres requirement. Phase 2 continues the remaining
+runtime compatibility and provisioning migration.
 
 The operator graph also runs an explicit source-admission policy for generated
 artifacts: selected packages must resolve to admitted lockfile/workspace

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -375,6 +375,7 @@ describe("deployment graph v1", () => {
               },
               {
                 name: "DATABASE_URL",
+                aliases: ["DATABASE_URL_DIRECT", "POSTGRES_URL"],
                 kind: "secret",
                 required: true,
                 description: "Primary database.",
@@ -398,6 +399,7 @@ describe("deployment graph v1", () => {
             env: [
               {
                 name: "DATABASE_URL",
+                aliases: ["POSTGRES_URL", "DATABASE_URL_DIRECT"],
                 kind: "secret",
                 required: true,
                 description: "Primary database.",
@@ -426,6 +428,10 @@ describe("deployment graph v1", () => {
     })
 
     expect(first.requirements.resources).toEqual(second.requirements.resources)
+    expect(first.requirements.resources[0]?.env[0]).toMatchObject({
+      name: "DATABASE_URL",
+      aliases: ["DATABASE_URL_DIRECT", "POSTGRES_URL"],
+    })
     expect(JSON.stringify(first.requirements)).not.toContain('"notes":null')
     expect(second.contentHash).toBe(first.contentHash)
   })

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -877,6 +877,7 @@ function normalizeResourceRequirement(
     required: requirement.required,
     env: [...requirement.env].sort(compareEnvRequirements).map((env) => ({
       name: env.name,
+      ...(env.aliases?.length ? { aliases: [...env.aliases].sort() } : {}),
       kind: env.kind,
       required: env.required,
       description: env.description,
@@ -932,6 +933,7 @@ function compareEnvRequirements(
     left.name.localeCompare(right.name) ||
     left.kind.localeCompare(right.kind) ||
     Number(left.required) - Number(right.required) ||
+    (left.aliases ?? []).join(",").localeCompare((right.aliases ?? []).join(",")) ||
     left.description.localeCompare(right.description)
   )
 }

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -138,6 +138,30 @@ describe("managed profile runtime entry", () => {
     expect(runtime.app.fetch).toEqual(expect.any(Function))
   })
 
+  it("accepts DATABASE_URL_DIRECT for a graph-derived Postgres requirement", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    const runtime = await loadManagedProfileRuntime({
+      profileSnapshotPath: snapshotPath,
+      env: { DATABASE_URL_DIRECT: "managed-profile-test-db" },
+    })
+
+    expect(runtime.app.fetch).toEqual(expect.any(Function))
+  })
+
   it("validates the graph-supplied deployment requirements at startup", async () => {
     const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
     const snapshotPath = join(dir, "managed-profile.json")

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -1180,9 +1180,9 @@ function managedProfileEnvIssues(
   for (const resource of requirements.resources) {
     for (const requirement of resource.env) {
       if (!requirement.required) continue
-      const value = getEnvValue(env, requirement.name)
-      const present =
-        typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+      const present = [requirement.name, ...(requirement.aliases ?? [])].some((name) =>
+        hasEnvValue(env, name),
+      )
       if (!present) {
         issues.push(
           `${requirement.kind} ${requirement.name} is required for ${resource.resourceKey}`,
@@ -1207,6 +1207,11 @@ function formatIssues(issues: readonly string[]): string {
 
 function getEnvValue(env: ManagedProfileRuntimeEnv, name: string): unknown {
   return Reflect.get(env, name)
+}
+
+function hasEnvValue(env: ManagedProfileRuntimeEnv, name: string): boolean {
+  const value = getEnvValue(env, name)
+  return typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
 }
 
 function dbUrl(env: ManagedProfileRuntimeEnv): string {

--- a/packages/framework/src/profile-requirements.ts
+++ b/packages/framework/src/profile-requirements.ts
@@ -55,6 +55,8 @@ function envForProvider(
       secret(
         "DATABASE_URL",
         "Primary Postgres connection URL used by migrations and fallback DB clients.",
+        true,
+        ["DATABASE_URL_DIRECT"],
       ),
       secret("DATABASE_URL_DIRECT", "Direct Postgres URL for the resident Node pool.", false),
       secret(
@@ -84,7 +86,9 @@ function envForProvider(
     provider === "postgres"
   ) {
     return [
-      secret("DATABASE_URL", `Postgres URL used for ${role} shared-state storage.`),
+      secret("DATABASE_URL", `Postgres URL used for ${role} shared-state storage.`, true, [
+        "DATABASE_URL_DIRECT",
+      ]),
       secret("DATABASE_URL_DIRECT", "Direct Postgres URL for the resident Node pool.", false),
     ]
   }
@@ -179,8 +183,13 @@ function resourceKeyFor(role: VoyantProjectProviderRole, provider: string): stri
   return `${role}:${provider}`
 }
 
-function secret(name: string, description: string, required = true): VoyantProfileEnvRequirement {
-  return { name, kind: "secret", required, description }
+function secret(
+  name: string,
+  description: string,
+  required = true,
+  aliases: readonly string[] = [],
+): VoyantProfileEnvRequirement {
+  return { name, ...(aliases.length > 0 ? { aliases } : {}), kind: "secret", required, description }
 }
 
 function variable(name: string, description: string, required = true): VoyantProfileEnvRequirement {

--- a/packages/framework/src/profile-types.ts
+++ b/packages/framework/src/profile-types.ts
@@ -109,6 +109,8 @@ export interface VoyantProfileValidationResult {
 
 export interface VoyantProfileEnvRequirement {
   name: string
+  /** Alternate environment names that satisfy the canonical requirement. */
+  aliases?: readonly string[]
   kind: "secret" | "variable" | "binding"
   required: boolean
   description: string

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -146,7 +146,12 @@ describe("managed profile contract", () => {
       requirements.resources.find((resource) => resource.roles.includes("database"))?.env,
     ).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ name: "DATABASE_URL", kind: "secret", required: true }),
+        expect.objectContaining({
+          name: "DATABASE_URL",
+          aliases: ["DATABASE_URL_DIRECT"],
+          kind: "secret",
+          required: true,
+        }),
         expect.objectContaining({ name: "DATABASE_URL_DIRECT", kind: "secret", required: false }),
       ]),
     )

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -362,7 +362,18 @@ function mergeEnvRequirements(
   for (const env of [...left, ...right]) {
     const key = `${env.kind}:${env.name}`
     const existing = merged.get(key)
-    merged.set(key, existing ? { ...existing, required: existing.required || env.required } : env)
+    merged.set(
+      key,
+      existing
+        ? {
+            ...existing,
+            required: existing.required || env.required,
+            ...(existing.aliases || env.aliases
+              ? { aliases: unique([...(existing.aliases ?? []), ...(env.aliases ?? [])]) }
+              : {}),
+          }
+        : env,
+    )
   }
   return [...merged.values()]
 }

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c",
+  "graphHash": "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c",
+      "graphHash": "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c",
+  "contentHash": "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -2349,6 +2349,7 @@
       {
         "env": [
           {
+            "aliases": ["DATABASE_URL_DIRECT"],
             "description": "Primary Postgres connection URL used by migrations and fallback DB clients.",
             "kind": "secret",
             "name": "DATABASE_URL",

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -127,6 +127,11 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(validateOperatorDeploymentGraphResourceEnv(summary, { DATABASE_URL: "   " })).toEqual([
       "secret DATABASE_URL is required for database:postgres",
     ])
+    expect(
+      validateOperatorDeploymentGraphResourceEnv(summary, {
+        DATABASE_URL_DIRECT: "postgres://user:pass@example.test:5432/voyant",
+      }),
+    ).toEqual([])
     expect(() => assertOperatorDeploymentGraphResourceEnv(summary, {})).toThrow(
       /Operator deployment graph resource requirements are not satisfied:\n- secret DATABASE_URL is required for database:postgres/,
     )
@@ -400,6 +405,7 @@ function writeFixture(
                   env: [
                     {
                       name: "DATABASE_URL",
+                      aliases: ["DATABASE_URL_DIRECT"],
                       kind: "secret",
                       required: true,
                       description: "Primary Postgres connection URL.",
@@ -483,7 +489,13 @@ interface FixtureDeploymentGraph {
       roles: string[]
       provider: string
       required: boolean
-      env: Array<{ name: string; kind: string; required: boolean; description: string }>
+      env: Array<{
+        name: string
+        aliases?: string[]
+        kind: string
+        required: boolean
+        description: string
+      }>
     }>
   }
   modules: Array<{ id: string }>

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: operator; graph artifact parsing and pre-boot validation stay co-located so the generated deployment contract has one trusted reader.
 import { createHash } from "node:crypto"
 import { existsSync, readFileSync } from "node:fs"
 import { fileURLToPath } from "node:url"
@@ -51,6 +52,7 @@ export interface OperatorDeploymentGraphMigrationSource {
 
 export interface OperatorDeploymentGraphEnvRequirement {
   name: string
+  aliases?: readonly string[]
   kind: string
   required: boolean
   description: string
@@ -244,9 +246,9 @@ export function validateOperatorDeploymentGraphResourceEnv(
   for (const resource of summary.resourceRequirements) {
     for (const requirement of resource.env) {
       if (!requirement.required) continue
-      const value = env[requirement.name]
-      const present =
-        typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+      const present = [requirement.name, ...(requirement.aliases ?? [])].some((name) =>
+        hasEnvValue(env, name),
+      )
       if (!present) {
         issues.push(
           `${requirement.kind} ${requirement.name} is required for ${resource.resourceKey}`,
@@ -355,6 +357,14 @@ function collectResourceRequirements(value: unknown): OperatorDeploymentGraphRes
         entry.name,
         `deployment graph requirements.resources[${index}].env[${envIndex}].name`,
       ),
+      ...(entry.aliases === undefined
+        ? {}
+        : {
+            aliases: collectStringArray(
+              entry.aliases,
+              `deployment graph requirements.resources[${index}].env[${envIndex}].aliases`,
+            ),
+          }),
       kind: requireString(
         entry.kind,
         `deployment graph requirements.resources[${index}].env[${envIndex}].kind`,
@@ -406,6 +416,11 @@ function readJsonFile<T>(url: URL, label: string): T {
   } catch (error) {
     throw new Error(`could not read ${label} at ${file}: ${reason(error)}`)
   }
+}
+
+function hasEnvValue(env: OperatorDeploymentGraphEnv, name: string): boolean {
+  const value = env[name]
+  return typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
 }
 
 function relativeArtifactUrl(value: string, baseUrl: URL): URL {

--- a/starters/operator/src/operator-node-provider-plan.test.ts
+++ b/starters/operator/src/operator-node-provider-plan.test.ts
@@ -64,8 +64,23 @@ describe("resolveOperatorNodeProviderPlan", () => {
       "env R2_BUCKET_MEDIA is required by the operator Node provider plan",
       "env R2_BUCKET_DOCUMENTS is required by the operator Node provider plan",
       "env REDIS_URL is required by the operator Node provider plan",
-      "env DATABASE_URL is required by the operator Node provider plan",
+      "env DATABASE_URL or DATABASE_URL_DIRECT is required by the operator Node provider plan",
     ])
+  })
+
+  it("accepts DATABASE_URL_DIRECT for Postgres provider roles", () => {
+    const plan = resolveOperatorNodeProviderPlan({
+      storage: "memory",
+      cache: "postgres",
+      sharedState: "memory",
+      rateLimit: "memory",
+    })
+
+    expect(
+      validateOperatorNodeProviderPlanEnv(plan, {
+        DATABASE_URL_DIRECT: "postgres://user:pass@example.test:5432/voyant",
+      }),
+    ).toEqual([])
   })
 
   it("rejects unsupported graph providers", () => {

--- a/starters/operator/src/operator-node-provider-plan.ts
+++ b/starters/operator/src/operator-node-provider-plan.ts
@@ -26,6 +26,7 @@ export function validateOperatorNodeProviderPlanEnv(
   env: Record<string, unknown>,
 ): string[] {
   const required = new Set<string>()
+  let requiresPostgresUrl = false
   if (plan.storage === "r2" || plan.storage === "s3") {
     required.add("R2_S3_ENDPOINT")
     required.add("R2_ACCESS_KEY_ID")
@@ -36,12 +37,18 @@ export function validateOperatorNodeProviderPlanEnv(
 
   for (const role of KV_PROVIDER_ROLES) {
     if (plan[role] === "redis") required.add("REDIS_URL")
-    if (plan[role] === "postgres") required.add("DATABASE_URL")
+    if (plan[role] === "postgres") requiresPostgresUrl = true
   }
 
-  return Array.from(required)
+  const issues = Array.from(required)
     .filter((name) => !present(env[name]))
     .map((name) => `env ${name} is required by the operator Node provider plan`)
+  if (requiresPostgresUrl && !present(env.DATABASE_URL) && !present(env.DATABASE_URL_DIRECT)) {
+    issues.push(
+      "env DATABASE_URL or DATABASE_URL_DIRECT is required by the operator Node provider plan",
+    )
+  }
+  return issues
 }
 
 function objectStorageProvider(

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -7,7 +7,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework/deployment-graph"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:3d53ce2597059201397cec93ab0c0e4bea18a538f35368da56b475f7ad31175c" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary
- add compatible environment aliases to graph resource requirements
- allow `DATABASE_URL_DIRECT` to satisfy canonical Postgres requirements in graph, managed-runtime, and Node provider-plan validation
- regenerate operator deployment artifacts and document the shared compatibility contract

## Why
The Node runtime already prefers `DATABASE_URL_DIRECT`, but pre-boot graph validation required `DATABASE_URL` literally. Existing direct-only Node deployments could therefore fail before startup.

## Validation
- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts src/operator-node-provider-plan.test.ts`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- full test suite via the pre-push hook