### PR TITLE
feat(finance): declare booking schedule subscriber

### DIFF
--- a/.changeset/finance-booking-schedule-subscriber.md
+++ b/.changeset/finance-booking-schedule-subscriber.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Declare the inert Finance booking-schedule subscriber contract and publish its package-owned runtime factory for a later duplicate-free graph activation.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -985,13 +985,20 @@ The remaining Operator subscriber authorities are intentionally explicit:
 - `tripsPaymentBundle`: `payment.completed`
 - `smartbillOperatorBundle`: `invoice.issued`, `invoice.proforma.issued`, and
   `invoice.payment.recorded`
-- the graph-gated Netopia lazy bundle, whose packaged callback/subscriber runtime
-  is still adapted through the Operator plugin list
 
 These entries remain until each owning package manifest has executable runtime
 references and direct selected-graph parity. Deployment-local ordering,
 configuration, or orchestration is not sufficient reason to relabel a standard
 package subscriber as migrated.
+
+Finance now owns the inert `booking.confirmed` declaration for booking-schedule
+generation and exports a subscriber descriptor factory from
+`@voyant-travel/finance/booking-schedule-subscriber`. The factory preserves the
+existing generation-then-covered-settlement behavior through deployment-injected
+booking-schedule options and database lifecycle resolution. Its manifest entry
+intentionally omits a runtime reference while the central Operator bundle
+remains active; direct selected-graph activation must remove that central
+registration in the same change to avoid duplicate event handling.
 
 The broader event catalog is beyond the foundational substrate:
 

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -693,6 +693,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -688,6 +688,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -664,6 +664,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -659,6 +659,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -728,6 +728,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -729,6 +729,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -738,6 +738,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -739,6 +739,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -748,6 +748,9 @@
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
       "@voyant-travel/finance-contracts/validation": ["../finance-contracts/dist/validation.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -743,6 +743,9 @@
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
       "@voyant-travel/finance-contracts/validation": ["../finance-contracts/dist/validation.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -19,6 +19,7 @@
     "./schema": "./src/schema.ts",
     "./validation": "./src/validation.ts",
     "./booking-tax": "./src/booking-tax.ts",
+    "./booking-schedule-subscriber": "./src/booking-schedule/subscriber-runtime.ts",
     "./routes": "./src/routes.ts",
     "./public-routes": "./src/routes-public.ts",
     "./public-validation": "./src/validation-public.ts",
@@ -141,6 +142,11 @@
         "types": "./dist/booking-tax.d.ts",
         "import": "./dist/booking-tax.js",
         "default": "./dist/booking-tax.js"
+      },
+      "./booking-schedule-subscriber": {
+        "types": "./dist/booking-schedule/subscriber-runtime.d.ts",
+        "import": "./dist/booking-schedule/subscriber-runtime.js",
+        "default": "./dist/booking-schedule/subscriber-runtime.js"
       },
       "./routes": {
         "types": "./dist/routes.d.ts",

--- a/packages/finance/src/booking-schedule/subscriber-runtime.ts
+++ b/packages/finance/src/booking-schedule/subscriber-runtime.ts
@@ -1,0 +1,60 @@
+import type { SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type BookingScheduleRoutesOptions,
+  generatePaymentScheduleForBooking,
+} from "../payment-schedule/routes.js"
+import { settleCoveredBookingPaymentSchedules } from "../service-shared.js"
+
+export const FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID =
+  "@voyant-travel/finance#subscriber.booking-schedule-confirmed"
+
+export interface BookingScheduleSubscriberRuntimeOptions<TBindings = unknown> {
+  resolveRoutesOptions(
+    bindings: TBindings,
+  ): BookingScheduleRoutesOptions | Promise<BookingScheduleRoutesOptions>
+  /** Resolve the deployment database and retain ownership of its lifecycle. */
+  withDb<T>(bindings: TBindings, operation: (db: PostgresJsDatabase) => Promise<T>): Promise<T>
+  generateSchedule?: typeof generatePaymentScheduleForBooking
+  settleCoveredSchedules?: typeof settleCoveredBookingPaymentSchedules
+  logger?: Pick<Console, "error">
+}
+
+interface BookingConfirmedPayload {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+}
+
+/** Build the executable descriptor without activating it in the package manifest. */
+export function createBookingScheduleSubscriberRuntime<TBindings = unknown>(
+  options: BookingScheduleSubscriberRuntimeOptions<TBindings>,
+): SubscriberRuntimeDescriptor {
+  const generateSchedule = options.generateSchedule ?? generatePaymentScheduleForBooking
+  const settleCoveredSchedules =
+    options.settleCoveredSchedules ?? settleCoveredBookingPaymentSchedules
+  const logger = options.logger ?? console
+
+  return {
+    id: FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ bindings, eventBus }) => {
+      const runtimeBindings = bindings as TBindings
+      eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
+        try {
+          const routesOptions = await options.resolveRoutesOptions(runtimeBindings)
+          await options.withDb(runtimeBindings, async (db) => {
+            await generateSchedule(db, data.bookingId, routesOptions)
+            await settleCoveredSchedules(db, data.bookingId)
+          })
+        } catch (error) {
+          logger.error("[booking-schedule] failed to generate schedule", {
+            bookingId: data.bookingId,
+            error: error instanceof Error ? error.message : String(error),
+          })
+        }
+      })
+    },
+  }
+}

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -252,6 +252,13 @@ export const financeBookingScheduleVoyantPlugin = defineExtension({
       },
     },
   ],
+  subscribers: [
+    {
+      id: "@voyant-travel/finance#subscriber.booking-schedule-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/finance/booking-schedule-subscriber",
+    },
+  ],
   meta: {
     ownership: "package",
   },

--- a/packages/finance/tests/unit/booking-schedule-subscriber-runtime.test.ts
+++ b/packages/finance/tests/unit/booking-schedule-subscriber-runtime.test.ts
@@ -1,0 +1,94 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import { describe, expect, it, vi } from "vitest"
+import {
+  createBookingScheduleSubscriberRuntime,
+  FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID,
+} from "../../src/booking-schedule/subscriber-runtime.js"
+import type { BookingScheduleRoutesOptions } from "../../src/payment-schedule/routes.js"
+
+const routesOptions = {} as BookingScheduleRoutesOptions
+
+describe("finance booking-schedule subscriber runtime", () => {
+  it("registers the package-owned descriptor and preserves schedule processing order", async () => {
+    const calls: string[] = []
+    const db = {} as never
+    const bindings = { DATABASE_URL: "postgres://finance" }
+    const resolveRoutesOptions = vi.fn(async () => routesOptions)
+    const generateSchedule = vi.fn(async () => {
+      calls.push("generate")
+    })
+    const settleCoveredSchedules = vi.fn(async () => {
+      calls.push("settle")
+      return []
+    })
+    const withDb = vi.fn(async (_bindings, operation) => {
+      calls.push("db")
+      return operation(db)
+    })
+    const eventBus = createEventBus()
+    let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
+    vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
+      handler = registeredHandler as typeof handler
+      return { unsubscribe: vi.fn() }
+    })
+    const descriptor = createBookingScheduleSubscriberRuntime({
+      resolveRoutesOptions,
+      withDb,
+      generateSchedule,
+      settleCoveredSchedules,
+    })
+
+    await descriptor.register({ bindings, container: createContainer(), eventBus })
+
+    expect({ id: descriptor.id, eventType: descriptor.eventType }).toEqual({
+      id: FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID,
+      eventType: "booking.confirmed",
+    })
+
+    await handler?.({
+      name: "booking.confirmed",
+      data: { bookingId: "booking_1", bookingNumber: "BK-1", actorId: null },
+      emittedAt: new Date().toISOString(),
+      metadata: undefined,
+    })
+
+    expect(resolveRoutesOptions).toHaveBeenCalledWith(bindings)
+    expect(withDb).toHaveBeenCalledWith(bindings, expect.any(Function))
+    expect(generateSchedule).toHaveBeenCalledWith(db, "booking_1", routesOptions)
+    expect(settleCoveredSchedules).toHaveBeenCalledWith(db, "booking_1")
+    expect(calls).toEqual(["db", "generate", "settle"])
+  })
+
+  it("logs processing failures without rejecting event delivery", async () => {
+    const error = new Error("database unavailable")
+    const logger = { error: vi.fn() }
+    const eventBus = createEventBus()
+    let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
+    vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
+      handler = registeredHandler as typeof handler
+      return { unsubscribe: vi.fn() }
+    })
+    const descriptor = createBookingScheduleSubscriberRuntime({
+      resolveRoutesOptions: () => routesOptions,
+      withDb: async () => {
+        throw error
+      },
+      logger,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await expect(
+      handler?.({
+        name: "booking.confirmed",
+        data: { bookingId: "booking_2", bookingNumber: "BK-2", actorId: null },
+        emittedAt: new Date().toISOString(),
+        metadata: undefined,
+      }),
+    ).resolves.toBeUndefined()
+    expect(logger.error).toHaveBeenCalledWith("[booking-schedule] failed to generate schedule", {
+      bookingId: "booking_2",
+      error: "database unavailable",
+    })
+  })
+})

--- a/packages/finance/tests/unit/package-exports.test.ts
+++ b/packages/finance/tests/unit/package-exports.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, { types: string; import: string; default: string }>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/finance package exports", () => {
+  it("publishes the booking-schedule subscriber runtime subpath", () => {
+    expect(packageJson.exports["./booking-schedule-subscriber"]).toBe(
+      "./src/booking-schedule/subscriber-runtime.ts",
+    )
+    expect(packageJson.publishConfig.exports["./booking-schedule-subscriber"]).toEqual({
+      types: "./dist/booking-schedule/subscriber-runtime.d.ts",
+      import: "./dist/booking-schedule/subscriber-runtime.js",
+      default: "./dist/booking-schedule/subscriber-runtime.js",
+    })
+  })
+})

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -98,7 +98,15 @@ describe("finance deployment manifest", () => {
           },
         },
       ],
+      subscribers: [
+        {
+          id: "@voyant-travel/finance#subscriber.booking-schedule-confirmed",
+          eventType: "booking.confirmed",
+          source: "@voyant-travel/finance/booking-schedule-subscriber",
+        },
+      ],
     })
+    expect(financeBookingScheduleVoyantPlugin.subscribers?.[0]).not.toHaveProperty("runtime")
   })
 
   it("declares finance routes and existing cross-package widgets", () => {

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -758,6 +758,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -759,6 +759,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -764,6 +764,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -759,6 +759,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -758,6 +758,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -759,6 +759,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -759,6 +759,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -764,6 +764,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -759,6 +759,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -757,6 +757,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -758,6 +758,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -759,6 +759,9 @@
       "@voyant-travel/finance-react/query-keys": ["../finance-react/dist/query-keys.d.ts"],
       "@voyant-travel/finance-react/ui": ["../finance-react/dist/ui.d.ts"],
       "@voyant-travel/finance/action-ledger-drift": ["../finance/dist/action-ledger-drift.d.ts"],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../finance/dist/checkout-service.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -956,6 +956,9 @@
       "@voyant-travel/finance/action-ledger-drift": [
         "../../packages/finance/dist/action-ledger-drift.d.ts"
       ],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../../packages/finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../../packages/finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../../packages/finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../../packages/finance/dist/checkout-service.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -956,6 +956,9 @@
       "@voyant-travel/finance/action-ledger-drift": [
         "../../packages/finance/dist/action-ledger-drift.d.ts"
       ],
+      "@voyant-travel/finance/booking-schedule-subscriber": [
+        "../../packages/finance/dist/booking-schedule/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/finance/booking-tax": ["../../packages/finance/dist/booking-tax.d.ts"],
       "@voyant-travel/finance/card-payment": ["../../packages/finance/dist/card-payment.d.ts"],
       "@voyant-travel/finance/checkout": ["../../packages/finance/dist/checkout-service.d.ts"],


### PR DESCRIPTION
## Summary

- declare the Finance booking-schedule `booking.confirmed` subscriber without a runtime reference, keeping activation inert until the central registration is removed
- publish a package-owned subscriber runtime factory with injected booking-schedule options and database lifecycle resolution
- preserve generation-before-covered-settlement behavior and existing failure logging
- add runtime, manifest, package export, architecture, and changeset coverage

## Dependency

This uses the `SubscriberRuntimeDescriptor` contract introduced by #3207. The manifest intentionally omits `runtime` to prevent duplicate activation while the central booking-schedule bundle remains active.

## Verification

- focused Finance runtime, manifest, and export tests: 7 passed
- Finance lint passed with one pre-existing warning in `service-vouchers-migration.ts`
- staged diff check passed
- Finance typecheck was capped and stopped after 3 minutes with no diagnostics
- broad local Turbo/typecheck and pre-push test lanes were stopped after spending 10+ minutes on unrelated packages; CI is authoritative

No `starters/operator` files or `app.ts` were changed.