### PR TITLE
feat(mice): lower selected graph admin runtime

### DIFF
--- a/.changeset/calm-mice-admin.md
+++ b/.changeset/calm-mice-admin.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/mice": minor
+---
+
+Declare the package-owned MICE admin factory as a selected-graph runtime while
+preserving its existing routes and host-supplied navigation options.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -792,10 +792,11 @@ separate first-party admin catalog.
 
 ### Selected-graph admin bundle cutline
 
-The first Phase 4 admin slice is active for `@voyant-travel/action-ledger`:
+The first Phase 4 admin slices are active for `@voyant-travel/action-ledger` and
+`@voyant-travel/mice`:
 
 - the package manifest opts its import-cheap admin extension factory into
-  `admin.runtime` and retains the stable Logs route declaration
+  `admin.runtime` and retains its stable route declarations
 - project resolution emits `.voyant/admin/selected-graph-admin.generated.ts`
   from only selected units with `admin.runtime`; package page modules remain
   behind the lazy imports owned by the UI export
@@ -1387,10 +1388,10 @@ package surfaces in `voyant#3080`.
   namespaced copy and deployment overrides
 - generate the admin bundle only from selected package exports and graph data
 
-Progress: the action-ledger nav/route/page factory is the first package lowered
-into the selected-graph admin bundle. Slots/contributions, copy, and the
-remaining first-party Operator compatibility registry are not part of this
-slice.
+Progress: the action-ledger and MICE nav/route/page factories are lowered into
+the selected-graph admin bundle. The Operator still owns their lightweight
+localization/icon wrappers. Slots/contributions, copy, and the remaining
+first-party Operator compatibility registry are not part of this slice.
 
 Exit: a custom package contributes a secured, documented API and complete admin
 surface without operator edits; all grants and message references validate.

--- a/packages/mice-react/src/admin/admin-manifest.test.ts
+++ b/packages/mice-react/src/admin/admin-manifest.test.ts
@@ -6,9 +6,17 @@ import { createMiceAdminExtension } from "./index.js"
 describe("MICE admin deployment facets", () => {
   it("tracks the package-owned extension routes", () => {
     const extension = createMiceAdminExtension()
+    expect(miceVoyantModule.admin?.runtime).toEqual({
+      entry: "@voyant-travel/mice-react/admin",
+      export: "createMiceAdminExtension",
+    })
     expect(miceVoyantModule.admin?.routes?.map((route) => route.path)).toEqual(
       extension.routes?.map((route) => route.path),
     )
+    expect(extension.routes?.map((route) => route.destination)).toEqual([
+      "mice.program.list",
+      "mice.program.detail",
+    ])
     expect(miceVoyantModule.admin?.routes?.map((route) => route.runtime)).toEqual(
       extension.routes?.map(() => ({
         entry: "@voyant-travel/mice-react/admin",

--- a/packages/mice/src/voyant.ts
+++ b/packages/mice/src/voyant.ts
@@ -47,6 +47,10 @@ export const miceVoyantModule = defineModule({
     },
   ],
   admin: {
+    runtime: {
+      entry: "@voyant-travel/mice-react/admin",
+      export: "createMiceAdminExtension",
+    },
     routes: [
       {
         id: "@voyant-travel/mice#admin.route.programs-index",

--- a/packages/mice/tests/unit/voyant-manifest.test.ts
+++ b/packages/mice/tests/unit/voyant-manifest.test.ts
@@ -20,6 +20,22 @@ describe("MICE deployment manifests", () => {
       ],
       schema: [{ id: "@voyant-travel/mice#schema" }],
       migrations: [{ id: "@voyant-travel/mice#migrations" }],
+      admin: {
+        runtime: {
+          entry: "@voyant-travel/mice-react/admin",
+          export: "createMiceAdminExtension",
+        },
+        routes: [
+          {
+            id: "@voyant-travel/mice#admin.route.programs-index",
+            path: "/mice",
+          },
+          {
+            id: "@voyant-travel/mice#admin.route.programs-detail",
+            path: "/mice/$id",
+          },
+        ],
+      },
       links: [
         { id: "@voyant-travel/mice#linkable.program" },
         { id: "@voyant-travel/mice#linkable.session" },

--- a/starters/operator/src/admin.extensions.generated.ts
+++ b/starters/operator/src/admin.extensions.generated.ts
@@ -10,7 +10,6 @@ import { createFinanceAdminExtension } from "@voyant-travel/finance-react/admin"
 import { createFlightsAdminExtension } from "@voyant-travel/flights-react/admin"
 import { createInventoryAdminExtension } from "@voyant-travel/inventory-react/admin"
 import { createLegalAdminExtension } from "@voyant-travel/legal-react/admin"
-import { createMiceAdminExtension } from "@voyant-travel/mice-react/admin"
 import { createNotificationsAdminExtension } from "@voyant-travel/notifications-react/admin"
 import { createOperationsAdminExtension } from "@voyant-travel/operations-react/admin"
 import { createQuotesAdminExtension } from "@voyant-travel/quotes-react/admin"
@@ -31,7 +30,6 @@ export const generatedAdminExtensionFactories = {
   flights: createFlightsAdminExtension,
   inventory: createInventoryAdminExtension,
   legal: createLegalAdminExtension,
-  mice: createMiceAdminExtension,
   notifications: createNotificationsAdminExtension,
   operations: createOperationsAdminExtension,
   quotes: createQuotesAdminExtension,

--- a/starters/operator/src/lib/admin-extensions.tsx
+++ b/starters/operator/src/lib/admin-extensions.tsx
@@ -626,7 +626,7 @@ function createQuotesExtension(messages: AdminExtensionNavMessages) {
 // program's per-currency cost sheet lives. The app only supplies the localized
 // label and the icon.
 function createMiceExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.mice({
+  return selectedGraphAdminExtensionFactories["@voyant-travel/mice"]({
     labels: { programs: messages.mice },
     icon: CalendarRange,
   })

--- a/starters/operator/src/selected-graph-mice-admin.test.ts
+++ b/starters/operator/src/selected-graph-mice-admin.test.ts
@@ -1,0 +1,55 @@
+import { operatorAdminNavMessages } from "@voyant-travel/i18n"
+import { CalendarRange } from "lucide-react"
+import { describe, expect, it } from "vitest"
+
+import { selectedGraphAdminExtensionFactories } from "../.voyant/admin/selected-graph-admin.generated.js"
+import { generatedAdminExtensionFactories } from "./admin.extensions.generated.js"
+import { createOperatorAdminExtensions } from "./lib/admin-extensions.js"
+
+describe("selected-graph MICE admin composition", () => {
+  it("uses the selected package factory without compatibility duplication", () => {
+    expect(selectedGraphAdminExtensionFactories["@voyant-travel/mice"]).toBeTypeOf("function")
+    expect("mice" in generatedAdminExtensionFactories).toBe(false)
+  })
+
+  it("preserves MICE navigation, routes, and destinations through host options", () => {
+    const extension = createOperatorAdminExtensions(operatorAdminNavMessages.ro.nav).find(
+      ({ id }) => id === "mice",
+    )
+
+    expect(extension?.navigation).toEqual([
+      {
+        insertAfter: "bookings",
+        items: [
+          {
+            id: "mice-programs",
+            title: "Programe",
+            url: "/mice",
+            icon: CalendarRange,
+          },
+        ],
+      },
+    ])
+    expect(
+      extension?.routes?.map(({ id, path, destination, destinationParams }) => ({
+        id,
+        path,
+        destination,
+        destinationParams,
+      })),
+    ).toEqual([
+      {
+        id: "mice-programs-index",
+        path: "/mice",
+        destination: "mice.program.list",
+        destinationParams: undefined,
+      },
+      {
+        id: "mice-programs-detail",
+        path: "/mice/$id",
+        destination: "mice.program.detail",
+        destinationParams: { id: "programId" },
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- declare the existing MICE admin factory as the package-selected `admin.runtime`
- compose MICE through the selected-graph factory while preserving Romanian `Programe`, `CalendarRange`, routes, and destinations
- remove the MICE compatibility registry entry and add dedicated package/operator parity coverage

Part of #3080.

## Verification

- `pnpm --filter @voyant-travel/mice test`
- `pnpm --filter @voyant-travel/mice typecheck`
- `pnpm --filter @voyant-travel/mice-react test`
- `pnpm --filter @voyant-travel/mice-react typecheck`
- `pnpm --filter operator exec vitest run src/selected-graph-mice-admin.test.ts`
- `pnpm --filter operator admin:check`
- `pnpm verify:admin-composition-drift`
- `pnpm --filter @voyant-travel/mice lint`
- `pnpm --filter @voyant-travel/mice-react lint`
- `pnpm --filter operator lint`