### PR TITLE
feat(framework): compile project API conventions

### DIFF
--- a/.changeset/clean-project-api-conventions.md
+++ b/.changeset/clean-project-api-conventions.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/hono": minor
+---
+
+Add the application-local API route authoring contract, method-aware graph metadata, and build-time convention compiler.

--- a/docs/architecture/api-route-authoring.md
+++ b/docs/architecture/api-route-authoring.md
@@ -43,6 +43,46 @@ Rule:
 Every new package route should declare whether it belongs to the admin or
 public surface.
 
+### Application-local route files
+
+Applications may author deployment-local API routes in these directories:
+
+- `src/api/admin/**/route.ts` for the authenticated admin surface
+- `src/api/store/**/route.ts` for the authenticated public surface
+
+Each route file exports at least one named uppercase HTTP handler: `GET`,
+`POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, or `OPTIONS`. Route files
+must not use a default export or expose other runtime exports. Type-only exports
+are allowed.
+
+```ts
+import {
+  parseJsonBody,
+  parseQuery,
+  type VoyantRouteHandler,
+} from "@voyant-travel/hono"
+
+export const GET: VoyantRouteHandler = (c) => {
+  const query = parseQuery(c, listOrdersQuerySchema)
+  return c.json({ query })
+}
+
+export const POST: VoyantRouteHandler = async (c) => {
+  const body = await parseJsonBody(c, createOrderSchema)
+  return c.json(body, 201)
+}
+```
+
+Directory names map to Hono paths. Route groups such as `(internal)` do not
+add a URL segment, `[orderId]` maps to `:orderId`, `[...slug]` maps to
+`*slug`, and `[[...slug]]` maps to `*slug?`.
+
+The build-time convention compiler inspects exports with the TypeScript AST and
+emits `.voyant/runtime/project-api.generated.ts`. It rejects duplicate
+surface, method, and canonical-path combinations. Auth is inherited from the
+admin or public surface; application-local anonymous overrides are not
+supported.
+
 ### 2. Keep `storefront` as a package concept, not an HTTP namespace
 
 Voyant should keep `storefront` as the customer-facing package/runtime term:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -110,6 +110,7 @@ export type {
   VoyantGraphProjectSelectionProvenance,
   VoyantGraphProjectSelections,
   VoyantGraphRouteBundle,
+  VoyantGraphRouteMethod,
   VoyantGraphRouteSurface,
   VoyantGraphRuntimeReference,
   VoyantGraphSubscriber,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -28,6 +28,14 @@ export const VOYANT_GRAPH_PLUGIN_SCHEMA_VERSION = "voyant.plugin.v1" as const
 
 export type VoyantGraphUnitKind = "module" | "extension" | "plugin"
 export type VoyantGraphRouteSurface = "admin" | "public" | "webhook" | "internal"
+export type VoyantGraphRouteMethod =
+  | "DELETE"
+  | "GET"
+  | "HEAD"
+  | "OPTIONS"
+  | "PATCH"
+  | "POST"
+  | "PUT"
 
 export type VoyantGraphJsonValue =
   | null
@@ -58,6 +66,7 @@ export interface VoyantGraphRuntimeReference {
 export interface VoyantGraphRouteBundle {
   id: string
   surface: VoyantGraphRouteSurface
+  methods?: readonly VoyantGraphRouteMethod[]
   mount?: string
   resource?: string
   requiredScopes?: readonly string[]

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -9,6 +9,7 @@
     "./deployment-artifacts": "./src/deployment-artifacts.ts",
     "./deployment-graph": "./src/deployment-graph.ts",
     "./operator-distribution": "./src/operator-distribution.ts",
+    "./project-api-conventions": "./src/project-api-conventions.ts",
     "./project": "./src/project.ts",
     "./profile": "./src/profile.ts",
     "./managed-jobs": "./src/managed-jobs.ts",
@@ -76,7 +77,8 @@
     "@voyant-travel/workflows": "workspace:*",
     "@voyant-travel/workflows-orchestrator": "workspace:*",
     "drizzle-orm": "catalog:",
-    "pg": "^8.22.0"
+    "pg": "^8.22.0",
+    "typescript": "catalog:"
   },
   "peerDependencies": {
     "@hono/zod-openapi": "^1.4.0",
@@ -90,7 +92,6 @@
     "@types/node": "catalog:",
     "@types/pg": "^8.15.6",
     "hono": "catalog:",
-    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "publishConfig": {
@@ -115,6 +116,11 @@
       "./operator-distribution": {
         "types": "./dist/operator-distribution.d.ts",
         "import": "./dist/operator-distribution.js"
+      },
+      "./project-api-conventions": {
+        "types": "./dist/project-api-conventions.d.ts",
+        "import": "./dist/project-api-conventions.js",
+        "default": "./dist/project-api-conventions.js"
       },
       "./project": {
         "types": "./dist/project.d.ts",

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -77,6 +77,7 @@ describe("deployment graph v1", () => {
         {
           id: "@acme/voyant-loyalty#api.admin",
           surface: "admin",
+          methods: ["POST", "GET"],
           requiredScopes: ["loyalty:read"],
           runtime: { entry: "@acme/voyant-loyalty/routes", export: "adminRoutes" },
         },
@@ -214,6 +215,7 @@ describe("deployment graph v1", () => {
     expect(graph.diagnostics).toEqual([])
     expect(graph.modules[0]).toMatchObject({
       id: "@acme/voyant-loyalty",
+      api: [{ id: "@acme/voyant-loyalty#api.admin", methods: ["GET", "POST"] }],
       tools: [{ id: "@acme/voyant-loyalty#tool.adjust-points" }],
       admin: { routes: [{ id: "@acme/voyant-loyalty#admin.route.index" }] },
       lifecycle: { uninstall: { default: "retain-data" } },
@@ -653,6 +655,7 @@ describe("deployment graph v1", () => {
           {
             id: "@acme/voyant-loyalty#api.admin",
             surface: "admin",
+            methods: ["POST", "GET"],
             mount: "/v1/admin/loyalty",
             resource: "loyalty.points",
             requiredScopes: ["loyalty:read", "loyalty-points:write"],
@@ -670,6 +673,7 @@ describe("deployment graph v1", () => {
           {
             id: "@acme/voyant-loyalty#api.invalid",
             surface: "worker",
+            methods: ["get", "GET", "GET"],
             mount: "",
             resource: "Loyalty Points",
             requiredScopes: ["loyalty.points.read", "loyalty:Read"],
@@ -682,6 +686,10 @@ describe("deployment graph v1", () => {
         expect.objectContaining({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
           facet: "api[0].surface",
+        }),
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          facet: "api[0].methods",
         }),
         expect.objectContaining({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -25,6 +25,7 @@ import {
   type VoyantGraphProviderDeclaration,
   type VoyantGraphResourceDeclaration,
   type VoyantGraphRouteBundle,
+  type VoyantGraphRouteMethod,
   type VoyantGraphRouteSurface,
   type VoyantGraphRuntimeReference,
   type VoyantGraphSecretDeclaration,
@@ -104,6 +105,7 @@ export {
   type VoyantGraphProviderDeclaration,
   type VoyantGraphResourceDeclaration,
   type VoyantGraphRouteBundle,
+  type VoyantGraphRouteMethod,
   type VoyantGraphRouteSurface,
   type VoyantGraphRuntimeReference,
   type VoyantGraphSecretDeclaration,
@@ -444,6 +446,15 @@ const GRAPH_ID_PATTERN =
 const ROUTE_RESOURCE_PATTERN = /^[a-z][a-z0-9-]*(?:[.-][a-z][a-z0-9-]*)*$/
 const ROUTE_SCOPE_PATTERN =
   /^[a-z][a-z0-9-]*(?:[.-][a-z][a-z0-9-]*)*:[a-z][a-z0-9-]*(?:-[a-z][a-z0-9-]*)*$/
+const ROUTE_METHODS = new Set<VoyantGraphRouteMethod>([
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PUT",
+])
 const STANDARD_CAPABILITY_PREFIXES = new Set([
   "action-ledger",
   "booking",
@@ -1158,7 +1169,12 @@ function resolveUnit(
       capabilities: sortedUnique(unit.requires?.capabilities ?? []),
       ports: sortPorts(unit.requires?.ports ?? []),
     },
-    api: sortFacetEntities(unit.api ?? []) as VoyantGraphRouteBundle[],
+    api: sortFacetEntities(unit.api ?? []).map((route) => ({
+      ...route,
+      ...(route.methods
+        ? { methods: sortedUnique(route.methods) as VoyantGraphRouteMethod[] }
+        : {}),
+    })) as VoyantGraphRouteBundle[],
     schema: sortFacetEntities(unit.schema ?? []),
     migrations: sortFacetEntities(unit.migrations ?? []),
     links: sortFacetEntities(unit.links ?? []),
@@ -1749,6 +1765,26 @@ function validateRouteBundles(value: unknown, source: string | undefined): Voyan
           source,
           facet: `${facet}.surface`,
           message: `Route bundle "${route.id ?? index}" must declare surface as admin, public, webhook, or internal.`,
+        }),
+      )
+    }
+
+    if (
+      route.methods !== undefined &&
+      (!Array.isArray(route.methods) ||
+        route.methods.length === 0 ||
+        route.methods.some(
+          (method) =>
+            typeof method !== "string" || !ROUTE_METHODS.has(method as VoyantGraphRouteMethod),
+        ) ||
+        new Set(route.methods).size !== route.methods.length)
+    ) {
+      diagnostics.push(
+        diagnostic({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          source,
+          facet: `${facet}.methods`,
+          message: `Route bundle "${route.id ?? index}" methods must be a non-empty array of unique supported uppercase HTTP methods.`,
         }),
       )
     }

--- a/packages/framework/src/project-api-conventions.test.ts
+++ b/packages/framework/src/project-api-conventions.test.ts
@@ -1,0 +1,216 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  analyzeProjectApiConventions,
+  compileProjectApiConventions,
+  ProjectApiConventionError,
+} from "./project-api-conventions.js"
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  )
+})
+
+describe("project API conventions", () => {
+  it("compiles deterministic route metadata and adapter source", async () => {
+    const root = await projectFixture({
+      "src/api/admin/orders/[orderId]/route.ts": [
+        'import type { VoyantRouteHandler } from "@voyant-travel/hono"',
+        "export type RouteState = { loaded: true }",
+        "export const POST: VoyantRouteHandler = (c) => c.json({ id: c.req.param('orderId') })",
+        "export const GET: VoyantRouteHandler = (c) => c.json({ id: c.req.param('orderId') })",
+      ].join("\n"),
+      "src/api/store/catalog/(sales)/[...slug]/route.ts":
+        "export const OPTIONS = (c: any) => c.body(null, 204)\n",
+    })
+
+    const compilation = await compileProjectApiConventions({ projectRoot: root })
+
+    expect(
+      compilation.routes.map(({ methods, route, sourcePath, surface }) => ({
+        methods,
+        route,
+        sourcePath,
+        surface,
+      })),
+    ).toEqual([
+      {
+        methods: ["GET", "POST"],
+        route: "/orders/:orderId",
+        sourcePath: "src/api/admin/orders/[orderId]/route.ts",
+        surface: "admin",
+      },
+      {
+        methods: ["OPTIONS"],
+        route: "/catalog/*slug",
+        sourcePath: "src/api/store/catalog/(sales)/[...slug]/route.ts",
+        surface: "public",
+      },
+    ])
+    expect(compilation.graphRoutes).toEqual([
+      {
+        id: "project.api.admin.orders.by-orderid",
+        methods: ["GET", "POST"],
+        mount: "/orders/:orderId",
+        surface: "admin",
+      },
+      {
+        id: "project.api.public.catalog.all-slug",
+        methods: ["OPTIONS"],
+        mount: "/catalog/*slug",
+        surface: "public",
+      },
+    ])
+    expect(compilation.generatedFile.path).toBe(".voyant/runtime/project-api.generated.ts")
+    expect(compilation.generatedFile.contents).toBe(
+      [
+        'import type { HonoModule } from "@voyant-travel/hono/module"',
+        'import type { VoyantBindings, VoyantVariables } from "@voyant-travel/hono/types"',
+        'import { Hono } from "hono"',
+        'import * as route0 from "../../src/api/admin/orders/[orderId]/route.js"',
+        'import * as route1 from "../../src/api/store/catalog/(sales)/[...slug]/route.js"',
+        "",
+        "type ProjectApiEnv = { Bindings: VoyantBindings; Variables: VoyantVariables }",
+        "const adminRoutes = new Hono<ProjectApiEnv>()",
+        'adminRoutes.on("GET", "/orders/:orderId", route0.GET)',
+        'adminRoutes.on("POST", "/orders/:orderId", route0.POST)',
+        "const publicRoutes = new Hono<ProjectApiEnv>()",
+        'publicRoutes.on("OPTIONS", "/catalog/*slug", route1.OPTIONS)',
+        "",
+        "export const projectApiHonoModule = {",
+        '  module: { name: "project-api" },',
+        "  adminRoutes,",
+        "  publicRoutes,",
+        '  publicPath: "/",',
+        "} satisfies HonoModule",
+        "",
+      ].join("\n"),
+    )
+  })
+
+  it("allows disjoint methods at one canonical path and rejects duplicate methods", async () => {
+    const root = await projectFixture({
+      "src/api/admin/orders/[id]/route.ts": "export const GET = () => new Response()\n",
+      "src/api/admin/(internal)/orders/[orderId]/route.ts":
+        "export const POST = () => new Response()\n",
+      "src/api/admin/(duplicate)/orders/[slug]/route.ts":
+        "export const GET = () => new Response()\n",
+      "src/api/store/orders/[id]/route.ts": "export const GET = () => new Response()\n",
+    })
+
+    const analysis = await analyzeProjectApiConventions({ projectRoot: root })
+
+    expect(analysis.diagnostics).toEqual([
+      {
+        code: "PROJECT_API_DUPLICATE_ROUTE_METHOD",
+        message:
+          'GET routes on the admin surface collide at "/orders/:param": "src/api/admin/(duplicate)/orders/[slug]/route.ts", "src/api/admin/orders/[id]/route.ts".',
+        method: "GET",
+        route: "/orders/:param",
+        severity: "error",
+        sourcePaths: [
+          "src/api/admin/(duplicate)/orders/[slug]/route.ts",
+          "src/api/admin/orders/[id]/route.ts",
+        ],
+        surface: "admin",
+      },
+    ])
+  })
+
+  it("rejects missing methods, default exports, and unsupported runtime exports", async () => {
+    const root = await projectFixture({
+      "src/api/admin/empty/route.ts": "export type Empty = true\n",
+      "src/api/admin/defaulted/route.ts":
+        "const handler = () => new Response()\nexport default handler\nexport const GET = handler\n",
+      "src/api/store/unsupported/route.ts":
+        "export const schema = {}\nexport const PATCH = () => new Response()\n",
+    })
+
+    const analysis = await analyzeProjectApiConventions({ projectRoot: root })
+
+    expect(
+      analysis.diagnostics.map(({ code, exportName, sourcePaths }) => ({
+        code,
+        exportName,
+        sourcePath: sourcePaths[0],
+      })),
+    ).toEqual([
+      {
+        code: "PROJECT_API_DEFAULT_EXPORT",
+        exportName: "default",
+        sourcePath: "src/api/admin/defaulted/route.ts",
+      },
+      {
+        code: "PROJECT_API_MISSING_METHOD",
+        exportName: undefined,
+        sourcePath: "src/api/admin/empty/route.ts",
+      },
+      {
+        code: "PROJECT_API_UNSUPPORTED_EXPORT",
+        exportName: "schema",
+        sourcePath: "src/api/store/unsupported/route.ts",
+      },
+    ])
+    await expect(compileProjectApiConventions({ projectRoot: root })).rejects.toBeInstanceOf(
+      ProjectApiConventionError,
+    )
+  })
+
+  it("rejects static, re-export, and dynamic import paths that escape the project", async () => {
+    const root = await projectFixture({
+      "src/api/admin/escaped/route.ts": [
+        'import "../../../../../outside.js"',
+        'import "file:///tmp/absolute.js"',
+        'export { value } from "../../../../../shared.js"',
+        'const load = () => import("../../../../../secret.js")',
+        "export const GET = () => new Response(String(load))",
+      ].join("\n"),
+    })
+
+    const analysis = await analyzeProjectApiConventions({ projectRoot: root })
+
+    expect(analysis.diagnostics).toHaveLength(5)
+    expect(analysis.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "PROJECT_API_IMPORT_ESCAPE",
+          message: expect.stringContaining('"file:///tmp/absolute.js"'),
+        }),
+        expect.objectContaining({
+          code: "PROJECT_API_IMPORT_ESCAPE",
+          message: expect.stringContaining('"../../../../../secret.js"'),
+        }),
+        expect.objectContaining({
+          code: "PROJECT_API_IMPORT_ESCAPE",
+          message: expect.stringContaining('"../../../../../shared.js"'),
+        }),
+        expect.objectContaining({
+          code: "PROJECT_API_IMPORT_ESCAPE",
+          message: expect.stringContaining('"../../../../../outside.js"'),
+        }),
+        expect.objectContaining({
+          code: "PROJECT_API_UNSUPPORTED_EXPORT",
+          exportName: "value",
+        }),
+      ]),
+    )
+  })
+})
+
+async function projectFixture(files: Readonly<Record<string, string>>): Promise<string> {
+  const root = await mkdtemp(path.join(process.cwd(), ".project-api-test-"))
+  fixtureRoots.push(root)
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, contents]) => {
+      const filePath = path.join(root, ...relativePath.split("/"))
+      await mkdir(path.dirname(filePath), { recursive: true })
+      await writeFile(filePath, contents)
+    }),
+  )
+  return root
+}

--- a/packages/framework/src/project-api-conventions.ts
+++ b/packages/framework/src/project-api-conventions.ts
@@ -1,0 +1,448 @@
+import { readFile, realpath } from "node:fs/promises"
+import path from "node:path"
+import type { VoyantGraphRouteBundle, VoyantGraphRouteMethod } from "@voyant-travel/core/project"
+import ts from "typescript"
+
+import {
+  discoverProjectConventions,
+  type ProjectConventionApiRoute,
+  type ProjectConventionRouteSurface,
+} from "./project-conventions.js"
+
+export const PROJECT_API_GENERATED_PATH = ".voyant/runtime/project-api.generated.ts"
+
+const SUPPORTED_METHODS = new Set<VoyantGraphRouteMethod>([
+  "DELETE",
+  "GET",
+  "HEAD",
+  "OPTIONS",
+  "PATCH",
+  "POST",
+  "PUT",
+])
+
+export const PROJECT_API_CONVENTION_DIAGNOSTIC_CODES = {
+  PROJECT_API_DEFAULT_EXPORT: "Route files cannot have a default export.",
+  PROJECT_API_DUPLICATE_ROUTE_METHOD:
+    "Two route files cannot handle the same method and canonical route.",
+  PROJECT_API_IMPORT_ESCAPE: "Route file imports cannot escape the project root.",
+  PROJECT_API_MISSING_METHOD: "Route files must export at least one supported HTTP method.",
+  PROJECT_API_UNSUPPORTED_EXPORT:
+    "Route files cannot have runtime exports other than supported HTTP methods.",
+} as const
+
+export type ProjectApiConventionDiagnosticCode =
+  keyof typeof PROJECT_API_CONVENTION_DIAGNOSTIC_CODES
+
+export interface ProjectApiConventionDiagnostic {
+  code: ProjectApiConventionDiagnosticCode
+  severity: "error"
+  message: string
+  sourcePaths: readonly string[]
+  exportName?: string
+  method?: VoyantGraphRouteMethod
+  route?: string
+  surface?: ProjectConventionRouteSurface
+}
+
+export interface ProjectApiConventionRoute extends ProjectConventionApiRoute {
+  methods: readonly VoyantGraphRouteMethod[]
+}
+
+export interface ProjectApiConventionAnalysis {
+  routes: readonly ProjectApiConventionRoute[]
+  diagnostics: readonly ProjectApiConventionDiagnostic[]
+}
+
+export interface ProjectApiGeneratedFile {
+  path: typeof PROJECT_API_GENERATED_PATH
+  contents: string
+}
+
+export interface ProjectApiConventionCompilation {
+  routes: readonly ProjectApiConventionRoute[]
+  graphRoutes: readonly VoyantGraphRouteBundle[]
+  generatedFile: ProjectApiGeneratedFile
+}
+
+export interface ProjectApiConventionsOptions {
+  projectRoot: string
+}
+
+export class ProjectApiConventionError extends Error {
+  readonly diagnostics: readonly ProjectApiConventionDiagnostic[]
+
+  constructor(diagnostics: readonly ProjectApiConventionDiagnostic[]) {
+    super(diagnostics.map((diagnostic) => diagnostic.message).join("\n"))
+    this.name = "ProjectApiConventionError"
+    this.diagnostics = diagnostics
+  }
+}
+
+export async function analyzeProjectApiConventions(
+  options: ProjectApiConventionsOptions,
+): Promise<ProjectApiConventionAnalysis> {
+  const projectRoot = path.resolve(options.projectRoot)
+  const realProjectRoot = await realpath(projectRoot)
+  const discovery = await discoverProjectConventions(projectRoot)
+  const discoveredRoutes = discovery.contributions.filter(
+    (contribution): contribution is ProjectConventionApiRoute => contribution.kind === "api-route",
+  )
+  const routes: ProjectApiConventionRoute[] = []
+  const diagnostics: ProjectApiConventionDiagnostic[] = []
+
+  for (const route of discoveredRoutes) {
+    const sourceFilePath = resolveInsideProject(projectRoot, route.sourcePath)
+    const realSourceFilePath = await realpath(sourceFilePath)
+    if (!isInside(realProjectRoot, realSourceFilePath)) {
+      diagnostics.push(importEscapeDiagnostic(route.sourcePath, route.sourcePath))
+      continue
+    }
+
+    const source = await readFile(realSourceFilePath, "utf8")
+    const sourceFile = ts.createSourceFile(
+      realSourceFilePath,
+      source,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    )
+    const analysis = analyzeRouteSource(sourceFile, route.sourcePath, projectRoot)
+    diagnostics.push(...analysis.diagnostics)
+    if (analysis.methods.length > 0) routes.push({ ...route, methods: analysis.methods })
+  }
+
+  diagnostics.push(...findDuplicateRouteMethods(routes))
+  routes.sort(compareRoutes)
+  diagnostics.sort(compareDiagnostics)
+  return { routes, diagnostics }
+}
+
+export async function compileProjectApiConventions(
+  options: ProjectApiConventionsOptions,
+): Promise<ProjectApiConventionCompilation> {
+  const analysis = await analyzeProjectApiConventions(options)
+  if (analysis.diagnostics.length > 0) {
+    throw new ProjectApiConventionError(analysis.diagnostics)
+  }
+
+  return {
+    routes: analysis.routes,
+    graphRoutes: analysis.routes.map(({ id, methods, route, surface }) => ({
+      id,
+      methods,
+      mount: route,
+      surface,
+    })),
+    generatedFile: {
+      path: PROJECT_API_GENERATED_PATH,
+      contents: generateProjectApiAdapterSource(analysis.routes),
+    },
+  }
+}
+
+export function generateProjectApiAdapterSource(
+  routes: readonly ProjectApiConventionRoute[],
+): string {
+  const orderedRoutes = [...routes].sort(compareRoutes)
+  const imports = orderedRoutes.map(
+    (route, index) =>
+      `import * as route${index} from ${JSON.stringify(generatedImportSpecifier(route.sourcePath))}`,
+  )
+  const admin = routeRegistrations(orderedRoutes, "admin")
+  const public_ = routeRegistrations(orderedRoutes, "public")
+
+  return [
+    'import type { HonoModule } from "@voyant-travel/hono/module"',
+    'import type { VoyantBindings, VoyantVariables } from "@voyant-travel/hono/types"',
+    'import { Hono } from "hono"',
+    ...imports,
+    "",
+    "type ProjectApiEnv = { Bindings: VoyantBindings; Variables: VoyantVariables }",
+    ...(admin.length > 0 ? ["const adminRoutes = new Hono<ProjectApiEnv>()", ...admin] : []),
+    ...(public_.length > 0 ? ["const publicRoutes = new Hono<ProjectApiEnv>()", ...public_] : []),
+    "",
+    "export const projectApiHonoModule = {",
+    '  module: { name: "project-api" },',
+    ...(admin.length > 0 ? ["  adminRoutes,"] : []),
+    ...(public_.length > 0 ? ["  publicRoutes,", '  publicPath: "/",'] : []),
+    "} satisfies HonoModule",
+    "",
+  ].join("\n")
+}
+
+function analyzeRouteSource(
+  sourceFile: ts.SourceFile,
+  sourcePath: string,
+  projectRoot: string,
+): {
+  methods: VoyantGraphRouteMethod[]
+  diagnostics: ProjectApiConventionDiagnostic[]
+} {
+  const methods = new Set<VoyantGraphRouteMethod>()
+  const diagnostics: ProjectApiConventionDiagnostic[] = []
+
+  inspectModuleSpecifiers(sourceFile, (specifier) => {
+    if (!isPathImport(specifier)) return
+    if (specifier.startsWith("file:")) {
+      diagnostics.push(importEscapeDiagnostic(sourcePath, specifier))
+      return
+    }
+    const resolved = path.resolve(path.dirname(sourceFile.fileName), specifier)
+    if (!isInside(projectRoot, resolved)) {
+      diagnostics.push(importEscapeDiagnostic(sourcePath, specifier))
+    }
+  })
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportAssignment(statement)) {
+      diagnostics.push(defaultExportDiagnostic(sourcePath))
+      continue
+    }
+
+    if (ts.isExportDeclaration(statement)) {
+      if (!statement.exportClause) {
+        if (!statement.isTypeOnly) diagnostics.push(unsupportedExportDiagnostic(sourcePath, "*"))
+        continue
+      }
+      if (!ts.isNamedExports(statement.exportClause)) continue
+      for (const element of statement.exportClause.elements) {
+        if (statement.isTypeOnly || element.isTypeOnly) continue
+        recordExport(element.name.text, sourcePath, methods, diagnostics)
+      }
+      continue
+    }
+
+    if (!hasModifier(statement, ts.SyntaxKind.ExportKeyword)) continue
+    if (hasModifier(statement, ts.SyntaxKind.DefaultKeyword)) {
+      diagnostics.push(defaultExportDiagnostic(sourcePath))
+      continue
+    }
+    if (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) continue
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        for (const name of bindingNames(declaration.name)) {
+          recordExport(name, sourcePath, methods, diagnostics)
+        }
+      }
+      continue
+    }
+    const name = "name" in statement && statement.name ? statement.name.text : "(anonymous)"
+    recordExport(name, sourcePath, methods, diagnostics)
+  }
+
+  if (methods.size === 0) {
+    diagnostics.push({
+      code: "PROJECT_API_MISSING_METHOD",
+      severity: "error",
+      sourcePaths: [sourcePath],
+      message: `Route file "${sourcePath}" must export at least one of ${[
+        ...SUPPORTED_METHODS,
+      ].join(", ")}.`,
+    })
+  }
+
+  return { methods: [...methods].sort(compareStrings), diagnostics }
+}
+
+function inspectModuleSpecifiers(
+  sourceFile: ts.SourceFile,
+  inspect: (specifier: string) => void,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      inspect(node.moduleSpecifier.text)
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    ) {
+      inspect(node.moduleReference.expression.text)
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0]!)
+    ) {
+      inspect(node.arguments[0].text)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+function recordExport(
+  name: string,
+  sourcePath: string,
+  methods: Set<VoyantGraphRouteMethod>,
+  diagnostics: ProjectApiConventionDiagnostic[],
+): void {
+  if (name === "default") {
+    diagnostics.push(defaultExportDiagnostic(sourcePath))
+  } else if (SUPPORTED_METHODS.has(name as VoyantGraphRouteMethod)) {
+    methods.add(name as VoyantGraphRouteMethod)
+  } else {
+    diagnostics.push(unsupportedExportDiagnostic(sourcePath, name))
+  }
+}
+
+function findDuplicateRouteMethods(
+  routes: readonly ProjectApiConventionRoute[],
+): ProjectApiConventionDiagnostic[] {
+  const identities = new Map<string, ProjectApiConventionRoute[]>()
+  for (const route of routes) {
+    for (const method of route.methods) {
+      const key = [route.surface, method, canonicalRoutePattern(route.route)].join("\0")
+      const matches = identities.get(key)
+      if (matches) matches.push(route)
+      else identities.set(key, [route])
+    }
+  }
+
+  const diagnostics: ProjectApiConventionDiagnostic[] = []
+  for (const [key, matches] of identities) {
+    if (matches.length < 2) continue
+    const [surface, method, route] = key.split("\0") as [
+      ProjectConventionRouteSurface,
+      VoyantGraphRouteMethod,
+      string,
+    ]
+    const sourcePaths = [...new Set(matches.map((match) => match.sourcePath))].sort(compareStrings)
+    diagnostics.push({
+      code: "PROJECT_API_DUPLICATE_ROUTE_METHOD",
+      severity: "error",
+      method,
+      route,
+      sourcePaths,
+      surface,
+      message: `${method} routes on the ${surface} surface collide at "${route}": ${sourcePaths
+        .map((sourcePath) => `"${sourcePath}"`)
+        .join(", ")}.`,
+    })
+  }
+  return diagnostics
+}
+
+function routeRegistrations(
+  routes: readonly ProjectApiConventionRoute[],
+  surface: ProjectConventionRouteSurface,
+): string[] {
+  const app = surface === "admin" ? "adminRoutes" : "publicRoutes"
+  return routes.flatMap((route, index) =>
+    route.surface === surface
+      ? route.methods.map(
+          (method) =>
+            `${app}.on(${JSON.stringify(method)}, ${JSON.stringify(route.route)}, route${index}.${method})`,
+        )
+      : [],
+  )
+}
+
+function generatedImportSpecifier(sourcePath: string): string {
+  const withoutExtension = sourcePath.replace(/\.ts$/, ".js")
+  return `../../${withoutExtension}`
+}
+
+function canonicalRoutePattern(route: string): string {
+  return route
+    .split("/")
+    .map((segment) => {
+      if (segment.startsWith(":")) return ":param"
+      if (segment.startsWith("*")) return segment.endsWith("?") ? "*optional" : "*catch-all"
+      return segment
+    })
+    .join("/")
+}
+
+function resolveInsideProject(projectRoot: string, sourcePath: string): string {
+  if (path.isAbsolute(sourcePath))
+    throw new Error(`Expected a project-relative path: ${sourcePath}`)
+  const resolved = path.resolve(projectRoot, sourcePath)
+  if (!isInside(projectRoot, resolved)) throw new Error(`Path escapes project root: ${sourcePath}`)
+  return resolved
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+function isPathImport(specifier: string): boolean {
+  return specifier.startsWith(".") || path.isAbsolute(specifier) || specifier.startsWith("file:")
+}
+
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return Boolean(
+    ts.canHaveModifiers(node) && ts.getModifiers(node)?.some((item) => item.kind === kind),
+  )
+}
+
+function bindingNames(name: ts.BindingName): string[] {
+  if (ts.isIdentifier(name)) return [name.text]
+  return name.elements.flatMap((element) =>
+    ts.isOmittedExpression(element) ? [] : bindingNames(element.name),
+  )
+}
+
+function defaultExportDiagnostic(sourcePath: string): ProjectApiConventionDiagnostic {
+  return {
+    code: "PROJECT_API_DEFAULT_EXPORT",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    exportName: "default",
+    message: `Route file "${sourcePath}" cannot have a default export.`,
+  }
+}
+
+function unsupportedExportDiagnostic(
+  sourcePath: string,
+  exportName: string,
+): ProjectApiConventionDiagnostic {
+  return {
+    code: "PROJECT_API_UNSUPPORTED_EXPORT",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    exportName,
+    message: `Route file "${sourcePath}" has unsupported runtime export "${exportName}".`,
+  }
+}
+
+function importEscapeDiagnostic(
+  sourcePath: string,
+  specifier: string,
+): ProjectApiConventionDiagnostic {
+  return {
+    code: "PROJECT_API_IMPORT_ESCAPE",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    message: `Route file "${sourcePath}" import "${specifier}" escapes the project root.`,
+  }
+}
+
+function compareRoutes(left: ProjectApiConventionRoute, right: ProjectApiConventionRoute): number {
+  return (
+    compareStrings(left.surface, right.surface) ||
+    compareStrings(left.route, right.route) ||
+    compareStrings(left.sourcePath, right.sourcePath)
+  )
+}
+
+function compareDiagnostics(
+  left: ProjectApiConventionDiagnostic,
+  right: ProjectApiConventionDiagnostic,
+): number {
+  return (
+    compareStrings(left.code, right.code) ||
+    compareStrings(left.sourcePaths.join("\0"), right.sourcePaths.join("\0")) ||
+    compareStrings(left.exportName ?? "", right.exportName ?? "")
+  )
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -15,6 +15,15 @@ export type {
   SetupMigrationHandler,
 } from "./node-migration-runner.js"
 export type {
+  ProjectApiConventionAnalysis,
+  ProjectApiConventionCompilation,
+  ProjectApiConventionDiagnostic,
+  ProjectApiConventionDiagnosticCode,
+  ProjectApiConventionRoute,
+  ProjectApiConventionsOptions,
+  ProjectApiGeneratedFile,
+} from "./project-api-conventions.js"
+export type {
   DiscoverProjectConventionsInput,
   DiscoverProjectConventionsOptions,
   ProjectConventionApiRoute,
@@ -60,6 +69,20 @@ export async function discoverProjectConventions(
 ): Promise<import("./project-conventions.js").ProjectConventionDiscovery> {
   const conventions = await import("./project-conventions.js")
   return conventions.discoverProjectConventions(input)
+}
+
+export async function analyzeProjectApiConventions(
+  options: import("./project-api-conventions.js").ProjectApiConventionsOptions,
+): Promise<import("./project-api-conventions.js").ProjectApiConventionAnalysis> {
+  const conventions = await import("./project-api-conventions.js")
+  return conventions.analyzeProjectApiConventions(options)
+}
+
+export async function compileProjectApiConventions(
+  options: import("./project-api-conventions.js").ProjectApiConventionsOptions,
+): Promise<import("./project-api-conventions.js").ProjectApiConventionCompilation> {
+  const conventions = await import("./project-api-conventions.js")
+  return conventions.compileProjectApiConventions(options)
 }
 
 export async function executeNodeMigrationPlan(

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -132,6 +132,7 @@ export type {
   VoyantExecutionContext,
   VoyantQueryRuntime,
   VoyantRequestAuthContext,
+  VoyantRouteHandler,
   VoyantVariables,
 } from "./types.js"
 export {

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -16,7 +16,7 @@ import type { DriverFactory } from "@voyant-travel/workflows/driver"
 import type { NeonHttpDatabase } from "drizzle-orm/neon-http"
 import type { NeonDatabase as NeonWsDatabase } from "drizzle-orm/neon-serverless"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import type { Hono } from "hono"
+import type { Handler, Hono } from "hono"
 
 import type { HonoExtension, HonoModule } from "./module.js"
 import type { Reporter } from "./observability/reporter.js"
@@ -72,6 +72,12 @@ export type VoyantVariables = CoreVoyantVariables & {
   /** Per-request db metrics counter populated by the metrics middleware. */
   __voyantDbMetrics?: import("./middleware/metrics.js").RequestDbMetrics
 }
+
+/** Handler contract for application-authored Hono API routes. */
+export type VoyantRouteHandler<TBindings extends VoyantBindings = VoyantBindings> = Handler<{
+  Bindings: TBindings
+  Variables: VoyantVariables
+}>
 
 /**
  * Per-request handle returned by a {@link DbFactory} that owns its own

--- a/packages/hono/tests/unit/route-handler.test.ts
+++ b/packages/hono/tests/unit/route-handler.test.ts
@@ -1,0 +1,28 @@
+import { Hono } from "hono"
+import { describe, expect, expectTypeOf, it } from "vitest"
+
+import type { VoyantBindings, VoyantRouteHandler, VoyantVariables } from "../../src/types.js"
+
+describe("VoyantRouteHandler", () => {
+  it("uses Voyant bindings and preserves request variables", async () => {
+    const handler: VoyantRouteHandler = (c) =>
+      c.json({ databaseUrl: c.env.DATABASE_URL, requestId: c.get("requestId") })
+
+    expectTypeOf(handler).toMatchTypeOf<
+      VoyantRouteHandler<VoyantBindings & { FEATURE_FLAG?: string }>
+    >()
+
+    const app = new Hono<{ Bindings: VoyantBindings; Variables: VoyantVariables }>()
+    app.use("*", async (c, next) => {
+      c.set("requestId", "request-123")
+      await next()
+    })
+    app.get("/", handler)
+
+    const response = await app.request("/", undefined, { DATABASE_URL: "postgres://test" })
+    await expect(response.json()).resolves.toEqual({
+      databaseUrl: "postgres://test",
+      requestId: "request-123",
+    })
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2085,6 +2085,9 @@ importers:
       pg:
         specifier: ^8.22.0
         version: 8.22.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
     devDependencies:
       '@hono/zod-openapi':
         specifier: 'catalog:'
@@ -2104,9 +2107,6 @@ importers:
       hono:
         specifier: 4.12.25
         version: 4.12.25
-      typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))


### PR DESCRIPTION
## Summary
- define named Hono route-handler exports for `src/api/{admin,store}/**/route.ts`
- parse route modules with the TypeScript AST and reject default/unsupported/missing handlers
- compile deterministic graph route methods and a static `.voyant/runtime/project-api.generated.ts` HonoModule adapter
- validate route-method collisions and project-root import confinement

## Verification
- Hono handler test
- framework compiler/graph tests (40 passed)
- core and Hono typechecks
- scoped Biome and `git diff --check`
- full framework typecheck delegated to CI after an 11-minute CPU-active worktree run without diagnostics

This slice defines the compiler only; resolver activation follows after project-source admission.

Part of #3080.