### PR TITLE
feat(framework): declare standard Operator distribution

### DIFF
--- a/.changeset/clean-operator-distribution.md
+++ b/.changeset/clean-operator-distribution.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add the framework-owned standard Operator distribution declaration and resolver-facing defaults for modules, extensions, and external plugins.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./deployment-artifacts": "./src/deployment-artifacts.ts",
     "./deployment-graph": "./src/deployment-graph.ts",
+    "./operator-distribution": "./src/operator-distribution.ts",
     "./project": "./src/project.ts",
     "./profile": "./src/profile.ts",
     "./managed-jobs": "./src/managed-jobs.ts",
@@ -110,6 +111,10 @@
       "./deployment-graph": {
         "types": "./dist/deployment-graph.d.ts",
         "import": "./dist/deployment-graph.js"
+      },
+      "./operator-distribution": {
+        "types": "./dist/operator-distribution.d.ts",
+        "import": "./dist/operator-distribution.js"
       },
       "./project": {
         "types": "./dist/project.d.ts",

--- a/packages/framework/src/operator-distribution.test.ts
+++ b/packages/framework/src/operator-distribution.test.ts
@@ -1,0 +1,83 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+import {
+  mergeOperatorDistributionDefaults,
+  STANDARD_OPERATOR_DISTRIBUTION,
+} from "./operator-distribution.js"
+
+describe("standard Operator distribution", () => {
+  it("declares the complete package-owned Node closure in stable order", () => {
+    expect(STANDARD_OPERATOR_DISTRIBUTION).toMatchObject({
+      id: "operator-standard",
+      target: "node",
+    })
+    expect(STANDARD_OPERATOR_DISTRIBUTION.modules).toHaveLength(35)
+    expect(STANDARD_OPERATOR_DISTRIBUTION.modules.slice(0, 3)).toEqual([
+      "@voyant-travel/action-ledger",
+      "@voyant-travel/relationships",
+      "@voyant-travel/quotes",
+    ])
+    expect(STANDARD_OPERATOR_DISTRIBUTION.modules.slice(-3)).toEqual([
+      "@voyant-travel/availability",
+      "@voyant-travel/catalog-authoring",
+      "@voyant-travel/workflow-runs",
+    ])
+    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toHaveLength(20)
+    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toContain(
+      "@voyant-travel/distribution/extension",
+    )
+    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions.at(-1)).toBe(
+      "@voyant-travel/mice/booking-extension",
+    )
+    expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.modules).size).toBe(35)
+    expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.extensions).size).toBe(20)
+    expect(STANDARD_OPERATOR_DISTRIBUTION).not.toHaveProperty("presetLineage")
+  })
+
+  it("defaults authored differences without treating extensions as plugins", () => {
+    expect(mergeOperatorDistributionDefaults()).toEqual({
+      modules: STANDARD_OPERATOR_DISTRIBUTION.modules,
+      extensions: STANDARD_OPERATOR_DISTRIBUTION.extensions,
+      plugins: [],
+    })
+  })
+
+  it("appends each consumer-owned unit kind independently and deterministically", () => {
+    const differences = {
+      modules: [{ resolve: "./src/modules/team" }],
+      extensions: [{ resolve: "./src/extensions/reporting" }],
+      plugins: [{ resolve: "@voyant-travel/plugin-netopia" }],
+    } as const
+
+    const first = mergeOperatorDistributionDefaults(differences)
+    const second = mergeOperatorDistributionDefaults(differences)
+
+    expect(first).toEqual(second)
+    expect(first.modules.at(-1)).toEqual(differences.modules[0])
+    expect(first.extensions.at(-1)).toEqual(differences.extensions[0])
+    expect(first.plugins).toEqual(differences.plugins)
+    expect(first.extensions).not.toContain(differences.plugins[0])
+  })
+
+  it("accepts future distribution variants without adding runtime lineage", () => {
+    const variant = {
+      id: "operator-compact",
+      target: "node",
+      modules: ["@voyant-travel/identity"],
+      extensions: [],
+    } as const
+
+    expect(mergeOperatorDistributionDefaults({}, variant)).toEqual({
+      modules: variant.modules,
+      extensions: [],
+      plugins: [],
+    })
+  })
+
+  it("has no runtime imports or starter coupling", () => {
+    const source = readFileSync(new URL("operator-distribution.ts", import.meta.url), "utf8")
+    expect(source).not.toMatch(/^import (?!type\b)/m)
+    expect(source).not.toContain("starters/")
+    expect(source).not.toContain("managed-operator")
+  })
+})

--- a/packages/framework/src/operator-distribution.ts
+++ b/packages/framework/src/operator-distribution.ts
@@ -1,0 +1,103 @@
+import type { DefineVoyantGraphProjectUnitInput } from "@voyant-travel/core/project"
+
+export interface OperatorDistributionDeclaration {
+  id: string
+  target: "node"
+  modules: readonly DefineVoyantGraphProjectUnitInput[]
+  extensions: readonly DefineVoyantGraphProjectUnitInput[]
+}
+
+/** Consumer-owned differences applied after the framework distribution. */
+export interface OperatorDistributionDifferences {
+  modules?: readonly DefineVoyantGraphProjectUnitInput[]
+  extensions?: readonly DefineVoyantGraphProjectUnitInput[]
+  plugins?: readonly DefineVoyantGraphProjectUnitInput[]
+}
+
+/** Resolver input after framework defaults and consumer differences are merged. */
+export interface ResolvedOperatorDistribution {
+  modules: readonly DefineVoyantGraphProjectUnitInput[]
+  extensions: readonly DefineVoyantGraphProjectUnitInput[]
+  plugins: readonly DefineVoyantGraphProjectUnitInput[]
+}
+
+/**
+ * Applies the standard Operator product closure before consumer-owned
+ * differences. This is a resolver/default-config boundary: authored config
+ * describes differences and does not need to spread the standard declaration.
+ */
+export function mergeOperatorDistributionDefaults(
+  differences: OperatorDistributionDifferences = {},
+  distribution: OperatorDistributionDeclaration = STANDARD_OPERATOR_DISTRIBUTION,
+): ResolvedOperatorDistribution {
+  return {
+    modules: [...distribution.modules, ...(differences.modules ?? [])],
+    extensions: [...distribution.extensions, ...(differences.extensions ?? [])],
+    plugins: [...(differences.plugins ?? [])],
+  }
+}
+
+/** The package-owned product closure used by a standard Node operator. */
+export const STANDARD_OPERATOR_DISTRIBUTION = {
+  id: "operator-standard",
+  target: "node",
+  modules: [
+    "@voyant-travel/action-ledger",
+    "@voyant-travel/relationships",
+    "@voyant-travel/quotes",
+    "@voyant-travel/operations",
+    "@voyant-travel/identity",
+    "@voyant-travel/distribution",
+    "@voyant-travel/inventory/extras",
+    "@voyant-travel/bookings/requirements",
+    "@voyant-travel/commerce",
+    "@voyant-travel/inventory",
+    "@voyant-travel/catalog",
+    "@voyant-travel/catalog/booking-engine",
+    "@voyant-travel/accommodations",
+    "@voyant-travel/bookings",
+    "@voyant-travel/finance",
+    "@voyant-travel/legal",
+    "@voyant-travel/legal/contract-document",
+    "@voyant-travel/public-document-delivery",
+    "@voyant-travel/notifications",
+    "@voyant-travel/storage",
+    "@voyant-travel/storefront",
+    "@voyant-travel/storefront/customer-portal",
+    "@voyant-travel/storefront/verification",
+    "@voyant-travel/storefront/payment-link",
+    "@voyant-travel/trips",
+    "@voyant-travel/flights",
+    "@voyant-travel/operator-settings",
+    "@voyant-travel/charters",
+    "@voyant-travel/cruises",
+    "@voyant-travel/realtime",
+    "@voyant-travel/mice",
+    "@voyant-travel/db",
+    "@voyant-travel/availability",
+    "@voyant-travel/catalog-authoring",
+    "@voyant-travel/workflow-runs",
+  ],
+  extensions: [
+    "@voyant-travel/bookings/booking-supplier-extension",
+    "@voyant-travel/finance/bookings-create-extension",
+    "@voyant-travel/inventory/booking-extension",
+    "@voyant-travel/inventory/authoring/extension",
+    "@voyant-travel/quotes/booking-extension",
+    "@voyant-travel/distribution/extension",
+    "@voyant-travel/distribution/channel-push-extension",
+    "@voyant-travel/finance/booking-tax-extension",
+    "@voyant-travel/inventory/content-extension",
+    "@voyant-travel/cruises/content-extension",
+    "@voyant-travel/accommodations/content-extension",
+    "@voyant-travel/inventory/brochure-extension",
+    "@voyant-travel/finance/booking-schedule-extension",
+    "@voyant-travel/quotes/quote-version-snapshot-extension",
+    "@voyant-travel/commerce/booking-maintenance-extension",
+    "@voyant-travel/action-ledger/health-extension",
+    "@voyant-travel/quotes/proposal-extension",
+    "@voyant-travel/catalog/offers-extension",
+    "@voyant-travel/commerce/catalog-checkout-extension",
+    "@voyant-travel/mice/booking-extension",
+  ],
+} as const satisfies OperatorDistributionDeclaration


### PR DESCRIPTION
## Summary
- move the standard Operator module and extension closure into a framework-owned declaration
- keep authored modules, extensions, and external plugins as independent differences
- expose a deterministic resolver-facing default merge without starter or runtime coupling

## Verification
- framework tests (227 passed)
- scoped Biome check
- agent quality and secret scan
- framework BOM check (19 dependencies)

Part of #3080.