### PR TITLE
feat(trips): stage payment completion subscriber

### DIFF
--- a/.changeset/stage-trips-payment-subscriber.md
+++ b/.changeset/stage-trips-payment-subscriber.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": patch
+---
+
+Stage the package-owned Trips payment completion subscriber contract and published runtime descriptor without activating graph execution.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1415,6 +1415,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1410,6 +1410,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1386,6 +1386,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1381,6 +1381,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1450,6 +1450,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1451,6 +1451,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1460,6 +1460,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1461,6 +1461,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1470,6 +1470,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1465,6 +1465,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1474,6 +1474,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1475,6 +1475,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1471,6 +1471,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1466,6 +1466,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1479,6 +1479,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1480,6 +1480,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1481,6 +1481,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1367,6 +1367,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1362,6 +1362,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/trips/package.json
+++ b/packages/trips/package.json
@@ -13,6 +13,7 @@
     "./catalog-component": "./src/catalog-component.ts",
     "./flight-component": "./src/flight-component.ts",
     "./cruise-extension": "./src/cruise-extension.ts",
+    "./payment-subscribers": "./src/payment-subscriber-runtime.ts",
     "./routes": "./src/routes.ts",
     "./voyant": "./src/voyant.ts"
   },
@@ -119,6 +120,11 @@
         "types": "./dist/cruise-extension.d.ts",
         "import": "./dist/cruise-extension.js",
         "default": "./dist/cruise-extension.js"
+      },
+      "./payment-subscribers": {
+        "types": "./dist/payment-subscriber-runtime.d.ts",
+        "import": "./dist/payment-subscriber-runtime.js",
+        "default": "./dist/payment-subscriber-runtime.js"
       },
       "./routes": {
         "types": "./dist/routes.d.ts",

--- a/packages/trips/src/payment-subscriber-runtime.ts
+++ b/packages/trips/src/payment-subscriber-runtime.ts
@@ -1,0 +1,45 @@
+import type { BootstrapContext } from "@voyant-travel/core"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { PaymentCompletedEvent } from "@voyant-travel/finance"
+
+import { completeTripCheckout } from "./service-checkout.js"
+
+const TRIPS_PAYMENT_COMPLETED_SUBSCRIBER_ID = "@voyant-travel/trips#subscriber.payment-completed"
+
+export const TRIPS_PAYMENT_SUBSCRIBER_RUNTIME_KEY = "trips.payment-subscriber.runtime" as const
+
+export interface TripsPaymentSubscriberRuntime {
+  withDb<T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+}
+
+/** Executable descriptor staged for the graph cutover after central bundle removal. */
+export const tripsPaymentCompletedSubscriber = {
+  id: TRIPS_PAYMENT_COMPLETED_SUBSCRIBER_ID,
+  eventType: "payment.completed",
+  register: ({ container, eventBus }: BootstrapContext) => {
+    eventBus.subscribe<PaymentCompletedEvent>("payment.completed", async ({ data }) => {
+      if (data.targetType !== "other" || !data.targetId?.startsWith("trip_")) return
+
+      try {
+        const runtime = container.resolve<TripsPaymentSubscriberRuntime>(
+          TRIPS_PAYMENT_SUBSCRIBER_RUNTIME_KEY,
+        )
+        await runtime.withDb((db) =>
+          completeTripCheckout(db, {
+            envelopeId: data.targetId ?? undefined,
+            paymentSessionId: data.paymentSessionId,
+            payload: {
+              amountCents: data.amountCents,
+              currency: data.currency,
+              provider: data.provider,
+              targetType: data.targetType,
+              targetId: data.targetId,
+            },
+          }),
+        )
+      } catch (error) {
+        console.error("[trips] payment completion failed", error)
+      }
+    })
+  },
+}

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -116,6 +116,13 @@ export const tripsVoyantModule = defineModule({
       from: { tools: ["@voyant-travel/trips#tool.price-trip"] },
     },
   ],
+  subscribers: [
+    {
+      id: "@voyant-travel/trips#subscriber.payment-completed",
+      eventType: "payment.completed",
+      source: "@voyant-travel/trips",
+    },
+  ],
   admin: {
     routes: [
       {

--- a/packages/trips/tests/package-exports.test.ts
+++ b/packages/trips/tests/package-exports.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PublishedExport {
+  types: string
+  import: string
+  default: string
+}
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, PublishedExport>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/trips package exports", () => {
+  it("publishes the payment subscriber runtime subpath", () => {
+    expect(packageJson.exports["./payment-subscribers"]).toBe("./src/payment-subscriber-runtime.ts")
+    expect(packageJson.publishConfig.exports["./payment-subscribers"]).toEqual({
+      types: "./dist/payment-subscriber-runtime.d.ts",
+      import: "./dist/payment-subscriber-runtime.js",
+      default: "./dist/payment-subscriber-runtime.js",
+    })
+  })
+})

--- a/packages/trips/tests/payment-subscriber-runtime.test.ts
+++ b/packages/trips/tests/payment-subscriber-runtime.test.ts
@@ -1,0 +1,89 @@
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { PaymentCompletedEvent } from "@voyant-travel/finance"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { completeTripCheckout } = vi.hoisted(() => ({
+  completeTripCheckout: vi.fn(),
+}))
+
+vi.mock("../src/service-checkout.js", () => ({ completeTripCheckout }))
+
+import {
+  TRIPS_PAYMENT_SUBSCRIBER_RUNTIME_KEY,
+  tripsPaymentCompletedSubscriber,
+} from "../src/payment-subscriber-runtime.js"
+
+const paymentCompleted = (
+  overrides: Partial<PaymentCompletedEvent> = {},
+): PaymentCompletedEvent => ({
+  paymentSessionId: "payment_sessions_123",
+  targetType: "other",
+  targetId: "trip_123",
+  bookingId: null,
+  legacyOrderId: null,
+  invoiceId: null,
+  bookingPaymentScheduleId: null,
+  bookingGuaranteeId: null,
+  amountCents: 12_500,
+  currency: "EUR",
+  provider: "netopia",
+  ...overrides,
+})
+
+describe("trips payment subscriber runtime", () => {
+  beforeEach(() => {
+    completeTripCheckout.mockReset()
+  })
+
+  it("matches the staged graph subscriber declaration", () => {
+    expect(tripsPaymentCompletedSubscriber).toMatchObject({
+      id: "@voyant-travel/trips#subscriber.payment-completed",
+      eventType: "payment.completed",
+      register: expect.any(Function),
+    })
+  })
+
+  it("completes trip checkouts for other targets with trip ids", async () => {
+    const db = { kind: "test-db" } as unknown as AnyDrizzleDb
+    const container = createContainer()
+    const eventBus = createEventBus()
+    const withDb = vi.fn(async (operation: (input: AnyDrizzleDb) => Promise<unknown>) =>
+      operation(db),
+    )
+    container.register(TRIPS_PAYMENT_SUBSCRIBER_RUNTIME_KEY, { withDb })
+
+    await tripsPaymentCompletedSubscriber.register({ container, eventBus })
+    await eventBus.emit("payment.completed", paymentCompleted())
+
+    expect(withDb).toHaveBeenCalledOnce()
+    expect(completeTripCheckout).toHaveBeenCalledWith(db, {
+      envelopeId: "trip_123",
+      paymentSessionId: "payment_sessions_123",
+      payload: {
+        amountCents: 12_500,
+        currency: "EUR",
+        provider: "netopia",
+        targetType: "other",
+        targetId: "trip_123",
+      },
+    })
+  })
+
+  it.each([
+    paymentCompleted({ targetType: "booking" }),
+    paymentCompleted({ targetId: "order_123" }),
+    paymentCompleted({ targetId: null }),
+  ])("ignores payment completion outside the trips target contract", async (event) => {
+    const container = createContainer()
+    const eventBus = createEventBus()
+    const withDb = vi.fn()
+    container.register(TRIPS_PAYMENT_SUBSCRIBER_RUNTIME_KEY, { withDb })
+
+    await tripsPaymentCompletedSubscriber.register({ container, eventBus })
+    await eventBus.emit("payment.completed", event)
+
+    expect(withDb).not.toHaveBeenCalled()
+    expect(completeTripCheckout).not.toHaveBeenCalled()
+  })
+})

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -24,6 +24,17 @@ describe("trips deployment manifest", () => {
       ],
       schema: [{ id: "@voyant-travel/trips#schema" }],
       migrations: [{ id: "@voyant-travel/trips#migrations" }],
+      subscribers: [
+        {
+          id: "@voyant-travel/trips#subscriber.payment-completed",
+          eventType: "payment.completed",
+          source: "@voyant-travel/trips",
+        },
+      ],
     })
+  })
+
+  it("keeps payment completion graph-declared but inert", () => {
+    expect(tripsVoyantModule.subscribers?.[0]).not.toHaveProperty("runtime")
   })
 })

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1479,6 +1479,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1480,6 +1480,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1481,6 +1481,7 @@
       "@voyant-travel/trips/checkout": ["../trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": ["../trips/dist/payment-subscriber-runtime.d.ts"],
       "@voyant-travel/trips/routes": ["../trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../trips/dist/service.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1902,6 +1902,9 @@
       "@voyant-travel/trips/checkout": ["../../packages/trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../../packages/trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../../packages/trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": [
+        "../../packages/trips/dist/payment-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/trips/routes": ["../../packages/trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../../packages/trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../../packages/trips/dist/service.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1902,6 +1902,9 @@
       "@voyant-travel/trips/checkout": ["../../packages/trips/dist/checkout/index.d.ts"],
       "@voyant-travel/trips/cruise-extension": ["../../packages/trips/dist/cruise-extension.d.ts"],
       "@voyant-travel/trips/flight-component": ["../../packages/trips/dist/flight-component.d.ts"],
+      "@voyant-travel/trips/payment-subscribers": [
+        "../../packages/trips/dist/payment-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/trips/routes": ["../../packages/trips/dist/routes.d.ts"],
       "@voyant-travel/trips/schema": ["../../packages/trips/dist/schema.d.ts"],
       "@voyant-travel/trips/service": ["../../packages/trips/dist/service.d.ts"],


### PR DESCRIPTION
## Summary

- declare the package-owned Trips `payment.completed` subscriber without a runtime reference, keeping graph execution inert
- publish a structurally compatible subscriber runtime descriptor at `@voyant-travel/trips/payment-subscribers`
- preserve the `targetType === "other"` and `trip_` target guards before calling the existing `completeTripCheckout` service
- add manifest, runtime guard/delegation, package export, and changeset coverage

The central Operator `tripsPaymentBundle` remains unchanged and active. This PR does not activate or remove central wiring. The runtime descriptor is staged for the later graph cutover after the ordinary subscriber lowering in #3207 is available.

## Verification

- `pnpm --filter @voyant-travel/trips exec vitest run tests/payment-subscriber-runtime.test.ts tests/voyant-manifest.test.ts tests/package-exports.test.ts` (8 tests passed)
- `pnpm --filter @voyant-travel/trips lint`
- `pnpm exec tsx scripts/verify-package-exports.ts --package @voyant-travel/trips`
- `git diff --check`

## Local limitation

The focused Trips typecheck was capped at 90 seconds and terminated without diagnostics because the shared local host was resource-constrained by concurrent TypeScript builds. Build/tarball verification was not completed locally for the same reason; CI is authoritative for those lanes.