### PR TITLE
feat(workflows): inject workflow resolver at execution boundary

### DIFF
--- a/.changeset/explicit-workflow-resolver.md
+++ b/.changeset/explicit-workflow-resolver.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/workflows": minor
+"@voyant-travel/workflows-orchestrator": patch
+---
+
+Add an explicit workflow resolver dependency to step handlers and use an
+entry-scoped workflow registry for self-host execution.

--- a/.changeset/explicit-workflow-resolver.md
+++ b/.changeset/explicit-workflow-resolver.md
@@ -3,5 +3,5 @@
 "@voyant-travel/workflows-orchestrator": patch
 ---
 
-Add an explicit workflow resolver dependency to step handlers and use an
-entry-scoped workflow registry for self-host execution.
+Add an explicit workflow resolver dependency to step handlers and runtime
+drivers, and use an entry-scoped workflow registry for self-host execution.

--- a/docs/architecture/workflows-runtime-architecture.md
+++ b/docs/architecture/workflows-runtime-architecture.md
@@ -118,6 +118,13 @@ importing the bundle and before executing any workflow step. The bootstrap must
 be idempotent and process-local: it may cache clients/registries for the worker
 process, but it must not depend on request context or app middleware.
 
+Workflow execution resolves definitions through an explicit `WorkflowResolver`
+passed to the step handler. Runtime composition snapshots or constructs that
+resolver after loading the selected workflow bundle; step execution must not
+use the process-global authoring registry as its source of truth. The handler's
+global-registry fallback exists only for backward compatibility with direct SDK
+callers and is not the canonical runtime wiring.
+
 The operator starter uses this contract to wire channel-push workflow deps from
 `DATABASE_URL` and the booking-engine adapter registry. Channel-push workflow
 registration is opt-in through

--- a/packages/workflows-orchestrator/src/__tests__/http-step-handler.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/http-step-handler.test.ts
@@ -1,5 +1,5 @@
-import { __resetRegistry, workflow } from "@voyant-travel/workflows"
-import { handleStepRequest } from "@voyant-travel/workflows/handler"
+import { __resetRegistry, getWorkflow, workflow } from "@voyant-travel/workflows"
+import { handleStepRequest, type WorkflowResolver } from "@voyant-travel/workflows/handler"
 import { describe, expect, it } from "vitest"
 import { createHttpStepHandler } from "../http-step-handler.js"
 
@@ -19,7 +19,10 @@ describe("createHttpStepHandler", () => {
           url: "https://tenant.internal/__voyant/workflow-step",
           async fetch(req: Request): Promise<Response> {
             const body = await req.json()
-            const out = await handleStepRequest(body)
+            const workflowResolver: WorkflowResolver = {
+              resolve: (workflowId) => getWorkflow(workflowId),
+            }
+            const out = await handleStepRequest(body, { workflowResolver })
             return new Response(JSON.stringify(out.body), {
               status: out.status,
               headers: { "content-type": "application/json" },

--- a/packages/workflows-orchestrator/src/__tests__/orchestrator-test-support.ts
+++ b/packages/workflows-orchestrator/src/__tests__/orchestrator-test-support.ts
@@ -1,10 +1,18 @@
-import { __resetRegistry } from "@voyant-travel/workflows"
-import { handleStepRequest, type WorkflowStepRequest } from "@voyant-travel/workflows/handler"
+import { __resetRegistry, getWorkflow } from "@voyant-travel/workflows"
+import {
+  handleStepRequest,
+  type WorkflowResolver,
+  type WorkflowStepRequest,
+} from "@voyant-travel/workflows/handler"
 import { beforeEach } from "vitest"
 import type { StepHandler } from "../index.js"
 
+export const workflowResolver: WorkflowResolver = {
+  resolve: (workflowId) => getWorkflow(workflowId),
+}
+
 export const handler: StepHandler = async (req: WorkflowStepRequest, opts) => {
-  return await handleStepRequest(req, {}, opts)
+  return await handleStepRequest(req, { workflowResolver }, opts)
 }
 
 export const tenantMeta = {

--- a/packages/workflows-orchestrator/src/__tests__/orchestrator-timeout-idempotency-cancel.test.ts
+++ b/packages/workflows-orchestrator/src/__tests__/orchestrator-timeout-idempotency-cancel.test.ts
@@ -2,7 +2,7 @@ import { workflow } from "@voyant-travel/workflows"
 import { handleStepRequest } from "@voyant-travel/workflows/handler"
 import { describe, expect, it } from "vitest"
 import { cancel, createInMemoryRunStore, resume, type StepHandler, trigger } from "../index.js"
-import { handler, tenantMeta } from "./orchestrator-test-support.js"
+import { handler, tenantMeta, workflowResolver } from "./orchestrator-test-support.js"
 
 describe("workflow-level timeout", () => {
   it("fails a run that exceeds its compute-time budget across invocations", async () => {
@@ -23,7 +23,7 @@ describe("workflow-level timeout", () => {
     const advancingHandler: StepHandler = async (req, opts) => {
       // Each invocation costs 400ms of compute time.
       clock += 400
-      return await handleStepRequest(req, {}, opts)
+      return await handleStepRequest(req, { workflowResolver }, opts)
     }
     const deps = {
       store,
@@ -70,7 +70,7 @@ describe("workflow-level timeout", () => {
     let clock = 0
     const cheapHandler: StepHandler = async (req, opts) => {
       clock += 50 // each invocation costs 50ms
-      return await handleStepRequest(req, {}, opts)
+      return await handleStepRequest(req, { workflowResolver }, opts)
     }
     const store = createInMemoryRunStore()
     const deps = { store, handler: cheapHandler, now: () => clock }
@@ -167,7 +167,7 @@ describe("cancel during drive", () => {
     const store = createInMemoryRunStore()
     let cancelFired = false
     const wrappedHandler: StepHandler = async (req) => {
-      const out = await handleStepRequest(req)
+      const out = await handleStepRequest(req, { workflowResolver })
       // After the FIRST invocation completes, fire a cancel from
       // outside the drive loop. The second invocation must not run.
       if (!cancelFired && req.runId === "run_parent_cancel") {
@@ -255,7 +255,7 @@ describe("cancel during drive", () => {
       // in the store (trigger saves up-front).
       const found = await store.get(req.runId)
       expect(found).toBeDefined()
-      return handleStepRequest(req)
+      return handleStepRequest(req, { workflowResolver })
     }
     await trigger(
       {

--- a/packages/workflows-orchestrator/src/driver-inmemory.ts
+++ b/packages/workflows-orchestrator/src/driver-inmemory.ts
@@ -20,6 +20,7 @@ import type {
   RunSummary,
   TriggerOptions,
 } from "@voyant-travel/workflows"
+import { getWorkflow } from "@voyant-travel/workflows"
 import {
   type DriverFactory,
   type DriverFactoryDeps,
@@ -31,7 +32,11 @@ import {
   type WorkflowDriver,
 } from "@voyant-travel/workflows/driver"
 import { deriveStableEventId } from "@voyant-travel/workflows/events"
-import { handleStepRequest, type WorkflowStepRequest } from "@voyant-travel/workflows/handler"
+import {
+  handleStepRequest,
+  type WorkflowResolver,
+  type WorkflowStepRequest,
+} from "@voyant-travel/workflows/handler"
 import type { WorkflowManifest } from "@voyant-travel/workflows/protocol"
 
 import {
@@ -58,6 +63,13 @@ export interface InMemoryDriverOptions {
   tenantMeta?: RunRecord["tenantMeta"]
   /** Injectable clock; defaults to `Date.now`. */
   now?: () => number
+  /**
+   * Executable workflow lookup for this driver instance.
+   *
+   * Omitting this dependency is deprecated and falls back to the process-global
+   * authoring registry for backward compatibility with existing consumers.
+   */
+  workflowResolver?: WorkflowResolver
   /** Step handler override — defaults to in-process `handleStepRequest`. */
   handler?: StepHandler
   /** Schedule runner tick interval. Defaults to 1_000 ms. */
@@ -70,6 +82,10 @@ const DEFAULT_TENANT_META: RunRecord["tenantMeta"] = {
   tenantId: "default",
   projectId: "default",
   organizationId: "default",
+}
+
+const legacyWorkflowResolver: WorkflowResolver = {
+  resolve: getWorkflow,
 }
 
 /**
@@ -91,13 +107,14 @@ export function createInMemoryDriver(opts: InMemoryDriverOptions = {}): DriverFa
     const now = opts.now ?? deps.now ?? (() => Date.now())
     const tenantMeta = opts.tenantMeta ?? DEFAULT_TENANT_META
     const defaultEnv: EnvironmentName = opts.defaultEnvironment ?? "development"
+    const workflowResolver = opts.workflowResolver ?? legacyWorkflowResolver
     // Wire the framework-supplied service container through to step bodies.
     // The handler closes over `deps.services` so every step invocation
     // surfaces it as `ctx.services` inside the workflow body.
     const handler: StepHandler =
       opts.handler ??
       (async (req: WorkflowStepRequest, stepOpts) =>
-        handleStepRequest(req, { services: deps.services }, stepOpts))
+        handleStepRequest(req, { workflowResolver, services: deps.services }, stepOpts))
 
     let shuttingDown = false
     const concurrency = createInProcessConcurrencyCoordinator({

--- a/packages/workflows-orchestrator/src/node/__tests__/dashboard-server.test.ts
+++ b/packages/workflows-orchestrator/src/node/__tests__/dashboard-server.test.ts
@@ -1,5 +1,6 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
+import { __resetRegistry } from "@voyant-travel/workflows"
 import { describe, expect, it } from "vitest"
 import { createSelfHostDeps, handleRequest } from "../dashboard-server.js"
 import type { SnapshotRunStore } from "../snapshot-run-store.js"
@@ -210,6 +211,55 @@ describe("createSelfHostDeps validation", () => {
       })
     } finally {
       await deps?.shutdown?.()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("executes from the entry snapshot after the global registry is cleared", async () => {
+    const root = await mkdtemp(join(process.cwd(), ".tmp-resolver-workflow-entry-"))
+    let deps: Awaited<ReturnType<typeof createSelfHostDeps>> | undefined
+    try {
+      const entryFile = join(root, "resolver-workflows.mjs")
+      const staticDir = join(root, "static")
+      await mkdir(staticDir, { recursive: true })
+      await writeFile(
+        entryFile,
+        [
+          'import { workflow } from "@voyant-travel/workflows";',
+          'workflow({ id: "resolver_probe", async run() {',
+          '  return { source: "entry snapshot" };',
+          "}});",
+        ].join("\n"),
+        "utf8",
+      )
+
+      deps = await createSelfHostDeps({
+        entryFile,
+        staticDir,
+        cacheBustEntry: true,
+        store: createFsSnapshotRunStore({ rootDir: join(root, "runs") }),
+      })
+      __resetRegistry()
+
+      const response = await handleRequest(
+        {
+          method: "POST",
+          url: "http://local/api/runs",
+          body: JSON.stringify({ workflowId: "resolver_probe", input: {} }),
+        },
+        deps,
+      )
+
+      expect(response.status).toBe(200)
+      expect(JSON.parse(String(response.body))).toMatchObject({
+        saved: {
+          status: "completed",
+          result: { output: { source: "entry snapshot" } },
+        },
+      })
+    } finally {
+      await deps?.shutdown?.()
+      __resetRegistry()
       await rm(root, { recursive: true, force: true })
     }
   })

--- a/packages/workflows-orchestrator/src/node/node-selfhost-deps.ts
+++ b/packages/workflows-orchestrator/src/node/node-selfhost-deps.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:http"
 import { resolve as resolvePath } from "node:path"
-import { handleStepRequest } from "@voyant-travel/workflows/handler"
+import { handleStepRequest, type WorkflowResolver } from "@voyant-travel/workflows/handler"
 import { createInMemoryRateLimiter } from "@voyant-travel/workflows/rate-limit"
 import {
   createInMemoryRunStore,
@@ -94,17 +94,22 @@ export async function createSelfHostDeps(
   await loadEntryFile(entryAbs, { cacheBust: opts.cacheBustEntry })
 
   const _handlerMod = await import("@voyant-travel/workflows/handler")
+  const workflowDefinitions = wfMod.__listRegisteredWorkflows()
+  const workflowsById = new Map(workflowDefinitions.map((workflow) => [workflow.id, workflow]))
+  const workflowResolver: WorkflowResolver = {
+    resolve: (workflowId) => workflowsById.get(workflowId),
+  }
   const rateLimiter = createInMemoryRateLimiter()
   const chunkBus = createChunkBus()
 
   const stepHandler: StepHandler = async (req, stepOpts) =>
-    handleStepRequest(req, { rateLimiter, services: opts.services }, stepOpts)
+    handleStepRequest(req, { workflowResolver, rateLimiter, services: opts.services }, stepOpts)
 
   const wakeupStore = pg ? createPostgresWakeupStore({ db: pg.db }) : createFsWakeupStore()
   const leaseOwner = opts.wakeupLeaseOwner ?? createDefaultWakeupLeaseOwner()
 
   const listWorkflows = () =>
-    wfMod.__listRegisteredWorkflows().map((workflow) => ({
+    workflowDefinitions.map((workflow) => ({
       id: workflow.id,
       description: workflow.config.description,
     }))
@@ -227,7 +232,7 @@ export async function createSelfHostDeps(
     tags,
     triggeredByUserId,
   }) => {
-    const workflow = wfMod.__listRegisteredWorkflows().find((entry) => entry.id === workflowId)
+    const workflow = workflowResolver.resolve(workflowId)
     if (!workflow) {
       return {
         ok: false,
@@ -309,7 +314,7 @@ export async function createSelfHostDeps(
     }
 
     const workflowId = parent?.workflowId ?? requestedWorkflowId!
-    const workflow = wfMod.__listRegisteredWorkflows().find((entry) => entry.id === workflowId)
+    const workflow = workflowResolver.resolve(workflowId)
     if (!workflow) {
       return {
         ok: false,

--- a/packages/workflows-orchestrator/src/node/node-standalone-driver.ts
+++ b/packages/workflows-orchestrator/src/node/node-standalone-driver.ts
@@ -25,6 +25,7 @@ import type {
   RunSummary,
   TriggerOptions,
 } from "@voyant-travel/workflows"
+import { getWorkflow } from "@voyant-travel/workflows"
 import type {
   DriverFactory,
   DriverFactoryDeps,
@@ -35,7 +36,11 @@ import type {
   WorkflowDriver,
 } from "@voyant-travel/workflows/driver"
 import { deriveStableEventId } from "@voyant-travel/workflows/events"
-import { handleStepRequest, type WorkflowStepRequest } from "@voyant-travel/workflows/handler"
+import {
+  handleStepRequest,
+  type WorkflowResolver,
+  type WorkflowStepRequest,
+} from "@voyant-travel/workflows/handler"
 import type { WorkflowManifest } from "@voyant-travel/workflows/protocol"
 import type { drizzle } from "drizzle-orm/node-postgres"
 import {
@@ -74,6 +79,13 @@ export interface StandaloneDriverOptions {
   tenantMeta?: RunRecord["tenantMeta"]
   /** Injectable clock; defaults to `Date.now`. */
   now?: () => number
+  /**
+   * Executable workflow lookup for this driver instance.
+   *
+   * Omitting this dependency is deprecated and falls back to the process-global
+   * authoring registry for backward compatibility with existing consumers.
+   */
+  workflowResolver?: WorkflowResolver
   /**
    * Step handler override. Defaults to in-process `handleStepRequest`
    * with the framework-supplied `services` container plumbed through
@@ -125,6 +137,10 @@ const DEFAULT_TENANT_META: RunRecord["tenantMeta"] = {
 }
 
 const DEFAULT_MANIFEST_KEEP = 3
+
+const legacyWorkflowResolver: WorkflowResolver = {
+  resolve: getWorkflow,
+}
 
 function serializeWorkflowManifest(manifest: WorkflowManifest): Record<string, unknown> {
   return { ...manifest }
@@ -238,6 +254,7 @@ export function createStandaloneDriver(opts: StandaloneDriverOptions): DriverFac
     const defaultEnv = opts.defaultEnvironment ?? "development"
     const keep = opts.manifestVersionsToKeep ?? DEFAULT_MANIFEST_KEEP
     const leaseOwner = opts.wakeupLeaseOwner ?? `selfhost-standalone-${randomToken()}`
+    const workflowResolver = opts.workflowResolver ?? legacyWorkflowResolver
 
     // Wire the framework-supplied service container through to step bodies.
     // The handler closes over `deps.services` so every step invocation
@@ -245,7 +262,7 @@ export function createStandaloneDriver(opts: StandaloneDriverOptions): DriverFac
     const handler: StepHandler =
       opts.handler ??
       (async (req: WorkflowStepRequest, stepOpts) =>
-        handleStepRequest(req, { services: deps.services }, stepOpts))
+        handleStepRequest(req, { workflowResolver, services: deps.services }, stepOpts))
 
     // Persistent wakeup manager — polls `voyant_wakeups` for runs
     // parked on DATETIME waitpoints and resumes them via the orchestrator's

--- a/packages/workflows/src/handler/__tests__/handler.test.ts
+++ b/packages/workflows/src/handler/__tests__/handler.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { snapshotWorkflowWaitpoint } from "../../protocol/index.js"
 import { emptyJournal } from "../../runtime/journal.js"
 import type { RunTrigger } from "../../types.js"
@@ -342,6 +342,41 @@ describe("createStepHandler (fetch adapter)", () => {
 })
 
 describe("handleStepRequest (transport-free)", () => {
+  it("uses the explicit workflow resolver instead of the process-global registry", async () => {
+    const definition = workflow<void, string>({
+      id: "wf",
+      async run() {
+        return "resolved explicitly"
+      },
+    })
+    __resetRegistry()
+    const resolve = vi.fn(() => definition)
+
+    const out = await handleStepRequest(mkRequest(), {
+      workflowResolver: { resolve },
+    })
+
+    expect(out.status).toBe(200)
+    expect("output" in out.body && out.body.output).toBe("resolved explicitly")
+    expect(resolve).toHaveBeenCalledWith("wf")
+  })
+
+  it("does not fall back to the global registry when an explicit resolver misses", async () => {
+    workflow<void, string>({
+      id: "wf",
+      async run() {
+        return "global"
+      },
+    })
+
+    const out = await handleStepRequest(mkRequest(), {
+      workflowResolver: { resolve: () => undefined },
+    })
+
+    expect(out.status).toBe(404)
+    expect("error" in out.body && out.body.error).toBe("workflow_not_found")
+  })
+
   it("returns body + status without touching Request/Response", async () => {
     workflow<void, string>({
       id: "wf",

--- a/packages/workflows/src/handler/index.ts
+++ b/packages/workflows/src/handler/index.ts
@@ -37,9 +37,23 @@ import type { RateLimiter } from "../rate-limit/index.js"
 import type { RuntimeEnvironment } from "../runtime/ctx.js"
 import type { JournalSlice, StepJournalEntry } from "../runtime/journal.js"
 import type { RunTrigger } from "../types.js"
-import { getWorkflow } from "../workflow.js"
+import { getWorkflow, type WorkflowDefinition } from "../workflow.js"
+
+/** Resolves executable workflow definitions at the step execution boundary. */
+export interface WorkflowResolver {
+  resolve(workflowId: string): WorkflowDefinition | undefined
+}
 
 export interface StepHandlerDeps {
+  /**
+   * Explicit workflow lookup for this runtime. Runtime composition should
+   * always provide this dependency so execution is isolated from the
+   * process-global authoring registry.
+   *
+   * When omitted, the handler falls back to the legacy process-global
+   * registry for backward compatibility with direct SDK callers.
+   */
+  workflowResolver?: WorkflowResolver
   /**
    * Optional. Called before parsing the body. Should throw / reject
    * if the request is not from a trusted orchestrator. In production
@@ -190,7 +204,9 @@ async function runStepInner(
     }
   }
 
-  const def = getWorkflow(reqBody.workflowId)
+  const def = deps.workflowResolver
+    ? deps.workflowResolver.resolve(reqBody.workflowId)
+    : getWorkflow(reqBody.workflowId)
   if (!def) {
     return {
       status: 404,

--- a/packages/workflows/src/handler/index.ts
+++ b/packages/workflows/src/handler/index.ts
@@ -50,8 +50,9 @@ export interface StepHandlerDeps {
    * always provide this dependency so execution is isolated from the
    * process-global authoring registry.
    *
-   * When omitted, the handler falls back to the legacy process-global
-   * registry for backward compatibility with direct SDK callers.
+   * Omitting this dependency is deprecated. The handler falls back to the
+   * legacy process-global registry only for backward compatibility with
+   * direct external SDK callers.
    */
   workflowResolver?: WorkflowResolver
   /**

--- a/starters/operator/src/workflows-bundle.test.ts
+++ b/starters/operator/src/workflows-bundle.test.ts
@@ -72,6 +72,7 @@ function bundleStepScript(outDir: string): string {
   return `
 ;(async () => {
 const bundle = await import(${JSON.stringify(bundleUrl)})
+const { getWorkflow } = await import("@voyant-travel/workflows")
 const { handleStepRequest } = await import("@voyant-travel/workflows/handler")
 const { PROTOCOL_VERSION } = await import("@voyant-travel/workflows/protocol")
 
@@ -130,6 +131,8 @@ const result = await handleStepRequest({
     tags: [],
     startedAt: Date.now(),
   },
+}, {
+  workflowResolver: { resolve: (workflowId) => getWorkflow(workflowId) },
 })
 
 console.log(JSON.stringify({ result, selectCalls }))


### PR DESCRIPTION
## Summary
- add an explicit `WorkflowResolver` dependency to step execution
- snapshot entry-loaded workflows into the self-host runtime instead of resolving through process-global authoring state
- migrate every in-repo handler caller and test helper to pass a resolver explicitly
- retain the global registry only as a documented deprecated fallback for external callers

## Verification
- workflows: 270 tests and typecheck
- workflows orchestrator: 147 tests, 37 skipped, and typecheck
- Operator workflow bundle test
- changed-file lint and workflows package-surface checker