### PR TITLE
feat: apply graph deployment at runtime

### DIFF
--- a/.changeset/graph-runtime-deployment-contract.md
+++ b/.changeset/graph-runtime-deployment-contract.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Allow managed runtime entries to apply graph-resolved deployment mode and provider bindings instead of snapshot compatibility values.

--- a/docs/architecture/managed-profile-runtime.md
+++ b/docs/architecture/managed-profile-runtime.md
@@ -19,6 +19,12 @@ is missing instead of silently falling back to process-local storage. Local and
 self-hosted profiles may still use explicit memory providers for offline/dev
 execution.
 
+When a checked deployment graph is available, the generated runtime entry
+supplies its deployment mode and complete provider map alongside the resolved
+resource requirements. The JSON snapshot remains a compatibility input for
+profile/module metadata, but cannot override graph-selected self-hosted
+providers.
+
 The source-free managed runtime is not yet a complete managed Cloud image by
 itself. Redis-backed `CACHE`/`RATE_LIMIT` bindings, Voyant Cloud admin auth
 broker integration, snapshot plugin resolution, and route families still backed

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -823,8 +823,9 @@ runtime compatibility input for the generated managed Node entry and legacy
 scheduled-job derivation, but it does not select graph units, providers, or the
 deployment target. Deployment requirements derive from the graph's declared
 provider bindings using the existing v1 provider contract, and generated Node
-runtime entries pass those resolved requirements into boot validation. Phase 2
-also models compatible environment aliases on canonical resource requirements:
+runtime entries pass both the resolved requirements and deployment mode/provider
+bindings into boot validation. Phase 2 also models compatible environment aliases
+on canonical resource requirements:
 for example, either `DATABASE_URL` or the Node-pool `DATABASE_URL_DIRECT`
 satisfies the graph's Postgres requirement. Phase 2 continues the remaining
 runtime compatibility and provisioning migration.

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -107,11 +107,13 @@ describe("deployment graph artifacts", () => {
     expect(source).toContain('from "node:url"')
     expect(source).toContain("assertGeneratedDeploymentGraphArtifact()")
     expect(source).toContain("resolveGeneratedDeploymentRequirements")
+    expect(source).toContain("resolveGeneratedRuntimeDeployment")
     expect(source).toContain('await import("@voyant-travel/framework/managed-runtime")')
     expect(
       source.indexOf("if (isMainModule) {\n  assertGeneratedDeploymentGraphArtifact()"),
     ).toBeLessThan(source.indexOf('await import("@voyant-travel/framework/managed-runtime")'))
     expect(source).toContain("startManagedProfileRuntime")
+    expect(source).toContain("deployment: resolveGeneratedRuntimeDeployment()")
     expect(source).toContain("deploymentRequirements: resolveGeneratedDeploymentRequirements()")
     expect(source).not.toContain("starters/")
   })

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -1,5 +1,5 @@
 import { canonicalJson, type ResolvedVoyantDeploymentGraph } from "./deployment-graph.js"
-import type { VoyantProjectDeploymentMode } from "./profile.js"
+import { PROVIDER_ROLES, type VoyantProjectDeploymentMode } from "./profile.js"
 
 export const VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION = "voyant.deployment-artifacts.v1" as const
 export const VOYANT_MANAGED_NODE_RUNTIME_ENTRY_ID = "@voyant-travel/framework#runtime.node" as const
@@ -105,6 +105,7 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework/deployment-graph"
+import type { ManagedProfileRuntimeDeployment } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = ${quote(input.graph.schemaVersion)} as const
 export const GENERATED_DEPLOYMENT_GRAPH_HASH = ${quote(input.graph.contentHash)} as const
@@ -183,10 +184,52 @@ export function resolveGeneratedDeploymentRequirements(): VoyantGraphDeploymentR
   return candidate as VoyantGraphDeploymentRequirements
 }
 
+export function resolveGeneratedRuntimeDeployment(): ManagedProfileRuntimeDeployment {
+  const deployment = readGeneratedDeploymentGraph().deployment
+  if (!deployment || typeof deployment !== "object" || Array.isArray(deployment)) {
+    throw new Error("Generated deployment graph deployment is missing or invalid")
+  }
+  const candidate = deployment as { mode?: unknown; providers?: unknown }
+  if (
+    candidate.mode !== "local" &&
+    candidate.mode !== "managed-cloud" &&
+    candidate.mode !== "self-hosted"
+  ) {
+    throw new Error("Generated deployment graph deployment.mode is invalid")
+  }
+  if (!isGeneratedRecord(candidate.providers)) {
+    throw new Error("Generated deployment graph deployment.providers is missing or invalid")
+  }
+  const providers: ManagedProfileRuntimeDeployment["providers"] = ${formatRuntimeDeploymentProviders()}
+  return {
+    mode: candidate.mode,
+    providers,
+  }
+}
+
+function requireGeneratedDeploymentProvider<
+  Role extends keyof ManagedProfileRuntimeDeployment["providers"],
+>(
+  providers: Record<string, unknown>,
+  role: Role,
+): ManagedProfileRuntimeDeployment["providers"][Role] {
+  const provider = providers[role]
+  if (typeof provider !== "string" || provider.trim().length === 0) {
+    throw new Error(
+      \`Generated deployment graph deployment.providers.\${role} must be a non-empty string\`,
+    )
+  }
+  return provider as ManagedProfileRuntimeDeployment["providers"][Role]
+}
+
+function isGeneratedRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
 function readGeneratedDeploymentGraph(): {
   schemaVersion?: unknown
   contentHash?: unknown
-  deployment?: { target?: unknown; mode?: unknown }
+  deployment?: { target?: unknown; mode?: unknown; providers?: unknown }
   requirements?: unknown
   diagnostics?: unknown
 } {
@@ -198,7 +241,7 @@ function readGeneratedDeploymentGraph(): {
   ) as {
     schemaVersion?: unknown
     contentHash?: unknown
-    deployment?: { target?: unknown; mode?: unknown }
+    deployment?: { target?: unknown; mode?: unknown; providers?: unknown }
     requirements?: unknown
     diagnostics?: unknown
   }
@@ -210,6 +253,7 @@ if (isMainModule) {
   const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
+    deployment: resolveGeneratedRuntimeDeployment(),
     deploymentRequirements: resolveGeneratedDeploymentRequirements(),
   })
   console.info(
@@ -243,6 +287,13 @@ function formatGeneratedDiagnostic(value: unknown): string {
 function formatConstArray(values: readonly string[]): string {
   if (values.length === 0) return "[] as const"
   return `[\n${values.map((value) => `  ${quote(value)},`).join("\n")}\n] as const`
+}
+
+function formatRuntimeDeploymentProviders(): string {
+  return `{\n${PROVIDER_ROLES.map(
+    (role) =>
+      `    ${role}: requireGeneratedDeploymentProvider(candidate.providers, ${quote(role)}),`,
+  ).join("\n")}\n  }`
 }
 
 function quote(value: string | VoyantProjectDeploymentMode | undefined): string {

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -204,6 +204,52 @@ describe("managed profile runtime entry", () => {
     ).rejects.toThrow(/GRAPH_RUNTIME_SECRET is required for graph:runtime/)
   })
 
+  it("uses graph deployment providers instead of snapshot compatibility providers", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    const runtime = await loadManagedProfileRuntime({
+      profileSnapshotPath: snapshotPath,
+      env: { DATABASE_URL: "managed-profile-test-db" },
+      deployment: {
+        mode: "self-hosted",
+        providers: {
+          ...localProviders,
+          cache: "postgres",
+          sharedState: "postgres",
+          rateLimit: "postgres",
+        },
+      },
+    })
+
+    expect(runtime.project.mode).toBe("self-hosted")
+    expect(runtime.project.providers).toMatchObject({
+      cache: "postgres",
+      sharedState: "postgres",
+      rateLimit: "postgres",
+    })
+    expect(runtime.requirements.resources).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          resourceKey: "postgres-shared-state",
+          roles: ["cache", "sharedState", "rateLimit"],
+        }),
+      ]),
+    )
+  })
+
   it("fails fast when a managed-cloud profile is missing required runtime substrate", async () => {
     const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
     const snapshotPath = join(dir, "managed-profile.json")

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -167,7 +167,9 @@ import {
   resolveActiveModuleIds,
   toCreateVoyantAppProfileConfig,
   type VoyantProfileRequirements,
+  type VoyantProjectDeploymentMode,
   type VoyantProjectManifest,
+  type VoyantProjectProviders,
   validateVoyantProject,
 } from "./profile.js"
 
@@ -244,6 +246,11 @@ type ManagedProfileAppExtensions = Record<string, ExtensionFactory<FrameworkProv
 export interface ManagedProfileRuntimeOptions {
   profileSnapshotPath: string
   /**
+   * Resolved deployment mode and providers supplied by a checked graph artifact.
+   * Omit this only for legacy snapshot-only callers.
+   */
+  deployment?: ManagedProfileRuntimeDeployment
+  /**
    * Resolved deployment requirements supplied by a checked graph artifact.
    * Omit this only for legacy snapshot-only callers.
    */
@@ -270,6 +277,11 @@ export interface ManagedProfileRuntimeOptions {
    * instead of node resolution.
    */
   importCustomSourceModule?: (specifier: string) => Promise<Record<string, unknown>>
+}
+
+export interface ManagedProfileRuntimeDeployment {
+  mode: VoyantProjectDeploymentMode
+  providers: VoyantProjectProviders
 }
 
 export interface ManagedProfileRuntime {
@@ -327,7 +339,10 @@ interface ManagedSharedStores {
 export async function loadManagedProfileRuntime(
   options: ManagedProfileRuntimeOptions,
 ): Promise<ManagedProfileRuntime> {
-  const project = await loadManagedProfileSnapshot(options.profileSnapshotPath)
+  const project = applyManagedRuntimeDeployment(
+    await loadManagedProfileSnapshot(options.profileSnapshotPath),
+    options.deployment,
+  )
   const env = createManagedProfileNodeEnv(options.env ?? process.env)
   const profileRequirements = getVoyantProjectRequirements(project)
   const requirements: VoyantProfileRequirements = {
@@ -421,6 +436,29 @@ export async function loadManagedProfileSnapshot(
     )
   }
   return parsed as VoyantProjectManifest
+}
+
+function applyManagedRuntimeDeployment(
+  snapshot: VoyantProjectManifest,
+  deployment: ManagedProfileRuntimeDeployment | undefined,
+): VoyantProjectManifest {
+  if (!deployment) return snapshot
+
+  const { providers: _snapshotProviders, ...projectWithoutSnapshotProviders } = snapshot
+  const project: VoyantProjectManifest = {
+    ...projectWithoutSnapshotProviders,
+    mode: deployment.mode,
+    ...(deployment.mode === "managed-cloud" ? {} : { providers: deployment.providers }),
+  }
+  const validation = validateVoyantProject(project)
+  if (!validation.ok) {
+    throw new Error(
+      `Invalid graph runtime deployment:\n${validation.issues
+        .map((issue) => `- ${issue.path || "<root>"}: ${issue.message}`)
+        .join("\n")}`,
+    )
+  }
+  return project
 }
 
 export function createManagedProfileApp(options: {

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58",
+  "graphHash": "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58",
+      "graphHash": "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58",
+  "contentHash": "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1511,7 +1511,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.29.5"
+      "version": "0.30.0"
     },
     {
       "metadata": {

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -5,9 +5,10 @@ import { readFileSync } from "node:fs"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
 import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework/deployment-graph"
+import type { ManagedProfileRuntimeDeployment } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:eed73644c7277f9dc91d9e8fb81eff7a192251eac2e992205e4404edc1bcca58" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const
@@ -167,10 +168,64 @@ export function resolveGeneratedDeploymentRequirements(): VoyantGraphDeploymentR
   return candidate as VoyantGraphDeploymentRequirements
 }
 
+export function resolveGeneratedRuntimeDeployment(): ManagedProfileRuntimeDeployment {
+  const deployment = readGeneratedDeploymentGraph().deployment
+  if (!deployment || typeof deployment !== "object" || Array.isArray(deployment)) {
+    throw new Error("Generated deployment graph deployment is missing or invalid")
+  }
+  const candidate = deployment as { mode?: unknown; providers?: unknown }
+  if (
+    candidate.mode !== "local" &&
+    candidate.mode !== "managed-cloud" &&
+    candidate.mode !== "self-hosted"
+  ) {
+    throw new Error("Generated deployment graph deployment.mode is invalid")
+  }
+  if (!isGeneratedRecord(candidate.providers)) {
+    throw new Error("Generated deployment graph deployment.providers is missing or invalid")
+  }
+  const providers: ManagedProfileRuntimeDeployment["providers"] = {
+    database: requireGeneratedDeploymentProvider(candidate.providers, "database"),
+    storage: requireGeneratedDeploymentProvider(candidate.providers, "storage"),
+    cache: requireGeneratedDeploymentProvider(candidate.providers, "cache"),
+    sharedState: requireGeneratedDeploymentProvider(candidate.providers, "sharedState"),
+    rateLimit: requireGeneratedDeploymentProvider(candidate.providers, "rateLimit"),
+    search: requireGeneratedDeploymentProvider(candidate.providers, "search"),
+    email: requireGeneratedDeploymentProvider(candidate.providers, "email"),
+    sms: requireGeneratedDeploymentProvider(candidate.providers, "sms"),
+    auth: requireGeneratedDeploymentProvider(candidate.providers, "auth"),
+    scheduledJobs: requireGeneratedDeploymentProvider(candidate.providers, "scheduledJobs"),
+    workflows: requireGeneratedDeploymentProvider(candidate.providers, "workflows"),
+  }
+  return {
+    mode: candidate.mode,
+    providers,
+  }
+}
+
+function requireGeneratedDeploymentProvider<
+  Role extends keyof ManagedProfileRuntimeDeployment["providers"],
+>(
+  providers: Record<string, unknown>,
+  role: Role,
+): ManagedProfileRuntimeDeployment["providers"][Role] {
+  const provider = providers[role]
+  if (typeof provider !== "string" || provider.trim().length === 0) {
+    throw new Error(
+      `Generated deployment graph deployment.providers.${role} must be a non-empty string`,
+    )
+  }
+  return provider as ManagedProfileRuntimeDeployment["providers"][Role]
+}
+
+function isGeneratedRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
 function readGeneratedDeploymentGraph(): {
   schemaVersion?: unknown
   contentHash?: unknown
-  deployment?: { target?: unknown; mode?: unknown }
+  deployment?: { target?: unknown; mode?: unknown; providers?: unknown }
   requirements?: unknown
   diagnostics?: unknown
 } {
@@ -182,7 +237,7 @@ function readGeneratedDeploymentGraph(): {
   ) as {
     schemaVersion?: unknown
     contentHash?: unknown
-    deployment?: { target?: unknown; mode?: unknown }
+    deployment?: { target?: unknown; mode?: unknown; providers?: unknown }
     requirements?: unknown
     diagnostics?: unknown
   }
@@ -194,6 +249,7 @@ if (isMainModule) {
   const { startManagedProfileRuntime } = await import("@voyant-travel/framework/managed-runtime")
   const handle = await startManagedProfileRuntime({
     profileSnapshotPath: resolveGeneratedProfileSnapshotPath(),
+    deployment: resolveGeneratedRuntimeDeployment(),
     deploymentRequirements: resolveGeneratedDeploymentRequirements(),
   })
   console.info(


### PR DESCRIPTION
## Summary
- pass graph-resolved deployment mode and provider bindings into generated managed-runtime entries
- apply that deployment contract before profile requirements and application support are resolved
- regenerate operator graph artifacts and document the snapshot compatibility boundary

## Why
Generated entries already used graph-derived resource requirements, but self-hosted mode and provider choices still came from the managed-profile snapshot. That left a drift path where the runtime could select different provider requirements than the checked deployment graph.

## Impact
For graph-backed runtime entries, the graph is now authoritative for deployment mode and self-hosted provider bindings. Snapshot-only callers retain their existing behavior.

## Validation
- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter operator typecheck`
- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- full test suite via the pre-push hook