### PR TITLE
feat(commerce): stage promotion redemption subscriber

### DIFF
--- a/.changeset/commerce-promotion-redemption-subscriber.md
+++ b/.changeset/commerce-promotion-redemption-subscriber.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/commerce": patch
+---
+
+Declare the inert Commerce promotion-redemption subscriber contract and publish its package-owned runtime factory for later graph activation.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -426,6 +426,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -421,6 +421,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -397,6 +397,9 @@
       "@voyant-travel/commerce": ["../commerce/dist/index.d.ts"],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -392,6 +392,9 @@
       "@voyant-travel/commerce": ["../commerce/dist/index.d.ts"],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -8,6 +8,7 @@
     "./schema": "./src/schema.ts",
     "./checkout": "./src/checkout/index.ts",
     "./markets/validation": "./src/markets/validation.ts",
+    "./promotion-redemption-subscriber": "./src/promotions/subscriber-runtime.ts",
     "./promotions/validation": "./src/promotions/validation.ts",
     "./promotions/workflow-bulk-reindex-manifest": "./src/promotions/workflow-bulk-reindex-manifest.ts",
     "./promotions/workflow-bulk-reindex": "./src/promotions/workflow-bulk-reindex.ts",
@@ -88,6 +89,11 @@
         "types": "./dist/markets/validation.d.ts",
         "import": "./dist/markets/validation.js",
         "default": "./dist/markets/validation.js"
+      },
+      "./promotion-redemption-subscriber": {
+        "types": "./dist/promotions/subscriber-runtime.d.ts",
+        "import": "./dist/promotions/subscriber-runtime.js",
+        "default": "./dist/promotions/subscriber-runtime.js"
       },
       "./promotions/validation": {
         "types": "./dist/promotions/validation.d.ts",

--- a/packages/commerce/src/promotions/service-booking-confirmed.ts
+++ b/packages/commerce/src/promotions/service-booking-confirmed.ts
@@ -129,31 +129,3 @@ export async function recordPromotionRedemptionsForBooking(
     rowsUpserted: aggregated.size,
   }
 }
-
-/**
- * Wiring guidance for the operator starter — the canonical subscriber
- * pattern (mirrors how `catalog-bridge.ts` wires `captureSnapshotGraph`):
- *
- *   eventBus.subscribe<BookingConfirmedEvent>("booking.confirmed", async ({ data }) => {
- *     await withDbFromEnv(env, async (db) => {
- *       try {
- *         await recordPromotionRedemptionsForBooking(db, data.bookingId)
- *       } catch (err) {
- *         // Failing here leaves the booking committed without a
- *         // redemption row. Ops can backfill from
- *         // `pricing_applied_offers` on the snapshot. Log so the gap
- *         // is visible.
- *         console.warn("[promotions] redemption subscriber failed", { …err })
- *       }
- *     })
- *   })
- *
- * The factory is intentionally kept in the template (not here) because:
- *   - The subscriber needs the template's `withDbFromEnv` from
- *     `starters/operator/src/api/lib/db.ts` (the Pool lifecycle helper
- *     introduced in #510 / #512). That helper isn't exported from a
- *     package.
- *   - Keeping the package package-side core (`recordPromotionRedemptionsForBooking`)
- *     and the wiring template-side mirrors the existing catalog-bridge
- *     subscriber pattern.
- */

--- a/packages/commerce/src/promotions/subscriber-runtime.ts
+++ b/packages/commerce/src/promotions/subscriber-runtime.ts
@@ -1,0 +1,46 @@
+import type { SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+
+import { recordPromotionRedemptionsForBooking } from "./service-booking-confirmed.js"
+
+export const COMMERCE_PROMOTION_REDEMPTION_SUBSCRIBER_ID =
+  "@voyant-travel/commerce#subscriber.promotion-redemption-booking-confirmed"
+
+export interface PromotionRedemptionSubscriberRuntimeOptions<TBindings = unknown> {
+  /** Resolve the deployment database and retain ownership of its lifecycle. */
+  withDb<T>(bindings: TBindings, operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+  recordRedemptions?: typeof recordPromotionRedemptionsForBooking
+  logger?: Pick<Console, "warn">
+}
+
+interface BookingConfirmedPayload {
+  bookingId: string
+}
+
+/** Build the executable descriptor without activating it in the package manifest. */
+export function createPromotionRedemptionSubscriberRuntime<TBindings = unknown>(
+  options: PromotionRedemptionSubscriberRuntimeOptions<TBindings>,
+): SubscriberRuntimeDescriptor {
+  const recordRedemptions = options.recordRedemptions ?? recordPromotionRedemptionsForBooking
+  const logger = options.logger ?? console
+
+  return {
+    id: COMMERCE_PROMOTION_REDEMPTION_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ bindings, eventBus }) => {
+      const runtimeBindings = bindings as TBindings
+      eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
+        await options.withDb(runtimeBindings, async (db) => {
+          try {
+            await recordRedemptions(db, data.bookingId)
+          } catch (error) {
+            logger.warn("[catalog-bridge] promotion redemption recorder failed", {
+              bookingId: data.bookingId,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        })
+      })
+    },
+  }
+}

--- a/packages/commerce/src/voyant.test.ts
+++ b/packages/commerce/src/voyant.test.ts
@@ -20,6 +20,11 @@ describe("commerce deployment manifest", () => {
     ])
     expect(commerceVoyantModule.subscribers).toEqual([
       {
+        id: "@voyant-travel/commerce#subscriber.promotion-redemption-booking-confirmed",
+        eventType: "booking.confirmed",
+        source: "@voyant-travel/commerce/promotion-redemption-subscriber",
+      },
+      {
         id: `@voyant-travel/commerce#subscriber.${promotionAffectedAllFilter.id}`,
         eventType: promotionAffectedAllFilter.eventType,
         eventFilterId: promotionAffectedAllFilter.id,

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -112,6 +112,11 @@ export const commerceVoyantModule = defineModule({
   ],
   subscribers: [
     {
+      id: "@voyant-travel/commerce#subscriber.promotion-redemption-booking-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/commerce/promotion-redemption-subscriber",
+    },
+    {
       id: "@voyant-travel/commerce#subscriber.ef_6f8e4b4ce409d04c",
       eventType: "promotion.changed",
       eventFilterId: promotionAffectedAllFilter.id,

--- a/packages/commerce/tests/unit/package-exports.test.ts
+++ b/packages/commerce/tests/unit/package-exports.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PublishedExport {
+  types: string
+  import: string
+  default: string
+}
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, PublishedExport>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/commerce package exports", () => {
+  it("publishes the promotion-redemption subscriber runtime subpath", () => {
+    expect(packageJson.exports["./promotion-redemption-subscriber"]).toBe(
+      "./src/promotions/subscriber-runtime.ts",
+    )
+    expect(packageJson.publishConfig.exports["./promotion-redemption-subscriber"]).toEqual({
+      types: "./dist/promotions/subscriber-runtime.d.ts",
+      import: "./dist/promotions/subscriber-runtime.js",
+      default: "./dist/promotions/subscriber-runtime.js",
+    })
+  })
+})

--- a/packages/commerce/tests/unit/promotion-redemption-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/promotion-redemption-subscriber-runtime.test.ts
@@ -1,0 +1,84 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  COMMERCE_PROMOTION_REDEMPTION_SUBSCRIBER_ID,
+  createPromotionRedemptionSubscriberRuntime,
+} from "../../src/promotions/subscriber-runtime.js"
+
+function captureHandler() {
+  const eventBus = createEventBus()
+  let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
+  vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
+    handler = registeredHandler as typeof handler
+    return { unsubscribe: vi.fn() }
+  })
+  return { eventBus, getHandler: () => handler }
+}
+
+function bookingConfirmed(bookingId: string): EventEnvelope {
+  return {
+    name: "booking.confirmed",
+    data: { bookingId },
+    emittedAt: new Date().toISOString(),
+    metadata: undefined,
+  }
+}
+
+describe("commerce promotion-redemption subscriber runtime", () => {
+  it("registers the package-owned descriptor and records every delivery", async () => {
+    const db = { kind: "test-db" } as unknown as AnyDrizzleDb
+    const bindings = { DATABASE_URL: "postgres://commerce" }
+    const recordRedemptions = vi.fn(async () => ({
+      quotesScanned: 1,
+      offersFound: 1,
+      rowsUpserted: 1,
+    }))
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const { eventBus, getHandler } = captureHandler()
+    const descriptor = createPromotionRedemptionSubscriberRuntime({
+      withDb,
+      recordRedemptions,
+    })
+
+    await descriptor.register({ bindings, container: createContainer(), eventBus })
+
+    expect({ id: descriptor.id, eventType: descriptor.eventType }).toEqual({
+      id: COMMERCE_PROMOTION_REDEMPTION_SUBSCRIBER_ID,
+      eventType: "booking.confirmed",
+    })
+
+    await getHandler()?.(bookingConfirmed("booking_1"))
+    await getHandler()?.(bookingConfirmed("booking_1"))
+
+    expect(withDb).toHaveBeenCalledTimes(2)
+    expect(withDb).toHaveBeenNthCalledWith(1, bindings, expect.any(Function))
+    expect(recordRedemptions).toHaveBeenCalledTimes(2)
+    expect(recordRedemptions).toHaveBeenNthCalledWith(1, db, "booking_1")
+  })
+
+  it("warns and swallows recorder failures", async () => {
+    const logger = { warn: vi.fn() }
+    const recordRedemptions = vi.fn(async () => {
+      throw new Error("database unavailable")
+    })
+    const { eventBus, getHandler } = captureHandler()
+    const descriptor = createPromotionRedemptionSubscriberRuntime({
+      withDb: async (_bindings, operation) => operation({} as AnyDrizzleDb),
+      recordRedemptions,
+      logger,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await expect(getHandler()?.(bookingConfirmed("booking_2"))).resolves.toBeUndefined()
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[catalog-bridge] promotion redemption recorder failed",
+      {
+        bookingId: "booking_2",
+        error: "database unavailable",
+      },
+    )
+  })
+})

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -86,6 +86,11 @@ describe("commerce deployment manifest", () => {
       ],
       subscribers: [
         {
+          id: "@voyant-travel/commerce#subscriber.promotion-redemption-booking-confirmed",
+          eventType: "booking.confirmed",
+          source: "@voyant-travel/commerce/promotion-redemption-subscriber",
+        },
+        {
           id: "@voyant-travel/commerce#subscriber.ef_6f8e4b4ce409d04c",
           eventType: "promotion.changed",
           eventFilterId: "ef_6f8e4b4ce409d04c",
@@ -98,6 +103,7 @@ describe("commerce deployment manifest", () => {
         },
       ],
     })
+    expect(commerceVoyantModule.subscribers?.[0]).not.toHaveProperty("runtime")
   })
 
   it("owns the catalog checkout and booking maintenance bridges", () => {

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -491,6 +491,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -491,6 +491,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -497,6 +497,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -491,6 +491,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -497,6 +497,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -491,6 +491,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -497,6 +497,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -490,6 +490,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -491,6 +491,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -492,6 +492,9 @@
       ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../commerce/dist/promotions/validation.d.ts"
       ],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -631,6 +631,9 @@
       "@voyant-travel/commerce/markets/validation": [
         "../../packages/commerce/dist/markets/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../../packages/commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../../packages/commerce/dist/promotions/validation.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -631,6 +631,9 @@
       "@voyant-travel/commerce/markets/validation": [
         "../../packages/commerce/dist/markets/validation.d.ts"
       ],
+      "@voyant-travel/commerce/promotion-redemption-subscriber": [
+        "../../packages/commerce/dist/promotions/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/promotions/validation": [
         "../../packages/commerce/dist/promotions/validation.d.ts"
       ],


### PR DESCRIPTION
## Summary

- declare the Commerce `booking.confirmed` promotion-redemption subscriber as an inert package-owned graph contract, without a runtime reference or central-handler cutover
- publish a package-owned `SubscriberRuntimeDescriptor` factory that delegates to the existing idempotent redemption upsert and preserves the current warning-and-swallow behavior
- add focused runtime, manifest, and dual package-export coverage plus regenerated dist-path metadata

## Dependency

- follows #3207 for the shared `SubscriberRuntimeDescriptor` contract and subscriber lowering; this PR does not activate or remove the existing central handler

## Verification

- `pnpm --filter @voyant-travel/commerce exec vitest run tests/unit/promotion-redemption-subscriber-runtime.test.ts tests/unit/voyant-manifest.test.ts tests/unit/package-exports.test.ts` (3 files, 6 tests passed)
- changed-file `biome check` for Commerce source/tests/package metadata and generated configs
- `pnpm verify:dist-configs`
- `git diff --check`

## Local Limitation

- the focused Commerce TypeScript process remained stuck under concurrent local workspace TypeScript load and was terminated; package prepack/tarball generation was consequently not completed locally. CI is authoritative for typecheck, build, and package publication validation.
