### PR TITLE
feat(inventory): export PDF workflow runtime contract

### DIFF
--- a/.changeset/inventory-workflow-runtime.md
+++ b/.changeset/inventory-workflow-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Publish the product PDF workflow deployment runtime service contract for graph activation.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -915,6 +915,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -910,6 +910,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -886,6 +886,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -881,6 +881,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -950,6 +950,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -951,6 +951,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -966,6 +966,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -967,6 +967,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -970,6 +970,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -965,6 +965,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -974,6 +974,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -975,6 +975,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -971,6 +971,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -966,6 +966,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -17,6 +17,7 @@
     "./public-validation": "./src/public-validation.ts",
     "./tasks": "./src/tasks.ts",
     "./workflows": "./src/workflow-entry.ts",
+    "./workflow-runtime": "./src/workflow-runtime.ts",
     "./booking-extension": "./src/booking-extension.ts",
     "./catalog-policy": "./src/catalog-policy.ts",
     "./catalog-policy-destinations": "./src/catalog-policy-destinations.ts",
@@ -152,6 +153,11 @@
         "types": "./dist/workflow-entry.d.ts",
         "import": "./dist/workflow-entry.js",
         "default": "./dist/workflow-entry.js"
+      },
+      "./workflow-runtime": {
+        "types": "./dist/workflow-runtime.d.ts",
+        "import": "./dist/workflow-runtime.js",
+        "default": "./dist/workflow-runtime.js"
       },
       "./booking-extension": {
         "types": "./dist/booking-extension.d.ts",

--- a/packages/inventory/src/index.ts
+++ b/packages/inventory/src/index.ts
@@ -39,6 +39,12 @@ export { publicProductRoutes } from "./routes-public.js"
 export { productsService } from "./service.js"
 export { catalogProductsService } from "./service-catalog.js"
 export { publicProductsService } from "./service-public.js"
+export {
+  PRODUCTS_GENERATE_PDF_WORKFLOW_RUNTIME_KEY,
+  type ProductsGeneratePdfWorkflowInput,
+  type ProductsGeneratePdfWorkflowOutput,
+  type ProductsGeneratePdfWorkflowRuntime,
+} from "./workflow-runtime.js"
 
 export const productsModule: Module = {
   name: "products",

--- a/packages/inventory/src/workflow-entry.ts
+++ b/packages/inventory/src/workflow-entry.ts
@@ -1,26 +1,13 @@
 import type { WorkflowDescriptor } from "@voyant-travel/core"
 import { workflow } from "@voyant-travel/workflows"
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-
 import { generateProductPdf } from "./tasks/generate-pdf.js"
+import type {
+  ProductsGeneratePdfWorkflowInput,
+  ProductsGeneratePdfWorkflowOutput,
+  ProductsGeneratePdfWorkflowRuntime,
+} from "./workflow-runtime.js"
 
-export interface ProductsGeneratePdfWorkflowInput {
-  productId: string
-}
-
-export interface ProductsGeneratePdfWorkflowOutput {
-  base64: string
-  filename: string
-  sizeBytes: number
-}
-
-export interface CreateProductsGeneratePdfWorkflowOptions {
-  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
-  render?: (
-    db: PostgresJsDatabase,
-    input: ProductsGeneratePdfWorkflowInput,
-  ) => ProductsGeneratePdfWorkflowOutput | Promise<ProductsGeneratePdfWorkflowOutput>
-}
+export type CreateProductsGeneratePdfWorkflowOptions = ProductsGeneratePdfWorkflowRuntime
 
 export const productsGeneratePdfWorkflowManifest = {
   id: "products.generate-pdf",
@@ -37,17 +24,24 @@ export function createProductsGeneratePdfWorkflow(
     ...productsGeneratePdfWorkflowManifest.config,
     id: productsGeneratePdfWorkflowManifest.id,
     async run(input) {
-      const db = await options.resolveDb()
-      if (options.render) return options.render(db, input)
-
-      const generated = await generateProductPdf(db, input.productId)
-      return {
-        base64: bytesToBase64(generated.pdfBytes),
-        filename: generated.filename,
-        sizeBytes: generated.sizeBytes,
-      }
+      return runGenerateProductPdf(options, input)
     },
   })
+}
+
+async function runGenerateProductPdf(
+  options: ProductsGeneratePdfWorkflowRuntime,
+  input: ProductsGeneratePdfWorkflowInput,
+): Promise<ProductsGeneratePdfWorkflowOutput> {
+  const db = await options.resolveDb()
+  if (options.render) return options.render(db, input)
+
+  const generated = await generateProductPdf(db, input.productId)
+  return {
+    base64: bytesToBase64(generated.pdfBytes),
+    filename: generated.filename,
+    sizeBytes: generated.sizeBytes,
+  }
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
@@ -58,3 +52,9 @@ function bytesToBase64(bytes: Uint8Array): string {
   }
   return btoa(binary)
 }
+
+export type {
+  ProductsGeneratePdfWorkflowInput,
+  ProductsGeneratePdfWorkflowOutput,
+  ProductsGeneratePdfWorkflowRuntime,
+} from "./workflow-runtime.js"

--- a/packages/inventory/src/workflow-runtime.ts
+++ b/packages/inventory/src/workflow-runtime.ts
@@ -1,0 +1,22 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+export interface ProductsGeneratePdfWorkflowInput {
+  productId: string
+}
+
+export interface ProductsGeneratePdfWorkflowOutput {
+  base64: string
+  filename: string
+  sizeBytes: number
+}
+
+export const PRODUCTS_GENERATE_PDF_WORKFLOW_RUNTIME_KEY =
+  "inventory.workflows.generate-product-pdf.runtime" as const
+
+export interface ProductsGeneratePdfWorkflowRuntime {
+  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
+  render?: (
+    db: PostgresJsDatabase,
+    input: ProductsGeneratePdfWorkflowInput,
+  ) => ProductsGeneratePdfWorkflowOutput | Promise<ProductsGeneratePdfWorkflowOutput>
+}

--- a/packages/inventory/tests/unit/voyant-manifest.test.ts
+++ b/packages/inventory/tests/unit/voyant-manifest.test.ts
@@ -132,4 +132,8 @@ describe("inventory deployment manifests", () => {
     expect(definition.id).toBe("products.generate-pdf")
     expect(definition.config.defaultRuntime).toBe("node")
   })
+
+  it("defers executable PDF workflow runtime activation", () => {
+    expect(inventoryVoyantModule.workflows?.[0]).not.toHaveProperty("runtime")
+  })
 })

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -980,6 +980,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -981,6 +981,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -981,6 +981,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -986,6 +986,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -981,6 +981,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -979,6 +979,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -980,6 +980,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -981,6 +981,7 @@
       "@voyant-travel/inventory/tools": ["../inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": ["../inventory/dist/workflow-runtime.d.ts"],
       "@voyant-travel/inventory/workflows": ["../inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../legal-contracts/dist/index.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1258,6 +1258,9 @@
       "@voyant-travel/inventory/tools": ["../../packages/inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../../packages/inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../../packages/inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": [
+        "../../packages/inventory/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/inventory/workflows": ["../../packages/inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../../packages/legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../../packages/legal-contracts/dist/index.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1258,6 +1258,9 @@
       "@voyant-travel/inventory/tools": ["../../packages/inventory/dist/tools.d.ts"],
       "@voyant-travel/inventory/validation": ["../../packages/inventory/dist/validation.d.ts"],
       "@voyant-travel/inventory/voyant": ["../../packages/inventory/dist/voyant.d.ts"],
+      "@voyant-travel/inventory/workflow-runtime": [
+        "../../packages/inventory/dist/workflow-runtime.d.ts"
+      ],
       "@voyant-travel/inventory/workflows": ["../../packages/inventory/dist/workflow-entry.d.ts"],
       "@voyant-travel/legal": ["../../packages/legal/dist/index.d.ts"],
       "@voyant-travel/legal-contracts": ["../../packages/legal-contracts/dist/index.d.ts"],


### PR DESCRIPTION
## Summary
- publish the product PDF workflow deployment runtime service key and contract through a stable package subpath
- preserve the existing configurable workflow factory without adding a service-resolving import side effect
- regenerate composition dependency paths and package dist configs

## Scope boundary
This PR is definition/contract-only. The inventory manifest keeps declaration metadata without a workflow `runtime` selector, and this PR does not instantiate a service-dependent executable workflow. Runtime selection, executable definition, service registration, scheduler loading, and removal of legacy Operator wiring are intentionally deferred to one atomic Operator integration PR.

## Verification
- inventory tests: 378 passed, 43 skipped
- inventory typecheck
- inventory lint
- `pnpm verify:dep-paths`
- `pnpm verify:dist-configs`