### PR TITLE
feat(catalog): add projection runtime contract

### DIFF
--- a/.changeset/catalog-projection-runtime-contract.md
+++ b/.changeset/catalog-projection-runtime-contract.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": minor
+---
+
+Add the injected Catalog projection subscriber runtime contract, target validation, and shared collection-setup serialization.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -270,6 +270,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -265,6 +265,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -38,6 +38,7 @@
     "./booking-engine/contracts": "./src/booking-engine/contracts.ts",
     "./booking-engine/drafts-schema": "./src/booking-engine/drafts-schema.ts",
     "./offers": "./src/offers/operator-routes.ts",
+    "./projection-runtime": "./src/projection-runtime.ts",
     "./voyant": "./src/voyant.ts"
   },
   "voyant": {
@@ -246,6 +247,11 @@
         "types": "./dist/offers/operator-routes.d.ts",
         "import": "./dist/offers/operator-routes.js",
         "default": "./dist/offers/operator-routes.js"
+      },
+      "./projection-runtime": {
+        "types": "./dist/projection-runtime.d.ts",
+        "import": "./dist/projection-runtime.js",
+        "default": "./dist/projection-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/catalog/src/projection-runtime.test.ts
+++ b/packages/catalog/src/projection-runtime.test.ts
@@ -1,0 +1,69 @@
+import { assertPortConforms } from "@voyant-travel/core/project"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY,
+  catalogProjectionRuntimePort,
+  createEnsureCatalogCollectionsSerializer,
+  parseCatalogProjectionTarget,
+} from "./projection-runtime.js"
+
+describe("Catalog projection subscriber runtime contract", () => {
+  it("publishes a stable container key and validates event-derived targets", () => {
+    expect(CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY).toBe("runtime.catalog.projection")
+    expect(
+      parseCatalogProjectionTarget({ entityModule: " products ", entityId: " product_123 " }),
+    ).toEqual({ entityModule: "products", entityId: "product_123" })
+
+    expect(() => parseCatalogProjectionTarget({ entityModule: "products", entityId: "" })).toThrow()
+    expect(() =>
+      parseCatalogProjectionTarget({
+        entityModule: "products",
+        entityId: "product_123",
+        untrusted: true,
+      }),
+    ).toThrow()
+  })
+
+  it("ships a conformance kit for injected projection runtimes", async () => {
+    await expect(
+      assertPortConforms(catalogProjectionRuntimePort, {
+        reindexEntity: async () => undefined,
+        deleteEntity: async () => undefined,
+      }),
+    ).resolves.toBeUndefined()
+    await expect(assertPortConforms(catalogProjectionRuntimePort, {} as never)).rejects.toThrow(
+      /reindexEntity/,
+    )
+  })
+
+  it("serializes collection setup and continues after a rejected attempt", async () => {
+    const serialize = createEnsureCatalogCollectionsSerializer()
+    const order: string[] = []
+    let releaseFirst: (() => void) | undefined
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+
+    const first = serialize(async () => {
+      order.push("first:start")
+      await firstGate
+      order.push("first:end")
+    })
+    const second = serialize(async () => {
+      order.push("second")
+      throw new Error("schema update failed")
+    })
+    const third = serialize(async () => {
+      order.push("third")
+    })
+
+    await vi.waitFor(() => expect(order).toEqual(["first:start"]))
+    releaseFirst?.()
+
+    await first
+    await expect(second).rejects.toThrow("schema update failed")
+    await third
+    expect(order).toEqual(["first:start", "first:end", "second", "third"])
+  })
+})

--- a/packages/catalog/src/projection-runtime.ts
+++ b/packages/catalog/src/projection-runtime.ts
@@ -1,0 +1,62 @@
+import { definePort } from "@voyant-travel/core/project"
+import { z } from "zod"
+
+/** Service-container key used by package-owned Catalog projection subscribers. */
+export const CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY = "runtime.catalog.projection"
+
+/** Identifies one Catalog entity whose search projection must be refreshed or removed. */
+export const catalogProjectionTargetSchema = z
+  .object({
+    entityModule: z.string().trim().min(1),
+    entityId: z.string().trim().min(1),
+  })
+  .strict()
+
+export type CatalogProjectionTarget = z.infer<typeof catalogProjectionTargetSchema>
+
+/** Parse an event-derived projection target before invoking deployment runtime code. */
+export function parseCatalogProjectionTarget(input: unknown): CatalogProjectionTarget {
+  return catalogProjectionTargetSchema.parse(input)
+}
+
+/**
+ * Deployment-owned indexing boundary consumed by Catalog's projection subscribers.
+ *
+ * The deployment supplies database lifetime, configured slices, field-policy
+ * registries, document builders, embedding providers, and the index adapter.
+ */
+export interface CatalogProjectionRuntime {
+  reindexEntity(target: CatalogProjectionTarget): Promise<void>
+  deleteEntity(target: CatalogProjectionTarget): Promise<void>
+}
+
+/** Typed deployment port for the package-owned Catalog projection runtime. */
+export const catalogProjectionRuntimePort = definePort<CatalogProjectionRuntime>({
+  id: "catalog.projection-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("catalog.projection-runtime provider must be an object.")
+    }
+    for (const method of ["reindexEntity", "deleteEntity"] as const) {
+      if (typeof provider[method] !== "function") {
+        throw new Error(`catalog.projection-runtime provider must implement ${method}().`)
+      }
+    }
+  },
+})
+
+export type EnsureCatalogCollections = (ensureCollections: () => Promise<void>) => Promise<void>
+
+/**
+ * Serialize engine schema setup across event bursts without poisoning later
+ * attempts when one setup call fails.
+ */
+export function createEnsureCatalogCollectionsSerializer(): EnsureCatalogCollections {
+  let tail: Promise<void> = Promise.resolve()
+
+  return async (ensureCollections) => {
+    const run = tail.then(ensureCollections)
+    tail = run.catch(() => undefined)
+    await run
+  }
+}

--- a/packages/catalog/tests/unit/package-exports.test.ts
+++ b/packages/catalog/tests/unit/package-exports.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PublishedExport {
+  types: string
+  import: string
+  default: string
+}
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, PublishedExport>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/catalog package exports", () => {
+  it("publishes the projection subscriber runtime contract", () => {
+    expect(packageJson.exports["./projection-runtime"]).toBe("./src/projection-runtime.ts")
+    expect(packageJson.publishConfig.exports["./projection-runtime"]).toEqual({
+      types: "./dist/projection-runtime.d.ts",
+      import: "./dist/projection-runtime.js",
+      default: "./dist/projection-runtime.js",
+    })
+  })
+})

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -341,6 +341,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -335,6 +335,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -335,6 +335,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -341,6 +341,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -335,6 +335,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -341,6 +341,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -335,6 +335,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -341,6 +341,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -334,6 +334,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -335,6 +335,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -336,6 +336,7 @@
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],
       "@voyant-travel/catalog/overlay/resolver": ["../catalog/dist/overlay/resolver.d.ts"],
       "@voyant-travel/catalog/overlay/schema": ["../catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -437,6 +437,9 @@
         "../../packages/catalog/dist/overlay/resolver.d.ts"
       ],
       "@voyant-travel/catalog/overlay/schema": ["../../packages/catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": [
+        "../../packages/catalog/dist/projection-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/provenance": ["../../packages/catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../../packages/catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -437,6 +437,9 @@
         "../../packages/catalog/dist/overlay/resolver.d.ts"
       ],
       "@voyant-travel/catalog/overlay/schema": ["../../packages/catalog/dist/overlay/schema.d.ts"],
+      "@voyant-travel/catalog/projection-runtime": [
+        "../../packages/catalog/dist/projection-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/provenance": ["../../packages/catalog/dist/provenance.d.ts"],
       "@voyant-travel/catalog/schema": ["../../packages/catalog/dist/schema.d.ts"],
       "@voyant-travel/catalog/schema-sourced-entries": [


### PR DESCRIPTION
## Summary

- add an import-cheap `@voyant-travel/catalog/projection-runtime` contract for deployment-injected projection indexing
- expose the typed `catalog.projection-runtime` port and stable `runtime.catalog.projection` service-container key
- validate generic `{ entityModule, entityId }` targets before deployment runtime invocation
- serialize `ensureCollections()` work across event bursts without poisoning later attempts after a rejection
- publish matching development and `publishConfig.exports` subpaths with a minor changeset

## Scope

This is package-contract PR 1 for the Catalog projection subscriber migration tracked by #3080. It intentionally does not add subscriber descriptors, change `starters/operator/src/api/app.ts`, or import concrete Accommodations, Charters, Commerce, Cruises, Distribution, Inventory, or Operations implementations into Catalog. The Catalog manifest does not require the port yet; activation belongs with the later subscriber descriptor slice.

## API

`CatalogProjectionRuntime` exposes only `reindexEntity(target)` and `deleteEntity(target)`. Deployments retain ownership of database lifetime, configured slices, field-policy registries, document builders, embeddings, and index adapters. `createEnsureCatalogCollectionsSerializer()` is shared package logic for later descriptor factories.

## Verification

- `pnpm --filter @voyant-travel/catalog test` (39 files / 437 tests passed; 4 files / 27 tests skipped)
- `pnpm --filter @voyant-travel/catalog typecheck`
- `pnpm --filter @voyant-travel/catalog lint`
- direct package export parity test
- `node scripts/verify-package-tarballs.mjs --package @voyant-travel/catalog`
- changed-file formatting, secret scan, and quality check completed before the broad hook was stopped

The local broad Turbo typecheck/test hooks were resource-contended by concurrent worktrees and were stopped per repository coordination after focused Catalog verification passed. GitHub CI is authoritative for broad repository validation.

Based on current `origin/main` including merged #3209 (`3ed420a829`).