### PR TITLE
feat(catalog): declare index subscribers

### DIFF
--- a/.changeset/catalog-index-subscriber-contract.md
+++ b/.changeset/catalog-index-subscriber-contract.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": minor
+---
+
+Declare the central Catalog indexing subscribers and publish their inert runtime descriptors.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -265,6 +265,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -260,6 +260,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -38,6 +38,7 @@
     "./booking-engine/contracts": "./src/booking-engine/contracts.ts",
     "./booking-engine/drafts-schema": "./src/booking-engine/drafts-schema.ts",
     "./offers": "./src/offers/operator-routes.ts",
+    "./index-subscribers": "./src/index-subscriber-runtime.ts",
     "./projection-runtime": "./src/projection-runtime.ts",
     "./voyant": "./src/voyant.ts"
   },
@@ -247,6 +248,11 @@
         "types": "./dist/offers/operator-routes.d.ts",
         "import": "./dist/offers/operator-routes.js",
         "default": "./dist/offers/operator-routes.js"
+      },
+      "./index-subscribers": {
+        "types": "./dist/index-subscriber-runtime.d.ts",
+        "import": "./dist/index-subscriber-runtime.js",
+        "default": "./dist/index-subscriber-runtime.js"
       },
       "./projection-runtime": {
         "types": "./dist/projection-runtime.d.ts",

--- a/packages/catalog/src/index-subscriber-declarations.ts
+++ b/packages/catalog/src/index-subscriber-declarations.ts
@@ -1,0 +1,42 @@
+export const catalogIndexSubscriberDeclarations = [
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-created",
+    eventType: "product.created",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-updated",
+    eventType: "product.updated",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.delete-product",
+    eventType: "product.deleted",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-content-changed",
+    eventType: "product.content.changed",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-availability-changed",
+    eventType: "availability.slot.changed",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-pricing-changed",
+    eventType: "pricing.rule.changed",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-publication-changed",
+    eventType: "product.publication.changed",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+  {
+    id: "@voyant-travel/catalog#subscriber.index-product-promotion-changed",
+    eventType: "promotion.changed",
+    source: "@voyant-travel/catalog/index-subscribers",
+  },
+] as const

--- a/packages/catalog/src/index-subscriber-runtime.test.ts
+++ b/packages/catalog/src/index-subscriber-runtime.test.ts
@@ -1,0 +1,158 @@
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import { describe, expect, it, vi } from "vitest"
+import {
+  catalogAvailabilityChangedIndexSubscriber,
+  catalogIndexSubscriberRuntimeDescriptors,
+  catalogPricingChangedIndexSubscriber,
+  catalogProductContentChangedIndexSubscriber,
+  catalogProductCreatedIndexSubscriber,
+  catalogProductDeletedIndexSubscriber,
+  catalogProductUpdatedIndexSubscriber,
+  catalogPromotionChangedIndexSubscriber,
+  catalogPublicationChangedIndexSubscriber,
+} from "./index-subscriber-runtime.js"
+import {
+  CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY,
+  type CatalogProjectionRuntime,
+} from "./projection-runtime.js"
+
+function runtimeHarness() {
+  const runtime: CatalogProjectionRuntime = {
+    reindexEntity: vi.fn(async () => undefined),
+    deleteEntity: vi.fn(async () => undefined),
+  }
+  const container = createContainer()
+  const eventBus = createEventBus()
+  container.register(CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY, runtime)
+  return { runtime, container, eventBus, context: { bindings: {}, container, eventBus } }
+}
+
+describe("Catalog index subscriber runtime descriptors", () => {
+  it("match the eight inert package declarations", () => {
+    expect(
+      catalogIndexSubscriberRuntimeDescriptors.map(({ id, eventType }) => ({ id, eventType })),
+    ).toMatchInlineSnapshot(`
+        [
+          {
+            "eventType": "product.created",
+            "id": "@voyant-travel/catalog#subscriber.index-product-created",
+          },
+          {
+            "eventType": "product.updated",
+            "id": "@voyant-travel/catalog#subscriber.index-product-updated",
+          },
+          {
+            "eventType": "product.deleted",
+            "id": "@voyant-travel/catalog#subscriber.delete-product",
+          },
+          {
+            "eventType": "product.content.changed",
+            "id": "@voyant-travel/catalog#subscriber.index-product-content-changed",
+          },
+          {
+            "eventType": "availability.slot.changed",
+            "id": "@voyant-travel/catalog#subscriber.index-product-availability-changed",
+          },
+          {
+            "eventType": "pricing.rule.changed",
+            "id": "@voyant-travel/catalog#subscriber.index-product-pricing-changed",
+          },
+          {
+            "eventType": "product.publication.changed",
+            "id": "@voyant-travel/catalog#subscriber.index-product-publication-changed",
+          },
+          {
+            "eventType": "promotion.changed",
+            "id": "@voyant-travel/catalog#subscriber.index-product-promotion-changed",
+          },
+        ]
+      `)
+  })
+
+  it.each([
+    [catalogProductCreatedIndexSubscriber, "product.created"],
+    [catalogProductUpdatedIndexSubscriber, "product.updated"],
+    [catalogProductContentChangedIndexSubscriber, "product.content.changed"],
+  ])("reindexes product id payloads for %s", async (descriptor, eventType) => {
+    const harness = runtimeHarness()
+    await descriptor.register(harness.context)
+    await harness.eventBus.emit(eventType, { id: "product_123", ignored: true })
+    expect(harness.runtime.reindexEntity).toHaveBeenCalledWith({
+      entityModule: "products",
+      entityId: "product_123",
+    })
+  })
+
+  it("deletes product projections for product.deleted", async () => {
+    const harness = runtimeHarness()
+    await catalogProductDeletedIndexSubscriber.register(harness.context)
+    await harness.eventBus.emit("product.deleted", { id: "product_123" })
+    expect(harness.runtime.deleteEntity).toHaveBeenCalledWith({
+      entityModule: "products",
+      entityId: "product_123",
+    })
+    expect(harness.runtime.reindexEntity).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [catalogAvailabilityChangedIndexSubscriber, "availability.slot.changed"],
+    [catalogPricingChangedIndexSubscriber, "pricing.rule.changed"],
+    [catalogPublicationChangedIndexSubscriber, "product.publication.changed"],
+  ])("reindexes present productId payloads and skips missing ids for %s", async (descriptor, eventType) => {
+    const harness = runtimeHarness()
+    await descriptor.register(harness.context)
+    await harness.eventBus.emit(eventType, { productId: "product_123", ignored: true })
+    await harness.eventBus.emit(eventType, { ignored: true })
+    expect(harness.runtime.reindexEntity).toHaveBeenCalledTimes(1)
+    expect(harness.runtime.reindexEntity).toHaveBeenCalledWith({
+      entityModule: "products",
+      entityId: "product_123",
+    })
+  })
+
+  it("reindexes product-scoped promotions sequentially and skips global changes", async () => {
+    const harness = runtimeHarness()
+    await catalogPromotionChangedIndexSubscriber.register(harness.context)
+    await harness.eventBus.emit("promotion.changed", {
+      affected: { kind: "products", productIds: ["product_1", "product_2"] },
+    })
+    await harness.eventBus.emit("promotion.changed", { affected: { kind: "all" } })
+    expect(harness.runtime.reindexEntity).toHaveBeenNthCalledWith(1, {
+      entityModule: "products",
+      entityId: "product_1",
+    })
+    expect(harness.runtime.reindexEntity).toHaveBeenNthCalledWith(2, {
+      entityModule: "products",
+      entityId: "product_2",
+    })
+    expect(harness.runtime.reindexEntity).toHaveBeenCalledTimes(2)
+  })
+
+  it("skips non-targeting events without resolving a projection runtime", async () => {
+    const container = createContainer()
+    const eventBus = createEventBus()
+    const context = { bindings: {}, container, eventBus }
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    await catalogAvailabilityChangedIndexSubscriber.register(context)
+    await catalogPromotionChangedIndexSubscriber.register(context)
+
+    await eventBus.emit("availability.slot.changed", { slotId: "slot_123" })
+    await eventBus.emit("promotion.changed", { affected: { kind: "all" } })
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it("rejects malformed direct product payloads before runtime invocation", async () => {
+    const harness = runtimeHarness()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    await catalogProductCreatedIndexSubscriber.register(harness.context)
+    await harness.eventBus.emit("product.created", {})
+    expect(harness.runtime.reindexEntity).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('subscriber error for "product.created"'),
+      expect.anything(),
+    )
+    consoleError.mockRestore()
+  })
+})

--- a/packages/catalog/src/index-subscriber-runtime.ts
+++ b/packages/catalog/src/index-subscriber-runtime.ts
@@ -1,0 +1,176 @@
+import type { BootstrapContext } from "@voyant-travel/core"
+import { z } from "zod"
+
+import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
+import {
+  CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY,
+  type CatalogProjectionRuntime,
+  type CatalogProjectionTarget,
+  parseCatalogProjectionTarget,
+} from "./projection-runtime.js"
+
+const PRODUCTS_ENTITY_MODULE = "products"
+
+const entityIdPayloadSchema = z.object({ id: z.string().min(1) }).passthrough()
+const productIdPayloadSchema = z.object({ productId: z.string().min(1).optional() }).passthrough()
+const promotionPayloadSchema = z
+  .object({
+    affected: z.discriminatedUnion("kind", [
+      z.object({ kind: z.literal("all") }).passthrough(),
+      z
+        .object({
+          kind: z.literal("products"),
+          productIds: z.array(z.string().min(1)),
+        })
+        .passthrough(),
+    ]),
+  })
+  .passthrough()
+
+export interface CatalogIndexSubscriberRuntimeDescriptor {
+  readonly id: string
+  readonly eventType: string
+  readonly register: (context: BootstrapContext) => void | Promise<void>
+}
+
+export interface CatalogIndexSubscriberDescriptorOptions {
+  id: string
+  eventType: string
+  selectTargets(payload: unknown): readonly CatalogProjectionTarget[]
+}
+
+function resolveRuntime(context: BootstrapContext): CatalogProjectionRuntime {
+  return context.container.resolve<CatalogProjectionRuntime>(
+    CATALOG_PROJECTION_RUNTIME_CONTAINER_KEY,
+  )
+}
+
+export function createCatalogReindexSubscriberDescriptor(
+  options: CatalogIndexSubscriberDescriptorOptions,
+): CatalogIndexSubscriberRuntimeDescriptor {
+  return {
+    id: options.id,
+    eventType: options.eventType,
+    register(context) {
+      context.eventBus.subscribe(
+        options.eventType,
+        async ({ data }) => {
+          const targets = options.selectTargets(data)
+          if (targets.length === 0) return
+          const runtime = resolveRuntime(context)
+          for (const target of targets) {
+            await runtime.reindexEntity(target)
+          }
+        },
+        { inline: false },
+      )
+    },
+  }
+}
+
+export function createCatalogDeleteSubscriberDescriptor(
+  options: CatalogIndexSubscriberDescriptorOptions,
+): CatalogIndexSubscriberRuntimeDescriptor {
+  return {
+    id: options.id,
+    eventType: options.eventType,
+    register(context) {
+      context.eventBus.subscribe(
+        options.eventType,
+        async ({ data }) => {
+          const targets = options.selectTargets(data)
+          if (targets.length === 0) return
+          const runtime = resolveRuntime(context)
+          for (const target of targets) {
+            await runtime.deleteEntity(target)
+          }
+        },
+        { inline: false },
+      )
+    },
+  }
+}
+
+function productTarget(entityId: string): CatalogProjectionTarget {
+  return parseCatalogProjectionTarget({ entityModule: PRODUCTS_ENTITY_MODULE, entityId })
+}
+
+function selectEntityId(payload: unknown): readonly CatalogProjectionTarget[] {
+  return [productTarget(entityIdPayloadSchema.parse(payload).id)]
+}
+
+function selectOptionalProductId(payload: unknown): readonly CatalogProjectionTarget[] {
+  const { productId } = productIdPayloadSchema.parse(payload)
+  return productId ? [productTarget(productId)] : []
+}
+
+function selectPromotionProducts(payload: unknown): readonly CatalogProjectionTarget[] {
+  const { affected } = promotionPayloadSchema.parse(payload)
+  return affected.kind === "products" ? affected.productIds.map(productTarget) : []
+}
+
+const declarationsByEvent = new Map(
+  catalogIndexSubscriberDeclarations.map((declaration) => [declaration.eventType, declaration]),
+)
+
+type CatalogIndexEventType = (typeof catalogIndexSubscriberDeclarations)[number]["eventType"]
+
+function declaration(eventType: CatalogIndexEventType) {
+  const value = declarationsByEvent.get(eventType)
+  if (!value) throw new Error(`Catalog index subscriber declaration is missing "${eventType}".`)
+  return value
+}
+
+function reindexDescriptor(
+  eventType: CatalogIndexEventType,
+  selectTargets: CatalogIndexSubscriberDescriptorOptions["selectTargets"],
+) {
+  return createCatalogReindexSubscriberDescriptor({
+    ...declaration(eventType),
+    selectTargets,
+  })
+}
+
+export const catalogProductCreatedIndexSubscriber = reindexDescriptor(
+  "product.created",
+  selectEntityId,
+)
+export const catalogProductUpdatedIndexSubscriber = reindexDescriptor(
+  "product.updated",
+  selectEntityId,
+)
+export const catalogProductDeletedIndexSubscriber = createCatalogDeleteSubscriberDescriptor({
+  ...declaration("product.deleted"),
+  selectTargets: selectEntityId,
+})
+export const catalogProductContentChangedIndexSubscriber = reindexDescriptor(
+  "product.content.changed",
+  selectEntityId,
+)
+export const catalogAvailabilityChangedIndexSubscriber = reindexDescriptor(
+  "availability.slot.changed",
+  selectOptionalProductId,
+)
+export const catalogPricingChangedIndexSubscriber = reindexDescriptor(
+  "pricing.rule.changed",
+  selectOptionalProductId,
+)
+export const catalogPublicationChangedIndexSubscriber = reindexDescriptor(
+  "product.publication.changed",
+  selectOptionalProductId,
+)
+export const catalogPromotionChangedIndexSubscriber = reindexDescriptor(
+  "promotion.changed",
+  selectPromotionProducts,
+)
+
+export const catalogIndexSubscriberRuntimeDescriptors = [
+  catalogProductCreatedIndexSubscriber,
+  catalogProductUpdatedIndexSubscriber,
+  catalogProductDeletedIndexSubscriber,
+  catalogProductContentChangedIndexSubscriber,
+  catalogAvailabilityChangedIndexSubscriber,
+  catalogPricingChangedIndexSubscriber,
+  catalogPublicationChangedIndexSubscriber,
+  catalogPromotionChangedIndexSubscriber,
+] as const

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -1,4 +1,5 @@
 import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
 
 const catalogAdminRuntime = {
   entry: "@voyant-travel/catalog-react/admin",
@@ -85,6 +86,7 @@ export const catalogVoyantModule = defineModule({
       eventType: "catalog.source.reconnected",
     },
   ],
+  subscribers: catalogIndexSubscriberDeclarations,
   access: {
     resources: [
       {

--- a/packages/catalog/tests/unit/package-exports.test.ts
+++ b/packages/catalog/tests/unit/package-exports.test.ts
@@ -27,4 +27,13 @@ describe("@voyant-travel/catalog package exports", () => {
       default: "./dist/projection-runtime.js",
     })
   })
+
+  it("publishes the inert index subscriber descriptors", () => {
+    expect(packageJson.exports["./index-subscribers"]).toBe("./src/index-subscriber-runtime.ts")
+    expect(packageJson.publishConfig.exports["./index-subscribers"]).toEqual({
+      types: "./dist/index-subscriber-runtime.d.ts",
+      import: "./dist/index-subscriber-runtime.js",
+      default: "./dist/index-subscriber-runtime.js",
+    })
+  })
 })

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -35,6 +35,26 @@ describe("catalog deployment manifest", () => {
     })
   })
 
+  it("owns inert declarations for the central Catalog indexing subscribers", () => {
+    expect(catalogVoyantModule.subscribers).toEqual(
+      [
+        ["index-product-created", "product.created"],
+        ["index-product-updated", "product.updated"],
+        ["delete-product", "product.deleted"],
+        ["index-product-content-changed", "product.content.changed"],
+        ["index-product-availability-changed", "availability.slot.changed"],
+        ["index-product-pricing-changed", "pricing.rule.changed"],
+        ["index-product-publication-changed", "product.publication.changed"],
+        ["index-product-promotion-changed", "promotion.changed"],
+      ].map(([localId, eventType]) => ({
+        id: `@voyant-travel/catalog#subscriber.${localId}`,
+        eventType,
+        source: "@voyant-travel/catalog/index-subscribers",
+      })),
+    )
+    expect(catalogVoyantModule.subscribers?.every((subscriber) => !subscriber.runtime)).toBe(true)
+  })
+
   it("owns the booking engine and offers bridge declarations", () => {
     expect(catalogBookingEngineVoyantModule).toMatchObject({
       schemaVersion: "voyant.module.v1",

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -336,6 +336,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -330,6 +330,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -330,6 +330,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -336,6 +336,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -330,6 +330,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -336,6 +336,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -330,6 +330,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -336,6 +336,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -329,6 +329,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -330,6 +330,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -331,6 +331,7 @@
       ],
       "@voyant-travel/catalog/embeddings/openai": ["../catalog/dist/embeddings/openai.d.ts"],
       "@voyant-travel/catalog/events/taxonomy": ["../catalog/dist/events/taxonomy.d.ts"],
+      "@voyant-travel/catalog/index-subscribers": ["../catalog/dist/index-subscriber-runtime.d.ts"],
       "@voyant-travel/catalog/indexer/contract": ["../catalog/dist/indexer/contract.d.ts"],
       "@voyant-travel/catalog/indexer/typesense": ["../catalog/dist/indexer/typesense.d.ts"],
       "@voyant-travel/catalog/offers": ["../catalog/dist/offers/operator-routes.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -426,6 +426,9 @@
       "@voyant-travel/catalog/events/taxonomy": [
         "../../packages/catalog/dist/events/taxonomy.d.ts"
       ],
+      "@voyant-travel/catalog/index-subscribers": [
+        "../../packages/catalog/dist/index-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/indexer/contract": [
         "../../packages/catalog/dist/indexer/contract.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -426,6 +426,9 @@
       "@voyant-travel/catalog/events/taxonomy": [
         "../../packages/catalog/dist/events/taxonomy.d.ts"
       ],
+      "@voyant-travel/catalog/index-subscribers": [
+        "../../packages/catalog/dist/index-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/indexer/contract": [
         "../../packages/catalog/dist/indexer/contract.d.ts"
       ],


### PR DESCRIPTION
## Summary

- add Catalog-owned inert subscriber declarations for product create, update, delete, and content changes
- declare product reindex reactions for availability, pricing, publication, and product-scoped promotion changes
- publish structurally compatible runtime descriptor factories backed by the injected `CatalogProjectionRuntime` from #3213
- preserve central-handler payload semantics: direct product ids validate, missing optional product ids skip, deletes remove projections, product promotions reindex sequentially, and global promotions remain workflow-owned no-ops
- publish the `@voyant-travel/catalog/index-subscribers` subpath and add a minor changeset

## Stack

- base PR: #3213
- base branch: `refactor/catalog-projection-runtime`
- base commit: `5836db5a1ac3f89931fa005c8459079475e5938f`

## Activation boundary

The eight manifest declarations intentionally have no `runtime` references. This PR does not register subscribers, require the projection runtime port in the Catalog manifest, or change Operator composition. Later ordinary-subscriber lowering can activate these package exports after the graph runtime contract lands.

No concrete Accommodations, Charters, Commerce, Cruises, Distribution, Inventory, or Operations implementation is imported into Catalog. Deployments continue to own database lifetime, index adapter construction, field-policy registries, slices, and document builders through `CatalogProjectionRuntime`.

## Verification

- `pnpm --filter @voyant-travel/catalog test` (40 files / 450 tests passed; 4 files / 27 tests skipped)
- `pnpm --filter @voyant-travel/catalog typecheck`
- `pnpm --filter @voyant-travel/catalog lint`
- `pnpm exec vitest run tests/unit/package-exports.test.ts` from `packages/catalog` (2 tests passed)
- `node scripts/verify-package-tarballs.mjs --package @voyant-travel/catalog`

Only focused Catalog verification was run. Broad local Turbo hooks were bypassed as requested; GitHub CI is authoritative for repository-wide validation.