### PR TITLE
feat(distribution): export channel-push workflow runtime contract

### DIFF
--- a/.changeset/distribution-workflow-runtime.md
+++ b/.changeset/distribution-workflow-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/distribution": patch
+---
+
+Publish the channel-push workflow runtime service contract for graph activation.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -649,6 +649,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -644,6 +644,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -620,6 +620,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -615,6 +615,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -684,6 +684,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -685,6 +685,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./channel-push-workflows": "./src/channel-push/workflow-entry.ts",
+    "./channel-push-runtime": "./src/channel-push/types.ts",
     "./external-refs/validation": "./src/external-refs/validation.ts",
     "./suppliers/linkables": "./src/suppliers/linkables.ts",
     "./schema": "./src/schema.ts",
@@ -59,6 +60,11 @@
         "types": "./dist/channel-push/workflow-entry.d.ts",
         "import": "./dist/channel-push/workflow-entry.js",
         "default": "./dist/channel-push/workflow-entry.js"
+      },
+      "./channel-push-runtime": {
+        "types": "./dist/channel-push/types.d.ts",
+        "import": "./dist/channel-push/types.js",
+        "default": "./dist/channel-push/types.js"
       },
       "./external-refs/validation": {
         "types": "./dist/external-refs/validation.d.ts",

--- a/packages/distribution/src/channel-push/index.ts
+++ b/packages/distribution/src/channel-push/index.ts
@@ -60,6 +60,7 @@ export {
   triggerBookingPushForBooking,
 } from "./subscriber.js"
 export {
+  CHANNEL_PUSH_WORKFLOW_RUNTIME_KEY,
   type ChannelPushDeps,
   type ChannelPushLogger,
   clearChannelPushDeps,

--- a/packages/distribution/src/channel-push/types.ts
+++ b/packages/distribution/src/channel-push/types.ts
@@ -29,6 +29,9 @@ export interface ChannelPushDeps {
   logger?: ChannelPushLogger
 }
 
+export const CHANNEL_PUSH_WORKFLOW_RUNTIME_KEY =
+  "distribution.workflows.channel-push.runtime" as const
+
 export interface ChannelPushLogger {
   info?: (message: string, meta?: Record<string, unknown>) => void
   warn?: (message: string, meta?: Record<string, unknown>) => void

--- a/packages/distribution/src/channel-push/workflow-entry.ts
+++ b/packages/distribution/src/channel-push/workflow-entry.ts
@@ -8,6 +8,7 @@
  */
 
 export {
+  CHANNEL_PUSH_WORKFLOW_RUNTIME_KEY,
   type ChannelPushDeps,
   type ChannelPushLogger,
   clearChannelPushDeps,

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -720,6 +720,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -714,6 +714,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -720,6 +720,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -714,6 +714,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -720,6 +720,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -713,6 +713,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -714,6 +714,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -715,6 +715,9 @@
         "../distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -898,6 +898,9 @@
         "../../packages/distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../../packages/distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../../packages/distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../../packages/distribution/dist/channel-push/workflow-entry.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -898,6 +898,9 @@
         "../../packages/distribution-react/dist/suppliers/ui.d.ts"
       ],
       "@voyant-travel/distribution-react/ui": ["../../packages/distribution-react/dist/ui.d.ts"],
+      "@voyant-travel/distribution/channel-push-runtime": [
+        "../../packages/distribution/dist/channel-push/types.d.ts"
+      ],
       "@voyant-travel/distribution/channel-push-workflows": [
         "../../packages/distribution/dist/channel-push/workflow-entry.d.ts"
       ],


### PR DESCRIPTION
## Summary
- publish the channel-push workflow runtime service key and contract through a stable package subpath
- retain the existing channel-push workflow definitions and dependency behavior
- regenerate composition dependency paths and package dist configs

## Scope boundary
This PR is definition/contract-only. It does not add workflow `runtime` selectors to the package manifest and does not activate graph-selected execution. Runtime service registration and activation are intentionally deferred to the atomic Operator integration PR, which will pair manifest selection, service bindings, scheduler loading, and removal of the legacy hand-wired registrations.

## Verification
- distribution tests: 89 passed, 184 skipped
- distribution typecheck
- distribution lint
- `pnpm verify:dep-paths`
- `pnpm verify:dist-configs`