### PR TITLE
feat: add typed deployment graph ports

### DIFF
--- a/.changeset/typed-port-graph-contracts.md
+++ b/.changeset/typed-port-graph-contracts.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add typed provider port declarations, conformance kits, and deployment graph validation for required ports.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -912,6 +912,9 @@ that build on the same graph contract.
 
 ### Phase 4: typed ports and adapter conformance
 
+- **Shipped first slice:** public ports now carry mandatory conformance kits,
+  lower to serializable graph declarations, and participate in required-port
+  closure diagnostics. The first-party provider container remains unchanged.
 - migrate `FrameworkProviders` toward typed ports where there are real
   replacements
 - provide conformance test kits for public ports

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -18,6 +18,7 @@ import {
   VOYANT_RESOLVED_GRAPH_SCHEMA_VERSION,
   validateGraphUnitManifest,
 } from "./deployment-graph.js"
+import { assertPortConforms, definePort, providePort, requirePort } from "./ports.js"
 import { defineVoyantProject } from "./profile.js"
 
 describe("deployment graph v1", () => {
@@ -771,6 +772,7 @@ describe("deployment graph v1", () => {
       "VOYANT_GRAPH_INVALID_SCHEMA_VERSION",
       "VOYANT_GRAPH_INVALID_SCOPE",
       "VOYANT_GRAPH_MISSING_CAPABILITY",
+      "VOYANT_GRAPH_MISSING_PORT",
       "VOYANT_GRAPH_PACKAGE_INCOMPATIBLE",
       "VOYANT_GRAPH_PACKAGE_SOURCE_UNADMITTED",
       "VOYANT_GRAPH_UNKNOWN_FACET",
@@ -800,6 +802,75 @@ describe("deployment graph v1", () => {
     expect(() => deployment.migrations.expectReplayParity()).not.toThrow()
     expect(deployment.routes.list()).toEqual(["/v1/admin/loyalty"])
     expect(() => deployment.routes.expectMounted("/v1/admin/loyalty")).not.toThrow()
+  })
+
+  it("closes required typed ports from selected providers", async () => {
+    expect(() => definePort({ id: "booking", test: () => {} })).toThrow(/dot-case/)
+    expect(() => definePort({ id: "booking.read-model", test: undefined as never })).toThrow(
+      /conformance test kit/,
+    )
+
+    const bookingReadModel = definePort<{ getBooking: (id: string) => string }>({
+      id: "booking.read-model",
+      test: (provider) => {
+        if (provider.getBooking("booking_1") !== "booking_1") {
+          throw new Error("getBooking must return the requested booking.")
+        }
+      },
+    })
+
+    await expect(
+      assertPortConforms(bookingReadModel, { getBooking: (id) => id }),
+    ).resolves.toBeUndefined()
+    await expect(
+      assertPortConforms(bookingReadModel, { getBooking: () => "wrong" }),
+    ).rejects.toThrow(/requested booking/)
+
+    const graph = await resolveDeploymentGraph({
+      project: defineProject({
+        modules: [
+          defineModule({
+            id: "@acme/voyant-bookings",
+            provides: { ports: [providePort(bookingReadModel)] },
+          }),
+          defineModule({
+            id: "@acme/voyant-loyalty",
+            requires: { ports: [requirePort(bookingReadModel)] },
+          }),
+        ],
+      }),
+    })
+
+    expect(graph.diagnostics).toEqual([])
+    expect(graph.modules[1]?.requires.ports).toEqual([{ id: "booking.read-model" }])
+  })
+
+  it("reports missing required ports while allowing optional ports", async () => {
+    const peopleDirectory = definePort({ id: "identity.people-directory", test: () => {} })
+
+    const graph = await resolveDeploymentGraph({
+      project: defineProject({
+        modules: [
+          defineModule({
+            id: "@acme/voyant-loyalty",
+            requires: {
+              ports: [
+                requirePort(peopleDirectory),
+                requirePort(peopleDirectory, { optional: true }),
+              ],
+            },
+          }),
+        ],
+      }),
+    })
+
+    expect(graph.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "VOYANT_GRAPH_MISSING_PORT",
+        source: "@acme/voyant-loyalty",
+        facet: "requires.ports",
+      }),
+    ])
   })
 
   it("surfaces graph diagnostics through the author test harness", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -76,6 +76,8 @@ export const VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY = {
     "An API route bundle required scope does not match v1 resource:action syntax.",
   VOYANT_GRAPH_MISSING_CAPABILITY:
     "A selected graph unit requires a capability that no selected graph unit provides.",
+  VOYANT_GRAPH_MISSING_PORT:
+    "A selected graph unit requires a typed port that no selected graph unit provides.",
   VOYANT_GRAPH_PACKAGE_INCOMPATIBLE:
     "A package metadata record is incompatible with the selected target or deployment mode.",
   VOYANT_GRAPH_PACKAGE_SOURCE_UNADMITTED:
@@ -375,6 +377,7 @@ const SUPPORTED_GRAPH_UNIT_KEYS = new Set([
 
 const RESERVED_GRAPH_UNIT_KEYS = new Set<string>(VOYANT_GRAPH_RESERVED_FACETS)
 const CAPABILITY_TOKEN_PATTERN = /^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$/
+const PORT_ID_PATTERN = /^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$/
 const GRAPH_ID_PATTERN =
   /^(?:@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*|[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*)(?:#[a-zA-Z0-9][a-zA-Z0-9._-]*)?$/
 const ROUTE_RESOURCE_PATTERN = /^[a-z][a-z0-9-]*(?:[.-][a-z][a-z0-9-]*)*$/
@@ -576,6 +579,7 @@ export async function resolveDeploymentGraph(
     ...selectedUnits.flatMap((unit) => validateGraphUnitManifest(unit.original, unit.kind)),
     ...validateDuplicateGraphIds(selectedUnits),
     ...validateCapabilityClosure(selectedUnits),
+    ...validatePortClosure(selectedUnits),
     ...validateDuplicateEntityIds(selectedUnits),
     ...validatePackageAdmission(packageRecords, {
       frameworkVersion: input.frameworkVersion,
@@ -1145,31 +1149,69 @@ function validateCapabilityDeclaration(
 ): VoyantGraphDiagnostic[] {
   if (!isRecord(value)) return []
   const capabilities = value.capabilities
-  if (!Array.isArray(capabilities)) return []
-
   const diagnostics: VoyantGraphDiagnostic[] = []
-  for (const token of capabilities) {
-    if (typeof token !== "string" || !CAPABILITY_TOKEN_PATTERN.test(token)) {
+  if (Array.isArray(capabilities)) {
+    for (const token of capabilities) {
+      if (typeof token !== "string" || !CAPABILITY_TOKEN_PATTERN.test(token)) {
+        diagnostics.push(
+          diagnostic({
+            code: "VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN",
+            source,
+            facet: `${facet}.capabilities`,
+            message: `Capability token "${String(token)}" must use dot-case namespace segments.`,
+            hint: 'Use a token such as "identity.people" or "acme.loyalty.points".',
+          }),
+        )
+        continue
+      }
+
+      if (!isFirstPartyPackage(packageName) && usesReservedCapabilityNamespace(token)) {
+        diagnostics.push(
+          diagnostic({
+            code: "VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN",
+            source,
+            facet: `${facet}.capabilities`,
+            message: `Capability token "${token}" uses a Voyant-reserved namespace.`,
+            hint: 'Third-party packages should prefix capabilities with a namespace they control, such as "acme.loyalty.points".',
+          }),
+        )
+      }
+    }
+  }
+
+  const ports = value.ports
+  if (ports === undefined) return diagnostics
+  if (!Array.isArray(ports)) {
+    diagnostics.push(
+      diagnostic({
+        code: "VOYANT_GRAPH_INVALID_ENTITY_ID",
+        source,
+        facet: `${facet}.ports`,
+        message: "Port declarations must be an array with stable dot-case ids.",
+      }),
+    )
+    return diagnostics
+  }
+  for (let index = 0; index < ports.length; index += 1) {
+    const port = ports[index]
+    if (!isRecord(port) || typeof port.id !== "string" || !PORT_ID_PATTERN.test(port.id)) {
       diagnostics.push(
         diagnostic({
-          code: "VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN",
+          code: "VOYANT_GRAPH_INVALID_ENTITY_ID",
           source,
-          facet: `${facet}.capabilities`,
-          message: `Capability token "${String(token)}" must use dot-case namespace segments.`,
-          hint: 'Use a token such as "identity.people" or "acme.loyalty.points".',
+          facet: `${facet}.ports[${index}]`,
+          message: "Port declarations must include a stable dot-case id.",
         }),
       )
       continue
     }
-
-    if (!isFirstPartyPackage(packageName) && usesReservedCapabilityNamespace(token)) {
+    if (port.optional !== undefined && typeof port.optional !== "boolean") {
       diagnostics.push(
         diagnostic({
-          code: "VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN",
+          code: "VOYANT_GRAPH_INVALID_ENTITY_ID",
           source,
-          facet: `${facet}.capabilities`,
-          message: `Capability token "${token}" uses a Voyant-reserved namespace.`,
-          hint: 'Third-party packages should prefix capabilities with a namespace they control, such as "acme.loyalty.points".',
+          facet: `${facet}.ports[${index}].optional`,
+          message: "Port declaration optional must be a boolean when provided.",
         }),
       )
     }
@@ -1373,6 +1415,28 @@ function validateCapabilityClosure(
           facet: "requires.capabilities",
           message: `Required capability ${capability} is not provided by the selected graph.`,
           hint: "Select a module or plugin that provides the required capability.",
+        }),
+      )
+    }
+  }
+  return diagnostics
+}
+
+function validatePortClosure(
+  units: readonly (ResolvedVoyantGraphUnit & { original: VoyantGraphUnitManifest })[],
+): VoyantGraphDiagnostic[] {
+  const providers = new Set(units.flatMap((unit) => unit.provides.ports.map((port) => port.id)))
+  const diagnostics: VoyantGraphDiagnostic[] = []
+  for (const unit of units) {
+    for (const port of unit.requires.ports) {
+      if (port.optional || providers.has(port.id)) continue
+      diagnostics.push(
+        diagnostic({
+          code: "VOYANT_GRAPH_MISSING_PORT",
+          source: unit.id,
+          facet: "requires.ports",
+          message: `Required port ${port.id} is not provided by the selected graph.`,
+          hint: "Select a module or plugin that provides the required port.",
         }),
       )
     }

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -38,6 +38,16 @@ export {
   subsetStandardManifest,
 } from "./manifest.js"
 export {
+  assertPortConforms,
+  type DefineVoyantPortInput,
+  definePort,
+  providePort,
+  type RequireVoyantPortOptions,
+  requirePort,
+  type VoyantPort,
+  type VoyantPortConformanceTest,
+} from "./ports.js"
+export {
   type DefineVoyantProjectInput,
   defineVoyantProject,
   getVoyantProjectMigrationMetadata,

--- a/packages/framework/src/ports.ts
+++ b/packages/framework/src/ports.ts
@@ -1,0 +1,59 @@
+import type { VoyantGraphPortDeclaration } from "./deployment-graph.js"
+
+export interface VoyantPort<TProvider> {
+  readonly id: string
+  readonly test: VoyantPortConformanceTest<TProvider>
+}
+
+export type VoyantPortConformanceTest<TProvider> = (provider: TProvider) => void | Promise<void>
+
+export interface DefineVoyantPortInput<TProvider> {
+  id: string
+  test: VoyantPortConformanceTest<TProvider>
+}
+
+export interface RequireVoyantPortOptions {
+  optional?: boolean
+}
+
+/**
+ * Define a public provider port together with the conformance test every
+ * replacement must pass before it is advertised by a deployment graph.
+ */
+export function definePort<TProvider>(
+  input: DefineVoyantPortInput<TProvider>,
+): VoyantPort<TProvider> {
+  if (!PORT_ID_PATTERN.test(input.id)) {
+    throw new Error(`Port id "${input.id}" must use dot-case namespace segments.`)
+  }
+  if (typeof input.test !== "function") {
+    throw new Error(`Port "${input.id}" must provide a conformance test kit.`)
+  }
+  return Object.freeze({ id: input.id, test: input.test })
+}
+
+/** Lower a provided typed port to the serializable deployment graph contract. */
+export function providePort<TProvider>(port: VoyantPort<TProvider>): VoyantGraphPortDeclaration {
+  return { id: port.id }
+}
+
+/** Lower a required typed port to the serializable deployment graph contract. */
+export function requirePort<TProvider>(
+  port: VoyantPort<TProvider>,
+  options: RequireVoyantPortOptions = {},
+): VoyantGraphPortDeclaration {
+  return {
+    id: port.id,
+    ...(options.optional ? { optional: true } : {}),
+  }
+}
+
+/** Run the public conformance kit for a provider implementation. */
+export async function assertPortConforms<TProvider>(
+  port: VoyantPort<TProvider>,
+  provider: TProvider,
+): Promise<void> {
+  await port.test(provider)
+}
+
+const PORT_ID_PATTERN = /^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$/


### PR DESCRIPTION
## What changed

- Add public typed-port descriptors with mandatory conformance kits.
- Lower provided and required ports to serializable deployment graph declarations.
- Validate required port closure during graph resolution with `VOYANT_GRAPH_MISSING_PORT` diagnostics.
- Document the shipped first Phase 4 slice.

## Why

The unified deployment graph needs to distinguish static capability closure from runtime provider contracts. Ports provide that contract without serializing provider implementations into graph artifacts.

## Impact

Packages can now declare a public port, verify provider conformance in tests, and express required or optional graph dependencies. No existing first-party provider wiring changes in this slice.

## Validation

- `pnpm --filter @voyant-travel/framework test -- src/deployment-graph.test.ts` (13 files, 150 tests)
- `pnpm --filter @voyant-travel/framework typecheck`
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm --filter @voyant-travel/framework build`
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- Push hook: repository test suite