### PR TITLE
fix(framework): narrow convention AST nodes

### DIFF
--- a/packages/framework/src/project-api-conventions.ts
+++ b/packages/framework/src/project-api-conventions.ts
@@ -228,7 +228,9 @@ function analyzeRouteSource(
       }
       continue
     }
-    const name = "name" in statement && statement.name ? statement.name.text : "(anonymous)"
+    const declarationName = (statement as ts.NamedDeclaration).name
+    const name =
+      declarationName && ts.isIdentifier(declarationName) ? declarationName.text : "(anonymous)"
     recordExport(name, sourcePath, methods, diagnostics)
   }
 

--- a/packages/framework/src/project-convention-static-data.ts
+++ b/packages/framework/src/project-convention-static-data.ts
@@ -102,10 +102,13 @@ export function stringProperty(
       : ts.isShorthandPropertyAssignment(item) && item.name.text === name,
   )
   if (!property) return undefined
-  const value = resolveExpression(
-    ts.isPropertyAssignment(property) ? property.initializer : property.name,
-    constants,
-  )
+  const expression = ts.isPropertyAssignment(property)
+    ? property.initializer
+    : ts.isShorthandPropertyAssignment(property)
+      ? property.name
+      : undefined
+  if (!expression) return undefined
+  const value = resolveExpression(expression, constants)
   return ts.isStringLiteralLike(value) && value.text.length > 0 ? value.text : undefined
 }
 

--- a/packages/framework/src/project-subscriber-link-conventions.ts
+++ b/packages/framework/src/project-subscriber-link-conventions.ts
@@ -297,7 +297,9 @@ function analyzeConventionModule(
       continue
     }
     if (ts.isInterfaceDeclaration(statement) || ts.isTypeAliasDeclaration(statement)) continue
-    const name = "name" in statement && statement.name ? statement.name.text : "(anonymous)"
+    const declarationName = (statement as ts.NamedDeclaration).name
+    const name =
+      declarationName && ts.isIdentifier(declarationName) ? declarationName.text : "(anonymous)"
     diagnostics.push(unsupportedExportDiagnostic(sourcePath, name))
   }
 

--- a/packages/framework/src/project-workflow-job-conventions.ts
+++ b/packages/framework/src/project-workflow-job-conventions.ts
@@ -68,6 +68,9 @@ export interface ProjectJobConvention extends ProjectConventionFileContribution 
   schedule: VoyantGraphJsonValue
 }
 
+type DiscoveredWorkflowConvention = ProjectConventionFileContribution & { kind: "workflow" }
+type DiscoveredJobConvention = ProjectConventionFileContribution & { kind: "job" }
+
 export interface ProjectWorkflowJobConventionAnalysis {
   workflows: readonly ProjectWorkflowConvention[]
   jobs: readonly ProjectJobConvention[]
@@ -107,12 +110,11 @@ export async function analyzeProjectWorkflowJobConventions(
   const realProjectRoot = await realpath(projectRoot)
   const discovery = await discoverProjectConventions(projectRoot)
   const discoveredWorkflows = discovery.contributions.filter(
-    (contribution): contribution is ProjectConventionFileContribution =>
+    (contribution): contribution is DiscoveredWorkflowConvention =>
       contribution.kind === "workflow",
   )
   const discoveredJobs = discovery.contributions.filter(
-    (contribution): contribution is ProjectConventionFileContribution =>
-      contribution.kind === "job",
+    (contribution): contribution is DiscoveredJobConvention => contribution.kind === "job",
   )
   const workflows: ProjectWorkflowConvention[] = []
   const jobs: ProjectJobConvention[] = []
@@ -399,7 +401,10 @@ function collectRuntimeExports(sourceFile: ts.SourceFile): RuntimeExports {
       }
       continue
     }
-    named.push("name" in statement && statement.name ? statement.name.text : "(anonymous)")
+    const declarationName = (statement as ts.NamedDeclaration).name
+    named.push(
+      declarationName && ts.isIdentifier(declarationName) ? declarationName.text : "(anonymous)",
+    )
   }
   return { hasDefault, defaultExpression, named: [...new Set(named)].sort(compareStrings) }
 }


### PR DESCRIPTION
## Summary
- narrow exported declaration names before reading identifier text
- narrow workflow and job discovery contributions to their literal kinds
- avoid treating unsupported object properties as static expressions

## Verification
- focused convention tests (14 passed)
- repository pre-push suite (101 tasks passed)
- Biome checks passed
- local framework build enters the known cold-worktree TypeScript performance path; this PR directly addresses the exact CI diagnostics from #3180
