### PR TITLE
refactor(migrations): lower sources from selected manifests

### DIFF
--- a/.changeset/calm-plums-lower.md
+++ b/.changeset/calm-plums-lower.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Lower deployment migration sources directly from selected package manifests.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1046,18 +1046,17 @@ deployment. Examples include foundational schema packages, additional schema
 packages, and route-deferred verticals whose migrations still apply. The
 resolved graph must still represent those packages as schema-only units with
 stable `schema` and `migrations` entity ids, and its package records must cover
-every package-backed migration source discovered from the generated schema
-manifest. This is the bridge that keeps D.2 package-owned migration discovery
-and deployment-graph lowering from drifting while richer per-migration entity
-generation lands.
+every package-backed migration source selected into the graph.
 
-The source-backed operator deployment artifact manifest also records the
-package-backed migration source list derived from
-`drizzle.schemas.generated.ts`. Runtime migration execution consumes that
-validated artifact list, then still uses the D.2 collector to resolve package
-migration folders and apply the deployment-local migration source last. Graph
-artifact validation rejects sources that are not represented in graph package
-records.
+The deployment artifact manifest records package-backed migration sources
+directly from selected package manifests. Runtime migration execution derives
+the dependency-ordered plan from those same selected graph units, resolves each
+package's migration folder through the D.2 collector, and applies explicit
+deployment-local migrations last. Deselecting a package therefore removes its
+schema migration from both the artifact and executable plan. The committed
+`drizzle.schemas.generated.ts` remains a Drizzle generation and replay-parity
+input; it is not migration selection authority. Graph artifact validation
+rejects sources that are not represented in graph package records.
 
 The operator graph now also lowers the first declarative workflow/event-filter
 pair from first-party metadata: commerce contributes

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildDeploymentArtifactManifest,
   buildDeploymentGraphJson,
+  buildDeploymentMigrationSources,
   buildGraphRuntimeModule,
   buildGraphWorkflowRuntimeModule,
   buildManagedNodeRuntimeEntry,
@@ -153,6 +154,43 @@ describe("deployment graph artifacts", () => {
         },
       ],
     })
+  })
+
+  it("lowers migration schema inputs only from selected migration owners", async () => {
+    const foundation = defineModule({
+      id: "@acme/foundation",
+      schema: [{ id: "@acme/foundation#schema", source: "@acme/foundation/schema" }],
+      migrations: [{ id: "@acme/foundation#migrations", source: "./migrations" }],
+    })
+    const feature = defineModule({
+      id: "@acme/feature",
+      schema: [{ id: "@acme/feature#schema", source: "@acme/feature/schema" }],
+      migrations: [{ id: "@acme/feature#migrations", source: "./migrations" }],
+    })
+    const featureExtension = defineExtension({
+      id: "@acme/feature#extension",
+      packageName: "@acme/feature",
+      schema: [{ id: "@acme/feature#schema.extension", source: "@acme/feature/schema" }],
+    })
+    const schemaOnly = defineModule({
+      id: "@acme/schema-only",
+      schema: [{ id: "@acme/schema-only#schema", source: "@acme/schema-only/schema" }],
+    })
+
+    const complete = await graphWithSelectedUnits(
+      [foundation, feature, schemaOnly],
+      [],
+      [featureExtension],
+    )
+    const subset = await graphWithSelectedUnits([foundation])
+
+    expect(buildDeploymentMigrationSources(complete)).toEqual([
+      { packageName: "@acme/feature", schema: "@acme/feature/schema" },
+      { packageName: "@acme/foundation", schema: "@acme/foundation/schema" },
+    ])
+    expect(buildDeploymentMigrationSources(subset)).toEqual([
+      { packageName: "@acme/foundation", schema: "@acme/foundation/schema" },
+    ])
   })
 
   it("builds a tiny managed Node runtime entry tied to the graph hash", async () => {

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -318,6 +318,31 @@ export function buildDeploymentArtifactManifest(
   }
 }
 
+/** Lower schema inputs for packages with migrations selected into the resolved graph. */
+export function buildDeploymentMigrationSources(
+  graph: ResolvedVoyantDeploymentGraph,
+): VoyantDeploymentMigrationSourceArtifact[] {
+  const units = [...graph.modules, ...graph.extensions, ...graph.plugins]
+  const migrationPackages = new Set(
+    units
+      .filter((unit) => unit.migrations.some((migration) => Boolean(migration.source)))
+      .map((unit) => unit.packageName),
+  )
+  const sources = new Map<string, VoyantDeploymentMigrationSourceArtifact>()
+  for (const unit of units) {
+    if (!migrationPackages.has(unit.packageName)) continue
+    for (const schema of unit.schema) {
+      if (!schema.source) continue
+      const source = { packageName: unit.packageName, schema: schema.source }
+      sources.set(`${source.packageName}\0${source.schema}`, source)
+    }
+  }
+  return [...sources.values()].sort(
+    (left, right) =>
+      left.packageName.localeCompare(right.packageName) || left.schema.localeCompare(right.schema),
+  )
+}
+
 export function buildManagedNodeRuntimeEntryArtifact(
   input: BuildManagedNodeRuntimeEntryArtifactInput,
 ): VoyantDeploymentRuntimeEntryArtifact {

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework; project resolution, package admission, generated runtime, and migration fixtures share one project harness.
 import { createHash } from "node:crypto"
 import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
@@ -200,6 +201,41 @@ describe("framework project resolver", () => {
         source: { kind: "deployment", path: "./migrations" },
       },
     ])
+  })
+
+  it("removes deselected package migrations from the Node runtime plan", async () => {
+    const root = projectRoot()
+    for (const packageName of ["@acme/foundation", "@acme/feature"]) {
+      writePackage(root, {
+        name: packageName,
+        manifest: `export default ${JSON.stringify(moduleManifest(packageName))}\n`,
+      })
+    }
+    const deployment = {
+      migrations: [{ id: "deployment-links", source: "./migrations" }],
+    } as const
+
+    const complete = await resolve(
+      root,
+      defineProject({ modules: ["@acme/foundation", "@acme/feature"], deployment }),
+    )
+    const subset = await resolve(root, defineProject({ modules: ["@acme/foundation"], deployment }))
+
+    expect(complete.artifacts.migrationPlan.migrations.map((migration) => migration.id)).toEqual([
+      "@acme/feature#migrations",
+      "@acme/foundation#migrations",
+      "deployment-links",
+    ])
+    expect(subset.artifacts.migrationPlan.migrations.map((migration) => migration.id)).toEqual([
+      "@acme/foundation#migrations",
+      "deployment-links",
+    ])
+    const runner = subset.artifacts.files.find(
+      (file) => file.path === subset.artifacts.migrationRunner,
+    )
+    expect(runner?.contents).toContain(
+      `export const migrationPlan = ${JSON.stringify(subset.artifacts.migrationPlan, null, 2)}`,
+    )
   })
 
   it("topologically orders package migrations from voyant.requiresSchemas", async () => {

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url"
 import {
   buildDeploymentArtifactManifest,
   buildDeploymentGraphJson,
+  buildDeploymentMigrationSources,
   buildManagedNodeRuntimeEntry,
   buildManagedNodeRuntimeEntryArtifact,
   VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION,
@@ -19,7 +20,6 @@ import {
 import { getManagedProfileScheduledJobs } from "../packages/framework/src/managed-jobs.ts"
 import { defineVoyantProject } from "../packages/framework/src/profile.ts"
 import { runtimeReferencePackageNames } from "../packages/framework/src/project-resolver.ts"
-import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
 import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "../starters/operator/src/local-scheduled-jobs.ts"
 import operatorProject from "../starters/operator/voyant.config.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
@@ -145,7 +145,7 @@ async function main(): Promise<void> {
         profileSnapshot: "./managed-profile.json",
       }),
     ],
-    migrationSources: operatorMigrationSources(),
+    migrationSources: buildDeploymentMigrationSources(first),
   })
   if (artifactManifest.schemaVersion !== VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION) {
     failures.push("expected deployment artifact manifest schema version v1")
@@ -161,7 +161,7 @@ async function main(): Promise<void> {
   )
   if (
     JSON.stringify(artifactMigrationSourcePackageNames) !==
-    JSON.stringify(operatorMigrationSourcePackageNames())
+    JSON.stringify(buildDeploymentMigrationSources(first).map((source) => source.packageName))
   ) {
     failures.push("expected deployment artifacts to preserve operator migration source packages")
   }
@@ -414,7 +414,9 @@ async function main(): Promise<void> {
   if (!operatorPluginIds.has("@voyant-travel/plugin-netopia")) {
     failures.push("expected operator graph to include @voyant-travel/plugin-netopia")
   }
-  for (const packageName of operatorMigrationSourcePackageNames()) {
+  for (const packageName of new Set(
+    buildDeploymentMigrationSources(operatorGraph).map((source) => source.packageName),
+  )) {
     if (!operatorPackageRecords.has(packageName)) {
       failures.push(
         `expected operator graph package records to include migration source ${packageName}`,
@@ -435,6 +437,15 @@ async function main(): Promise<void> {
   ) {
     failures.push(
       "expected operator db:migrate to derive and execute the admitted graph migration plan",
+    )
+  }
+  const deploymentGraphEmitterSource = await readFile(
+    new URL("./emit-deployment-graph.ts", import.meta.url),
+    "utf8",
+  )
+  if (deploymentGraphEmitterSource.includes("drizzle.schemas.generated")) {
+    failures.push(
+      "expected deployment artifact emission to derive migration sources from selected manifests",
     )
   }
 
@@ -475,24 +486,6 @@ async function main(): Promise<void> {
   console.log(
     `check-deployment-graph: OK (${first.modules.length} modules, ${first.plugins.length} plugins, ${first.contentHash})`,
   )
-}
-
-function operatorMigrationSourcePackageNames(): string[] {
-  return operatorMigrationSources().map((source) => source.packageName)
-}
-
-function operatorMigrationSources(): Array<{ packageName: string; schema: string }> {
-  const seen = new Set<string>()
-  const sources: Array<{ packageName: string; schema: string }> = []
-  for (const schemaPath of operatorSchemaPaths) {
-    const match = schemaPath.match(/(?:^|\/)packages\/([^/]+)\//)
-    if (!match?.[1]) continue
-    const packageName = `@voyant-travel/${match[1]}`
-    if (seen.has(packageName)) continue
-    seen.add(packageName)
-    sources.push({ packageName, schema: schemaPath })
-  }
-  return sources
 }
 
 main().catch((error) => {

--- a/scripts/emit-deployment-graph.ts
+++ b/scripts/emit-deployment-graph.ts
@@ -6,6 +6,7 @@ import { fileURLToPath, pathToFileURL } from "node:url"
 import {
   buildDeploymentArtifactManifest,
   buildDeploymentGraphJson,
+  buildDeploymentMigrationSources,
   buildGraphRuntimeModule,
   buildManagedNodeRuntimeEntry,
   buildManagedNodeRuntimeEntryArtifact,
@@ -21,7 +22,6 @@ import {
   writeProjectArtifacts,
 } from "../packages/framework/src/project-artifacts.ts"
 import type { ResolvedProjectArtifacts } from "../packages/framework/src/project-resolver.ts"
-import { schema as operatorSchemaPaths } from "../starters/operator/drizzle.schemas.generated.ts"
 import { OPERATOR_LOCAL_SCHEDULED_JOBS } from "../starters/operator/src/local-scheduled-jobs.ts"
 import {
   buildDeploymentGraphDoctorJson,
@@ -94,7 +94,7 @@ async function main(): Promise<void> {
         profileSnapshot: toPosixRelativePath(manifestDirectory, options.profileOutputPath),
       }),
     ],
-    migrationSources: operatorMigrationSources(graph),
+    migrationSources: buildDeploymentMigrationSources(graph),
   })
   const profileText = formatGeneratedText(
     options.profileOutputPath,
@@ -264,32 +264,6 @@ function compatibilityManagedProfile(
     providers: project.deployment.providers,
     admin: { enabled: true, path: "/app" },
   }
-}
-
-function operatorMigrationSources(graph: ResolvedVoyantDeploymentGraph) {
-  const units = [...graph.modules, ...graph.plugins]
-  const packageOwnedMigrationSources = new Set(
-    units
-      .filter((unit) => unit.schema.length > 0 && unit.migrations.length > 0)
-      .map((unit) => unit.packageName),
-  )
-  const manifestPackages = new Set(
-    graph.packageRecords
-      .filter((record) => record.metadata?.manifest)
-      .map((record) => record.packageName),
-  )
-
-  const sources: Array<{ packageName: string; schema: string }> = []
-  for (const schemaPath of operatorSchemaPaths) {
-    const match = schemaPath.match(/(?:^|\/)packages\/([^/]+)\//)
-    if (!match?.[1]) continue
-    sources.push({ packageName: `@voyant-travel/${match[1]}`, schema: schemaPath })
-  }
-  return sources.filter(
-    (source) =>
-      !manifestPackages.has(source.packageName) ||
-      packageOwnedMigrationSources.has(source.packageName),
-  )
 }
 
 async function writeGeneratedFile(filePath: string, text: string): Promise<void> {

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -39,7 +39,7 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
       expect.arrayContaining(["@voyant-travel/db", "@voyant-travel/bookings"]),
     )
     expect(summary.migrationSources.map((source) => source.schema)).toContain(
-      "../../packages/db/src/schema/index.ts",
+      "@voyant-travel/db/schema",
     )
     expect(summary.providers).toMatchObject({
       database: "postgres",


### PR DESCRIPTION
## Summary\n\n- lower migration sources from graph-selected package manifests instead of treating the Operator schema aggregate as authority\n- emit deterministic migration ownership into deployment artifacts and generated project output\n- validate migration-source parity and keep deployment-local migrations last\n- extend framework and Operator artifact tests plus architecture checks\n\n## Verification\n\n- framework tests: 284 passed\n- Operator deployment-artifact tests: 21 passed\n- deployment graph architecture checker\n- import-cheap checker: 34 entry surfaces, 45 files\n- Biome and diff checks\n- full pre-push suite after rebase: 101 tasks passed