### PR TITLE
feat: derive admin composition from graph

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "verify:native-date-inputs": "node scripts/check-native-date-inputs.mjs",
     "verify:raw-minor-unit-labels": "node scripts/check-raw-minor-unit-labels.mjs",
     "verify:lockstep-membership": "node scripts/check-lockstep-membership.mjs",
-    "verify:admin-composition-drift": "node scripts/check-admin-composition-drift.mjs",
+    "verify:admin-composition-drift": "node --test scripts/tests/check-admin-composition-drift.test.mjs && node scripts/check-admin-composition-drift.mjs",
     "verify:deployment-graph-openapi-coverage": "node --test scripts/tests/check-deployment-graph-openapi-coverage.test.mjs && node scripts/check-deployment-graph-openapi-coverage.mjs",
     "verify:deployment-graph": "node --test scripts/tests/deployment-graph-provenance.test.mjs && node --import tsx --test scripts/tests/deployment-graph-doctor.test.ts && node --test scripts/tests/check-deployment-graph-import-cheap.test.mjs && node scripts/check-deployment-graph-import-cheap.mjs && pnpm verify:deployment-graph-openapi-coverage && tsx scripts/check-deployment-graph.ts && tsx scripts/emit-deployment-graph.ts",
     "verify:framework-bom": "node scripts/generate-framework-bom.mjs",

--- a/scripts/check-admin-composition-drift.mjs
+++ b/scripts/check-admin-composition-drift.mjs
@@ -1,21 +1,21 @@
 /**
- * Guards against admin-composition drift between voyant.config `modules` and the
- * generated admin surface. RFC: docs/architecture/consolidated-deployments-rfc.md
- * (Workstream C — checker hardening).
+ * Guards against admin-composition drift between the resolved deployment graph
+ * and the generated admin surface. RFC:
+ * docs/architecture/unified-deployment-graph.md (Phase 3).
  *
  * The silent-failure this prevents (the #1 upgrade risk in the deployment-DX
- * assessment): a module is mounted (or newly arrives upstream) and exposes a
- * packaged admin (`@voyant-travel/<m>-react/admin`), but is missing from the
- * generated `admin.extensions.generated.ts` — so its nav/pages silently vanish.
- * And the reverse: a generated admin entry whose module is no longer mounted.
+ * assessment): a graph-selected package exposes a packaged admin
+ * (`@voyant-travel/<m>-react/admin`), but is missing from the generated
+ * `admin.extensions.generated.ts` — so its nav/pages silently vanish. And the
+ * reverse: a generated admin entry whose package is no longer graph-selected.
  *
  * Rule:
- *   expected = mounted modules (voyant.config `modules`) whose `<m>-react`
- *              package exposes a `./admin` export.
+ *   expected = graph-selected module/plugin packages with an admin route
+ *              surface whose `<m>-react` package exposes a `./admin` export.
  *   actual   = the `@voyant-travel/<m>-react/admin` imports wired into
  *              admin.extensions.generated.ts.
- *   FAIL on  (expected \ actual)  [silently dropped admin]
- *        or  (actual not mounted) [admin for an unmounted module].
+ *   FAIL on  (expected \ actual) [silently dropped admin]
+ *        or  (actual not graph-selected) [admin for an unselected package].
  */
 import { existsSync, readFileSync } from "node:fs"
 import { dirname, join } from "node:path"
@@ -23,31 +23,43 @@ import { fileURLToPath } from "node:url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const ROOT = join(__dirname, "..")
-const CONFIG = join(ROOT, "starters/operator/voyant.config.ts")
-const EXTENSIONS = join(ROOT, "starters/operator/src/admin.extensions.generated.ts")
+const GRAPH = optionPath("--graph", join(ROOT, "starters/operator/deployment-graph.generated.json"))
+const EXTENSIONS = optionPath(
+  "--extensions",
+  join(ROOT, "starters/operator/src/admin.extensions.generated.ts"),
+)
 const DESTINATIONS = join(ROOT, "starters/operator/src/admin.destinations.generated.ts")
 const ROUTES = join(ROOT, "starters/operator/src/admin.routes.generated.tsx")
 
-function readMountedModules() {
-  const src = readFileSync(CONFIG, "utf-8")
-  const start = src.indexOf("modules: [")
-  if (start === -1) throw new Error("voyant.config.ts: `modules: [` not found")
-  let depth = 0
-  let end = -1
-  for (let i = src.indexOf("[", start); i < src.length; i++) {
-    if (src[i] === "[") depth++
-    else if (src[i] === "]" && --depth === 0) {
-      end = i
-      break
+function optionPath(name, fallback) {
+  const index = process.argv.indexOf(name)
+  if (index === -1) return fallback
+  const value = process.argv[index + 1]
+  if (!value) throw new Error(`${name} requires a path`)
+  return value
+}
+
+function readGraphSelectedAdminPackages() {
+  if (!existsSync(GRAPH)) {
+    throw new Error(
+      "starters/operator/deployment-graph.generated.json is missing — run `pnpm --filter operator graph:emit`",
+    )
+  }
+
+  const graph = JSON.parse(readFileSync(GRAPH, "utf-8"))
+  const units = [...(graph.modules ?? []), ...(graph.plugins ?? [])]
+  const packages = new Set()
+
+  for (const unit of units) {
+    if (
+      typeof unit?.packageName === "string" &&
+      unit.api?.some((route) => route?.surface === "admin")
+    ) {
+      packages.add(unit.packageName)
     }
   }
-  const block = src.slice(start, end)
-  const names = []
-  for (const line of block.split("\n")) {
-    const m = line.replace(/\/\/.*$/, "").match(/"(@voyant-travel\/[^"]+)"/)
-    if (m) names.push(m[1])
-  }
-  return [...new Set(names)]
+
+  return [...packages].sort()
 }
 
 /** Does `<module>-react` expose a `./admin` export? */
@@ -89,25 +101,25 @@ if (!existsSync(EXTENSIONS)) {
   )
 }
 
-const mounted = readMountedModules()
-const mountedSet = new Set(mounted)
-const expected = mounted.filter(hasAdminSurface)
+const selected = readGraphSelectedAdminPackages()
+const selectedSet = new Set(selected)
+const expected = selected.filter(hasAdminSurface)
 const actual = adminImportsIn(EXTENSIONS)
 
-// Silently-dropped admin: mounted + has ./admin, but not wired.
+// Silently-dropped admin: graph-selected + has ./admin, but not wired.
 for (const name of expected) {
   if (!actual.has(name)) {
     violations.push(
-      `${name} is mounted and exposes ${name}-react/admin but is missing from admin.extensions.generated.ts — run \`voyant admin generate\` (its admin nav/pages would silently disappear)`,
+      `${name} is selected by the deployment graph and exposes ${name}-react/admin but is missing from admin.extensions.generated.ts — run \`voyant admin generate\` (its admin nav/pages would silently disappear)`,
     )
   }
 }
 
-// Orphan admin: wired for a module that is not mounted.
+// Orphan admin: wired for a package the graph did not select.
 for (const name of actual) {
-  if (!mountedSet.has(name)) {
+  if (!selectedSet.has(name)) {
     violations.push(
-      `admin.extensions.generated.ts wires ${name}-react/admin but ${name} is not in voyant.config modules — remove it or mount the module`,
+      `admin.extensions.generated.ts wires ${name}-react/admin but ${name} is not selected by the deployment graph — remove it or select the package`,
     )
   }
 }
@@ -127,11 +139,11 @@ for (const [label, file] of [
 
 if (violations.length) {
   console.error("Admin composition drift.")
-  console.error("See docs/architecture/consolidated-deployments-rfc.md (Workstream C).\n")
+  console.error("See docs/architecture/unified-deployment-graph.md (Phase 3).\n")
   for (const v of violations) console.error(`  - ${v}`)
   process.exit(1)
 }
 
 console.log(
-  `check-admin-composition-drift: OK (${expected.length} admin domains in sync with mounted modules)`,
+  `check-admin-composition-drift: OK (${expected.length} admin domains in sync with the deployment graph)`,
 )

--- a/scripts/tests/check-admin-composition-drift.test.mjs
+++ b/scripts/tests/check-admin-composition-drift.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict"
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import test from "node:test"
+
+const ROOT = join(import.meta.dirname, "..", "..")
+const CHECKER = join(ROOT, "scripts/check-admin-composition-drift.mjs")
+
+test("derives expected admin entries from the resolved graph, not voyant.config", () => {
+  const dir = mkdtempSync(join(tmpdir(), "voyant-admin-composition-"))
+  const graph = join(dir, "deployment-graph.generated.json")
+  const extensions = join(dir, "admin.extensions.generated.ts")
+
+  try {
+    writeFileSync(graph, JSON.stringify({ modules: [], plugins: [] }))
+    writeFileSync(extensions, "export const generatedAdminExtensionFactories = {}\n")
+
+    assert.doesNotThrow(() => runChecker({ graph, extensions }))
+
+    writeFileSync(
+      graph,
+      JSON.stringify({
+        modules: [
+          {
+            api: [{ surface: "admin" }],
+            packageName: "@voyant-travel/action-ledger",
+          },
+        ],
+        plugins: [],
+      }),
+    )
+
+    assert.throws(
+      () => runChecker({ graph, extensions }),
+      /selected by the deployment graph.*missing from admin\.extensions\.generated\.ts/s,
+    )
+  } finally {
+    rmSync(dir, { force: true, recursive: true })
+  }
+})
+
+function runChecker({ graph, extensions }) {
+  return execFileSync(process.execPath, [CHECKER, "--graph", graph, "--extensions", extensions], {
+    encoding: "utf8",
+  })
+}

--- a/starters/operator/deployment-artifacts.generated.json
+++ b/starters/operator/deployment-artifacts.generated.json
@@ -1,13 +1,13 @@
 {
   "schemaVersion": "voyant.deployment-artifacts.v1",
-  "graphHash": "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f",
+  "graphHash": "sha256:5437efbd41150df211f7218d0ac45e16f66b75a0c7519da53f16d9bf7751ced5",
   "graph": "deployment-graph.generated.json",
   "runtimeEntries": [
     {
       "id": "@voyant-travel/framework#runtime.node",
       "target": "node",
       "file": "src/runtime-entry.generated.ts",
-      "graphHash": "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f",
+      "graphHash": "sha256:5437efbd41150df211f7218d0ac45e16f66b75a0c7519da53f16d9bf7751ced5",
       "kind": "managed-profile-node",
       "profileSnapshot": "managed-profile.json"
     }

--- a/starters/operator/deployment-graph.generated.json
+++ b/starters/operator/deployment-graph.generated.json
@@ -3,7 +3,7 @@
     "provided": [],
     "required": []
   },
-  "contentHash": "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f",
+  "contentHash": "sha256:5437efbd41150df211f7218d0ac45e16f66b75a0c7519da53f16d9bf7751ced5",
   "deployment": {
     "mode": "self-hosted",
     "providers": {
@@ -1511,7 +1511,7 @@
         "kind": "workspace",
         "reference": "link:../framework"
       },
-      "version": "0.30.0"
+      "version": "0.31.0"
     },
     {
       "metadata": {

--- a/starters/operator/src/runtime-entry.generated.ts
+++ b/starters/operator/src/runtime-entry.generated.ts
@@ -8,7 +8,7 @@ import type { VoyantGraphDeploymentRequirements } from "@voyant-travel/framework
 import type { ManagedProfileRuntimeDeployment } from "@voyant-travel/framework/managed-runtime"
 
 export const GENERATED_DEPLOYMENT_GRAPH_SCHEMA_VERSION = "voyant.resolved-graph.v1" as const
-export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:7ae3ecba924a3d1ac54d4142ab517e138740790d1c6fe459c93ed8d8c61d203f" as const
+export const GENERATED_DEPLOYMENT_GRAPH_HASH = "sha256:5437efbd41150df211f7218d0ac45e16f66b75a0c7519da53f16d9bf7751ced5" as const
 export const GENERATED_DEPLOYMENT_GRAPH_TARGET = "node" as const
 export const GENERATED_DEPLOYMENT_GRAPH_MODE = "self-hosted" as const
 export const GENERATED_DEPLOYMENT_GRAPH_ARTIFACT_PATH = "../deployment-graph.generated.json" as const


### PR DESCRIPTION
## Summary
- derive the expected packaged admin contribution set from the resolved deployment graph rather than `voyant.config.ts`
- include graph-selected modules and plugins, while retaining package export checks to avoid API-only false positives
- add regression coverage for graph selection and refresh generated graph artifacts

## Why
The deployment graph is the canonical selected-package contract. Keeping the admin drift gate config-driven could silently allow generated admin output to diverge from the runtime graph.

## Validation
- `pnpm verify:admin-composition-drift`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- commit and push hooks ran the repository test suite