### PR TITLE
feat(framework): emit selected graph OpenAPI

### DIFF
--- a/.changeset/selected-graph-openapi.md
+++ b/.changeset/selected-graph-openapi.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/identity": minor
+---
+
+Emit selected-graph OpenAPI documents from route-owned metadata, beginning with
+the identity admin API authority.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -843,6 +843,38 @@ RBAC/API-key/tool/action-ledger unification ships.
 OpenAPI metadata belongs with route declarations. The graph resolver should
 collect it after package admission, not require a separate OpenAPI facet first.
 
+The first selected-graph OpenAPI authority is active for
+`@voyant-travel/identity#api.admin`. A route bundle opts in with a stable
+document slug:
+
+```ts
+{
+  id: "@voyant-travel/identity#api.admin",
+  surface: "admin",
+  mount: "identity",
+  openapi: { document: "identity" },
+  runtime: {
+    entry: "@voyant-travel/identity",
+    export: "identityHonoModule",
+  },
+}
+```
+
+At build time, the framework considers opted-in routes from selected modules,
+extensions, and plugins only. It resolves their absolute mounts through the
+same normalization used by runtime route posture, replays eager and lazy Hono
+OpenAPI registries, and emits only matching operations. Every emitted operation
+carries exact `x-voyant-api-id`, `x-voyant-unit-id`, and
+`x-voyant-package-name` ownership. Zero-operation bundles, duplicate document
+slugs, and overlapping operation claims are build failures.
+
+The Operator still emits compatibility documents for unmigrated bundles. Its
+`identity.json` entry is replaced by the graph-derived document only after a
+parity check proves that paths, schemas, operation ids, and all pre-existing
+content are unchanged apart from the graph ownership extensions. Coverage uses
+exact API ids for opted-in bundles; filename/module heuristics and temporary
+allowlists remain available only to unmigrated bundles.
+
 API scopes, staff RBAC, user scopes, tool permissions, and action-ledger
 capabilities should converge toward one permission catalog, but that is a
 later dependency-ordered phase. It is high leverage and should be designed once,
@@ -1407,7 +1439,8 @@ Progress: the action-ledger, MICE, and Quotes nav/route/page factories are
 lowered into the selected-graph admin bundle. The Operator still owns their
 lightweight localization/icon wrappers. Slots/contributions, copy, and the
 remaining first-party Operator compatibility registry are not part of this
-slice.
+slice. Identity admin routes are the first package-owned selected-graph OpenAPI
+authority; other API documents remain on the Operator compatibility path.
 
 Exit: a custom package contributes a secured, documented API and complete admin
 surface without operator edits; all grants and message references validate.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -811,6 +811,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -806,6 +806,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -782,6 +782,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -777,6 +777,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -100,6 +100,7 @@ export type {
   VoyantGraphProjectSelections,
   VoyantGraphRouteBundle,
   VoyantGraphRouteMethod,
+  VoyantGraphRouteOpenApi,
   VoyantGraphRouteSurface,
   VoyantGraphRuntimeReference,
   VoyantGraphSubscriber,

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -125,6 +125,7 @@ export interface VoyantGraphRouteBundle {
   surface: VoyantGraphRouteSurface
   methods?: readonly VoyantGraphRouteMethod[]
   mount?: string
+  openapi?: VoyantGraphRouteOpenApi
   resource?: string
   requiredScopes?: readonly string[]
   /** Anonymous public access for the whole public mount or route-relative path subsets. */
@@ -132,6 +133,11 @@ export interface VoyantGraphRouteBundle {
   /** Transactional DB routing for the whole mount or route-relative path subsets. */
   transactional?: boolean | readonly string[]
   runtime?: VoyantGraphRuntimeReference
+}
+
+/** Build-time API document ownership declared by the route bundle. */
+export interface VoyantGraphRouteOpenApi {
+  document: string
 }
 
 export interface VoyantGraphFacetEntity {

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -846,6 +846,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -847,6 +847,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -856,6 +856,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -857,6 +857,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -866,6 +866,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -861,6 +861,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./deployment-artifacts": "./src/deployment-artifacts.ts",
     "./deployment-graph": "./src/deployment-graph.ts",
+    "./selected-graph-openapi": "./src/selected-graph-openapi.ts",
     "./operator-distribution": "./src/operator-distribution.ts",
     "./project-api-conventions": "./src/project-api-conventions.ts",
     "./project-admin-conventions": "./src/project-admin-conventions.ts",

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -669,6 +669,7 @@ describe("deployment graph v1", () => {
             surface: "public",
             methods: ["POST", "GET"],
             mount: "loyalty",
+            openapi: { document: "loyalty" },
             resource: "loyalty.points",
             requiredScopes: ["loyalty:read", "loyalty-points:write"],
             anonymous: ["/status", "health"],
@@ -694,6 +695,7 @@ describe("deployment graph v1", () => {
             surface: "worker",
             methods: ["get", "GET", "GET"],
             mount: "",
+            openapi: { document: "Loyalty API" },
             resource: "Loyalty Points",
             requiredScopes: ["loyalty.points.read", "loyalty:Read"],
             anonymous: true,
@@ -714,6 +716,10 @@ describe("deployment graph v1", () => {
         expect.objectContaining({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
           facet: "api[0].mount",
+        }),
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          facet: "api[0].openapi.document",
         }),
         expect.objectContaining({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
@@ -889,7 +895,13 @@ describe("deployment graph v1", () => {
         defineModule({
           id: "@acme/voyant-crm",
           provides: { capabilities: ["acme.crm.people"] },
-          api: [{ id: "@acme/voyant-crm#api.admin", surface: "admin" }],
+          api: [
+            {
+              id: "@acme/voyant-crm#api.admin",
+              surface: "admin",
+              openapi: { document: "crm" },
+            },
+          ],
         }),
         defineModule({
           id: "@acme/voyant-loyalty",
@@ -933,6 +945,7 @@ describe("deployment graph v1", () => {
     expect(first.diagnostics).toEqual([])
     expect(first.contentHash).toMatch(/^sha256:[a-f0-9]{64}$/)
     expect(second.contentHash).toBe(first.contentHash)
+    expect(first.modules[0]?.api[0]?.openapi).toEqual({ document: "crm" })
   })
 
   it("keeps resolved unit ordering independent of declaration order", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -448,6 +448,7 @@ const GRAPH_ID_PATTERN =
 const ROUTE_RESOURCE_PATTERN = /^[a-z][a-z0-9-]*(?:[.-][a-z][a-z0-9-]*)*$/
 const ROUTE_SCOPE_PATTERN =
   /^[a-z][a-z0-9-]*(?:[.-][a-z][a-z0-9-]*)*:[a-z][a-z0-9-]*(?:-[a-z][a-z0-9-]*)*$/
+const OPENAPI_DOCUMENT_SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 const ROUTE_METHODS = new Set<VoyantGraphRouteMethod>([
   "DELETE",
   "GET",
@@ -1853,6 +1854,23 @@ function validateRouteBundles(value: unknown, source: string | undefined): Voyan
           message: `Route bundle "${route.id ?? index}" mount must be a non-empty string when present.`,
         }),
       )
+    }
+
+    if (route.openapi !== undefined) {
+      if (
+        !isRecord(route.openapi) ||
+        typeof route.openapi.document !== "string" ||
+        !OPENAPI_DOCUMENT_SLUG_PATTERN.test(route.openapi.document)
+      ) {
+        diagnostics.push(
+          diagnostic({
+            code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+            source,
+            facet: `${facet}.openapi.document`,
+            message: `Route bundle "${route.id ?? index}" OpenAPI document must be a non-empty lowercase slug.`,
+          }),
+        )
+      }
     }
 
     if (

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -109,6 +109,7 @@ export {
   type ComposeVoyantGraphRuntimeInput,
   composeVoyantGraphRuntime,
   composeVoyantGraphRuntimeFacetModules,
+  resolveVoyantGraphRouteMountPath,
   type VoyantGraphRuntimeBinding,
   type VoyantGraphRuntimeBindingContext,
   type VoyantGraphRuntimeBindings,

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -130,10 +130,12 @@ interface UnitRoutePosture extends VoyantGraphRuntimeRoutePosture {
 
 function deriveUnitRoutePosture(unit: VoyantGraphRuntimeUnitLoader): UnitRoutePosture {
   const publicRoutes = unit.routes.filter(({ route }) => route.surface === "public")
-  const publicMounts = sortedUnique(publicRoutes.map(({ route }) => routeMountPath(unit, route)))
+  const publicMounts = sortedUnique(
+    publicRoutes.map(({ route }) => resolveVoyantGraphRouteMountPath(unit, route)),
+  )
   const publicPaths = sortedUnique(
     unit.routes.flatMap(({ route }) => {
-      const mount = routeMountPath(unit, route)
+      const mount = resolveVoyantGraphRouteMountPath(unit, route)
       if (route.anonymous === true) return [mount]
       if (!route.anonymous) return []
       return route.anonymous.map((path) => resolveRoutePosturePath(mount, path))
@@ -141,7 +143,7 @@ function deriveUnitRoutePosture(unit: VoyantGraphRuntimeUnitLoader): UnitRoutePo
   )
   const transactionalPaths = sortedUnique(
     unit.routes.flatMap(({ route }) => {
-      const mount = routeMountPath(unit, route)
+      const mount = resolveVoyantGraphRouteMountPath(unit, route)
       if (route.transactional === true) return [mount]
       if (!route.transactional) return []
       return route.transactional.map((path) => resolveRoutePosturePath(mount, path))
@@ -153,8 +155,8 @@ function deriveUnitRoutePosture(unit: VoyantGraphRuntimeUnitLoader): UnitRoutePo
   return { publicPaths, transactionalPaths, publicMount, anonymous }
 }
 
-function routeMountPath(
-  unit: VoyantGraphRuntimeUnitLoader,
+export function resolveVoyantGraphRouteMountPath(
+  unit: Pick<VoyantGraphRuntimeUnitLoader, "id" | "localId">,
   route: VoyantGraphRuntimeUnitLoader["routes"][number]["route"],
 ): string {
   if (route.mount?.startsWith("/v1/")) return normalizeAbsolutePath(route.mount)

--- a/packages/framework/src/runtime-lowering.test.ts
+++ b/packages/framework/src/runtime-lowering.test.ts
@@ -23,6 +23,7 @@ function runtimeInput(load: () => Promise<unknown>) {
             route: {
               id: "@acme/voyant-loyalty#api.admin",
               surface: "admin" as const,
+              openapi: { document: "loyalty" },
               runtime: {
                 entry: "./runtime",
                 export: "createLoyaltyModule",
@@ -111,6 +112,7 @@ describe("graph runtime lowering", () => {
     const runtime = createVoyantGraphRuntime(runtimeInput(importRuntime))
 
     expect(importRuntime).not.toHaveBeenCalled()
+    expect(runtime.modules[0]?.routes[0]?.route.openapi).toEqual({ document: "loyalty" })
     await expect(runtime.modules[0]?.routes[0]?.load()).resolves.toBe(factory)
     await expect(runtime.modules[0]?.load()).resolves.toEqual([factory])
     await expect(runtime.modules[0]?.routes[1]?.load()).resolves.toBe(factory)

--- a/packages/framework/src/selected-graph-openapi.test.ts
+++ b/packages/framework/src/selected-graph-openapi.test.ts
@@ -1,0 +1,227 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import type { VoyantGraphRouteBundle } from "@voyant-travel/core/project"
+import type { LazyMount, ModuleMount } from "@voyant-travel/hono/openapi"
+import { describe, expect, it } from "vitest"
+
+import type { VoyantGraphRuntime, VoyantGraphRuntimeUnitLoader } from "./runtime-lowering.js"
+import { buildSelectedGraphOpenApiDocuments } from "./selected-graph-openapi.js"
+
+const options = { info: { title: "Selected graph", version: "1" } }
+
+function documentedApp(paths: readonly string[]) {
+  const app = new OpenAPIHono() as OpenAPIHono & {
+    lazyMounts: LazyMount[]
+    moduleMounts: ModuleMount[]
+  }
+  app.lazyMounts = []
+  app.moduleMounts = []
+  for (const path of paths) {
+    app.openapi(
+      createRoute({
+        method: "get",
+        path,
+        responses: {
+          200: {
+            content: { "application/json": { schema: z.object({ ok: z.boolean() }) } },
+            description: "OK",
+          },
+        },
+      }),
+      (context) => context.json({ ok: true }),
+    )
+  }
+  return app
+}
+
+function methodSplitApp(path: string) {
+  const app = documentedApp([])
+  for (const method of ["get", "post"] as const) {
+    app.openapi(
+      createRoute({
+        method,
+        path,
+        responses: {
+          200: {
+            content: { "application/json": { schema: z.object({ ok: z.boolean() }) } },
+            description: "OK",
+          },
+        },
+      }),
+      (context) => context.json({ ok: true }),
+    )
+  }
+  return app
+}
+
+function unit(
+  id: string,
+  routes: readonly VoyantGraphRouteBundle[],
+  kind: "module" | "extension" | "plugin" = "module",
+): VoyantGraphRuntimeUnitLoader {
+  return {
+    id,
+    localId: id.split("/").at(-1)?.split("#").at(-1),
+    kind,
+    packageName: id.split("#")[0]!,
+    order: 0,
+    references: [],
+    config: [],
+    secrets: [],
+    resources: [],
+    providers: [],
+    requiredPorts: [],
+    runtimePorts: [],
+    requiredRuntimePorts: [],
+    accessScopes: [],
+    tools: [],
+    workflows: [],
+    actions: [],
+    selectedIds: {
+      routes: routes.map(({ id }) => id),
+      tools: [],
+      workflows: [],
+      events: [],
+      webhooks: [],
+    },
+    routes: routes.map((route) => ({
+      unitId: id,
+      route,
+      importEntry: route.runtime?.entry ?? id,
+      load: async () => ({}),
+    })),
+    load: async () => [],
+  }
+}
+
+function runtime(
+  modules: readonly VoyantGraphRuntimeUnitLoader[],
+  extensions: readonly VoyantGraphRuntimeUnitLoader[] = [],
+  plugins: readonly VoyantGraphRuntimeUnitLoader[] = [],
+): Pick<VoyantGraphRuntime, "modules" | "extensions" | "plugins"> {
+  return { modules, extensions, plugins }
+}
+
+function route(
+  id: string,
+  mount: string,
+  document?: string,
+  methods?: VoyantGraphRouteBundle["methods"],
+): VoyantGraphRouteBundle {
+  return {
+    id,
+    surface: "admin",
+    mount,
+    ...(document ? { openapi: { document } } : {}),
+    ...(methods ? { methods } : {}),
+    runtime: { entry: id },
+  }
+}
+
+describe("buildSelectedGraphOpenApiDocuments", () => {
+  it("follows graph selection and removal without leaking unclaimed paths", async () => {
+    const app = documentedApp(["/v1/admin/identity/contacts", "/v1/admin/bookings"])
+    const identity = unit("@voyant-travel/identity", [
+      route("@voyant-travel/identity#api.admin", "identity", "identity"),
+    ])
+
+    const selected = await buildSelectedGraphOpenApiDocuments({
+      runtime: runtime([identity]),
+      app,
+      options,
+    })
+
+    expect([...selected.keys()]).toEqual(["identity"])
+    expect(Object.keys(selected.get("identity")?.paths ?? {})).toEqual([
+      "/v1/admin/identity/contacts",
+    ])
+    await expect(
+      buildSelectedGraphOpenApiDocuments({ runtime: runtime([]), app, options }),
+    ).resolves.toEqual(new Map())
+  })
+
+  it("normalizes relative mounts and replays lazy route registries", async () => {
+    const app = documentedApp([])
+    const lazy = documentedApp(["/addresses"])
+    app.lazyMounts.push({ prefix: "/v1/admin/identity", load: async () => lazy })
+    app.moduleMounts.push({
+      moduleName: "identity",
+      prefix: "/v1/admin/identity",
+      load: async () => lazy,
+    })
+    const identity = unit("@voyant-travel/identity", [
+      route("@voyant-travel/identity#api.admin", "identity", "identity", ["GET"]),
+    ])
+
+    const documents = await buildSelectedGraphOpenApiDocuments({
+      runtime: runtime([identity]),
+      app,
+      options,
+    })
+    const operation = documents.get("identity")?.paths?.["/v1/admin/identity/addresses"]
+      ?.get as Record<string, unknown>
+
+    expect(operation).toMatchObject({
+      operationId: "getAdminIdentityAddresses",
+      "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+      "x-voyant-unit-id": "@voyant-travel/identity",
+      "x-voyant-package-name": "@voyant-travel/identity",
+    })
+  })
+
+  it("fails an opted-in bundle that owns no documented operations", async () => {
+    const app = documentedApp(["/v1/admin/bookings"])
+    const identity = unit("@voyant-travel/identity", [
+      route("@voyant-travel/identity#api.admin", "identity", "identity"),
+    ])
+
+    await expect(
+      buildSelectedGraphOpenApiDocuments({ runtime: runtime([identity]), app, options }),
+    ).rejects.toThrow(/matched zero operations/)
+  })
+
+  it("fails duplicate document claims across all selected unit kinds", async () => {
+    const app = documentedApp(["/v1/admin/identity", "/v1/admin/identity-extra"])
+    const module = unit("@voyant-travel/identity", [
+      route("@voyant-travel/identity#api.admin", "identity", "identity"),
+    ])
+    const extension = unit(
+      "@acme/identity-extension",
+      [route("@acme/identity-extension#api.admin", "identity-extra", "identity")],
+      "extension",
+    )
+
+    await expect(
+      buildSelectedGraphOpenApiDocuments({ runtime: runtime([module], [extension]), app, options }),
+    ).rejects.toThrow(/document "identity" is claimed by both/)
+  })
+
+  it("fails overlapping mounts that claim the same path", async () => {
+    const app = documentedApp(["/v1/admin/identity/contacts"])
+    const identity = unit("@voyant-travel/identity", [
+      route("@voyant-travel/identity#api.admin", "identity", "identity"),
+      route("@voyant-travel/identity#api.contacts", "identity/contacts", "identity-contacts"),
+    ])
+
+    await expect(
+      buildSelectedGraphOpenApiDocuments({ runtime: runtime([identity]), app, options }),
+    ).rejects.toThrow(/path "\/v1\/admin\/identity\/contacts" method "GET" is claimed by both/)
+  })
+
+  it("allows separate bundles to claim different methods on the same path", async () => {
+    const path = "/v1/admin/identity/contacts"
+    const app = methodSplitApp(path)
+    const identity = unit("@voyant-travel/identity", [
+      route("@voyant-travel/identity#api.contacts.read", "identity", "identity-read", ["GET"]),
+      route("@voyant-travel/identity#api.contacts.write", "identity", "identity-write", ["POST"]),
+    ])
+
+    const documents = await buildSelectedGraphOpenApiDocuments({
+      runtime: runtime([identity]),
+      app,
+      options,
+    })
+
+    expect(Object.keys(documents.get("identity-read")?.paths?.[path] ?? {})).toEqual(["get"])
+    expect(Object.keys(documents.get("identity-write")?.paths?.[path] ?? {})).toEqual(["post"])
+  })
+})

--- a/packages/framework/src/selected-graph-openapi.ts
+++ b/packages/framework/src/selected-graph-openapi.ts
@@ -1,0 +1,155 @@
+import type { VoyantGraphRouteMethod } from "@voyant-travel/core/project"
+import {
+  buildModulePathOwnership,
+  type GenerateOpenApiOptions,
+  generateOpenApiDocument,
+  type LazyMount,
+  type ModuleMount,
+  mergeLazyOpenApiPaths,
+  type OpenApiDocument,
+  stampModuleMetadata,
+} from "@voyant-travel/hono/openapi"
+
+import { resolveVoyantGraphRouteMountPath } from "./runtime-composition.js"
+import type { VoyantGraphRuntime, VoyantGraphRuntimeUnitLoader } from "./runtime-lowering.js"
+
+const HTTP_METHODS = new Set(["delete", "get", "head", "options", "patch", "post", "put", "trace"])
+
+type OpenApiSourceApp = Parameters<typeof generateOpenApiDocument>[0] & {
+  lazyMounts?: readonly LazyMount[]
+  moduleMounts?: readonly ModuleMount[]
+}
+
+export interface BuildSelectedGraphOpenApiDocumentsInput {
+  runtime: Pick<VoyantGraphRuntime, "modules" | "extensions" | "plugins">
+  app: OpenApiSourceApp
+  options: GenerateOpenApiOptions
+}
+
+interface OpenApiClaim {
+  document: string
+  mount: string
+  route: VoyantGraphRuntimeUnitLoader["routes"][number]["route"]
+  unit: VoyantGraphRuntimeUnitLoader
+}
+
+/**
+ * Emit one OpenAPI document for each opted-in API bundle in the selected graph.
+ * This entry point is build-time only and is intentionally excluded from the
+ * framework runtime barrel.
+ */
+export async function buildSelectedGraphOpenApiDocuments(
+  input: BuildSelectedGraphOpenApiDocumentsInput,
+): Promise<Map<string, OpenApiDocument>> {
+  const eager = generateOpenApiDocument(input.app, input.options)
+  const merged = await mergeLazyOpenApiPaths(eager, input.app.lazyMounts ?? [], input.options)
+  const ownership = await buildModulePathOwnership(input.app.moduleMounts ?? [], input.options)
+  const source = stampModuleMetadata(merged, ownership)
+  const claims = collectClaims(input.runtime)
+  validateDocumentClaims(claims)
+
+  const claimedOperations = new Map<string, OpenApiClaim>()
+  const documents = new Map<string, OpenApiDocument>()
+  for (const claim of claims) {
+    const paths: Record<string, unknown> = {}
+    let operationCount = 0
+
+    for (const [path, pathItem] of Object.entries(source.paths ?? {})) {
+      if (!isWithinMount(path, claim.mount) || !isRecord(pathItem)) continue
+
+      const selectedItem: Record<string, unknown> = {}
+      let selectedOperationCount = 0
+      for (const [key, value] of Object.entries(pathItem)) {
+        const method = key.toLowerCase()
+        if (!HTTP_METHODS.has(method)) {
+          selectedItem[key] = value
+          continue
+        }
+        if (!isRecord(value) || !routeClaimsMethod(claim, method)) continue
+
+        const operation = `${method.toUpperCase()} ${path}`
+        const previous = claimedOperations.get(operation)
+        if (previous) {
+          throw new Error(
+            `Selected graph OpenAPI path "${path}" method "${method.toUpperCase()}" is claimed by both "${previous.route.id}" (${previous.document}) and "${claim.route.id}" (${claim.document}).`,
+          )
+        }
+        claimedOperations.set(operation, claim)
+
+        operationCount += 1
+        selectedOperationCount += 1
+        selectedItem[key] = {
+          ...value,
+          "x-voyant-api-id": claim.route.id,
+          "x-voyant-unit-id": claim.unit.id,
+          "x-voyant-package-name": claim.unit.packageName,
+        }
+      }
+
+      if (selectedOperationCount === 0) continue
+      paths[path] = selectedItem
+    }
+
+    if (operationCount === 0) {
+      throw new Error(
+        `Selected graph OpenAPI bundle "${claim.route.id}" (${claim.document}) matched zero operations at "${claim.mount}".`,
+      )
+    }
+
+    documents.set(claim.document, { ...source, paths } as OpenApiDocument)
+  }
+
+  return documents
+}
+
+function collectClaims(
+  runtime: Pick<VoyantGraphRuntime, "modules" | "extensions" | "plugins">,
+): OpenApiClaim[] {
+  return [...runtime.modules, ...runtime.extensions, ...runtime.plugins]
+    .flatMap((unit) =>
+      unit.routes.flatMap(({ route }) =>
+        route.openapi
+          ? [
+              {
+                document: route.openapi.document,
+                mount: resolveVoyantGraphRouteMountPath(unit, route),
+                route,
+                unit,
+              },
+            ]
+          : [],
+      ),
+    )
+    .sort(
+      (left, right) =>
+        left.document.localeCompare(right.document) || left.route.id.localeCompare(right.route.id),
+    )
+}
+
+function validateDocumentClaims(claims: readonly OpenApiClaim[]): void {
+  const byDocument = new Map<string, OpenApiClaim>()
+  for (const claim of claims) {
+    const previous = byDocument.get(claim.document)
+    if (previous) {
+      throw new Error(
+        `Selected graph OpenAPI document "${claim.document}" is claimed by both "${previous.route.id}" and "${claim.route.id}".`,
+      )
+    }
+    byDocument.set(claim.document, claim)
+  }
+}
+
+function routeClaimsMethod(claim: OpenApiClaim, method: string): boolean {
+  return (
+    !claim.route.methods ||
+    claim.route.methods.includes(method.toUpperCase() as VoyantGraphRouteMethod)
+  )
+}
+
+function isWithinMount(path: string, mount: string): boolean {
+  return mount === "/" || path === mount || path.startsWith(`${mount}/`)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -870,6 +870,7 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "./dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": ["./dist/selected-graph-openapi.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -871,6 +871,7 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "./dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": ["./dist/selected-graph-openapi.d.ts"],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/identity/src/voyant.ts
+++ b/packages/identity/src/voyant.ts
@@ -10,6 +10,7 @@ export const identityVoyantModule = defineModule({
       id: "@voyant-travel/identity#api.admin",
       surface: "admin",
       mount: "identity",
+      openapi: { document: "identity" },
       runtime: {
         entry: "@voyant-travel/identity",
         export: "identityHonoModule",

--- a/packages/identity/tests/unit/voyant-manifest.test.ts
+++ b/packages/identity/tests/unit/voyant-manifest.test.ts
@@ -11,6 +11,7 @@ describe("identity deployment manifest", () => {
         {
           id: "@voyant-travel/identity#api.admin",
           surface: "admin",
+          openapi: { document: "identity" },
           runtime: { entry: "@voyant-travel/identity", export: "identityHonoModule" },
         },
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -882,6 +882,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -877,6 +877,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -876,6 +876,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -877,6 +877,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -877,6 +877,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -882,6 +882,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -877,6 +877,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -875,6 +875,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -876,6 +876,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -877,6 +877,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../hono/dist/auth/index.d.ts"],

--- a/scripts/check-deployment-graph-openapi-coverage.mjs
+++ b/scripts/check-deployment-graph-openapi-coverage.mjs
@@ -34,6 +34,10 @@ const HTTP_METHODS = new Set([
 
 const DEFAULT_ALLOWLIST = new Map([
   [
+    "@voyant-travel/accommodations#content-extension.api.public",
+    "the accommodations content extension public routes do not yet expose committed OpenAPI operations",
+  ],
+  [
     "@voyant-travel/public-document-delivery#api.public",
     "public document delivery routes are currently documented through the operator contract-document surface",
   ],
@@ -48,6 +52,10 @@ const DEFAULT_ALLOWLIST = new Map([
   [
     "@voyant-travel/realtime#api.public",
     "realtime public routes are not yet emitted as a storefront OpenAPI document",
+  ],
+  [
+    "@voyant-travel/quotes#proposal-extension.api.public",
+    "the quote proposal extension public routes do not yet expose committed OpenAPI operations",
   ],
   [
     "@voyant-travel/storage#api.admin.media",
@@ -87,9 +95,14 @@ const allowlistedGaps = []
 for (const bundle of bundles) {
   if (!CHECKED_SURFACES.has(bundle.surface)) continue
 
-  const matched = bundle.candidateModules.some((module) =>
-    docs.keys.has(coverageKey(bundle.surface, module)),
-  )
+  if (bundle.openapiDocument && allowlist.has(bundle.apiId)) {
+    failures.push({ kind: "stale-allowlist", bundle })
+    continue
+  }
+
+  const matched = bundle.openapiDocument
+    ? docs.apiIds.has(bundle.apiId)
+    : bundle.candidateModules.some((module) => docs.keys.has(coverageKey(bundle.surface, module)))
   if (matched) {
     coveredBundles.push(bundle)
     if (allowlist.has(bundle.apiId)) {
@@ -143,7 +156,11 @@ console.log(
 )
 
 function readApiBundles(resolvedGraph) {
-  const units = [...arrayOf(resolvedGraph.modules), ...arrayOf(resolvedGraph.plugins)]
+  const units = [
+    ...arrayOf(resolvedGraph.modules),
+    ...arrayOf(resolvedGraph.extensions),
+    ...arrayOf(resolvedGraph.plugins),
+  ]
   const bundles = []
 
   for (const unit of units) {
@@ -158,6 +175,8 @@ function readApiBundles(resolvedGraph) {
         localId: stringOrEmpty(unit.localId),
         packageName: stringOrEmpty(unit.packageName),
         mount: stringOrEmpty(api.mount),
+        openapiDocument:
+          api.openapi && typeof api.openapi === "object" ? stringOrEmpty(api.openapi.document) : "",
         candidateModules: candidateModules(unit, api),
       })
     }
@@ -172,6 +191,7 @@ function readOpenApiCoverage(openapiDirPath) {
   }
 
   const keys = new Set()
+  const apiIds = new Set()
   const files = []
   for (const surfaceEntry of readdirSync(openapiDirPath, { withFileTypes: true })) {
     if (!surfaceEntry.isDirectory()) continue
@@ -188,6 +208,9 @@ function readOpenApiCoverage(openapiDirPath) {
 
       let operationKeys = 0
       for (const operation of operations) {
+        if (typeof operation["x-voyant-api-id"] === "string") {
+          apiIds.add(operation["x-voyant-api-id"])
+        }
         const operationSurface = normalizeSurface(operation["x-voyant-surface"] ?? fileSurface)
         const operationModule = operation["x-voyant-module"] ?? fileModule
         if (typeof operationModule !== "string" || operationModule.length === 0) continue
@@ -200,7 +223,7 @@ function readOpenApiCoverage(openapiDirPath) {
     }
   }
 
-  return { files, keys }
+  return { files, keys, apiIds }
 }
 
 function documentedOperations(doc) {

--- a/scripts/lib/deployment-graph-openapi-coverage-report.mjs
+++ b/scripts/lib/deployment-graph-openapi-coverage-report.mjs
@@ -10,6 +10,7 @@ export function buildDeploymentGraphOpenApiCoverageReport(input, relativePath) {
     localId: bundle.localId,
     packageName: bundle.packageName,
     mount: bundle.mount,
+    ...(bundle.openapiDocument ? { openapiDocument: bundle.openapiDocument } : {}),
     candidateModules: [...bundle.candidateModules].sort(),
   })
   const sortedBundles = (bundles) =>

--- a/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
+++ b/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
@@ -21,8 +21,8 @@ async function createFixture(files) {
   return root
 }
 
-function graph(units) {
-  return `${JSON.stringify({ schemaVersion: "voyant.resolved-graph.v1", modules: units }, null, 2)}\n`
+function graph(units, extensions = [], plugins = []) {
+  return `${JSON.stringify({ schemaVersion: "voyant.resolved-graph.v1", modules: units, extensions, plugins }, null, 2)}\n`
 }
 
 function openapi(paths) {
@@ -283,6 +283,108 @@ describe("check-deployment-graph-openapi-coverage", () => {
         null,
         2,
       ),
+    })
+
+    await assert.rejects(runChecker(root, ["--allowlist", "allowlist.json"]), (error) => {
+      assert.match(error.stderr, /deployment-graph-openapi-coverage:stale-allowlist/)
+      return true
+    })
+  })
+
+  it("requires an exact API id for opted-in bundles instead of filename heuristics", async () => {
+    const root = await createFixture({
+      "graph.json": graph([
+        {
+          id: "@voyant-travel/identity",
+          localId: "identity",
+          packageName: "@voyant-travel/identity",
+          api: [
+            {
+              id: "@voyant-travel/identity#api.admin",
+              surface: "admin",
+              mount: "identity",
+              openapi: { document: "identity" },
+            },
+          ],
+        },
+      ]),
+      "openapi/admin/identity.json": openapi({
+        "/v1/admin/identity": {
+          get: {
+            responses: { 200: { description: "OK" } },
+            "x-voyant-module": "identity",
+            "x-voyant-surface": "admin",
+            "x-voyant-api-id": "@voyant-travel/identity#api.wrong",
+          },
+        },
+      }),
+    })
+
+    await assert.rejects(runChecker(root), (error) => {
+      assert.match(error.stderr, /deployment-graph-openapi-coverage:missing-docs/)
+      assert.match(error.stderr, /@voyant-travel\/identity#api.admin/)
+      return true
+    })
+  })
+
+  it("covers opted-in extension bundles by exact API id", async () => {
+    const extension = {
+      id: "@acme/identity-extension",
+      localId: "identity-extension",
+      packageName: "@acme/identity-extension",
+      api: [
+        {
+          id: "@acme/identity-extension#api.admin",
+          surface: "admin",
+          mount: "identity-extension",
+          openapi: { document: "identity-extension" },
+        },
+      ],
+    }
+    const root = await createFixture({
+      "graph.json": graph([], [extension]),
+      "openapi/admin/custom-name.json": openapi({
+        "/v1/admin/identity-extension": {
+          get: {
+            responses: { 200: { description: "OK" } },
+            "x-voyant-api-id": "@acme/identity-extension#api.admin",
+          },
+        },
+      }),
+    })
+
+    const result = await runChecker(root)
+
+    assert.match(result.stdout, /1 covered graph API bundles/)
+  })
+
+  it("rejects allowlist exceptions for opted-in bundles", async () => {
+    const root = await createFixture({
+      "graph.json": graph([
+        {
+          id: "@voyant-travel/identity",
+          localId: "identity",
+          packageName: "@voyant-travel/identity",
+          api: [
+            {
+              id: "@voyant-travel/identity#api.admin",
+              surface: "admin",
+              openapi: { document: "identity" },
+            },
+          ],
+        },
+      ]),
+      "openapi/admin/identity.json": openapi({
+        "/v1/admin/identity": {
+          get: {
+            responses: { 200: { description: "OK" } },
+            "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+          },
+        },
+      }),
+      "allowlist.json": JSON.stringify({
+        "@voyant-travel/identity#api.admin": "must not mask migrated authority",
+      }),
     })
 
     await assert.rejects(runChecker(root, ["--allowlist", "allowlist.json"]), (error) => {

--- a/starters/operator/openapi/admin/identity.json
+++ b/starters/operator/openapi/admin/identity.json
@@ -358,7 +358,10 @@
         },
         "operationId": "getAdminIdentityContactPoints",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "post": {
         "tags": [
@@ -559,7 +562,10 @@
         },
         "operationId": "postAdminIdentityContactPoints",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/contact-points/{id}": {
@@ -694,7 +700,10 @@
         },
         "operationId": "getAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "patch": {
         "tags": [
@@ -917,7 +926,10 @@
         },
         "operationId": "patchAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "delete": {
         "tags": [
@@ -977,7 +989,10 @@
         },
         "operationId": "deleteAdminIdentityContactPointsById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/addresses": {
@@ -1234,7 +1249,10 @@
         },
         "operationId": "getAdminIdentityAddresses",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "post": {
         "tags": [
@@ -1526,7 +1544,10 @@
         },
         "operationId": "postAdminIdentityAddresses",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/addresses/{id}": {
@@ -1712,7 +1733,10 @@
         },
         "operationId": "getAdminIdentityAddressesById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "patch": {
         "tags": [
@@ -2028,7 +2052,10 @@
         },
         "operationId": "patchAdminIdentityAddressesById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "delete": {
         "tags": [
@@ -2088,7 +2115,10 @@
         },
         "operationId": "deleteAdminIdentityAddressesById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/named-contacts": {
@@ -2304,7 +2334,10 @@
         },
         "operationId": "getAdminIdentityNamedContacts",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "post": {
         "tags": [
@@ -2521,7 +2554,10 @@
         },
         "operationId": "postAdminIdentityNamedContacts",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/named-contacts/{id}": {
@@ -2664,7 +2700,10 @@
         },
         "operationId": "getAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "patch": {
         "tags": [
@@ -2904,7 +2943,10 @@
         },
         "operationId": "patchAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "delete": {
         "tags": [
@@ -2964,7 +3006,10 @@
         },
         "operationId": "deleteAdminIdentityNamedContactsById",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/contact-points": {
@@ -3092,7 +3137,10 @@
         },
         "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdContactPoints",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "post": {
         "tags": [
@@ -3299,7 +3347,10 @@
         },
         "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdContactPoints",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/addresses": {
@@ -3478,7 +3529,10 @@
         },
         "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdAddresses",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "post": {
         "tags": [
@@ -3774,7 +3828,10 @@
         },
         "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdAddresses",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     },
     "/v1/admin/identity/entities/{entityType}/{entityId}/named-contacts": {
@@ -3910,7 +3967,10 @@
         },
         "operationId": "getAdminIdentityEntitiesByEntityTypeByEntityIdNamedContacts",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       },
       "post": {
         "tags": [
@@ -4133,7 +4193,10 @@
         },
         "operationId": "postAdminIdentityEntitiesByEntityTypeByEntityIdNamedContacts",
         "x-voyant-module": "identity",
-        "x-voyant-surface": "admin"
+        "x-voyant-surface": "admin",
+        "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+        "x-voyant-unit-id": "@voyant-travel/identity",
+        "x-voyant-package-name": "@voyant-travel/identity"
       }
     }
   },

--- a/starters/operator/src/api/openapi.test.ts
+++ b/starters/operator/src/api/openapi.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import { join } from "node:path"
-import { selectSurface } from "@voyant-travel/hono/openapi"
+import { type OpenApiDocument, selectSurface } from "@voyant-travel/hono/openapi"
 import { describe, expect, it } from "vitest"
-import { buildOperatorOpenApiDocuments } from "./openapi.js"
+import { buildOperatorOpenApiDocuments, mergeOperatorOpenApiModuleDocuments } from "./openapi.js"
 
 /**
  * OpenAPI drift gate for the operator deployment (voyant#2733, was #2114).
@@ -88,6 +88,103 @@ describe("operator openapi spec", () => {
 
   it("emits at least one per-module document", () => {
     expect(Object.keys(perModule).length).toBeGreaterThan(0)
+  })
+
+  it("emits identity from its exact selected graph API authority", () => {
+    const identity = docs.modules.get("identity")
+    const operations = Object.values(identity?.paths ?? {}).flatMap((pathItem) =>
+      Object.values(pathItem ?? {}).filter(
+        (value): value is Record<string, unknown> =>
+          typeof value === "object" && value !== null && "responses" in value,
+      ),
+    )
+
+    expect(operations.length).toBeGreaterThan(0)
+    expect(new Set(operations.map((operation) => operation["x-voyant-api-id"]))).toEqual(
+      new Set(["@voyant-travel/identity#api.admin"]),
+    )
+    expect(
+      operations.every(
+        (operation) =>
+          operation["x-voyant-unit-id"] === "@voyant-travel/identity" &&
+          operation["x-voyant-package-name"] === "@voyant-travel/identity",
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps every module path in exactly one Scalar-discoverable document", () => {
+    const owners = new Map<string, string>()
+    for (const [document, moduleDoc] of docs.modules) {
+      for (const path of Object.keys(moduleDoc.paths ?? {})) {
+        expect(
+          owners.get(path),
+          `${path} appears in ${owners.get(path)} and ${document}`,
+        ).toBeUndefined()
+        owners.set(path, document)
+      }
+    }
+  })
+
+  it("rejects graph replacement drift and cross-document duplicate paths", () => {
+    const operation = { operationId: "getAdminIdentity", responses: { 200: { description: "OK" } } }
+    const compatibility = new Map([
+      [
+        "identity",
+        {
+          openapi: "3.1.0",
+          info: { title: "x", version: "1" },
+          paths: { "/v1/admin/identity": { get: operation } },
+        },
+      ],
+      [
+        "bookings",
+        {
+          openapi: "3.1.0",
+          info: { title: "x", version: "1" },
+          paths: { "/v1/admin/bookings": { get: operation } },
+        },
+      ],
+    ]) as never
+    const graphIdentity: OpenApiDocument = {
+      openapi: "3.1.0",
+      info: { title: "x", version: "1" },
+      paths: {
+        "/v1/admin/identity": {
+          get: {
+            ...operation,
+            "x-voyant-api-id": "@voyant-travel/identity#api.admin",
+            "x-voyant-unit-id": "@voyant-travel/identity",
+            "x-voyant-package-name": "@voyant-travel/identity",
+          },
+        },
+      },
+    } as OpenApiDocument
+    const identityPath = graphIdentity.paths?.["/v1/admin/identity"]
+    if (!identityPath) throw new Error("expected identity fixture path")
+
+    expect(
+      mergeOperatorOpenApiModuleDocuments(compatibility, new Map([["identity", graphIdentity]])),
+    ).toHaveProperty("size", 2)
+    expect(() =>
+      mergeOperatorOpenApiModuleDocuments(
+        compatibility,
+        new Map([
+          [
+            "other",
+            {
+              ...graphIdentity,
+              paths: { "/v1/admin/bookings": identityPath },
+            } as never,
+          ],
+        ]),
+      ),
+    ).toThrow(/duplicates path/)
+    expect(() =>
+      mergeOperatorOpenApiModuleDocuments(
+        compatibility,
+        new Map([["identity", { ...graphIdentity, paths: {} } as never]]),
+      ),
+    ).toThrow(/does not preserve/)
   })
 
   it("keeps every per-module path within the aggregate (no invented routes)", () => {

--- a/starters/operator/src/api/openapi.ts
+++ b/starters/operator/src/api/openapi.ts
@@ -1,3 +1,4 @@
+import { buildSelectedGraphOpenApiDocuments } from "@voyant-travel/framework/selected-graph-openapi"
 import {
   buildModulePathOwnership,
   type GenerateOpenApiOptions,
@@ -8,7 +9,24 @@ import {
   selectSurface,
   stampModuleMetadata,
 } from "@voyant-travel/hono/openapi"
+import { createGeneratedGraphRuntime } from "../../.voyant/runtime/graph-runtime.generated"
 import { app } from "./app.js"
+
+const GRAPH_OWNERSHIP_FIELDS = [
+  "x-voyant-api-id",
+  "x-voyant-unit-id",
+  "x-voyant-package-name",
+] as const
+const OPENAPI_HTTP_METHODS = new Set([
+  "delete",
+  "get",
+  "head",
+  "options",
+  "patch",
+  "post",
+  "put",
+  "trace",
+])
 
 const OPENAPI_OPTIONS: GenerateOpenApiOptions = {
   info: {
@@ -60,10 +78,69 @@ export async function buildOperatorOpenApiDocuments(): Promise<OperatorOpenApiDo
   // directly-mounted routes aren't dropped.
   const owner = await buildModulePathOwnership(app.moduleMounts ?? [], options)
   const full = stampModuleMetadata(merged, owner)
+  const compatibilityModules = partitionByModule(full, owner)
+  const graphModules = await buildSelectedGraphOpenApiDocuments({
+    runtime: createGeneratedGraphRuntime(),
+    app,
+    options,
+  })
   return {
     full,
     admin: selectSurface(full, "admin"),
     storefront: selectSurface(full, "storefront"),
-    modules: partitionByModule(full, owner),
+    modules: mergeOperatorOpenApiModuleDocuments(compatibilityModules, graphModules),
   }
+}
+
+/** Replace migrated compatibility documents only after proving contract parity. */
+export function mergeOperatorOpenApiModuleDocuments(
+  compatibility: ReadonlyMap<string, OpenApiDocument>,
+  graph: ReadonlyMap<string, OpenApiDocument>,
+): Map<string, OpenApiDocument> {
+  const merged = new Map(compatibility)
+  for (const [document, graphDocument] of graph) {
+    const compatibilityDocument = compatibility.get(document)
+    if (compatibilityDocument) {
+      const expected = JSON.stringify(compatibilityDocument)
+      const actual = JSON.stringify(withoutGraphOwnership(graphDocument))
+      if (actual !== expected) {
+        throw new Error(
+          `Selected graph OpenAPI document "${document}" does not preserve its Operator compatibility document.`,
+        )
+      }
+    }
+
+    const graphPaths = new Set(Object.keys(graphDocument.paths ?? {}))
+    for (const [compatibilityName, compatibilityDoc] of compatibility) {
+      if (compatibilityName === document) continue
+      const duplicate = Object.keys(compatibilityDoc.paths ?? {}).find((path) =>
+        graphPaths.has(path),
+      )
+      if (duplicate) {
+        throw new Error(
+          `Selected graph OpenAPI document "${document}" duplicates path "${duplicate}" from compatibility document "${compatibilityName}".`,
+        )
+      }
+    }
+    merged.set(document, graphDocument)
+  }
+  return merged
+}
+
+function withoutGraphOwnership(document: OpenApiDocument): OpenApiDocument {
+  const paths = Object.fromEntries(
+    Object.entries(document.paths ?? {}).map(([path, pathItem]) => {
+      if (!pathItem || typeof pathItem !== "object") return [path, pathItem]
+      const nextItem = { ...pathItem } as Record<string, unknown>
+      for (const [method, value] of Object.entries(nextItem)) {
+        if (!OPENAPI_HTTP_METHODS.has(method.toLowerCase())) continue
+        if (!value || typeof value !== "object") continue
+        const operation = { ...value } as Record<string, unknown>
+        for (const field of GRAPH_OWNERSHIP_FIELDS) Reflect.deleteProperty(operation, field)
+        nextItem[method] = operation
+      }
+      return [path, nextItem]
+    }),
+  )
+  return { ...document, paths } as OpenApiDocument
 }

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../../packages/framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../../packages/framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../../packages/hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../../packages/hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../../packages/hono/dist/auth/index.d.ts"],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/framework/project-workflow-job-conventions": [
         "../../packages/framework/dist/project-workflow-job-conventions.d.ts"
       ],
+      "@voyant-travel/framework/selected-graph-openapi": [
+        "../../packages/framework/dist/selected-graph-openapi.d.ts"
+      ],
       "@voyant-travel/hono": ["../../packages/hono/dist/index.d.ts"],
       "@voyant-travel/hono/app": ["../../packages/hono/dist/app.d.ts"],
       "@voyant-travel/hono/auth": ["../../packages/hono/dist/auth/index.d.ts"],


### PR DESCRIPTION
## Summary

- add route-owned `openapi.document` metadata with graph validation and deterministic lowering
- emit selected module, extension, and plugin OpenAPI documents at build time with exact API, unit, and package ownership
- migrate `@voyant-travel/identity#api.admin` while preserving the Operator compatibility contract and Scalar document discovery
- require exact API-ID coverage for opted-in bundles and include extensions in coverage

## Validation

- framework focused tests: 58 passed
- operator OpenAPI tests: 56 passed
- OpenAPI coverage checker tests: 10 passed
- core and identity typechecks passed
- framework source-focused TypeScript checks passed
- core, framework, identity, and operator lint passed
- deployment graph emit/check and import-cheap checker passed

## Notes

- The full framework typecheck was stopped after repeated multi-minute resource contention with no diagnostics; focused source TypeScript checks passed.
- Package export verification was blocked by pre-existing missing build outputs in unrelated packages.