### PR TITLE
feat(graph): add unit-level runtime references

### DIFF
--- a/.changeset/clean-unit-runtime.md
+++ b/.changeset/clean-unit-runtime.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+---
+
+Add unit-level graph runtime references for single-entry application modules and extensions while retaining route runtime fallback.

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -110,6 +110,8 @@ export interface VoyantGraphUnitManifest {
   id: string
   localId?: string
   packageName?: string
+  /** The package export that creates this unit's runtime module or extension. */
+  runtime?: VoyantGraphRuntimeReference
   provides?: VoyantGraphCapabilityDeclaration
   requires?: VoyantGraphCapabilityDeclaration
   api?: readonly VoyantGraphRouteBundle[]

--- a/packages/core/tests/unit/project.test.ts
+++ b/packages/core/tests/unit/project.test.ts
@@ -117,11 +117,16 @@ describe("defineProject", () => {
   it("preserves direct manifests for advanced authoring", () => {
     const manifest = defineModule({
       id: "@acme/voyant-loyalty",
+      runtime: { entry: "./runtime", export: "createLoyaltyModule" },
       schema: [{ id: "@acme/voyant-loyalty#schema" }],
     })
     const project = defineProject({ modules: [manifest] })
 
     expect(project.modules[0]).toBe(manifest)
+    expect(project.modules[0]?.runtime).toEqual({
+      entry: "./runtime",
+      export: "createLoyaltyModule",
+    })
     expect(project.selections).toBeUndefined()
   })
 

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -10,6 +10,7 @@ import {
   VOYANT_MANAGED_NODE_RUNTIME_ENTRY_ID,
 } from "./deployment-artifacts.js"
 import {
+  defineExtension,
   defineModule,
   definePlugin,
   defineProject,
@@ -56,10 +57,11 @@ async function sampleGraph() {
 async function graphWithSelectedUnits(
   modules: readonly VoyantGraphUnitManifest[],
   plugins: readonly VoyantGraphUnitManifest[] = [],
+  extensions: readonly VoyantGraphUnitManifest[] = [],
 ) {
-  const units = [...modules, ...plugins]
+  const units = [...modules, ...extensions, ...plugins]
   return resolveDeploymentGraph({
-    project: defineProject({ modules, plugins }),
+    project: defineProject({ modules, extensions, plugins }),
     target: "node",
     mode: "self-hosted",
     packageRecords: [
@@ -193,6 +195,42 @@ describe("deployment graph artifacts", () => {
     expect(first).toContain('"createLoyaltyModule"')
     expect(first).toContain("createGeneratedGraphRuntime")
     expect(first).not.toContain("FRAMEWORK_RUNTIME_MANIFEST")
+  })
+
+  it("preserves and lowers unit runtimes for modules, extensions, and plugins", async () => {
+    const module = defineModule({
+      id: "@acme/catalog",
+      runtime: { entry: "./runtime", export: "createCatalogModule" },
+    })
+    const extension = defineExtension({
+      id: "@acme/catalog#admin",
+      runtime: { entry: "./admin-runtime", export: "createCatalogAdmin" },
+    })
+    const plugin = definePlugin({
+      id: "@acme/catalog#audit",
+      runtime: { entry: "./audit-runtime", export: "createCatalogAudit" },
+    })
+    const graph = await graphWithSelectedUnits([module], [plugin], [extension])
+    const withoutRuntime = await graphWithSelectedUnits([defineModule({ id: "@acme/catalog" })])
+
+    expect(graph.contentHash).not.toBe(withoutRuntime.contentHash)
+    expect(graph.modules[0]?.runtime).toEqual(module.runtime)
+    expect(graph.extensions[0]?.runtime).toEqual(extension.runtime)
+    expect(graph.plugins[0]?.runtime).toEqual(plugin.runtime)
+    expect(JSON.parse(buildDeploymentGraphJson(graph))).toMatchObject({
+      modules: [{ runtime: module.runtime }],
+      extensions: [{ runtime: extension.runtime }],
+      plugins: [{ runtime: plugin.runtime }],
+    })
+
+    const source = buildGraphRuntimeModule({ graph })
+    expect(source.match(/"facet": "runtime"/g)).toHaveLength(3)
+    expect(source).toContain('import("@acme/catalog/runtime")')
+    expect(source).toContain('import("@acme/catalog/admin-runtime")')
+    expect(source).toContain('import("@acme/catalog/audit-runtime")')
+    expect(source).toContain('"runtimeReferenceId": "%40acme%2Fcatalog/runtime/%40acme%2Fcatalog"')
+    expect(source).toContain('"kind": "extension"')
+    expect(source).toContain('"kind": "plugin"')
   })
 
   it("lowers every package-owned executable facet through deduplicated lazy imports", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -327,6 +327,7 @@ export interface ResolvedVoyantGraphUnit {
   order: number
   /** JSON-safe values authored on this unit's project selection. */
   projectConfig?: VoyantGraphJsonObject
+  runtime?: VoyantGraphRuntimeReference
   provides: {
     capabilities: readonly string[]
     ports: readonly VoyantGraphPortDeclaration[]
@@ -410,6 +411,7 @@ const SUPPORTED_GRAPH_UNIT_KEYS = new Set([
   "id",
   "localId",
   "packageName",
+  "runtime",
   "provides",
   "requires",
   "api",
@@ -587,6 +589,9 @@ export function validateGraphUnitManifest(
   diagnostics.push(
     ...validateCapabilityDeclaration(input.requires, "requires", source, packageName),
   )
+  if (input.runtime !== undefined) {
+    validateRuntimeReference(input.runtime, "runtime", source, diagnostics)
+  }
   diagnostics.push(...validateRouteBundles(input.api, source))
   diagnostics.push(...validateFacetEntities(input.schema, "schema", source))
   diagnostics.push(...validateFacetEntities(input.migrations, "migrations", source))
@@ -1143,6 +1148,7 @@ function resolveUnit(
     ...(unit.localId ? { localId: unit.localId } : {}),
     order: 0,
     ...(projectConfig ? { projectConfig } : {}),
+    ...(unit.runtime ? { runtime: unit.runtime } : {}),
     provides: {
       capabilities: sortedUnique(unit.provides?.capabilities ?? []),
       ports: sortPorts(unit.provides?.ports ?? []),
@@ -2318,6 +2324,7 @@ function validateRuntimeReferenceAdmission(
     const add = (facet: string, runtime?: { entry: string }) => {
       if (runtime) references.push({ entry: runtime.entry, facet })
     }
+    add("runtime.entry", unit.runtime)
     for (const route of unit.api) add(`api.${route.id}.runtime.entry`, route.runtime)
     for (const config of unit.config ?? []) {
       add(`config.validator.${config.id}.entry`, config.validator)

--- a/packages/framework/src/graph-runtime-generation.ts
+++ b/packages/framework/src/graph-runtime-generation.ts
@@ -27,6 +27,7 @@ export interface GeneratedRuntimeUnitDefinition {
   packageName: string
   order: number
   projectConfig?: ResolvedVoyantGraphUnit["projectConfig"]
+  runtimeReferenceId?: string
   references: VoyantGraphRuntimeReferenceDefinition[]
   config: VoyantGraphRuntimeConfigDefinition[]
   secrets: VoyantGraphRuntimeSecretDefinition[]
@@ -143,6 +144,9 @@ export function lowerGraphRuntimeUnits(
         packageName: unit.packageName,
         order: unit.order,
         ...(unit.projectConfig ? { projectConfig: unit.projectConfig } : {}),
+        ...(unit.runtime
+          ? { runtimeReferenceId: runtimeReferenceId(unit.id, "runtime", unit.id) }
+          : {}),
         references,
         config,
         secrets,
@@ -211,6 +215,7 @@ function collectRuntimeReferences(
     })
   }
 
+  if (unit.runtime) add("runtime", unit.id, unit.runtime)
   for (const route of unit.api) if (route.runtime) add("api", route.id, route.runtime)
   for (const config of unit.config ?? []) {
     if (config.validator) add("config.validator", config.id, config.validator)

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -238,6 +238,7 @@ function runtimePackageReferences(
   }
 
   for (const unit of units) {
+    add(unit, unit.runtime)
     for (const route of unit.api) add(unit, route.runtime)
     for (const config of unit.config ?? []) add(unit, config.validator)
     for (const secret of unit.secrets ?? []) add(unit, secret.validator)

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from "vitest"
 
 import { canonicalJson } from "./deployment-graph.js"
 import { defineProject, resolveProject } from "./project.js"
+import { runtimeReferencePackageNames } from "./project-resolver.js"
 
 const roots: string[] = []
 
@@ -396,6 +397,36 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
     ).rejects.toThrow(/VOYANT_GRAPH_PACKAGE_INCOMPATIBLE.*@acme\/loyalty-tools/s)
   })
 
+  it("materializes external unit runtime packages in the runtime reference closure", async () => {
+    const root = projectRoot()
+    writePackage(root, {
+      name: "@acme/loyalty",
+      manifest: `export default ${JSON.stringify({
+        ...moduleManifest("@acme/loyalty"),
+        runtime: {
+          entry: "@acme/loyalty-runtime/factory",
+          export: "createLoyaltyModule",
+        },
+      })}\n`,
+    })
+    writePackage(root, {
+      name: "@acme/loyalty-runtime",
+      manifest: "",
+      voyant: null,
+      extraExports: { "./factory": "./factory.mjs" },
+    })
+
+    const resolution = await resolve(root, defineProject({ modules: ["@acme/loyalty"] }))
+
+    expect(runtimeReferencePackageNames(resolution.graph.modules)).toEqual([
+      "@acme/loyalty-runtime",
+    ])
+    expect(
+      resolution.artifacts.files.find((file) => file.path === resolution.artifacts.runtimeEntry)
+        ?.contents,
+    ).toContain('"@acme/loyalty-runtime/factory": () => import("@acme/loyalty-runtime/factory")')
+  })
+
   it("rejects runtime subpaths that are absent from the referenced package exports", async () => {
     const root = projectRoot()
     writePackage(root, {
@@ -432,6 +463,7 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
       name: "@fixture/loyalty",
       manifest: `export default ${JSON.stringify({
         ...moduleManifest("@fixture/loyalty", { runtimeEntry: "./runtime" }),
+        runtime: { entry: "./module-runtime", export: "createLoyaltyModule" },
         tools: [
           {
             id: "@fixture/loyalty#tool.members",
@@ -441,8 +473,16 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
           },
         ],
       })}\n`,
-      extraExports: { "./runtime": "./runtime.mjs", "./tools": "./tools.mjs" },
+      extraExports: {
+        "./module-runtime": "./module-runtime.mjs",
+        "./runtime": "./runtime.mjs",
+        "./tools": "./tools.mjs",
+      },
     })
+    writeFileSync(
+      path.join(localDirectory, "module-runtime.mjs"),
+      "export const createLoyaltyModule = () => ({})\n",
+    )
     writeFileSync(path.join(localDirectory, "runtime.mjs"), "export const routes = {}\n")
     writeFileSync(path.join(localDirectory, "tools.mjs"), "export const listMembers = {}\n")
 
@@ -459,6 +499,9 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
       kind: "file",
       reference: "./src/modules/loyalty",
     })
+    expect(runtimeSource).toContain(
+      '"../../src/modules/loyalty/module-runtime.mjs": () => import("../../src/modules/loyalty/module-runtime.mjs")',
+    )
     expect(runtimeSource).toContain(
       '"../../src/modules/loyalty/runtime.mjs": () => import("../../src/modules/loyalty/runtime.mjs")',
     )

--- a/packages/framework/src/runtime-lowering.test.ts
+++ b/packages/framework/src/runtime-lowering.test.ts
@@ -117,6 +117,51 @@ describe("graph runtime lowering", () => {
     expect(importRuntime).toHaveBeenCalledTimes(1)
   })
 
+  it("prefers a unit runtime over route runtime factories", async () => {
+    const unitFactory = () => ({ module: { name: "loyalty" } })
+    const routeFactory = () => ({ module: { name: "legacy-loyalty" } })
+    const importRuntime = vi.fn(async () => ({ unitFactory, routeFactory }))
+    const runtime = createVoyantGraphRuntime({
+      graphHash: "sha256:test",
+      entries: { "@acme/loyalty/runtime": importRuntime },
+      modules: [
+        {
+          id: "@acme/loyalty",
+          kind: "module",
+          packageName: "@acme/loyalty",
+          order: 0,
+          runtimeReferenceId: "loyalty-runtime",
+          references: [
+            {
+              id: "loyalty-runtime",
+              unitId: "@acme/loyalty",
+              facet: "runtime",
+              entityId: "@acme/loyalty",
+              runtime: { entry: "./runtime", export: "unitFactory" },
+              importEntry: "@acme/loyalty/runtime",
+            },
+          ],
+          routes: [
+            {
+              route: {
+                id: "@acme/loyalty#api.admin",
+                surface: "admin",
+                runtime: { entry: "./runtime", export: "routeFactory" },
+              },
+              importEntry: "@acme/loyalty/runtime",
+            },
+          ],
+        },
+      ],
+      plugins: [],
+    })
+
+    expect(importRuntime).not.toHaveBeenCalled()
+    await expect(runtime.modules[0]?.load()).resolves.toEqual([unitFactory])
+    await expect(runtime.modules[0]?.routes[0]?.load()).resolves.toBe(routeFactory)
+    expect(importRuntime).toHaveBeenCalledTimes(1)
+  })
+
   it("loads typed package exports for non-route facets by stable reference id", async () => {
     const provider = { kind: "ledger-provider" }
     const tool = () => "adjusted"

--- a/packages/framework/src/runtime-lowering.ts
+++ b/packages/framework/src/runtime-lowering.ts
@@ -20,6 +20,7 @@ import type {
 } from "./deployment-graph.js"
 
 export type VoyantGraphRuntimeReferenceFacet =
+  | "runtime"
   | "api"
   | "config.validator"
   | "secrets.validator"
@@ -146,6 +147,7 @@ export interface VoyantGraphRuntimeUnitDefinition {
   packageName: string
   order: number
   projectConfig?: VoyantGraphJsonObject
+  runtimeReferenceId?: string
   references?: readonly VoyantGraphRuntimeReferenceDefinition[]
   config?: readonly VoyantGraphRuntimeConfigDefinition[]
   secrets?: readonly VoyantGraphRuntimeSecretDefinition[]
@@ -199,7 +201,7 @@ export interface VoyantGraphRuntimeUnitLoader
   actions: readonly VoyantGraphRuntimeActionDefinition[]
   selectedIds: VoyantGraphRuntimeSelectedIds
   routes: readonly VoyantGraphRuntimeRouteLoader[]
-  /** Load each distinct package entry/export reference in this unit once. */
+  /** Load the unit runtime, or each distinct route runtime for legacy units. */
   load: () => Promise<readonly unknown[]>
 }
 
@@ -413,6 +415,15 @@ function createRuntimeUnitLoader(
     createRuntimeReferenceLoader(definition, entries),
   )
   const referenceById = new Map(references.map((reference) => [reference.id, reference]))
+  const unitRuntime = unit.runtimeReferenceId
+    ? requireDeclarationReference(
+        unit.id,
+        unit.id,
+        unit.runtimeReferenceId,
+        "runtime",
+        referenceById,
+      )
+    : undefined
   const config = unit.config.map((definition) =>
     createRuntimeValueDeclarationLoader(definition, "config.validator", referenceById),
   )
@@ -464,6 +475,7 @@ function createRuntimeUnitLoader(
     packageName: unit.packageName,
     order: unit.order,
     ...(unit.projectConfig ? { projectConfig: unit.projectConfig } : {}),
+    ...(unit.runtimeReferenceId ? { runtimeReferenceId: unit.runtimeReferenceId } : {}),
     references,
     config,
     secrets,
@@ -476,7 +488,9 @@ function createRuntimeUnitLoader(
     selectedIds: unit.selectedIds,
     routes,
     load: memoizePromise(() =>
-      Promise.all(uniqueRuntimeRouteLoaders(routes).map((route) => route.load())),
+      unitRuntime
+        ? unitRuntime.load().then((runtimeExport) => [runtimeExport])
+        : Promise.all(uniqueRuntimeRouteLoaders(routes).map((route) => route.load())),
     ),
   }
 }


### PR DESCRIPTION
## Summary
- add optional unit-level runtime references for modules, extensions, and plugins
- preserve them through validation, graph resolution/hash, project admission, artifacts, and project-relative import overrides
- prefer the unit runtime when loading a graph unit while retaining route-loader fallback for existing manifests

## Verification
- scoped Biome (10 files)
- core focused tests (8 passed) and core typecheck
- framework focused tests (38 passed)
- full framework typecheck delegated to CI after a 10-minute CPU-active local run without diagnostics

Part of #3080.