### PR TITLE
feat(framework): discover project conventions

### DIFF
--- a/.changeset/clean-project-conventions.md
+++ b/.changeset/clean-project-conventions.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Add build-time discovery for source-backed project conventions.

--- a/packages/framework/src/project-conventions.test.ts
+++ b/packages/framework/src/project-conventions.test.ts
@@ -1,0 +1,277 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import { discoverProjectConventions } from "./project-conventions.js"
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  )
+})
+
+describe("discoverProjectConventions", () => {
+  it("discovers every supported source convention with normalized metadata", async () => {
+    const root = await projectFixture([
+      "src/api/admin/route.ts",
+      "src/api/admin/orders/[orderId]/route.ts",
+      "src/api/store/catalog/(sales)/[...slug]/route.ts",
+      "src/workflows/booking/confirm.ts",
+      "src/jobs/reconcile.ts",
+      "src/subscribers/booking/created.ts",
+      "src/links/booking-person.ts",
+      "src/admin/dashboard/page.tsx",
+      "src/admin/dashboard/styles.css",
+      "src/modules/loyalty/index.ts",
+    ])
+
+    await expect(discoverProjectConventions({ projectRoot: root })).resolves.toEqual({
+      contributions: [
+        {
+          id: "project.admin.dashboard.page",
+          kind: "admin",
+          sourcePath: "src/admin/dashboard/page.tsx",
+        },
+        {
+          id: "project.admin.dashboard.styles",
+          kind: "admin",
+          sourcePath: "src/admin/dashboard/styles.css",
+        },
+        {
+          id: "project.api.admin.orders.by-orderid",
+          kind: "api-route",
+          route: "/orders/:orderId",
+          sourcePath: "src/api/admin/orders/[orderId]/route.ts",
+          surface: "admin",
+        },
+        {
+          id: "project.api.admin.root",
+          kind: "api-route",
+          route: "/",
+          sourcePath: "src/api/admin/route.ts",
+          surface: "admin",
+        },
+        {
+          id: "project.api.public.catalog.all-slug",
+          kind: "api-route",
+          route: "/catalog/*slug",
+          sourcePath: "src/api/store/catalog/(sales)/[...slug]/route.ts",
+          surface: "public",
+        },
+        {
+          id: "project.job.reconcile",
+          kind: "job",
+          sourcePath: "src/jobs/reconcile.ts",
+        },
+        {
+          id: "project.link.booking-person",
+          kind: "link",
+          sourcePath: "src/links/booking-person.ts",
+        },
+        {
+          id: "project.module.loyalty",
+          kind: "module",
+          sourcePath: "src/modules/loyalty/index.ts",
+        },
+        {
+          id: "project.subscriber.booking.created",
+          kind: "subscriber",
+          sourcePath: "src/subscribers/booking/created.ts",
+        },
+        {
+          id: "project.workflow.booking.confirm",
+          kind: "workflow",
+          sourcePath: "src/workflows/booking/confirm.ts",
+        },
+      ],
+      diagnostics: [],
+    })
+  })
+
+  it("returns deterministic project-relative paths and ordering", async () => {
+    const root = await projectFixture([
+      "src/workflows/z-last.ts",
+      "src/workflows/a-first.ts",
+      "src/admin/z/page.tsx",
+      "src/admin/a/page.tsx",
+      "src/jobs/middle.ts",
+    ])
+
+    const fromString = await discoverProjectConventions(`${root}${path.sep}`)
+    const fromOptions = await discoverProjectConventions({ projectRoot: path.join(root, ".") })
+
+    expect(fromString).toEqual(fromOptions)
+    expect(fromString.contributions.map((contribution) => contribution.sourcePath)).toEqual([
+      "src/admin/a/page.tsx",
+      "src/admin/z/page.tsx",
+      "src/jobs/middle.ts",
+      "src/workflows/a-first.ts",
+      "src/workflows/z-last.ts",
+    ])
+    expect(
+      fromString.contributions.every((contribution) => !contribution.sourcePath.includes("\\")),
+    ).toBe(true)
+  })
+
+  it("ignores generated, vendor, hidden, and build output directories", async () => {
+    const ignoredDirectories = [
+      ".cache",
+      ".generated",
+      ".voyant",
+      "__generated__",
+      "build",
+      "coverage",
+      "dist",
+      "generated",
+      "node_modules",
+      "vendor",
+    ]
+    const root = await projectFixture([
+      "src/workflows/kept.ts",
+      "src/modules/kept/index.ts",
+      ...ignoredDirectories.flatMap((directory) => [
+        `src/workflows/${directory}/ignored.ts`,
+        `src/admin/${directory}/ignored.tsx`,
+        `src/api/admin/${directory}/route.ts`,
+        `src/modules/${directory}/index.ts`,
+      ]),
+    ])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toEqual([
+      {
+        id: "project.module.kept",
+        kind: "module",
+        sourcePath: "src/modules/kept/index.ts",
+      },
+      {
+        id: "project.workflow.kept",
+        kind: "workflow",
+        sourcePath: "src/workflows/kept.ts",
+      },
+    ])
+    expect(result.diagnostics).toEqual([])
+  })
+
+  it("discovers an index-only local module and ignores voyant-only or nested modules", async () => {
+    const root = await projectFixture([
+      "src/api/admin/orders/route.tsx",
+      "src/api/admin/orders/routes.ts",
+      "src/workflows/run.js",
+      "src/jobs/run.tsx",
+      "src/modules/accepted/index.ts",
+      "src/modules/group/loyalty/index.ts",
+      "src/modules/package-style/voyant.ts",
+    ])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toEqual([
+      {
+        id: "project.module.accepted",
+        kind: "module",
+        sourcePath: "src/modules/accepted/index.ts",
+      },
+    ])
+  })
+
+  it("reports same-surface dynamic and route-group collisions", async () => {
+    const root = await projectFixture([
+      "src/api/admin/orders/[id]/route.ts",
+      "src/api/admin/orders/[orderId]/route.ts",
+      "src/api/admin/(internal)/orders/[slug]/route.ts",
+      "src/api/store/orders/[id]/route.ts",
+    ])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toHaveLength(4)
+    expect(result.diagnostics).toEqual([
+      {
+        code: "PROJECT_CONVENTION_ROUTE_COLLISION",
+        message:
+          'Convention routes on the admin surface collide at "/orders/:param": "src/api/admin/(internal)/orders/[slug]/route.ts", "src/api/admin/orders/[id]/route.ts", "src/api/admin/orders/[orderId]/route.ts".',
+        route: "/orders/:param",
+        severity: "error",
+        sourcePaths: [
+          "src/api/admin/(internal)/orders/[slug]/route.ts",
+          "src/api/admin/orders/[id]/route.ts",
+          "src/api/admin/orders/[orderId]/route.ts",
+        ],
+        surface: "admin",
+      },
+    ])
+  })
+
+  it("reports stable ID collisions without discarding either contribution", async () => {
+    const root = await projectFixture([
+      "src/admin/order-history.ts",
+      "src/admin/order_history.tsx",
+      "src/workflows/send-email.ts",
+      "src/workflows/send_email.ts",
+    ])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toHaveLength(4)
+    expect(result.diagnostics).toEqual([
+      {
+        code: "PROJECT_CONVENTION_ID_COLLISION",
+        id: "project.admin.order-history",
+        message:
+          'Convention ID "project.admin.order-history" is produced by "src/admin/order-history.ts", "src/admin/order_history.tsx".',
+        severity: "error",
+        sourcePaths: ["src/admin/order-history.ts", "src/admin/order_history.tsx"],
+      },
+      {
+        code: "PROJECT_CONVENTION_ID_COLLISION",
+        id: "project.workflow.send-email",
+        message:
+          'Convention ID "project.workflow.send-email" is produced by "src/workflows/send-email.ts", "src/workflows/send_email.ts".',
+        severity: "error",
+        sourcePaths: ["src/workflows/send-email.ts", "src/workflows/send_email.ts"],
+      },
+    ])
+  })
+
+  it("normalizes optional catch-all routes", async () => {
+    const root = await projectFixture(["src/api/store/docs/[[...parts]]/route.ts"])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toEqual([
+      {
+        id: "project.api.public.docs.all-parts-optional",
+        kind: "api-route",
+        route: "/docs/*parts?",
+        sourcePath: "src/api/store/docs/[[...parts]]/route.ts",
+        surface: "public",
+      },
+    ])
+  })
+
+  it("returns an empty discovery for a project without convention directories", async () => {
+    const root = await projectFixture(["src/index.ts", "package.json"])
+
+    await expect(discoverProjectConventions(root)).resolves.toEqual({
+      contributions: [],
+      diagnostics: [],
+    })
+  })
+})
+
+async function projectFixture(files: readonly string[]): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "voyant-project-conventions-"))
+  fixtureRoots.push(root)
+  await Promise.all(files.map((file) => writeFixtureFile(root, file)))
+  return root
+}
+
+async function writeFixtureFile(root: string, relativePath: string): Promise<void> {
+  const filePath = path.join(root, ...relativePath.split("/"))
+  await mkdir(path.dirname(filePath), { recursive: true })
+  await writeFile(filePath, "export {}\n")
+}

--- a/packages/framework/src/project-conventions.ts
+++ b/packages/framework/src/project-conventions.ts
@@ -1,0 +1,372 @@
+import { readdir } from "node:fs/promises"
+import path from "node:path"
+
+export type ProjectConventionKind =
+  | "admin"
+  | "api-route"
+  | "job"
+  | "link"
+  | "module"
+  | "subscriber"
+  | "workflow"
+
+export type ProjectConventionRouteSurface = "admin" | "public"
+
+interface ProjectConventionContributionBase {
+  /** Stable, path-derived identifier. Source files are never evaluated. */
+  id: string
+  kind: ProjectConventionKind
+  /** POSIX-formatted path relative to the project root. */
+  sourcePath: string
+}
+
+export interface ProjectConventionApiRoute extends ProjectConventionContributionBase {
+  kind: "api-route"
+  surface: ProjectConventionRouteSurface
+  /** Surface-relative URL path, including a leading slash. */
+  route: string
+}
+
+export interface ProjectConventionFileContribution extends ProjectConventionContributionBase {
+  kind: Exclude<ProjectConventionKind, "api-route">
+}
+
+export type ProjectConventionContribution =
+  | ProjectConventionApiRoute
+  | ProjectConventionFileContribution
+
+export const PROJECT_CONVENTION_DIAGNOSTIC_CODES = {
+  PROJECT_CONVENTION_ID_COLLISION:
+    "Two convention contributions resolve to the same stable identifier.",
+  PROJECT_CONVENTION_ROUTE_COLLISION:
+    "Two convention API routes resolve to the same surface and route pattern.",
+} as const
+
+export type ProjectConventionDiagnosticCode = keyof typeof PROJECT_CONVENTION_DIAGNOSTIC_CODES
+
+export interface ProjectConventionDiagnostic {
+  code: ProjectConventionDiagnosticCode
+  severity: "error"
+  message: string
+  /** Colliding identifier for ID diagnostics. */
+  id?: string
+  /** Colliding surface for route diagnostics. */
+  surface?: ProjectConventionRouteSurface
+  /** Canonical route pattern for route diagnostics. */
+  route?: string
+  /** Sorted project-relative paths involved in the collision. */
+  sourcePaths: readonly string[]
+}
+
+export interface ProjectConventionDiscovery {
+  contributions: readonly ProjectConventionContribution[]
+  diagnostics: readonly ProjectConventionDiagnostic[]
+}
+
+export interface DiscoverProjectConventionsOptions {
+  projectRoot: string
+}
+
+export type DiscoverProjectConventionsInput = string | DiscoverProjectConventionsOptions
+
+interface RecursiveConvention {
+  directory: string
+  kind: Exclude<ProjectConventionKind, "api-route" | "module">
+  accepts: (fileName: string) => boolean
+}
+
+const IGNORED_DIRECTORY_NAMES = new Set([
+  ".git",
+  ".generated",
+  ".voyant",
+  "__generated__",
+  "build",
+  "coverage",
+  "dist",
+  "generated",
+  "node_modules",
+  "vendor",
+])
+
+const RECURSIVE_CONVENTIONS: readonly RecursiveConvention[] = [
+  { directory: "src/workflows", kind: "workflow", accepts: isTypeScriptFile },
+  { directory: "src/jobs", kind: "job", accepts: isTypeScriptFile },
+  { directory: "src/subscribers", kind: "subscriber", accepts: isTypeScriptFile },
+  { directory: "src/links", kind: "link", accepts: isTypeScriptFile },
+  { directory: "src/admin", kind: "admin", accepts: () => true },
+]
+
+/**
+ * Discover source-backed project contributions from conventional locations.
+ *
+ * This is a build-time, Node-only filesystem scan. It does not import, parse,
+ * or execute project source files.
+ */
+export async function discoverProjectConventions(
+  input: DiscoverProjectConventionsInput,
+): Promise<ProjectConventionDiscovery> {
+  const projectRoot = path.resolve(typeof input === "string" ? input : input.projectRoot)
+  const contributions: ProjectConventionContribution[] = []
+
+  await Promise.all([
+    discoverApiRoutes(projectRoot, "admin", "src/api/admin", contributions),
+    discoverApiRoutes(projectRoot, "public", "src/api/store", contributions),
+    ...RECURSIVE_CONVENTIONS.map((convention) =>
+      discoverRecursiveConvention(projectRoot, convention, contributions),
+    ),
+    discoverModules(projectRoot, contributions),
+  ])
+
+  contributions.sort(compareContributions)
+
+  return {
+    contributions,
+    diagnostics: findDiagnostics(contributions),
+  }
+}
+
+async function discoverApiRoutes(
+  projectRoot: string,
+  surface: ProjectConventionRouteSurface,
+  directory: string,
+  contributions: ProjectConventionContribution[],
+): Promise<void> {
+  const files = await walkFiles(projectRoot, directory, (fileName) => fileName === "route.ts")
+  for (const sourcePath of files) {
+    const routeSegments = sourcePath
+      .slice(`${directory}/`.length, -"/route.ts".length)
+      .split("/")
+      .filter(Boolean)
+      .filter((segment) => !isRouteGroup(segment))
+    const route = routeFromSegments(routeSegments)
+    contributions.push({
+      id: stableId("api", surface, ...(routeSegments.length === 0 ? ["root"] : routeSegments)),
+      kind: "api-route",
+      sourcePath,
+      surface,
+      route,
+    })
+  }
+}
+
+async function discoverRecursiveConvention(
+  projectRoot: string,
+  convention: RecursiveConvention,
+  contributions: ProjectConventionContribution[],
+): Promise<void> {
+  const files = await walkFiles(projectRoot, convention.directory, convention.accepts)
+  for (const sourcePath of files) {
+    const relativeEntry = sourcePath.slice(`${convention.directory}/`.length)
+    contributions.push({
+      id: stableId(convention.kind, ...withoutFinalExtension(relativeEntry).split("/")),
+      kind: convention.kind,
+      sourcePath,
+    })
+  }
+}
+
+async function discoverModules(
+  projectRoot: string,
+  contributions: ProjectConventionContribution[],
+): Promise<void> {
+  const directory = "src/modules"
+  for (const entry of await readDirectory(path.join(projectRoot, directory))) {
+    if (!entry.isDirectory() || shouldIgnoreDirectory(entry.name)) continue
+
+    const sourcePath = `${directory}/${entry.name}/index.ts`
+    if (!(await containsFile(projectRoot, sourcePath))) continue
+
+    contributions.push({
+      id: stableId("module", entry.name),
+      kind: "module",
+      sourcePath,
+    })
+  }
+}
+
+async function walkFiles(
+  projectRoot: string,
+  relativeDirectory: string,
+  accepts: (fileName: string) => boolean,
+): Promise<string[]> {
+  const discovered: string[] = []
+
+  async function visit(directory: string): Promise<void> {
+    for (const entry of await readDirectory(path.join(projectRoot, directory))) {
+      const entryPath = `${directory}/${entry.name}`
+      if (entry.isDirectory()) {
+        if (!shouldIgnoreDirectory(entry.name)) await visit(entryPath)
+      } else if (entry.isFile() && accepts(entry.name)) {
+        discovered.push(entryPath)
+      }
+    }
+  }
+
+  await visit(relativeDirectory)
+  return discovered.sort(compareStrings)
+}
+
+async function readDirectory(directory: string) {
+  try {
+    return await readdir(directory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
+    throw error
+  }
+}
+
+async function containsFile(projectRoot: string, sourcePath: string): Promise<boolean> {
+  const directory = path.dirname(path.join(projectRoot, sourcePath))
+  const fileName = path.basename(sourcePath)
+  return (await readDirectory(directory)).some((entry) => entry.isFile() && entry.name === fileName)
+}
+
+function findDiagnostics(
+  contributions: readonly ProjectConventionContribution[],
+): ProjectConventionDiagnostic[] {
+  const diagnostics: ProjectConventionDiagnostic[] = []
+  const ids = groupBy(contributions, (contribution) => contribution.id)
+
+  for (const [id, matches] of ids) {
+    if (matches.length < 2) continue
+    const sourcePaths = sortedUnique(matches.map((match) => match.sourcePath))
+    diagnostics.push({
+      code: "PROJECT_CONVENTION_ID_COLLISION",
+      severity: "error",
+      id,
+      sourcePaths,
+      message: `Convention ID "${id}" is produced by ${formatSources(sourcePaths)}.`,
+    })
+  }
+
+  const routes = contributions.filter(
+    (contribution): contribution is ProjectConventionApiRoute => contribution.kind === "api-route",
+  )
+  const routePatterns = groupBy(
+    routes,
+    (route) => `${route.surface}\0${canonicalRoutePattern(route.route)}`,
+  )
+
+  for (const [key, matches] of routePatterns) {
+    if (matches.length < 2) continue
+    const [surface, route] = key.split("\0") as [ProjectConventionRouteSurface, string]
+    const sourcePaths = sortedUnique(matches.map((match) => match.sourcePath))
+    diagnostics.push({
+      code: "PROJECT_CONVENTION_ROUTE_COLLISION",
+      severity: "error",
+      surface,
+      route,
+      sourcePaths,
+      message: `Convention routes on the ${surface} surface collide at "${route}": ${formatSources(sourcePaths)}.`,
+    })
+  }
+
+  return diagnostics.sort(compareDiagnostics)
+}
+
+function groupBy<T>(values: readonly T[], keyFor: (value: T) => string): Map<string, T[]> {
+  const groups = new Map<string, T[]>()
+  for (const value of values) {
+    const key = keyFor(value)
+    const group = groups.get(key)
+    if (group) group.push(value)
+    else groups.set(key, [value])
+  }
+  return groups
+}
+
+function routeFromSegments(segments: readonly string[]): string {
+  if (segments.length === 0) return "/"
+  return `/${segments.map(routeSegment).join("/")}`
+}
+
+function routeSegment(segment: string): string {
+  const optionalCatchAll = segment.match(/^\[\[\.\.\.([^\]]+)\]\]$/)
+  if (optionalCatchAll) return `*${optionalCatchAll[1]}?`
+  const catchAll = segment.match(/^\[\.\.\.([^\]]+)\]$/)
+  if (catchAll) return `*${catchAll[1]}`
+  const dynamic = segment.match(/^\[([^\]]+)\]$/)
+  if (dynamic) return `:${dynamic[1]}`
+  return segment
+}
+
+function canonicalRoutePattern(route: string): string {
+  return route
+    .split("/")
+    .map((segment) => {
+      if (segment.startsWith(":")) return ":param"
+      if (segment.startsWith("*")) return segment.endsWith("?") ? "*optional" : "*catch-all"
+      return segment
+    })
+    .join("/")
+}
+
+function stableId(namespace: string, ...parts: readonly string[]): string {
+  return ["project", namespace, ...parts.map(stableIdPart)].join(".")
+}
+
+function stableIdPart(part: string): string {
+  const routeValue = routeSegment(part)
+    .replace(/^:/, "by-")
+    .replace(/^\*/, "all-")
+    .replace(/\?$/, "-optional")
+  return (
+    routeValue
+      .normalize("NFKD")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "root"
+  )
+}
+
+function withoutFinalExtension(filePath: string): string {
+  return filePath.replace(/\.[^./]+$/, "")
+}
+
+function isTypeScriptFile(fileName: string): boolean {
+  return fileName.endsWith(".ts")
+}
+
+function isRouteGroup(segment: string): boolean {
+  return segment.startsWith("(") && segment.endsWith(")")
+}
+
+function shouldIgnoreDirectory(name: string): boolean {
+  return IGNORED_DIRECTORY_NAMES.has(name) || name.startsWith(".")
+}
+
+function compareContributions(
+  left: ProjectConventionContribution,
+  right: ProjectConventionContribution,
+): number {
+  return (
+    compareStrings(left.sourcePath, right.sourcePath) ||
+    compareStrings(left.kind, right.kind) ||
+    compareStrings(left.id, right.id)
+  )
+}
+
+function compareDiagnostics(
+  left: ProjectConventionDiagnostic,
+  right: ProjectConventionDiagnostic,
+): number {
+  return (
+    compareStrings(left.code, right.code) ||
+    compareStrings(left.id ?? "", right.id ?? "") ||
+    compareStrings(left.surface ?? "", right.surface ?? "") ||
+    compareStrings(left.route ?? "", right.route ?? "") ||
+    compareStrings(left.sourcePaths.join("\0"), right.sourcePaths.join("\0"))
+  )
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort(compareStrings)
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function formatSources(sourcePaths: readonly string[]): string {
+  return sourcePaths.map((sourcePath) => `"${sourcePath}"`).join(", ")
+}

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -5,6 +5,18 @@ export type {
   SetupMigrationHandler,
 } from "./node-migration-runner.js"
 export type {
+  DiscoverProjectConventionsInput,
+  DiscoverProjectConventionsOptions,
+  ProjectConventionApiRoute,
+  ProjectConventionContribution,
+  ProjectConventionDiagnostic,
+  ProjectConventionDiagnosticCode,
+  ProjectConventionDiscovery,
+  ProjectConventionFileContribution,
+  ProjectConventionKind,
+  ProjectConventionRouteSurface,
+} from "./project-conventions.js"
+export type {
   FrameworkGeneratedProjectFile,
   ResolvedProjectArtifacts,
   ResolvedVoyantProject,
@@ -15,6 +27,13 @@ export type {
   VoyantProjectSchemaMigration,
   VoyantProjectSetupMigration,
 } from "./project-resolver.js"
+
+export async function discoverProjectConventions(
+  input: import("./project-conventions.js").DiscoverProjectConventionsInput,
+): Promise<import("./project-conventions.js").ProjectConventionDiscovery> {
+  const conventions = await import("./project-conventions.js")
+  return conventions.discoverProjectConventions(input)
+}
 
 export async function executeNodeMigrationPlan(
   plan: import("./project-resolver.js").VoyantProjectMigrationPlan,


### PR DESCRIPTION
## Summary
- discover application-owned API routes, workflows, jobs, subscribers, links, admin entries, and local modules from conventional source folders
- derive deterministic IDs and normalized route metadata without executing project code
- fail deterministically on local ID and route-pattern collisions
- use a single `src/modules/<name>/index.ts` entry for app-local modules

## Verification
- `pnpm exec biome check packages/framework/src/project-conventions.ts packages/framework/src/project-conventions.test.ts packages/framework/src/project.ts`
- `pnpm --filter @voyant-travel/framework exec vitest run src/project-conventions.test.ts` (8 passed)
- full framework typecheck delegated to CI because isolated worktree pnpm symlinks caused a non-terminating workspace traversal

Part of #3080.