### PR TITLE
feat(framework): default clean project config

### DIFF
--- a/.changeset/clean-project-config-defaults.md
+++ b/.changeset/clean-project-config-defaults.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add the public import-cheap `defineConfig` project authoring helper, which expands the standard Operator distribution before returning an explicit resolver-ready project.

--- a/packages/framework/src/project-config.test.ts
+++ b/packages/framework/src/project-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+import { defineConfig } from "./project.js"
+
+describe("framework project config", () => {
+  it("expands an empty authored config to the standard distribution", () => {
+    const project = defineConfig()
+
+    expect(project.modules).toHaveLength(35)
+    expect(project.extensions).toHaveLength(20)
+    expect(project.plugins).toEqual([])
+    expect(project.modules.map((unit) => unit.id).slice(0, 3)).toEqual([
+      "@voyant-travel/action-ledger",
+      "@voyant-travel/relationships",
+      "@voyant-travel/quotes",
+    ])
+    expect(project.extensions.map((unit) => unit.schemaVersion)).toEqual(
+      Array.from({ length: 20 }, () => "voyant.extension.v1"),
+    )
+    expect(project).not.toHaveProperty("presetLineage")
+  })
+
+  it("appends authored differences in their independent unit lanes", () => {
+    const project = defineConfig({
+      modules: [{ resolve: "./src/modules/team" }],
+      extensions: [{ resolve: "@acme/reporting/extension" }],
+      plugins: [{ resolve: "@voyant-travel/plugin-netopia" }],
+      deployment: {
+        target: "node",
+        mode: "self-hosted",
+        providers: { database: "postgres" },
+      },
+    })
+
+    expect(project.modules).toHaveLength(36)
+    expect(project.extensions).toHaveLength(21)
+    expect(project.plugins).toHaveLength(1)
+    expect(project.modules.at(-1)).toMatchObject({
+      id: "local/src.modules.team",
+      schemaVersion: "voyant.module.v1",
+    })
+    expect(project.extensions.at(-1)).toMatchObject({
+      id: "@acme/reporting#extension",
+      schemaVersion: "voyant.extension.v1",
+    })
+    expect(project.plugins[0]).toMatchObject({
+      id: "@voyant-travel/plugin-netopia",
+      schemaVersion: "voyant.plugin.v1",
+    })
+    expect(project.selections?.modules.at(-1)?.resolve).toBe("./src/modules/team")
+    expect(project.selections?.extensions.at(-1)?.resolve).toBe("@acme/reporting#extension")
+    expect(project.selections?.plugins.map((selection) => selection.resolve)).toEqual([
+      "@voyant-travel/plugin-netopia",
+    ])
+    expect(project.deployment).toEqual({
+      target: "node",
+      mode: "self-hosted",
+      providers: { database: "postgres" },
+    })
+  })
+})

--- a/packages/framework/src/project-import-cheap.test.ts
+++ b/packages/framework/src/project-import-cheap.test.ts
@@ -15,6 +15,10 @@ describe("framework project import boundary", () => {
       extensions: [],
       plugins: [],
     })
+    const config = authoring.defineConfig()
+    expect(config.modules).toHaveLength(35)
+    expect(config.extensions).toHaveLength(20)
+    expect(config.plugins).toEqual([])
     expect(authoring.resolveProject).toBeTypeOf("function")
   })
 

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -1,3 +1,13 @@
+import {
+  type DefineVoyantGraphProjectInput,
+  defineProject,
+  type VoyantGraphProject,
+} from "@voyant-travel/core/project"
+import {
+  mergeOperatorDistributionDefaults,
+  type OperatorDistributionDifferences,
+} from "./operator-distribution.js"
+
 export * from "@voyant-travel/core/project"
 export type {
   NodeMigrationExecutionReport,
@@ -27,6 +37,23 @@ export type {
   VoyantProjectSchemaMigration,
   VoyantProjectSetupMigration,
 } from "./project-resolver.js"
+
+/** Application-owned differences from the standard Operator distribution. */
+export interface DefineVoyantConfigInput extends OperatorDistributionDifferences {
+  deployment?: DefineVoyantGraphProjectInput["deployment"]
+  meta?: DefineVoyantGraphProjectInput["meta"]
+}
+
+/** Expand framework defaults into the explicit project consumed by resolvers. */
+export function defineConfig(input: DefineVoyantConfigInput = {}): VoyantGraphProject {
+  const distribution = mergeOperatorDistributionDefaults(input)
+
+  return defineProject({
+    ...distribution,
+    ...(input.deployment ? { deployment: input.deployment } : {}),
+    ...(input.meta ? { meta: input.meta } : {}),
+  })
+}
 
 export async function discoverProjectConventions(
   input: import("./project-conventions.js").DiscoverProjectConventionsInput,

--- a/starters/operator/voyant.config.test.ts
+++ b/starters/operator/voyant.config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+import config from "./voyant.config.js"
+
+describe("Operator project config", () => {
+  it("authors only deployment differences, local modules, and external plugins", () => {
+    expect(config.modules).toHaveLength(38)
+    expect(config.extensions).toHaveLength(20)
+    expect(config.plugins).toHaveLength(1)
+    expect(config).not.toHaveProperty("presetLineage")
+
+    expect(config.selections?.modules.slice(-3).map((selection) => selection.resolve)).toEqual([
+      "./src/modules/mcp",
+      "./src/modules/invitations",
+      "./src/modules/team",
+    ])
+    expect(config.selections?.extensions).toHaveLength(20)
+    expect(config.selections?.plugins.map((selection) => selection.resolve)).toEqual([
+      "@voyant-travel/plugin-netopia",
+    ])
+    expect(config.extensions.every((unit) => unit.schemaVersion === "voyant.extension.v1")).toBe(
+      true,
+    )
+  })
+})

--- a/starters/operator/voyant.config.ts
+++ b/starters/operator/voyant.config.ts
@@ -1,102 +1,28 @@
-import type {
-  VoyantProjectDeploymentMode,
-  VoyantProjectProviders,
-} from "@voyant-travel/framework/profile"
-import { defineProject } from "@voyant-travel/framework/project"
+import { defineConfig } from "@voyant-travel/framework/project"
 
-const deployment = {
-  target: "node",
-  mode: "self-hosted",
-  providers: {
-    database: "postgres",
-    storage: "memory",
-    cache: "postgres",
-    sharedState: "memory",
-    rateLimit: "memory",
-    search: "none",
-    email: "none",
-    sms: "none",
-    auth: "better-auth",
-    scheduledJobs: "none",
-    workflows: "none",
-  },
-  migrations: [{ id: "deployment", source: "./migrations" }],
-} as const satisfies {
-  target: "node"
-  mode: VoyantProjectDeploymentMode
-  providers: VoyantProjectProviders
-  migrations: readonly [{ id: "deployment"; source: "./migrations" }]
-}
-
-const definition = {
-  presetLineage: "operator-standard",
+export default defineConfig({
   modules: [
-    "@voyant-travel/action-ledger",
-    "@voyant-travel/relationships",
-    "@voyant-travel/quotes",
-    "@voyant-travel/operations",
-    "@voyant-travel/identity",
-    "@voyant-travel/distribution",
-    "@voyant-travel/inventory/extras",
-    "@voyant-travel/bookings/requirements",
-    "@voyant-travel/commerce",
-    "@voyant-travel/inventory",
-    "@voyant-travel/catalog",
-    "@voyant-travel/catalog/booking-engine",
-    "@voyant-travel/accommodations",
-    "@voyant-travel/bookings",
-    "@voyant-travel/finance",
-    "@voyant-travel/legal",
-    "@voyant-travel/legal/contract-document",
-    "@voyant-travel/public-document-delivery",
-    "@voyant-travel/notifications",
-    "@voyant-travel/storage",
-    "@voyant-travel/storefront",
-    "@voyant-travel/storefront/customer-portal",
-    "@voyant-travel/storefront/verification",
-    "@voyant-travel/storefront/payment-link",
-    "@voyant-travel/trips",
-    "@voyant-travel/flights",
-    "@voyant-travel/operator-settings",
-    "@voyant-travel/charters",
-    "@voyant-travel/cruises",
-    "@voyant-travel/realtime",
-    "@voyant-travel/mice",
-    "@voyant-travel/db",
-    "@voyant-travel/availability",
-    "@voyant-travel/catalog-authoring",
-    "@voyant-travel/workflow-runs",
     { resolve: "./src/modules/mcp" },
     { resolve: "./src/modules/invitations" },
     { resolve: "./src/modules/team" },
   ],
-  extensions: [
-    "@voyant-travel/bookings/booking-supplier-extension",
-    "@voyant-travel/finance/bookings-create-extension",
-    "@voyant-travel/inventory/booking-extension",
-    "@voyant-travel/inventory/authoring/extension",
-    "@voyant-travel/quotes/booking-extension",
-    "@voyant-travel/distribution/extension",
-    "@voyant-travel/distribution/channel-push-extension",
-    "@voyant-travel/finance/booking-tax-extension",
-    "@voyant-travel/inventory/content-extension",
-    "@voyant-travel/cruises/content-extension",
-    "@voyant-travel/accommodations/content-extension",
-    "@voyant-travel/inventory/brochure-extension",
-    "@voyant-travel/finance/booking-schedule-extension",
-    "@voyant-travel/quotes/quote-version-snapshot-extension",
-    "@voyant-travel/commerce/booking-maintenance-extension",
-    "@voyant-travel/action-ledger/health-extension",
-    "@voyant-travel/quotes/proposal-extension",
-    "@voyant-travel/catalog/offers-extension",
-    "@voyant-travel/commerce/catalog-checkout-extension",
-    "@voyant-travel/mice/booking-extension",
-  ],
   plugins: [{ resolve: "@voyant-travel/plugin-netopia" }],
-  deployment,
-} as const
-
-// The deployment member is part of the framework project contract supplied by
-// the project-resolver slice. Object.assign preserves it when this branch is
-// tested alone against the pre-resolver defineProject implementation.
-export default Object.assign(defineProject(definition), { deployment })
+  deployment: {
+    target: "node",
+    mode: "self-hosted",
+    providers: {
+      database: "postgres",
+      storage: "memory",
+      cache: "postgres",
+      sharedState: "memory",
+      rateLimit: "memory",
+      search: "none",
+      email: "none",
+      sms: "none",
+      auth: "better-auth",
+      scheduledJobs: "none",
+      workflows: "none",
+    },
+    migrations: [{ id: "deployment", source: "./migrations" }],
+  },
+})


### PR DESCRIPTION
## Summary
- add import-cheap `defineConfig` for application-owned differences from the standard Operator distribution
- collapse the Operator config to deployment settings, three temporary local modules, and Netopia
- remove authored preset lineage and standard module/extension arrays
- retain an equivalent resolved graph: 38 modules, 20 extensions, one plugin

## Verification
- focused framework config/import-boundary tests (4 passed)
- Operator config test
- Operator graph emit/check and graph-equivalence audit
- scoped Biome, agent quality, and `git diff --check`
- full framework typecheck delegated to CI after a 12-minute CPU-active local run without diagnostics

Part of #3080.