### PR TITLE
feat(framework): activate project subscribers and links

### DIFF
--- a/.changeset/activate-project-subscriber-links.md
+++ b/.changeset/activate-project-subscriber-links.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Resolve project subscribers and links into graph facets and explicit generated runtime artifacts.

--- a/docs/architecture/custom-modules.md
+++ b/docs/architecture/custom-modules.md
@@ -208,6 +208,14 @@ and duplicate subscriber IDs, then emits deterministic static imports in
 these directories are not convention entries. Runtime directory scanning is
 not part of this contract.
 
+`resolveProject()` adds both generated files to the disposable artifact set.
+Subscribers must include a complete durable `manifest` whose `id` and
+`eventType` match the descriptor and whose `payloadHash` and
+`targetWorkflowId` are non-empty. Each subscriber becomes a graph runtime
+reference; each link becomes a path-owned graph facet. This makes missing
+workflow targets and duplicate graph identities resolver errors instead of
+runtime surprises.
+
 ## Custom routes on an *existing* module (extensions)
 
 A `HonoExtension` adds routes to an **existing** module's surface (e.g. a

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -897,8 +897,11 @@ Application-local `src/subscribers` and `src/links` contributions are compiled
 with the TypeScript AST. Subscriber files default-export durable
 `EventFilterDescriptor` data, while link files default-export `defineLink`
 definitions. The compiler emits deterministic static TypeScript imports under
-`.voyant/runtime`; it does not import application source, mutate runtime wiring,
-or defer discovery to application startup.
+`.voyant/runtime`; it does not import application source or defer discovery to
+application startup. `resolveProject()` promotes complete subscriber manifests
+to graph subscriber facets with named runtime references and promotes links to
+path-owned graph facets while retaining the generated link collection for
+migration/query consumers.
 
 The broader event catalog is beyond the foundational substrate:
 

--- a/packages/framework/src/project-convention-static-data.ts
+++ b/packages/framework/src/project-convention-static-data.ts
@@ -1,4 +1,58 @@
+import type { VoyantGraphJsonValue } from "@voyant-travel/core/project"
 import ts from "typescript"
+
+export function durableJsonValue(
+  expression: ts.Expression,
+  constants: ReadonlyMap<string, ts.Expression>,
+  seen: ReadonlySet<string> = new Set(),
+): VoyantGraphJsonValue | undefined {
+  const value = unwrapExpression(expression)
+  if (ts.isIdentifier(value)) {
+    if (value.text === "undefined" || seen.has(value.text)) return undefined
+    const initializer = constants.get(value.text)
+    if (!initializer) return undefined
+    return durableJsonValue(initializer, constants, new Set([...seen, value.text]))
+  }
+  if (ts.isStringLiteralLike(value)) return value.text
+  if (ts.isNumericLiteral(value)) return Number(value.text)
+  if (value.kind === ts.SyntaxKind.TrueKeyword) return true
+  if (value.kind === ts.SyntaxKind.FalseKeyword) return false
+  if (value.kind === ts.SyntaxKind.NullKeyword) return null
+  if (
+    ts.isPrefixUnaryExpression(value) &&
+    value.operator === ts.SyntaxKind.MinusToken &&
+    ts.isNumericLiteral(value.operand)
+  ) {
+    return -Number(value.operand.text)
+  }
+  if (ts.isArrayLiteralExpression(value)) {
+    const items: VoyantGraphJsonValue[] = []
+    for (const element of value.elements) {
+      if (ts.isSpreadElement(element)) return undefined
+      const item = durableJsonValue(element, constants, seen)
+      if (item === undefined) return undefined
+      items.push(item)
+    }
+    return items
+  }
+  if (!ts.isObjectLiteralExpression(value)) return undefined
+  const object: Record<string, VoyantGraphJsonValue> = {}
+  for (const property of value.properties) {
+    if (ts.isPropertyAssignment(property)) {
+      const name = propertyName(property.name)
+      const item = durableJsonValue(property.initializer, constants, seen)
+      if (!name || item === undefined) return undefined
+      object[name] = item
+    } else if (ts.isShorthandPropertyAssignment(property)) {
+      const item = durableJsonValue(property.name, constants, seen)
+      if (item === undefined) return undefined
+      object[property.name.text] = item
+    } else {
+      return undefined
+    }
+  }
+  return object
+}
 
 export function isDurableExpression(
   expression: ts.Expression,

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -34,6 +34,12 @@ import {
   type ProjectConventionFileContribution,
 } from "./project-conventions.js"
 import {
+  compileProjectSubscriberLinkConventions,
+  PROJECT_LINKS_GENERATED_PATH,
+  PROJECT_SUBSCRIBERS_GENERATED_PATH,
+  type ProjectSubscriberLinkConventionCompilation,
+} from "./project-subscriber-link-conventions.js"
+import {
   compileProjectWorkflowJobConventions,
   PROJECT_JOBS_GENERATED_PATH,
   PROJECT_WORKFLOWS_GENERATED_PATH,
@@ -141,19 +147,27 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
   assertPathInside(projectRoot, configPath, "configPath")
   const conventions = await discoverProjectConventions({ projectRoot })
   assertProjectConventionDiagnostics(conventions)
-  const [projectApi, projectAdmin, projectWorkflowJobs] = await Promise.all([
-    compileProjectApiConventions({ projectRoot }),
-    compileProjectAdminConventions({
-      projectRoot,
-      contributions: conventions.contributions,
-    }),
-    compileProjectWorkflowJobConventions({ projectRoot }),
-  ])
+  const [projectApi, projectAdmin, projectWorkflowJobs, projectSubscriberLinks] = await Promise.all(
+    [
+      compileProjectApiConventions({ projectRoot }),
+      compileProjectAdminConventions({
+        projectRoot,
+        contributions: conventions.contributions,
+      }),
+      compileProjectWorkflowJobConventions({ projectRoot }),
+      compileProjectSubscriberLinkConventions({ projectRoot }),
+    ],
+  )
 
   const materialized = await materializeProjectSelections(project, projectRoot)
   await materializeProjectModuleConventions(materialized, conventions, projectRoot)
   await materializeProjectApiConventions(materialized, projectApi, projectRoot)
   await materializeProjectWorkflowJobConventions(materialized, projectWorkflowJobs, projectRoot)
+  await materializeProjectSubscriberLinkConventions(
+    materialized,
+    projectSubscriberLinks,
+    projectRoot,
+  )
   const providers = { ...(project.deployment?.providers ?? {}) }
   const mode = project.deployment?.mode
   const frameworkVersion = await readFrameworkVersion()
@@ -191,6 +205,7 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
     projectApi.generatedFile,
     projectAdmin.file,
     ...projectWorkflowJobs.generatedFiles,
+    ...projectSubscriberLinks.generatedFiles,
     {
       path: runtimeEntry,
       contents: buildProjectRuntimeModule({
@@ -217,6 +232,33 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
       files: files.sort((left, right) => left.path.localeCompare(right.path)),
       migrationPlan,
     },
+  }
+}
+
+async function materializeProjectSubscriberLinkConventions(
+  materialized: MaterializedProject,
+  compilation: ProjectSubscriberLinkConventionCompilation,
+  projectRoot: string,
+): Promise<void> {
+  if (compilation.graphSubscribers.length === 0 && compilation.graphLinks.length === 0) return
+  const packageName = await admitProjectSourcePackage(materialized, projectRoot)
+  materialized.project = {
+    ...materialized.project,
+    modules: [
+      ...materialized.project.modules,
+      {
+        schemaVersion: "voyant.module.v1",
+        id: graphIdForSelection(packageName, `${packageName}#project-subscribers-links`),
+        packageName,
+        localId: "project-subscribers-links",
+        subscribers: compilation.graphSubscribers,
+        links: compilation.graphLinks,
+        meta: {
+          source: "project-convention",
+          generatedPaths: [PROJECT_SUBSCRIBERS_GENERATED_PATH, PROJECT_LINKS_GENERATED_PATH],
+        },
+      },
+    ],
   }
 }
 
@@ -714,6 +756,7 @@ function isGeneratedProjectRuntimeEntry(entry: string): boolean {
     PROJECT_API_GENERATED_PATH,
     PROJECT_WORKFLOWS_GENERATED_PATH,
     PROJECT_JOBS_GENERATED_PATH,
+    PROJECT_SUBSCRIBERS_GENERATED_PATH,
   ].some((generatedPath) => entry === `./.voyant/${generatedPath}`)
 }
 

--- a/packages/framework/src/project-subscriber-link-conventions.test.ts
+++ b/packages/framework/src/project-subscriber-link-conventions.test.ts
@@ -29,7 +29,7 @@ describe("project subscriber and link conventions", () => {
         "export default manifest",
       ].join("\n"),
       "src/subscribers/alpha/created.ts":
-        'export default { id: "filter.alpha", eventType: "person.created" }\n',
+        'export default { id: "filter.alpha", eventType: "person.created", manifest: { id: "filter.alpha", eventType: "person.created", payloadHash: "def", targetWorkflowId: "workflow.alpha" } }\n',
       "src/links/zeta.ts": [
         'import { defineLink as link } from "@voyant-travel/core/links"',
         'import { left, right } from "../linkables.js"',
@@ -48,18 +48,20 @@ describe("project subscriber and link conventions", () => {
     const second = await compileProjectSubscriberLinkConventions({ projectRoot: root })
 
     expect(first).toEqual(second)
-    expect(first.subscribers).toEqual([
+    expect(
+      first.subscribers.map(({ subscriberId, eventType, sourcePath }) => ({
+        subscriberId,
+        eventType,
+        sourcePath,
+      })),
+    ).toEqual([
       {
         eventType: "person.created",
-        id: "project.subscriber.alpha.created",
-        kind: "subscriber",
         sourcePath: "src/subscribers/alpha/created.ts",
         subscriberId: "filter.alpha",
       },
       {
         eventType: "booking.created",
-        id: "project.subscriber.zeta",
-        kind: "subscriber",
         sourcePath: "src/subscribers/zeta.ts",
         subscriberId: "filter.zeta",
       },
@@ -76,6 +78,9 @@ describe("project subscriber and link conventions", () => {
           'import subscriber0 from "../../src/subscribers/alpha/created.js"',
           'import subscriber1 from "../../src/subscribers/zeta.js"',
           "",
+          "export { subscriber0 as projectSubscriber0 }",
+          "export { subscriber1 as projectSubscriber1 }",
+          "",
           "export const projectSubscribers = [subscriber0, subscriber1] as const satisfies readonly EventFilterDescriptor[]",
           "",
         ].join("\n"),
@@ -87,10 +92,39 @@ describe("project subscriber and link conventions", () => {
           'import link0 from "../../src/links/alpha.js"',
           'import link1 from "../../src/links/zeta.js"',
           "",
+          "export { link0 as projectLink0 }",
+          "export { link1 as projectLink1 }",
+          "",
           "export const projectLinks = [link0, link1] as const satisfies readonly LinkDefinition[]",
           "",
         ].join("\n"),
       },
+    ])
+    expect(first.graphSubscribers).toEqual([
+      expect.objectContaining({
+        id: "filter.alpha",
+        eventType: "person.created",
+        eventFilterId: "filter.alpha",
+        workflowId: "workflow.alpha",
+        runtime: {
+          entry: "./.voyant/runtime/project-subscribers.generated.ts",
+          export: "projectSubscriber0",
+        },
+      }),
+      expect.objectContaining({
+        id: "filter.zeta",
+        eventType: "booking.created",
+        eventFilterId: "filter.zeta",
+        workflowId: "workflow.zeta",
+        runtime: {
+          entry: "./.voyant/runtime/project-subscribers.generated.ts",
+          export: "projectSubscriber1",
+        },
+      }),
+    ])
+    expect(first.graphLinks).toEqual([
+      { id: "project.link.alpha", source: "src/links/alpha.ts" },
+      { id: "project.link.zeta", source: "src/links/zeta.ts" },
     ])
   })
 
@@ -101,9 +135,9 @@ describe("project subscriber and link conventions", () => {
       "src/subscribers/function.ts":
         'export default { id: "function-filter", eventType: "x", input: () => true }\n',
       "src/subscribers/literals.ts":
-        'const id = "literal-filter"; const eventType = "x"; export default { id, eventType }\n',
+        'const id = "literal-filter"; const eventType = "x"; export default { id, eventType, manifest: { id, eventType, payloadHash: "a", targetWorkflowId: "target" } }\n',
       "src/subscribers/named-destructuring.ts":
-        'export const { named } = { named: true }; export default { id: "named", eventType: "x" }\n',
+        'export const { named } = { named: true }; export default { id: "named", eventType: "x", manifest: { id: "named", eventType: "x", payloadHash: "a", targetWorkflowId: "target" } }\n',
       "src/links/plain.ts": "export default { tableName: 'plain' }\n",
       "src/links/wrong-helper.ts": [
         'import { defineLink } from "./helper.js"',
@@ -156,9 +190,10 @@ describe("project subscriber and link conventions", () => {
     const root = await projectFixture({
       "src/subscribers/a.ts": [
         'import "../../../outside.js"',
-        'export default { id: "duplicate", eventType: "a" }',
+        'export default { id: "duplicate", eventType: "a", manifest: { id: "duplicate", eventType: "a", payloadHash: "a", targetWorkflowId: "target" } }',
       ].join("\n"),
-      "src/subscribers/b.ts": 'export default { id: "duplicate", eventType: "b" }\n',
+      "src/subscribers/b.ts":
+        'export default { id: "duplicate", eventType: "b", manifest: { id: "duplicate", eventType: "b", payloadHash: "b", targetWorkflowId: "target" } }\n',
       "src/links/escaped.ts": [
         'import { defineLink } from "@voyant-travel/core"',
         'import left from "file:///tmp/left.js"',

--- a/packages/framework/src/project-subscriber-link-conventions.ts
+++ b/packages/framework/src/project-subscriber-link-conventions.ts
@@ -1,5 +1,10 @@
 import { readFile, realpath } from "node:fs/promises"
 import path from "node:path"
+import type {
+  VoyantGraphFacetEntity,
+  VoyantGraphJsonObject,
+  VoyantGraphSubscriber,
+} from "@voyant-travel/core/project"
 import ts from "typescript"
 
 import {
@@ -10,6 +15,7 @@ import {
   resolveInsideProject,
 } from "./project-convention-compiler-utils.js"
 import {
+  durableJsonValue,
   isDurableExpression,
   resolveExpression,
   stringProperty,
@@ -35,6 +41,8 @@ export const PROJECT_SUBSCRIBER_LINK_DIAGNOSTIC_CODES = {
   PROJECT_SUBSCRIBER_ID_COLLISION: "Subscriber descriptor ids must be unique.",
   PROJECT_SUBSCRIBER_INVALID_DESCRIPTOR:
     "Subscriber files must default-export an EventFilterDescriptor object with literal id and eventType fields.",
+  PROJECT_SUBSCRIBER_MISSING_MANIFEST:
+    "Subscriber descriptors must include a complete durable event-filter manifest.",
   PROJECT_SUBSCRIBER_NON_DURABLE_DESCRIPTOR:
     "Subscriber descriptors must contain only durable, serializable data.",
 } as const
@@ -57,6 +65,8 @@ export interface ProjectSubscriberConvention extends ProjectConventionFileContri
   kind: "subscriber"
   subscriberId: string
   eventType: string
+  descriptor: VoyantGraphJsonObject
+  manifest: VoyantGraphJsonObject
 }
 
 export interface ProjectLinkConvention extends ProjectConventionFileContribution {
@@ -66,6 +76,8 @@ export interface ProjectLinkConvention extends ProjectConventionFileContribution
 export interface ProjectSubscriberLinkConventionAnalysis {
   subscribers: readonly ProjectSubscriberConvention[]
   links: readonly ProjectLinkConvention[]
+  graphSubscribers: readonly VoyantGraphSubscriber[]
+  graphLinks: readonly VoyantGraphFacetEntity[]
   diagnostics: readonly ProjectSubscriberLinkDiagnostic[]
 }
 
@@ -138,7 +150,7 @@ export async function analyzeProjectSubscriberLinkConventions(
       true,
       ts.ScriptKind.TS,
     )
-    const common = analyzeConventionModule(sourceFile, contribution.sourcePath, projectRoot)
+    const common = analyzeConventionModule(sourceFile, contribution.sourcePath, realProjectRoot)
     diagnostics.push(...common.diagnostics)
     if (!common.defaultExport) continue
 
@@ -176,6 +188,18 @@ export async function compileProjectSubscriberLinkConventions(
   return {
     subscribers: analysis.subscribers,
     links: analysis.links,
+    graphSubscribers: analysis.subscribers.map((subscriber, index) => ({
+      id: subscriber.subscriberId,
+      eventType: subscriber.eventType,
+      eventFilterId: subscriber.manifest.id as string,
+      workflowId: subscriber.manifest.targetWorkflowId as string,
+      filter: subscriber.descriptor,
+      runtime: {
+        entry: `./.voyant/${PROJECT_SUBSCRIBERS_GENERATED_PATH}`,
+        export: `projectSubscriber${index}`,
+      },
+    })),
+    graphLinks: analysis.links.map((link) => ({ id: link.id, source: link.sourcePath })),
     generatedFiles: [
       {
         path: PROJECT_SUBSCRIBERS_GENERATED_PATH,
@@ -306,8 +330,41 @@ function analyzeSubscriber(
   if (!isDurableExpression(resolved, constants)) {
     return { diagnostics: [nonDurableSubscriberDiagnostic(contribution.sourcePath, subscriberId)] }
   }
+  const descriptor = durableJsonValue(resolved, constants)
+  if (!isJsonObject(descriptor)) {
+    return { diagnostics: [nonDurableSubscriberDiagnostic(contribution.sourcePath, subscriberId)] }
+  }
+  const manifest = descriptor.manifest
+  if (
+    !isJsonObject(manifest) ||
+    manifest.id !== subscriberId ||
+    manifest.eventType !== eventType ||
+    typeof manifest.payloadHash !== "string" ||
+    manifest.payloadHash.length === 0 ||
+    typeof manifest.targetWorkflowId !== "string" ||
+    manifest.targetWorkflowId.length === 0
+  ) {
+    return {
+      diagnostics: [
+        {
+          code: "PROJECT_SUBSCRIBER_MISSING_MANIFEST",
+          severity: "error",
+          subscriberId,
+          sourcePaths: [contribution.sourcePath],
+          message: `Subscriber "${subscriberId}" in "${contribution.sourcePath}" must include a manifest with matching id/eventType, payloadHash, and targetWorkflowId.`,
+        },
+      ],
+    }
+  }
   return {
-    value: { ...contribution, kind: "subscriber", subscriberId, eventType },
+    value: {
+      ...contribution,
+      kind: "subscriber",
+      subscriberId,
+      eventType,
+      descriptor,
+      manifest,
+    },
     diagnostics: [],
   }
 }
@@ -385,9 +442,18 @@ function generatedCollectionSource(
         `import ${importName}${index} from ${JSON.stringify(generatedImportSpecifier(sourcePath))}`,
     ),
     "",
+    ...contributions.map(
+      (_, index) =>
+        `export { ${importName}${index} as project${importName[0]!.toUpperCase()}${importName.slice(1)}${index} }`,
+    ),
+    ...(contributions.length > 0 ? [""] : []),
     `export const ${exportName} = [${contributions.map((_, index) => `${importName}${index}`).join(", ")}] as const satisfies readonly ${typeName}[]`,
     "",
   ].join("\n")
+}
+
+function isJsonObject(value: unknown): value is VoyantGraphJsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function generatedImportSpecifier(sourcePath: string): string {

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -59,8 +59,10 @@ describe("framework project resolver", () => {
       "admin/project-admin.generated.ts",
       "runtime/project-api.generated.ts",
       "runtime/project-jobs.generated.ts",
+      "runtime/project-links.generated.ts",
       "runtime/project-migrations.generated.mjs",
       "runtime/project-runtime.generated.ts",
+      "runtime/project-subscribers.generated.ts",
       "runtime/project-workflows.generated.ts",
     ])
     const runtimeSource = first.artifacts.files.find(
@@ -589,7 +591,7 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
     expect(composed.modules.map((module) => module.module.name)).toEqual(["concierge"])
   })
 
-  it("compiles project API, admin, workflow, and job conventions into graph artifacts", async () => {
+  it("compiles every project source convention into graph artifacts", async () => {
     const root = projectRoot()
     writeFile(
       root,
@@ -607,6 +609,27 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
     )
     writeFile(
       root,
+      "src/subscribers/health-updated.ts",
+      [
+        "export default {",
+        '  id: "health.updated.sync",',
+        '  eventType: "health.updated",',
+        '  manifest: { id: "health.updated.sync", eventType: "health.updated", payloadHash: "hash", targetWorkflowId: "health.sync" },',
+        "}",
+      ].join("\n"),
+    )
+    writeFile(
+      root,
+      "src/links/health-owner.ts",
+      [
+        'import { defineLink } from "@voyant-travel/core"',
+        'import { left, right } from "../linkables.js"',
+        "export default defineLink(left, right)",
+      ].join("\n"),
+    )
+    writeFile(root, "src/linkables.ts", "export const left = {}; export const right = {}\n")
+    writeFile(
+      root,
       "src/jobs/cleanup.ts",
       [
         'export const schedule = { cron: "0 3 * * *", input: { source: "project" } }',
@@ -618,6 +641,9 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
     const projectApi = resolution.graph.modules.find(({ localId }) => localId === "project-api")
     const projectWorkflows = resolution.graph.modules.find(
       ({ localId }) => localId === "project-workflows",
+    )
+    const projectSubscriberLinks = resolution.graph.modules.find(
+      ({ localId }) => localId === "project-subscribers-links",
     )
 
     expect(projectApi).toMatchObject({
@@ -669,6 +695,27 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
         },
       ],
     })
+    expect(projectSubscriberLinks).toMatchObject({
+      id: "npm/fixture#project-subscribers-links",
+      subscribers: [
+        {
+          id: "health.updated.sync",
+          eventType: "health.updated",
+          eventFilterId: "health.updated.sync",
+          workflowId: "health.sync",
+          runtime: {
+            entry: "./.voyant/runtime/project-subscribers.generated.ts",
+            export: "projectSubscriber0",
+          },
+        },
+      ],
+      links: [
+        {
+          id: "project.link.health-owner",
+          source: "src/links/health-owner.ts",
+        },
+      ],
+    })
     expect(resolution.graph.provisioning.scheduledJobs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ cron: "0 * * * *", workflowId: "health.sync" }),
@@ -697,6 +744,15 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
         ?.contents,
     ).toContain("export const projectJobWorkflow0 = defineWorkflow({")
     expect(
+      resolution.artifacts.files.find(
+        ({ path }) => path === "runtime/project-subscribers.generated.ts",
+      )?.contents,
+    ).toContain("export { subscriber0 as projectSubscriber0 }")
+    expect(
+      resolution.artifacts.files.find(({ path }) => path === "runtime/project-links.generated.ts")
+        ?.contents,
+    ).toContain("export { link0 as projectLink0 }")
+    expect(
       resolution.artifacts.files.find(({ path }) => path === resolution.artifacts.runtimeEntry)
         ?.contents,
     ).toContain('"./project-api.generated.ts": () => import("./project-api.generated.ts")')
@@ -705,6 +761,12 @@ export default ${JSON.stringify(moduleManifest("@acme/cloud-only"))}
         ?.contents,
     ).toContain(
       '"./project-workflows.generated.ts": () => import("./project-workflows.generated.ts")',
+    )
+    expect(
+      resolution.artifacts.files.find(({ path }) => path === resolution.artifacts.runtimeEntry)
+        ?.contents,
+    ).toContain(
+      '"./project-subscribers.generated.ts": () => import("./project-subscribers.generated.ts")',
     )
   })
 


### PR DESCRIPTION
## Summary
- require complete durable event-filter manifests for project subscribers
- lower subscribers into graph facets with named generated runtime references
- lower project links into graph facets and emit explicit link collections for migration/query consumers

## Verification
- `pnpm --filter @voyant-travel/framework test` (268 passed)
- repository pre-push suite (101 tasks passed)
- Biome changed-file checks passed
- framework typecheck was stopped after five minutes due the known cold-worktree TypeScript performance pathology
