### PR TITLE
feat(bookings): export stale-hold workflow runtime contract

### DIFF
--- a/.changeset/bookings-workflow-runtime.md
+++ b/.changeset/bookings-workflow-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Publish the stale-hold workflow deployment runtime service contract for graph activation.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -188,6 +188,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -183,6 +183,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/bookings/package.json
+++ b/packages/bookings/package.json
@@ -15,6 +15,7 @@
     "./requirements/public-routes": "./src/requirements/routes-public.ts",
     "./tasks": "./src/tasks/index.ts",
     "./workflows": "./src/workflow-entry.ts",
+    "./workflow-runtime": "./src/workflow-runtime.ts",
     "./validation": "./src/validation.ts",
     "./routes": "./src/routes.ts",
     "./action-ledger-drift": "./src/action-ledger-drift.ts",
@@ -123,6 +124,11 @@
         "types": "./dist/workflow-entry.d.ts",
         "import": "./dist/workflow-entry.js",
         "default": "./dist/workflow-entry.js"
+      },
+      "./workflow-runtime": {
+        "types": "./dist/workflow-runtime.d.ts",
+        "import": "./dist/workflow-runtime.js",
+        "default": "./dist/workflow-runtime.js"
       },
       "./validation": {
         "types": "./dist/validation.d.ts",

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -101,6 +101,10 @@ export {
   type ExpireStaleBookingHoldsResult,
   expireStaleBookingHolds,
 } from "./tasks/index.js"
+export {
+  BOOKINGS_EXPIRE_STALE_HOLDS_RUNTIME_KEY,
+  type BookingsExpireStaleHoldsWorkflowRuntime,
+} from "./workflow-runtime.js"
 
 export const bookingsModule: Module = {
   name: "bookings",

--- a/packages/bookings/src/workflow-entry.ts
+++ b/packages/bookings/src/workflow-entry.ts
@@ -1,22 +1,13 @@
 import type { WorkflowDescriptor } from "@voyant-travel/core"
 import { workflow } from "@voyant-travel/workflows"
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
-import type { BookingServiceRuntime } from "./service.js"
 import {
   type ExpireStaleBookingHoldsInput,
   type ExpireStaleBookingHoldsResult,
   expireStaleBookingHolds,
 } from "./tasks/expire-stale-holds.js"
+import type { BookingsExpireStaleHoldsWorkflowRuntime } from "./workflow-runtime.js"
 
-export interface CreateBookingsExpireStaleHoldsWorkflowOptions {
-  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
-  resolveRuntime?: (
-    db: PostgresJsDatabase,
-    input: ExpireStaleBookingHoldsInput,
-  ) => BookingServiceRuntime | Promise<BookingServiceRuntime>
-  userId?: string
-}
+export type CreateBookingsExpireStaleHoldsWorkflowOptions = BookingsExpireStaleHoldsWorkflowRuntime
 
 export const bookingsExpireStaleHoldsWorkflowManifest = {
   id: "bookings.expire-stale-holds",
@@ -34,11 +25,18 @@ export function createBookingsExpireStaleHoldsWorkflow(
     ...bookingsExpireStaleHoldsWorkflowManifest.config,
     id: bookingsExpireStaleHoldsWorkflowManifest.id,
     async run(input) {
-      const db = await options.resolveDb()
-      const runtime = (await options.resolveRuntime?.(db, input)) ?? {}
-      return expireStaleBookingHolds(db, input, options.userId ?? "system", runtime)
+      return runExpireStaleBookingHolds(options, input)
     },
   })
+}
+
+async function runExpireStaleBookingHolds(
+  options: BookingsExpireStaleHoldsWorkflowRuntime,
+  input: ExpireStaleBookingHoldsInput,
+): Promise<ExpireStaleBookingHoldsResult> {
+  const db = await options.resolveDb()
+  const runtime = (await options.resolveRuntime?.(db, input)) ?? {}
+  return expireStaleBookingHolds(db, input, options.userId ?? "system", runtime)
 }
 
 export type { ExpireStaleBookingHoldsInput, ExpireStaleBookingHoldsResult }

--- a/packages/bookings/src/workflow-runtime.ts
+++ b/packages/bookings/src/workflow-runtime.ts
@@ -1,0 +1,16 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { BookingServiceRuntime } from "./service.js"
+import type { ExpireStaleBookingHoldsInput } from "./tasks/expire-stale-holds.js"
+
+export const BOOKINGS_EXPIRE_STALE_HOLDS_RUNTIME_KEY =
+  "bookings.workflows.expire-stale-holds.runtime" as const
+
+export interface BookingsExpireStaleHoldsWorkflowRuntime {
+  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
+  resolveRuntime?: (
+    db: PostgresJsDatabase,
+    input: ExpireStaleBookingHoldsInput,
+  ) => BookingServiceRuntime | Promise<BookingServiceRuntime>
+  userId?: string
+}

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -38,6 +38,8 @@ describe("bookings deployment manifest", () => {
         },
       ],
     })
+
+    expect(bookingsVoyantModule.workflows[0]).not.toHaveProperty("runtime")
   })
 
   it("owns the requirements module and supplier extension", () => {

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -259,6 +259,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -253,6 +253,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -253,6 +253,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -259,6 +259,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -253,6 +253,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -259,6 +259,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -253,6 +253,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -259,6 +259,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -252,6 +252,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -253,6 +253,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -254,6 +254,7 @@
       "@voyant-travel/bookings/tools": ["../bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": ["../bookings/dist/workflow-runtime.d.ts"],
       "@voyant-travel/bookings/workflows": ["../bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../catalog-authoring/dist/index.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -317,6 +317,9 @@
       "@voyant-travel/bookings/tools": ["../../packages/bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../../packages/bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../../packages/bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": [
+        "../../packages/bookings/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/bookings/workflows": ["../../packages/bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../../packages/catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../../packages/catalog-authoring/dist/index.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -317,6 +317,9 @@
       "@voyant-travel/bookings/tools": ["../../packages/bookings/dist/tools.d.ts"],
       "@voyant-travel/bookings/validation": ["../../packages/bookings/dist/validation.d.ts"],
       "@voyant-travel/bookings/voyant": ["../../packages/bookings/dist/voyant.d.ts"],
+      "@voyant-travel/bookings/workflow-runtime": [
+        "../../packages/bookings/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/bookings/workflows": ["../../packages/bookings/dist/workflow-entry.d.ts"],
       "@voyant-travel/catalog": ["../../packages/catalog/dist/index.d.ts"],
       "@voyant-travel/catalog-authoring": ["../../packages/catalog-authoring/dist/index.d.ts"],


### PR DESCRIPTION
## Summary
- publish the stale-hold workflow deployment runtime service key and contract through a stable package subpath
- preserve the existing configurable workflow factory without adding a service-resolving import side effect
- regenerate composition dependency paths and package dist configs

## Scope boundary
This PR is definition/contract-only. The bookings manifest keeps declaration metadata without a workflow `runtime` selector, and this PR does not instantiate a service-dependent executable workflow. Runtime selection, executable definition, service registration, scheduler loading, and removal of the duplicate Operator registration are intentionally deferred to one atomic Operator integration PR.

## Verification
- bookings tests: 446 passed, 204 skipped
- bookings typecheck
- bookings lint
- `pnpm verify:dep-paths`
- `pnpm verify:dist-configs`