### PR TITLE
feat: validate graph resource configuration

### DIFF
--- a/.changeset/graph-resource-config-validation.md
+++ b/.changeset/graph-resource-config-validation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Validate graph-declared Postgres, Redis, and HTTP endpoint environment values before managed runtime boot.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -68,7 +68,9 @@ workload class well. On Node none of it is necessary.
   [performance-enterprise-scale-assessment.md](./performance-enterprise-scale-assessment.md)
   §2.6.
   The canonical graph `DATABASE_URL` requirement accepts `DATABASE_URL_DIRECT`
-  as a compatible alias, so either value satisfies pre-boot validation.
+  as a compatible alias, so either value satisfies pre-boot validation. The
+  graph also verifies Postgres/Redis connection URLs and S3-compatible endpoints
+  before boot.
 - **Crons:** declared runtime-neutrally in `src/scheduled-crons.ts`
   (`OPERATOR_CRON_JOBS`). On Node they can't run on a timer inside the process, so
   `pnpm --filter operator emit:cloud-scheduler` fans them out to Cloud Scheduler

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -825,10 +825,11 @@ deployment target. Deployment requirements derive from the graph's declared
 provider bindings using the existing v1 provider contract, and generated Node
 runtime entries pass both the resolved requirements and deployment mode/provider
 bindings into boot validation. Phase 2 also models compatible environment aliases
-on canonical resource requirements:
+and value formats on canonical resource requirements:
 for example, either `DATABASE_URL` or the Node-pool `DATABASE_URL_DIRECT`
-satisfies the graph's Postgres requirement. Phase 2 continues the remaining
-runtime compatibility and provisioning migration.
+satisfies the graph's Postgres requirement, and the resolved value must be a
+valid Postgres URL. Phase 2 continues the remaining runtime compatibility and
+provisioning migration.
 
 The operator graph also runs an explicit source-admission policy for generated
 artifacts: selected packages must resolve to admitted lockfile/workspace

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -878,6 +878,7 @@ function normalizeResourceRequirement(
     env: [...requirement.env].sort(compareEnvRequirements).map((env) => ({
       name: env.name,
       ...(env.aliases?.length ? { aliases: [...env.aliases].sort() } : {}),
+      ...(env.format ? { format: env.format } : {}),
       kind: env.kind,
       required: env.required,
       description: env.description,
@@ -934,6 +935,7 @@ function compareEnvRequirements(
     left.kind.localeCompare(right.kind) ||
     Number(left.required) - Number(right.required) ||
     (left.aliases ?? []).join(",").localeCompare((right.aliases ?? []).join(",")) ||
+    (left.format ?? "").localeCompare(right.format ?? "") ||
     left.description.localeCompare(right.description)
   )
 }

--- a/packages/framework/src/managed-runtime.test.ts
+++ b/packages/framework/src/managed-runtime.test.ts
@@ -30,6 +30,8 @@ const localProviders = {
   workflows: "none",
 } satisfies VoyantProjectProviders
 
+const MANAGED_PROFILE_TEST_DATABASE_URL = "postgresql://voyant:secret@localhost:5432/voyant_test"
+
 function managedCloudProject() {
   return defineVoyantProject({
     profile: "operator",
@@ -129,7 +131,7 @@ describe("managed profile runtime entry", () => {
     const runtime = await loadManagedProfileRuntime({
       profileSnapshotPath: snapshotPath,
       env: {
-        DATABASE_URL: "managed-profile-test-db",
+        DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL,
       },
     })
 
@@ -156,10 +158,34 @@ describe("managed profile runtime entry", () => {
 
     const runtime = await loadManagedProfileRuntime({
       profileSnapshotPath: snapshotPath,
-      env: { DATABASE_URL_DIRECT: "managed-profile-test-db" },
+      env: { DATABASE_URL_DIRECT: MANAGED_PROFILE_TEST_DATABASE_URL },
     })
 
     expect(runtime.app.fetch).toEqual(expect.any(Function))
+  })
+
+  it("rejects malformed graph-derived Postgres configuration before startup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "voyant-profile-"))
+    const snapshotPath = join(dir, "managed-profile.json")
+    await writeFile(
+      snapshotPath,
+      JSON.stringify(
+        defineVoyantProject({
+          profile: "operator",
+          frameworkVersion: "0.12.22",
+          mode: "local",
+          modules: ["catalog", "bookings", "finance", "relationships"],
+          providers: localProviders,
+        }),
+      ),
+    )
+
+    await expect(
+      loadManagedProfileRuntime({
+        profileSnapshotPath: snapshotPath,
+        env: { DATABASE_URL: "not-a-postgres-url" },
+      }),
+    ).rejects.toThrow(/DATABASE_URL must be a Postgres URL for database:postgres/)
   })
 
   it("validates the graph-supplied deployment requirements at startup", async () => {
@@ -181,7 +207,7 @@ describe("managed profile runtime entry", () => {
     await expect(
       loadManagedProfileRuntime({
         profileSnapshotPath: snapshotPath,
-        env: { DATABASE_URL: "managed-profile-test-db" },
+        env: { DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL },
         deploymentRequirements: {
           resources: [
             {
@@ -222,7 +248,7 @@ describe("managed profile runtime entry", () => {
 
     const runtime = await loadManagedProfileRuntime({
       profileSnapshotPath: snapshotPath,
-      env: { DATABASE_URL: "managed-profile-test-db" },
+      env: { DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL },
       deployment: {
         mode: "self-hosted",
         providers: {
@@ -268,7 +294,7 @@ describe("managed profile runtime entry", () => {
       loadManagedProfileRuntime({
         profileSnapshotPath: snapshotPath,
         env: {
-          DATABASE_URL: "managed-profile-test-db",
+          DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL,
         },
       }),
     ).rejects.toThrow(/REDIS_URL|R2_S3_ENDPOINT/)
@@ -423,7 +449,7 @@ describe("managed profile runtime entry", () => {
 
     const runtime = await loadManagedProfileRuntime({
       profileSnapshotPath: snapshotPath,
-      env: { DATABASE_URL: "managed-profile-test-db" },
+      env: { DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL },
       importPluginModule: async () => ({ voyantPlugin: factory }),
     })
 
@@ -456,7 +482,7 @@ describe("managed profile runtime entry", () => {
     await expect(
       loadManagedProfileRuntime({
         profileSnapshotPath: snapshotPath,
-        env: { DATABASE_URL: "managed-profile-test-db" },
+        env: { DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL },
         importPluginModule: async () => ({ notAFactory: 42 }),
       }),
     ).rejects.toThrow(/does not export a managed-plugin entry/)
@@ -501,7 +527,7 @@ describe("managed profile runtime entry", () => {
 
     const runtime = await loadManagedProfileRuntime({
       profileSnapshotPath: snapshotPath,
-      env: { DATABASE_URL: "managed-profile-test-db" },
+      env: { DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL },
       importCustomSourceModule,
     })
 
@@ -532,7 +558,7 @@ describe("managed profile runtime entry", () => {
     await expect(
       loadManagedProfileRuntime({
         profileSnapshotPath: snapshotPath,
-        env: { DATABASE_URL: "managed-profile-test-db" },
+        env: { DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL },
         importCustomSourceModule: async () => ({ notAFactory: 42 }),
       }),
     ).rejects.toThrow(/does not export a managed-module entry/)
@@ -540,7 +566,7 @@ describe("managed profile runtime entry", () => {
 
   it("builds managed Node bindings from plain env/secrets", () => {
     const env = createManagedProfileNodeEnv({
-      DATABASE_URL: "managed-profile-test-db",
+      DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL,
       R2_S3_ENDPOINT: "https://r2.example.test",
       R2_ACCESS_KEY_ID: "access",
       R2_SECRET_ACCESS_KEY: "secret",
@@ -568,7 +594,7 @@ describe("managed profile runtime entry", () => {
     }
 
     const env = createManagedProfileNodeEnv({
-      DATABASE_URL: "managed-profile-test-db",
+      DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL,
       CACHE: kv,
       RATE_LIMIT: kv,
       MEDIA_BUCKET: bucket,
@@ -706,7 +732,7 @@ describe("managed profile runtime entry", () => {
   }, 10000)
 
   it("wires package-owned contract document routes in the default managed providers", async () => {
-    const env = createManagedProfileNodeEnv({ DATABASE_URL: "managed-profile-test-db" })
+    const env = createManagedProfileNodeEnv({ DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL })
     await env.DOCUMENTS_BUCKET?.put("contracts/test.pdf", new TextEncoder().encode("%PDF-1.4"))
     const app = await createManagedProfileProviders().loadContractDocumentRoutes()
 
@@ -719,7 +745,7 @@ describe("managed profile runtime entry", () => {
 
   it("wires package-owned media routes in the default managed providers", async () => {
     const env = createManagedProfileNodeEnv({
-      DATABASE_URL: "managed-profile-test-db",
+      DATABASE_URL: MANAGED_PROFILE_TEST_DATABASE_URL,
       APP_URL: "https://api.example.test",
     })
     await env.MEDIA_BUCKET?.put("uploads/test.txt", "hello", {

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -166,6 +166,7 @@ import {
   getVoyantProjectRequirements,
   resolveActiveModuleIds,
   toCreateVoyantAppProfileConfig,
+  type VoyantProfileEnvRequirement,
   type VoyantProfileRequirements,
   type VoyantProjectDeploymentMode,
   type VoyantProjectManifest,
@@ -1217,13 +1218,19 @@ function managedProfileEnvIssues(
   const issues: string[] = []
   for (const resource of requirements.resources) {
     for (const requirement of resource.env) {
-      if (!requirement.required) continue
-      const present = [requirement.name, ...(requirement.aliases ?? [])].some((name) =>
-        hasEnvValue(env, name),
-      )
-      if (!present) {
+      const values = [requirement.name, ...(requirement.aliases ?? [])]
+        .map((name) => getEnvValue(env, name))
+        .filter(hasValue)
+      if (requirement.required && values.length === 0) {
         issues.push(
           `${requirement.kind} ${requirement.name} is required for ${resource.resourceKey}`,
+        )
+        continue
+      }
+      const format = requirement.format
+      if (format && values.length > 0 && !values.every((value) => hasFormat(value, format))) {
+        issues.push(
+          `${requirement.kind} ${requirement.name} must be ${formatDescription(format)} for ${resource.resourceKey}`,
         )
       }
     }
@@ -1247,9 +1254,30 @@ function getEnvValue(env: ManagedProfileRuntimeEnv, name: string): unknown {
   return Reflect.get(env, name)
 }
 
-function hasEnvValue(env: ManagedProfileRuntimeEnv, name: string): boolean {
-  const value = getEnvValue(env, name)
+function hasValue(value: unknown): boolean {
   return typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+}
+
+function hasFormat(
+  value: unknown,
+  format: NonNullable<VoyantProfileEnvRequirement["format"]>,
+): boolean {
+  if (typeof value !== "string" || value.trim().length === 0) return false
+  try {
+    const parsed = new URL(value)
+    if (format === "postgres-url")
+      return parsed.protocol === "postgres:" || parsed.protocol === "postgresql:"
+    if (format === "redis-url") return parsed.protocol === "redis:" || parsed.protocol === "rediss:"
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function formatDescription(format: NonNullable<VoyantProfileEnvRequirement["format"]>): string {
+  if (format === "postgres-url") return "a Postgres URL"
+  if (format === "redis-url") return "a Redis URL"
+  return "an HTTP(S) URL"
 }
 
 function dbUrl(env: ManagedProfileRuntimeEnv): string {

--- a/packages/framework/src/profile-requirements.ts
+++ b/packages/framework/src/profile-requirements.ts
@@ -57,8 +57,15 @@ function envForProvider(
         "Primary Postgres connection URL used by migrations and fallback DB clients.",
         true,
         ["DATABASE_URL_DIRECT"],
+        "postgres-url",
       ),
-      secret("DATABASE_URL_DIRECT", "Direct Postgres URL for the resident Node pool.", false),
+      secret(
+        "DATABASE_URL_DIRECT",
+        "Direct Postgres URL for the resident Node pool.",
+        false,
+        [],
+        "postgres-url",
+      ),
       secret(
         "DATABASE_URL_REPLICAS",
         "Comma-separated read replica URLs for the HTTP data plane.",
@@ -68,7 +75,12 @@ function envForProvider(
   }
   if (role === "storage" && (provider === "s3" || provider === "r2")) {
     return [
-      variable("R2_S3_ENDPOINT", "S3-compatible endpoint for media and document buckets."),
+      variable(
+        "R2_S3_ENDPOINT",
+        "S3-compatible endpoint for media and document buckets.",
+        true,
+        "http-url",
+      ),
       variable("R2_BUCKET_MEDIA", "Object bucket for public media."),
       variable("R2_BUCKET_DOCUMENTS", "Object bucket for private/generated documents."),
       secret(R2_ACCESS_KEY_ID_ENV, R2_STORAGE_ID_COPY),
@@ -79,17 +91,35 @@ function envForProvider(
     (role === "cache" || role === "sharedState" || role === "rateLimit") &&
     provider === "redis"
   ) {
-    return [secret("REDIS_URL", "Redis URL used for cache, shared state, and rate limiting.")]
+    return [
+      secret(
+        "REDIS_URL",
+        "Redis URL used for cache, shared state, and rate limiting.",
+        true,
+        [],
+        "redis-url",
+      ),
+    ]
   }
   if (
     (role === "cache" || role === "sharedState" || role === "rateLimit") &&
     provider === "postgres"
   ) {
     return [
-      secret("DATABASE_URL", `Postgres URL used for ${role} shared-state storage.`, true, [
+      secret(
+        "DATABASE_URL",
+        `Postgres URL used for ${role} shared-state storage.`,
+        true,
+        ["DATABASE_URL_DIRECT"],
+        "postgres-url",
+      ),
+      secret(
         "DATABASE_URL_DIRECT",
-      ]),
-      secret("DATABASE_URL_DIRECT", "Direct Postgres URL for the resident Node pool.", false),
+        "Direct Postgres URL for the resident Node pool.",
+        false,
+        [],
+        "postgres-url",
+      ),
     ]
   }
   if (role === "search" && (provider === "typesense" || provider === "algolia")) {
@@ -188,10 +218,23 @@ function secret(
   description: string,
   required = true,
   aliases: readonly string[] = [],
+  format?: VoyantProfileEnvRequirement["format"],
 ): VoyantProfileEnvRequirement {
-  return { name, ...(aliases.length > 0 ? { aliases } : {}), kind: "secret", required, description }
+  return {
+    name,
+    ...(aliases.length > 0 ? { aliases } : {}),
+    ...(format ? { format } : {}),
+    kind: "secret",
+    required,
+    description,
+  }
 }
 
-function variable(name: string, description: string, required = true): VoyantProfileEnvRequirement {
-  return { name, kind: "variable", required, description }
+function variable(
+  name: string,
+  description: string,
+  required = true,
+  format?: VoyantProfileEnvRequirement["format"],
+): VoyantProfileEnvRequirement {
+  return { name, ...(format ? { format } : {}), kind: "variable", required, description }
 }

--- a/packages/framework/src/profile-types.ts
+++ b/packages/framework/src/profile-types.ts
@@ -111,10 +111,13 @@ export interface VoyantProfileEnvRequirement {
   name: string
   /** Alternate environment names that satisfy the canonical requirement. */
   aliases?: readonly string[]
+  format?: VoyantProfileEnvValueFormat
   kind: "secret" | "variable" | "binding"
   required: boolean
   description: string
 }
+
+export type VoyantProfileEnvValueFormat = "postgres-url" | "redis-url" | "http-url"
 
 export interface VoyantProfileResourceRequirement {
   resourceKey: string

--- a/packages/framework/src/profile.test.ts
+++ b/packages/framework/src/profile.test.ts
@@ -149,6 +149,7 @@ describe("managed profile contract", () => {
         expect.objectContaining({
           name: "DATABASE_URL",
           aliases: ["DATABASE_URL_DIRECT"],
+          format: "postgres-url",
           kind: "secret",
           required: true,
         }),

--- a/packages/framework/src/profile.ts
+++ b/packages/framework/src/profile.ts
@@ -30,6 +30,7 @@ import {
 } from "./profile-types.js"
 import { isJsonValue, isRecord, validateVoyantProjectRecord } from "./profile-validation.js"
 
+export type { VoyantProfileEnvValueFormat } from "./profile-types.js"
 export {
   type DefineVoyantProjectInput,
   MANAGED_OPERATOR_DEFAULT_PROVIDERS,

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60",
+  "graphHash": "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60",
+      "graphHash": "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60",
+  "contentHash": "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -2351,12 +2351,14 @@
           {
             "aliases": ["DATABASE_URL_DIRECT"],
             "description": "Primary Postgres connection URL used by migrations and fallback DB clients.",
+            "format": "postgres-url",
             "kind": "secret",
             "name": "DATABASE_URL",
             "required": true
           },
           {
             "description": "Direct Postgres URL for the resident Node pool.",
+            "format": "postgres-url",
             "kind": "secret",
             "name": "DATABASE_URL_DIRECT",
             "required": false

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: operator; artifact fixtures, canonical-hash checks, and resource-contract validation stay co-located around the deployment graph reader.
 import { createHash } from "node:crypto"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -132,9 +133,59 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
         DATABASE_URL_DIRECT: "postgres://user:pass@example.test:5432/voyant",
       }),
     ).toEqual([])
+    expect(
+      validateOperatorDeploymentGraphResourceEnv(summary, { DATABASE_URL: "not-a-postgres-url" }),
+    ).toEqual(["secret DATABASE_URL must be a Postgres URL for database:postgres"])
     expect(() => assertOperatorDeploymentGraphResourceEnv(summary, {})).toThrow(
       /Operator deployment graph resource requirements are not satisfied:\n- secret DATABASE_URL is required for database:postgres/,
     )
+  })
+
+  it("validates Redis and HTTP resource configuration formats before boot", () => {
+    const summary = {
+      resourceRequirements: [
+        {
+          resourceKey: "redis",
+          roles: ["cache"],
+          provider: "redis",
+          required: true,
+          env: [
+            {
+              name: "REDIS_URL",
+              format: "redis-url" as const,
+              kind: "secret",
+              required: true,
+              description: "Redis URL.",
+            },
+          ],
+        },
+        {
+          resourceKey: "object-storage",
+          roles: ["storage"],
+          provider: "s3",
+          required: true,
+          env: [
+            {
+              name: "R2_S3_ENDPOINT",
+              format: "http-url" as const,
+              kind: "variable",
+              required: true,
+              description: "S3 endpoint.",
+            },
+          ],
+        },
+      ],
+    }
+
+    expect(
+      validateOperatorDeploymentGraphResourceEnv(summary, {
+        REDIS_URL: "https://redis.example.test",
+        R2_S3_ENDPOINT: "redis://r2.example.test",
+      }),
+    ).toEqual([
+      "secret REDIS_URL must be a Redis URL for redis",
+      "variable R2_S3_ENDPOINT must be an HTTP(S) URL for object-storage",
+    ])
   })
 
   it("loads graph-derived scheduled jobs for provisioning", () => {
@@ -406,6 +457,7 @@ function writeFixture(
                     {
                       name: "DATABASE_URL",
                       aliases: ["DATABASE_URL_DIRECT"],
+                      format: "postgres-url",
                       kind: "secret",
                       required: true,
                       description: "Primary Postgres connection URL.",
@@ -492,6 +544,7 @@ interface FixtureDeploymentGraph {
       env: Array<{
         name: string
         aliases?: string[]
+        format?: "postgres-url" | "redis-url" | "http-url"
         kind: string
         required: boolean
         description: string

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -53,6 +53,7 @@ export interface OperatorDeploymentGraphMigrationSource {
 export interface OperatorDeploymentGraphEnvRequirement {
   name: string
   aliases?: readonly string[]
+  format?: "postgres-url" | "redis-url" | "http-url"
   kind: string
   required: boolean
   description: string
@@ -245,13 +246,19 @@ export function validateOperatorDeploymentGraphResourceEnv(
   const issues: string[] = []
   for (const resource of summary.resourceRequirements) {
     for (const requirement of resource.env) {
-      if (!requirement.required) continue
-      const present = [requirement.name, ...(requirement.aliases ?? [])].some((name) =>
-        hasEnvValue(env, name),
-      )
-      if (!present) {
+      const values = [requirement.name, ...(requirement.aliases ?? [])]
+        .map((name) => env[name])
+        .filter(hasValue)
+      if (requirement.required && values.length === 0) {
         issues.push(
           `${requirement.kind} ${requirement.name} is required for ${resource.resourceKey}`,
+        )
+        continue
+      }
+      const format = requirement.format
+      if (format && values.length > 0 && !values.every((value) => hasFormat(value, format))) {
+        issues.push(
+          `${requirement.kind} ${requirement.name} must be ${formatDescription(format)} for ${resource.resourceKey}`,
         )
       }
     }
@@ -365,6 +372,14 @@ function collectResourceRequirements(value: unknown): OperatorDeploymentGraphRes
               `deployment graph requirements.resources[${index}].env[${envIndex}].aliases`,
             ),
           }),
+      ...(entry.format === undefined
+        ? {}
+        : {
+            format: requireEnvFormat(
+              entry.format,
+              `deployment graph requirements.resources[${index}].env[${envIndex}].format`,
+            ),
+          }),
       kind: requireString(
         entry.kind,
         `deployment graph requirements.resources[${index}].env[${envIndex}].kind`,
@@ -418,9 +433,40 @@ function readJsonFile<T>(url: URL, label: string): T {
   }
 }
 
-function hasEnvValue(env: OperatorDeploymentGraphEnv, name: string): boolean {
-  const value = env[name]
+function hasValue(value: unknown): boolean {
   return typeof value === "string" ? value.trim().length > 0 : value !== null && value !== undefined
+}
+
+function hasFormat(
+  value: unknown,
+  format: NonNullable<OperatorDeploymentGraphEnvRequirement["format"]>,
+): boolean {
+  if (typeof value !== "string" || value.trim().length === 0) return false
+  try {
+    const parsed = new URL(value)
+    if (format === "postgres-url")
+      return parsed.protocol === "postgres:" || parsed.protocol === "postgresql:"
+    if (format === "redis-url") return parsed.protocol === "redis:" || parsed.protocol === "rediss:"
+    return parsed.protocol === "http:" || parsed.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+function formatDescription(
+  format: NonNullable<OperatorDeploymentGraphEnvRequirement["format"]>,
+): string {
+  if (format === "postgres-url") return "a Postgres URL"
+  if (format === "redis-url") return "a Redis URL"
+  return "an HTTP(S) URL"
+}
+
+function requireEnvFormat(
+  value: unknown,
+  label: string,
+): NonNullable<OperatorDeploymentGraphEnvRequirement["format"]> {
+  if (value === "postgres-url" || value === "redis-url" || value === "http-url") return value
+  throw new Error(`${label} must be a supported environment value format`)
 }
 
 function relativeArtifactUrl(value: string, baseUrl: URL): URL {

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -8,7 +8,7 @@ import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework
 import type { ManagedProfileRuntimeDeployment } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:10f57840772bca7458d07bd130958aabd9b0d3ed9054f0377d170e7075f44d60" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary
- add optional value-format metadata to graph resource environment requirements
- declare and validate Postgres URLs, Redis URLs, and HTTP(S) object-storage endpoints before boot
- enforce the same metadata in managed-runtime and operator graph-artifact validation
- regenerate the operator deployment graph and document the pre-boot contract

## Why
Required environment variables were only checked for presence. A malformed connection string or endpoint could therefore pass graph validation and fail later when a provider was first used.

## Impact
Graph-backed Node boot and managed runtime boot now fail early with resource-specific diagnostics for malformed provider configuration. Environment aliases retain their existing compatibility behavior.

## Validation
- `pnpm --filter @voyant-travel/framework test`
- `pnpm --filter operator exec vitest run src/deployment-graph-artifacts.test.ts src/operator-node-provider-plan.test.ts`
- `pnpm --filter operator typecheck`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- full test suite via the pre-push hook