### PR TITLE
refactor(runtime): derive route posture from graph

### DIFF
--- a/.changeset/graph-route-posture.md
+++ b/.changeset/graph-route-posture.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/inventory": patch
+"@voyant-travel/accommodations": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/storefront": patch
+---
+
+Derive anonymous public and transactional path posture from selected deployment graph API bundles, including partial transactional path declarations.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1275,6 +1275,18 @@ are no longer authoritative.
 
 ### Phase 3: package-owned runtime composition and first non-Cloud target
 
+API bundle posture is inspectable before package runtime imports. `anonymous:
+true` opens the resolved public mount, while an `anonymous` path array records
+route-relative anonymous exceptions. `transactional: true` selects the resolved
+bundle mount and a `transactional` path array selects route-relative path
+prefixes. Resolution validates and normalizes either leading-slash or plain
+relative authoring, and graph runtime composition resolves each path against its
+selected bundle mount exactly once. It exposes the absolute selected union as
+`routePosture.publicPaths` and `routePosture.transactionalPaths`. Composition
+also applies representable public-mount and transactional metadata to the Hono
+module or extension output. Deployment-local escape hatches remain separate and
+must not be folded back into package manifests.
+
 - migrate API bundles, anonymous/transactional posture, subscribers, workflow
   descriptors, schedules, and event filters to package manifests
 - lower package factories into the existing Hono composition and explicit

--- a/packages/accommodations/src/voyant.ts
+++ b/packages/accommodations/src/voyant.ts
@@ -61,6 +61,7 @@ export const accommodationsContentVoyantPlugin = defineExtension({
       id: "@voyant-travel/accommodations#content-extension.api.public",
       surface: "public",
       mount: "accommodations",
+      anonymous: true,
       runtime: {
         entry: "@voyant-travel/accommodations/routes-content",
         export: "createAccommodationContentHonoExtension",

--- a/packages/accommodations/tests/unit/voyant-manifest.test.ts
+++ b/packages/accommodations/tests/unit/voyant-manifest.test.ts
@@ -49,6 +49,7 @@ describe("accommodations deployment manifest", () => {
         {
           surface: "public",
           mount: "accommodations",
+          anonymous: true,
           runtime: { export: "createAccommodationContentHonoExtension" },
         },
       ],

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -203,6 +203,7 @@ export const catalogBookingEngineVoyantModule = defineModule({
       id: "@voyant-travel/catalog#booking-engine.api.admin",
       surface: "admin",
       mount: "catalog",
+      transactional: ["/book", "/holds", "/orders", "/quote", "/quotes/batch"],
       runtime: {
         entry: "@voyant-travel/catalog/booking-engine",
         export: "createCatalogBookingEngineHonoModule",
@@ -212,6 +213,7 @@ export const catalogBookingEngineVoyantModule = defineModule({
       id: "@voyant-travel/catalog#booking-engine.api.public",
       surface: "public",
       mount: "catalog",
+      transactional: ["/book", "/holds", "/quote", "/quotes/batch"],
       runtime: {
         entry: "@voyant-travel/catalog/booking-engine",
         export: "createCatalogBookingEngineHonoModule",

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -45,6 +45,7 @@ describe("catalog deployment manifest", () => {
           id: "@voyant-travel/catalog#booking-engine.api.admin",
           surface: "admin",
           mount: "catalog",
+          transactional: ["/book", "/holds", "/orders", "/quote", "/quotes/batch"],
           runtime: {
             entry: "@voyant-travel/catalog/booking-engine",
             export: "createCatalogBookingEngineHonoModule",
@@ -54,6 +55,7 @@ describe("catalog deployment manifest", () => {
           id: "@voyant-travel/catalog#booking-engine.api.public",
           surface: "public",
           mount: "catalog",
+          transactional: ["/book", "/holds", "/quote", "/quotes/batch"],
           runtime: {
             entry: "@voyant-travel/catalog/booking-engine",
             export: "createCatalogBookingEngineHonoModule",

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -127,8 +127,10 @@ export interface VoyantGraphRouteBundle {
   mount?: string
   resource?: string
   requiredScopes?: readonly string[]
+  /** Anonymous public access for the whole public mount or route-relative path subsets. */
   anonymous?: boolean | readonly string[]
-  transactional?: boolean
+  /** Transactional DB routing for the whole mount or route-relative path subsets. */
+  transactional?: boolean | readonly string[]
   runtime?: VoyantGraphRuntimeReference
 }
 

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1,6 +1,8 @@
 // agent-quality: file-size exception -- owner: framework; deployment graph v1 tests stay co-located while the resolver, diagnostics, hashing, and managed-profile bridge share one contract harness.
 
 import { bookingsVoyantModule } from "@voyant-travel/bookings/voyant"
+import { financeVoyantModule } from "@voyant-travel/finance/voyant"
+import { storefrontVoyantModule } from "@voyant-travel/storefront/voyant"
 import { describe, expect, it } from "vitest"
 import {
   createTestDeployment,
@@ -653,13 +655,20 @@ describe("deployment graph v1", () => {
         id: "@acme/voyant-loyalty",
         api: [
           {
-            id: "@acme/voyant-loyalty#api.admin",
-            surface: "admin",
+            id: "@acme/voyant-loyalty#api.public",
+            surface: "public",
             methods: ["POST", "GET"],
-            mount: "/v1/admin/loyalty",
+            mount: "loyalty",
             resource: "loyalty.points",
             requiredScopes: ["loyalty:read", "loyalty-points:write"],
-            anonymous: ["/v1/public/loyalty/status"],
+            anonymous: ["/status", "health"],
+          },
+          {
+            id: "@acme/voyant-loyalty#api.webhook",
+            surface: "webhook",
+            mount: "loyalty",
+            anonymous: true,
+            transactional: true,
           },
         ],
       }),
@@ -677,7 +686,8 @@ describe("deployment graph v1", () => {
             mount: "",
             resource: "Loyalty Points",
             requiredScopes: ["loyalty.points.read", "loyalty:Read"],
-            anonymous: "yes",
+            anonymous: true,
+            transactional: ["/commit", "commit"],
           },
         ],
       }),
@@ -711,8 +721,37 @@ describe("deployment graph v1", () => {
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
           facet: "api[0].anonymous",
         }),
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          facet: "api[0].transactional",
+        }),
       ]),
     )
+
+    expect(
+      validateGraphUnitManifest({
+        schemaVersion: "voyant.module.v1",
+        id: "@acme/voyant-loyalty",
+        api: [
+          {
+            id: "@acme/voyant-loyalty#api.invalid-paths",
+            surface: "public",
+            anonymous: ["/"],
+            transactional: ["../commit"],
+          },
+        ],
+      }),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ facet: "api[0].anonymous" }),
+        expect.objectContaining({ facet: "api[0].transactional" }),
+      ]),
+    )
+  })
+
+  it("accepts established route-relative anonymous manifest paths", () => {
+    expect(validateGraphUnitManifest(storefrontVoyantModule)).toEqual([])
+    expect(validateGraphUnitManifest(financeVoyantModule)).toEqual([])
   })
 
   it("detects duplicate graph ids and missing required capabilities", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -1895,26 +1895,30 @@ function validateRouteBundles(value: unknown, source: string | undefined): Voyan
 
     if (
       route.anonymous !== undefined &&
-      typeof route.anonymous !== "boolean" &&
-      !isStringArray(route.anonymous)
+      ((typeof route.anonymous !== "boolean" && !isRouteRelativePathArray(route.anonymous)) ||
+        (route.surface !== "public" && route.surface !== "webhook"))
     ) {
       diagnostics.push(
         diagnostic({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
           source,
           facet: `${facet}.anonymous`,
-          message: `Route bundle "${route.id ?? index}" anonymous metadata must be a boolean or string array.`,
+          message: `Route bundle "${route.id ?? index}" anonymous metadata must be declared on a public or webhook bundle as true or a non-empty array of unique route-relative paths.`,
         }),
       )
     }
 
-    if (route.transactional !== undefined && typeof route.transactional !== "boolean") {
+    if (
+      route.transactional !== undefined &&
+      typeof route.transactional !== "boolean" &&
+      !isRouteRelativePathArray(route.transactional)
+    ) {
       diagnostics.push(
         diagnostic({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
           source,
           facet: `${facet}.transactional`,
-          message: `Route bundle "${route.id ?? index}" transactional metadata must be a boolean.`,
+          message: `Route bundle "${route.id ?? index}" transactional metadata must be a boolean or non-empty array of unique route-relative paths.`,
         }),
       )
     }
@@ -1948,6 +1952,23 @@ function isRouteSurface(value: unknown): value is VoyantGraphRouteSurface {
 
 function isStringArray(value: unknown): value is string[] {
   return Array.isArray(value) && value.every((entry) => typeof entry === "string")
+}
+
+function isRouteRelativePathArray(value: unknown): value is string[] {
+  if (!isStringArray(value) || value.length === 0) return false
+  const normalized = value.map(normalizeRouteRelativePath)
+  return (
+    normalized.every((entry) => entry !== undefined) &&
+    new Set(normalized).size === normalized.length
+  )
+}
+
+function normalizeRouteRelativePath(value: string): string | undefined {
+  if (value.trim() !== value || value.includes("?") || value.includes("#")) return undefined
+  const normalized = value.replace(/^\/+|\/+$/g, "")
+  if (!normalized || normalized.includes("//")) return undefined
+  const segments = normalized.split("/")
+  return segments.some((segment) => segment === "." || segment === "..") ? undefined : normalized
 }
 
 function validateWorkflows(value: unknown, source: string | undefined): VoyantGraphDiagnostic[] {

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -47,6 +47,13 @@ export interface ComposeVoyantGraphRuntimeInput<TCapabilities> {
 export interface VoyantGraphRuntimeComposition {
   modules: HonoModule[]
   extensions: HonoExtension[]
+  routePosture: VoyantGraphRuntimeRoutePosture
+}
+
+/** Absolute path posture derived only from selected graph API bundles. */
+export interface VoyantGraphRuntimeRoutePosture {
+  publicPaths: string[]
+  transactionalPaths: string[]
 }
 
 /** Load graph-owned workflow/subscriber metadata without composing API routes. */
@@ -75,22 +82,24 @@ export async function composeVoyantGraphRuntime<TCapabilities>(
   for (const unit of input.runtime.modules) {
     const outputs = await resolveRuntimeUnit(input, unit)
     assertWebhookRoutePosture(input.runtime, unit, outputs)
+    const routePosture = deriveUnitRoutePosture(unit)
     for (const output of outputs) {
       if (!isHonoModule(output)) {
         throw invalidRuntimeOutput(unit, "HonoModule", output)
       }
-      modules.push(output)
+      modules.push(applyModuleRoutePosture(output, routePosture))
     }
   }
 
   for (const unit of [...input.runtime.extensions, ...input.runtime.plugins]) {
     const outputs = await resolveRuntimeUnit(input, unit)
     assertWebhookRoutePosture(input.runtime, unit, outputs)
+    const routePosture = deriveUnitRoutePosture(unit)
     for (const output of outputs) {
       if (!isHonoExtension(output)) {
         throw invalidRuntimeOutput(unit, "HonoExtension", output)
       }
-      extensions.push(output)
+      extensions.push(applyExtensionRoutePosture(output, routePosture))
     }
   }
 
@@ -98,7 +107,140 @@ export async function composeVoyantGraphRuntime<TCapabilities>(
   const outboundWebhookModule = createGraphOutboundWebhookModule(input)
   if (outboundWebhookModule) modules.push(outboundWebhookModule)
 
-  return { modules, extensions }
+  return {
+    modules,
+    extensions,
+    routePosture: mergeRoutePostures(
+      [...input.runtime.modules, ...input.runtime.extensions, ...input.runtime.plugins].map(
+        deriveUnitRoutePosture,
+      ),
+    ),
+  }
+}
+
+interface UnitRoutePosture extends VoyantGraphRuntimeRoutePosture {
+  publicMount?: string
+  anonymous: boolean | readonly string[] | undefined
+}
+
+function deriveUnitRoutePosture(unit: VoyantGraphRuntimeUnitLoader): UnitRoutePosture {
+  const publicRoutes = unit.routes.filter(({ route }) => route.surface === "public")
+  const publicMounts = sortedUnique(publicRoutes.map(({ route }) => routeMountPath(unit, route)))
+  const publicPaths = sortedUnique(
+    unit.routes.flatMap(({ route }) => {
+      const mount = routeMountPath(unit, route)
+      if (route.anonymous === true) return [mount]
+      if (!route.anonymous) return []
+      return route.anonymous.map((path) => resolveRoutePosturePath(mount, path))
+    }),
+  )
+  const transactionalPaths = sortedUnique(
+    unit.routes.flatMap(({ route }) => {
+      const mount = routeMountPath(unit, route)
+      if (route.transactional === true) return [mount]
+      if (!route.transactional) return []
+      return route.transactional.map((path) => resolveRoutePosturePath(mount, path))
+    }),
+  )
+  const publicMount = publicMounts.length === 1 ? publicMounts[0] : undefined
+  const anonymous = publicMount ? anonymousForPublicMount(publicMount, publicPaths) : undefined
+
+  return { publicPaths, transactionalPaths, publicMount, anonymous }
+}
+
+function routeMountPath(
+  unit: VoyantGraphRuntimeUnitLoader,
+  route: VoyantGraphRuntimeUnitLoader["routes"][number]["route"],
+): string {
+  if (route.mount?.startsWith("/v1/")) return normalizeAbsolutePath(route.mount)
+  const segment = route.mount ?? unit.localId ?? unit.id.split("#").at(-1) ?? unit.id
+  const mount = segment.replace(/^\/+|\/+$/g, "")
+  if (route.surface === "admin") return appendPath("/v1/admin", mount)
+  if (route.surface === "public") return appendPath("/v1/public", mount)
+  if (route.surface === "webhook") return appendPath("/v1", mount)
+  return `/${mount}`
+}
+
+function resolveRoutePosturePath(mount: string, path: string): string {
+  const normalizedPath = normalizeAbsolutePath(path)
+  if (normalizedPath === mount || normalizedPath.startsWith(`${mount}/`)) return normalizedPath
+  return appendPath(mount, path.replace(/^\/+|\/+$/g, ""))
+}
+
+function appendPath(mount: string, relative: string): string {
+  return relative ? `${normalizeAbsolutePath(mount)}/${relative}` : normalizeAbsolutePath(mount)
+}
+
+function anonymousForPublicMount(
+  publicMount: string,
+  publicPaths: readonly string[],
+): boolean | readonly string[] | undefined {
+  if (publicPaths.includes(publicMount)) return true
+  const prefix = `${publicMount}/`
+  const relative = publicPaths
+    .filter((path) => path.startsWith(prefix))
+    .map((path) => path.slice(publicMount.length))
+  return relative.length > 0 ? relative : undefined
+}
+
+function applyModuleRoutePosture(output: HonoModule, posture: UnitRoutePosture): HonoModule {
+  return {
+    ...output,
+    ...(posture.publicMount ? { publicPath: publicPathFromMount(posture.publicMount) } : {}),
+    ...(posture.anonymous !== undefined ? { anonymous: posture.anonymous } : {}),
+    ...(posture.transactionalPaths.length > 0
+      ? {
+          transactionalPaths: sortedUnique([
+            ...(output.transactionalPaths ?? []),
+            ...posture.transactionalPaths,
+          ]),
+        }
+      : {}),
+  }
+}
+
+function applyExtensionRoutePosture(
+  output: HonoExtension,
+  posture: UnitRoutePosture,
+): HonoExtension {
+  return {
+    ...output,
+    ...(posture.publicMount ? { publicPath: publicPathFromMount(posture.publicMount) } : {}),
+    ...(posture.anonymous !== undefined ? { anonymous: posture.anonymous } : {}),
+    ...(posture.transactionalPaths.length > 0
+      ? {
+          transactionalPaths: sortedUnique([
+            ...(output.transactionalPaths ?? []),
+            ...posture.transactionalPaths,
+          ]),
+        }
+      : {}),
+  }
+}
+
+function publicPathFromMount(mount: string): string {
+  if (mount === "/v1/public") return "/"
+  const prefix = "/v1/public/"
+  return mount.startsWith(prefix) ? mount.slice(prefix.length) : mount
+}
+
+function mergeRoutePostures(
+  postures: readonly VoyantGraphRuntimeRoutePosture[],
+): VoyantGraphRuntimeRoutePosture {
+  return {
+    publicPaths: sortedUnique(postures.flatMap(({ publicPaths }) => publicPaths)),
+    transactionalPaths: sortedUnique(
+      postures.flatMap(({ transactionalPaths }) => transactionalPaths),
+    ),
+  }
+}
+
+function normalizeAbsolutePath(path: string): string {
+  return path === "/" ? path : path.replace(/\/+$/g, "")
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
 }
 
 function createGraphOutboundWebhookModule<TCapabilities>(

--- a/packages/framework/src/runtime-route-posture.test.ts
+++ b/packages/framework/src/runtime-route-posture.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi } from "vitest"
+import { composeVoyantGraphRuntime } from "./runtime-composition.js"
+import { createVoyantGraphRuntime } from "./runtime-lowering.js"
+
+function createRoutePostureRuntime(
+  load = vi.fn(async () => ({
+    createCatalogModule: () => ({ module: { name: "internal-catalog" } }),
+  })),
+) {
+  return {
+    load,
+    runtime: createVoyantGraphRuntime({
+      graphHash: "sha256:route-posture",
+      entries: { "@acme/catalog": load },
+      modules: [
+        {
+          id: "@acme/catalog",
+          localId: "catalog",
+          kind: "module",
+          packageName: "@acme/catalog",
+          order: 0,
+          routes: [
+            {
+              route: {
+                id: "@acme/catalog#api.admin",
+                surface: "admin",
+                mount: "catalog",
+                transactional: ["/book", "/v1/admin/catalog/quote"],
+                runtime: { entry: "@acme/catalog", export: "createCatalogModule" },
+              },
+              importEntry: "@acme/catalog",
+            },
+            {
+              route: {
+                id: "@acme/catalog#api.public",
+                surface: "public",
+                mount: "catalog",
+                anonymous: true,
+                transactional: ["/book"],
+                runtime: { entry: "@acme/catalog", export: "createCatalogModule" },
+              },
+              importEntry: "@acme/catalog",
+            },
+          ],
+        },
+      ],
+      plugins: [],
+    }),
+  }
+}
+
+describe("graph runtime route posture", () => {
+  it("keeps selected route posture inspectable without loading the package", () => {
+    const { load, runtime } = createRoutePostureRuntime()
+
+    expect(runtime.modules[0]?.routes[1]?.route).toMatchObject({
+      surface: "public",
+      mount: "catalog",
+      anonymous: true,
+      transactional: ["/book"],
+    })
+    expect(load).not.toHaveBeenCalled()
+  })
+
+  it("derives public and transactional posture from selected units", async () => {
+    const { runtime } = createRoutePostureRuntime()
+    const composition = await composeVoyantGraphRuntime({ runtime, capabilities: {} })
+
+    expect(composition.routePosture).toEqual({
+      publicPaths: ["/v1/public/catalog"],
+      transactionalPaths: [
+        "/v1/admin/catalog/book",
+        "/v1/admin/catalog/quote",
+        "/v1/public/catalog/book",
+      ],
+    })
+    expect(composition.modules[0]).toMatchObject({
+      publicPath: "catalog",
+      anonymous: true,
+      transactionalPaths: [
+        "/v1/admin/catalog/book",
+        "/v1/admin/catalog/quote",
+        "/v1/public/catalog/book",
+      ],
+    })
+  })
+
+  it("normalizes existing storefront and finance anonymous forms against their mounts", async () => {
+    const createModule = (name: string) => () => ({ module: { name } })
+    const runtime = createVoyantGraphRuntime({
+      graphHash: "sha256:existing-anonymous-forms",
+      entries: {
+        "@voyant-travel/storefront": async () => ({
+          createStorefrontModule: createModule("storefront"),
+        }),
+        "@voyant-travel/finance": async () => ({
+          createFinanceModule: createModule("finance"),
+        }),
+      },
+      modules: [
+        {
+          id: "@voyant-travel/storefront",
+          kind: "module",
+          packageName: "@voyant-travel/storefront",
+          order: 0,
+          routes: [
+            {
+              route: {
+                id: "@voyant-travel/storefront#api.public",
+                surface: "public",
+                mount: "/",
+                anonymous: ["/leads", "/newsletter", "offers"],
+                runtime: {
+                  entry: "@voyant-travel/storefront",
+                  export: "createStorefrontModule",
+                },
+              },
+              importEntry: "@voyant-travel/storefront",
+            },
+          ],
+        },
+        {
+          id: "@voyant-travel/finance",
+          kind: "module",
+          packageName: "@voyant-travel/finance",
+          order: 1,
+          routes: [
+            {
+              route: {
+                id: "@voyant-travel/finance#api.public",
+                surface: "public",
+                mount: "finance",
+                anonymous: ["/bookings", "/collections", "payment-sessions"],
+                transactional: true,
+                runtime: {
+                  entry: "@voyant-travel/finance",
+                  export: "createFinanceModule",
+                },
+              },
+              importEntry: "@voyant-travel/finance",
+            },
+          ],
+        },
+      ],
+      plugins: [],
+    })
+
+    const composition = await composeVoyantGraphRuntime({ runtime, capabilities: {} })
+
+    expect(composition.routePosture).toEqual({
+      publicPaths: [
+        "/v1/public/finance/bookings",
+        "/v1/public/finance/collections",
+        "/v1/public/finance/payment-sessions",
+        "/v1/public/leads",
+        "/v1/public/newsletter",
+        "/v1/public/offers",
+      ],
+      transactionalPaths: ["/v1/public/finance"],
+    })
+    expect(composition.modules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          publicPath: "/",
+          anonymous: ["/leads", "/newsletter", "/offers"],
+        }),
+        expect.objectContaining({
+          publicPath: "finance",
+          anonymous: ["/bookings", "/collections", "/payment-sessions"],
+        }),
+      ]),
+    )
+  })
+
+  it("preserves the payment-link root mount instead of falling back to its local id", async () => {
+    const runtime = createVoyantGraphRuntime({
+      graphHash: "sha256:payment-link-root-posture",
+      entries: {
+        "@voyant-travel/storefront/payment-link": async () => ({
+          createPaymentLinkModule: () => ({
+            module: { name: "payment-link" },
+            publicPath: "/",
+          }),
+        }),
+      },
+      modules: [
+        {
+          id: "@voyant-travel/storefront#payment-link",
+          localId: "storefront.payment-link",
+          kind: "module",
+          packageName: "@voyant-travel/storefront",
+          order: 0,
+          routes: [
+            {
+              route: {
+                id: "@voyant-travel/storefront#payment-link.api",
+                surface: "public",
+                mount: "/",
+                anonymous: ["payment-link-config", "payment-link"],
+                runtime: {
+                  entry: "@voyant-travel/storefront/payment-link",
+                  export: "createPaymentLinkModule",
+                },
+              },
+              importEntry: "@voyant-travel/storefront/payment-link",
+            },
+          ],
+        },
+      ],
+      plugins: [],
+    })
+
+    const composition = await composeVoyantGraphRuntime({ runtime, capabilities: {} })
+
+    expect(composition.routePosture.publicPaths).toEqual([
+      "/v1/public/payment-link",
+      "/v1/public/payment-link-config",
+    ])
+    expect(composition.modules[0]).toMatchObject({
+      publicPath: "/",
+      anonymous: ["/payment-link", "/payment-link-config"],
+    })
+  })
+})

--- a/packages/inventory/src/voyant.ts
+++ b/packages/inventory/src/voyant.ts
@@ -19,6 +19,7 @@ export const inventoryVoyantModule = defineModule({
       id: "@voyant-travel/inventory#api.public",
       surface: "public",
       mount: "products",
+      anonymous: true,
       runtime: {
         entry: "@voyant-travel/inventory",
         export: "inventoryHonoModule",
@@ -255,6 +256,7 @@ export const inventoryContentVoyantPlugin = defineExtension({
       id: "@voyant-travel/inventory#content-extension.api.public",
       surface: "public",
       mount: "products",
+      anonymous: true,
       runtime: {
         entry: "@voyant-travel/inventory/routes-content",
         export: "createProductContentHonoExtension",

--- a/packages/inventory/tests/unit/voyant-manifest.test.ts
+++ b/packages/inventory/tests/unit/voyant-manifest.test.ts
@@ -29,6 +29,7 @@ describe("inventory deployment manifests", () => {
         {
           id: "@voyant-travel/inventory#api.public",
           surface: "public",
+          anonymous: true,
           runtime: { entry: "@voyant-travel/inventory", export: "inventoryHonoModule" },
         },
       ],
@@ -106,6 +107,7 @@ describe("inventory deployment manifests", () => {
         {
           surface: "public",
           mount: "products",
+          anonymous: true,
           runtime: { export: "createProductContentHonoExtension" },
         },
       ],

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -127,6 +127,7 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
     {
       id: "@voyant-travel/storefront#payment-link.api",
       surface: "public",
+      mount: "/",
       anonymous: ["payment-link-config", "payment-link"],
       runtime: {
         entry: "@voyant-travel/storefront/payment-link",

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -124,6 +124,7 @@ describe("storefront deployment manifest", () => {
         {
           id: "@voyant-travel/storefront#payment-link.api",
           surface: "public",
+          mount: "/",
           anonymous: ["payment-link-config", "payment-link"],
           runtime: {
             entry: "@voyant-travel/storefront/payment-link",


### PR DESCRIPTION
## Summary

- extend graph API bundles with validated route-relative anonymous and partial transactional path metadata
- derive absolute public and transactional posture from selected runtime units and apply representable posture to composed Hono modules/extensions
- annotate inventory and accommodations public surfaces plus catalog booking transactional subsets
- document the Phase 3 contract and add release changesets

## Why

Route posture still depended on runtime/starter hand-maintained metadata even after package selection moved into the deployment graph. This slice makes package manifests inspectable before runtime imports and gives the next operator cutover one selected-graph result to consume.

Relative metadata accepts both established leading-slash and plain forms, normalizes once against the route mount, and produces deterministic absolute output. Anonymous metadata remains restricted to public bundles.

## Validation

- focused Vitest: 7 files, 76 tests
- targeted TypeScript compile for changed framework sources/tests
- commit hook: 193 lint/build/typecheck tasks passed
- pre-push hook: 101 test tasks passed
- `pnpm verify:architecture`
- `pnpm verify:deployment-graph`
- `pnpm verify:operator-runtime-ports`
- Biome, agent-quality, changeset status, and `git diff --check`

## Stack and dependencies

- stacked on #3204 (`refactor/typed-runtime-ports`) at `bc3f25dd44`
- merge/rebase #3204 first
- next dependent slice should update the operator starter app/composition/public-paths wiring to consume `routePosture`; those files are intentionally untouched here
