### PR TITLE
feat(catalog): declare booking snapshot subscriber

### DIFF
--- a/.changeset/catalog-booking-snapshot-subscriber.md
+++ b/.changeset/catalog-booking-snapshot-subscriber.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": minor
+---
+
+Declare the Catalog booking snapshot subscriber and its injected runtime contract.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -256,6 +256,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -251,6 +251,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -37,6 +37,7 @@
     "./booking-engine/draft-shape": "./src/booking-engine/draft-shape.ts",
     "./booking-engine/contracts": "./src/booking-engine/contracts.ts",
     "./booking-engine/drafts-schema": "./src/booking-engine/drafts-schema.ts",
+    "./booking-snapshot-subscriber": "./src/booking-snapshot-subscriber-runtime.ts",
     "./offers": "./src/offers/operator-routes.ts",
     "./index-subscribers": "./src/index-subscriber-runtime.ts",
     "./projection-runtime": "./src/projection-runtime.ts",
@@ -243,6 +244,11 @@
         "types": "./dist/booking-engine/drafts-schema.d.ts",
         "import": "./dist/booking-engine/drafts-schema.js",
         "default": "./dist/booking-engine/drafts-schema.js"
+      },
+      "./booking-snapshot-subscriber": {
+        "types": "./dist/booking-snapshot-subscriber-runtime.d.ts",
+        "import": "./dist/booking-snapshot-subscriber-runtime.js",
+        "default": "./dist/booking-snapshot-subscriber-runtime.js"
       },
       "./offers": {
         "types": "./dist/offers/operator-routes.d.ts",

--- a/packages/catalog/src/booking-snapshot-subscriber-declaration.ts
+++ b/packages/catalog/src/booking-snapshot-subscriber-declaration.ts
@@ -1,0 +1,5 @@
+export const catalogBookingSnapshotSubscriberDeclaration = {
+  id: "@voyant-travel/catalog#subscriber.capture-booking-snapshot",
+  eventType: "booking.confirmed",
+  source: "@voyant-travel/catalog/booking-snapshot-subscriber",
+} as const

--- a/packages/catalog/src/booking-snapshot-subscriber-runtime.test.ts
+++ b/packages/catalog/src/booking-snapshot-subscriber-runtime.test.ts
@@ -1,0 +1,158 @@
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import { assertPortConforms } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  CATALOG_BOOKING_SNAPSHOT_RUNTIME_CONTAINER_KEY,
+  type CatalogBookingSnapshotExecutionContext,
+  type CatalogBookingSnapshotRuntime,
+  catalogBookingConfirmedSnapshotSubscriber,
+  catalogBookingSnapshotRuntimePort,
+  createCatalogBookingSnapshotSubscriberDescriptor,
+} from "./booking-snapshot-subscriber-runtime.js"
+import type { CaptureSnapshotInput } from "./services/snapshot-service.js"
+
+function snapshotInput(entityId: string): Omit<CaptureSnapshotInput, "bookingId"> {
+  return {
+    entityModule: "products",
+    entityId,
+    sourceKind: "owned",
+    frozenPayload: { name: entityId },
+    overlayStateAtCapture: {},
+  }
+}
+
+function runtimeHarness(
+  overrides: Partial<CatalogBookingSnapshotExecutionContext> = {},
+  captureSnapshotGraph = vi.fn(async () => []),
+) {
+  const snapshotContext: CatalogBookingSnapshotExecutionContext = {
+    db: {} as AnyDrizzleDb,
+    sellerOperatorId: "seller_123",
+    findBookingProductIds: vi.fn(async () => ["product_1"]),
+    buildSnapshotInput: vi.fn(async (productId) => snapshotInput(productId)),
+    ...overrides,
+  }
+  const runtime: CatalogBookingSnapshotRuntime = {
+    withContext: async (operation) => operation(snapshotContext),
+  }
+  const container = createContainer()
+  const eventBus = createEventBus()
+  container.register(CATALOG_BOOKING_SNAPSHOT_RUNTIME_CONTAINER_KEY, runtime)
+  const descriptor = createCatalogBookingSnapshotSubscriberDescriptor({ captureSnapshotGraph })
+  return {
+    captureSnapshotGraph,
+    descriptor,
+    eventBus,
+    snapshotContext,
+    context: { bindings: {}, container, eventBus },
+  }
+}
+
+describe("Catalog booking snapshot subscriber runtime", () => {
+  it("ships an inert descriptor and runtime conformance kit", async () => {
+    expect(catalogBookingConfirmedSnapshotSubscriber).toMatchObject({
+      id: "@voyant-travel/catalog#subscriber.capture-booking-snapshot",
+      eventType: "booking.confirmed",
+    })
+    await expect(
+      assertPortConforms(catalogBookingSnapshotRuntimePort, {
+        withContext: async (operation) =>
+          operation({
+            db: {} as AnyDrizzleDb,
+            sellerOperatorId: "seller_123",
+            findBookingProductIds: async () => [],
+            buildSnapshotInput: async () => null,
+          }),
+      }),
+    ).resolves.toBeUndefined()
+    await expect(
+      assertPortConforms(catalogBookingSnapshotRuntimePort, {} as never),
+    ).rejects.toThrow(/withContext/)
+  })
+
+  it("deduplicates booking products and captures the idempotent snapshot graph", async () => {
+    const harness = runtimeHarness({
+      findBookingProductIds: vi.fn(async () => [
+        "product_1",
+        null,
+        "product_1",
+        "product_2",
+        undefined,
+      ]),
+    })
+    await harness.descriptor.register(harness.context)
+    await harness.eventBus.emit("booking.confirmed", {
+      bookingId: "booking_123",
+      bookingNumber: "B-123",
+      actorId: null,
+      ignored: true,
+    })
+
+    expect(harness.snapshotContext.buildSnapshotInput).toHaveBeenNthCalledWith(1, "product_1", {
+      sellerOperatorId: "seller_123",
+      scope: {
+        locale: "en-GB",
+        audience: "staff",
+        market: "default",
+        actor: "staff",
+      },
+    })
+    expect(harness.snapshotContext.buildSnapshotInput).toHaveBeenNthCalledWith(2, "product_2", {
+      sellerOperatorId: "seller_123",
+      scope: {
+        locale: "en-GB",
+        audience: "staff",
+        market: "default",
+        actor: "staff",
+      },
+    })
+    expect(harness.captureSnapshotGraph).toHaveBeenCalledWith(
+      harness.snapshotContext.db,
+      "booking_123",
+      [snapshotInput("product_1"), snapshotInput("product_2")],
+    )
+  })
+
+  it("does nothing when the booking has no product items", async () => {
+    const harness = runtimeHarness({ findBookingProductIds: vi.fn(async () => []) })
+    await harness.descriptor.register(harness.context)
+    await harness.eventBus.emit("booking.confirmed", { bookingId: "missing_booking" })
+    expect(harness.snapshotContext.buildSnapshotInput).not.toHaveBeenCalled()
+    expect(harness.captureSnapshotGraph).not.toHaveBeenCalled()
+  })
+
+  it("skips missing products when no snapshot inputs can be built", async () => {
+    const harness = runtimeHarness({ buildSnapshotInput: vi.fn(async () => null) })
+    await harness.descriptor.register(harness.context)
+    await harness.eventBus.emit("booking.confirmed", { bookingId: "booking_123" })
+    expect(harness.captureSnapshotGraph).not.toHaveBeenCalled()
+  })
+
+  it("leaves snapshot errors to the event bus without retrying or translating them", async () => {
+    const captureSnapshotGraph = vi.fn(async () => {
+      throw new Error("snapshot insert failed")
+    })
+    const harness = runtimeHarness({}, captureSnapshotGraph)
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    await harness.descriptor.register(harness.context)
+    await harness.eventBus.emit("booking.confirmed", { bookingId: "booking_123" })
+    expect(captureSnapshotGraph).toHaveBeenCalledTimes(1)
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringContaining('subscriber error for "booking.confirmed"'),
+      expect.objectContaining({ message: "snapshot insert failed" }),
+    )
+    consoleError.mockRestore()
+  })
+
+  it("validates bookingId before resolving runtime context", async () => {
+    const harness = runtimeHarness()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    await harness.descriptor.register(harness.context)
+    await harness.eventBus.emit("booking.confirmed", { bookingNumber: "B-123" })
+    expect(harness.captureSnapshotGraph).not.toHaveBeenCalled()
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+})

--- a/packages/catalog/src/booking-snapshot-subscriber-runtime.ts
+++ b/packages/catalog/src/booking-snapshot-subscriber-runtime.ts
@@ -1,0 +1,123 @@
+import type { BootstrapContext } from "@voyant-travel/core"
+import { definePort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { z } from "zod"
+
+import { catalogBookingSnapshotSubscriberDeclaration } from "./booking-snapshot-subscriber-declaration.js"
+import {
+  type CaptureSnapshotInput,
+  captureSnapshotGraphIdempotent,
+} from "./services/snapshot-service.js"
+
+export const CATALOG_BOOKING_SNAPSHOT_RUNTIME_CONTAINER_KEY = "runtime.catalog.booking-snapshot"
+
+export interface CatalogBookingSnapshotScope {
+  locale: string
+  audience: "staff"
+  market: string
+  actor: "staff"
+}
+
+export interface CatalogBookingSnapshotBuildOptions {
+  sellerOperatorId: string
+  scope: CatalogBookingSnapshotScope
+}
+
+export interface CatalogBookingSnapshotExecutionContext {
+  db: AnyDrizzleDb
+  sellerOperatorId: string
+  findBookingProductIds(bookingId: string): Promise<readonly (string | null | undefined)[]>
+  buildSnapshotInput(
+    productId: string,
+    options: CatalogBookingSnapshotBuildOptions,
+  ): Promise<Omit<CaptureSnapshotInput, "bookingId"> | null>
+}
+
+export interface CatalogBookingSnapshotRuntime {
+  withContext<TResult>(
+    operation: (context: CatalogBookingSnapshotExecutionContext) => Promise<TResult>,
+  ): Promise<TResult>
+}
+
+export const catalogBookingSnapshotRuntimePort = definePort<CatalogBookingSnapshotRuntime>({
+  id: "catalog.booking-snapshot-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("catalog.booking-snapshot-runtime provider must be an object.")
+    }
+    if (typeof provider.withContext !== "function") {
+      throw new Error("catalog.booking-snapshot-runtime provider must implement withContext().")
+    }
+  },
+})
+
+export interface CatalogBookingSnapshotSubscriberRuntimeDescriptor {
+  readonly id: string
+  readonly eventType: string
+  readonly register: (context: BootstrapContext) => void | Promise<void>
+}
+
+type CaptureSnapshotGraph = typeof captureSnapshotGraphIdempotent
+
+export interface CatalogBookingSnapshotSubscriberDescriptorOptions {
+  captureSnapshotGraph?: CaptureSnapshotGraph
+}
+
+const bookingConfirmedPayloadSchema = z.object({ bookingId: z.string().min(1) }).passthrough()
+
+const snapshotScope: CatalogBookingSnapshotScope = {
+  locale: "en-GB",
+  audience: "staff",
+  market: "default",
+  actor: "staff",
+}
+
+export function createCatalogBookingSnapshotSubscriberDescriptor(
+  options: CatalogBookingSnapshotSubscriberDescriptorOptions = {},
+): CatalogBookingSnapshotSubscriberRuntimeDescriptor {
+  const captureSnapshotGraph = options.captureSnapshotGraph ?? captureSnapshotGraphIdempotent
+
+  return {
+    id: catalogBookingSnapshotSubscriberDeclaration.id,
+    eventType: catalogBookingSnapshotSubscriberDeclaration.eventType,
+    register(context) {
+      context.eventBus.subscribe(
+        catalogBookingSnapshotSubscriberDeclaration.eventType,
+        async ({ data }) => {
+          const { bookingId } = bookingConfirmedPayloadSchema.parse(data)
+          const runtime = context.container.resolve<CatalogBookingSnapshotRuntime>(
+            CATALOG_BOOKING_SNAPSHOT_RUNTIME_CONTAINER_KEY,
+          )
+
+          await runtime.withContext(async (snapshotContext) => {
+            const productIds = Array.from(
+              new Set(
+                (await snapshotContext.findBookingProductIds(bookingId)).filter(
+                  (productId): productId is string => Boolean(productId),
+                ),
+              ),
+            )
+            if (productIds.length === 0) return
+
+            const inputs: Array<Omit<CaptureSnapshotInput, "bookingId">> = []
+            for (const productId of productIds) {
+              const input = await snapshotContext.buildSnapshotInput(productId, {
+                sellerOperatorId: snapshotContext.sellerOperatorId,
+                scope: snapshotScope,
+              })
+              if (input) inputs.push(input)
+            }
+
+            if (inputs.length > 0) {
+              await captureSnapshotGraph(snapshotContext.db, bookingId, inputs)
+            }
+          })
+        },
+        { inline: false },
+      )
+    },
+  }
+}
+
+export const catalogBookingConfirmedSnapshotSubscriber =
+  createCatalogBookingSnapshotSubscriberDescriptor()

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -1,4 +1,5 @@
 import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { catalogBookingSnapshotSubscriberDeclaration } from "./booking-snapshot-subscriber-declaration.js"
 import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
 
 const catalogAdminRuntime = {
@@ -86,7 +87,7 @@ export const catalogVoyantModule = defineModule({
       eventType: "catalog.source.reconnected",
     },
   ],
-  subscribers: catalogIndexSubscriberDeclarations,
+  subscribers: [...catalogIndexSubscriberDeclarations, catalogBookingSnapshotSubscriberDeclaration],
   access: {
     resources: [
       {

--- a/packages/catalog/tests/unit/package-exports.test.ts
+++ b/packages/catalog/tests/unit/package-exports.test.ts
@@ -36,4 +36,15 @@ describe("@voyant-travel/catalog package exports", () => {
       default: "./dist/index-subscriber-runtime.js",
     })
   })
+
+  it("publishes the inert booking snapshot subscriber descriptor", () => {
+    expect(packageJson.exports["./booking-snapshot-subscriber"]).toBe(
+      "./src/booking-snapshot-subscriber-runtime.ts",
+    )
+    expect(packageJson.publishConfig.exports["./booking-snapshot-subscriber"]).toEqual({
+      types: "./dist/booking-snapshot-subscriber-runtime.d.ts",
+      import: "./dist/booking-snapshot-subscriber-runtime.js",
+      default: "./dist/booking-snapshot-subscriber-runtime.js",
+    })
+  })
 })

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -46,10 +46,14 @@ describe("catalog deployment manifest", () => {
         ["index-product-pricing-changed", "pricing.rule.changed"],
         ["index-product-publication-changed", "product.publication.changed"],
         ["index-product-promotion-changed", "promotion.changed"],
+        ["capture-booking-snapshot", "booking.confirmed"],
       ].map(([localId, eventType]) => ({
         id: `@voyant-travel/catalog#subscriber.${localId}`,
         eventType,
-        source: "@voyant-travel/catalog/index-subscribers",
+        source:
+          eventType === "booking.confirmed"
+            ? "@voyant-travel/catalog/booking-snapshot-subscriber"
+            : "@voyant-travel/catalog/index-subscribers",
       })),
     )
     expect(catalogVoyantModule.subscribers?.every((subscriber) => !subscriber.runtime)).toBe(true)

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -327,6 +327,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -321,6 +321,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -321,6 +321,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -327,6 +327,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -321,6 +321,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -327,6 +327,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -321,6 +321,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -327,6 +327,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -320,6 +320,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -321,6 +321,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -322,6 +322,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": ["../catalog/dist/embeddings/contract.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -409,6 +409,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../../packages/catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../../packages/catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../../packages/catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../../packages/catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": [

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -409,6 +409,9 @@
       "@voyant-travel/catalog/booking-engine/schema": [
         "../../packages/catalog/dist/booking-engine/schema.d.ts"
       ],
+      "@voyant-travel/catalog/booking-snapshot-subscriber": [
+        "../../packages/catalog/dist/booking-snapshot-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/catalog/contract": ["../../packages/catalog/dist/contract.d.ts"],
       "@voyant-travel/catalog/drift/events": ["../../packages/catalog/dist/drift/events.d.ts"],
       "@voyant-travel/catalog/embeddings/contract": [


### PR DESCRIPTION
## Summary

- add an inert Catalog-owned `booking.confirmed` subscriber declaration for booking snapshot capture
- add the `catalog.booking-snapshot-runtime` port and `runtime.catalog.booking-snapshot` container key
- inject database lifetime, seller operator identity, booking-product lookup, and vertical snapshot-input construction
- preserve the central handler orchestration: deduplicate non-empty product ids, build inputs sequentially with the staff audit scope, skip absent bookings/items/products, and capture only non-empty graphs
- delegate capture to Catalog's existing `captureSnapshotGraphIdempotent` service without catching, retrying, or translating failures
- publish `@voyant-travel/catalog/booking-snapshot-subscriber` and add a minor changeset

## Stack

- base PR: #3217
- base branch: `refactor/catalog-index-subscribers`
- base commit: `1c95ee6c232b73593c6e46edbc78b835cac41ea7`

## Activation boundary

The manifest declaration intentionally has no `runtime` reference and does not require the runtime port. This PR does not register the subscriber or change Operator composition. No Bookings schema/runtime or Inventory snapshot builder is imported into Catalog; deployments provide those two boundaries through `CatalogBookingSnapshotExecutionContext`.

## Verification

- `pnpm --filter @voyant-travel/catalog test` (41 files / 457 tests passed; 4 files / 27 tests skipped)
- `pnpm --filter @voyant-travel/catalog typecheck`
- `pnpm --filter @voyant-travel/catalog lint`
- `pnpm exec vitest run tests/unit/package-exports.test.ts` from `packages/catalog` (3 tests passed)
- `node scripts/verify-package-tarballs.mjs --package @voyant-travel/catalog`

Only focused Catalog verification was run. Broad local Turbo hooks were bypassed as requested; GitHub CI is authoritative for repository-wide validation.