### PR TITLE
feat(framework): write resolved project artifacts

### DIFF
--- a/.changeset/write-project-artifacts.md
+++ b/.changeset/write-project-artifacts.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Add a public, target-neutral writer and staleness checker for resolved project artifacts under `.voyant`.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -781,6 +781,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -776,6 +776,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -752,6 +752,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -747,6 +747,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -835,6 +835,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/core/tsconfig.typecheck.json
+++ b/packages/core/tsconfig.typecheck.json
@@ -831,6 +831,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -816,6 +816,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -817,6 +817,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -832,6 +832,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -833,6 +833,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -836,6 +836,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -831,6 +831,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -13,6 +13,7 @@
     "./project-admin-conventions": "./src/project-admin-conventions.ts",
     "./project-workflow-job-conventions": "./src/project-workflow-job-conventions.ts",
     "./project-subscriber-link-conventions": "./src/project-subscriber-link-conventions.ts",
+    "./project-artifacts": "./src/project-artifacts.ts",
     "./project": "./src/project.ts",
     "./profile": "./src/profile.ts",
     "./managed-jobs": "./src/managed-jobs.ts",
@@ -138,6 +139,10 @@
         "types": "./dist/project-subscriber-link-conventions.d.ts",
         "import": "./dist/project-subscriber-link-conventions.js",
         "default": "./dist/project-subscriber-link-conventions.js"
+      },
+      "./project-artifacts": {
+        "types": "./dist/project-artifacts.d.ts",
+        "import": "./dist/project-artifacts.js"
       },
       "./project": {
         "types": "./dist/project.d.ts",

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -91,8 +91,8 @@ export {
   type ProjectArtifactWriteMode,
   type ProjectArtifactWriteResult,
   type ProjectArtifactWriteStatus,
-  type WriteResolvedProjectArtifactsInput,
-  writeResolvedProjectArtifacts,
+  type WriteProjectArtifactsInput,
+  writeProjectArtifacts,
 } from "./project-artifacts.js"
 export {
   type ComposeVoyantGraphRuntimeInput,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -87,6 +87,14 @@ export {
   validateVoyantProject,
 } from "./profile.js"
 export {
+  type ProjectArtifactWriteEntry,
+  type ProjectArtifactWriteMode,
+  type ProjectArtifactWriteResult,
+  type ProjectArtifactWriteStatus,
+  type WriteResolvedProjectArtifactsInput,
+  writeResolvedProjectArtifacts,
+} from "./project-artifacts.js"
+export {
   type ComposeVoyantGraphRuntimeInput,
   composeVoyantGraphRuntime,
   composeVoyantGraphRuntimeFacetModules,

--- a/packages/framework/src/project-artifacts.test.ts
+++ b/packages/framework/src/project-artifacts.test.ts
@@ -1,0 +1,151 @@
+import { mkdir, mkdtemp, readdir, readFile, rm, stat, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+import { writeResolvedProjectArtifacts } from "./project-artifacts.js"
+import type { FrameworkGeneratedProjectFile, ResolvedProjectArtifacts } from "./project-resolver.js"
+
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  )
+})
+
+describe("writeResolvedProjectArtifacts", () => {
+  it("writes nested files in deterministic order and preserves unchanged files", async () => {
+    const projectRoot = await temporaryProject()
+    const artifacts = projectArtifacts([
+      { path: "runtime/z.generated.ts", contents: "export const z = true\n" },
+      { path: "admin/a.generated.ts", contents: "export const a = true\n" },
+    ])
+
+    const first = await writeResolvedProjectArtifacts({ projectRoot, artifacts })
+    const firstStats = await stat(path.join(projectRoot, ".voyant/admin/a.generated.ts"))
+    const second = await writeResolvedProjectArtifacts({ projectRoot, artifacts })
+    const secondStats = await stat(path.join(projectRoot, ".voyant/admin/a.generated.ts"))
+
+    expect(first).toEqual({
+      mode: "write",
+      outputRoot: path.join(projectRoot, ".voyant"),
+      ok: true,
+      files: [
+        { path: "admin/a.generated.ts", status: "written" },
+        { path: "runtime/z.generated.ts", status: "written" },
+      ],
+    })
+    expect(second.files).toEqual([
+      { path: "admin/a.generated.ts", status: "unchanged" },
+      { path: "runtime/z.generated.ts", status: "unchanged" },
+    ])
+    expect(secondStats.mtimeMs).toBe(firstStats.mtimeMs)
+    expect(await readFile(path.join(projectRoot, ".voyant/runtime/z.generated.ts"), "utf8")).toBe(
+      "export const z = true\n",
+    )
+    expect(await readdir(path.join(projectRoot, ".voyant/admin"))).toEqual(["a.generated.ts"])
+  })
+
+  it("reports unchanged, stale, and missing files without writing in check mode", async () => {
+    const projectRoot = await temporaryProject()
+    await mkdir(path.join(projectRoot, ".voyant/runtime"), { recursive: true })
+    await writeFile(path.join(projectRoot, ".voyant/runtime/current.ts"), "current\n")
+    await writeFile(path.join(projectRoot, ".voyant/runtime/stale.ts"), "old\n")
+    const artifacts = projectArtifacts([
+      { path: "runtime/stale.ts", contents: "new\n" },
+      { path: "runtime/missing.ts", contents: "missing\n" },
+      { path: "runtime/current.ts", contents: "current\n" },
+    ])
+
+    const result = await writeResolvedProjectArtifacts({ projectRoot, artifacts, mode: "check" })
+
+    expect(result.ok).toBe(false)
+    expect(result.files).toEqual([
+      { path: "runtime/current.ts", status: "unchanged" },
+      { path: "runtime/missing.ts", status: "missing" },
+      { path: "runtime/stale.ts", status: "stale" },
+    ])
+    expect(await readFile(path.join(projectRoot, ".voyant/runtime/stale.ts"), "utf8")).toBe("old\n")
+    await expect(stat(path.join(projectRoot, ".voyant/runtime/missing.ts"))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+  })
+
+  it.each([
+    "../outside.ts",
+    "/absolute.ts",
+    "C:\\absolute.ts",
+    "runtime//alias.ts",
+  ])("rejects unsafe artifact path %s before creating output", async (artifactPath) => {
+    const projectRoot = await temporaryProject()
+    const artifacts = projectArtifacts([{ path: artifactPath, contents: "unsafe\n" }])
+
+    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+      /must (?:be relative|not escape)/,
+    )
+    await expect(stat(path.join(projectRoot, ".voyant"))).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("rejects duplicate portable paths before writing any artifact", async () => {
+    const projectRoot = await temporaryProject()
+    const artifacts = projectArtifacts([
+      { path: "runtime/entry.ts", contents: "first\n" },
+      { path: "Runtime\\Entry.ts", contents: "second\n" },
+    ])
+
+    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+      "Duplicate project artifact paths",
+    )
+    await expect(stat(path.join(projectRoot, ".voyant"))).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("rejects unsafe runtime references even when they are not file entries", async () => {
+    const projectRoot = await temporaryProject()
+    const artifacts = { ...projectArtifacts([]), runtimeEntry: "../runtime.ts" }
+
+    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+      "artifacts.runtimeEntry",
+    )
+  })
+
+  it("rejects symbolic-link traversal before writing any artifact", async () => {
+    const projectRoot = await temporaryProject()
+    const outsideRoot = await temporaryProject()
+    await mkdir(path.join(projectRoot, ".voyant"))
+    await symlink(outsideRoot, path.join(projectRoot, ".voyant/runtime"), "dir")
+    const artifacts = projectArtifacts([
+      { path: "admin/safe.ts", contents: "safe\n" },
+      { path: "runtime/escaped.ts", contents: "escaped\n" },
+    ])
+
+    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+      "traverses a symbolic link",
+    )
+    expect(await readdir(outsideRoot)).toEqual([])
+    await expect(stat(path.join(projectRoot, ".voyant/admin"))).rejects.toMatchObject({
+      code: "ENOENT",
+    })
+  })
+})
+
+async function temporaryProject(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "voyant-project-artifacts-"))
+  temporaryRoots.push(root)
+  return root
+}
+
+function projectArtifacts(
+  files: readonly FrameworkGeneratedProjectFile[],
+): ResolvedProjectArtifacts {
+  return {
+    runtimeEntry: "runtime/project-runtime.generated.ts",
+    migrationRunner: "runtime/project-migrations.generated.mjs",
+    files,
+    migrationPlan: {
+      schemaVersion: "voyant.migration-plan.v1",
+      contentHash: "sha256:test",
+      migrations: [],
+    },
+  }
+}

--- a/packages/framework/src/project-artifacts.test.ts
+++ b/packages/framework/src/project-artifacts.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import path from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
-import { writeResolvedProjectArtifacts } from "./project-artifacts.js"
+import { writeProjectArtifacts } from "./project-artifacts.js"
 import type { FrameworkGeneratedProjectFile, ResolvedProjectArtifacts } from "./project-resolver.js"
 
 const temporaryRoots: string[] = []
@@ -14,7 +14,7 @@ afterEach(async () => {
   )
 })
 
-describe("writeResolvedProjectArtifacts", () => {
+describe("writeProjectArtifacts", () => {
   it("writes nested files in deterministic order and preserves unchanged files", async () => {
     const projectRoot = await temporaryProject()
     const artifacts = projectArtifacts([
@@ -22,9 +22,9 @@ describe("writeResolvedProjectArtifacts", () => {
       { path: "admin/a.generated.ts", contents: "export const a = true\n" },
     ])
 
-    const first = await writeResolvedProjectArtifacts({ projectRoot, artifacts })
+    const first = await writeProjectArtifacts({ projectRoot, artifacts })
     const firstStats = await stat(path.join(projectRoot, ".voyant/admin/a.generated.ts"))
-    const second = await writeResolvedProjectArtifacts({ projectRoot, artifacts })
+    const second = await writeProjectArtifacts({ projectRoot, artifacts })
     const secondStats = await stat(path.join(projectRoot, ".voyant/admin/a.generated.ts"))
 
     expect(first).toEqual({
@@ -58,7 +58,7 @@ describe("writeResolvedProjectArtifacts", () => {
       { path: "runtime/current.ts", contents: "current\n" },
     ])
 
-    const result = await writeResolvedProjectArtifacts({ projectRoot, artifacts, mode: "check" })
+    const result = await writeProjectArtifacts({ projectRoot, artifacts, mode: "check" })
 
     expect(result.ok).toBe(false)
     expect(result.files).toEqual([
@@ -81,7 +81,7 @@ describe("writeResolvedProjectArtifacts", () => {
     const projectRoot = await temporaryProject()
     const artifacts = projectArtifacts([{ path: artifactPath, contents: "unsafe\n" }])
 
-    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+    await expect(writeProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
       /must (?:be relative|not escape)/,
     )
     await expect(stat(path.join(projectRoot, ".voyant"))).rejects.toMatchObject({ code: "ENOENT" })
@@ -94,7 +94,7 @@ describe("writeResolvedProjectArtifacts", () => {
       { path: "Runtime\\Entry.ts", contents: "second\n" },
     ])
 
-    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+    await expect(writeProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
       "Duplicate project artifact paths",
     )
     await expect(stat(path.join(projectRoot, ".voyant"))).rejects.toMatchObject({ code: "ENOENT" })
@@ -104,7 +104,7 @@ describe("writeResolvedProjectArtifacts", () => {
     const projectRoot = await temporaryProject()
     const artifacts = { ...projectArtifacts([]), runtimeEntry: "../runtime.ts" }
 
-    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+    await expect(writeProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
       "artifacts.runtimeEntry",
     )
   })
@@ -119,7 +119,7 @@ describe("writeResolvedProjectArtifacts", () => {
       { path: "runtime/escaped.ts", contents: "escaped\n" },
     ])
 
-    await expect(writeResolvedProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
+    await expect(writeProjectArtifacts({ projectRoot, artifacts })).rejects.toThrow(
       "traverses a symbolic link",
     )
     expect(await readdir(outsideRoot)).toEqual([])

--- a/packages/framework/src/project-artifacts.ts
+++ b/packages/framework/src/project-artifacts.ts
@@ -1,0 +1,215 @@
+import { lstat, mkdir, readFile, rename, rm, writeFile } from "node:fs/promises"
+import path from "node:path"
+
+import type { ResolvedProjectArtifacts } from "./project-resolver.js"
+
+export type ProjectArtifactWriteMode = "write" | "check"
+
+export type ProjectArtifactWriteStatus = "written" | "unchanged" | "missing" | "stale"
+
+export interface WriteResolvedProjectArtifactsInput {
+  projectRoot: string
+  artifacts: ResolvedProjectArtifacts
+  mode?: ProjectArtifactWriteMode
+}
+
+export interface ProjectArtifactWriteEntry {
+  /** Path relative to `<projectRoot>/.voyant`. */
+  path: string
+  status: ProjectArtifactWriteStatus
+}
+
+export interface ProjectArtifactWriteResult {
+  mode: ProjectArtifactWriteMode
+  outputRoot: string
+  /** Whether every artifact matched after the requested operation. */
+  ok: boolean
+  files: readonly ProjectArtifactWriteEntry[]
+}
+
+interface ValidatedArtifact {
+  path: string
+  segments: readonly string[]
+  contents: string
+}
+
+let temporaryFileSequence = 0
+
+/**
+ * Materialize resolver output beneath `<projectRoot>/.voyant`, or check it for staleness.
+ * Artifact paths are treated as portable paths and cannot be absolute, escape the output
+ * directory, alias another artifact, or traverse symbolic links.
+ */
+export async function writeResolvedProjectArtifacts(
+  input: WriteResolvedProjectArtifactsInput,
+): Promise<ProjectArtifactWriteResult> {
+  const mode = input.mode ?? "write"
+  if (mode !== "write" && mode !== "check") {
+    throw new TypeError(`Unsupported project artifact write mode: ${String(mode)}`)
+  }
+  if (typeof input.projectRoot !== "string" || input.projectRoot.length === 0) {
+    throw new TypeError("projectRoot must be a non-empty string")
+  }
+
+  const projectRoot = path.resolve(input.projectRoot)
+  const outputRoot = path.join(projectRoot, ".voyant")
+  const files = validateArtifacts(input.artifacts)
+
+  await preflightOutputTree(outputRoot, files)
+  if (mode === "write") await ensureOutputDirectories(outputRoot, files)
+
+  const results: ProjectArtifactWriteEntry[] = []
+  for (const file of files) {
+    const target = path.join(outputRoot, ...file.segments)
+    const actual = await readTextIfFile(target)
+
+    if (actual === file.contents) {
+      results.push({ path: file.path, status: "unchanged" })
+      continue
+    }
+    if (mode === "check") {
+      results.push({ path: file.path, status: actual === undefined ? "missing" : "stale" })
+      continue
+    }
+
+    await atomicWriteFile(target, file.contents)
+    results.push({ path: file.path, status: "written" })
+  }
+
+  return {
+    mode,
+    outputRoot,
+    ok: mode === "write" || results.every((file) => file.status === "unchanged"),
+    files: results,
+  }
+}
+
+function validateArtifacts(artifacts: ResolvedProjectArtifacts): ValidatedArtifact[] {
+  if (!artifacts || !Array.isArray(artifacts.files)) {
+    throw new TypeError("artifacts.files must be an array")
+  }
+
+  validatePortablePath(artifacts.runtimeEntry, "artifacts.runtimeEntry")
+  validatePortablePath(artifacts.migrationRunner, "artifacts.migrationRunner")
+
+  const seen = new Map<string, string>()
+  const files = artifacts.files.map((file, index) => {
+    if (!file || typeof file.contents !== "string") {
+      throw new TypeError(`artifacts.files[${index}].contents must be a string`)
+    }
+    const segments = validatePortablePath(file.path, `artifacts.files[${index}].path`)
+    const portablePath = segments.join("/")
+    const duplicateKey = portablePath.toLocaleLowerCase("en-US")
+    const duplicate = seen.get(duplicateKey)
+    if (duplicate !== undefined) {
+      throw new TypeError(`Duplicate project artifact paths: ${duplicate} and ${file.path}`)
+    }
+    seen.set(duplicateKey, file.path)
+    return { path: portablePath, segments, contents: file.contents }
+  })
+
+  return files.sort((left, right) => compareText(left.path, right.path))
+}
+
+function validatePortablePath(value: unknown, label: string): string[] {
+  if (typeof value !== "string" || value.length === 0 || value.includes("\0")) {
+    throw new TypeError(`${label} must be a non-empty artifact path`)
+  }
+  if (path.posix.isAbsolute(value) || path.win32.isAbsolute(value) || /^[A-Za-z]:/.test(value)) {
+    throw new TypeError(`${label} must be relative to the .voyant directory: ${value}`)
+  }
+
+  const segments = value.replaceAll("\\", "/").split("/")
+  if (segments.some((segment) => segment === "" || segment === "." || segment === "..")) {
+    throw new TypeError(
+      `${label} must not escape or alias a path in the .voyant directory: ${value}`,
+    )
+  }
+  return segments
+}
+
+async function preflightOutputTree(
+  outputRoot: string,
+  files: readonly ValidatedArtifact[],
+): Promise<void> {
+  await inspectPathComponent(outputRoot, "directory")
+  for (const file of files) {
+    let current = outputRoot
+    for (const segment of file.segments.slice(0, -1)) {
+      current = path.join(current, segment)
+      const state = await inspectPathComponent(current, "directory")
+      if (state === "missing") break
+    }
+    await inspectPathComponent(path.join(outputRoot, ...file.segments), "file")
+  }
+}
+
+async function ensureOutputDirectories(
+  outputRoot: string,
+  files: readonly ValidatedArtifact[],
+): Promise<void> {
+  await mkdir(outputRoot, { recursive: true })
+  await inspectPathComponent(outputRoot, "directory")
+  for (const file of files) {
+    let current = outputRoot
+    for (const segment of file.segments.slice(0, -1)) {
+      current = path.join(current, segment)
+      await mkdir(current).catch((error: unknown) => {
+        if (!isNodeError(error, "EEXIST")) throw error
+      })
+      await inspectPathComponent(current, "directory")
+    }
+  }
+}
+
+async function inspectPathComponent(
+  candidate: string,
+  expected: "directory" | "file",
+): Promise<"present" | "missing"> {
+  try {
+    const stats = await lstat(candidate)
+    if (stats.isSymbolicLink()) {
+      throw new Error(`Project artifact path traverses a symbolic link: ${candidate}`)
+    }
+    const valid = expected === "directory" ? stats.isDirectory() : stats.isFile()
+    if (!valid) throw new Error(`Project artifact path is not a ${expected}: ${candidate}`)
+    return "present"
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) return "missing"
+    throw error
+  }
+}
+
+async function readTextIfFile(filePath: string): Promise<string | undefined> {
+  try {
+    return await readFile(filePath, "utf8")
+  } catch (error) {
+    if (isNodeError(error, "ENOENT")) return undefined
+    throw error
+  }
+}
+
+async function atomicWriteFile(filePath: string, contents: string): Promise<void> {
+  temporaryFileSequence += 1
+  const temporaryPath = path.join(
+    path.dirname(filePath),
+    `.${path.basename(filePath)}.${process.pid}.${temporaryFileSequence}.tmp`,
+  )
+  let temporaryFileCreated = false
+  try {
+    await writeFile(temporaryPath, contents, { encoding: "utf8", flag: "wx" })
+    temporaryFileCreated = true
+    await rename(temporaryPath, filePath)
+    temporaryFileCreated = false
+  } finally {
+    if (temporaryFileCreated) await rm(temporaryPath, { force: true })
+  }
+}
+
+function isNodeError(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return error instanceof Error && "code" in error && error.code === code
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0
+}

--- a/packages/framework/src/project-artifacts.ts
+++ b/packages/framework/src/project-artifacts.ts
@@ -7,7 +7,7 @@ export type ProjectArtifactWriteMode = "write" | "check"
 
 export type ProjectArtifactWriteStatus = "written" | "unchanged" | "missing" | "stale"
 
-export interface WriteResolvedProjectArtifactsInput {
+export interface WriteProjectArtifactsInput {
   projectRoot: string
   artifacts: ResolvedProjectArtifacts
   mode?: ProjectArtifactWriteMode
@@ -40,8 +40,8 @@ let temporaryFileSequence = 0
  * Artifact paths are treated as portable paths and cannot be absolute, escape the output
  * directory, alias another artifact, or traverse symbolic links.
  */
-export async function writeResolvedProjectArtifacts(
-  input: WriteResolvedProjectArtifactsInput,
+export async function writeProjectArtifacts(
+  input: WriteProjectArtifactsInput,
 ): Promise<ProjectArtifactWriteResult> {
   const mode = input.mode ?? "write"
   if (mode !== "write" && mode !== "check") {

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -40,8 +40,8 @@ export {
   type ProjectArtifactWriteMode,
   type ProjectArtifactWriteResult,
   type ProjectArtifactWriteStatus,
-  type WriteResolvedProjectArtifactsInput,
-  writeResolvedProjectArtifacts,
+  type WriteProjectArtifactsInput,
+  writeProjectArtifacts,
 } from "./project-artifacts.js"
 export type {
   DiscoverProjectConventionsInput,

--- a/packages/framework/src/project.ts
+++ b/packages/framework/src/project.ts
@@ -35,6 +35,14 @@ export type {
   ProjectApiConventionsOptions,
   ProjectApiGeneratedFile,
 } from "./project-api-conventions.js"
+export {
+  type ProjectArtifactWriteEntry,
+  type ProjectArtifactWriteMode,
+  type ProjectArtifactWriteResult,
+  type ProjectArtifactWriteStatus,
+  type WriteResolvedProjectArtifactsInput,
+  writeResolvedProjectArtifacts,
+} from "./project-artifacts.js"
 export type {
   DiscoverProjectConventionsInput,
   DiscoverProjectConventionsOptions,

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -840,6 +840,7 @@
         "./dist/project-admin-conventions.d.ts"
       ],
       "@voyant-travel/framework/project-api-conventions": ["./dist/project-api-conventions.d.ts"],
+      "@voyant-travel/framework/project-artifacts": ["./dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "./dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -841,6 +841,7 @@
         "./dist/project-admin-conventions.d.ts"
       ],
       "@voyant-travel/framework/project-api-conventions": ["./dist/project-api-conventions.d.ts"],
+      "@voyant-travel/framework/project-artifacts": ["./dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "./dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -852,6 +852,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -847,6 +847,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -846,6 +846,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -847,6 +847,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -847,6 +847,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -852,6 +852,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -847,6 +847,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -845,6 +845,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -846,6 +846,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -847,6 +847,7 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": ["../framework/dist/project-artifacts.d.ts"],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1070,6 +1070,9 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../../packages/framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": [
+        "../../packages/framework/dist/project-artifacts.d.ts"
+      ],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../../packages/framework/dist/project-subscriber-link-conventions.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1070,6 +1070,9 @@
       "@voyant-travel/framework/project-api-conventions": [
         "../../packages/framework/dist/project-api-conventions.d.ts"
       ],
+      "@voyant-travel/framework/project-artifacts": [
+        "../../packages/framework/dist/project-artifacts.d.ts"
+      ],
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../../packages/framework/dist/project-subscriber-link-conventions.d.ts"
       ],


### PR DESCRIPTION
## Summary
- expose target-neutral `writeProjectArtifacts(...)` from the framework project API
- write resolver artifacts deterministically under `.voyant` with atomic replacement
- add non-mutating stale/missing check mode
- reject absolute, escaping, duplicate, aliased, and symlink-traversing paths before writes
- register the public subpath in generated composition configs

## Verification
- framework: 277 tests
- framework lint
- dependency-path, dist-config, and framework-BOM checks
- repository pre-push test lane