### PR TITLE
feat(graph): add first-class extensions

### DIFF
--- a/.changeset/clean-first-class-extensions.md
+++ b/.changeset/clean-first-class-extensions.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/accommodations": patch
+"@voyant-travel/action-ledger": patch
+"@voyant-travel/bookings": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/charters": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/cruises": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/inventory": patch
+"@voyant-travel/mice": patch
+"@voyant-travel/quotes": patch
+---
+
+Model package-owned Hono extensions as first-class deployment graph units while keeping externally distributed integrations in the plugin lane.

--- a/packages/accommodations/src/voyant.ts
+++ b/packages/accommodations/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declaration owned by the accommodations package. */
 export const accommodationsVoyantModule = defineModule({
@@ -43,7 +43,7 @@ export const accommodationsVoyantModule = defineModule({
   },
 })
 
-export const accommodationsContentVoyantPlugin = definePlugin({
+export const accommodationsContentVoyantPlugin = defineExtension({
   id: "@voyant-travel/accommodations#content-extension",
   packageName: "@voyant-travel/accommodations",
   localId: "accommodations.content-extension",

--- a/packages/accommodations/tests/unit/voyant-manifest.test.ts
+++ b/packages/accommodations/tests/unit/voyant-manifest.test.ts
@@ -38,7 +38,7 @@ describe("accommodations deployment manifest", () => {
 
   it("owns its catalog content extension", () => {
     expect(accommodationsContentVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/accommodations#content-extension",
       api: [
         {

--- a/packages/action-ledger/src/voyant.ts
+++ b/packages/action-ledger/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declaration owned by the action-ledger package. */
 export const actionLedgerVoyantModule = defineModule({
@@ -48,7 +48,7 @@ export const actionLedgerVoyantModule = defineModule({
   },
 })
 
-export const actionLedgerHealthVoyantPlugin = definePlugin({
+export const actionLedgerHealthVoyantPlugin = defineExtension({
   id: "@voyant-travel/action-ledger#health-extension",
   packageName: "@voyant-travel/action-ledger",
   localId: "action-ledger.health-extension",

--- a/packages/action-ledger/tests/unit/voyant-manifest.test.ts
+++ b/packages/action-ledger/tests/unit/voyant-manifest.test.ts
@@ -24,7 +24,7 @@ describe("action-ledger deployment manifest", () => {
 
   it("owns the health extension bridge", () => {
     expect(actionLedgerHealthVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/action-ledger#health-extension",
       packageName: "@voyant-travel/action-ledger",
       api: [

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 import { BOOKING_VOYANT_ACTIONS } from "./action-declarations.js"
 
@@ -201,7 +201,7 @@ export const bookingRequirementsVoyantModule = defineModule({
   },
 })
 
-export const bookingsSupplierVoyantPlugin = definePlugin({
+export const bookingsSupplierVoyantPlugin = defineExtension({
   id: "@voyant-travel/bookings#booking-supplier-extension",
   packageName: "@voyant-travel/bookings",
   localId: "bookings.booking-supplier-extension",

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -68,7 +68,7 @@ describe("bookings deployment manifest", () => {
     })
 
     expect(bookingsSupplierVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/bookings#booking-supplier-extension",
       packageName: "@voyant-travel/bookings",
       api: [

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 const catalogAdminRuntime = {
   entry: "@voyant-travel/catalog-react/admin",
@@ -223,7 +223,7 @@ export const catalogBookingEngineVoyantModule = defineModule({
   },
 })
 
-export const catalogOffersVoyantPlugin = definePlugin({
+export const catalogOffersVoyantPlugin = defineExtension({
   id: "@voyant-travel/catalog#offers-extension",
   packageName: "@voyant-travel/catalog",
   localId: "catalog.offers-extension",

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -63,7 +63,7 @@ describe("catalog deployment manifest", () => {
     })
 
     expect(catalogOffersVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/catalog#offers-extension",
       packageName: "@voyant-travel/catalog",
       api: [

--- a/packages/charters/src/voyant.ts
+++ b/packages/charters/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declaration owned by the charters package. */
 export const chartersVoyantModule = defineModule({
@@ -62,7 +62,7 @@ export const chartersVoyantModule = defineModule({
   },
 })
 
-export const chartersBookingVoyantPlugin = definePlugin({
+export const chartersBookingVoyantPlugin = defineExtension({
   id: "@voyant-travel/charters#booking-extension",
   packageName: "@voyant-travel/charters",
   localId: "charters.booking-extension",

--- a/packages/charters/tests/unit/voyant-manifest.test.ts
+++ b/packages/charters/tests/unit/voyant-manifest.test.ts
@@ -35,7 +35,7 @@ describe("charters deployment manifest", () => {
 
   it("owns the bookings extension and preserves injected lazy bridges", () => {
     expect(chartersBookingVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/charters#booking-extension",
       api: [
         { surface: "admin", mount: "bookings", runtime: { export: "chartersBookingExtension" } },

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 const commerceAdminRouteId = "@voyant-travel/commerce#admin.route.promotions-index"
 const commerceAdminRuntime = {
@@ -182,7 +182,7 @@ export const commerceVoyantModule = defineModule({
   },
 })
 
-export const commerceCatalogCheckoutVoyantPlugin = definePlugin({
+export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
   id: "@voyant-travel/commerce#catalog-checkout-extension",
   packageName: "@voyant-travel/commerce",
   localId: "commerce.catalog-checkout-extension",
@@ -202,7 +202,7 @@ export const commerceCatalogCheckoutVoyantPlugin = definePlugin({
   },
 })
 
-export const commerceBookingMaintenanceVoyantPlugin = definePlugin({
+export const commerceBookingMaintenanceVoyantPlugin = defineExtension({
   id: "@voyant-travel/commerce#booking-maintenance-extension",
   packageName: "@voyant-travel/commerce",
   localId: "commerce.booking-maintenance-extension",

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -102,7 +102,7 @@ describe("commerce deployment manifest", () => {
 
   it("owns the catalog checkout and booking maintenance bridges", () => {
     expect(commerceCatalogCheckoutVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/commerce#catalog-checkout-extension",
       packageName: "@voyant-travel/commerce",
       api: [
@@ -119,7 +119,7 @@ describe("commerce deployment manifest", () => {
     })
 
     expect(commerceBookingMaintenanceVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/commerce#booking-maintenance-extension",
       packageName: "@voyant-travel/commerce",
       api: [

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -23,9 +23,10 @@ export type * from "./project-facets.js"
 
 export const VOYANT_GRAPH_PROJECT_SCHEMA_VERSION = "voyant.project.v1" as const
 export const VOYANT_GRAPH_MODULE_SCHEMA_VERSION = "voyant.module.v1" as const
+export const VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION = "voyant.extension.v1" as const
 export const VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION = "voyant.plugin.v1" as const
 
-export type VoyantGraphUnitKind = "module" | "plugin"
+export type VoyantGraphUnitKind = "module" | "extension" | "plugin"
 export type VoyantGraphRouteSurface = "admin" | "public" | "webhook" | "internal"
 
 export type VoyantGraphJsonValue =
@@ -104,6 +105,7 @@ export interface VoyantGraphWorkflowSchedule extends VoyantGraphFacetEntity {
 export interface VoyantGraphUnitManifest {
   schemaVersion:
     | typeof VOYANT_GRAPH_MODULE_SCHEMA_VERSION
+    | typeof VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION
     | typeof VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION
   id: string
   localId?: string
@@ -167,6 +169,7 @@ export interface VoyantGraphProjectSelection {
 
 export interface VoyantGraphProjectSelections {
   modules: readonly VoyantGraphProjectSelection[]
+  extensions: readonly VoyantGraphProjectSelection[]
   plugins: readonly VoyantGraphProjectSelection[]
 }
 
@@ -195,6 +198,7 @@ export interface DefineVoyantGraphProjectInput {
   schemaVersion?: typeof VOYANT_GRAPH_PROJECT_SCHEMA_VERSION
   presetLineage?: string
   modules: readonly DefineVoyantGraphProjectUnitInput[]
+  extensions?: readonly DefineVoyantGraphProjectUnitInput[]
   plugins?: readonly DefineVoyantGraphProjectUnitInput[]
   deployment?: VoyantGraphProjectDeployment
   meta?: VoyantGraphJsonObject
@@ -204,6 +208,7 @@ export interface VoyantGraphProject {
   schemaVersion: typeof VOYANT_GRAPH_PROJECT_SCHEMA_VERSION
   presetLineage?: string
   modules: readonly VoyantGraphUnitManifest[]
+  extensions: readonly VoyantGraphUnitManifest[]
   plugins: readonly VoyantGraphUnitManifest[]
   selections?: VoyantGraphProjectSelections
   deployment?: VoyantGraphProjectDeployment
@@ -212,6 +217,10 @@ export interface VoyantGraphProject {
 
 export function defineModule(input: DefineVoyantGraphUnitInput): VoyantGraphUnitManifest {
   return defineGraphUnit(VOYANT_GRAPH_MODULE_SCHEMA_VERSION, input)
+}
+
+export function defineExtension(input: DefineVoyantGraphUnitInput): VoyantGraphUnitManifest {
+  return defineGraphUnit(VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION, input)
 }
 
 export function definePlugin(input: DefineVoyantGraphUnitInput): VoyantGraphUnitManifest {
@@ -227,19 +236,25 @@ export function defineProject(input: DefineVoyantGraphProjectInput): VoyantGraph
   }
 
   const modules = normalizeProjectUnits(input.modules, "module")
+  const extensions = normalizeProjectUnits(input.extensions ?? [], "extension")
   const plugins = normalizeProjectUnits(input.plugins ?? [], "plugin")
-  const hasSelections = modules.selections.length > 0 || plugins.selections.length > 0
+  const hasSelections =
+    modules.selections.length > 0 ||
+    extensions.selections.length > 0 ||
+    plugins.selections.length > 0
   const deployment = normalizeProjectDeployment(input.deployment)
 
   return {
     schemaVersion,
     ...(input.presetLineage ? { presetLineage: input.presetLineage } : {}),
     modules: modules.units,
+    extensions: extensions.units,
     plugins: plugins.units,
     ...(hasSelections
       ? {
           selections: {
             modules: modules.selections,
+            extensions: extensions.selections,
             plugins: plugins.selections,
           },
         }
@@ -370,7 +385,7 @@ function normalizeProjectUnits(
       continue
     }
 
-    const label = `${kind === "module" ? "modules" : "plugins"}[${index}]`
+    const label = `${kind === "module" ? "modules" : kind === "extension" ? "extensions" : "plugins"}[${index}]`
     if (typeof input !== "string") {
       const unsupportedKeys = Object.keys(input).filter(
         (key) => key !== "resolve" && key !== "config",
@@ -388,7 +403,11 @@ function normalizeProjectUnits(
     )
     units.push(
       defineGraphUnit(
-        kind === "module" ? VOYANT_GRAPH_MODULE_SCHEMA_VERSION : VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION,
+        kind === "module"
+          ? VOYANT_GRAPH_MODULE_SCHEMA_VERSION
+          : kind === "extension"
+            ? VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION
+            : VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION,
         { id: selection.id, packageName: selection.packageName },
       ),
     )

--- a/packages/core/tests/unit/project.test.ts
+++ b/packages/core/tests/unit/project.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { defineModule, defineProject } from "../../src/project.js"
+import { defineExtension, defineModule, defineProject } from "../../src/project.js"
 
 describe("defineProject", () => {
   it("normalizes package strings and records to the same module selection", () => {
@@ -74,6 +74,24 @@ describe("defineProject", () => {
         provenance: { kind: "path", path: "./src/plugins/smartbill" },
       },
     ])
+  })
+
+  it("keeps package-owned extensions distinct from external plugins", () => {
+    const extension = defineExtension({
+      id: "@acme/voyant-suite#admin-extension",
+      requires: { capabilities: ["acme.loyalty.points"] },
+    })
+    const project = defineProject({
+      modules: [],
+      extensions: [extension],
+      plugins: ["@acme/voyant-tax-provider"],
+    })
+
+    expect(project.extensions).toEqual([extension])
+    expect(project.extensions[0]?.schemaVersion).toBe("voyant.extension.v1")
+    expect(project.plugins[0]?.schemaVersion).toBe("voyant.plugin.v1")
+    expect(project.selections?.extensions).toEqual([])
+    expect(project.selections?.plugins[0]?.resolve).toBe("@acme/voyant-tax-provider")
   })
 
   it("retains deterministic JSON config without turning it into a unit facet", () => {

--- a/packages/cruises/src/voyant.ts
+++ b/packages/cruises/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declaration owned by the cruises package. */
 export const cruisesVoyantModule = defineModule({
@@ -74,7 +74,7 @@ export const cruisesVoyantModule = defineModule({
   },
 })
 
-export const cruisesContentVoyantPlugin = definePlugin({
+export const cruisesContentVoyantPlugin = defineExtension({
   id: "@voyant-travel/cruises#content-extension",
   packageName: "@voyant-travel/cruises",
   localId: "cruises.content-extension",
@@ -103,7 +103,7 @@ export const cruisesContentVoyantPlugin = definePlugin({
   },
 })
 
-export const cruisesBookingVoyantPlugin = definePlugin({
+export const cruisesBookingVoyantPlugin = defineExtension({
   id: "@voyant-travel/cruises#booking-extension",
   packageName: "@voyant-travel/cruises",
   localId: "cruises.booking-extension",

--- a/packages/cruises/tests/unit/voyant-manifest.test.ts
+++ b/packages/cruises/tests/unit/voyant-manifest.test.ts
@@ -41,7 +41,7 @@ describe("cruises deployment manifest", () => {
 
   it("owns content and booking extensions", () => {
     expect(cruisesContentVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/cruises#content-extension",
       api: [
         {
@@ -57,7 +57,7 @@ describe("cruises deployment manifest", () => {
       ],
     })
     expect(cruisesBookingVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/cruises#booking-extension",
       api: [
         { surface: "admin", mount: "bookings", runtime: { export: "cruisesBookingExtension" } },

--- a/packages/distribution/src/voyant.ts
+++ b/packages/distribution/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declarations owned by the distribution package. */
 export const distributionVoyantModule = defineModule({
@@ -124,7 +124,7 @@ export const distributionVoyantModule = defineModule({
   },
 })
 
-export const distributionBookingVoyantPlugin = definePlugin({
+export const distributionBookingVoyantPlugin = defineExtension({
   id: "@voyant-travel/distribution#extension",
   packageName: "@voyant-travel/distribution",
   localId: "distribution",
@@ -144,7 +144,7 @@ export const distributionBookingVoyantPlugin = definePlugin({
   },
 })
 
-export const distributionChannelPushVoyantPlugin = definePlugin({
+export const distributionChannelPushVoyantPlugin = defineExtension({
   id: "@voyant-travel/distribution#channel-push-extension",
   packageName: "@voyant-travel/distribution",
   localId: "distribution.channel-push-extension",

--- a/packages/distribution/tests/unit/voyant-manifest.test.ts
+++ b/packages/distribution/tests/unit/voyant-manifest.test.ts
@@ -55,7 +55,7 @@ describe("distribution deployment manifests", () => {
 
   it("owns the booking and channel-push extensions", () => {
     expect(distributionBookingVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/distribution#extension",
       localId: "distribution",
       api: [
@@ -72,7 +72,7 @@ describe("distribution deployment manifests", () => {
     })
 
     expect(distributionChannelPushVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/distribution#channel-push-extension",
       localId: "distribution.channel-push-extension",
       api: [

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 const financeAdminRuntime = {
   entry: "@voyant-travel/finance-react/admin",
@@ -183,7 +183,7 @@ export const financeVoyantModule = defineModule({
   },
 })
 
-export const financeBookingTaxVoyantPlugin = definePlugin({
+export const financeBookingTaxVoyantPlugin = defineExtension({
   id: "@voyant-travel/finance#booking-tax-extension",
   packageName: "@voyant-travel/finance",
   localId: "finance.booking-tax-extension",
@@ -204,7 +204,7 @@ export const financeBookingTaxVoyantPlugin = definePlugin({
   },
 })
 
-export const financeBookingsCreateVoyantPlugin = definePlugin({
+export const financeBookingsCreateVoyantPlugin = defineExtension({
   id: "@voyant-travel/finance#bookings-create-extension",
   packageName: "@voyant-travel/finance",
   localId: "finance.bookings-create-extension",
@@ -225,7 +225,7 @@ export const financeBookingsCreateVoyantPlugin = definePlugin({
   },
 })
 
-export const financeBookingScheduleVoyantPlugin = definePlugin({
+export const financeBookingScheduleVoyantPlugin = defineExtension({
   id: "@voyant-travel/finance#booking-schedule-extension",
   packageName: "@voyant-travel/finance",
   localId: "finance.booking-schedule-extension",

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -49,7 +49,7 @@ describe("finance deployment manifest", () => {
   it("owns the finance extensions", () => {
     expect([financeBookingTaxVoyantPlugin, financeBookingsCreateVoyantPlugin]).toMatchObject([
       {
-        schemaVersion: "voyant.plugin.v1",
+        schemaVersion: "voyant.extension.v1",
         id: "@voyant-travel/finance#booking-tax-extension",
         api: [
           {
@@ -61,7 +61,7 @@ describe("finance deployment manifest", () => {
         ],
       },
       {
-        schemaVersion: "voyant.plugin.v1",
+        schemaVersion: "voyant.extension.v1",
         id: "@voyant-travel/finance#bookings-create-extension",
         api: [
           {
@@ -74,7 +74,7 @@ describe("finance deployment manifest", () => {
 
   it("owns the booking schedule bridge with package runtime references", () => {
     expect(financeBookingScheduleVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/finance#booking-schedule-extension",
       packageName: "@voyant-travel/finance",
       api: [

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -130,6 +130,11 @@ export function buildGraphRuntimeModule(input: BuildGraphRuntimeModuleInput): st
     input.graph,
     input.runtimeEntryOverrides,
   )
+  const extensions = lowerGraphRuntimeUnits(
+    input.graph.extensions,
+    input.graph,
+    input.runtimeEntryOverrides,
+  )
   const plugins = lowerGraphRuntimeUnits(
     input.graph.plugins,
     input.graph,
@@ -137,7 +142,7 @@ export function buildGraphRuntimeModule(input: BuildGraphRuntimeModuleInput): st
   )
   const entries = [
     ...new Set(
-      [...modules, ...plugins].flatMap((unit) =>
+      [...modules, ...extensions, ...plugins].flatMap((unit) =>
         unit.references.map((definition) => definition.importEntry),
       ),
     ),
@@ -157,6 +162,9 @@ export const GENERATED_GRAPH_RUNTIME_ENTRY_SPECIFIERS = ${formatConstArray(entri
 export const GENERATED_GRAPH_RUNTIME_MODULE_IDS = ${formatConstArray(
     modules.map((unit) => unit.id),
   )}
+export const GENERATED_GRAPH_RUNTIME_EXTENSION_IDS = ${formatConstArray(
+    extensions.map((unit) => unit.id),
+  )}
 export const GENERATED_GRAPH_RUNTIME_PLUGIN_IDS = ${formatConstArray(
     plugins.map((unit) => unit.id),
   )}
@@ -173,6 +181,7 @@ export function createGeneratedGraphRuntime(): VoyantGraphRuntime {
     providerSelections: ${formatGeneratedValue(input.graph.deployment.providers, 4)},
     entries: GENERATED_GRAPH_RUNTIME_IMPORTERS,
     modules: ${formatGeneratedValue(modules, 4)},
+    extensions: ${formatGeneratedValue(extensions, 4)},
     plugins: ${formatGeneratedValue(plugins, 4)},
     webhookPlan: GENERATED_GRAPH_RUNTIME_WEBHOOK_PLAN,
   })
@@ -279,6 +288,9 @@ export const GENERATED_MANAGED_PROFILE_SNAPSHOT_PATH = ${quote(input.profileSnap
 
 export const GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS = ${formatConstArray(
     input.graph.modules.map((unit) => unit.id),
+  )}
+export const GENERATED_DEPLOYMENT_GRAPH_EXTENSION_IDS = ${formatConstArray(
+    input.graph.extensions.map((unit) => unit.id),
   )}
 export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = ${formatConstArray(
     input.graph.plugins.map((unit) => unit.id),

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest"
 import {
   createTestDeployment,
   defineDeployment,
+  defineExtension,
   defineModule,
   definePlugin,
   defineProject,
@@ -21,7 +22,7 @@ import { assertPortConforms, definePort, providePort, requirePort } from "./port
 import { defineVoyantProject } from "./profile.js"
 
 describe("deployment graph v1", () => {
-  it("defines closed module and plugin manifests", () => {
+  it("defines closed module, extension, and plugin manifests", () => {
     const module = defineModule({
       id: "@acme/voyant-loyalty",
       provides: { capabilities: ["acme.loyalty.points"] },
@@ -31,8 +32,10 @@ describe("deployment graph v1", () => {
       id: "@acme/voyant-fiscal#smartbill",
       provides: { capabilities: ["acme.fiscal.invoice"] },
     })
+    const extension = defineExtension({ id: "@acme/voyant-loyalty#admin-extension" })
 
     expect(module.schemaVersion).toBe("voyant.module.v1")
+    expect(extension.schemaVersion).toBe("voyant.extension.v1")
     expect(plugin.schemaVersion).toBe("voyant.plugin.v1")
 
     expect(
@@ -54,6 +57,17 @@ describe("deployment graph v1", () => {
       ]),
     )
     expect(validateGraphUnitManifest(module)).toEqual([])
+  })
+
+  it("normalizes legacy v1 projects without an extension lane", async () => {
+    const plugin = definePlugin({ id: "@acme/voyant-fiscal#smartbill" })
+    const project = defineProject({ modules: [], plugins: [plugin] })
+    Reflect.deleteProperty(project, "extensions")
+
+    const graph = await resolveDeploymentGraph({ project })
+
+    expect(graph.extensions).toEqual([])
+    expect(graph.plugins.map((unit) => unit.id)).toEqual(["@acme/voyant-fiscal#smartbill"])
   })
 
   it("resolves the full package-owned facet contract without starter catalogs", async () => {
@@ -864,7 +878,7 @@ describe("deployment graph v1", () => {
     expect(second.contentHash).toBe(first.contentHash)
   })
 
-  it("keeps resolved module and plugin ordering independent of declaration order", async () => {
+  it("keeps resolved unit ordering independent of declaration order", async () => {
     const crm = defineModule({
       id: "@acme/voyant-crm",
       provides: { capabilities: ["acme.crm.people"] },
@@ -882,10 +896,13 @@ describe("deployment graph v1", () => {
       id: "@acme/voyant-webhooks#hubspot",
       provides: { capabilities: ["acme.webhooks.hubspot"] },
     })
+    const admin = defineExtension({ id: "@acme/voyant-loyalty#admin-extension" })
+    const checkout = defineExtension({ id: "@acme/voyant-loyalty#checkout-extension" })
 
     const first = await resolveDeploymentGraph({
       project: defineProject({
         modules: [loyalty, crm],
+        extensions: [checkout, admin],
         plugins: [webhook, fiscal],
       }),
       target: "node",
@@ -894,6 +911,7 @@ describe("deployment graph v1", () => {
     const second = await resolveDeploymentGraph({
       project: defineProject({
         modules: [crm, loyalty],
+        extensions: [admin, checkout],
         plugins: [fiscal, webhook],
       }),
       target: "node",
@@ -904,6 +922,10 @@ describe("deployment graph v1", () => {
     expect(first.modules.map((unit) => [unit.id, unit.order])).toEqual([
       ["@acme/voyant-crm", 0],
       ["@acme/voyant-loyalty", 1],
+    ])
+    expect(first.extensions.map((unit) => [unit.id, unit.order])).toEqual([
+      ["@acme/voyant-loyalty#admin-extension", 0],
+      ["@acme/voyant-loyalty#checkout-extension", 1],
     ])
     expect(first.plugins.map((unit) => [unit.id, unit.order])).toEqual([
       ["@acme/voyant-fiscal#smartbill", 0],
@@ -1171,9 +1193,8 @@ describe("deployment graph v1", () => {
     expect(commerce?.workflows).toEqual([])
     expect(commerce?.events).toEqual([])
     expect(commerce?.subscribers).toEqual([])
-    expect(graph.plugins.map((unit) => unit.id)).toEqual(
-      expect.arrayContaining(["@voyant-travel/plugin-netopia", "@acme/voyant-loyalty-admin"]),
-    )
+    expect(graph.extensions.map((unit) => unit.id)).toContain("@acme/voyant-loyalty-admin")
+    expect(graph.plugins.map((unit) => unit.id)).toEqual(["@voyant-travel/plugin-netopia"])
     expect(graph.packageRecords).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -1,8 +1,10 @@
 // agent-quality: file-size exception -- reason: first v1 deployment-graph cut keeps schema versions, diagnostics, resolver, managed-profile bridge, and author harness co-located until generated runtime lowering defines stable split points.
 import {
+  defineExtension,
   defineModule,
   definePlugin,
   defineProject,
+  VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION,
   VOYANT_GRAPH_MODULE_SCHEMA_VERSION,
   VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION,
   type VoyantGraphAccessDeclaration,
@@ -74,9 +76,11 @@ export {
   type DefineVoyantGraphProjectSelection,
   type DefineVoyantGraphProjectUnitInput,
   type DefineVoyantGraphUnitInput,
+  defineExtension,
   defineModule,
   definePlugin,
   defineProject,
+  VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION,
   VOYANT_GRAPH_MODULE_SCHEMA_VERSION,
   VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION,
   VOYANT_GRAPH_PROJECT_SCHEMA_VERSION,
@@ -308,6 +312,7 @@ export interface ResolveDeploymentGraphWithPackageManifestsInput
 
 export interface CreateTestDeploymentInput {
   modules: readonly VoyantGraphUnitManifest[]
+  extensions?: readonly VoyantGraphUnitManifest[]
   plugins?: readonly VoyantGraphUnitManifest[]
   target?: VoyantGraphRuntimeTarget
   mode?: VoyantProjectDeploymentMode
@@ -364,6 +369,7 @@ export interface ResolvedVoyantDeploymentGraph {
   }
   requirements: VoyantGraphDeploymentRequirements
   modules: readonly ResolvedVoyantGraphUnit[]
+  extensions: readonly ResolvedVoyantGraphUnit[]
   plugins: readonly ResolvedVoyantGraphUnit[]
   capabilities: {
     provided: readonly string[]
@@ -508,10 +514,15 @@ export function validateGraphUnitManifest(
   const source = typeof input.id === "string" ? input.id : undefined
   const diagnostics: VoyantGraphDiagnostic[] = []
   const expectedSchema =
-    kind === "plugin" ? VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION : VOYANT_GRAPH_MODULE_SCHEMA_VERSION
+    kind === "module"
+      ? VOYANT_GRAPH_MODULE_SCHEMA_VERSION
+      : kind === "extension"
+        ? VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION
+        : VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION
 
   if (
     input.schemaVersion !== VOYANT_GRAPH_MODULE_SCHEMA_VERSION &&
+    input.schemaVersion !== VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION &&
     input.schemaVersion !== VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION
   ) {
     diagnostics.push(
@@ -519,7 +530,7 @@ export function validateGraphUnitManifest(
         code: "VOYANT_GRAPH_INVALID_SCHEMA_VERSION",
         source,
         facet: "schemaVersion",
-        message: `schemaVersion must be "${VOYANT_GRAPH_MODULE_SCHEMA_VERSION}" or "${VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION}".`,
+        message: `schemaVersion must be "${VOYANT_GRAPH_MODULE_SCHEMA_VERSION}", "${VOYANT_GRAPH_EXTENSION_SCHEMA_VERSION}", or "${VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION}".`,
       }),
     )
   } else if (kind && input.schemaVersion !== expectedSchema) {
@@ -600,7 +611,11 @@ export async function resolveDeploymentGraph(
   const requirements = normalizeDeploymentRequirements(input.deployment?.requirements)
   const migrations = input.deployment?.migrations ?? input.project.deployment?.migrations
   const selectionConfigById = new Map(
-    [...(input.project.selections?.modules ?? []), ...(input.project.selections?.plugins ?? [])]
+    [
+      ...(input.project.selections?.modules ?? []),
+      ...(input.project.selections?.extensions ?? []),
+      ...(input.project.selections?.plugins ?? []),
+    ]
       .filter((selection) => selection.config !== undefined)
       .map((selection) => [selection.id, selection.config!]),
   )
@@ -609,12 +624,17 @@ export async function resolveDeploymentGraph(
       resolveUnit(unit, "module", selectionConfigById.get(unit.id)),
     ),
   )
+  const selectedExtensions = sortResolvedUnits(
+    (input.project.extensions ?? []).map((unit) =>
+      resolveUnit(unit, "extension", selectionConfigById.get(unit.id)),
+    ),
+  )
   const selectedPlugins = sortResolvedUnits(
     input.project.plugins.map((unit) =>
       resolveUnit(unit, "plugin", selectionConfigById.get(unit.id)),
     ),
   )
-  const selectedUnits = [...selectedModules, ...selectedPlugins]
+  const selectedUnits = [...selectedModules, ...selectedExtensions, ...selectedPlugins]
 
   const packageRecords = mergePackageRecords(
     selectedUnits,
@@ -643,6 +663,7 @@ export async function resolveDeploymentGraph(
   ])
 
   const modules = selectedModules.map(({ original: _original, ...unit }) => unit)
+  const extensions = selectedExtensions.map(({ original: _original, ...unit }) => unit)
   const plugins = selectedPlugins.map(({ original: _original, ...unit }) => unit)
   const graphWithoutHash: Omit<ResolvedVoyantDeploymentGraph, "contentHash"> = {
     schemaVersion: VOYANT_RESOLVED_GRAPH_SCHEMA_VERSION,
@@ -657,6 +678,7 @@ export async function resolveDeploymentGraph(
     },
     requirements,
     modules,
+    extensions,
     plugins,
     capabilities: {
       provided: sortedUnique(selectedUnits.flatMap((unit) => unit.provides.capabilities)),
@@ -693,7 +715,11 @@ export async function resolveDeploymentGraphWithPackageManifests(
   )
   if (admissionFailed) return admitted
 
-  const selectedUnits = [...resolveInput.project.modules, ...(resolveInput.project.plugins ?? [])]
+  const selectedUnits = [
+    ...resolveInput.project.modules,
+    ...(resolveInput.project.extensions ?? []),
+    ...resolveInput.project.plugins,
+  ]
   const selectedIds = new Set(selectedUnits.map((unit) => unit.id))
   const replacements = new Map<string, VoyantGraphUnitManifest>()
   const diagnostics: VoyantGraphDiagnostic[] = []
@@ -750,6 +776,9 @@ export async function resolveDeploymentGraphWithPackageManifests(
   const project: VoyantGraphProject = {
     ...resolveInput.project,
     modules: resolveInput.project.modules.map((unit) => replacements.get(unit.id) ?? unit),
+    extensions: (resolveInput.project.extensions ?? []).map(
+      (unit) => replacements.get(unit.id) ?? unit,
+    ),
     plugins: resolveInput.project.plugins.map((unit) => replacements.get(unit.id) ?? unit),
   }
   const resolved = await resolveDeploymentGraph({ ...resolveInput, project })
@@ -766,17 +795,17 @@ export function defineProjectFromManagedProfile(
       ...generateFrameworkModuleManifests(bridge.manifest.modules),
       ...generateCustomSourceModuleManifests(project.customSource?.modules),
     ],
-    plugins: [
-      ...generateFrameworkPluginManifests(bridge.manifest.extensions),
-      ...generateCustomSourcePluginManifests(project.customSource?.extensions),
-      ...project.plugins.map((specifier) =>
-        definePlugin({
-          id: graphIdFromSpecifier(specifier),
-          packageName: packageNameFromSpecifier(specifier),
-          localId: moduleIdFromSpecifier(specifier),
-        }),
-      ),
+    extensions: [
+      ...generateFrameworkExtensionManifests(bridge.manifest.extensions),
+      ...generateCustomSourceExtensionManifests(project.customSource?.extensions),
     ],
+    plugins: project.plugins.map((specifier) =>
+      definePlugin({
+        id: graphIdFromSpecifier(specifier),
+        packageName: packageNameFromSpecifier(specifier),
+        localId: moduleIdFromSpecifier(specifier),
+      }),
+    ),
     meta: {
       compatibilityProfile: project.profile,
       managedProfileSchemaVersion: project.schemaVersion,
@@ -825,6 +854,7 @@ export async function createTestDeployment(
 ): Promise<TestDeployment> {
   const project = defineProject({
     modules: input.modules,
+    extensions: input.extensions ?? [],
     plugins: input.plugins ?? [],
   })
   const graph = await resolveDeploymentGraph({
@@ -851,6 +881,7 @@ export async function createTestDeployment(
       expectDeclared: (id: string) => {
         const ids = graph.modules
           .flatMap((unit) => unit.migrations)
+          .concat(graph.extensions.flatMap((unit) => unit.migrations))
           .concat(graph.plugins.flatMap((unit) => unit.migrations))
           .map((migration) => migration.id)
         assert(ids.includes(id), `Expected deployment graph to include migration "${id}".`)
@@ -858,6 +889,7 @@ export async function createTestDeployment(
       expectReplayParity: () => {
         const migrationIds = graph.modules
           .flatMap((unit) => unit.migrations)
+          .concat(graph.extensions.flatMap((unit) => unit.migrations))
           .concat(graph.plugins.flatMap((unit) => unit.migrations))
           .map((migration) => migration.id)
         const uniqueIds = new Set(migrationIds)
@@ -911,14 +943,14 @@ export function generateFrameworkModuleManifests(
   })
 }
 
-export function generateFrameworkPluginManifests(
+export function generateFrameworkExtensionManifests(
   specifiers: readonly string[] = subsetStandardManifest().extensions,
 ): VoyantGraphUnitManifest[] {
   const moduleIds = new Set(FRAMEWORK_RUNTIME_MANIFEST.modules.map(graphIdFromSpecifier))
   return specifiers.map((specifier) => {
     const baseId = graphIdFromSpecifier(specifier)
     const id = moduleIds.has(baseId) ? childGraphEntityId(baseId, "extension") : baseId
-    return definePlugin({
+    return defineExtension({
       id,
       packageName: packageNameFromSpecifier(specifier),
       localId: moduleIdFromSpecifier(specifier),
@@ -946,11 +978,11 @@ export function generateCustomSourceModuleManifests(
   )
 }
 
-export function generateCustomSourcePluginManifests(
+export function generateCustomSourceExtensionManifests(
   specifiers: readonly string[] = [],
 ): VoyantGraphUnitManifest[] {
   return validCustomSourceSpecifiers(specifiers).map((specifier) =>
-    definePlugin({
+    defineExtension({
       id: graphIdFromSpecifier(specifier),
       packageName: packageNameFromSpecifier(specifier),
       localId: moduleIdFromSpecifier(specifier),
@@ -958,6 +990,12 @@ export function generateCustomSourcePluginManifests(
     }),
   )
 }
+
+/** @deprecated Use generateFrameworkExtensionManifests. */
+export const generateFrameworkPluginManifests = generateFrameworkExtensionManifests
+
+/** @deprecated Use generateCustomSourceExtensionManifests. */
+export const generateCustomSourcePluginManifests = generateCustomSourceExtensionManifests
 
 export function graphIdFromSpecifier(specifier: string): string {
   const { packageName, subpath } = splitPackageSpecifier(specifier)
@@ -2456,10 +2494,11 @@ function mergePackageRecords(
   input: readonly VoyantGraphPackageRecord[],
 ): VoyantGraphPackageRecord[] {
   const selectionsById = new Map(
-    [...(selections?.modules ?? []), ...(selections?.plugins ?? [])].map((selection) => [
-      selection.id,
-      selection,
-    ]),
+    [
+      ...(selections?.modules ?? []),
+      ...(selections?.extensions ?? []),
+      ...(selections?.plugins ?? []),
+    ].map((selection) => [selection.id, selection]),
   )
   const records = new Map<string, VoyantGraphPackageRecord>()
   for (const unit of units) {
@@ -2491,6 +2530,7 @@ function generateWorkspacePackageRecords(
     "@voyant-travel/framework",
     "@voyant-travel/framework-migrations",
     ...project.modules.map((unit) => unit.packageName ?? packageNameFromGraphId(unit.id)),
+    ...project.extensions.map((unit) => unit.packageName ?? packageNameFromGraphId(unit.id)),
     ...project.plugins.map((unit) => unit.packageName ?? packageNameFromGraphId(unit.id)),
   ])
   return names.map((packageName) => ({
@@ -2514,7 +2554,7 @@ function normalizePackageRecord(record: VoyantGraphPackageRecord): VoyantGraphPa
 }
 
 function routePaths(graph: ResolvedVoyantDeploymentGraph): string[] {
-  return [...graph.modules, ...graph.plugins]
+  return [...graph.modules, ...graph.extensions, ...graph.plugins]
     .flatMap((unit) =>
       unit.api.map((route) => {
         if (route.mount?.startsWith("/")) return route.mount

--- a/packages/framework/src/project-import-cheap.test.ts
+++ b/packages/framework/src/project-import-cheap.test.ts
@@ -12,6 +12,7 @@ describe("framework project import boundary", () => {
     expect(authoring.defineProject({ modules: [] })).toEqual({
       schemaVersion: "voyant.project.v1",
       modules: [],
+      extensions: [],
       plugins: [],
     })
     expect(authoring.resolveProject).toBeTypeOf("function")

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -213,7 +213,11 @@ async function materializeRuntimeReferencePackages(
   projectRoot: string,
   packages: Map<string, InspectedPackage>,
 ): Promise<void> {
-  for (const reference of runtimePackageReferences([...graph.modules, ...graph.plugins])) {
+  for (const reference of runtimePackageReferences([
+    ...graph.modules,
+    ...graph.extensions,
+    ...graph.plugins,
+  ])) {
     const packageName = runtimeReferencePackageName(reference)
     let inspected = packages.get(packageName)
     if (!inspected) {
@@ -335,6 +339,13 @@ async function materializeProjectSelections(
     projectRoot,
     packages,
   )
+  const extensions = await materializeUnits(
+    project.extensions,
+    selections.extensions,
+    "extension",
+    projectRoot,
+    packages,
+  )
   const plugins = await materializeUnits(
     project.plugins,
     selections.plugins,
@@ -348,9 +359,11 @@ async function materializeProjectSelections(
     project: {
       ...project,
       modules: modules.units,
+      extensions: extensions.units,
       plugins: plugins.units,
       selections: {
         modules: modules.selections,
+        extensions: extensions.selections,
         plugins: plugins.selections,
       },
     },
@@ -479,7 +492,7 @@ async function buildLocalRuntimeEntryOverrides(
   const overrides: Record<string, string> = {}
   const runtimeDirectory = path.dirname(path.join(projectRoot, ".voyant", runtimeEntry))
 
-  for (const unit of [...graph.modules, ...graph.plugins]) {
+  for (const unit of [...graph.modules, ...graph.extensions, ...graph.plugins]) {
     const inspected = packages.get(unit.packageName)
     if (inspected?.record.source.kind !== "file") continue
     const packageJson = await readPackageJson(inspected.directory)
@@ -512,7 +525,7 @@ function lowerOwnerRuntimeEntry(packageName: string, entry: string): string {
 export function buildMigrationPlan(
   graph: ResolvedVoyantDeploymentGraph,
 ): VoyantProjectMigrationPlan {
-  const units = [...graph.modules, ...graph.plugins]
+  const units = [...graph.modules, ...graph.extensions, ...graph.plugins]
   const packageSchemaMigrations = units.flatMap((unit) =>
     unit.migrations
       .filter((migration): migration is typeof migration & { source: string } =>
@@ -941,7 +954,18 @@ function requireProject(value: unknown): VoyantGraphProject {
       "resolveProject: project must be the voyant.project.v1 result returned by defineProject(...).",
     )
   }
-  return value
+  return {
+    ...value,
+    extensions: value.extensions ?? [],
+    ...(value.selections
+      ? {
+          selections: {
+            ...value.selections,
+            extensions: value.selections.extensions ?? [],
+          },
+        }
+      : {}),
+  }
 }
 
 function isVoyantGraphProject(value: unknown): value is VoyantGraphProject {
@@ -950,6 +974,8 @@ function isVoyantGraphProject(value: unknown): value is VoyantGraphProject {
     value.schemaVersion !== "voyant.project.v1" ||
     !Array.isArray(value.modules) ||
     !value.modules.every(isGraphUnitManifest) ||
+    (value.extensions !== undefined &&
+      (!Array.isArray(value.extensions) || !value.extensions.every(isGraphUnitManifest))) ||
     !Array.isArray(value.plugins) ||
     !value.plugins.every(isGraphUnitManifest)
   ) {
@@ -960,6 +986,9 @@ function isVoyantGraphProject(value: unknown): value is VoyantGraphProject {
   return (
     Array.isArray(value.selections.modules) &&
     value.selections.modules.every(isProjectSelection) &&
+    (value.selections.extensions === undefined ||
+      (Array.isArray(value.selections.extensions) &&
+        value.selections.extensions.every(isProjectSelection))) &&
     Array.isArray(value.selections.plugins) &&
     value.selections.plugins.every(isProjectSelection)
   )
@@ -980,7 +1009,9 @@ function isGraphUnitManifest(value: unknown): value is VoyantGraphUnitManifest {
   return (
     isRecord(value) &&
     typeof value.id === "string" &&
-    (value.schemaVersion === "voyant.module.v1" || value.schemaVersion === "voyant.plugin.v1")
+    (value.schemaVersion === "voyant.module.v1" ||
+      value.schemaVersion === "voyant.extension.v1" ||
+      value.schemaVersion === "voyant.plugin.v1")
   )
 }
 

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -49,7 +49,7 @@ export async function composeVoyantGraphRuntimeFacetModules(
   runtime: VoyantGraphRuntime,
 ): Promise<HonoModule[]> {
   const modules: HonoModule[] = []
-  for (const unit of [...runtime.modules, ...runtime.plugins]) {
+  for (const unit of [...runtime.modules, ...runtime.extensions, ...runtime.plugins]) {
     const module = await resolveRuntimeFacetModule(unit)
     if (module) modules.push(module)
   }
@@ -78,7 +78,7 @@ export async function composeVoyantGraphRuntime<TCapabilities>(
     }
   }
 
-  for (const unit of input.runtime.plugins) {
+  for (const unit of [...input.runtime.extensions, ...input.runtime.plugins]) {
     const outputs = await resolveRuntimeUnit(input, unit)
     assertWebhookRoutePosture(input.runtime, unit, outputs)
     for (const output of outputs) {

--- a/packages/framework/src/runtime-lowering.ts
+++ b/packages/framework/src/runtime-lowering.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework; runtime metadata normalization, validation, and lazy loader construction share one contract boundary.
 import type {
   VoyantGraphActionBindings,
   VoyantGraphActionDeclaration,
@@ -213,6 +214,7 @@ export interface VoyantGraphRuntime {
   graphHash: string
   providerSelections: Readonly<Record<string, string>>
   modules: readonly VoyantGraphRuntimeUnitLoader[]
+  extensions: readonly VoyantGraphRuntimeUnitLoader[]
   plugins: readonly VoyantGraphRuntimeUnitLoader[]
   references: readonly VoyantGraphRuntimeReferenceLoader[]
   config: readonly VoyantGraphRuntimeConfigLoader[]
@@ -233,6 +235,7 @@ export interface CreateVoyantGraphRuntimeInput {
   providerSelections?: Readonly<Record<string, string>>
   entries: Readonly<Record<string, () => Promise<unknown>>>
   modules: readonly VoyantGraphRuntimeUnitDefinition[]
+  extensions?: readonly VoyantGraphRuntimeUnitDefinition[]
   plugins: readonly VoyantGraphRuntimeUnitDefinition[]
   webhookPlan?: VoyantGraphWebhookPlan
 }
@@ -257,17 +260,21 @@ export function createVoyantGraphRuntime(input: CreateVoyantGraphRuntimeInput): 
   }
 
   const modules = definitions.modules.map((unit) => createRuntimeUnitLoader(unit, importEntries))
+  const extensions = definitions.extensions.map((unit) =>
+    createRuntimeUnitLoader(unit, importEntries),
+  )
   const plugins = definitions.plugins.map((unit) => createRuntimeUnitLoader(unit, importEntries))
-  const references = [...modules, ...plugins].flatMap((unit) => unit.references)
-  const config = [...modules, ...plugins].flatMap((unit) => unit.config)
-  const secrets = [...modules, ...plugins].flatMap((unit) => unit.secrets)
-  const resources = [...modules, ...plugins].flatMap((unit) => unit.resources)
-  const providers = [...modules, ...plugins].flatMap((unit) => unit.providers)
-  const requiredPorts = sortedUnique([...modules, ...plugins].flatMap((unit) => unit.requiredPorts))
-  const accessScopes = sortedUnique([...modules, ...plugins].flatMap((unit) => unit.accessScopes))
-  const tools = [...modules, ...plugins].flatMap((unit) => unit.tools)
-  const actions = [...modules, ...plugins].flatMap((unit) => unit.actions)
-  const selectedIds = mergeSelectedIds([...modules, ...plugins].map((unit) => unit.selectedIds))
+  const units = [...modules, ...extensions, ...plugins]
+  const references = units.flatMap((unit) => unit.references)
+  const config = units.flatMap((unit) => unit.config)
+  const secrets = units.flatMap((unit) => unit.secrets)
+  const resources = units.flatMap((unit) => unit.resources)
+  const providers = units.flatMap((unit) => unit.providers)
+  const requiredPorts = sortedUnique(units.flatMap((unit) => unit.requiredPorts))
+  const accessScopes = sortedUnique(units.flatMap((unit) => unit.accessScopes))
+  const tools = units.flatMap((unit) => unit.tools)
+  const actions = units.flatMap((unit) => unit.actions)
+  const selectedIds = mergeSelectedIds(units.map((unit) => unit.selectedIds))
   const referenceById = new Map(references.map((reference) => [reference.id, reference]))
   const webhooks = createRuntimeWebhookPlan(definitions.webhookPlan)
 
@@ -275,6 +282,7 @@ export function createVoyantGraphRuntime(input: CreateVoyantGraphRuntimeInput): 
     graphHash: input.graphHash,
     providerSelections: { ...(input.providerSelections ?? {}) },
     modules,
+    extensions,
     plugins,
     references,
     config,
@@ -329,8 +337,12 @@ interface NormalizedVoyantGraphRuntimeUnitDefinition
 }
 
 interface NormalizedVoyantGraphRuntimeInput
-  extends Omit<CreateVoyantGraphRuntimeInput, "modules" | "plugins" | "webhookPlan"> {
+  extends Omit<
+    CreateVoyantGraphRuntimeInput,
+    "modules" | "extensions" | "plugins" | "webhookPlan"
+  > {
   modules: readonly NormalizedVoyantGraphRuntimeUnitDefinition[]
+  extensions: readonly NormalizedVoyantGraphRuntimeUnitDefinition[]
   plugins: readonly NormalizedVoyantGraphRuntimeUnitDefinition[]
   webhookPlan: VoyantGraphWebhookPlan
 }
@@ -342,6 +354,7 @@ function normalizeRuntimeDefinition(
     ...input,
     webhookPlan: normalizeWebhookPlan(input.webhookPlan),
     modules: input.modules.map(normalizeRuntimeUnitDefinition),
+    extensions: (input.extensions ?? []).map(normalizeRuntimeUnitDefinition),
     plugins: input.plugins.map(normalizeRuntimeUnitDefinition),
   }
 }
@@ -605,10 +618,11 @@ function validateRuntimeDefinition(input: NormalizedVoyantGraphRuntimeInput): st
   const toolIds = new Set<string>()
   const toolNames = new Set<string>()
   const accessScopes = new Set(
-    [...input.modules, ...input.plugins].flatMap((unit) => unit.accessScopes),
+    [...input.modules, ...input.extensions, ...input.plugins].flatMap((unit) => unit.accessScopes),
   )
   for (const [expectedKind, units] of [
     ["module", input.modules],
+    ["extension", input.extensions],
     ["plugin", input.plugins],
   ] as const) {
     for (const unit of units) {
@@ -709,7 +723,7 @@ function normalizeWebhookPlan(plan: VoyantGraphWebhookPlan | undefined): VoyantG
 }
 
 function validateRuntimeWebhookPlan(input: NormalizedVoyantGraphRuntimeInput): void {
-  const units = [...input.modules, ...input.plugins]
+  const units = [...input.modules, ...input.extensions, ...input.plugins]
   const unitById = new Map(units.map((unit) => [unit.id, unit]))
   const routeById = new Map(
     units.flatMap((unit) => unit.routes.map((route) => [route.route.id, { route, unit }] as const)),

--- a/packages/framework/src/runtime-values.ts
+++ b/packages/framework/src/runtime-values.ts
@@ -79,7 +79,10 @@ export async function resolveVoyantGraphRuntimeValues(
   const deploymentValues = input.deploymentValues ?? {}
   const deploymentValueAliases = input.deploymentValueAliases ?? {}
   const unitConfig = new Map(
-    [...runtime.modules, ...runtime.plugins].map((unit) => [unit.id, unit.projectConfig ?? {}]),
+    [...runtime.modules, ...runtime.extensions, ...runtime.plugins].map((unit) => [
+      unit.id,
+      unit.projectConfig ?? {},
+    ]),
   )
   const configValues = new Map<string, unknown>()
   const secretValues = new Map<string, unknown>()

--- a/packages/inventory/src/voyant.ts
+++ b/packages/inventory/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declarations owned by the inventory package. */
 export const inventoryVoyantModule = defineModule({
@@ -192,7 +192,7 @@ export const inventoryExtrasVoyantModule = defineModule({
   },
 })
 
-export const inventoryAuthoringVoyantPlugin = definePlugin({
+export const inventoryAuthoringVoyantPlugin = defineExtension({
   id: "@voyant-travel/inventory#authoring.extension",
   packageName: "@voyant-travel/inventory",
   localId: "inventory.authoring.extension",
@@ -213,7 +213,7 @@ export const inventoryAuthoringVoyantPlugin = definePlugin({
   },
 })
 
-export const inventoryBookingVoyantPlugin = definePlugin({
+export const inventoryBookingVoyantPlugin = defineExtension({
   id: "@voyant-travel/inventory#booking-extension",
   packageName: "@voyant-travel/inventory",
   localId: "inventory.booking-extension",
@@ -233,7 +233,7 @@ export const inventoryBookingVoyantPlugin = definePlugin({
   },
 })
 
-export const inventoryContentVoyantPlugin = definePlugin({
+export const inventoryContentVoyantPlugin = defineExtension({
   id: "@voyant-travel/inventory#content-extension",
   packageName: "@voyant-travel/inventory",
   localId: "inventory.content-extension",
@@ -262,7 +262,7 @@ export const inventoryContentVoyantPlugin = definePlugin({
   },
 })
 
-export const inventoryBrochureVoyantPlugin = definePlugin({
+export const inventoryBrochureVoyantPlugin = defineExtension({
   id: "@voyant-travel/inventory#brochure-extension",
   packageName: "@voyant-travel/inventory",
   localId: "inventory.brochure-extension",

--- a/packages/inventory/tests/unit/voyant-manifest.test.ts
+++ b/packages/inventory/tests/unit/voyant-manifest.test.ts
@@ -57,7 +57,7 @@ describe("inventory deployment manifests", () => {
 
   it("owns the authoring and booking plugin surfaces", () => {
     expect(inventoryAuthoringVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/inventory#authoring.extension",
       api: [
         {
@@ -72,7 +72,7 @@ describe("inventory deployment manifests", () => {
     })
 
     expect(inventoryBookingVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/inventory#booking-extension",
       api: [
         {
@@ -88,7 +88,7 @@ describe("inventory deployment manifests", () => {
 
   it("owns the split content and brochure extensions", () => {
     expect(inventoryContentVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/inventory#content-extension",
       api: [
         {
@@ -104,7 +104,7 @@ describe("inventory deployment manifests", () => {
       ],
     })
     expect(inventoryBrochureVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/inventory#brochure-extension",
       api: [
         {

--- a/packages/mice/src/voyant.ts
+++ b/packages/mice/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declarations owned by the MICE package. */
 export const miceVoyantModule = defineModule({
@@ -74,7 +74,7 @@ export const miceVoyantModule = defineModule({
   },
 })
 
-export const miceBookingVoyantPlugin = definePlugin({
+export const miceBookingVoyantPlugin = defineExtension({
   id: "@voyant-travel/mice#booking-extension",
   packageName: "@voyant-travel/mice",
   localId: "mice.booking-extension",

--- a/packages/mice/tests/unit/voyant-manifest.test.ts
+++ b/packages/mice/tests/unit/voyant-manifest.test.ts
@@ -33,7 +33,7 @@ describe("MICE deployment manifests", () => {
 
   it("owns the booking extension", () => {
     expect(miceBookingVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/mice#booking-extension",
       packageName: "@voyant-travel/mice",
       api: [

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule, definePlugin } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 /** Import-cheap deployment declarations owned by the quotes package. */
 export const quotesVoyantModule = defineModule({
@@ -149,7 +149,7 @@ export const quotesVoyantModule = defineModule({
   },
 })
 
-export const quotesBookingVoyantPlugin = definePlugin({
+export const quotesBookingVoyantPlugin = defineExtension({
   id: "@voyant-travel/quotes#booking-extension",
   packageName: "@voyant-travel/quotes",
   localId: "quotes.booking-extension",
@@ -169,7 +169,7 @@ export const quotesBookingVoyantPlugin = definePlugin({
   },
 })
 
-export const quotesProposalVoyantPlugin = definePlugin({
+export const quotesProposalVoyantPlugin = defineExtension({
   id: "@voyant-travel/quotes#proposal-extension",
   packageName: "@voyant-travel/quotes",
   localId: "quotes.proposal-extension",
@@ -201,7 +201,7 @@ export const quotesProposalVoyantPlugin = definePlugin({
   },
 })
 
-export const quotesVersionSnapshotVoyantPlugin = definePlugin({
+export const quotesVersionSnapshotVoyantPlugin = defineExtension({
   id: "@voyant-travel/quotes#quote-version-snapshot-extension",
   packageName: "@voyant-travel/quotes",
   localId: "quotes.quote-version-snapshot-extension",

--- a/packages/quotes/tests/unit/voyant-manifest.test.ts
+++ b/packages/quotes/tests/unit/voyant-manifest.test.ts
@@ -32,7 +32,7 @@ describe("quotes deployment manifests", () => {
 
   it("owns the booking extension", () => {
     expect(quotesBookingVoyantPlugin).toMatchObject({
-      schemaVersion: "voyant.plugin.v1",
+      schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/quotes#booking-extension",
       packageName: "@voyant-travel/quotes",
       api: [
@@ -51,7 +51,7 @@ describe("quotes deployment manifests", () => {
   it("owns the proposal and quote-version snapshot bridges", () => {
     expect([quotesProposalVoyantPlugin, quotesVersionSnapshotVoyantPlugin]).toMatchObject([
       {
-        schemaVersion: "voyant.plugin.v1",
+        schemaVersion: "voyant.extension.v1",
         id: "@voyant-travel/quotes#proposal-extension",
         api: [
           {
@@ -74,7 +74,7 @@ describe("quotes deployment manifests", () => {
         ],
       },
       {
-        schemaVersion: "voyant.plugin.v1",
+        schemaVersion: "voyant.extension.v1",
         id: "@voyant-travel/quotes#quote-version-snapshot-extension",
         api: [
           {

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -480,6 +480,7 @@ function writeFixture(
           }
         : {}),
     modules: [{ id: "@voyant-travel/bookings" }],
+    extensions: [{ id: "@voyant-travel/bookings#booking-supplier-extension" }],
     plugins: [{ id: "@voyant-travel/plugin-smartbill" }],
     packageRecords: [{ packageName: "@voyant-travel/framework" }],
     ...(!options.omitProvisioning
@@ -548,6 +549,9 @@ function writeGeneratedGraphRuntimeSource(
       `export const GENERATED_GRAPH_RUNTIME_MODULE_IDS = ${stringArrayLiteral(
         graph.modules.map((module) => module.id),
       )} as const`,
+      `export const GENERATED_GRAPH_RUNTIME_EXTENSION_IDS = ${stringArrayLiteral(
+        graph.extensions.map((extension) => extension.id),
+      )} as const`,
       `export const GENERATED_GRAPH_RUNTIME_PLUGIN_IDS = ${stringArrayLiteral(
         graph.plugins.map((plugin) => plugin.id),
       )} as const`,
@@ -586,6 +590,7 @@ interface FixtureDeploymentGraph {
     }>
   }
   modules: Array<{ id: string }>
+  extensions: Array<{ id: string }>
   plugins: Array<{ id: string }>
   packageRecords: Array<{ packageName: string }>
   provisioning?: {
@@ -623,6 +628,9 @@ function writeGeneratedRuntimeEntrySource(
       'export const GENERATED_MANAGED_PROFILE_SNAPSHOT_PATH = "./managed-profile.json" as const',
       `export const GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS = ${stringArrayLiteral(
         graph.modules.map((module) => module.id),
+      )} as const`,
+      `export const GENERATED_DEPLOYMENT_GRAPH_EXTENSION_IDS = ${stringArrayLiteral(
+        graph.extensions.map((extension) => extension.id),
       )} as const`,
       `export const GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS = ${stringArrayLiteral(
         graph.plugins.map((plugin) => plugin.id),

--- a/starters/operator/src/deployment-graph-artifacts.ts
+++ b/starters/operator/src/deployment-graph-artifacts.ts
@@ -19,6 +19,7 @@ const SHA256_CONTENT_HASH_PATTERN = /^sha256:[a-f0-9]{64}$/
 export interface OperatorDeploymentGraphArtifactSummary {
   graphHash: string
   moduleIds: readonly string[]
+  extensionIds: readonly string[]
   pluginIds: readonly string[]
   packageNames: readonly string[]
   providers: Readonly<Record<string, string>>
@@ -87,6 +88,7 @@ interface ResolvedDeploymentGraph {
   requirements?: unknown
   provisioning?: unknown
   modules?: unknown
+  extensions?: unknown
   plugins?: unknown
   packageRecords?: unknown
 }
@@ -227,6 +229,10 @@ export function loadOperatorDeploymentGraphArtifacts(
   const summary = {
     graphHash,
     moduleIds: collectStringField(graph.modules, "deployment graph modules", "id"),
+    extensionIds:
+      graph.extensions === undefined
+        ? []
+        : collectStringField(graph.extensions, "deployment graph extensions", "id"),
     pluginIds: collectStringField(graph.plugins, "deployment graph plugins", "id"),
     packageNames,
     providers: collectDeploymentProviders(graph.deployment),
@@ -552,6 +558,11 @@ function validateGeneratedRuntimeEntrySource(input: {
     "GENERATED_DEPLOYMENT_GRAPH_MODULE_IDS",
     input.summary.moduleIds,
   )
+  assertGeneratedExtensionIds(
+    source,
+    "GENERATED_DEPLOYMENT_GRAPH_EXTENSION_IDS",
+    input.summary.extensionIds,
+  )
   assertGeneratedStringArrayConst(
     source,
     "GENERATED_DEPLOYMENT_GRAPH_PLUGIN_IDS",
@@ -580,6 +591,11 @@ function validateGeneratedGraphRuntimeSource(input: {
     "GENERATED_GRAPH_RUNTIME_MODULE_IDS",
     input.summary.moduleIds,
   )
+  assertGeneratedExtensionIds(
+    source,
+    "GENERATED_GRAPH_RUNTIME_EXTENSION_IDS",
+    input.summary.extensionIds,
+  )
   assertGeneratedStringArrayConst(
     source,
     "GENERATED_GRAPH_RUNTIME_PLUGIN_IDS",
@@ -593,6 +609,15 @@ function assertGeneratedStringConst(source: string, name: string, expected: stri
   throw new Error(
     `generated runtime entry ${name} must be ${String(expected)}, got ${String(actual)}`,
   )
+}
+
+function assertGeneratedExtensionIds(
+  source: string,
+  name: string,
+  expected: readonly string[],
+): void {
+  if (expected.length === 0 && !source.includes(name)) return
+  assertGeneratedStringArrayConst(source, name, expected)
 }
 
 function parseGeneratedStringConst(source: string, name: string): string | undefined {

--- a/starters/operator/voyant.config.ts
+++ b/starters/operator/voyant.config.ts
@@ -70,7 +70,7 @@ const definition = {
     { resolve: "./src/modules/invitations" },
     { resolve: "./src/modules/team" },
   ],
-  plugins: [
+  extensions: [
     "@voyant-travel/bookings/booking-supplier-extension",
     "@voyant-travel/finance/bookings-create-extension",
     "@voyant-travel/inventory/booking-extension",
@@ -91,8 +91,8 @@ const definition = {
     "@voyant-travel/catalog/offers-extension",
     "@voyant-travel/commerce/catalog-checkout-extension",
     "@voyant-travel/mice/booking-extension",
-    { resolve: "@voyant-travel/plugin-netopia" },
   ],
+  plugins: [{ resolve: "@voyant-travel/plugin-netopia" }],
   deployment,
 } as const
 


### PR DESCRIPTION
## Summary
- add a first-class `extension` deployment-graph unit kind
- keep package-owned Hono extensions separate from externally distributed plugins through resolution, runtime lowering, composition, and artifacts
- migrate first-party package manifests and Operator selection to the extension lane
- retain Netopia as the only authored external plugin

## Verification
- core lint, typecheck, build, and tests (188 tests)
- framework lint, typecheck, and tests (223 tests)
- package manifest tests (36 tests)
- Operator lint, typecheck, graph emission, and artifact tests (21 tests)
- repository lint hook (96 tasks)

Part of #3080.