### PR TITLE
feat(framework): resolve project conventions

### DIFF
--- a/.changeset/resolve-project-conventions.md
+++ b/.changeset/resolve-project-conventions.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Compile project API and admin source conventions into the resolved deployment graph and disposable project artifacts.

--- a/docs/architecture/custom-modules.md
+++ b/docs/architecture/custom-modules.md
@@ -160,6 +160,12 @@ it, requires a default export, and emits the client-only
 imports. The generated array is checked against `AdminExtension`, and duplicate
 extension IDs are reported when their string values can be read statically.
 
+`resolveProject()` owns this compilation. Its artifact contract uses paths
+relative to the disposable `.voyant/` root, and project API route files are
+also represented as individual API facets on a synthetic project-owned module.
+Generated route and admin entry modules are therefore inputs to the same graph
+resolution as package-owned facets, not separate starter scans.
+
 - **nav + widgets** merge via `adminExtensionsFromGlob` in
   `src/lib/admin-extensions.tsx` and resolve through the shared
   `resolveAdminNavigation` / `resolveAdminWidgets`.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1075,6 +1075,12 @@ a resolver-private relative import. The operator resolver adapter requires
 `resolveProject({ project, projectRoot, configPath })` and then adds target
 admission, lockfile provenance, and runtime-maintenance schedules.
 
+The same resolver compiles `src/api/{admin,store}/**/route.ts` into individual
+graph API facets backed by one generated static Hono adapter, and compiles
+`src/admin/<name>/index.tsx` entries into a deterministic client module. Both
+artifacts use paths relative to `.voyant/`; no runtime filesystem scan or
+starter-owned project convention registry participates in resolution.
+
 Schema-owning first-party package manifests publish `voyant.package.v1`
 compatibility metadata alongside the existing migration-facing `schema` and
 `requiresSchemas` declarations. Graph checks require every package-backed

--- a/packages/framework/src/project-admin-conventions.ts
+++ b/packages/framework/src/project-admin-conventions.ts
@@ -5,8 +5,7 @@ import ts from "typescript"
 
 import type { ProjectConventionContribution } from "./project-conventions.js"
 
-export const VOYANT_PROJECT_ADMIN_GENERATED_FILE =
-  ".voyant/admin/project-admin.generated.ts" as const
+export const VOYANT_PROJECT_ADMIN_GENERATED_FILE = "admin/project-admin.generated.ts" as const
 
 export const PROJECT_ADMIN_CONVENTION_DIAGNOSTIC_CODES = {
   PROJECT_ADMIN_DUPLICATE_EXTENSION_ID:

--- a/packages/framework/src/project-api-conventions.test.ts
+++ b/packages/framework/src/project-api-conventions.test.ts
@@ -66,7 +66,7 @@ describe("project API conventions", () => {
         surface: "public",
       },
     ])
-    expect(compilation.generatedFile.path).toBe(".voyant/runtime/project-api.generated.ts")
+    expect(compilation.generatedFile.path).toBe("runtime/project-api.generated.ts")
     expect(compilation.generatedFile.contents).toBe(
       [
         'import type { HonoModule } from "@voyant-travel/hono/module"',

--- a/packages/framework/src/project-api-conventions.ts
+++ b/packages/framework/src/project-api-conventions.ts
@@ -9,7 +9,8 @@ import {
   type ProjectConventionRouteSurface,
 } from "./project-conventions.js"
 
-export const PROJECT_API_GENERATED_PATH = ".voyant/runtime/project-api.generated.ts"
+/** Path relative to the project's disposable `.voyant` artifact root. */
+export const PROJECT_API_GENERATED_PATH = "runtime/project-api.generated.ts"
 
 const SUPPORTED_METHODS = new Set<VoyantGraphRouteMethod>([
   "DELETE",

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -22,6 +22,12 @@ import {
   type VoyantGraphPackageMetadata,
   type VoyantGraphPackageRecord,
 } from "./deployment-graph.js"
+import { compileProjectAdminConventions } from "./project-admin-conventions.js"
+import {
+  compileProjectApiConventions,
+  PROJECT_API_GENERATED_PATH,
+  type ProjectApiConventionCompilation,
+} from "./project-api-conventions.js"
 import {
   discoverProjectConventions,
   type ProjectConventionDiscovery,
@@ -129,9 +135,17 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
   assertPathInside(projectRoot, configPath, "configPath")
   const conventions = await discoverProjectConventions({ projectRoot })
   assertProjectConventionDiagnostics(conventions)
+  const [projectApi, projectAdmin] = await Promise.all([
+    compileProjectApiConventions({ projectRoot }),
+    compileProjectAdminConventions({
+      projectRoot,
+      contributions: conventions.contributions,
+    }),
+  ])
 
   const materialized = await materializeProjectSelections(project, projectRoot)
   await materializeProjectModuleConventions(materialized, conventions, projectRoot)
+  await materializeProjectApiConventions(materialized, projectApi, projectRoot)
   const providers = { ...(project.deployment?.providers ?? {}) }
   const mode = project.deployment?.mode
   const frameworkVersion = await readFrameworkVersion()
@@ -166,6 +180,8 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
     runtimeEntry,
   )
   const files: FrameworkGeneratedProjectFile[] = [
+    projectApi.generatedFile,
+    projectAdmin.file,
     {
       path: runtimeEntry,
       contents: buildProjectRuntimeModule({
@@ -195,6 +211,36 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
   }
 }
 
+async function materializeProjectApiConventions(
+  materialized: MaterializedProject,
+  compilation: ProjectApiConventionCompilation,
+  projectRoot: string,
+): Promise<void> {
+  if (compilation.graphRoutes.length === 0) return
+  const packageName = await admitProjectSourcePackage(materialized, projectRoot)
+  const generatedRuntime = `./.voyant/${PROJECT_API_GENERATED_PATH}`
+  materialized.project = {
+    ...materialized.project,
+    modules: [
+      ...materialized.project.modules,
+      {
+        schemaVersion: "voyant.module.v1",
+        id: graphIdForSelection(packageName, `${packageName}#project-api`),
+        packageName,
+        localId: "project-api",
+        api: compilation.graphRoutes.map((route) => ({
+          ...route,
+          runtime: { entry: generatedRuntime, export: "projectApiHonoModule" },
+        })),
+        meta: {
+          source: "project-convention",
+          generatedPath: PROJECT_API_GENERATED_PATH,
+        },
+      },
+    ],
+  }
+}
+
 function assertProjectConventionDiagnostics(discovery: ProjectConventionDiscovery): void {
   if (discovery.diagnostics.length === 0) return
   throw new Error(
@@ -214,23 +260,7 @@ async function materializeProjectModuleConventions(
       contribution.kind === "module",
   )
   if (modules.length === 0) return
-
-  const packageJson = await readPackageJson(projectRoot)
-  const packageName = requirePackageName(packageJson, projectRoot)
-  const inspected: InspectedPackage = {
-    directory: projectRoot,
-    record: {
-      packageName,
-      ...(typeof packageJson.version === "string" ? { version: packageJson.version } : {}),
-      source: { kind: "file", reference: "." },
-      metadata: { ...inferredNodeRuntimePackageMetadata(), kind: "module" },
-    },
-  }
-  const previous = materialized.packages.get(packageName)
-  if (previous && previous.directory !== projectRoot) {
-    throw new Error(`resolveProject: package ${packageName} resolves from more than one source.`)
-  }
-  materialized.packages.set(packageName, inspected)
+  const packageName = await admitProjectSourcePackage(materialized, projectRoot)
   materialized.project = {
     ...materialized.project,
     modules: [
@@ -238,6 +268,30 @@ async function materializeProjectModuleConventions(
       ...modules.map((module) => syntheticProjectModule(packageName, module)),
     ],
   }
+}
+
+async function admitProjectSourcePackage(
+  materialized: MaterializedProject,
+  projectRoot: string,
+): Promise<string> {
+  const packageJson = await readPackageJson(projectRoot)
+  const packageName = requirePackageName(packageJson, projectRoot)
+  const previous = materialized.packages.get(packageName)
+  if (previous && previous.directory !== projectRoot) {
+    throw new Error(`resolveProject: package ${packageName} resolves from more than one source.`)
+  }
+  if (!previous) {
+    materialized.packages.set(packageName, {
+      directory: projectRoot,
+      record: {
+        packageName,
+        ...(typeof packageJson.version === "string" ? { version: packageJson.version } : {}),
+        source: { kind: "file", reference: "." },
+        metadata: { ...inferredNodeRuntimePackageMetadata(), kind: "module" },
+      },
+    })
+  }
+  return packageName
 }
 
 function syntheticProjectModule(
@@ -614,10 +668,14 @@ function isProjectSourceRuntimeReference(
 function resolveProjectSourceRuntimeTarget(projectRoot: string, entry: string): string {
   const target = path.resolve(projectRoot, entry)
   assertPathInside(projectRoot, target, `project runtime entry ${entry}`)
-  if (!existsSync(target)) {
+  if (!isGeneratedProjectRuntimeEntry(entry) && !existsSync(target)) {
     throw new Error(`resolveProject: project runtime entry ${entry} does not exist.`)
   }
   return target
+}
+
+function isGeneratedProjectRuntimeEntry(entry: string): boolean {
+  return entry === `./.voyant/${PROJECT_API_GENERATED_PATH}`
 }
 
 function lowerOwnerRuntimeEntry(packageName: string, entry: string): string {

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -56,6 +56,8 @@ describe("framework project resolver", () => {
     expect(first.artifacts.runtimeEntry).toBe("runtime/project-runtime.generated.ts")
     expect(first.artifacts.migrationRunner).toBe("runtime/project-migrations.generated.mjs")
     expect(first.artifacts.files.map((file) => file.path)).toEqual([
+      "admin/project-admin.generated.ts",
+      "runtime/project-api.generated.ts",
       "runtime/project-migrations.generated.mjs",
       "runtime/project-runtime.generated.ts",
     ])
@@ -583,6 +585,54 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
     })
 
     expect(composed.modules.map((module) => module.module.name)).toEqual(["concierge"])
+  })
+
+  it("compiles project API and admin conventions into the resolved graph artifacts", async () => {
+    const root = projectRoot()
+    writeFile(
+      root,
+      "src/api/admin/health/route.ts",
+      "export const GET = (c: { json(value: unknown): unknown }) => c.json({ ok: true })\n",
+    )
+    writeFile(root, "src/admin/dashboard/index.tsx", 'export default { id: "project.dashboard" }\n')
+
+    const resolution = await resolve(root, defineProject({ modules: [] }))
+    const projectApi = resolution.graph.modules.find(({ localId }) => localId === "project-api")
+
+    expect(projectApi).toMatchObject({
+      id: "npm/fixture#project-api",
+      packageName: "fixture",
+      api: [
+        {
+          id: "project.api.admin.health",
+          methods: ["GET"],
+          mount: "/health",
+          surface: "admin",
+          runtime: {
+            entry: "./.voyant/runtime/project-api.generated.ts",
+            export: "projectApiHonoModule",
+          },
+        },
+      ],
+    })
+    expect(resolution.graph.packageRecords).toContainEqual(
+      expect.objectContaining({
+        packageName: "fixture",
+        source: { kind: "file", reference: "." },
+      }),
+    )
+    expect(
+      resolution.artifacts.files.find(({ path }) => path === "runtime/project-api.generated.ts")
+        ?.contents,
+    ).toContain('import * as route0 from "../../src/api/admin/health/route.js"')
+    expect(
+      resolution.artifacts.files.find(({ path }) => path === "admin/project-admin.generated.ts")
+        ?.contents,
+    ).toContain('import projectAdminExtension0 from "../../src/admin/dashboard/index.js"')
+    expect(
+      resolution.artifacts.files.find(({ path }) => path === resolution.artifacts.runtimeEntry)
+        ?.contents,
+    ).toContain('"./project-api.generated.ts": () => import("./project-api.generated.ts")')
   })
 
   it("rejects convention diagnostics and config paths outside the project root", async () => {


### PR DESCRIPTION
## Summary
- compile project API routes into individual graph facets backed by a generated static Hono adapter
- include deterministic project admin and API modules in the resolver artifact contract
- normalize compiler output paths relative to the disposable `.voyant` root

## Verification
- `pnpm --filter @voyant-travel/framework test` (257 passed)
- repository pre-push suite (101 tasks passed)
- Biome changed-file checks passed
- framework typecheck was stopped after five minutes due the known cold-worktree TypeScript performance pathology
