### PR TITLE
feat(commerce): stage checkout subscriber runtimes

### DIFF
--- a/.changeset/commerce-checkout-subscriber-contracts.md
+++ b/.changeset/commerce-checkout-subscriber-contracts.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/commerce": patch
+---
+
+Publish inert catalog-checkout subscriber descriptors and package-owned workflow runner registration contracts for later graph activation.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -426,6 +426,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -421,6 +421,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -397,6 +397,12 @@
       "@voyant-travel/charters/validation": ["../charters/dist/validation.d.ts"],
       "@voyant-travel/charters/voyant": ["../charters/dist/voyant.d.ts"],
       "@voyant-travel/commerce": ["../commerce/dist/index.d.ts"],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -392,6 +392,12 @@
       "@voyant-travel/charters/validation": ["../charters/dist/validation.d.ts"],
       "@voyant-travel/charters/voyant": ["../charters/dist/voyant.d.ts"],
       "@voyant-travel/commerce": ["../commerce/dist/index.d.ts"],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./catalog-checkout-runner": "./src/checkout/runner-runtime.ts",
+    "./catalog-checkout-subscribers": "./src/checkout/subscriber-runtime.ts",
     "./schema": "./src/schema.ts",
     "./checkout": "./src/checkout/index.ts",
     "./markets/validation": "./src/markets/validation.ts",
@@ -74,6 +76,16 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "default": "./dist/index.js"
+      },
+      "./catalog-checkout-runner": {
+        "types": "./dist/checkout/runner-runtime.d.ts",
+        "import": "./dist/checkout/runner-runtime.js",
+        "default": "./dist/checkout/runner-runtime.js"
+      },
+      "./catalog-checkout-subscribers": {
+        "types": "./dist/checkout/subscriber-runtime.d.ts",
+        "import": "./dist/checkout/subscriber-runtime.js",
+        "default": "./dist/checkout/subscriber-runtime.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/commerce/src/checkout/acceptance-signature.ts
+++ b/packages/commerce/src/checkout/acceptance-signature.ts
@@ -13,6 +13,42 @@ interface StoredAcceptance {
   renderedHtmlLength: number
 }
 
+export interface AcceptanceSignatureContract {
+  id: string
+  bookingId: string | null
+  metadata: unknown
+  status: string
+}
+
+export interface AcceptanceSignatureInput {
+  signerName: string
+  signerEmail: string | null
+  method: "electronic"
+  ipAddress: string | null
+  userAgent: string | null
+  metadata: Record<string, unknown>
+}
+
+/** Legal operations required by checkout acceptance-signature promotion. */
+export interface AcceptanceSignatureLegalPort {
+  getContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+  ): Promise<AcceptanceSignatureContract | null>
+  listSignatures(db: PostgresJsDatabase, contractId: string): Promise<ReadonlyArray<unknown>>
+  sendContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+    eventBus?: EventBus,
+  ): Promise<{ status: string }>
+  signContract(
+    db: PostgresJsDatabase,
+    contractId: string,
+    input: AcceptanceSignatureInput,
+    eventBus?: EventBus,
+  ): Promise<{ status: string }>
+}
+
 const ACCEPTANCE_MARKER_PREFIX = "__contract_acceptance__:"
 
 function readContractAcceptance(
@@ -41,14 +77,10 @@ export async function persistAcceptanceSignature(
   db: PostgresJsDatabase,
   contractId: string,
   eventBus?: EventBus,
+  legalPort?: AcceptanceSignatureLegalPort,
 ): Promise<void> {
-  const { contractsService } = await import("@voyant-travel/legal/contracts")
-  const { contracts: contractsTable } = await import("@voyant-travel/legal/contracts")
-  const [contract] = await db
-    .select()
-    .from(contractsTable)
-    .where(eq(contractsTable.id, contractId))
-    .limit(1)
+  const legal = legalPort ?? (await createDefaultAcceptanceSignatureLegalPort())
+  const contract = await legal.getContract(db, contractId)
   if (!contract?.bookingId) return
 
   const [booking] = await db
@@ -61,11 +93,11 @@ export async function persistAcceptanceSignature(
   const acceptance = readContractAcceptance(contract.metadata, booking.internalNotes)
   if (!acceptance) return
 
-  const existing = await contractsService.listSignatures(db, contractId)
+  const existing = await legal.listSignatures(db, contractId)
   if (existing.length > 0) return
 
   if (contract.status === "issued") {
-    const sent = await contractsService.sendContract(db, contractId, { eventBus })
+    const sent = await legal.sendContract(db, contractId, eventBus)
     if (sent.status !== "sent") {
       console.warn(
         `[catalog-checkout] could not send contract before acceptance signature for ${contractId}: ${sent.status}`,
@@ -82,7 +114,7 @@ export async function persistAcceptanceSignature(
     contactName ||
     `Storefront customer${booking.bookingNumber ? ` (${booking.bookingNumber})` : ""}`
 
-  const result = await contractsService.signContract(
+  const result = await legal.signContract(
     db,
     contractId,
     {
@@ -99,8 +131,8 @@ export async function persistAcceptanceSignature(
         acceptedMarketing: acceptance.acceptedMarketing,
         renderedHtmlLength: acceptance.renderedHtmlLength,
       },
-    } as never,
-    { eventBus },
+    },
+    eventBus,
   )
 
   if (result.status !== "signed") {
@@ -113,7 +145,7 @@ export async function persistAcceptanceSignature(
   if (booking.internalNotes?.includes(ACCEPTANCE_MARKER_PREFIX)) {
     const cleanedNotes = booking.internalNotes
       .split("\n")
-      .filter((line) => !line.startsWith(ACCEPTANCE_MARKER_PREFIX))
+      .filter((line: string) => !line.startsWith(ACCEPTANCE_MARKER_PREFIX))
       .join("\n")
       .replace(/\n{3,}/g, "\n\n")
       .trim()
@@ -124,5 +156,27 @@ export async function persistAcceptanceSignature(
         updatedAt: new Date(),
       })
       .where(eq(bookings.id, booking.id))
+  }
+}
+
+async function createDefaultAcceptanceSignatureLegalPort(): Promise<AcceptanceSignatureLegalPort> {
+  const { contracts: contractsTable, contractsService } = await import(
+    "@voyant-travel/legal/contracts"
+  )
+
+  return {
+    async getContract(db, contractId) {
+      const [contract] = await db
+        .select()
+        .from(contractsTable)
+        .where(eq(contractsTable.id, contractId))
+        .limit(1)
+      return contract ?? null
+    },
+    listSignatures: (db, contractId) => contractsService.listSignatures(db, contractId),
+    sendContract: (db, contractId, eventBus) =>
+      contractsService.sendContract(db, contractId, { eventBus }),
+    signContract: (db, contractId, input, eventBus) =>
+      contractsService.signContract(db, contractId, input as never, { eventBus }),
   }
 }

--- a/packages/commerce/src/checkout/index.ts
+++ b/packages/commerce/src/checkout/index.ts
@@ -11,12 +11,17 @@
  *     through `@voyant-travel/inventory`, which depends on commerce).
  *   - `resolveBankTransferInstructions` — operator profile / payment rows.
  *
- * The deployment keeps the thin HonoBundle wiring (workflow runner registry +
- * event-bus subscribers) and calls `dispatchCheckoutFinalize` /
- * `persistAcceptanceSignature` from there.
+ * Package-owned subscriber and workflow-runner factories are published on
+ * dedicated subpaths. Deployments inject database lifecycle, Legal, and
+ * contract-PDF ports without recreating checkout workflow knowledge.
  */
 
-export { persistAcceptanceSignature } from "./acceptance-signature.js"
+export {
+  type AcceptanceSignatureContract,
+  type AcceptanceSignatureInput,
+  type AcceptanceSignatureLegalPort,
+  persistAcceptanceSignature,
+} from "./acceptance-signature.js"
 export {
   type CatalogCheckoutContractPdfGenerator,
   type DispatchCheckoutFinalizeParams,

--- a/packages/commerce/src/checkout/runner-runtime.ts
+++ b/packages/commerce/src/checkout/runner-runtime.ts
@@ -1,0 +1,83 @@
+import type { EventBus } from "@voyant-travel/core"
+import type { WorkflowRunner } from "@voyant-travel/workflow-runs"
+
+import type { DispatchCheckoutFinalizeParams } from "./finalize.js"
+import { dispatchCheckoutFinalize } from "./finalize.js"
+import type { CheckoutFinalizeSubscriberRuntimeOptions } from "./subscriber-runtime.js"
+
+export interface CheckoutFinalizeRunnerRegistry {
+  register(runner: WorkflowRunner): void
+}
+
+export interface CheckoutFinalizeRunnerRegistrationOptions<TBindings = unknown>
+  extends CheckoutFinalizeSubscriberRuntimeOptions<TBindings> {
+  bindings: TBindings
+  eventBus: EventBus
+  registry: CheckoutFinalizeRunnerRegistry
+}
+
+function requireCheckoutFinalizeInput(rawInput: unknown, action: "rerun" | "resume") {
+  const input = rawInput as DispatchCheckoutFinalizeParams["input"] | null
+  if (!input?.bookingId) {
+    throw new Error(`checkout-finalize ${action}: recorded input has no bookingId`)
+  }
+  return input
+}
+
+/** Create the package-owned dashboard runner registration. */
+export function createCheckoutFinalizeWorkflowRunner<TBindings = unknown>(
+  options: Omit<CheckoutFinalizeRunnerRegistrationOptions<TBindings>, "registry">,
+): WorkflowRunner {
+  const dispatchFinalize = options.dispatchFinalize ?? dispatchCheckoutFinalize
+
+  return {
+    name: "checkout-finalize",
+    idempotency: "unsafe",
+    description:
+      "Confirms the booking and issues the final invoice. A fresh rerun issues another invoice number; use Resume to retry from a failed step.",
+    rerun: async (rawInput, context) => {
+      const input = requireCheckoutFinalizeInput(rawInput, "rerun")
+      return options.withDb(options.bindings, (db) =>
+        dispatchFinalize({
+          db,
+          eventBus: options.eventBus,
+          input,
+          trigger: "manual.rerun",
+          correlationId: context.correlationId,
+          tags: [...context.tags, "rerun:true"],
+          parentRunId: context.parentRunId,
+          triggeredByUserId: context.triggeredByUserId,
+          generateContractPdf: options.generateContractPdf,
+        }),
+      )
+    },
+    resume: async (rawInput, context) => {
+      const input = requireCheckoutFinalizeInput(rawInput, "resume")
+      return options.withDb(options.bindings, (db) =>
+        dispatchFinalize({
+          db,
+          eventBus: options.eventBus,
+          input,
+          trigger: "manual.resume",
+          correlationId: context.correlationId,
+          tags: [...context.tags, "resume:true"],
+          parentRunId: context.parentRunId,
+          triggeredByUserId: context.triggeredByUserId,
+          resumeFromStep: context.resumeFromStep,
+          seedResults: context.seedResults,
+          generateContractPdf: options.generateContractPdf,
+        }),
+      )
+    },
+  }
+}
+
+/** Register the package-owned runner without exposing its workflow metadata to the host. */
+export function registerCheckoutFinalizeWorkflowRunner<TBindings = unknown>(
+  options: CheckoutFinalizeRunnerRegistrationOptions<TBindings>,
+): WorkflowRunner {
+  const { registry, ...runnerOptions } = options
+  const runner = createCheckoutFinalizeWorkflowRunner(runnerOptions)
+  registry.register(runner)
+  return runner
+}

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -1,0 +1,118 @@
+import type { EventBus, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type AcceptanceSignatureLegalPort,
+  persistAcceptanceSignature,
+} from "./acceptance-signature.js"
+import { type CatalogCheckoutContractPdfGenerator, dispatchCheckoutFinalize } from "./finalize.js"
+
+export type { AcceptanceSignatureLegalPort } from "./acceptance-signature.js"
+
+export const COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID =
+  "@voyant-travel/commerce#subscriber.catalog-checkout-contract-document-generated"
+export const COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID =
+  "@voyant-travel/commerce#subscriber.catalog-checkout-payment-completed"
+
+export interface CatalogCheckoutRuntimeDatabase<TBindings = unknown> {
+  withDb<T>(bindings: TBindings, operation: (db: PostgresJsDatabase) => Promise<T>): Promise<T>
+}
+
+export interface AcceptanceSignatureSubscriberRuntimeOptions<TBindings = unknown>
+  extends CatalogCheckoutRuntimeDatabase<TBindings> {
+  legal: AcceptanceSignatureLegalPort
+  persistSignature?: typeof persistAcceptanceSignature
+  logger?: Pick<Console, "error">
+}
+
+export interface CheckoutFinalizeSubscriberRuntimeOptions<TBindings = unknown>
+  extends CatalogCheckoutRuntimeDatabase<TBindings> {
+  generateContractPdf?: CatalogCheckoutContractPdfGenerator
+  dispatchFinalize?: typeof dispatchCheckoutFinalize
+}
+
+interface ContractDocumentGeneratedPayload {
+  contractId: string
+}
+
+interface PaymentCompletedPayload {
+  bookingId: string | null
+  paymentSessionId?: string
+  paymentIntent?: "card" | "bank_transfer" | "hold" | "ticket_on_credit"
+}
+
+/** Build the acceptance-signature descriptor without activating its manifest runtime. */
+export function createAcceptanceSignatureSubscriberRuntime<TBindings = unknown>(
+  options: AcceptanceSignatureSubscriberRuntimeOptions<TBindings>,
+): SubscriberRuntimeDescriptor {
+  const persistSignature = options.persistSignature ?? persistAcceptanceSignature
+  const logger = options.logger ?? console
+
+  return {
+    id: COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID,
+    eventType: "contract.document.generated",
+    register: ({ bindings, eventBus }) => {
+      const runtimeBindings = bindings as TBindings
+      eventBus.subscribe<ContractDocumentGeneratedPayload>(
+        "contract.document.generated",
+        async ({ data }) => {
+          try {
+            await options.withDb(runtimeBindings, (db) =>
+              persistSignature(db, data.contractId, eventBus, options.legal),
+            )
+          } catch (error) {
+            logger.error("[catalog-checkout] persistAcceptanceSignature failed", error)
+          }
+        },
+      )
+    },
+  }
+}
+
+/** Build the payment-finalization descriptor without activating its manifest runtime. */
+export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
+  options: CheckoutFinalizeSubscriberRuntimeOptions<TBindings>,
+): SubscriberRuntimeDescriptor {
+  const dispatchFinalize = options.dispatchFinalize ?? dispatchCheckoutFinalize
+
+  return {
+    id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
+    eventType: "payment.completed",
+    register: ({ bindings, eventBus }) => {
+      const runtimeBindings = bindings as TBindings
+      eventBus.subscribe<PaymentCompletedPayload>(
+        "payment.completed",
+        async ({ data }, context) => {
+          if (!data.bookingId) return
+          const bookingId = data.bookingId
+          const nestedEventBus = (context?.eventBus ?? eventBus) as EventBus
+
+          try {
+            await options.withDb(runtimeBindings, (db) =>
+              dispatchFinalize({
+                db,
+                eventBus: nestedEventBus,
+                input: {
+                  bookingId,
+                  paymentSessionId: data.paymentSessionId,
+                  paymentIntent: data.paymentIntent,
+                },
+                trigger: "payment.completed",
+                correlationId: data.paymentSessionId ?? null,
+                tags: [
+                  `bookingId:${bookingId}`,
+                  ...(data.paymentSessionId ? [`paymentSessionId:${data.paymentSessionId}`] : []),
+                  ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
+                ],
+                generateContractPdf: options.generateContractPdf,
+              }),
+            )
+          } catch {
+            // The dispatcher records and logs workflow failures; delivery stays successful.
+          }
+        },
+        { inline: true },
+      )
+    },
+  }
+}

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -202,6 +202,18 @@ export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
       },
     },
   ],
+  subscribers: [
+    {
+      id: "@voyant-travel/commerce#subscriber.catalog-checkout-contract-document-generated",
+      eventType: "contract.document.generated",
+      source: "@voyant-travel/commerce/catalog-checkout-subscribers",
+    },
+    {
+      id: "@voyant-travel/commerce#subscriber.catalog-checkout-payment-completed",
+      eventType: "payment.completed",
+      source: "@voyant-travel/commerce/catalog-checkout-subscribers",
+    },
+  ],
   meta: {
     ownership: "package",
   },

--- a/packages/commerce/tests/unit/acceptance-signature-port.test.ts
+++ b/packages/commerce/tests/unit/acceptance-signature-port.test.ts
@@ -1,0 +1,52 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  type AcceptanceSignatureLegalPort,
+  persistAcceptanceSignature,
+} from "../../src/checkout/acceptance-signature.js"
+
+describe("acceptance-signature Legal port", () => {
+  it("keeps signature promotion idempotent when Legal already has a signature", async () => {
+    const booking = {
+      id: "booking_1",
+      bookingNumber: "BK-1",
+      contactFirstName: "Ada",
+      contactLastName: "Lovelace",
+      contactEmail: "ada@example.com",
+      internalNotes: null,
+    }
+    const limit = vi.fn(async () => [booking])
+    const db = {
+      select: () => ({
+        from: () => ({ where: () => ({ limit }) }),
+      }),
+    } as unknown as PostgresJsDatabase
+    const legal: AcceptanceSignatureLegalPort = {
+      getContract: vi.fn(async () => ({
+        id: "contract_1",
+        bookingId: "booking_1",
+        metadata: {
+          acceptance: {
+            templateId: "template_1",
+            templateSlug: "terms",
+            acceptedAt: "2026-07-11T12:00:00.000Z",
+            acceptedMarketing: false,
+            renderedHtmlLength: 1200,
+          },
+        },
+        status: "issued",
+      })),
+      listSignatures: vi.fn(async () => [{ id: "signature_1" }]),
+      sendContract: vi.fn(),
+      signContract: vi.fn(),
+    }
+
+    await persistAcceptanceSignature(db, "contract_1", undefined, legal)
+
+    expect(legal.getContract).toHaveBeenCalledWith(db, "contract_1")
+    expect(legal.listSignatures).toHaveBeenCalledWith(db, "contract_1")
+    expect(legal.sendContract).not.toHaveBeenCalled()
+    expect(legal.signContract).not.toHaveBeenCalled()
+  })
+})

--- a/packages/commerce/tests/unit/catalog-checkout-runner-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-runner-runtime.test.ts
@@ -1,0 +1,95 @@
+import { createEventBus } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createCheckoutFinalizeWorkflowRunner,
+  registerCheckoutFinalizeWorkflowRunner,
+} from "../../src/checkout/runner-runtime.js"
+
+const input = { bookingId: "booking_1", paymentSessionId: "session_1" }
+const rerunContext = {
+  parentRunId: "parent_1",
+  triggeredByUserId: "user_1",
+  correlationId: "correlation_1",
+  tags: ["bookingId:booking_1"],
+}
+
+describe("checkout-finalize workflow runner", () => {
+  it("registers package-owned workflow metadata", () => {
+    const registry = { register: vi.fn() }
+    const runner = registerCheckoutFinalizeWorkflowRunner({
+      registry,
+      bindings: {},
+      eventBus: createEventBus(),
+      withDb: vi.fn(),
+    })
+
+    expect(runner).toMatchObject({
+      name: "checkout-finalize",
+      idempotency: "unsafe",
+      rerun: expect.any(Function),
+      resume: expect.any(Function),
+    })
+    expect(registry.register).toHaveBeenCalledWith(runner)
+  })
+
+  it("dispatches reruns and resumes with recorded workflow context", async () => {
+    const db = {} as PostgresJsDatabase
+    const eventBus = createEventBus()
+    const dispatchFinalize = vi
+      .fn()
+      .mockResolvedValueOnce({ runId: "rerun_1" })
+      .mockResolvedValueOnce({ runId: "resume_1" })
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const runner = createCheckoutFinalizeWorkflowRunner({
+      bindings: { DATABASE_URL: "postgres://commerce" },
+      eventBus,
+      withDb,
+      dispatchFinalize,
+    })
+
+    await expect(runner.rerun(input, rerunContext)).resolves.toEqual({ runId: "rerun_1" })
+    await expect(
+      runner.resume(input, {
+        ...rerunContext,
+        resumeFromStep: "issue_invoice",
+        seedResults: { confirm_booking: { status: "ok" } },
+      }),
+    ).resolves.toEqual({ runId: "resume_1" })
+
+    expect(dispatchFinalize).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        db,
+        eventBus,
+        input,
+        trigger: "manual.rerun",
+        tags: ["bookingId:booking_1", "rerun:true"],
+        parentRunId: "parent_1",
+        triggeredByUserId: "user_1",
+      }),
+    )
+    expect(dispatchFinalize).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        trigger: "manual.resume",
+        tags: ["bookingId:booking_1", "resume:true"],
+        resumeFromStep: "issue_invoice",
+        seedResults: { confirm_booking: { status: "ok" } },
+      }),
+    )
+  })
+
+  it("rejects recorded inputs without a booking id", async () => {
+    const runner = createCheckoutFinalizeWorkflowRunner({
+      bindings: {},
+      eventBus: createEventBus(),
+      withDb: vi.fn(),
+    })
+
+    await expect(runner.rerun({}, rerunContext)).rejects.toThrow(
+      "checkout-finalize rerun: recorded input has no bookingId",
+    )
+  })
+})

--- a/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
+++ b/packages/commerce/tests/unit/catalog-checkout-subscriber-runtime.test.ts
@@ -1,0 +1,148 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import type { AcceptanceSignatureLegalPort } from "../../src/checkout/acceptance-signature.js"
+import {
+  COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID,
+  COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
+  createAcceptanceSignatureSubscriberRuntime,
+  createCheckoutFinalizeSubscriberRuntime,
+} from "../../src/checkout/subscriber-runtime.js"
+
+type Handler = (
+  event: EventEnvelope,
+  context?: { eventBus: ReturnType<typeof createEventBus> },
+) => Promise<void> | void
+
+function recordingEventBus() {
+  const eventBus = createEventBus()
+  const subscriptions: Array<{ eventType: string; handler: Handler; inline: boolean }> = []
+  vi.spyOn(eventBus, "subscribe").mockImplementation((eventType, handler, options) => {
+    subscriptions.push({
+      eventType,
+      handler: handler as Handler,
+      inline: options?.inline ?? false,
+    })
+    return { unsubscribe: vi.fn() }
+  })
+  return { eventBus, subscriptions }
+}
+
+function event(name: string, data: unknown): EventEnvelope {
+  return { name, data, emittedAt: new Date().toISOString(), metadata: undefined }
+}
+
+const legalPort = {
+  getContract: vi.fn(),
+  listSignatures: vi.fn(),
+  sendContract: vi.fn(),
+  signContract: vi.fn(),
+} as unknown as AcceptanceSignatureLegalPort
+
+describe("catalog-checkout subscriber runtimes", () => {
+  it("injects the Legal port into acceptance-signature persistence", async () => {
+    const db = {} as PostgresJsDatabase
+    const bindings = { DATABASE_URL: "postgres://commerce" }
+    const persistSignature = vi.fn(async () => {})
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createAcceptanceSignatureSubscriberRuntime({
+      legal: legalPort,
+      withDb,
+      persistSignature,
+    })
+
+    await descriptor.register({ bindings, container: createContainer(), eventBus })
+    await subscriptions[0]?.handler(
+      event("contract.document.generated", { contractId: "contract_1" }),
+    )
+
+    expect(descriptor).toMatchObject({
+      id: COMMERCE_ACCEPTANCE_SIGNATURE_SUBSCRIBER_ID,
+      eventType: "contract.document.generated",
+    })
+    expect(withDb).toHaveBeenCalledWith(bindings, expect.any(Function))
+    expect(persistSignature).toHaveBeenCalledWith(db, "contract_1", eventBus, legalPort)
+  })
+
+  it("logs and swallows acceptance-signature failures", async () => {
+    const error = new Error("legal unavailable")
+    const logger = { error: vi.fn() }
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createAcceptanceSignatureSubscriberRuntime({
+      legal: legalPort,
+      withDb: async () => {
+        throw error
+      },
+      logger,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await expect(
+      subscriptions[0]?.handler(event("contract.document.generated", { contractId: "contract_2" })),
+    ).resolves.toBeUndefined()
+    expect(logger.error).toHaveBeenCalledWith(
+      "[catalog-checkout] persistAcceptanceSignature failed",
+      error,
+    )
+  })
+
+  it("finalizes booking payments inline with the delivery-scoped event bus", async () => {
+    const db = {} as PostgresJsDatabase
+    const scopedEventBus = createEventBus()
+    const dispatchFinalize = vi.fn(async () => ({ runId: "run_1" }))
+    const withDb = vi.fn(async (_bindings, operation) => operation(db))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createCheckoutFinalizeSubscriberRuntime({ withDb, dispatchFinalize })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await subscriptions[0]?.handler(
+      event("payment.completed", {
+        bookingId: "booking_1",
+        paymentSessionId: "session_1",
+        paymentIntent: "card",
+      }),
+      { eventBus: scopedEventBus },
+    )
+
+    expect(descriptor).toMatchObject({
+      id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
+      eventType: "payment.completed",
+    })
+    expect(subscriptions[0]?.inline).toBe(true)
+    expect(dispatchFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        db,
+        eventBus: scopedEventBus,
+        input: {
+          bookingId: "booking_1",
+          paymentSessionId: "session_1",
+          paymentIntent: "card",
+        },
+        trigger: "payment.completed",
+        correlationId: "session_1",
+        tags: ["bookingId:booking_1", "paymentSessionId:session_1", "paymentIntent:card"],
+      }),
+    )
+  })
+
+  it("ignores unrelated payments and swallows dispatch failures", async () => {
+    const dispatchFinalize = vi.fn(async () => {
+      throw new Error("recorded workflow failure")
+    })
+    const withDb = vi.fn(async (_bindings, operation) => operation({} as PostgresJsDatabase))
+    const { eventBus, subscriptions } = recordingEventBus()
+    const descriptor = createCheckoutFinalizeSubscriberRuntime({ withDb, dispatchFinalize })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await subscriptions[0]?.handler(event("payment.completed", { bookingId: null }))
+    expect(withDb).not.toHaveBeenCalled()
+
+    await expect(
+      subscriptions[0]?.handler(event("payment.completed", { bookingId: "booking_2" })),
+    ).resolves.toBeUndefined()
+    expect(dispatchFinalize).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/commerce/tests/unit/package-exports.test.ts
+++ b/packages/commerce/tests/unit/package-exports.test.ts
@@ -19,6 +19,22 @@ const packageJson = JSON.parse(
 ) as PackageJson
 
 describe("@voyant-travel/commerce package exports", () => {
+  it.each([
+    ["./catalog-checkout-runner", "./src/checkout/runner-runtime.ts", "checkout/runner-runtime"],
+    [
+      "./catalog-checkout-subscribers",
+      "./src/checkout/subscriber-runtime.ts",
+      "checkout/subscriber-runtime",
+    ],
+  ])("publishes %s with matching source and distribution targets", (subpath, source, dist) => {
+    expect(packageJson.exports[subpath]).toBe(source)
+    expect(packageJson.publishConfig.exports[subpath]).toEqual({
+      types: `./dist/${dist}.d.ts`,
+      import: `./dist/${dist}.js`,
+      default: `./dist/${dist}.js`,
+    })
+  })
+
   it("publishes the promotion-redemption subscriber runtime subpath", () => {
     expect(packageJson.exports["./promotion-redemption-subscriber"]).toBe(
       "./src/promotions/subscriber-runtime.ts",

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -122,7 +122,23 @@ describe("commerce deployment manifest", () => {
           },
         },
       ],
+      subscribers: [
+        {
+          id: "@voyant-travel/commerce#subscriber.catalog-checkout-contract-document-generated",
+          eventType: "contract.document.generated",
+          source: "@voyant-travel/commerce/catalog-checkout-subscribers",
+        },
+        {
+          id: "@voyant-travel/commerce#subscriber.catalog-checkout-payment-completed",
+          eventType: "payment.completed",
+          source: "@voyant-travel/commerce/catalog-checkout-subscribers",
+        },
+      ],
     })
+    expect(commerceCatalogCheckoutVoyantPlugin.subscribers).toHaveLength(2)
+    for (const subscriber of commerceCatalogCheckoutVoyantPlugin.subscribers ?? []) {
+      expect(subscriber).not.toHaveProperty("runtime")
+    }
 
     expect(commerceBookingMaintenanceVoyantPlugin).toMatchObject({
       schemaVersion: "voyant.extension.v1",

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -491,6 +491,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -491,6 +491,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -497,6 +497,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -491,6 +491,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -497,6 +497,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -491,6 +491,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -497,6 +497,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -490,6 +490,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -491,6 +491,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -492,6 +492,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": ["../commerce/dist/markets/validation.d.ts"],
       "@voyant-travel/commerce/promotion-redemption-subscriber": [

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -633,6 +633,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../../packages/commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../../packages/commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../../packages/commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../../packages/commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": [
         "../../packages/commerce/dist/markets/validation.d.ts"

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -633,6 +633,12 @@
       "@voyant-travel/commerce-react/sellability/ui": [
         "../../packages/commerce-react/dist/sellability/ui.d.ts"
       ],
+      "@voyant-travel/commerce/catalog-checkout-runner": [
+        "../../packages/commerce/dist/checkout/runner-runtime.d.ts"
+      ],
+      "@voyant-travel/commerce/catalog-checkout-subscribers": [
+        "../../packages/commerce/dist/checkout/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/commerce/checkout": ["../../packages/commerce/dist/checkout/index.d.ts"],
       "@voyant-travel/commerce/markets/validation": [
         "../../packages/commerce/dist/markets/validation.d.ts"


### PR DESCRIPTION
## Summary

- declare separate inert `contract.document.generated` and `payment.completed` subscribers on the Commerce catalog-checkout extension without activating graph runtimes or removing central handlers
- publish package-owned subscriber descriptor factories that preserve acceptance-signature logging/swallowing, inline checkout finalization, scoped event delivery, and dispatcher-owned failure recording
- publish package-owned checkout-finalize workflow runner creation and registration contracts so hosts inject runtime resources without owning runner metadata or rerun/resume behavior
- replace the published subscriber's hidden Legal dependency with a required transport-neutral Legal port while retaining the existing lazy default adapter for current callers
- add dual source/publish exports and regenerate required dist-path maps

## Stack

- based on #3214 (`commerce-promotion-redemption-subscriber`)
- follows #3207 for the shared `SubscriberRuntimeDescriptor` and later subscriber lowering
- does not modify Operator wiring or activate/remove central handlers

## Verification

- focused Commerce Vitest: 6 files, 16 tests passed
- `pnpm --filter @voyant-travel/commerce lint` (passes with one pre-existing optional-chain warning)
- changed-file Biome: 30 files passed
- `pnpm verify:dist-configs`
- `git diff --check`
- focused checkout source graph: no local `src/checkout` diagnostics after correction

## Local Limitation

- the full Commerce typecheck exhausted the local 4 GB Node heap before reporting source diagnostics. The narrowed checkout check also surfaced unrelated dependency source-fallback diagnostics; CI is authoritative for the complete typecheck/build result.
