### PR TITLE
chore(operator): admit Netopia package manifest

### DIFF
--- a/.changeset/netopia-voyant-manifest-admission.md
+++ b/.changeset/netopia-voyant-manifest-admission.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/notifications": patch
+---
+
+Declare the payment-session and notification-delivery capabilities required by Netopia's package-owned Voyant manifest.

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -10,6 +10,7 @@ export const financeVoyantModule = defineModule({
   id: "@voyant-travel/finance",
   packageName: "@voyant-travel/finance",
   localId: "finance",
+  provides: { capabilities: ["finance.payment-sessions"] },
   api: [
     {
       id: "@voyant-travel/finance#api.admin",

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -7,6 +7,7 @@ export const notificationsVoyantModule = defineModule({
   id: "@voyant-travel/notifications",
   packageName: "@voyant-travel/notifications",
   localId: "notifications",
+  provides: { capabilities: ["notifications.delivery"] },
   api: [
     {
       id: "@voyant-travel/notifications#api.admin",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4778,8 +4778,8 @@ importers:
         specifier: workspace:^
         version: link:../../packages/plugins/flights-demo
       '@voyant-travel/plugin-netopia':
-        specifier: ^0.105.18
-        version: 0.105.18(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+        specifier: ^0.105.20
+        version: 0.105.20(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/plugin-smartbill':
         specifier: ^0.137.3
         version: 0.137.3(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@tanstack/react-query@5.101.2(react@19.2.7))(@types/pg@8.20.0)(@upstash/redis@1.35.6)(@voyant-travel/finance-react@packages+finance-react)(@voyant-travel/ui@packages+ui)(kysely@0.29.2)(lucide-react@1.23.0(react@19.2.7))(pg@8.22.0)(postgres@3.4.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7760,8 +7760,9 @@ packages:
   '@voyant-travel/notifications@0.116.9':
     resolution: {integrity: sha512-uFnzJCMz3wPcOITHqdurKCdng4OKdWTWH3n56MqPc4fntPeii1kxD3PyRhBzfNH8uXk0E64DeUyjSsR8Ffis2g==}
 
-  '@voyant-travel/plugin-netopia@0.105.18':
-    resolution: {integrity: sha512-HlchshFZnOWJtn8OXh9bjs+VM9QHMD925SuLL3fTuazbaV/e2ZU8PeCAeclKlXSI4ujBAfsZzNAi2Ucz46/6JQ==}
+  '@voyant-travel/plugin-netopia@0.105.20':
+    resolution: {integrity: sha512-BUOfdOkYFWZROLa6rZxlKF2X2fycFFYv5w3A2mLO/joZrWNV0RzIuTI3NxblHuQ7paRNWpJIqBiti6VhBH7uig==}
+    engines: {node: '>=20'}
 
   '@voyant-travel/plugin-smartbill@0.137.3':
     resolution: {integrity: sha512-myhj0h17+lzAOD37Tv8cN0AqiHUTgS+8wPAdjWjHMcPvFmPk3S7MdRzps3JtUsp1OmL51ytqwdVmVHZIGxrG7Q==}
@@ -15384,7 +15385,7 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/plugin-netopia@0.105.18(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+  '@voyant-travel/plugin-netopia@0.105.20(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
       '@voyant-travel/core': 0.111.0
       '@voyant-travel/finance': 0.137.2(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -25,7 +25,6 @@ import operatorProject from "../starters/operator/voyant.config.ts"
 import { readPnpmLockfilePackageRecords } from "./lib/deployment-graph-provenance.mjs"
 import {
   OPERATOR_GRAPH_ADMISSION_POLICY,
-  OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
   type OperatorAuthoredProject,
   resolveOperatorDeploymentGraph,
   withOperatorDeploymentLocalPackageRecords,
@@ -74,7 +73,6 @@ async function main(): Promise<void> {
   const packageRecords = withOperatorDeploymentLocalPackageRecords(
     readPnpmLockfilePackageRecords({
       packageNames: discoveredGraph.packageRecords.map((record) => record.packageName),
-      packageMetadata: OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
     }),
   )
   const first = await resolveManagedProfileDeploymentGraph(project, {

--- a/scripts/lib/operator-deployment-graph-package-records.ts
+++ b/scripts/lib/operator-deployment-graph-package-records.ts
@@ -14,7 +14,6 @@ import {
   type VoyantGraphProject,
   type VoyantGraphRuntimeTarget,
   type VoyantGraphUnitManifest,
-  type VoyantPackageMetadata,
 } from "../../packages/framework/src/deployment-graph.ts"
 import type { ManagedScheduledJob } from "../../packages/framework/src/managed-jobs.ts"
 import type { VoyantProjectProviders } from "../../packages/framework/src/profile-types.ts"
@@ -58,14 +57,6 @@ const OPERATOR_GRAPH_COMPATIBILITY = {
   targets: ["node"],
   modes: ["local", "managed-cloud", "self-hosted"],
 } as const
-
-export const OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES = {
-  "@voyant-travel/plugin-netopia": {
-    schemaVersion: VOYANT_GRAPH_PACKAGE_SCHEMA_VERSION,
-    kind: "plugin",
-    compatibleWith: OPERATOR_GRAPH_COMPATIBILITY,
-  },
-} as const satisfies Record<string, VoyantPackageMetadata>
 
 const OPERATOR_LOCAL_PACKAGE_RECORDS = [
   {
@@ -139,7 +130,6 @@ export async function resolveOperatorDeploymentGraph(
           "@voyant-travel/framework-migrations",
           ...discoveredGraph.packageRecords.map((record) => record.packageName),
         ],
-        packageMetadata: OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
       }),
     ),
   )
@@ -168,7 +158,6 @@ export async function resolveOperatorDeploymentGraph(
             ...manifestedGraph.packageRecords.map((record) => record.packageName),
             ...referencedPackageNames,
           ],
-          packageMetadata: OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES,
         }),
       ),
       referencedPackageNames,
@@ -203,28 +192,14 @@ async function resolveOperatorProject(
   project: OperatorAuthoredProject,
   projectRoot: string,
 ): Promise<ResolvedOperatorProject> {
-  const frameworkProjectInput = withoutCompatibilityMetadataSelections(project)
   return normalizeFrameworkResolution(
     await frameworkProject.resolveProject({
-      project: frameworkProjectInput,
+      project,
       projectRoot,
       configPath: path.join(projectRoot, "voyant.config.ts"),
     }),
     project,
   )
-}
-
-function withoutCompatibilityMetadataSelections(
-  project: OperatorAuthoredProject,
-): OperatorAuthoredProject {
-  if (!project.selections) return project
-  const plugins = project.selections.plugins.filter(
-    (selection) => !(selection.packageName in OPERATOR_GRAPH_PACKAGE_METADATA_OVERRIDES),
-  )
-  return {
-    ...project,
-    selections: { ...project.selections, plugins },
-  }
 }
 
 function normalizeFrameworkResolution(

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -103,7 +103,7 @@
     "@voyant-travel/operator-settings-react": "workspace:^",
     "@voyant-travel/plugin-catalog-demo": "workspace:^",
     "@voyant-travel/plugin-flights-demo": "workspace:^",
-    "@voyant-travel/plugin-netopia": "^0.105.18",
+    "@voyant-travel/plugin-netopia": "^0.105.20",
     "@voyant-travel/plugin-smartbill": "^0.137.3",
     "@voyant-travel/plugin-voyant-connect": "^0.3.2",
     "@voyant-travel/public-document-delivery": "workspace:^",

--- a/starters/operator/voyant.config.test.ts
+++ b/starters/operator/voyant.config.test.ts
@@ -1,5 +1,11 @@
+import path from "node:path"
+
+import { resolveProject } from "@voyant-travel/framework/project"
+import { netopiaVoyantPlugin } from "@voyant-travel/plugin-netopia/voyant"
 import { describe, expect, it } from "vitest"
 import config from "./voyant.config.js"
+
+const operatorRoot = process.cwd()
 
 describe("Operator project config", () => {
   it("authors only deployment differences and external plugins", () => {
@@ -19,5 +25,37 @@ describe("Operator project config", () => {
     expect(config.extensions.every((unit) => unit.schemaVersion === "voyant.extension.v1")).toBe(
       true,
     )
+  })
+
+  it("resolves Netopia from its package-owned Voyant manifest", async () => {
+    const { graph } = await resolveProject({
+      project: config,
+      projectRoot: operatorRoot,
+      configPath: path.join(operatorRoot, "voyant.config.ts"),
+    })
+    const plugin = graph.plugins.find((unit) => unit.id === netopiaVoyantPlugin.id)
+    const packageRecord = graph.packageRecords.find(
+      (record) => record.packageName === "@voyant-travel/plugin-netopia",
+    )
+
+    expect(config.plugins[0]).not.toHaveProperty("api")
+    expect(packageRecord).toMatchObject({
+      version: "0.105.20",
+      metadata: {
+        kind: "plugin",
+        manifest: "./voyant",
+      },
+    })
+    expect(plugin).toMatchObject({
+      id: netopiaVoyantPlugin.id,
+      packageName: netopiaVoyantPlugin.packageName,
+      provides: netopiaVoyantPlugin.provides,
+      requires: netopiaVoyantPlugin.requires,
+      api: expect.arrayContaining([...(netopiaVoyantPlugin.api ?? [])]),
+      config: expect.arrayContaining([...(netopiaVoyantPlugin.config ?? [])]),
+      secrets: expect.arrayContaining([...(netopiaVoyantPlugin.secrets ?? [])]),
+      webhooks: expect.arrayContaining([...(netopiaVoyantPlugin.webhooks ?? [])]),
+    })
+    expect(graph.diagnostics).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

- update the Operator to `@voyant-travel/plugin-netopia` 0.105.20
- remove the Netopia package-metadata override and selection bypass so graph resolution loads the published `./voyant` export
- declare the Finance and Notifications capabilities required by Netopia, with patch changesets
- add an Operator test proving the resolved plugin facets and package record come from the package-owned `voyant.plugin.v1` manifest

## Compatibility fallback

The Operator inline `netopiaHonoBundle()` registration in `starters/operator/src/api/app.ts` remains. It still provides the deployment-local Hono runtime mounting path while the runtime cutover is handled separately; this PR changes manifest admission and selected graph metadata only. No managed-plugin metadata alias or inline synthetic plugin metadata remains in selected graph resolution.

## Validation

- `pnpm --filter operator exec vitest run voyant.config.test.ts`
- `pnpm --filter operator graph:emit`
- `pnpm --filter operator graph:check`
- `pnpm exec tsx scripts/check-deployment-graph.ts`
- focused `pnpm exec biome check ...`
- `git diff origin/main...HEAD --check`

Broad typechecking is left to CI as requested.