### PR TITLE
feat(notifications): export reminder workflow runtime contracts

### DIFF
--- a/.changeset/notifications-workflow-runtime.md
+++ b/.changeset/notifications-workflow-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/notifications": patch
+---
+
+Publish the reminder workflow deployment runtime service contract for graph activation.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1025,6 +1025,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1020,6 +1020,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -996,6 +996,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -991,6 +991,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1060,6 +1060,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1061,6 +1061,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1076,6 +1076,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1077,6 +1077,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1080,6 +1080,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1075,6 +1075,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1084,6 +1084,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1085,6 +1085,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1081,6 +1081,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1076,6 +1076,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -13,6 +13,7 @@
     "./service": "./src/service.ts",
     "./tasks": "./src/tasks/index.ts",
     "./workflows": "./src/workflow-entry.ts",
+    "./workflow-runtime": "./src/workflow-runtime.ts",
     "./providers/local": "./src/providers/local.ts",
     "./providers/voyant-cloud-email": "./src/providers/voyant-cloud-email.ts",
     "./providers/voyant-cloud-sms": "./src/providers/voyant-cloud-sms.ts",
@@ -103,6 +104,11 @@
         "types": "./dist/workflow-entry.d.ts",
         "import": "./dist/workflow-entry.js",
         "default": "./dist/workflow-entry.js"
+      },
+      "./workflow-runtime": {
+        "types": "./dist/workflow-runtime.d.ts",
+        "import": "./dist/workflow-runtime.js",
+        "default": "./dist/workflow-runtime.js"
       },
       "./providers/local": {
         "types": "./dist/providers/local.d.ts",

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -184,6 +184,13 @@ export {
   updateNotificationSettingsSchema,
   updateNotificationTemplateSchema,
 } from "./validation.js"
+export {
+  type DeliverReminderWorkflowInput,
+  type DeliverReminderWorkflowOutput,
+  NOTIFICATION_REMINDER_WORKFLOW_RUNTIME_KEY,
+  type NotificationReminderWorkflowRuntime,
+  type SendDueRemindersWorkflowInput,
+} from "./workflow-runtime.js"
 
 /**
  * Auto-dispatch policy for the `booking.confirmed` subscriber. Set `enabled:

--- a/packages/notifications/src/workflow-entry.ts
+++ b/packages/notifications/src/workflow-entry.ts
@@ -1,31 +1,15 @@
 import type { WorkflowDescriptor } from "@voyant-travel/core"
 import { workflow } from "@voyant-travel/workflows"
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
-import type { NotificationTaskEnv, NotificationTaskRuntimeOptions } from "./task-runtime.js"
 import { deliverQueuedNotificationReminder } from "./tasks/deliver-reminder.js"
 import { sendDueNotificationReminders } from "./tasks/send-due-reminders.js"
+import type {
+  DeliverReminderWorkflowInput,
+  DeliverReminderWorkflowOutput,
+  NotificationReminderWorkflowRuntime,
+  SendDueRemindersWorkflowInput,
+} from "./workflow-runtime.js"
 
-export interface DeliverReminderWorkflowInput {
-  reminderRunId: string
-}
-
-export interface DeliverReminderWorkflowOutput {
-  reminderRunId: string
-  status: string | null
-}
-
-export interface SendDueRemindersWorkflowInput {
-  now?: string | null
-}
-
-export interface CreateNotificationReminderWorkflowsOptions {
-  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
-  resolveEnv: () => NotificationTaskEnv | Promise<NotificationTaskEnv>
-  resolveRuntimeOptions: (
-    env: NotificationTaskEnv,
-  ) => NotificationTaskRuntimeOptions | Promise<NotificationTaskRuntimeOptions>
-}
+export type CreateNotificationReminderWorkflowsOptions = NotificationReminderWorkflowRuntime
 
 export const notificationsDeliverReminderWorkflowManifest = {
   id: "notifications.deliver-reminder",
@@ -58,13 +42,7 @@ export function createNotificationReminderWorkflows(
     ...notificationsDeliverReminderWorkflowManifest.config,
     id: notificationsDeliverReminderWorkflowManifest.id,
     async run(input) {
-      const [db, env] = await Promise.all([options.resolveDb(), options.resolveEnv()])
-      return deliverQueuedNotificationReminder(
-        db,
-        env,
-        input,
-        await options.resolveRuntimeOptions(env),
-      )
+      return runDeliverReminder(options, input)
     },
   })
 
@@ -75,16 +53,39 @@ export function createNotificationReminderWorkflows(
     ...notificationsSendDueRemindersWorkflowManifest.config,
     id: notificationsSendDueRemindersWorkflowManifest.id,
     async run(input, ctx) {
-      const [db, env] = await Promise.all([options.resolveDb(), options.resolveEnv()])
-      const runtimeOptions = await options.resolveRuntimeOptions(env)
-      return sendDueNotificationReminders(db, env, input, {
-        ...runtimeOptions,
-        enqueueReminderDelivery: async (job) => {
-          await ctx.invoke(deliverReminderWorkflow, job, { detach: true })
-        },
+      return runSendDueReminders(options, input, async (job) => {
+        await ctx.invoke(deliverReminderWorkflow, job, { detach: true })
       })
     },
   })
 
   return { deliverReminderWorkflow, sendDueRemindersWorkflow }
 }
+
+async function runDeliverReminder(
+  options: NotificationReminderWorkflowRuntime,
+  input: DeliverReminderWorkflowInput,
+): Promise<DeliverReminderWorkflowOutput> {
+  const [db, env] = await Promise.all([options.resolveDb(), options.resolveEnv()])
+  return deliverQueuedNotificationReminder(db, env, input, await options.resolveRuntimeOptions(env))
+}
+
+async function runSendDueReminders(
+  options: NotificationReminderWorkflowRuntime,
+  input: SendDueRemindersWorkflowInput,
+  enqueueReminderDelivery: (job: DeliverReminderWorkflowInput) => Promise<void>,
+): Promise<Awaited<ReturnType<typeof sendDueNotificationReminders>>> {
+  const [db, env] = await Promise.all([options.resolveDb(), options.resolveEnv()])
+  const runtimeOptions = await options.resolveRuntimeOptions(env)
+  return sendDueNotificationReminders(db, env, input, {
+    ...runtimeOptions,
+    enqueueReminderDelivery,
+  })
+}
+
+export type {
+  DeliverReminderWorkflowInput,
+  DeliverReminderWorkflowOutput,
+  NotificationReminderWorkflowRuntime,
+  SendDueRemindersWorkflowInput,
+} from "./workflow-runtime.js"

--- a/packages/notifications/src/workflow-runtime.ts
+++ b/packages/notifications/src/workflow-runtime.ts
@@ -1,0 +1,27 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { NotificationTaskEnv, NotificationTaskRuntimeOptions } from "./task-runtime.js"
+
+export interface DeliverReminderWorkflowInput {
+  reminderRunId: string
+}
+
+export interface DeliverReminderWorkflowOutput {
+  reminderRunId: string
+  status: string | null
+}
+
+export interface SendDueRemindersWorkflowInput {
+  now?: string | null
+}
+
+export const NOTIFICATION_REMINDER_WORKFLOW_RUNTIME_KEY =
+  "notifications.workflows.reminders.runtime" as const
+
+export interface NotificationReminderWorkflowRuntime {
+  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
+  resolveEnv: () => NotificationTaskEnv | Promise<NotificationTaskEnv>
+  resolveRuntimeOptions: (
+    env: NotificationTaskEnv,
+  ) => NotificationTaskRuntimeOptions | Promise<NotificationTaskRuntimeOptions>
+}

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -47,7 +47,14 @@ describe("notifications deployment manifest", () => {
     ])
   })
 
-  it("exposes configurable reminder workflow factories", () => {
+  it("defers executable workflow runtime activation", () => {
+    expect(notificationsVoyantModule.workflows).toEqual([
+      expect.not.objectContaining({ runtime: expect.anything() }),
+      expect.not.objectContaining({ runtime: expect.anything() }),
+    ])
+  })
+
+  it("preserves configurable reminder workflow factories", () => {
     const definitions = createNotificationReminderWorkflows({
       resolveDb: () => ({}) as never,
       resolveEnv: () => ({}),

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1090,6 +1090,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],
       "@voyant-travel/octo/routes": ["../octo/dist/routes.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1091,6 +1091,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],
       "@voyant-travel/octo/routes": ["../octo/dist/routes.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1091,6 +1091,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1096,6 +1096,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1091,6 +1091,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1089,6 +1089,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1090,6 +1090,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1091,6 +1091,9 @@
       "@voyant-travel/notifications/types": ["../notifications/dist/types.d.ts"],
       "@voyant-travel/notifications/validation": ["../notifications/dist/validation.d.ts"],
       "@voyant-travel/notifications/voyant": ["../notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": ["../notifications/dist/workflow-entry.d.ts"],
       "@voyant-travel/observability-sentry": ["../observability-sentry/dist/index.d.ts"],
       "@voyant-travel/octo": ["../octo/dist/index.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1400,6 +1400,9 @@
         "../../packages/notifications/dist/validation.d.ts"
       ],
       "@voyant-travel/notifications/voyant": ["../../packages/notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../../packages/notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": [
         "../../packages/notifications/dist/workflow-entry.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1400,6 +1400,9 @@
         "../../packages/notifications/dist/validation.d.ts"
       ],
       "@voyant-travel/notifications/voyant": ["../../packages/notifications/dist/voyant.d.ts"],
+      "@voyant-travel/notifications/workflow-runtime": [
+        "../../packages/notifications/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/workflows": [
         "../../packages/notifications/dist/workflow-entry.d.ts"
       ],


### PR DESCRIPTION
## Summary
- publish the reminder workflow deployment runtime service key and contract through a stable package subpath
- preserve the existing configurable workflow factory without adding service-resolving import side effects
- regenerate composition dependency paths and package dist configs

## Scope boundary
This PR is definition/contract-only. The notifications manifest keeps declaration metadata without workflow `runtime` selectors, and this PR does not instantiate service-dependent executable workflows. Runtime selection, executable definitions, service registration, scheduler loading, and removal of legacy Operator wiring are intentionally deferred to one atomic Operator integration PR.

## Verification
- notifications tests: 116 passed, 18 skipped
- notifications typecheck
- notifications lint
- `pnpm verify:dep-paths`
- `pnpm verify:dist-configs`