### PR TITLE
fix: preserve extensions in Operator graph loading

### DIFF
--- a/scripts/lib/load-voyant-package-manifests.ts
+++ b/scripts/lib/load-voyant-package-manifests.ts
@@ -142,6 +142,7 @@ function isVoyantGraphUnitManifest(value: unknown): value is VoyantGraphUnitMani
   return (
     typeof candidate.id === "string" &&
     (candidate.schemaVersion === "voyant.module.v1" ||
+      candidate.schemaVersion === "voyant.extension.v1" ||
       candidate.schemaVersion === "voyant.plugin.v1")
   )
 }

--- a/scripts/lib/operator-deployment-graph-package-records.ts
+++ b/scripts/lib/operator-deployment-graph-package-records.ts
@@ -154,6 +154,7 @@ export async function resolveOperatorDeploymentGraph(
   })
   const referencedPackageNames = runtimeReferencePackageNames([
     ...manifestedGraph.modules,
+    ...manifestedGraph.extensions,
     ...manifestedGraph.plugins,
   ])
   const packageRecords = withOperatorNodePackageCompatibility(
@@ -271,6 +272,7 @@ function projectFromResolvedGraph(
   graph: {
     project: { presetLineage?: string }
     modules: readonly ResolvedVoyantGraphUnit[]
+    extensions: readonly ResolvedVoyantGraphUnit[]
     plugins: readonly ResolvedVoyantGraphUnit[]
   },
   authored: OperatorAuthoredProject,
@@ -280,6 +282,9 @@ function projectFromResolvedGraph(
     schemaVersion: "voyant.project.v1",
     ...(presetLineage ? { presetLineage } : {}),
     modules: graph.modules.map((unit) => manifestFromResolvedUnit(unit, "voyant.module.v1")),
+    extensions: graph.extensions.map((unit) =>
+      manifestFromResolvedUnit(unit, "voyant.extension.v1"),
+    ),
     plugins: graph.plugins.map((unit) => manifestFromResolvedUnit(unit, "voyant.plugin.v1")),
     deployment: authored.deployment,
   }
@@ -326,6 +331,11 @@ async function loadLocalProjectSelections(
     projectRoot,
     "voyant.module.v1",
   )
+  const localExtensions = await localManifestReplacements(
+    project.selections?.extensions ?? [],
+    projectRoot,
+    "voyant.extension.v1",
+  )
   const localPlugins = await localManifestReplacements(
     project.selections?.plugins ?? [],
     projectRoot,
@@ -335,11 +345,13 @@ async function loadLocalProjectSelections(
   return {
     ...project,
     modules: project.modules.map((unit) => localModules.get(unit.id) ?? unit),
+    extensions: project.extensions.map((unit) => localExtensions.get(unit.id) ?? unit),
     plugins: project.plugins.map((unit) => localPlugins.get(unit.id) ?? unit),
     ...(project.selections
       ? {
           selections: {
             modules: resolvedSelections(project.selections.modules, localModules),
+            extensions: resolvedSelections(project.selections.extensions, localExtensions),
             plugins: resolvedSelections(project.selections.plugins, localPlugins),
           },
         }
@@ -421,6 +433,7 @@ function isGraphProject(value: unknown): value is VoyantGraphProject {
   return (
     record.schemaVersion === "voyant.project.v1" &&
     Array.isArray(record.modules) &&
+    Array.isArray(record.extensions) &&
     Array.isArray(record.plugins)
   )
 }
@@ -428,11 +441,17 @@ function isGraphProject(value: unknown): value is VoyantGraphProject {
 function isResolvedGraph(value: unknown): value is {
   project: { presetLineage?: string }
   modules: readonly ResolvedVoyantGraphUnit[]
+  extensions: readonly ResolvedVoyantGraphUnit[]
   plugins: readonly ResolvedVoyantGraphUnit[]
 } {
   if (!value || typeof value !== "object") return false
   const record = value as Record<string, unknown>
-  return Boolean(record.project && Array.isArray(record.modules) && Array.isArray(record.plugins))
+  return Boolean(
+    record.project &&
+      Array.isArray(record.modules) &&
+      Array.isArray(record.extensions) &&
+      Array.isArray(record.plugins),
+  )
 }
 
 function deploymentMode(value: unknown): OperatorAuthoredProject["deployment"]["mode"] | undefined {

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -23,6 +23,14 @@ afterEach(() => {
 describe("loadOperatorDeploymentGraphArtifacts", () => {
   it("loads the generated operator graph artifacts", () => {
     const summary = loadOperatorDeploymentGraphArtifacts()
+    const graph = JSON.parse(
+      readFileSync(join(process.cwd(), ".voyant", "deployment-graph.generated.json"), "utf8"),
+    ) as {
+      extensions: Array<{
+        id: string
+        api: Array<{ runtime?: { entry: string; export?: string } }>
+      }>
+    }
 
     expect(summary.graphHash).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(summary.moduleIds).toContain("@voyant-travel/bookings")
@@ -57,6 +65,18 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
         }),
       ]),
     )
+    expect(
+      graph.extensions.find(
+        (extension) => extension.id === "@voyant-travel/distribution#channel-push-extension",
+      )?.api,
+    ).toEqual([
+      expect.objectContaining({
+        runtime: {
+          entry: "@voyant-travel/distribution",
+          export: "createChannelPushExtension",
+        },
+      }),
+    ])
   })
 
   it("fails when the artifact graph hash does not match the graph content hash", () => {


### PR DESCRIPTION
## Summary
- recognize first-class extension manifests in the Operator package-manifest loader
- preserve extensions when normalizing resolved projects and computing runtime package closure
- cover the channel-push extension runtime reference in generated artifact tests

## Root cause
The Operator compatibility loader still accepted only module/plugin schema versions, so extension placeholders survived without package facets. Runtime composition then loaded zero exports for `@voyant-travel/distribution#channel-push-extension`.

## Verification
- Operator graph emission
- Operator deployment artifact tests (21 passed)
- Operator production build
- local node smoke: `healthz=200`, API dispatch `401` (non-500)
- scoped Biome and `git diff --check`

Fixes the node-smoke regression observed on #3166 and #3167.