### PR TITLE
feat(framework): compile project admin conventions

### DIFF
--- a/.changeset/clean-project-admin-conventions.md
+++ b/.changeset/clean-project-admin-conventions.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Compile app-local admin conventions into a deterministic, type-checked client module.

--- a/docs/architecture/custom-modules.md
+++ b/docs/architecture/custom-modules.md
@@ -152,6 +152,14 @@ export default defineAdminExtension({
 })
 ```
 
+Each entry has exactly one `index.ts` or `index.tsx`; having both is an error.
+Other files in the entry directory are supporting implementation and are not
+discovered independently. Build-time analysis parses the entry without running
+it, requires a default export, and emits the client-only
+`.voyant/admin/project-admin.generated.ts` module with deterministic static
+imports. The generated array is checked against `AdminExtension`, and duplicate
+extension IDs are reported when their string values can be read statically.
+
 - **nav + widgets** merge via `adminExtensionsFromGlob` in
   `src/lib/admin-extensions.tsx` and resolve through the shared
   `resolveAdminNavigation` / `resolveAdminWidgets`.

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -10,6 +10,7 @@
     "./deployment-graph": "./src/deployment-graph.ts",
     "./operator-distribution": "./src/operator-distribution.ts",
     "./project-api-conventions": "./src/project-api-conventions.ts",
+    "./project-admin-conventions": "./src/project-admin-conventions.ts",
     "./project": "./src/project.ts",
     "./profile": "./src/profile.ts",
     "./managed-jobs": "./src/managed-jobs.ts",
@@ -121,6 +122,10 @@
         "types": "./dist/project-api-conventions.d.ts",
         "import": "./dist/project-api-conventions.js",
         "default": "./dist/project-api-conventions.js"
+      },
+      "./project-admin-conventions": {
+        "types": "./dist/project-admin-conventions.d.ts",
+        "import": "./dist/project-admin-conventions.js"
       },
       "./project": {
         "types": "./dist/project.d.ts",

--- a/packages/framework/src/project-admin-conventions.test.ts
+++ b/packages/framework/src/project-admin-conventions.test.ts
@@ -1,0 +1,200 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+import {
+  analyzeProjectAdminConventions,
+  compileProjectAdminConventions,
+  type ProjectAdminConventionError,
+  VOYANT_PROJECT_ADMIN_GENERATED_FILE,
+} from "./project-admin-conventions.js"
+import type { ProjectConventionContribution } from "./project-conventions.js"
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  )
+})
+
+describe("project admin conventions", () => {
+  it("analyzes default exports without executing project source", async () => {
+    const root = await projectFixture({
+      "src/admin/concierge/index.tsx": `
+        throw new Error("must not execute")
+        export default { id: "concierge", routes: [] }
+      `,
+    })
+
+    await expect(
+      analyzeProjectAdminConventions({
+        projectRoot: root,
+        contributions: [adminContribution("concierge", "src/admin/concierge/index.tsx")],
+      }),
+    ).resolves.toEqual({
+      entries: [
+        {
+          conventionId: "project.admin.concierge",
+          extensionId: "concierge",
+          sourcePath: "src/admin/concierge/index.tsx",
+        },
+      ],
+      diagnostics: [],
+    })
+  })
+
+  it("reports a missing default export", async () => {
+    const root = await projectFixture({
+      "src/admin/reports/index.ts": `export const reports = { id: "reports" }`,
+    })
+
+    const result = await analyzeProjectAdminConventions({
+      projectRoot: root,
+      contributions: [adminContribution("reports", "src/admin/reports/index.ts")],
+    })
+
+    expect(result.diagnostics).toEqual([
+      {
+        code: "PROJECT_ADMIN_MISSING_DEFAULT_EXPORT",
+        message:
+          'Project admin entry "src/admin/reports/index.ts" must default-export an AdminExtension.',
+        severity: "error",
+        sourcePaths: ["src/admin/reports/index.ts"],
+      },
+    ])
+  })
+
+  it("reports duplicate extension IDs when they are statically provable", async () => {
+    const root = await projectFixture({
+      "src/admin/alpha/index.ts": `
+        import { defineAdminExtension } from "@voyant-travel/admin"
+        export default defineAdminExtension({ id: "shared" })
+      `,
+      "src/admin/beta/index.tsx": `
+        const extension = { id: "shared", routes: [] } as const
+        export { extension as default }
+      `,
+    })
+
+    const result = await analyzeProjectAdminConventions({
+      projectRoot: root,
+      contributions: [
+        adminContribution("beta", "src/admin/beta/index.tsx"),
+        adminContribution("alpha", "src/admin/alpha/index.ts"),
+      ],
+    })
+
+    expect(result.diagnostics).toEqual([
+      {
+        code: "PROJECT_ADMIN_DUPLICATE_EXTENSION_ID",
+        extensionId: "shared",
+        message:
+          'AdminExtension ID "shared" is declared by "src/admin/alpha/index.ts", "src/admin/beta/index.tsx".',
+        severity: "error",
+        sourcePaths: ["src/admin/alpha/index.ts", "src/admin/beta/index.tsx"],
+      },
+    ])
+  })
+
+  it("fails compilation when both index variants are supplied", async () => {
+    const root = await projectFixture({
+      "src/admin/orders/index.ts": `export default { id: "orders-ts" }`,
+      "src/admin/orders/index.tsx": `export default { id: "orders-tsx" }`,
+    })
+
+    const compilation = compileProjectAdminConventions({
+      projectRoot: root,
+      contributions: [
+        adminContribution("orders", "src/admin/orders/index.ts"),
+        adminContribution("orders", "src/admin/orders/index.tsx"),
+      ],
+    })
+
+    await expect(compilation).rejects.toMatchObject({
+      name: "ProjectAdminConventionError",
+      diagnostics: [{ code: "PROJECT_ADMIN_DUPLICATE_ENTRY" }],
+    } satisfies Partial<ProjectAdminConventionError>)
+  })
+
+  it("generates deterministic sorted client source and metadata", async () => {
+    const root = await projectFixture({
+      "src/admin/zeta/index.tsx": `export default { id: "zeta" }`,
+      "src/admin/alpha/index.ts": `export default { id: "alpha" }`,
+    })
+    const contributions: ProjectConventionContribution[] = [
+      adminContribution("zeta", "src/admin/zeta/index.tsx"),
+      {
+        id: "project.api.admin.secret",
+        kind: "api-route",
+        route: "/secret",
+        sourcePath: "src/api/admin/secret/route.ts",
+        surface: "admin",
+      },
+      adminContribution("alpha", "src/admin/alpha/index.ts"),
+    ]
+
+    const first = await compileProjectAdminConventions({ projectRoot: root, contributions })
+    const second = await compileProjectAdminConventions({
+      projectRoot: root,
+      contributions: [...contributions].reverse(),
+    })
+
+    expect(first).toEqual(second)
+    expect(first.file).toEqual({
+      path: VOYANT_PROJECT_ADMIN_GENERATED_FILE,
+      contents: `// Generated by @voyant-travel/framework. Do not edit.
+import type { AdminExtension } from "@voyant-travel/admin"
+import projectAdminExtension0 from "../../src/admin/alpha/index.js"
+import projectAdminExtension1 from "../../src/admin/zeta/index.js"
+
+export const projectAdminExtensions = [
+  projectAdminExtension0,
+  projectAdminExtension1,
+] satisfies readonly AdminExtension[]
+`,
+    })
+    expect(first.file.contents).not.toContain("src/api")
+    expect(first.file.contents).not.toContain("server")
+  })
+
+  it("rejects lexical and symlink path escapes", async () => {
+    const outsideRoot = await projectFixture({ "outside.ts": `export default { id: "outside" }` })
+    const root = await projectFixture({})
+    await mkdir(path.join(root, "src/admin/escape"), { recursive: true })
+    await symlink(
+      path.join(outsideRoot, "outside.ts"),
+      path.join(root, "src/admin/escape/index.ts"),
+    )
+
+    const result = await analyzeProjectAdminConventions({
+      projectRoot: root,
+      contributions: [
+        adminContribution("outside", "../outside/index.ts"),
+        adminContribution("escape", "src/admin/escape/index.ts"),
+      ],
+    })
+
+    expect(result.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      "PROJECT_ADMIN_INVALID_ENTRY_PATH",
+      "PROJECT_ADMIN_INVALID_ENTRY_PATH",
+    ])
+  })
+})
+
+function adminContribution(name: string, sourcePath: string): ProjectConventionContribution {
+  return { id: `project.admin.${name}`, kind: "admin", sourcePath }
+}
+
+async function projectFixture(files: Readonly<Record<string, string>>): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "voyant-project-admin-conventions-"))
+  fixtureRoots.push(root)
+  await Promise.all(
+    Object.entries(files).map(async ([filePath, contents]) => {
+      const absolutePath = path.join(root, filePath)
+      await mkdir(path.dirname(absolutePath), { recursive: true })
+      await writeFile(absolutePath, contents)
+    }),
+  )
+  return root
+}

--- a/packages/framework/src/project-admin-conventions.ts
+++ b/packages/framework/src/project-admin-conventions.ts
@@ -1,0 +1,373 @@
+import { readFile, realpath } from "node:fs/promises"
+import path from "node:path"
+
+import ts from "typescript"
+
+import type { ProjectConventionContribution } from "./project-conventions.js"
+
+export const VOYANT_PROJECT_ADMIN_GENERATED_FILE =
+  ".voyant/admin/project-admin.generated.ts" as const
+
+export const PROJECT_ADMIN_CONVENTION_DIAGNOSTIC_CODES = {
+  PROJECT_ADMIN_DUPLICATE_EXTENSION_ID:
+    "Two project admin entries statically declare the same AdminExtension ID.",
+  PROJECT_ADMIN_DUPLICATE_ENTRY: "Multiple source files were supplied for one project admin entry.",
+  PROJECT_ADMIN_INVALID_ENTRY_PATH:
+    "A project admin source is outside the supported src/admin/<name>/index.ts[x] convention.",
+  PROJECT_ADMIN_MISSING_DEFAULT_EXPORT: "A project admin entry has no default export.",
+} as const
+
+export type ProjectAdminConventionDiagnosticCode =
+  keyof typeof PROJECT_ADMIN_CONVENTION_DIAGNOSTIC_CODES
+
+export interface ProjectAdminConventionDiagnostic {
+  code: ProjectAdminConventionDiagnosticCode
+  severity: "error"
+  message: string
+  sourcePaths: readonly string[]
+  extensionId?: string
+}
+
+export interface ProjectAdminConventionEntry {
+  conventionId: string
+  /** Statically known only for direct object literals and defineAdminExtension(...) calls. */
+  extensionId?: string
+  sourcePath: string
+}
+
+export interface AnalyzeProjectAdminConventionsInput {
+  projectRoot: string
+  contributions: readonly ProjectConventionContribution[]
+}
+
+export interface ProjectAdminConventionAnalysis {
+  entries: readonly ProjectAdminConventionEntry[]
+  diagnostics: readonly ProjectAdminConventionDiagnostic[]
+}
+
+export interface ProjectAdminGeneratedFile {
+  path: typeof VOYANT_PROJECT_ADMIN_GENERATED_FILE
+  contents: string
+}
+
+export interface CompiledProjectAdminConventions {
+  entries: readonly ProjectAdminConventionEntry[]
+  file: ProjectAdminGeneratedFile
+}
+
+export class ProjectAdminConventionError extends Error {
+  readonly diagnostics: readonly ProjectAdminConventionDiagnostic[]
+
+  constructor(diagnostics: readonly ProjectAdminConventionDiagnostic[]) {
+    super(diagnostics.map((diagnostic) => diagnostic.message).join("\n"))
+    this.name = "ProjectAdminConventionError"
+    this.diagnostics = diagnostics
+  }
+}
+
+/** Analyze project-admin entries without importing or executing project source. */
+export async function analyzeProjectAdminConventions(
+  input: AnalyzeProjectAdminConventionsInput,
+): Promise<ProjectAdminConventionAnalysis> {
+  const projectRoot = path.resolve(input.projectRoot)
+  const realProjectRoot = await realpath(projectRoot)
+  const entries: ProjectAdminConventionEntry[] = []
+  const diagnostics: ProjectAdminConventionDiagnostic[] = []
+  const adminContributions = input.contributions
+    .filter((contribution) => contribution.kind === "admin")
+    .sort((left, right) => compareStrings(left.sourcePath, right.sourcePath))
+
+  for (const contribution of adminContributions) {
+    const sourcePath = normalizeProjectPath(contribution.sourcePath)
+    if (!isAdminEntryPath(sourcePath)) {
+      diagnostics.push(invalidPathDiagnostic(contribution.sourcePath))
+      continue
+    }
+
+    const absoluteSourcePath = path.resolve(projectRoot, sourcePath)
+    if (!isPathInside(projectRoot, absoluteSourcePath)) {
+      diagnostics.push(invalidPathDiagnostic(contribution.sourcePath))
+      continue
+    }
+
+    let realSourcePath: string
+    try {
+      realSourcePath = await realpath(absoluteSourcePath)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      diagnostics.push(invalidPathDiagnostic(contribution.sourcePath))
+      continue
+    }
+    if (!isPathInside(realProjectRoot, realSourcePath)) {
+      diagnostics.push(invalidPathDiagnostic(contribution.sourcePath))
+      continue
+    }
+
+    const sourceText = await readFile(realSourcePath, "utf8")
+    const sourceFile = ts.createSourceFile(
+      sourcePath,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true,
+      sourcePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+    )
+    const defaultExport = findDefaultExport(sourceFile)
+    if (!defaultExport) {
+      diagnostics.push({
+        code: "PROJECT_ADMIN_MISSING_DEFAULT_EXPORT",
+        severity: "error",
+        sourcePaths: [sourcePath],
+        message: `Project admin entry "${sourcePath}" must default-export an AdminExtension.`,
+      })
+      continue
+    }
+
+    const extensionId = findStaticExtensionId(defaultExport, sourceFile)
+    entries.push({
+      conventionId: contribution.id,
+      ...(extensionId ? { extensionId } : {}),
+      sourcePath,
+    })
+  }
+
+  diagnostics.push(...findDuplicateEntryDiagnostics(entries))
+  diagnostics.push(...findDuplicateExtensionIdDiagnostics(entries))
+
+  return {
+    entries: entries.sort((left, right) => compareStrings(left.sourcePath, right.sourcePath)),
+    diagnostics: diagnostics.sort(compareDiagnostics),
+  }
+}
+
+/** Analyze and generate the deterministic client module consumed by later artifact stages. */
+export async function compileProjectAdminConventions(
+  input: AnalyzeProjectAdminConventionsInput,
+): Promise<CompiledProjectAdminConventions> {
+  const analysis = await analyzeProjectAdminConventions(input)
+  if (analysis.diagnostics.length > 0) throw new ProjectAdminConventionError(analysis.diagnostics)
+
+  return {
+    entries: analysis.entries,
+    file: {
+      path: VOYANT_PROJECT_ADMIN_GENERATED_FILE,
+      contents: generateProjectAdminModule(analysis.entries),
+    },
+  }
+}
+
+export function generateProjectAdminModule(
+  entries: readonly ProjectAdminConventionEntry[],
+): string {
+  const sortedEntries = [...entries].sort((left, right) =>
+    compareStrings(left.sourcePath, right.sourcePath),
+  )
+  const imports = sortedEntries.map((entry, index) => {
+    if (!isAdminEntryPath(entry.sourcePath)) {
+      throw new Error(`Invalid admin entry: ${entry.sourcePath}`)
+    }
+    return `import projectAdminExtension${index} from ${JSON.stringify(importSpecifier(entry.sourcePath))}`
+  })
+  const values = sortedEntries.map((_, index) => `  projectAdminExtension${index},`)
+
+  return [
+    "// Generated by @voyant-travel/framework. Do not edit.",
+    'import type { AdminExtension } from "@voyant-travel/admin"',
+    ...imports,
+    "",
+    "export const projectAdminExtensions = [",
+    ...values,
+    "] satisfies readonly AdminExtension[]",
+    "",
+  ].join("\n")
+}
+
+function findDefaultExport(sourceFile: ts.SourceFile): ts.Expression | true | undefined {
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) return statement.expression
+    if (
+      hasModifier(statement, ts.SyntaxKind.ExportKeyword) &&
+      hasModifier(statement, ts.SyntaxKind.DefaultKeyword)
+    ) {
+      return true
+    }
+    if (!ts.isExportDeclaration(statement) || !statement.exportClause) continue
+    if (!ts.isNamedExports(statement.exportClause)) continue
+    const defaultExport = statement.exportClause.elements.find(
+      (element) => element.name.text === "default",
+    )
+    if (!defaultExport) continue
+    if (statement.moduleSpecifier) return true
+    return ts.factory.createIdentifier(defaultExport.propertyName?.text ?? defaultExport.name.text)
+  }
+  return undefined
+}
+
+function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return Boolean(
+    ts.getModifiers(node as ts.HasModifiers)?.some((modifier) => modifier.kind === kind),
+  )
+}
+
+function findStaticExtensionId(
+  defaultExport: ts.Expression | true,
+  sourceFile: ts.SourceFile,
+): string | undefined {
+  if (defaultExport === true) return undefined
+  const expression = resolveExpression(defaultExport, sourceFile, new Set())
+  const objectLiteral = ts.isCallExpression(expression)
+    ? unwrapExpression(expression.arguments[0])
+    : expression
+  if (!objectLiteral || !ts.isObjectLiteralExpression(objectLiteral)) return undefined
+
+  for (const property of objectLiteral.properties) {
+    if (!ts.isPropertyAssignment(property) || propertyName(property.name) !== "id") continue
+    const value = unwrapExpression(property.initializer)
+    if (value && (ts.isStringLiteral(value) || ts.isNoSubstitutionTemplateLiteral(value))) {
+      return value.text
+    }
+  }
+  return undefined
+}
+
+function resolveExpression(
+  expression: ts.Expression,
+  sourceFile: ts.SourceFile,
+  seen: Set<string>,
+): ts.Expression {
+  const unwrapped = unwrapExpression(expression) ?? expression
+  if (!ts.isIdentifier(unwrapped) || seen.has(unwrapped.text)) return unwrapped
+  seen.add(unwrapped.text)
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) continue
+    for (const declaration of statement.declarationList.declarations) {
+      if (
+        ts.isIdentifier(declaration.name) &&
+        declaration.name.text === unwrapped.text &&
+        declaration.initializer
+      ) {
+        return resolveExpression(declaration.initializer, sourceFile, seen)
+      }
+    }
+  }
+  return unwrapped
+}
+
+function unwrapExpression(expression: ts.Expression | undefined): ts.Expression | undefined {
+  let current = expression
+  while (
+    current &&
+    (ts.isParenthesizedExpression(current) ||
+      ts.isAsExpression(current) ||
+      ts.isSatisfiesExpression(current) ||
+      ts.isTypeAssertionExpression(current))
+  ) {
+    current = current.expression
+  }
+  return current
+}
+
+function propertyName(name: ts.PropertyName): string | undefined {
+  if (ts.isIdentifier(name) || ts.isStringLiteral(name) || ts.isNumericLiteral(name)) {
+    return name.text
+  }
+  return undefined
+}
+
+function findDuplicateEntryDiagnostics(
+  entries: readonly ProjectAdminConventionEntry[],
+): ProjectAdminConventionDiagnostic[] {
+  return duplicateDiagnostics(
+    entries,
+    (entry) => entry.conventionId,
+    (id, sourcePaths) => ({
+      code: "PROJECT_ADMIN_DUPLICATE_ENTRY",
+      severity: "error",
+      sourcePaths,
+      message: `Project admin entry "${id}" has multiple index files: ${formatSources(sourcePaths)}.`,
+    }),
+  )
+}
+
+function findDuplicateExtensionIdDiagnostics(
+  entries: readonly ProjectAdminConventionEntry[],
+): ProjectAdminConventionDiagnostic[] {
+  return duplicateDiagnostics(
+    entries.filter((entry): entry is ProjectAdminConventionEntry & { extensionId: string } =>
+      Boolean(entry.extensionId),
+    ),
+    (entry) => entry.extensionId,
+    (extensionId, sourcePaths) => ({
+      code: "PROJECT_ADMIN_DUPLICATE_EXTENSION_ID",
+      severity: "error",
+      extensionId,
+      sourcePaths,
+      message: `AdminExtension ID "${extensionId}" is declared by ${formatSources(sourcePaths)}.`,
+    }),
+  )
+}
+
+function duplicateDiagnostics<T extends { sourcePath: string }>(
+  entries: readonly T[],
+  keyFor: (entry: T) => string,
+  diagnosticFor: (key: string, sourcePaths: string[]) => ProjectAdminConventionDiagnostic,
+): ProjectAdminConventionDiagnostic[] {
+  const groups = new Map<string, T[]>()
+  for (const entry of entries) {
+    const key = keyFor(entry)
+    groups.set(key, [...(groups.get(key) ?? []), entry])
+  }
+  return [...groups]
+    .filter(([, matches]) => matches.length > 1)
+    .map(([key, matches]) =>
+      diagnosticFor(key, matches.map((match) => match.sourcePath).sort(compareStrings)),
+    )
+}
+
+function invalidPathDiagnostic(sourcePath: string): ProjectAdminConventionDiagnostic {
+  return {
+    code: "PROJECT_ADMIN_INVALID_ENTRY_PATH",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    message: `Project admin source "${sourcePath}" must be a project-confined src/admin/<name>/index.ts or index.tsx file.`,
+  }
+}
+
+function importSpecifier(sourcePath: string): string {
+  return `../../${sourcePath.replace(/\.tsx?$/, ".js")}`
+}
+
+function normalizeProjectPath(sourcePath: string): string {
+  return sourcePath.split(path.sep).join("/")
+}
+
+function isAdminEntryPath(sourcePath: string): boolean {
+  return /^src\/admin\/[^/.][^/]*\/index\.tsx?$/.test(sourcePath)
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return (
+    relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && relative !== ".." && !path.isAbsolute(relative))
+  )
+}
+
+function compareDiagnostics(
+  left: ProjectAdminConventionDiagnostic,
+  right: ProjectAdminConventionDiagnostic,
+): number {
+  return (
+    compareStrings(left.code, right.code) ||
+    compareStrings(left.extensionId ?? "", right.extensionId ?? "") ||
+    compareStrings(left.sourcePaths.join("\0"), right.sourcePaths.join("\0"))
+  )
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function formatSources(sourcePaths: readonly string[]): string {
+  return sourcePaths.map((sourcePath) => `"${sourcePath}"`).join(", ")
+}

--- a/packages/framework/src/project-conventions.test.ts
+++ b/packages/framework/src/project-conventions.test.ts
@@ -22,6 +22,7 @@ describe("discoverProjectConventions", () => {
       "src/jobs/reconcile.ts",
       "src/subscribers/booking/created.ts",
       "src/links/booking-person.ts",
+      "src/admin/dashboard/index.tsx",
       "src/admin/dashboard/page.tsx",
       "src/admin/dashboard/styles.css",
       "src/modules/loyalty/index.ts",
@@ -30,14 +31,9 @@ describe("discoverProjectConventions", () => {
     await expect(discoverProjectConventions({ projectRoot: root })).resolves.toEqual({
       contributions: [
         {
-          id: "project.admin.dashboard.page",
+          id: "project.admin.dashboard",
           kind: "admin",
-          sourcePath: "src/admin/dashboard/page.tsx",
-        },
-        {
-          id: "project.admin.dashboard.styles",
-          kind: "admin",
-          sourcePath: "src/admin/dashboard/styles.css",
+          sourcePath: "src/admin/dashboard/index.tsx",
         },
         {
           id: "project.api.admin.orders.by-orderid",
@@ -94,8 +90,8 @@ describe("discoverProjectConventions", () => {
     const root = await projectFixture([
       "src/workflows/z-last.ts",
       "src/workflows/a-first.ts",
-      "src/admin/z/page.tsx",
-      "src/admin/a/page.tsx",
+      "src/admin/z/index.tsx",
+      "src/admin/a/index.ts",
       "src/jobs/middle.ts",
     ])
 
@@ -104,8 +100,8 @@ describe("discoverProjectConventions", () => {
 
     expect(fromString).toEqual(fromOptions)
     expect(fromString.contributions.map((contribution) => contribution.sourcePath)).toEqual([
-      "src/admin/a/page.tsx",
-      "src/admin/z/page.tsx",
+      "src/admin/a/index.ts",
+      "src/admin/z/index.tsx",
       "src/jobs/middle.ts",
       "src/workflows/a-first.ts",
       "src/workflows/z-last.ts",
@@ -133,7 +129,7 @@ describe("discoverProjectConventions", () => {
       "src/modules/kept/index.ts",
       ...ignoredDirectories.flatMap((directory) => [
         `src/workflows/${directory}/ignored.ts`,
-        `src/admin/${directory}/ignored.tsx`,
+        `src/admin/${directory}/ignored/index.tsx`,
         `src/api/admin/${directory}/route.ts`,
         `src/modules/${directory}/index.ts`,
       ]),
@@ -206,10 +202,50 @@ describe("discoverProjectConventions", () => {
     ])
   })
 
+  it("discovers only one-level index entries and ignores supporting files", async () => {
+    const root = await projectFixture([
+      "src/admin/accepted/index.tsx",
+      "src/admin/accepted/page.tsx",
+      "src/admin/accepted/styles.css",
+      "src/admin/file.ts",
+      "src/admin/nested/group/index.ts",
+      "src/admin/no-index/page.tsx",
+    ])
+
+    await expect(discoverProjectConventions(root)).resolves.toEqual({
+      contributions: [
+        {
+          id: "project.admin.accepted",
+          kind: "admin",
+          sourcePath: "src/admin/accepted/index.tsx",
+        },
+      ],
+      diagnostics: [],
+    })
+  })
+
+  it("reports both admin index variants as an ID collision", async () => {
+    const root = await projectFixture(["src/admin/orders/index.ts", "src/admin/orders/index.tsx"])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toHaveLength(2)
+    expect(result.diagnostics).toEqual([
+      {
+        code: "PROJECT_CONVENTION_ID_COLLISION",
+        id: "project.admin.orders",
+        message:
+          'Convention ID "project.admin.orders" is produced by "src/admin/orders/index.ts", "src/admin/orders/index.tsx".',
+        severity: "error",
+        sourcePaths: ["src/admin/orders/index.ts", "src/admin/orders/index.tsx"],
+      },
+    ])
+  })
+
   it("reports stable ID collisions without discarding either contribution", async () => {
     const root = await projectFixture([
-      "src/admin/order-history.ts",
-      "src/admin/order_history.tsx",
+      "src/admin/order-history/index.ts",
+      "src/admin/order_history/index.tsx",
       "src/workflows/send-email.ts",
       "src/workflows/send_email.ts",
     ])
@@ -222,9 +258,9 @@ describe("discoverProjectConventions", () => {
         code: "PROJECT_CONVENTION_ID_COLLISION",
         id: "project.admin.order-history",
         message:
-          'Convention ID "project.admin.order-history" is produced by "src/admin/order-history.ts", "src/admin/order_history.tsx".',
+          'Convention ID "project.admin.order-history" is produced by "src/admin/order-history/index.ts", "src/admin/order_history/index.tsx".',
         severity: "error",
-        sourcePaths: ["src/admin/order-history.ts", "src/admin/order_history.tsx"],
+        sourcePaths: ["src/admin/order-history/index.ts", "src/admin/order_history/index.tsx"],
       },
       {
         code: "PROJECT_CONVENTION_ID_COLLISION",

--- a/packages/framework/src/project-conventions.ts
+++ b/packages/framework/src/project-conventions.ts
@@ -71,7 +71,7 @@ export type DiscoverProjectConventionsInput = string | DiscoverProjectConvention
 
 interface RecursiveConvention {
   directory: string
-  kind: Exclude<ProjectConventionKind, "api-route" | "module">
+  kind: Exclude<ProjectConventionKind, "admin" | "api-route" | "module">
   accepts: (fileName: string) => boolean
 }
 
@@ -93,7 +93,6 @@ const RECURSIVE_CONVENTIONS: readonly RecursiveConvention[] = [
   { directory: "src/jobs", kind: "job", accepts: isTypeScriptFile },
   { directory: "src/subscribers", kind: "subscriber", accepts: isTypeScriptFile },
   { directory: "src/links", kind: "link", accepts: isTypeScriptFile },
-  { directory: "src/admin", kind: "admin", accepts: () => true },
 ]
 
 /**
@@ -114,6 +113,7 @@ export async function discoverProjectConventions(
     ...RECURSIVE_CONVENTIONS.map((convention) =>
       discoverRecursiveConvention(projectRoot, convention, contributions),
     ),
+    discoverAdminExtensions(projectRoot, contributions),
     discoverModules(projectRoot, contributions),
   ])
 
@@ -122,6 +122,27 @@ export async function discoverProjectConventions(
   return {
     contributions,
     diagnostics: findDiagnostics(contributions),
+  }
+}
+
+async function discoverAdminExtensions(
+  projectRoot: string,
+  contributions: ProjectConventionContribution[],
+): Promise<void> {
+  const directory = "src/admin"
+  for (const entry of await readDirectory(path.join(projectRoot, directory))) {
+    if (!entry.isDirectory() || shouldIgnoreDirectory(entry.name)) continue
+
+    for (const fileName of ["index.ts", "index.tsx"] as const) {
+      const sourcePath = `${directory}/${entry.name}/${fileName}`
+      if (!(await containsFile(projectRoot, sourcePath))) continue
+
+      contributions.push({
+        id: stableId("admin", entry.name),
+        kind: "admin",
+        sourcePath,
+      })
+    }
   }
 }
 

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -14,6 +14,18 @@ export type {
   NodeMigrationRunnerOptions,
   SetupMigrationHandler,
 } from "./node-migration-runner.js"
+export {
+  type AnalyzeProjectAdminConventionsInput,
+  type CompiledProjectAdminConventions,
+  PROJECT_ADMIN_CONVENTION_DIAGNOSTIC_CODES,
+  type ProjectAdminConventionAnalysis,
+  type ProjectAdminConventionDiagnostic,
+  type ProjectAdminConventionDiagnosticCode,
+  type ProjectAdminConventionEntry,
+  ProjectAdminConventionError,
+  type ProjectAdminGeneratedFile,
+  VOYANT_PROJECT_ADMIN_GENERATED_FILE,
+} from "./project-admin-conventions.js"
 export type {
   ProjectApiConventionAnalysis,
   ProjectApiConventionCompilation,
@@ -83,6 +95,20 @@ export async function compileProjectApiConventions(
 ): Promise<import("./project-api-conventions.js").ProjectApiConventionCompilation> {
   const conventions = await import("./project-api-conventions.js")
   return conventions.compileProjectApiConventions(options)
+}
+
+export async function analyzeProjectAdminConventions(
+  input: import("./project-admin-conventions.js").AnalyzeProjectAdminConventionsInput,
+): Promise<import("./project-admin-conventions.js").ProjectAdminConventionAnalysis> {
+  const conventions = await import("./project-admin-conventions.js")
+  return conventions.analyzeProjectAdminConventions(input)
+}
+
+export async function compileProjectAdminConventions(
+  input: import("./project-admin-conventions.js").AnalyzeProjectAdminConventionsInput,
+): Promise<import("./project-admin-conventions.js").CompiledProjectAdminConventions> {
+  const conventions = await import("./project-admin-conventions.js")
+  return conventions.compileProjectAdminConventions(input)
 }
 
 export async function executeNodeMigrationPlan(


### PR DESCRIPTION
## Summary
- compile `src/admin/<name>/index.tsx` conventions into deterministic static imports
- validate default exports and statically detect duplicate extension IDs
- expose the admin convention compiler through the framework project API

## Verification
- `pnpm exec vitest run packages/framework/src/project-admin-conventions.test.ts packages/framework/src/project-conventions.test.ts packages/framework/src/project-api-conventions.test.ts` (20 passed)
- `pnpm exec biome check ...` (clean)
- framework typecheck was stopped after six minutes due the known cold-worktree TypeScript performance pathology; CI remains authoritative
