### PR TITLE
refactor(operator): consume resolved project artifacts

### DIFF
--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -11,6 +11,7 @@ import {
   buildManagedNodeRuntimeEntryArtifact,
 } from "../packages/framework/src/deployment-artifacts.ts"
 import type { ResolvedVoyantDeploymentGraph } from "../packages/framework/src/deployment-graph.ts"
+import type { ResolvedProjectArtifacts } from "../packages/framework/src/project-resolver.ts"
 import { getManagedProfileScheduledJobs } from "../packages/framework/src/managed-jobs.ts"
 import type { VoyantProjectManifest } from "../packages/framework/src/profile-types.ts"
 import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
@@ -44,7 +45,7 @@ const command = "pnpm --filter operator graph:emit"
 
 async function main(): Promise<void> {
   const options = parseArgs(process.argv.slice(2))
-  const { graph, profile } = await resolveGraph(options.configPath)
+  const { graph, profile, projectArtifacts } = await resolveGraph(options.configPath)
   const graphText = formatGeneratedText(options.graphOutputPath, buildDeploymentGraphJson(graph))
   const graphArtifactPath = toPosixRelativePath(
     dirname(options.entryOutputPath),
@@ -107,6 +108,14 @@ async function main(): Promise<void> {
     { path: options.graphOutputPath, expected: graphText, facet: "deployment-graph" },
     { path: options.entryOutputPath, expected: entryText, facet: "runtime-entry" },
     { path: options.runtimeOutputPath, expected: runtimeText, facet: "graph-runtime" },
+    ...projectConventionArtifacts(projectArtifacts).map((artifact) => ({
+      path: join(defaultOperatorRoot, ".voyant", artifact.path),
+      expected: formatGeneratedText(
+        join(defaultOperatorRoot, ".voyant", artifact.path),
+        artifact.contents,
+      ),
+      facet: "project-convention",
+    })),
   ]
 
   if (options.emit) {
@@ -172,7 +181,13 @@ async function resolveGraph(configPath: string) {
     frameworkVersion,
     scheduledJobs: [...getManagedProfileScheduledJobs(profile), ...OPERATOR_LOCAL_SCHEDULED_JOBS],
   })
-  return { graph: resolved.graph, profile }
+  return { graph: resolved.graph, profile, projectArtifacts: resolved.artifacts }
+}
+
+function projectConventionArtifacts(artifacts: ResolvedProjectArtifacts) {
+  return artifacts.files.filter(
+    (file) => file.path !== artifacts.runtimeEntry && file.path !== artifacts.migrationRunner,
+  )
 }
 
 async function loadOperatorConfig(configPath: string): Promise<OperatorAuthoredProject> {
@@ -342,17 +357,39 @@ function projectRuntimeEntryOverrides(
   )
   const overrides: Record<string, string> = {}
   for (const unit of [...graph.modules, ...graph.extensions, ...graph.plugins]) {
-    if (!projectPackages.has(unit.packageName) || !unit.runtime?.entry.startsWith("./")) continue
-    const target = resolve(projectRoot, unit.runtime.entry)
-    const relativeTarget = path.relative(projectRoot, target)
-    if (relativeTarget.startsWith("..") || path.isAbsolute(relativeTarget)) {
-      throw new Error(`Project runtime entry ${unit.runtime.entry} escapes ${projectRoot}`)
+    if (!projectPackages.has(unit.packageName)) continue
+    for (const runtime of unitRuntimeReferences(unit)) {
+      if (!runtime.entry.startsWith("./")) continue
+      const target = resolve(projectRoot, runtime.entry)
+      const relativeTarget = path.relative(projectRoot, target)
+      if (relativeTarget.startsWith("..") || path.isAbsolute(relativeTarget)) {
+        throw new Error(`Project runtime entry ${runtime.entry} escapes ${projectRoot}`)
+      }
+      let relativeImport = path.relative(dirname(runtimeOutputPath), target).replaceAll(path.sep, "/")
+      if (!relativeImport.startsWith(".")) relativeImport = `./${relativeImport}`
+      overrides[`${unit.packageName}/${runtime.entry.slice(2)}`] = relativeImport
     }
-    let relativeImport = path.relative(dirname(runtimeOutputPath), target).replaceAll(path.sep, "/")
-    if (!relativeImport.startsWith(".")) relativeImport = `./${relativeImport}`
-    overrides[`${unit.packageName}/${unit.runtime.entry.slice(2)}`] = relativeImport
   }
   return overrides
+}
+
+function unitRuntimeReferences(
+  unit: ResolvedVoyantDeploymentGraph["modules"][number],
+): Array<{ entry: string }> {
+  return [
+    unit.runtime,
+    ...unit.api.map((route) => route.runtime),
+    ...(unit.config ?? []).map((entry) => entry.validator),
+    ...(unit.secrets ?? []).map((entry) => entry.validator),
+    ...(unit.providers ?? []).map((entry) => entry.runtime),
+    ...(unit.admin?.copy ?? []).map((entry) => entry.runtime),
+    ...(unit.admin?.routes ?? []).map((entry) => entry.runtime),
+    ...(unit.admin?.contributions ?? []).map((entry) => entry.runtime),
+    ...(unit.tools ?? []).map((entry) => entry.runtime),
+    ...(unit.setupMigrations ?? []).map((entry) => entry.runtime),
+    ...unit.workflows.map((entry) => entry.runtime),
+    ...unit.subscribers.map((entry) => entry.runtime),
+  ].filter((entry): entry is { entry: string } => Boolean(entry))
 }
 
 function printHelp(): void {

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -10,10 +10,17 @@ import {
   buildManagedNodeRuntimeEntry,
   buildManagedNodeRuntimeEntryArtifact,
 } from "../packages/framework/src/deployment-artifacts.ts"
-import type { ResolvedVoyantDeploymentGraph } from "../packages/framework/src/deployment-graph.ts"
-import type { ResolvedProjectArtifacts } from "../packages/framework/src/project-resolver.ts"
+import type {
+  ResolvedVoyantDeploymentGraph,
+  VoyantGraphDiagnostic,
+} from "../packages/framework/src/deployment-graph.ts"
 import { getManagedProfileScheduledJobs } from "../packages/framework/src/managed-jobs.ts"
 import type { VoyantProjectManifest } from "../packages/framework/src/profile-types.ts"
+import {
+  type ProjectArtifactWriteResult,
+  writeProjectArtifacts,
+} from "../packages/framework/src/project-artifacts.ts"
+import type { ResolvedProjectArtifacts } from "../packages/framework/src/project-resolver.ts"
 import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
 import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "../starters/operator/src/local-scheduled-jobs.ts"
 import {
@@ -97,6 +104,7 @@ async function main(): Promise<void> {
     options.manifestOutputPath,
     `${JSON.stringify(manifest, null, 2)}\n`,
   )
+  const conventionArtifacts = projectConventionArtifacts(projectArtifacts)
 
   const artifacts = [
     { path: options.profileOutputPath, expected: profileText, facet: "managed-profile" },
@@ -108,18 +116,14 @@ async function main(): Promise<void> {
     { path: options.graphOutputPath, expected: graphText, facet: "deployment-graph" },
     { path: options.entryOutputPath, expected: entryText, facet: "runtime-entry" },
     { path: options.runtimeOutputPath, expected: runtimeText, facet: "graph-runtime" },
-    ...projectConventionArtifacts(projectArtifacts).map((artifact) => ({
-      path: join(defaultOperatorRoot, ".voyant", artifact.path),
-      expected: formatGeneratedText(
-        join(defaultOperatorRoot, ".voyant", artifact.path),
-        artifact.contents,
-      ),
-      facet: "project-convention",
-    })),
   ]
 
   if (options.emit) {
     for (const artifact of artifacts) await writeGeneratedFile(artifact.path, artifact.expected)
+    const conventionResult = await writeProjectArtifacts({
+      projectRoot: defaultOperatorRoot,
+      artifacts: conventionArtifacts,
+    })
     const report = buildDeploymentGraphDoctorReport({ graph })
     if (options.json) {
       process.stdout.write(buildDeploymentGraphDoctorJson(report))
@@ -136,6 +140,11 @@ async function main(): Promise<void> {
     console.log(
       `emit-deployment-graph: wrote ${artifacts
         .map((artifact) => relativeToRepo(artifact.path))
+        .concat(
+          conventionResult.files.map((artifact) =>
+            relativeToRepo(join(conventionResult.outputRoot, artifact.path)),
+          ),
+        )
         .join(", ")} (${graph.contentHash})`,
     )
     return
@@ -148,7 +157,16 @@ async function main(): Promise<void> {
     })),
     { repoRoot },
   )
-  const report = buildDeploymentGraphDoctorReport({ graph, diagnostics: artifactDiagnostics })
+  const conventionResult = await writeProjectArtifacts({
+    projectRoot: defaultOperatorRoot,
+    artifacts: conventionArtifacts,
+    mode: "check",
+  })
+  const conventionDiagnostics = projectArtifactDiagnostics(conventionResult)
+  const report = buildDeploymentGraphDoctorReport({
+    graph,
+    diagnostics: [...artifactDiagnostics, ...conventionDiagnostics],
+  })
 
   if (options.json) {
     process.stdout.write(buildDeploymentGraphDoctorJson(report))
@@ -157,11 +175,13 @@ async function main(): Promise<void> {
   }
   if (!report.ok) {
     console.error("Deployment graph doctor failed.")
-    if (artifactDiagnostics.length > 0) {
+    if (artifactDiagnostics.length > 0 || conventionDiagnostics.length > 0) {
       console.error("Generated deployment graph artifacts are stale or missing.")
     }
     console.error(formatDeploymentGraphDoctorDiagnostics(report.diagnostics))
-    if (artifactDiagnostics.length > 0) console.error(`Run \`${command}\` to refresh them.`)
+    if (artifactDiagnostics.length > 0 || conventionDiagnostics.length > 0) {
+      console.error(`Run \`${command}\` to refresh them.`)
+    }
     process.exit(1)
   }
 
@@ -184,10 +204,31 @@ async function resolveGraph(configPath: string) {
   return { graph: resolved.graph, profile, projectArtifacts: resolved.artifacts }
 }
 
-function projectConventionArtifacts(artifacts: ResolvedProjectArtifacts) {
-  return artifacts.files.filter(
-    (file) => file.path !== artifacts.runtimeEntry && file.path !== artifacts.migrationRunner,
-  )
+function projectConventionArtifacts(artifacts: ResolvedProjectArtifacts): ResolvedProjectArtifacts {
+  return {
+    ...artifacts,
+    files: artifacts.files.filter(
+      (file) => file.path !== artifacts.runtimeEntry && file.path !== artifacts.migrationRunner,
+    ),
+  }
+}
+
+function projectArtifactDiagnostics(result: ProjectArtifactWriteResult): VoyantGraphDiagnostic[] {
+  return result.files.flatMap((artifact) => {
+    if (artifact.status === "unchanged" || artifact.status === "written") return []
+    const source = relativeToRepo(join(result.outputRoot, artifact.path))
+    const missing = artifact.status === "missing"
+    return [
+      {
+        code: missing ? "VOYANT_GRAPH_ARTIFACT_MISSING" : "VOYANT_GRAPH_ARTIFACT_STALE",
+        severity: "error",
+        source,
+        facet: "project-convention",
+        message: `${source} is ${missing ? "missing" : "stale"}.`,
+        hint: `Run \`${command}\` to refresh generated deployment graph artifacts.`,
+      },
+    ]
+  })
 }
 
 async function loadOperatorConfig(configPath: string): Promise<OperatorAuthoredProject> {
@@ -365,7 +406,9 @@ function projectRuntimeEntryOverrides(
       if (relativeTarget.startsWith("..") || path.isAbsolute(relativeTarget)) {
         throw new Error(`Project runtime entry ${runtime.entry} escapes ${projectRoot}`)
       }
-      let relativeImport = path.relative(dirname(runtimeOutputPath), target).replaceAll(path.sep, "/")
+      let relativeImport = path
+        .relative(dirname(runtimeOutputPath), target)
+        .replaceAll(path.sep, "/")
       if (!relativeImport.startsWith(".")) relativeImport = `./${relativeImport}`
       overrides[`${unit.packageName}/${runtime.entry.slice(2)}`] = relativeImport
     }

--- a/scripts/lib/operator-deployment-graph-package-records.ts
+++ b/scripts/lib/operator-deployment-graph-package-records.ts
@@ -21,6 +21,7 @@ import type { VoyantProjectProviders } from "../../packages/framework/src/profil
 import {
   inferredNodeRuntimePackageMetadata,
   runtimeReferencePackageNames,
+  type ResolvedProjectArtifacts,
 } from "../../packages/framework/src/project-resolver.ts"
 import { readPnpmLockfilePackageRecords } from "./deployment-graph-provenance.mjs"
 import { loadVoyantPackageManifests } from "./load-voyant-package-manifests.ts"
@@ -37,6 +38,7 @@ export interface OperatorAuthoredProject extends VoyantGraphProject {
 export interface ResolvedOperatorProject {
   project: VoyantGraphProject
   deployment: Omit<VoyantGraphDeployment, "project">
+  artifacts: ResolvedProjectArtifacts
 }
 
 interface ResolveOperatorDeploymentGraphOptions {
@@ -252,7 +254,24 @@ function normalizeFrameworkResolution(
   return {
     project,
     deployment: deploymentFromSettings(project, { mode, providers }),
+    artifacts: requireResolvedProjectArtifacts(record.artifacts),
   }
+}
+
+function requireResolvedProjectArtifacts(value: unknown): ResolvedProjectArtifacts {
+  if (!value || typeof value !== "object") {
+    throw new Error("resolveProject did not return generated project artifacts")
+  }
+  const artifacts = value as Partial<ResolvedProjectArtifacts>
+  if (
+    typeof artifacts.runtimeEntry !== "string" ||
+    typeof artifacts.migrationRunner !== "string" ||
+    !Array.isArray(artifacts.files) ||
+    !artifacts.migrationPlan
+  ) {
+    throw new Error("resolveProject returned an invalid generated project artifact contract")
+  }
+  return artifacts as ResolvedProjectArtifacts
 }
 
 function projectFromResolvedGraph(

--- a/scripts/lib/operator-deployment-graph-package-records.ts
+++ b/scripts/lib/operator-deployment-graph-package-records.ts
@@ -20,8 +20,8 @@ import type { ManagedScheduledJob } from "../../packages/framework/src/managed-j
 import type { VoyantProjectProviders } from "../../packages/framework/src/profile-types.ts"
 import {
   inferredNodeRuntimePackageMetadata,
-  runtimeReferencePackageNames,
   type ResolvedProjectArtifacts,
+  runtimeReferencePackageNames,
 } from "../../packages/framework/src/project-resolver.ts"
 import { readPnpmLockfilePackageRecords } from "./deployment-graph-provenance.mjs"
 import { loadVoyantPackageManifests } from "./load-voyant-package-manifests.ts"

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -77,6 +77,23 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
         },
       }),
     ])
+
+    for (const artifactPath of [
+      "admin/project-admin.generated.ts",
+      "runtime/project-api.generated.ts",
+      "runtime/project-jobs.generated.ts",
+      "runtime/project-links.generated.ts",
+      "runtime/project-subscribers.generated.ts",
+      "runtime/project-workflows.generated.ts",
+    ]) {
+      expect(readFileSync(join(process.cwd(), ".voyant", artifactPath), "utf8")).not.toBe("")
+    }
+    const projectLinks = readFileSync(
+      join(process.cwd(), ".voyant", "runtime/project-links.generated.ts"),
+      "utf8",
+    )
+    expect(projectLinks).toContain('import link0 from "../../src/links/bid-supplier.js"')
+    expect(projectLinks).toContain('import link19 from "../../src/links/session-function-space.js"')
   })
 
   it("fails when the artifact graph hash does not match the graph content hash", () => {


### PR DESCRIPTION
## Summary
- preserve the framework resolver artifact contract through the Operator graph adapter
- use `writeProjectArtifacts(...)` for convention artifact writes and staleness checks
- emit project admin, API, jobs, links, subscribers, and workflows under `.voyant`
- lower every project-owned facet runtime reference to the generated Node runtime loader
- verify the generated convention bundle in Operator artifact tests

## Verification
- `pnpm --filter operator graph:emit` and check mode
- Operator build
- Operator: 271 tests, 2 skipped
- repository pre-push test lane

Stacked on #3187.