### PR TITLE
feat(workflows): add pure workflow definitions

### DIFF
--- a/.changeset/clean-workflow-definitions.md
+++ b/.changeset/clean-workflow-definitions.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/workflows": minor
+---
+
+Add a pure `defineWorkflow` authoring API for explicitly collected workflow definitions while preserving legacy global registration through `workflow`.

--- a/packages/workflows/README.md
+++ b/packages/workflows/README.md
@@ -23,9 +23,26 @@ export const sendBookingReminders = workflow({
 });
 ```
 
+Projects and plugins that collect workflow definitions explicitly can use
+`defineWorkflow(...)`. It returns the same typed workflow definition without
+mutating the process-local legacy registry, so the definition can be exported
+directly from its module:
+
+```ts
+import { defineWorkflow } from "@voyant-travel/workflows";
+
+export default defineWorkflow({
+  id: "send-booking-reminders",
+  async run(input: { bookingId: string }, ctx) {
+    await ctx.step("send-reminder", async () => sendReminder(input.bookingId));
+  },
+});
+```
+
 ## Subpaths
 
-- `@voyant-travel/workflows` — authoring API (`workflow`, `workflows`, `trigger`, conditions, errors).
+- `@voyant-travel/workflows` — authoring API (`defineWorkflow`, `workflow`,
+  `workflows`, `trigger`, conditions, errors).
 - `@voyant-travel/workflows/client` — app/server-safe managed Cloud client and
   Cloud-mode driver. Use this from app code that only needs
   `workflows.trigger(...)` or event forwarding; it does not import workflow

--- a/packages/workflows/src/__tests__/fixtures/pure-workflow.ts
+++ b/packages/workflows/src/__tests__/fixtures/pure-workflow.ts
@@ -1,0 +1,10 @@
+import { defineWorkflow } from "../../index.js"
+
+export default defineWorkflow<{ bookingId: string }, string>({
+  id: "fixture.pure-workflow",
+  schedule: { cron: "0 8 * * *", timezone: "Europe/Bucharest" },
+  retry: { max: 3 },
+  async run(input) {
+    return input.bookingId
+  },
+})

--- a/packages/workflows/src/__tests__/workflow.test.ts
+++ b/packages/workflows/src/__tests__/workflow.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest"
+import { defineWorkflow, type WorkflowDefinition, workflow } from "../index.js"
+import { __listRegisteredWorkflows, __resetRegistry, getWorkflow } from "../workflow.js"
+
+beforeEach(() => {
+  __resetRegistry()
+})
+
+describe("defineWorkflow", () => {
+  it("constructs a workflow definition without registering it", () => {
+    const config = {
+      id: "booking.reminder",
+      schedule: { cron: "0 8 * * *", timezone: "Europe/Bucharest" },
+      retry: { max: 4 as const, backoff: "exponential" as const },
+      tags: ["booking"],
+      async run(input: { bookingId: string }) {
+        return input.bookingId
+      },
+    }
+
+    const definition = defineWorkflow(config)
+
+    expect(definition).toEqual({ id: config.id, config })
+    expect(definition.config).toBe(config)
+    expect(definition.config.schedule).toBe(config.schedule)
+    expect(definition.config.retry).toBe(config.retry)
+    expect(JSON.parse(JSON.stringify(definition))).toEqual({
+      id: "booking.reminder",
+      config: {
+        id: "booking.reminder",
+        schedule: { cron: "0 8 * * *", timezone: "Europe/Bucharest" },
+        retry: { max: 4, backoff: "exponential" },
+        tags: ["booking"],
+      },
+    })
+    expect(getWorkflow(config.id)).toBeUndefined()
+    expect(__listRegisteredWorkflows()).toEqual([])
+    expectTypeOf(definition).toEqualTypeOf<WorkflowDefinition<{ bookingId: string }, string>>()
+  })
+
+  it("supports default exports and explicit collection without registry side effects", async () => {
+    const { default: pureWorkflow } = await import("./fixtures/pure-workflow.js")
+    const definitions: WorkflowDefinition[] = [pureWorkflow]
+
+    expect(definitions).toEqual([pureWorkflow])
+    expect(pureWorkflow.id).toBe("fixture.pure-workflow")
+    expect(__listRegisteredWorkflows()).toEqual([])
+  })
+
+  it("has the same config typing and inference contract as workflow", () => {
+    expectTypeOf(defineWorkflow).toEqualTypeOf(workflow)
+  })
+})
+
+describe("workflow", () => {
+  it("registers a legacy workflow exactly once", () => {
+    const definition = workflow({ id: "legacy.once", async run() {} })
+
+    expect(getWorkflow(definition.id)).toBe(definition)
+    expect(__listRegisteredWorkflows()).toEqual([definition])
+  })
+
+  it("preserves duplicate replacement and warning behavior", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const first = workflow({ id: "legacy.duplicate", async run() {} })
+    const replacement = workflow({ id: "legacy.duplicate", async run() {} })
+
+    expect(warn).toHaveBeenCalledOnce()
+    expect(warn).toHaveBeenCalledWith(
+      '[workflows] workflow id "legacy.duplicate" re-registered — assuming HMR re-import. If this is a real duplicate, `voyant workflows build` will reject the bundle.',
+    )
+    expect(__listRegisteredWorkflows()).toEqual([replacement])
+    expect(getWorkflow(first.id)).toBe(replacement)
+
+    warn.mockRestore()
+  })
+})

--- a/packages/workflows/src/workflow.ts
+++ b/packages/workflows/src/workflow.ts
@@ -82,7 +82,20 @@ const REGISTRY: Map<string, WorkflowDefinition> =
   globalRef[REGISTRY_KEY] ?? new Map<string, WorkflowDefinition>()
 globalRef[REGISTRY_KEY] = REGISTRY
 
-/** Declare a workflow. See docs/sdk-surface.md §2.1. */
+/**
+ * Define a workflow without registering it in the process-local registry.
+ * Use this for definitions that are collected explicitly by a project or plugin.
+ */
+export function defineWorkflow<TInput = unknown, TOutput = unknown>(
+  config: WorkflowConfig<TInput, TOutput>,
+): WorkflowDefinition<TInput, TOutput> {
+  return {
+    id: config.id,
+    config,
+  }
+}
+
+/** Declare and register a workflow. See docs/sdk-surface.md §2.1. */
 export function workflow<TInput = unknown, TOutput = unknown>(
   config: WorkflowConfig<TInput, TOutput>,
 ): WorkflowDefinition<TInput, TOutput> {
@@ -100,10 +113,7 @@ export function workflow<TInput = unknown, TOutput = unknown>(
         `If this is a real duplicate, \`voyant workflows build\` will reject the bundle.`,
     )
   }
-  const def: WorkflowDefinition<TInput, TOutput> = {
-    id: config.id,
-    config,
-  }
+  const def = defineWorkflow(config)
   REGISTRY.set(config.id, def as WorkflowDefinition)
   return def
 }


### PR DESCRIPTION
## Summary
- add public `defineWorkflow` for explicit, side-effect-free workflow definitions
- retain legacy `workflow` registration by composing it over the pure helper
- preserve duplicate warnings, replacement behavior, generic inference, and config identity

## Verification
- workflows package typecheck
- workflows package tests (273 passed)
- workflows package build and built entrypoint export check
- scoped Biome and `git diff --check`

Part of #3080.