### PR TITLE
feat(runtime): activate generated project links

### DIFF
--- a/.changeset/activate-project-links.md
+++ b/.changeset/activate-project-links.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/db": minor
+"@voyant-travel/hono": minor
+---
+
+Activate link definitions as request-scoped link services backed by each request's database.

--- a/packages/db/src/links.ts
+++ b/packages/db/src/links.ts
@@ -117,25 +117,26 @@ async function listReadOnly(
   return rows
 }
 
-/**
- * Create a runtime {@link LinkService} for the given set of link definitions.
- *
- * The service supports both a positional API (`create(linkKey, leftId, rightId)`)
- * and a Medusa-style spec API (`create({ moduleA: { a_id }, moduleB: { b_id } })`)
- * resolved against the provided definitions.
- */
-export function createLinkService(
-  getDb: () => DrizzleClient,
-  definitions: LinkDefinition[],
-): LinkService {
+function prepareLinkDefinitions(definitions: readonly LinkDefinition[]): {
+  definitions: LinkDefinition[]
+  byKey: Map<string, LinkDefinition>
+} {
+  const prepared = [...definitions]
   const byKey = new Map<string, LinkDefinition>()
-  for (const def of definitions) {
+  for (const def of prepared) {
     if (byKey.has(def.tableName)) {
       throw new Error(`createLinkService: duplicate link definition for table "${def.tableName}"`)
     }
     byKey.set(def.tableName, def)
   }
+  return { definitions: prepared, byKey }
+}
 
+function createPreparedLinkService(
+  getDb: () => DrizzleClient,
+  definitions: LinkDefinition[],
+  byKey: Map<string, LinkDefinition>,
+): LinkService {
   function lookupByKey(linkKey: string): LinkDefinition {
     const def = byKey.get(linkKey)
     if (!def) {
@@ -318,12 +319,42 @@ export function createLinkService(
 }
 
 /**
+ * Prevalidate link definitions once, then build services against request-local
+ * database clients without repeating startup validation on every request.
+ */
+export function createLinkServiceFactory(
+  definitions: readonly LinkDefinition[],
+): (getDb: () => DrizzleClient) => LinkService {
+  const prepared = prepareLinkDefinitions(definitions)
+  return (getDb) => createPreparedLinkService(getDb, prepared.definitions, prepared.byKey)
+}
+
+/**
+ * Create a runtime {@link LinkService} for the given set of link definitions.
+ *
+ * The service supports both a positional API (`create(linkKey, leftId, rightId)`)
+ * and a Medusa-style spec API (`create({ moduleA: { a_id }, moduleB: { b_id } })`).
+ *
+ * Prefer {@link createLinkServiceFactory} when multiple services share the
+ * same definitions, such as one service per HTTP request.
+ */
+export function createLinkService(
+  getDb: () => DrizzleClient,
+  definitions: readonly LinkDefinition[],
+): LinkService {
+  return createLinkServiceFactory(definitions)(getDb)
+}
+
+/**
  * Materialise every link definition's pivot table (CREATE TABLE + indexes).
  * Intended for use by a `db:sync-links` CLI command in templates.
  *
  * Runs each DDL statement individually against the provided Drizzle client.
  */
-export async function syncLinks(db: DrizzleClient, definitions: LinkDefinition[]): Promise<void> {
+export async function syncLinks(
+  db: DrizzleClient,
+  definitions: readonly LinkDefinition[],
+): Promise<void> {
   for (const def of definitions) {
     if (def.readOnly) continue
     const { createTable, indexes } = generateLinkTableSql(def)

--- a/packages/db/tests/unit/links.test.ts
+++ b/packages/db/tests/unit/links.test.ts
@@ -3,7 +3,7 @@ import type { SQL } from "drizzle-orm"
 import { PgDialect } from "drizzle-orm/pg-core"
 import { describe, expect, it, vi } from "vitest"
 
-import { createLinkService, syncLinks } from "../../src/links.js"
+import { createLinkService, createLinkServiceFactory, syncLinks } from "../../src/links.js"
 
 const person: LinkableDefinition = {
   module: "crm",
@@ -59,6 +59,29 @@ function makeRawRow(
     deleted_at: null,
   }
 }
+
+describe("createLinkServiceFactory", () => {
+  it("validates duplicate table names when the factory is created", () => {
+    const link = defineLink(person, product)
+
+    expect(() => createLinkServiceFactory([link, link])).toThrow(
+      `duplicate link definition for table "${link.tableName}"`,
+    )
+  })
+
+  it("builds independent services against request-local databases", async () => {
+    const link = defineLink(person, product)
+    const first = makeMockDb()
+    const second = makeMockDb()
+    const createForRequest = createLinkServiceFactory([link])
+
+    await createForRequest(() => first.db).list(link.tableName)
+    await createForRequest(() => second.db).list(link.tableName)
+
+    expect(first.execute).toHaveBeenCalledTimes(1)
+    expect(second.execute).toHaveBeenCalledTimes(1)
+  })
+})
 
 describe("list — batched ID filters", () => {
   const link = defineLink(person, { linkable: product, isList: true })

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -8,6 +8,7 @@ import {
   type EventFilterDescriptor,
   type WorkflowDescriptor,
 } from "@voyant-travel/core"
+import { createLinkServiceFactory } from "@voyant-travel/db/links"
 import type { WorkflowDriver } from "@voyant-travel/workflows/driver"
 import type { Context, Hono } from "hono"
 
@@ -222,6 +223,14 @@ export function mountApp<TBindings extends VoyantBindings>(
   const expanded = eagerPlugins.length > 0 ? expandHonoBundles(eagerPlugins) : null
   const allModules = [...(config.modules ?? []), ...(expanded?.modules ?? [])]
   const allExtensions = [...(config.extensions ?? []), ...(expanded?.extensions ?? [])]
+  const linkDefinitions = [...(config.linkDefinitions ?? []), ...(expanded?.links ?? [])]
+  if (config.link && linkDefinitions.length > 0) {
+    throw new Error(
+      "createApp: cannot configure both an explicit link service and link definitions",
+    )
+  }
+  const createRequestLinkService =
+    linkDefinitions.length > 0 ? createLinkServiceFactory(linkDefinitions) : undefined
   // Anonymous-access allow-list (ADR-0008): assembled from module/extension
   // `anonymous` declarations + bundle-declared absolute anonymous paths (e.g. a
   // payment-processor webhook) + any explicit `publicPaths` escape-hatch entries.
@@ -675,6 +684,16 @@ export function mountApp<TBindings extends VoyantBindings>(
     "*",
     db(dbSource, { requiresTransactionalDb: txRequiringModules, basePath: config.basePath }),
   )
+
+  if (createRequestLinkService) {
+    app.use("*", async (c, next) => {
+      c.set(
+        "link",
+        createRequestLinkService(() => c.get("db")),
+      )
+      return next()
+    })
+  }
 
   // Actor guards for the two API surfaces
   const actorOptions = { basePath: config.basePath }

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -2,6 +2,7 @@ import type {
   Actor,
   VoyantVariables as CoreVoyantVariables,
   EventBus,
+  LinkDefinition,
   LinkService,
   ModuleContainer,
   QueryGraphContext,
@@ -266,6 +267,12 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
   extensions?: HonoExtension[]
   plugins?: HonoBundleInput[]
   eventBus?: EventBus
+  /**
+   * Link definitions activated against each request's resolved database.
+   * Combined with definitions contributed by eager bundles. Cannot be used
+   * together with an explicitly constructed `link` service.
+   */
+  linkDefinitions?: readonly LinkDefinition[]
   link?: LinkService
   query?: QueryGraphContext | VoyantQueryRuntime
   auth?: VoyantAuthIntegration<TBindings>

--- a/packages/hono/tests/unit/app-surfaces.test.ts
+++ b/packages/hono/tests/unit/app-surfaces.test.ts
@@ -350,4 +350,87 @@ describe("mountApp surface mounting", () => {
     expect(linkService.list).toHaveBeenCalledWith(link.tableName, { leftId: "pers_1" })
     expect(fetcher.list).toHaveBeenCalledWith({ filters: undefined, pagination: undefined })
   })
+
+  it("rejects an explicit link service combined with link definitions", () => {
+    const definition = defineLink(
+      { module: "crm", entity: "person", table: "people" },
+      { module: "catalog", entity: "product", table: "products" },
+    )
+    const linkService: LinkService = {
+      create: vi.fn(),
+      dismiss: vi.fn(),
+      delete: vi.fn(),
+      list: vi.fn(async () => []),
+      // biome-ignore lint/suspicious/noExplicitAny: LinkService has overloaded signatures -- owner: hono; test only needs identity.
+    } as any
+
+    expect(() =>
+      mountApp({
+        // biome-ignore lint/suspicious/noExplicitAny: startup validation does not use db -- owner: hono.
+        db: () => ({}) as any,
+        link: linkService,
+        linkDefinitions: [definition],
+      }),
+    ).toThrow("cannot configure both an explicit link service and link definitions")
+  })
+
+  it("validates duplicate configured and eager-bundle link tables at startup", () => {
+    const definition = defineLink(
+      { module: "crm", entity: "person", table: "people" },
+      { module: "catalog", entity: "product", table: "products" },
+    )
+
+    expect(() =>
+      mountApp({
+        // biome-ignore lint/suspicious/noExplicitAny: startup validation does not use db -- owner: hono.
+        db: () => ({}) as any,
+        linkDefinitions: [definition],
+        plugins: [{ name: "catalog-links", links: [definition] }],
+      }),
+    ).toThrow(`duplicate link definition for table "${definition.tableName}"`)
+  })
+
+  it("combines configured and eager-bundle links in a service bound to each request db", async () => {
+    const personProduct = defineLink(
+      { module: "crm", entity: "person", table: "people" },
+      { module: "catalog", entity: "product", table: "products" },
+    )
+    const organizationOrder = defineLink(
+      { module: "crm", entity: "organization", table: "organizations" },
+      { module: "sales", entity: "order", table: "orders" },
+    )
+    const requestDbs: Array<{ execute: ReturnType<typeof vi.fn> }> = []
+    const requestServices: LinkService[] = []
+    const adminRoutes = new Hono().get("/inspect", async (c) => {
+      const link = c.var.link
+      if (!link) return c.json({ error: "missing link service" }, 500)
+      requestServices.push(link)
+      await link.list(personProduct.tableName)
+      await link.list(organizationOrder.tableName)
+      return c.json({ ok: true })
+    })
+    const app = mountApp({
+      db: () => {
+        const requestDb = { execute: vi.fn(async () => []) }
+        requestDbs.push(requestDb)
+        // biome-ignore lint/suspicious/noExplicitAny: structural Drizzle client for request-scoping test -- owner: hono.
+        return requestDb as any
+      },
+      linkDefinitions: [personProduct],
+      plugins: [{ name: "sales-links", links: [organizationOrder] }],
+      modules: [{ module: { name: "runtime" }, adminRoutes }],
+      auth: { resolve: () => ({ userId: "u1", actor: "staff" }) },
+    })
+
+    const first = await app.request("/v1/admin/runtime/inspect", {}, TEST_ENV, TEST_CTX)
+    const second = await app.request("/v1/admin/runtime/inspect", {}, TEST_ENV, TEST_CTX)
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(requestServices).toHaveLength(2)
+    expect(requestServices[0]).not.toBe(requestServices[1])
+    expect(requestDbs).toHaveLength(2)
+    expect(requestDbs[0]?.execute).toHaveBeenCalledTimes(2)
+    expect(requestDbs[1]?.execute).toHaveBeenCalledTimes(2)
+  })
 })

--- a/starters/operator/src/api/app.ts
+++ b/starters/operator/src/api/app.ts
@@ -10,6 +10,7 @@ import {
   createGeneratedGraphRuntime,
   GENERATED_GRAPH_RUNTIME_PLUGIN_IDS,
 } from "../../.voyant/runtime/graph-runtime.generated"
+import { projectLinks } from "../../.voyant/runtime/project-links.generated"
 import { OPERATOR_APP_NAME, operatorReporter } from "../lib/observability"
 import authHandler, {
   hasAuthPermission,
@@ -81,6 +82,7 @@ export const app = mountApp<AppBindings>({
   db: (env) =>
     env.DB_FORCE_TRANSACTIONAL === "1" ? dbFromEnvForApp(env) : httpDbFromEnvForApp(env),
   dbTransactional: (env) => dbFromEnvForApp(env),
+  linkDefinitions: projectLinks,
   // Workflow runtime — managed Cloud forwarding. App code forwards
   // trigger/event calls to Voyant Cloud; workflow bundles execute in the
   // hosted Node runtime.


### PR DESCRIPTION
## Summary
- construct request-scoped LinkService instances from generated project link definitions
- merge eager Hono link bundles with deterministic duplicate/conflict validation
- activate the Operator's generated project links at runtime

## Verification
- focused DB, Hono, and Operator tests
- DB, Hono, and Operator typechecks and lint
- repository pre-push suite reached an unrelated commerce test failure after focused verification passed

## Follow-up
Entity fetchers for graph traversal remain an explicit graph-facet slice; they are not inferred from database tables.