### PR TITLE
feat(framework): compile project subscriber and link conventions

### DIFF
--- a/.changeset/compile-project-subscriber-links.md
+++ b/.changeset/compile-project-subscriber-links.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Add the build-time compiler and deterministic static artifacts for application-local subscriber descriptors and link definitions.

--- a/docs/architecture/custom-modules.md
+++ b/docs/architecture/custom-modules.md
@@ -158,6 +158,48 @@ schema glob (`./src/modules/*/schema.ts`) picks up every custom module. The full
 `drizzle.config.ts` globs them too, so `db:push`, `db:studio`, and the
 migration-replay oracle all see custom tables.
 
+## Project subscribers and links
+
+Application-local subscribers live under `src/subscribers/**/*.ts`. Each file
+default-exports durable `EventFilterDescriptor` data with non-empty literal
+`id` and `eventType` fields. Descriptor values must be serializable data; use a
+workflow definition for executable behavior.
+
+```ts
+import type { EventFilterDescriptor } from "@voyant-travel/core"
+
+export default {
+  id: "loyalty.credit-booking-points",
+  eventType: "booking.confirmed",
+  manifest: {
+    id: "loyalty.credit-booking-points",
+    eventType: "booking.confirmed",
+    payloadHash: "7dd9b0cbfd8c5e30",
+    targetWorkflowId: "loyalty.credit-points",
+  },
+} satisfies EventFilterDescriptor
+```
+
+Application-local links live under `src/links/**/*.ts`. Each file imports
+`defineLink` from `@voyant-travel/core` or `@voyant-travel/core/links` and
+default-exports one definition:
+
+```ts
+import { defineLink } from "@voyant-travel/core"
+import { booking } from "@voyant-travel/bookings/linkables"
+import { loyaltyAccount } from "../modules/loyalty/linkables.js"
+
+export default defineLink(booking, loyaltyAccount)
+```
+
+The build-time compiler parses these files without importing them, rejects
+named runtime exports, project-root import escapes, invalid declaration shapes,
+and duplicate subscriber IDs, then emits deterministic static imports in
+`.voyant/runtime/project-subscribers.generated.ts` and
+`.voyant/runtime/project-links.generated.ts`. Declaration and test files in
+these directories are not convention entries. Runtime directory scanning is
+not part of this contract.
+
 ## Custom routes on an *existing* module (extensions)
 
 A `HonoExtension` adds routes to an **existing** module's surface (e.g. a

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -889,6 +889,13 @@ remove it.
 V1 should include subscribers and workflow event filters that already map to
 existing descriptors.
 
+Application-local `src/subscribers` and `src/links` contributions are compiled
+with the TypeScript AST. Subscriber files default-export durable
+`EventFilterDescriptor` data, while link files default-export `defineLink`
+definitions. The compiler emits deterministic static TypeScript imports under
+`.voyant/runtime`; it does not import application source, mutate runtime wiring,
+or defer discovery to application startup.
+
 The broader event catalog is beyond the foundational substrate:
 
 - declared `events.emits` catalogs

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -12,6 +12,7 @@
     "./project-api-conventions": "./src/project-api-conventions.ts",
     "./project-admin-conventions": "./src/project-admin-conventions.ts",
     "./project-workflow-job-conventions": "./src/project-workflow-job-conventions.ts",
+    "./project-subscriber-link-conventions": "./src/project-subscriber-link-conventions.ts",
     "./project": "./src/project.ts",
     "./profile": "./src/profile.ts",
     "./managed-jobs": "./src/managed-jobs.ts",
@@ -132,6 +133,11 @@
         "types": "./dist/project-workflow-job-conventions.d.ts",
         "import": "./dist/project-workflow-job-conventions.js",
         "default": "./dist/project-workflow-job-conventions.js"
+      },
+      "./project-subscriber-link-conventions": {
+        "types": "./dist/project-subscriber-link-conventions.d.ts",
+        "import": "./dist/project-subscriber-link-conventions.js",
+        "default": "./dist/project-subscriber-link-conventions.js"
       },
       "./project": {
         "types": "./dist/project.d.ts",

--- a/packages/framework/src/project-convention-compiler-utils.ts
+++ b/packages/framework/src/project-convention-compiler-utils.ts
@@ -1,0 +1,55 @@
+import path from "node:path"
+import ts from "typescript"
+
+export function inspectModuleSpecifiers(
+  sourceFile: ts.SourceFile,
+  inspect: (specifier: string) => void,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    )
+      inspect(node.moduleSpecifier.text)
+    else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    )
+      inspect(node.moduleReference.expression.text)
+    else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0]!)
+    )
+      inspect(node.arguments[0].text)
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+}
+
+export function resolveInsideProject(projectRoot: string, sourcePath: string): string {
+  if (path.isAbsolute(sourcePath))
+    throw new Error(`Expected a project-relative path: ${sourcePath}`)
+  const resolved = path.resolve(projectRoot, sourcePath)
+  if (!isInside(projectRoot, resolved)) throw new Error(`Path escapes project root: ${sourcePath}`)
+  return resolved
+}
+
+export function isInside(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate)
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))
+}
+
+export function isPathImport(specifier: string): boolean {
+  return specifier.startsWith(".") || path.isAbsolute(specifier) || specifier.startsWith("file:")
+}
+
+export function hasModifier(node: ts.Node, kind: ts.SyntaxKind): boolean {
+  return Boolean(
+    ts.canHaveModifiers(node) && ts.getModifiers(node)?.some((item) => item.kind === kind),
+  )
+}

--- a/packages/framework/src/project-convention-static-data.ts
+++ b/packages/framework/src/project-convention-static-data.ts
@@ -1,0 +1,98 @@
+import ts from "typescript"
+
+export function isDurableExpression(
+  expression: ts.Expression,
+  constants: ReadonlyMap<string, ts.Expression>,
+  seen: Set<string> = new Set(),
+): boolean {
+  const value = unwrapExpression(expression)
+  if (
+    ts.isStringLiteralLike(value) ||
+    ts.isNumericLiteral(value) ||
+    value.kind === ts.SyntaxKind.TrueKeyword ||
+    value.kind === ts.SyntaxKind.FalseKeyword ||
+    value.kind === ts.SyntaxKind.NullKeyword ||
+    ts.isNoSubstitutionTemplateLiteral(value)
+  )
+    return true
+  if (ts.isPrefixUnaryExpression(value)) {
+    return value.operator === ts.SyntaxKind.MinusToken && ts.isNumericLiteral(value.operand)
+  }
+  if (ts.isArrayLiteralExpression(value)) {
+    return value.elements.every(
+      (element) => !ts.isSpreadElement(element) && isDurableExpression(element, constants, seen),
+    )
+  }
+  if (ts.isObjectLiteralExpression(value)) {
+    return value.properties.every((property) => {
+      if (ts.isPropertyAssignment(property))
+        return isDurableExpression(property.initializer, constants, seen)
+      if (ts.isShorthandPropertyAssignment(property)) {
+        return isDurableIdentifier(property.name.text, constants, seen)
+      }
+      return false
+    })
+  }
+  if (ts.isIdentifier(value)) return isDurableIdentifier(value.text, constants, seen)
+  return false
+}
+
+export function stringProperty(
+  object: ts.ObjectLiteralExpression,
+  name: string,
+  constants: ReadonlyMap<string, ts.Expression>,
+): string | undefined {
+  const property = object.properties.find((item) =>
+    ts.isPropertyAssignment(item)
+      ? propertyName(item.name) === name
+      : ts.isShorthandPropertyAssignment(item) && item.name.text === name,
+  )
+  if (!property) return undefined
+  const value = resolveExpression(
+    ts.isPropertyAssignment(property) ? property.initializer : property.name,
+    constants,
+  )
+  return ts.isStringLiteralLike(value) && value.text.length > 0 ? value.text : undefined
+}
+
+export function resolveExpression(
+  expression: ts.Expression,
+  constants: ReadonlyMap<string, ts.Expression>,
+): ts.Expression {
+  let current = unwrapExpression(expression)
+  const seen = new Set<string>()
+  while (ts.isIdentifier(current) && constants.has(current.text) && !seen.has(current.text)) {
+    seen.add(current.text)
+    current = unwrapExpression(constants.get(current.text)!)
+  }
+  return current
+}
+
+export function unwrapExpression(expression: ts.Expression): ts.Expression {
+  let current = expression
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current)
+  )
+    current = current.expression
+  return current
+}
+
+function isDurableIdentifier(
+  name: string,
+  constants: ReadonlyMap<string, ts.Expression>,
+  seen: Set<string>,
+): boolean {
+  if (seen.has(name)) return false
+  const initializer = constants.get(name)
+  if (!initializer) return false
+  const nextSeen = new Set(seen)
+  nextSeen.add(name)
+  return isDurableExpression(initializer, constants, nextSeen)
+}
+
+function propertyName(name: ts.PropertyName): string | undefined {
+  return ts.isIdentifier(name) || ts.isStringLiteralLike(name) ? name.text : undefined
+}

--- a/packages/framework/src/project-conventions.test.ts
+++ b/packages/framework/src/project-conventions.test.ts
@@ -176,6 +176,34 @@ describe("discoverProjectConventions", () => {
     ])
   })
 
+  it("ignores declaration and test files in subscriber and link directories", async () => {
+    const root = await projectFixture([
+      "src/subscribers/accepted.ts",
+      "src/subscribers/ignored.d.ts",
+      "src/subscribers/ignored.test.ts",
+      "src/subscribers/ignored.spec.ts",
+      "src/links/accepted.ts",
+      "src/links/ignored.d.ts",
+      "src/links/ignored.test.ts",
+      "src/links/ignored.spec.ts",
+    ])
+
+    const result = await discoverProjectConventions(root)
+
+    expect(result.contributions).toEqual([
+      {
+        id: "project.link.accepted",
+        kind: "link",
+        sourcePath: "src/links/accepted.ts",
+      },
+      {
+        id: "project.subscriber.accepted",
+        kind: "subscriber",
+        sourcePath: "src/subscribers/accepted.ts",
+      },
+    ])
+  })
+
   it("reports same-surface dynamic and route-group collisions", async () => {
     const root = await projectFixture([
       "src/api/admin/orders/[id]/route.ts",

--- a/packages/framework/src/project-conventions.ts
+++ b/packages/framework/src/project-conventions.ts
@@ -91,8 +91,8 @@ const IGNORED_DIRECTORY_NAMES = new Set([
 const RECURSIVE_CONVENTIONS: readonly RecursiveConvention[] = [
   { directory: "src/workflows", kind: "workflow", accepts: isTypeScriptFile },
   { directory: "src/jobs", kind: "job", accepts: isTypeScriptFile },
-  { directory: "src/subscribers", kind: "subscriber", accepts: isTypeScriptFile },
-  { directory: "src/links", kind: "link", accepts: isTypeScriptFile },
+  { directory: "src/subscribers", kind: "subscriber", accepts: isRuntimeTypeScriptFile },
+  { directory: "src/links", kind: "link", accepts: isRuntimeTypeScriptFile },
 ]
 
 /**
@@ -346,6 +346,15 @@ function withoutFinalExtension(filePath: string): string {
 
 function isTypeScriptFile(fileName: string): boolean {
   return fileName.endsWith(".ts") && !fileName.endsWith(".d.ts")
+}
+
+function isRuntimeTypeScriptFile(fileName: string): boolean {
+  return (
+    isTypeScriptFile(fileName) &&
+    !fileName.endsWith(".d.ts") &&
+    !fileName.endsWith(".test.ts") &&
+    !fileName.endsWith(".spec.ts")
+  )
 }
 
 function isRouteGroup(segment: string): boolean {

--- a/packages/framework/src/project-subscriber-link-conventions.test.ts
+++ b/packages/framework/src/project-subscriber-link-conventions.test.ts
@@ -1,0 +1,243 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  analyzeProjectSubscriberLinkConventions,
+  compileProjectSubscriberLinkConventions,
+  type ProjectSubscriberLinkConventionError,
+} from "./project-subscriber-link-conventions.js"
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  )
+})
+
+describe("project subscriber and link conventions", () => {
+  it("compiles deterministic static subscriber and link artifacts", async () => {
+    const root = await projectFixture({
+      "src/subscribers/zeta.ts": [
+        'import type { EventFilterDescriptor } from "@voyant-travel/core"',
+        "const manifest = {",
+        '  id: "filter.zeta",',
+        '  eventType: "booking.created",',
+        '  manifest: { id: "filter.zeta", eventType: "booking.created", payloadHash: "abc", targetWorkflowId: "workflow.zeta" },',
+        "} satisfies EventFilterDescriptor",
+        "export default manifest",
+      ].join("\n"),
+      "src/subscribers/alpha/created.ts":
+        'export default { id: "filter.alpha", eventType: "person.created" }\n',
+      "src/links/zeta.ts": [
+        'import { defineLink as link } from "@voyant-travel/core/links"',
+        'import { left, right } from "../linkables.js"',
+        "const definition = link(left, right)",
+        "export default definition",
+      ].join("\n"),
+      "src/links/alpha.ts": [
+        'import { defineLink } from "@voyant-travel/core"',
+        'import { left, right } from "../linkables.js"',
+        "export default defineLink(left, right, { deleteCascade: true })",
+      ].join("\n"),
+      "src/linkables.ts": "export const left = {}; export const right = {}\n",
+    })
+
+    const first = await compileProjectSubscriberLinkConventions({ projectRoot: root })
+    const second = await compileProjectSubscriberLinkConventions({ projectRoot: root })
+
+    expect(first).toEqual(second)
+    expect(first.subscribers).toEqual([
+      {
+        eventType: "person.created",
+        id: "project.subscriber.alpha.created",
+        kind: "subscriber",
+        sourcePath: "src/subscribers/alpha/created.ts",
+        subscriberId: "filter.alpha",
+      },
+      {
+        eventType: "booking.created",
+        id: "project.subscriber.zeta",
+        kind: "subscriber",
+        sourcePath: "src/subscribers/zeta.ts",
+        subscriberId: "filter.zeta",
+      },
+    ])
+    expect(first.links.map(({ id, sourcePath }) => ({ id, sourcePath }))).toEqual([
+      { id: "project.link.alpha", sourcePath: "src/links/alpha.ts" },
+      { id: "project.link.zeta", sourcePath: "src/links/zeta.ts" },
+    ])
+    expect(first.generatedFiles).toEqual([
+      {
+        path: "runtime/project-subscribers.generated.ts",
+        contents: [
+          'import type { EventFilterDescriptor } from "@voyant-travel/core"',
+          'import subscriber0 from "../../src/subscribers/alpha/created.js"',
+          'import subscriber1 from "../../src/subscribers/zeta.js"',
+          "",
+          "export const projectSubscribers = [subscriber0, subscriber1] as const satisfies readonly EventFilterDescriptor[]",
+          "",
+        ].join("\n"),
+      },
+      {
+        path: "runtime/project-links.generated.ts",
+        contents: [
+          'import type { LinkDefinition } from "@voyant-travel/core"',
+          'import link0 from "../../src/links/alpha.js"',
+          'import link1 from "../../src/links/zeta.js"',
+          "",
+          "export const projectLinks = [link0, link1] as const satisfies readonly LinkDefinition[]",
+          "",
+        ].join("\n"),
+      },
+    ])
+  })
+
+  it("reports missing defaults, named exports, and invalid declaration shapes", async () => {
+    const root = await projectFixture({
+      "src/subscribers/missing.ts": 'export const filter = { id: "x", eventType: "x" }\n',
+      "src/subscribers/call.ts": "export default makeSubscriber()\n",
+      "src/subscribers/function.ts":
+        'export default { id: "function-filter", eventType: "x", input: () => true }\n',
+      "src/subscribers/literals.ts":
+        'const id = "literal-filter"; const eventType = "x"; export default { id, eventType }\n',
+      "src/subscribers/named-destructuring.ts":
+        'export const { named } = { named: true }; export default { id: "named", eventType: "x" }\n',
+      "src/links/plain.ts": "export default { tableName: 'plain' }\n",
+      "src/links/wrong-helper.ts": [
+        'import { defineLink } from "./helper.js"',
+        "export default defineLink({}, {})",
+      ].join("\n"),
+      "src/links/helper.ts": "export const defineLink = () => ({})\n",
+    })
+
+    const analysis = await analyzeProjectSubscriberLinkConventions({ projectRoot: root })
+
+    expect(analysis.subscribers.map(({ subscriberId }) => subscriberId)).toEqual([
+      "literal-filter",
+      "named",
+    ])
+    expect(analysis.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "PROJECT_CONVENTION_MISSING_DEFAULT_EXPORT",
+          sourcePaths: ["src/subscribers/missing.ts"],
+        }),
+        expect.objectContaining({
+          code: "PROJECT_CONVENTION_UNSUPPORTED_EXPORT",
+          exportName: "filter",
+        }),
+        expect.objectContaining({
+          code: "PROJECT_CONVENTION_UNSUPPORTED_EXPORT",
+          exportName: "named",
+        }),
+        expect.objectContaining({
+          code: "PROJECT_SUBSCRIBER_INVALID_DESCRIPTOR",
+          sourcePaths: ["src/subscribers/call.ts"],
+        }),
+        expect.objectContaining({
+          code: "PROJECT_SUBSCRIBER_NON_DURABLE_DESCRIPTOR",
+          subscriberId: "function-filter",
+        }),
+        expect.objectContaining({
+          code: "PROJECT_LINK_INVALID_DEFINITION",
+          sourcePaths: ["src/links/plain.ts"],
+        }),
+        expect.objectContaining({
+          code: "PROJECT_LINK_INVALID_DEFINITION",
+          sourcePaths: ["src/links/wrong-helper.ts"],
+        }),
+      ]),
+    )
+  })
+
+  it("reports duplicate subscriber ids and project-root import escapes", async () => {
+    const root = await projectFixture({
+      "src/subscribers/a.ts": [
+        'import "../../../outside.js"',
+        'export default { id: "duplicate", eventType: "a" }',
+      ].join("\n"),
+      "src/subscribers/b.ts": 'export default { id: "duplicate", eventType: "b" }\n',
+      "src/links/escaped.ts": [
+        'import { defineLink } from "@voyant-travel/core"',
+        'import left from "file:///tmp/left.js"',
+        "export default defineLink(left, {})",
+      ].join("\n"),
+    })
+
+    const analysis = await analyzeProjectSubscriberLinkConventions({ projectRoot: root })
+
+    expect(analysis.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "PROJECT_CONVENTION_IMPORT_ESCAPE",
+        sourcePaths: ["src/links/escaped.ts"],
+      }),
+      expect.objectContaining({
+        code: "PROJECT_CONVENTION_IMPORT_ESCAPE",
+        sourcePaths: ["src/subscribers/a.ts"],
+      }),
+      {
+        code: "PROJECT_SUBSCRIBER_ID_COLLISION",
+        message:
+          'Subscriber id "duplicate" is exported by "src/subscribers/a.ts", "src/subscribers/b.ts".',
+        severity: "error",
+        sourcePaths: ["src/subscribers/a.ts", "src/subscribers/b.ts"],
+        subscriberId: "duplicate",
+      },
+    ])
+  })
+
+  it("preserves scanner diagnostics for path-derived ID collisions", async () => {
+    const root = await projectFixture({
+      "src/links/booking-person.ts": [
+        'import { defineLink } from "@voyant-travel/core"',
+        "export default defineLink({}, {})",
+      ].join("\n"),
+      "src/links/booking_person.ts": [
+        'import { defineLink } from "@voyant-travel/core"',
+        "export default defineLink({}, {})",
+      ].join("\n"),
+    })
+
+    const analysis = await analyzeProjectSubscriberLinkConventions({ projectRoot: root })
+
+    expect(analysis.diagnostics).toContainEqual({
+      code: "PROJECT_CONVENTION_ID_COLLISION",
+      message:
+        'Convention ID "project.link.booking-person" is produced by "src/links/booking-person.ts", "src/links/booking_person.ts".',
+      severity: "error",
+      sourcePaths: ["src/links/booking-person.ts", "src/links/booking_person.ts"],
+    })
+  })
+
+  it("throws one typed compilation error with sorted diagnostics", async () => {
+    const root = await projectFixture({
+      "src/links/bad.ts": "export default {}\n",
+      "src/subscribers/bad.ts": "export default {}\n",
+    })
+
+    await expect(compileProjectSubscriberLinkConventions({ projectRoot: root })).rejects.toEqual(
+      expect.objectContaining({
+        name: "ProjectSubscriberLinkConventionError",
+        diagnostics: [
+          expect.objectContaining({ code: "PROJECT_LINK_INVALID_DEFINITION" }),
+          expect.objectContaining({ code: "PROJECT_SUBSCRIBER_INVALID_DESCRIPTOR" }),
+        ],
+      } satisfies Partial<ProjectSubscriberLinkConventionError>),
+    )
+  })
+})
+
+async function projectFixture(files: Readonly<Record<string, string>>): Promise<string> {
+  const root = await mkdtemp(path.join(process.cwd(), ".project-subscriber-link-test-"))
+  fixtureRoots.push(root)
+  await Promise.all(
+    Object.entries(files).map(async ([relativePath, contents]) => {
+      const filePath = path.join(root, ...relativePath.split("/"))
+      await mkdir(path.dirname(filePath), { recursive: true })
+      await writeFile(filePath, contents)
+    }),
+  )
+  return root
+}

--- a/packages/framework/src/project-subscriber-link-conventions.ts
+++ b/packages/framework/src/project-subscriber-link-conventions.ts
@@ -1,0 +1,507 @@
+import { readFile, realpath } from "node:fs/promises"
+import path from "node:path"
+import ts from "typescript"
+
+import {
+  hasModifier,
+  inspectModuleSpecifiers,
+  isInside,
+  isPathImport,
+  resolveInsideProject,
+} from "./project-convention-compiler-utils.js"
+import {
+  isDurableExpression,
+  resolveExpression,
+  stringProperty,
+  unwrapExpression,
+} from "./project-convention-static-data.js"
+import {
+  discoverProjectConventions,
+  type ProjectConventionFileContribution,
+} from "./project-conventions.js"
+
+export const PROJECT_SUBSCRIBERS_GENERATED_PATH = "runtime/project-subscribers.generated.ts"
+export const PROJECT_LINKS_GENERATED_PATH = "runtime/project-links.generated.ts"
+
+export const PROJECT_SUBSCRIBER_LINK_DIAGNOSTIC_CODES = {
+  PROJECT_CONVENTION_ID_COLLISION: "Convention files must have unique path-derived identifiers.",
+  PROJECT_CONVENTION_IMPORT_ESCAPE: "Convention file imports cannot escape the project root.",
+  PROJECT_CONVENTION_MISSING_DEFAULT_EXPORT: "Convention files must have one default export.",
+  PROJECT_CONVENTION_MULTIPLE_DEFAULT_EXPORTS:
+    "Convention files cannot have more than one default export.",
+  PROJECT_CONVENTION_UNSUPPORTED_EXPORT: "Convention files cannot have named runtime exports.",
+  PROJECT_LINK_INVALID_DEFINITION:
+    "Link files must default-export a definition created by the imported defineLink helper.",
+  PROJECT_SUBSCRIBER_ID_COLLISION: "Subscriber descriptor ids must be unique.",
+  PROJECT_SUBSCRIBER_INVALID_DESCRIPTOR:
+    "Subscriber files must default-export an EventFilterDescriptor object with literal id and eventType fields.",
+  PROJECT_SUBSCRIBER_NON_DURABLE_DESCRIPTOR:
+    "Subscriber descriptors must contain only durable, serializable data.",
+} as const
+
+export type ProjectSubscriberLinkDiagnosticCode =
+  keyof typeof PROJECT_SUBSCRIBER_LINK_DIAGNOSTIC_CODES
+
+export interface ProjectSubscriberLinkDiagnostic {
+  code: ProjectSubscriberLinkDiagnosticCode
+  severity: "error"
+  message: string
+  sourcePaths: readonly string[]
+  exportName?: string
+  subscriberId?: string
+}
+
+export type ProjectSubscriberLinkConventionDiagnostic = ProjectSubscriberLinkDiagnostic
+
+export interface ProjectSubscriberConvention extends ProjectConventionFileContribution {
+  kind: "subscriber"
+  subscriberId: string
+  eventType: string
+}
+
+export interface ProjectLinkConvention extends ProjectConventionFileContribution {
+  kind: "link"
+}
+
+export interface ProjectSubscriberLinkConventionAnalysis {
+  subscribers: readonly ProjectSubscriberConvention[]
+  links: readonly ProjectLinkConvention[]
+  diagnostics: readonly ProjectSubscriberLinkDiagnostic[]
+}
+
+export interface ProjectSubscriberLinkGeneratedFile {
+  path: typeof PROJECT_SUBSCRIBERS_GENERATED_PATH | typeof PROJECT_LINKS_GENERATED_PATH
+  contents: string
+}
+
+export interface ProjectSubscriberLinkConventionCompilation {
+  subscribers: readonly ProjectSubscriberConvention[]
+  links: readonly ProjectLinkConvention[]
+  generatedFiles: readonly [ProjectSubscriberLinkGeneratedFile, ProjectSubscriberLinkGeneratedFile]
+}
+
+export interface ProjectSubscriberLinkConventionsOptions {
+  projectRoot: string
+}
+
+export class ProjectSubscriberLinkConventionError extends Error {
+  readonly diagnostics: readonly ProjectSubscriberLinkDiagnostic[]
+
+  constructor(diagnostics: readonly ProjectSubscriberLinkDiagnostic[]) {
+    super(diagnostics.map((diagnostic) => diagnostic.message).join("\n"))
+    this.name = "ProjectSubscriberLinkConventionError"
+    this.diagnostics = diagnostics
+  }
+}
+
+export async function analyzeProjectSubscriberLinkConventions(
+  options: ProjectSubscriberLinkConventionsOptions,
+): Promise<ProjectSubscriberLinkConventionAnalysis> {
+  const projectRoot = path.resolve(options.projectRoot)
+  const realProjectRoot = await realpath(projectRoot)
+  const discovery = await discoverProjectConventions(projectRoot)
+  const subscribers: ProjectSubscriberConvention[] = []
+  const links: ProjectLinkConvention[] = []
+  const diagnostics: ProjectSubscriberLinkDiagnostic[] = []
+  const contributions = discovery.contributions.filter(
+    (contribution): contribution is ProjectConventionFileContribution =>
+      contribution.kind === "subscriber" || contribution.kind === "link",
+  )
+  const contributionPaths = new Set(contributions.map(({ sourcePath }) => sourcePath))
+  diagnostics.push(
+    ...discovery.diagnostics
+      .filter(
+        (diagnostic) =>
+          diagnostic.code === "PROJECT_CONVENTION_ID_COLLISION" &&
+          diagnostic.sourcePaths.some((sourcePath) => contributionPaths.has(sourcePath)),
+      )
+      .map((diagnostic) => ({
+        code: "PROJECT_CONVENTION_ID_COLLISION" as const,
+        severity: "error" as const,
+        sourcePaths: diagnostic.sourcePaths,
+        message: diagnostic.message,
+      })),
+  )
+
+  for (const contribution of contributions) {
+    const sourceFilePath = resolveInsideProject(projectRoot, contribution.sourcePath)
+    const realSourceFilePath = await realpath(sourceFilePath)
+    if (!isInside(realProjectRoot, realSourceFilePath)) {
+      diagnostics.push(importEscapeDiagnostic(contribution.sourcePath, contribution.sourcePath))
+      continue
+    }
+
+    const sourceFile = ts.createSourceFile(
+      realSourceFilePath,
+      await readFile(realSourceFilePath, "utf8"),
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TS,
+    )
+    const common = analyzeConventionModule(sourceFile, contribution.sourcePath, projectRoot)
+    diagnostics.push(...common.diagnostics)
+    if (!common.defaultExport) continue
+
+    if (contribution.kind === "subscriber") {
+      const subscriber = analyzeSubscriber(contribution, common.defaultExport, common.constants)
+      diagnostics.push(...subscriber.diagnostics)
+      if (subscriber.value) subscribers.push(subscriber.value)
+    } else {
+      const linkDiagnostic = analyzeLink(
+        contribution.sourcePath,
+        common.defaultExport,
+        common.constants,
+        common.defineLinkImports,
+      )
+      if (linkDiagnostic) diagnostics.push(linkDiagnostic)
+      else links.push(contribution as ProjectLinkConvention)
+    }
+  }
+
+  diagnostics.push(...findSubscriberIdCollisions(subscribers))
+  subscribers.sort(compareConventions)
+  links.sort(compareConventions)
+  diagnostics.sort(compareDiagnostics)
+  return { subscribers, links, diagnostics }
+}
+
+export async function compileProjectSubscriberLinkConventions(
+  options: ProjectSubscriberLinkConventionsOptions,
+): Promise<ProjectSubscriberLinkConventionCompilation> {
+  const analysis = await analyzeProjectSubscriberLinkConventions(options)
+  if (analysis.diagnostics.length > 0) {
+    throw new ProjectSubscriberLinkConventionError(analysis.diagnostics)
+  }
+
+  return {
+    subscribers: analysis.subscribers,
+    links: analysis.links,
+    generatedFiles: [
+      {
+        path: PROJECT_SUBSCRIBERS_GENERATED_PATH,
+        contents: generateProjectSubscribersSource(analysis.subscribers),
+      },
+      {
+        path: PROJECT_LINKS_GENERATED_PATH,
+        contents: generateProjectLinksSource(analysis.links),
+      },
+    ],
+  }
+}
+
+export function generateProjectSubscribersSource(
+  subscribers: readonly ProjectSubscriberConvention[],
+): string {
+  const ordered = [...subscribers].sort(compareConventions)
+  return generatedCollectionSource(
+    ordered,
+    "EventFilterDescriptor",
+    "projectSubscribers",
+    "subscriber",
+  )
+}
+
+export function generateProjectLinksSource(links: readonly ProjectLinkConvention[]): string {
+  const ordered = [...links].sort(compareConventions)
+  return generatedCollectionSource(ordered, "LinkDefinition", "projectLinks", "link")
+}
+
+interface ModuleAnalysis {
+  defaultExport?: ts.Expression
+  constants: ReadonlyMap<string, ts.Expression>
+  defineLinkImports: ReadonlySet<string>
+  diagnostics: ProjectSubscriberLinkDiagnostic[]
+}
+
+function analyzeConventionModule(
+  sourceFile: ts.SourceFile,
+  sourcePath: string,
+  projectRoot: string,
+): ModuleAnalysis {
+  const constants = new Map<string, ts.Expression>()
+  const defineLinkImports = new Set<string>()
+  const defaultExports: ts.Expression[] = []
+  const diagnostics: ProjectSubscriberLinkDiagnostic[] = []
+
+  inspectModuleSpecifiers(sourceFile, (specifier) => {
+    if (!isPathImport(specifier)) return
+    if (specifier.startsWith("file:")) {
+      diagnostics.push(importEscapeDiagnostic(sourcePath, specifier))
+      return
+    }
+    const resolved = path.resolve(path.dirname(sourceFile.fileName), specifier)
+    if (!isInside(projectRoot, resolved))
+      diagnostics.push(importEscapeDiagnostic(sourcePath, specifier))
+  })
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      recordDefineLinkImports(statement, defineLinkImports)
+      continue
+    }
+    if (ts.isExportAssignment(statement) && !statement.isExportEquals) {
+      defaultExports.push(statement.expression)
+      continue
+    }
+    if (ts.isExportDeclaration(statement)) {
+      if (!statement.exportClause) {
+        if (!statement.isTypeOnly) diagnostics.push(unsupportedExportDiagnostic(sourcePath, "*"))
+        continue
+      }
+      if (!ts.isNamedExports(statement.exportClause)) continue
+      for (const element of statement.exportClause.elements) {
+        if (statement.isTypeOnly || element.isTypeOnly) continue
+        diagnostics.push(unsupportedExportDiagnostic(sourcePath, element.name.text))
+      }
+      continue
+    }
+    if (ts.isVariableStatement(statement)) {
+      const exported = hasModifier(statement, ts.SyntaxKind.ExportKeyword)
+      for (const declaration of statement.declarationList.declarations) {
+        if (ts.isIdentifier(declaration.name) && declaration.initializer) {
+          constants.set(declaration.name.text, declaration.initializer)
+        }
+        if (exported)
+          for (const exportName of bindingNames(declaration.name))
+            diagnostics.push(unsupportedExportDiagnostic(sourcePath, exportName))
+      }
+      continue
+    }
+    if (!hasModifier(statement, ts.SyntaxKind.ExportKeyword)) continue
+    if (hasModifier(statement, ts.SyntaxKind.DefaultKeyword)) {
+      diagnostics.push(invalidDefaultExportDiagnostic(sourcePath))
+      continue
+    }
+    if (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) continue
+    const name = "name" in statement && statement.name ? statement.name.text : "(anonymous)"
+    diagnostics.push(unsupportedExportDiagnostic(sourcePath, name))
+  }
+
+  if (defaultExports.length === 0) diagnostics.push(missingDefaultExportDiagnostic(sourcePath))
+  if (defaultExports.length > 1) diagnostics.push(multipleDefaultExportsDiagnostic(sourcePath))
+  return { defaultExport: defaultExports[0], constants, defineLinkImports, diagnostics }
+}
+
+function bindingNames(name: ts.BindingName): string[] {
+  if (ts.isIdentifier(name)) return [name.text]
+  return name.elements.flatMap((element) =>
+    ts.isOmittedExpression(element) ? [] : bindingNames(element.name),
+  )
+}
+
+function analyzeSubscriber(
+  contribution: ProjectConventionFileContribution,
+  expression: ts.Expression,
+  constants: ReadonlyMap<string, ts.Expression>,
+): { value?: ProjectSubscriberConvention; diagnostics: ProjectSubscriberLinkDiagnostic[] } {
+  const resolved = resolveExpression(expression, constants)
+  if (!ts.isObjectLiteralExpression(resolved)) {
+    return { diagnostics: [invalidSubscriberDiagnostic(contribution.sourcePath)] }
+  }
+  const subscriberId = stringProperty(resolved, "id", constants)
+  const eventType = stringProperty(resolved, "eventType", constants)
+  if (!subscriberId || !eventType) {
+    return { diagnostics: [invalidSubscriberDiagnostic(contribution.sourcePath)] }
+  }
+  if (!isDurableExpression(resolved, constants)) {
+    return { diagnostics: [nonDurableSubscriberDiagnostic(contribution.sourcePath, subscriberId)] }
+  }
+  return {
+    value: { ...contribution, kind: "subscriber", subscriberId, eventType },
+    diagnostics: [],
+  }
+}
+
+function analyzeLink(
+  sourcePath: string,
+  expression: ts.Expression,
+  constants: ReadonlyMap<string, ts.Expression>,
+  defineLinkImports: ReadonlySet<string>,
+): ProjectSubscriberLinkDiagnostic | undefined {
+  const resolved = unwrapExpression(resolveExpression(expression, constants))
+  if (
+    !ts.isCallExpression(resolved) ||
+    !ts.isIdentifier(resolved.expression) ||
+    !defineLinkImports.has(resolved.expression.text) ||
+    resolved.arguments.length < 2 ||
+    resolved.arguments.length > 3
+  ) {
+    return invalidLinkDiagnostic(sourcePath)
+  }
+  return undefined
+}
+
+function recordDefineLinkImports(declaration: ts.ImportDeclaration, imports: Set<string>): void {
+  if (!ts.isStringLiteralLike(declaration.moduleSpecifier)) return
+  if (declaration.importClause?.isTypeOnly) return
+  if (
+    declaration.moduleSpecifier.text !== "@voyant-travel/core" &&
+    declaration.moduleSpecifier.text !== "@voyant-travel/core/links"
+  )
+    return
+  for (const element of declaration.importClause?.namedBindings &&
+  ts.isNamedImports(declaration.importClause.namedBindings)
+    ? declaration.importClause.namedBindings.elements
+    : []) {
+    if ((element.propertyName?.text ?? element.name.text) === "defineLink" && !element.isTypeOnly) {
+      imports.add(element.name.text)
+    }
+  }
+}
+
+function findSubscriberIdCollisions(
+  subscribers: readonly ProjectSubscriberConvention[],
+): ProjectSubscriberLinkDiagnostic[] {
+  const byId = new Map<string, ProjectSubscriberConvention[]>()
+  for (const subscriber of subscribers) {
+    const matches = byId.get(subscriber.subscriberId)
+    if (matches) matches.push(subscriber)
+    else byId.set(subscriber.subscriberId, [subscriber])
+  }
+  return [...byId]
+    .filter(([, matches]) => matches.length > 1)
+    .map(([subscriberId, matches]) => {
+      const sourcePaths = matches.map(({ sourcePath }) => sourcePath).sort(compareStrings)
+      return {
+        code: "PROJECT_SUBSCRIBER_ID_COLLISION",
+        severity: "error",
+        subscriberId,
+        sourcePaths,
+        message: `Subscriber id "${subscriberId}" is exported by ${formatSources(sourcePaths)}.`,
+      }
+    })
+}
+
+function generatedCollectionSource(
+  contributions: readonly ProjectConventionFileContribution[],
+  typeName: "EventFilterDescriptor" | "LinkDefinition",
+  exportName: "projectSubscribers" | "projectLinks",
+  importName: "subscriber" | "link",
+): string {
+  return [
+    `import type { ${typeName} } from "@voyant-travel/core"`,
+    ...contributions.map(
+      ({ sourcePath }, index) =>
+        `import ${importName}${index} from ${JSON.stringify(generatedImportSpecifier(sourcePath))}`,
+    ),
+    "",
+    `export const ${exportName} = [${contributions.map((_, index) => `${importName}${index}`).join(", ")}] as const satisfies readonly ${typeName}[]`,
+    "",
+  ].join("\n")
+}
+
+function generatedImportSpecifier(sourcePath: string): string {
+  return `../../${sourcePath.replace(/\.ts$/, ".js")}`
+}
+
+function importEscapeDiagnostic(
+  sourcePath: string,
+  specifier: string,
+): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_CONVENTION_IMPORT_ESCAPE",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    message: `Convention file "${sourcePath}" import "${specifier}" escapes the project root.`,
+  }
+}
+
+function missingDefaultExportDiagnostic(sourcePath: string): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_CONVENTION_MISSING_DEFAULT_EXPORT",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    exportName: "default",
+    message: `Convention file "${sourcePath}" must have a default export.`,
+  }
+}
+
+function multipleDefaultExportsDiagnostic(sourcePath: string): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_CONVENTION_MULTIPLE_DEFAULT_EXPORTS",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    exportName: "default",
+    message: `Convention file "${sourcePath}" has more than one default export.`,
+  }
+}
+
+function invalidDefaultExportDiagnostic(sourcePath: string): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_CONVENTION_MISSING_DEFAULT_EXPORT",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    exportName: "default",
+    message: `Convention file "${sourcePath}" must default-export an expression.`,
+  }
+}
+
+function unsupportedExportDiagnostic(
+  sourcePath: string,
+  exportName: string,
+): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_CONVENTION_UNSUPPORTED_EXPORT",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    exportName,
+    message: `Convention file "${sourcePath}" has unsupported runtime export "${exportName}".`,
+  }
+}
+
+function invalidSubscriberDiagnostic(sourcePath: string): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_SUBSCRIBER_INVALID_DESCRIPTOR",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    message: `Subscriber file "${sourcePath}" must default-export an object with non-empty literal "id" and "eventType" fields.`,
+  }
+}
+
+function nonDurableSubscriberDiagnostic(
+  sourcePath: string,
+  subscriberId: string,
+): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_SUBSCRIBER_NON_DURABLE_DESCRIPTOR",
+    severity: "error",
+    subscriberId,
+    sourcePaths: [sourcePath],
+    message: `Subscriber "${subscriberId}" in "${sourcePath}" must contain only literal, serializable data.`,
+  }
+}
+
+function invalidLinkDiagnostic(sourcePath: string): ProjectSubscriberLinkDiagnostic {
+  return {
+    code: "PROJECT_LINK_INVALID_DEFINITION",
+    severity: "error",
+    sourcePaths: [sourcePath],
+    message: `Link file "${sourcePath}" must default-export defineLink(left, right, options?).`,
+  }
+}
+
+function compareConventions(
+  left: ProjectConventionFileContribution,
+  right: ProjectConventionFileContribution,
+): number {
+  return compareStrings(left.sourcePath, right.sourcePath) || compareStrings(left.id, right.id)
+}
+
+function compareDiagnostics(
+  left: ProjectSubscriberLinkDiagnostic,
+  right: ProjectSubscriberLinkDiagnostic,
+): number {
+  return (
+    compareStrings(left.code, right.code) ||
+    compareStrings(left.sourcePaths.join("\0"), right.sourcePaths.join("\0")) ||
+    compareStrings(left.exportName ?? "", right.exportName ?? "")
+  )
+}
+
+function compareStrings(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}
+
+function formatSources(sourcePaths: readonly string[]): string {
+  return sourcePaths.map((sourcePath) => `"${sourcePath}"`).join(", ")
+}

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -59,6 +59,16 @@ export type {
   VoyantProjectSetupMigration,
 } from "./project-resolver.js"
 export type {
+  ProjectLinkConvention,
+  ProjectSubscriberConvention,
+  ProjectSubscriberLinkConventionAnalysis,
+  ProjectSubscriberLinkConventionCompilation,
+  ProjectSubscriberLinkConventionDiagnostic,
+  ProjectSubscriberLinkConventionsOptions,
+  ProjectSubscriberLinkDiagnosticCode,
+  ProjectSubscriberLinkGeneratedFile,
+} from "./project-subscriber-link-conventions.js"
+export type {
   ProjectJobConvention,
   ProjectWorkflowConvention,
   ProjectWorkflowJobConventionAnalysis,
@@ -135,6 +145,24 @@ export async function compileProjectWorkflowJobConventions(
 > {
   const conventions = await import("./project-workflow-job-conventions.js")
   return conventions.compileProjectWorkflowJobConventions(options)
+}
+
+export async function analyzeProjectSubscriberLinkConventions(
+  options: import("./project-subscriber-link-conventions.js").ProjectSubscriberLinkConventionsOptions,
+): Promise<
+  import("./project-subscriber-link-conventions.js").ProjectSubscriberLinkConventionAnalysis
+> {
+  const conventions = await import("./project-subscriber-link-conventions.js")
+  return conventions.analyzeProjectSubscriberLinkConventions(options)
+}
+
+export async function compileProjectSubscriberLinkConventions(
+  options: import("./project-subscriber-link-conventions.js").ProjectSubscriberLinkConventionsOptions,
+): Promise<
+  import("./project-subscriber-link-conventions.js").ProjectSubscriberLinkConventionCompilation
+> {
+  const conventions = await import("./project-subscriber-link-conventions.js")
+  return conventions.compileProjectSubscriberLinkConventions(options)
 }
 
 export async function executeNodeMigrationPlan(


### PR DESCRIPTION
## Summary
- statically validate durable project subscriber descriptors and link declarations
- emit deterministic generated runtime registries without evaluating project source
- share confined-source and durable-data AST helpers across convention compilers

## Verification
- `pnpm --filter @voyant-travel/framework test` (268 passed)
- repository pre-push suite (101 tasks passed)
- framework typecheck passed in the implementation worktree
- Biome changed-file checks passed
