### PR TITLE
feat: emit graph OpenAPI coverage reports

### DIFF
--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -928,7 +928,10 @@ Candidate follow-ups:
   capabilities
 - graph-derived tools/MCP/agent manifests
 - action-ledger action metadata
-- graph-derived OpenAPI reports
+- **Shipped:** graph-derived OpenAPI coverage reports are available through
+  `scripts/check-deployment-graph-openapi-coverage.mjs --json`, including
+  covered bundles, allowlisted gaps, missing documentation, and stable errors
+- graph-derived admin copy
 - graph-derived admin copy
 - admin slots and UI extension points
 - package admission policy hardening for managed Cloud

--- a/scripts/check-deployment-graph-openapi-coverage.mjs
+++ b/scripts/check-deployment-graph-openapi-coverage.mjs
@@ -12,6 +12,11 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import path from "node:path"
 
+import {
+  buildDeploymentGraphOpenApiCoverageReport,
+  formatDeploymentGraphOpenApiCoverageFailure,
+} from "./lib/deployment-graph-openapi-coverage-report.mjs"
+
 const DEFAULT_GRAPH = "starters/operator/deployment-graph.generated.json"
 const DEFAULT_OPENAPI_DIR = "starters/operator/openapi"
 const CHECKED_SURFACES = new Set(["admin", "storefront"])
@@ -124,9 +129,8 @@ const graph = readJson(graphPath)
 const docs = readOpenApiCoverage(openapiDir)
 const bundles = readApiBundles(graph)
 const failures = []
-const warnings = []
 const coveredBundles = []
-const allowedBundleIds = new Set()
+const allowlistedGaps = []
 
 for (const bundle of bundles) {
   if (!CHECKED_SURFACES.has(bundle.surface)) continue
@@ -137,33 +141,39 @@ for (const bundle of bundles) {
   if (matched) {
     coveredBundles.push(bundle)
     if (allowlist.has(bundle.apiId)) {
-      failures.push(
-        `[deployment-graph-openapi-coverage:stale-allowlist] ${bundle.apiId} is allowlisted but now has documented ${bundle.surface} paths for one of: ${bundle.candidateModules.join(", ")}`,
-      )
+      failures.push({ kind: "stale-allowlist", bundle })
     }
     continue
   }
 
   const reason = allowlist.get(bundle.apiId)
   if (reason) {
-    allowedBundleIds.add(bundle.apiId)
-    warnings.push(formatGap(bundle, reason))
+    allowlistedGaps.push({ bundle, reason })
   } else {
-    failures.push(formatGap(bundle, undefined))
+    failures.push({ kind: "missing-docs", bundle })
   }
 }
 
 for (const id of allowlist.keys()) {
   if (!bundles.some((bundle) => bundle.apiId === id)) {
-    failures.push(
-      `[deployment-graph-openapi-coverage:stale-allowlist] ${id} is allowlisted but no longer appears in the deployment graph`,
-    )
+    failures.push({ kind: "stale-allowlist", apiId: id })
   }
 }
 
-if (warnings.length > 0) {
+const report = buildDeploymentGraphOpenApiCoverageReport(
+  { graph, graphPath, openapiDir, docs, coveredBundles, allowlistedGaps, failures },
+  relativeToRepo,
+)
+
+if (options.json) {
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+  if (!report.ok) process.exit(1)
+  process.exit(0)
+}
+
+if (allowlistedGaps.length > 0) {
   console.warn("Deployment graph OpenAPI coverage warnings.")
-  for (const warning of warnings) console.warn(warning)
+  for (const gap of allowlistedGaps) console.warn(formatGap(gap.bundle, gap.reason))
 }
 
 if (failures.length > 0) {
@@ -171,12 +181,13 @@ if (failures.length > 0) {
   console.error(
     `Checked graph ${relativeToRepo(graphPath)} against OpenAPI docs in ${relativeToRepo(openapiDir)}.\n`,
   )
-  for (const failure of failures) console.error(failure)
+  for (const failure of failures)
+    console.error(formatDeploymentGraphOpenApiCoverageFailure(failure))
   process.exit(1)
 }
 
 console.log(
-  `check-deployment-graph-openapi-coverage: OK (${coveredBundles.length} covered graph API bundles, ${allowedBundleIds.size} allowlisted gaps, ${docs.keys.size} documented surface/module pairs)`,
+  `check-deployment-graph-openapi-coverage: OK (${coveredBundles.length} covered graph API bundles, ${allowlistedGaps.length} allowlisted gaps, ${docs.keys.size} documented surface/module pairs)`,
 )
 
 function readApiBundles(resolvedGraph) {
@@ -387,6 +398,7 @@ function parseArgs(args) {
     openapiDir: DEFAULT_OPENAPI_DIR,
     allowlistFiles: [],
     useDefaultAllowlist: true,
+    json: false,
   }
 
   for (let index = 0; index < args.length; index += 1) {
@@ -398,6 +410,7 @@ Options:
   --graph <path>            Resolved graph JSON path. Default: ${DEFAULT_GRAPH}
   --openapi-dir <path>      Directory containing openapi/<surface>/*.json. Default: ${DEFAULT_OPENAPI_DIR}
   --allowlist <path>        JSON object or array of { "id", "reason" } entries to merge.
+  --json                    Emit the stable OpenAPI coverage report as JSON.
   --no-default-allowlist    Disable the repository's temporary allowlist, useful for fixture tests.`)
       process.exit(0)
     }
@@ -412,6 +425,8 @@ Options:
       options.allowlistFiles.push(requireValue(args, index, arg))
     } else if (arg === "--no-default-allowlist") {
       options.useDefaultAllowlist = false
+    } else if (arg === "--json") {
+      options.json = true
     } else {
       throw new Error(`Unknown argument: ${arg}`)
     }

--- a/scripts/lib/deployment-graph-openapi-coverage-report.mjs
+++ b/scripts/lib/deployment-graph-openapi-coverage-report.mjs
@@ -1,0 +1,85 @@
+export const VOYANT_GRAPH_OPENAPI_COVERAGE_REPORT_SCHEMA_VERSION =
+  "voyant.graph-openapi-coverage-report.v1"
+
+export function buildDeploymentGraphOpenApiCoverageReport(input, relativePath) {
+  const bundleSummary = (bundle) => ({
+    id: bundle.apiId,
+    graphSurface: bundle.graphSurface,
+    surface: bundle.surface,
+    moduleId: bundle.moduleId,
+    localId: bundle.localId,
+    packageName: bundle.packageName,
+    mount: bundle.mount,
+    candidateModules: [...bundle.candidateModules].sort(),
+  })
+  const sortedBundles = (bundles) =>
+    [...bundles].sort((left, right) => left.apiId.localeCompare(right.apiId))
+  const diagnostics = input.failures
+    .map((failure) => {
+      if (failure.kind === "missing-docs") {
+        return {
+          code: "VOYANT_GRAPH_OPENAPI_MISSING_DOCS",
+          severity: "error",
+          ...bundleSummary(failure.bundle),
+          message: `No documented OpenAPI paths match ${failure.bundle.apiId}.`,
+        }
+      }
+      if (failure.bundle) {
+        return {
+          code: "VOYANT_GRAPH_OPENAPI_STALE_ALLOWLIST",
+          severity: "error",
+          ...bundleSummary(failure.bundle),
+          message: `${failure.bundle.apiId} is allowlisted but now has documented OpenAPI paths.`,
+        }
+      }
+      return {
+        code: "VOYANT_GRAPH_OPENAPI_STALE_ALLOWLIST",
+        severity: "error",
+        id: failure.apiId,
+        message: `${failure.apiId} is allowlisted but no longer appears in the deployment graph.`,
+      }
+    })
+    .sort((left, right) => (left.id ?? "").localeCompare(right.id ?? ""))
+
+  return {
+    schemaVersion: VOYANT_GRAPH_OPENAPI_COVERAGE_REPORT_SCHEMA_VERSION,
+    ok: diagnostics.length === 0,
+    graph: {
+      path: relativePath(input.graphPath),
+      ...(typeof input.graph.schemaVersion === "string"
+        ? { schemaVersion: input.graph.schemaVersion }
+        : {}),
+      ...(typeof input.graph.contentHash === "string"
+        ? { contentHash: input.graph.contentHash }
+        : {}),
+    },
+    openapi: {
+      directory: relativePath(input.openapiDir),
+      documents: [...input.docs.files].sort(),
+      documentedSurfaceModules: input.docs.keys.size,
+    },
+    bundles: {
+      covered: sortedBundles(input.coveredBundles).map(bundleSummary),
+      allowlistedGaps: [...input.allowlistedGaps]
+        .sort((left, right) => left.bundle.apiId.localeCompare(right.bundle.apiId))
+        .map(({ bundle, reason }) => ({ ...bundleSummary(bundle), reason })),
+      missingDocs: input.failures
+        .filter((failure) => failure.kind === "missing-docs")
+        .map((failure) => bundleSummary(failure.bundle))
+        .sort((left, right) => left.id.localeCompare(right.id)),
+    },
+    diagnostics,
+  }
+}
+
+export function formatDeploymentGraphOpenApiCoverageFailure(failure) {
+  if (failure.kind === "missing-docs") return formatGap(failure.bundle)
+  if (failure.bundle) {
+    return `[deployment-graph-openapi-coverage:stale-allowlist] ${failure.bundle.apiId} is allowlisted but now has documented ${failure.bundle.surface} paths for one of: ${failure.bundle.candidateModules.join(", ")}`
+  }
+  return `[deployment-graph-openapi-coverage:stale-allowlist] ${failure.apiId} is allowlisted but no longer appears in the deployment graph`
+}
+
+function formatGap(bundle) {
+  return `  - [deployment-graph-openapi-coverage:missing-docs] ${bundle.apiId} (${bundle.graphSurface} -> ${bundle.surface}, ${bundle.localId || bundle.moduleId}) has no documented OpenAPI paths for candidates: ${bundle.candidateModules.join(", ")}.`
+}

--- a/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
+++ b/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
@@ -217,6 +217,40 @@ describe("check-deployment-graph-openapi-coverage", () => {
     assert.match(result.stdout, /0 covered graph API bundles, 1 allowlisted gaps/)
   })
 
+  it("emits a stable JSON coverage report", async () => {
+    const root = await createFixture({
+      "graph.json": graph([
+        {
+          id: "@voyant-travel/flights",
+          localId: "flights",
+          packageName: "@voyant-travel/flights",
+          api: [
+            {
+              id: "@voyant-travel/flights#api",
+              surface: "admin",
+              mount: "@voyant-travel/flights",
+            },
+          ],
+        },
+      ]),
+      "openapi/admin/bookings.json": openapi({
+        "/v1/admin/bookings": {
+          get: { responses: { 200: { description: "OK" } } },
+        },
+      }),
+      "allowlist.json": JSON.stringify({ "@voyant-travel/flights#api": "fixture gap" }),
+    })
+
+    const result = await runChecker(root, ["--allowlist", "allowlist.json", "--json"])
+    const report = JSON.parse(result.stdout)
+
+    assert.equal(report.schemaVersion, "voyant.graph-openapi-coverage-report.v1")
+    assert.equal(report.ok, true)
+    assert.equal(report.bundles.allowlistedGaps[0].id, "@voyant-travel/flights#api")
+    assert.equal(report.bundles.allowlistedGaps[0].reason, "fixture gap")
+    assert.deepEqual(report.diagnostics, [])
+  })
+
   it("fails stale allowlist entries once coverage exists", async () => {
     const root = await createFixture({
       "graph.json": graph([


### PR DESCRIPTION
## What changed

Add `--json` to the deployment-graph OpenAPI coverage checker. It emits a stable report containing graph identity, OpenAPI documents, covered API bundles, allowlisted gaps, missing documentation, and stale-allowlist diagnostics.

## Why

The graph already drives OpenAPI coverage validation, but downstream tooling could only parse human-readable output. The JSON report makes the same graph-derived coverage data consumable without changing route ownership or CI behavior.

## Impact

`node scripts/check-deployment-graph-openapi-coverage.mjs --json` can now be used by tooling and release checks. Existing human output and non-zero exit behavior are unchanged.

## Validation

- `node --test scripts/tests/check-deployment-graph-openapi-coverage.test.mjs` (7 tests)
- Real operator `--json` report check
- `pnpm verify:deployment-graph`
- `pnpm verify:fast`
- Push hook: repository test suite