### PR TITLE
docs: define clean application authoring

### DIFF
--- a/docs/adr/0012-application-authoring-and-product-defaults.md
+++ b/docs/adr/0012-application-authoring-and-product-defaults.md
@@ -1,0 +1,84 @@
+# ADR-0012: Application authoring and product defaults
+
+- **Status:** Accepted (2026-07-11)
+- **Relates to:** [ADR-0007](./0007-module-subsetting-and-capability-ports.md),
+  [ADR-0008](./0008-convention-driven-deployment-surface.md),
+  [unified deployment graph](../architecture/unified-deployment-graph.md),
+  [module/provider/extension/plugin taxonomy](../architecture/module-provider-plugin-taxonomy.md)
+
+## Context
+
+The unified deployment graph made package-owned facets inspectable and
+deterministic, but the first source-backed operator exposed the resolved graph
+as its authored configuration. A new application repeated the standard module
+closure and package-owned extensions, classified extensions as plugins, and
+kept parallel starter registries for local routes, workflows, subscribers, and
+jobs.
+
+That surface is accurate as generated deployment data but too shallow as an
+application interface. Standard product knowledge belongs to the product
+distribution, not every consumer project.
+
+## Decision
+
+**Authored configuration expresses differences from the standard Operator;
+the generated graph expresses the complete deployment.**
+
+1. The framework-owned Operator distribution supplies the standard module and
+   package-owned extension closure. A normal project does not repeat it.
+2. `plugins` contains reusable distribution packages installed by the
+   application. Package-owned extensions are extension contributions, not
+   plugins.
+3. Application-local contributions are discovered at build time from
+   conventional directories:
+   `src/api/{admin,store}`, `src/admin`, `src/workflows`, `src/jobs`,
+   `src/subscribers`, `src/links`, and `src/modules`.
+4. Discovery is deterministic and Node-only. It produces normalized stable IDs,
+   validates collisions and requirements, and writes the complete result under
+   disposable `.voyant/` output before runtime code is loaded.
+5. Reusable custom modules and external plugins remain explicit authored
+   selections. Local conventional API routes, workflows, jobs, subscribers,
+   links, and admin contributions do not require duplicate config entries.
+6. Standard defaults may change only through a dependency or lockfile change.
+   `voyant upgrade`, graph diffing, and `voyant doctor` must report the
+   resulting facet, migration, provider, access, schedule, and resource changes.
+7. Route and stable-ID collisions fail by default. Replacing standard behavior
+   requires a separately named explicit override contract; file order never
+   decides precedence.
+8. The public configuration helper is `defineConfig`. Authored definitions and
+   resolved manifests are separate types; placeholder manifests are not part of
+   the public application interface.
+
+The initial standard Operator remains the only composed application runtime and
+always lowers to Node. This decision does not create a managed-operator variant
+or an edge deployment target.
+
+## Consequences
+
+- A new project starts with an almost-empty `voyant.config.ts` and empty
+  extension directories while retaining the complete standard Operator.
+- Adding a conventional local file intentionally changes the generated graph,
+  and the graph remains inspectable, hashable, and reviewable.
+- Packages own standard extensions once. Consumer applications configure only
+  external plugins, custom modules, provider choices, and deliberate overrides.
+- The operator starter can delete manual composition maps as each conventional
+  contribution is generated.
+- ADR-0007 default-on compatibility remains an internal migration bridge, not
+  the application authoring interface.
+- ADR-0008 convention discovery applies to application-local contributions and
+  package-owned facets at build time; Workers are not a composed deployment
+  target.
+
+## Alternatives considered
+
+- **Scaffold every standard graph selection into each project.** Rejected
+  because it makes framework-owned wiring look application-owned and creates
+  noisy, stale configuration.
+- **Commit the resolved graph.** Rejected because the package lockfile and source
+  definition are authoritative; `.voyant/` is reproducible build output.
+- **Treat every extension as a plugin.** Rejected because plugin is a
+  distribution concept, while extension is runtime behavior owned by a module
+  or plugin bundle.
+- **Runtime directory scanning.** Rejected because deployment planning,
+  admission, migrations, OpenAPI, and Node bundling require static build-time
+  composition.

--- a/docs/architecture/module-provider-plugin-taxonomy.md
+++ b/docs/architecture/module-provider-plugin-taxonomy.md
@@ -160,6 +160,13 @@ Rule:
 Use plugins when you want to ship a reusable bundle across projects. Do not use
 plugins as the default answer to every customization problem.
 
+Package-owned extensions remain extension contributions in the resolved graph.
+They do not become plugins merely because the runtime lowers them to an
+extension factory. A standard application does not list these contributions in
+its authored `plugins` array; the selected product distribution and package
+manifests provide them. Authored `plugins` entries identify reusable
+distribution packages such as an external adapter bundle.
+
 ## Decision Rules
 
 ### 7. Start with the narrowest category that fits

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -71,17 +71,21 @@ while package-owned facets remain absent.
 
 ## Core Decisions
 
-### 1. Use an explicit graph, not runtime profile modes
+### 1. Keep the resolved graph explicit without exposing it as application config
 
-Profiles such as `operator-standard` or `pms-standard` should be scaffolding
-presets, not runtime modes.
+The resolved deployment graph is explicit and deterministic. The authored
+application configuration records only differences from the standard Operator,
+as decided by [ADR-0012](../adr/0012-application-authoring-and-product-defaults.md).
+Standard product closure belongs to a framework-owned distribution rather than
+being copied into every project.
 
 ```sh
 voyant new --preset pms-standard
 ```
 
-The scaffold writes a project declaration with concrete selected modules and
-plugins. After that point, the deployment is just a graph.
+The scaffold writes a minimal project declaration. The resolver expands the
+standard distribution, explicit custom modules and external plugins, and
+conventional local contributions into the complete graph.
 
 The resolved graph must not admit packages or choose runtime behavior based on
 profile names. Existing managed snapshots still carry `profile: "operator"` in
@@ -89,15 +93,10 @@ profile names. Existing managed snapshots still carry `profile: "operator"` in
 should treat that as a compatibility bridge and translate it into selected
 modules, capabilities, product surfaces, and substrate requirements.
 
-If a project records a scaffold source, that field is diagnostic only:
-
-```ts
-presetLineage: "operator-standard" // optional; never used for graph closure
-```
-
 Package compatibility should target framework version, the Node runtime
 contract, deployment mode, and required capabilities/surfaces. It should not
-target `profiles: ["operator"]` or treat a hosting provider as a runtime.
+target `profiles: ["operator"]`, expose `presetLineage` as authored runtime
+behavior, or treat a hosting provider as a runtime.
 
 ### 2. Default to Voyant Cloud, but keep Node substrate lowering separate
 
@@ -378,16 +377,10 @@ import { defineProject } from "@voyant-travel/framework/project"
 
 export default defineProject({
   schemaVersion: "voyant.project.v1",
-  presetLineage: "operator-standard",
-  modules: [
-    "@voyant-travel/bookings",
-    "@voyant-travel/inventory",
-    "@voyant-travel/finance",
-    {
-      resolve: "./src/modules/loyalty",
-      config: { tiers: ["silver", "gold", "platinum"] },
-    },
-  ],
+  modules: [{
+    resolve: "./src/modules/loyalty",
+    config: { tiers: ["silver", "gold", "platinum"] },
+  }],
   plugins: ["@acme/voyant-smartbill"],
   deployment: {
     target: "node",
@@ -400,12 +393,12 @@ export default defineProject({
 })
 ```
 
-Package specifiers and `{ resolve, config }` selections are the normal authoring
-forms. The resolver reads package metadata and performs admission before it
-imports `./voyant`. Trusted deployment-local declarations may be imported by an
-advanced project, but registry package imports must not become a path around
-pre-admission. A preset writes explicit selections and may record
-`presetLineage`, but the preset is never consulted after scaffolding.
+Package specifiers and `{ resolve, config }` selections remain the normal
+authoring forms for reusable custom modules and external plugins. The resolver
+reads package metadata and performs admission before it imports `./voyant`.
+The framework-owned standard Operator distribution and conventional local
+contributions are expanded during resolution and are explicit in generated
+artifacts, not repeated in authored config.
 
 ### Clean project ergonomics
 
@@ -437,13 +430,13 @@ acme-voyant/
   .voyant/                     # generated, disposable, gitignored
 ```
 
-Conventions apply **inside an explicitly selected unit**. They may provide
-defaults for `schema.ts`, `migrations/`, `api/`, `admin/`, `workflows/`, and
-`subscribers/`, but dropping a file in `src/` must not silently change the graph.
-`index.ts` owns the manifest, and `voyant.config.ts` activates the unit. A
-project-level link or cross-module workflow remains explicit because no one
-package owns it; it should be declared in `links/` or in a small
-deployment-local module selected by the project.
+Package conventions apply inside package-owned units. Application conventions
+also discover local routes, workflows, jobs, subscribers, links, admin
+contributions, and module manifests from the directories defined by ADR-0012.
+Adding such a file is authored intent and changes the graph at build time; it
+never triggers runtime scanning. Reusable local modules remain explicitly
+selected until their `src/modules/*/voyant.ts` manifests are admitted by the
+local convention compiler.
 
 The ordinary workflow is:
 


### PR DESCRIPTION
## Summary
- distinguish minimal authored configuration from the complete resolved deployment graph
- classify package-owned extensions as extension contributions rather than plugins
- define build-time application conventions and a framework-owned standard Operator distribution

## Verification
- `git diff --check`
- docs-only diff reviewed against issue #3080 and the unified deployment graph RFC

Part of #3080.