### PR TITLE
refactor(finance): activate booking schedule subscriber

### DIFF
--- a/.changeset/finance-booking-schedule-cutover.md
+++ b/.changeset/finance-booking-schedule-cutover.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+"@voyant-travel/framework": patch
+---
+
+Activate the package-owned booking-schedule subscriber through selected graph lowering and shared host-provided runtime capabilities.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -975,7 +975,6 @@ it no longer lists or implements those three subscriber handlers.
 
 The remaining Operator subscriber authorities are intentionally explicit:
 
-- `bookingScheduleBundle`: `booking.confirmed`
 - `catalogBridgeBundle`: `product.created`, `product.updated`,
   `product.deleted`, `product.content.changed`, `availability.slot.changed`,
   `pricing.rule.changed`, `product.publication.changed`, `promotion.changed`,
@@ -991,14 +990,14 @@ references and direct selected-graph parity. Deployment-local ordering,
 configuration, or orchestration is not sufficient reason to relabel a standard
 package subscriber as migrated.
 
-Finance now owns the inert `booking.confirmed` declaration for booking-schedule
-generation and exports a subscriber descriptor factory from
-`@voyant-travel/finance/booking-schedule-subscriber`. The factory preserves the
-existing generation-then-covered-settlement behavior through deployment-injected
-booking-schedule options and database lifecycle resolution. Its manifest entry
-intentionally omits a runtime reference while the central Operator bundle
-remains active; direct selected-graph activation must remove that central
-registration in the same change to avoid duplicate event handling.
+Finance owns and executes booking-schedule generation from its selected
+`booking.confirmed` subscriber runtime. Operator contributes only the payment
+policy options and database lifecycle service through the selected extension's
+graph runtime binding; it no longer declares or registers a parallel subscriber.
+The package handler preserves generation followed by covered-schedule settlement
+and logs processing failures. This cutover adds no ordering guarantee relative
+to Legal or any other `booking.confirmed` subscriber because the event bus runs
+independent handlers in parallel.
 
 The broader event catalog is beyond the foundational substrate:
 

--- a/packages/finance/src/booking-schedule/subscriber-runtime.ts
+++ b/packages/finance/src/booking-schedule/subscriber-runtime.ts
@@ -1,4 +1,4 @@
-import type { SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { ModuleContainer, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import {
@@ -9,13 +9,17 @@ import { settleCoveredBookingPaymentSchedules } from "../service-shared.js"
 
 export const FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID =
   "@voyant-travel/finance#subscriber.booking-schedule-confirmed"
+export const BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY = "finance.bookingScheduleSubscriberRuntime"
 
-export interface BookingScheduleSubscriberRuntimeOptions<TBindings = unknown> {
+export interface BookingScheduleSubscriberRuntime {
   resolveRoutesOptions(
-    bindings: TBindings,
+    bindings: unknown,
   ): BookingScheduleRoutesOptions | Promise<BookingScheduleRoutesOptions>
   /** Resolve the deployment database and retain ownership of its lifecycle. */
-  withDb<T>(bindings: TBindings, operation: (db: PostgresJsDatabase) => Promise<T>): Promise<T>
+  withDb<T>(bindings: unknown, operation: (db: PostgresJsDatabase) => Promise<T>): Promise<T>
+}
+
+export interface BookingScheduleSubscriberDependencies {
   generateSchedule?: typeof generatePaymentScheduleForBooking
   settleCoveredSchedules?: typeof settleCoveredBookingPaymentSchedules
   logger?: Pick<Console, "error">
@@ -27,24 +31,24 @@ interface BookingConfirmedPayload {
   actorId: string | null
 }
 
-/** Build the executable descriptor without activating it in the package manifest. */
-export function createBookingScheduleSubscriberRuntime<TBindings = unknown>(
-  options: BookingScheduleSubscriberRuntimeOptions<TBindings>,
+/** Build the package-owned descriptor resolved by selected-graph lowering. */
+export function createBookingScheduleSubscriberRuntime(
+  dependencies: BookingScheduleSubscriberDependencies = {},
 ): SubscriberRuntimeDescriptor {
-  const generateSchedule = options.generateSchedule ?? generatePaymentScheduleForBooking
+  const generateSchedule = dependencies.generateSchedule ?? generatePaymentScheduleForBooking
   const settleCoveredSchedules =
-    options.settleCoveredSchedules ?? settleCoveredBookingPaymentSchedules
-  const logger = options.logger ?? console
+    dependencies.settleCoveredSchedules ?? settleCoveredBookingPaymentSchedules
+  const logger = dependencies.logger ?? console
 
   return {
     id: FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID,
     eventType: "booking.confirmed",
-    register: ({ bindings, eventBus }) => {
-      const runtimeBindings = bindings as TBindings
+    register: ({ bindings, container, eventBus }) => {
       eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
         try {
-          const routesOptions = await options.resolveRoutesOptions(runtimeBindings)
-          await options.withDb(runtimeBindings, async (db) => {
+          const runtime = resolveBookingScheduleSubscriberRuntime(container)
+          const routesOptions = await runtime.resolveRoutesOptions(bindings)
+          await runtime.withDb(bindings, async (db) => {
             await generateSchedule(db, data.bookingId, routesOptions)
             await settleCoveredSchedules(db, data.bookingId)
           })
@@ -58,3 +62,18 @@ export function createBookingScheduleSubscriberRuntime<TBindings = unknown>(
     },
   }
 }
+
+function resolveBookingScheduleSubscriberRuntime(
+  container: ModuleContainer,
+): BookingScheduleSubscriberRuntime {
+  if (!container.has(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY)) {
+    throw new Error(
+      `Booking-schedule subscriber runtime is not registered at "${BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY}".`,
+    )
+  }
+  return container.resolve<BookingScheduleSubscriberRuntime>(
+    BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY,
+  )
+}
+
+export const bookingScheduleConfirmedSubscriber = createBookingScheduleSubscriberRuntime()

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -257,6 +257,10 @@ export const financeBookingScheduleVoyantPlugin = defineExtension({
       id: "@voyant-travel/finance#subscriber.booking-schedule-confirmed",
       eventType: "booking.confirmed",
       source: "@voyant-travel/finance/booking-schedule-subscriber",
+      runtime: {
+        entry: "./booking-schedule-subscriber",
+        export: "bookingScheduleConfirmedSubscriber",
+      },
     },
   ],
   meta: {

--- a/packages/finance/tests/unit/booking-schedule-subscriber-runtime.test.ts
+++ b/packages/finance/tests/unit/booking-schedule-subscriber-runtime.test.ts
@@ -2,6 +2,7 @@ import type { EventEnvelope } from "@voyant-travel/core"
 import { createContainer, createEventBus } from "@voyant-travel/core"
 import { describe, expect, it, vi } from "vitest"
 import {
+  BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY,
   createBookingScheduleSubscriberRuntime,
   FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID,
 } from "../../src/booking-schedule/subscriber-runtime.js"
@@ -27,19 +28,22 @@ describe("finance booking-schedule subscriber runtime", () => {
       return operation(db)
     })
     const eventBus = createEventBus()
+    const container = createContainer()
+    container.register(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY, {
+      resolveRoutesOptions,
+      withDb,
+    })
     let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
     vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
       handler = registeredHandler as typeof handler
       return { unsubscribe: vi.fn() }
     })
     const descriptor = createBookingScheduleSubscriberRuntime({
-      resolveRoutesOptions,
-      withDb,
       generateSchedule,
       settleCoveredSchedules,
     })
 
-    await descriptor.register({ bindings, container: createContainer(), eventBus })
+    await descriptor.register({ bindings, container, eventBus })
 
     expect({ id: descriptor.id, eventType: descriptor.eventType }).toEqual({
       id: FINANCE_BOOKING_SCHEDULE_SUBSCRIBER_ID,
@@ -64,19 +68,22 @@ describe("finance booking-schedule subscriber runtime", () => {
     const error = new Error("database unavailable")
     const logger = { error: vi.fn() }
     const eventBus = createEventBus()
+    const container = createContainer()
+    container.register(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY, {
+      resolveRoutesOptions: () => routesOptions,
+      withDb: async () => {
+        throw error
+      },
+    })
     let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
     vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
       handler = registeredHandler as typeof handler
       return { unsubscribe: vi.fn() }
     })
     const descriptor = createBookingScheduleSubscriberRuntime({
-      resolveRoutesOptions: () => routesOptions,
-      withDb: async () => {
-        throw error
-      },
       logger,
     })
-    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+    await descriptor.register({ bindings: {}, container, eventBus })
 
     await expect(
       handler?.({

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -103,10 +103,13 @@ describe("finance deployment manifest", () => {
           id: "@voyant-travel/finance#subscriber.booking-schedule-confirmed",
           eventType: "booking.confirmed",
           source: "@voyant-travel/finance/booking-schedule-subscriber",
+          runtime: {
+            entry: "./booking-schedule-subscriber",
+            export: "bookingScheduleConfirmedSubscriber",
+          },
         },
       ],
     })
-    expect(financeBookingScheduleVoyantPlugin.subscribers?.[0]).not.toHaveProperty("runtime")
   })
 
   it("declares finance routes and existing cross-package widgets", () => {

--- a/packages/framework/src/composition-lazy.ts
+++ b/packages/framework/src/composition-lazy.ts
@@ -9,6 +9,8 @@ import type {
 } from "@voyant-travel/bookings"
 import type { CatalogSearchRoutesOptions } from "@voyant-travel/catalog"
 import type { BootstrapHandler } from "@voyant-travel/core"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { BookingScheduleRoutesOptions } from "@voyant-travel/finance"
 import type { CheckoutNotificationDelivery } from "@voyant-travel/finance/checkout"
 import type { CheckoutReminderRunRecord } from "@voyant-travel/finance/checkout-validation"
 import type { LazyRoutesLoader } from "@voyant-travel/hono"
@@ -40,6 +42,8 @@ export interface FrameworkProviders {
   resolveDocumentDownloadUrl: (bindings: unknown, storageKey: string) => Promise<string | null>
   resolveNotificationProviders: NonNullable<StorefrontVerificationRoutesOptions["resolveProviders"]>
   createTripsRoutesOptions: TripsRoutesOptionsProvider
+  /** Runs out-of-request work with a deployment-owned database lifecycle. */
+  withDb?: <T>(bindings: unknown, operation: (db: AnyDrizzleDb) => Promise<T>) => Promise<T>
   resolveDb: NonNullable<CreateLegalHonoModuleOptions["resolveDb"]>
   createOperatorDocumentStorage: NonNullable<CreateLegalHonoModuleOptions["resolveDocumentStorage"]>
   resolveContractDocumentGenerator: NonNullable<
@@ -92,6 +96,9 @@ export interface FrameworkProviders {
   loadInventoryBrochureRoutes: LazyRoutesLoader
   loadPaymentLinkRoutes: LazyRoutesLoader
   loadContractDocumentRoutes: LazyRoutesLoader
+  createBookingScheduleRoutesOptions: () =>
+    | BookingScheduleRoutesOptions
+    | Promise<BookingScheduleRoutesOptions>
   loadBookingScheduleAdminRoutes: LazyRoutesLoader
   loadPaymentPolicyPublicRoutes: LazyRoutesLoader
   loadQuoteVersionSnapshotRoutes: LazyRoutesLoader
@@ -943,7 +950,20 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
       },
     }),
     "@voyant-travel/finance/booking-schedule-extension": ({ capabilities }) => ({
-      extension: { name: "booking-schedule", module: "bookings" },
+      extension: {
+        name: "booking-schedule",
+        module: "bookings",
+        bootstrap: async ({ container }) => {
+          const { BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY } = await import(
+            "@voyant-travel/finance/booking-schedule-subscriber"
+          )
+          container.register(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY, {
+            resolveRoutesOptions: capabilities.createBookingScheduleRoutesOptions,
+            withDb: <T>(runtimeBindings: unknown, operation: (db: AnyDrizzleDb) => Promise<T>) =>
+              runWithFrameworkDb(capabilities, runtimeBindings, operation),
+          })
+        },
+      },
       publicPath: "payment-policy",
       lazyAdminRoutes: capabilities.loadBookingScheduleAdminRoutes,
       lazyPublicRoutes: capabilities.loadPaymentPolicyPublicRoutes,
@@ -976,4 +996,14 @@ export const frameworkComposition: CompositionRegistry<FrameworkProviders> = {
       lazyPublicRoutes: capabilities.loadCatalogCheckoutRoutes,
     }),
   },
+}
+
+function runWithFrameworkDb<T>(
+  capabilities: FrameworkProviders,
+  bindings: unknown,
+  operation: (db: AnyDrizzleDb) => Promise<T>,
+): Promise<T> {
+  return capabilities.withDb
+    ? capabilities.withDb(bindings, operation)
+    : operation(capabilities.resolveDb(bindings as Record<string, unknown>))
 }

--- a/packages/framework/src/composition-policy.test.ts
+++ b/packages/framework/src/composition-policy.test.ts
@@ -1,3 +1,4 @@
+import { createContainer } from "@voyant-travel/core"
 import type { CompositionContext } from "@voyant-travel/hono/composition"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import { type FrameworkProviders, frameworkComposition } from "./composition-lazy.js"
@@ -195,5 +196,36 @@ describe("frameworkComposition policy injection", () => {
         "/v1/public/cruises/:id/sailings/:sailingExternalId/pricing",
       ]),
     )
+  })
+
+  it("registers the booking-schedule subscriber runtime for every graph host", async () => {
+    const db = { source: "managed" }
+    const options = { resolveDb: vi.fn() }
+    const withDb = vi.fn(async (_bindings, operation) => operation(db as never))
+    const extension = frameworkComposition.extensions?.[
+      "@voyant-travel/finance/booking-schedule-extension"
+    ]?.(
+      compositionContext({
+        createBookingScheduleRoutesOptions: () => options as never,
+        loadBookingScheduleAdminRoutes: vi.fn(),
+        loadPaymentPolicyPublicRoutes: vi.fn(),
+        resolveDb: () => db as never,
+        withDb,
+      }),
+    )
+    if (Array.isArray(extension)) throw new Error("expected one booking-schedule extension")
+    const container = createContainer()
+    await extension?.extension.bootstrap?.({ container, bindings: { host: "managed" } } as never)
+    const { BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY } = await import(
+      "@voyant-travel/finance/booking-schedule-subscriber"
+    )
+    const runtime = container.resolve<{
+      resolveRoutesOptions(): unknown
+      withDb<T>(bindings: unknown, operation: (value: unknown) => Promise<T>): Promise<T>
+    }>(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY)
+
+    expect(await runtime.resolveRoutesOptions()).toBe(options)
+    await expect(runtime.withDb({}, async (value) => value)).resolves.toBe(db)
+    expect(withDb).toHaveBeenCalledOnce()
   })
 })

--- a/packages/framework/src/managed-runtime.ts
+++ b/packages/framework/src/managed-runtime.ts
@@ -614,6 +614,7 @@ export function createManagedProfileProviders(
     createInvoiceExchangeRateResolver: createInvoiceExchangeRateResolver,
     createInvoiceSettlementPollers: () => ({}),
     createTripsRoutesOptions: async () => ({}),
+    withDb: async (bindings, operation) => operation(resolveDb(bindings)),
     storefrontIntakePersistence: createNoopStorefrontIntakePersistence(),
     resolvePaymentStarters: () => ({}),
     resolveCardPaymentStarter: () => null,
@@ -629,6 +630,7 @@ export function createManagedProfileProviders(
     loadPaymentLinkRoutes: async () =>
       createManagedPaymentLinkRoutes(providers.resolveCardPaymentStarter),
     loadContractDocumentRoutes: async () => createManagedContractDocumentRoutes(),
+    createBookingScheduleRoutesOptions: createManagedBookingScheduleRoutesOptions,
     loadBookingScheduleAdminRoutes: createManagedBookingScheduleAdminRoutes,
     loadPaymentPolicyPublicRoutes: createManagedPaymentPolicyPublicRoutes,
     loadQuoteVersionSnapshotRoutes: createManagedQuoteVersionSnapshotRoutes,

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -443,6 +443,34 @@ async function main(): Promise<void> {
       "expected package-owned distribution subscribers to stay absent from Operator hand lists and route wiring",
     )
   }
+  const bookingScheduleUnit = operatorGraph.extensions.find(
+    (unit) => unit.id === "@voyant-travel/finance#booking-schedule-extension",
+  )
+  const bookingScheduleSubscriber = bookingScheduleUnit?.subscribers.find(
+    (subscriber) =>
+      subscriber.id === "@voyant-travel/finance#subscriber.booking-schedule-confirmed",
+  )
+  if (
+    bookingScheduleSubscriber?.runtime?.entry !== "./booking-schedule-subscriber" ||
+    bookingScheduleSubscriber.runtime.export !== "bookingScheduleConfirmedSubscriber"
+  ) {
+    failures.push(
+      "expected Finance booking-schedule subscriber to retain its package-owned runtime reference",
+    )
+  }
+  const operatorBookingScheduleSource = await readFile(
+    join(operatorRoot, "src/api/routes/booking-schedule.ts"),
+    "utf8",
+  )
+  if (
+    operatorAppSource.includes("bookingScheduleBundle") ||
+    operatorBookingScheduleSource.includes("bookingScheduleBundle") ||
+    operatorBookingScheduleSource.includes("eventBus.subscribe")
+  ) {
+    failures.push(
+      "expected package-owned Finance booking-schedule subscriber to stay absent from Operator hand lists and route wiring",
+    )
+  }
   for (const specifier of OPERATOR_SCHEMA_ONLY_MODULE_SPECIFIERS) {
     const id = graphIdFromSpecifier(specifier)
     if (!operatorModuleIds.has(id)) {

--- a/starters/operator/src/api/app.ts
+++ b/starters/operator/src/api/app.ts
@@ -20,7 +20,6 @@ import {
   operatorGraphRuntimeBindings,
 } from "./composition"
 import { dbFromEnvForApp, httpDbFromEnvForApp } from "./lib/db"
-import { bookingScheduleBundle } from "./routes/booking-schedule"
 import {
   createOperatorWorkflowDriver,
   generateContractPdfForBooking,
@@ -107,10 +106,6 @@ export const app = mountApp<AppBindings>({
         )
       },
     },
-    // bookingScheduleBundle subscribes to booking.confirmed BEFORE
-    // legal's auto-generate-contract subscriber so the rendered
-    // contract reads the freshly-written deposit/balance rows.
-    bookingScheduleBundle,
     catalogBridgeBundle,
     createCatalogCheckoutBundle({
       workflowRunnerRegistry,

--- a/starters/operator/src/api/composition.test.ts
+++ b/starters/operator/src/api/composition.test.ts
@@ -1,7 +1,9 @@
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import { BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY } from "@voyant-travel/finance/booking-schedule-subscriber"
 import { composeVoyantGraphRuntime } from "@voyant-travel/framework"
 import { realtimeRuntimePort } from "@voyant-travel/realtime"
 import { storageMediaRuntimePort } from "@voyant-travel/storage/routes"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   createGeneratedGraphRuntime,
@@ -74,6 +76,54 @@ describe("operator graph runtime composition", () => {
         (module) => module.module.name === "distribution.channel-push-extension.graph-runtime",
       )?.module.bootstrap,
     ).toBeTypeOf("function")
+  })
+
+  it("registers the selected Finance booking-schedule subscriber exactly once", async () => {
+    const composed = await composeOperatorGraph()
+    const runtimeModule = composed.modules.find(
+      (module) => module.module.name === "finance.booking-schedule-extension.graph-runtime",
+    )
+    const extension = composed.extensions.find(
+      (candidate) => candidate.extension.name === "booking-schedule",
+    )
+    const eventBus = createEventBus()
+    const subscribe = vi.spyOn(eventBus, "subscribe")
+    const container = createContainer()
+    const context = { bindings: { DATABASE_URL: "postgres://test" }, container, eventBus }
+
+    await runtimeModule?.module.bootstrap?.(context)
+    await extension?.extension.bootstrap?.(context)
+
+    expect(runtimeModule?.module.bootstrap).toBeTypeOf("function")
+    expect(extension?.extension.bootstrap).toBeTypeOf("function")
+    expect(container.has(BOOKING_SCHEDULE_SUBSCRIBER_RUNTIME_KEY)).toBe(true)
+    expect(
+      subscribe.mock.calls.filter(([eventType]) => eventType === "booking.confirmed"),
+    ).toHaveLength(1)
+  })
+
+  it("does not lower or bind the Finance subscriber when its extension is deselected", async () => {
+    const runtime = createGeneratedGraphRuntime()
+    const composed = await composeVoyantGraphRuntime({
+      runtime: {
+        ...runtime,
+        extensions: runtime.extensions.filter(
+          (unit) => unit.id !== "@voyant-travel/finance#booking-schedule-extension",
+        ),
+      },
+      capabilities: buildOperatorProviders(),
+      bindings: operatorGraphRuntimeBindings,
+      ports: buildOperatorRuntimePorts(),
+    })
+
+    expect(
+      composed.modules.some(
+        (module) => module.module.name === "finance.booking-schedule-extension.graph-runtime",
+      ),
+    ).toBe(false)
+    expect(
+      composed.extensions.some((extension) => extension.extension.name === "booking-schedule"),
+    ).toBe(false)
   })
 
   it("selects package-owned bridge units and discovered project modules directly", () => {

--- a/starters/operator/src/api/composition.ts
+++ b/starters/operator/src/api/composition.ts
@@ -38,6 +38,7 @@ import { resolveOperatorCustomFields } from "../lib/custom-fields"
 import { resolveNotificationProviders } from "../lib/notifications"
 import { operatorRealtimeBridgeRoutes, resolveRealtimeProviders } from "../lib/realtime"
 import { resolveBookingRequirementsProductSnapshot } from "./lib/booking-requirements-product-snapshot"
+import { withDbFromEnv } from "./lib/db"
 import { createChannelPushExtension } from "./routes/channel-push"
 import { AUTO_GENERATE_CONTRACT_OPTIONS } from "./runtime/contract-document-variables"
 import {
@@ -110,6 +111,7 @@ export function buildOperatorProviders(): OperatorCapabilities {
     resolveDocumentDownloadUrl: resolveOperatorDocumentDownloadUrl,
     readDocumentContentBase64: readOperatorDocumentContentBase64,
     resolveDb: resolveOperatorDb,
+    withDb: (bindings, operation) => withDbFromEnv(bindings as AppBindings, operation),
     createOperatorDocumentStorage,
     createInvoiceExchangeRateResolver: createOperatorInvoiceExchangeRateResolver,
     createInvoiceSettlementPollers: createOperatorInvoiceSettlementPollers,
@@ -191,6 +193,8 @@ export function buildOperatorProviders(): OperatorCapabilities {
     loadContractDocumentRoutes: () =>
       import("./runtime/contract-document-runtime").then((m) => m.buildContractDocumentRoutes()),
     // Lazy `operator/*` standard extension builders/loaders.
+    createBookingScheduleRoutesOptions: () =>
+      import("./routes/booking-schedule").then((m) => m.createBookingScheduleRoutesOptions()),
     loadBookingScheduleAdminRoutes: () =>
       import("./routes/booking-schedule").then((m) =>
         m.createBookingScheduleAdminRoutesForOperator(),
@@ -609,7 +613,7 @@ export const operatorGraphRuntimeBindings: VoyantGraphRuntimeBindings<OperatorCa
         runtimeExports,
       ),
     )
-    return withExtensionWorkflowService(configured, registerDistributionWorkflowService)
+    return withExtensionRuntimeService(configured, registerDistributionWorkflowService)
   },
   "@voyant-travel/finance#booking-tax-extension": async ({ runtimeExports, unit }) => {
     const createBookingTax = singleRuntimeFactory<
@@ -664,14 +668,14 @@ function singleRuntimeValue<T>(unitId: string, runtimeExports: readonly unknown[
   return runtimeExports[0] as T
 }
 
-type WorkflowServiceRegistration = (
+type RuntimeServiceRegistration = (
   container: import("@voyant-travel/core").ModuleContainer,
   bindings: AppBindings,
 ) => Promise<void> | void
 
 function withModuleWorkflowService<T extends HonoModule>(
   configured: T,
-  register: WorkflowServiceRegistration,
+  register: RuntimeServiceRegistration,
 ): T {
   const bootstrap = configured.module.bootstrap
   return {
@@ -686,9 +690,9 @@ function withModuleWorkflowService<T extends HonoModule>(
   }
 }
 
-function withExtensionWorkflowService<T extends HonoExtension>(
+function withExtensionRuntimeService<T extends HonoExtension>(
   configured: T,
-  register: WorkflowServiceRegistration,
+  register: RuntimeServiceRegistration,
 ): T {
   const bootstrap = configured.extension.bootstrap
   return {

--- a/starters/operator/src/api/routes/booking-schedule.ts
+++ b/starters/operator/src/api/routes/booking-schedule.ts
@@ -5,15 +5,9 @@
  * `@voyant-travel/finance` (`createBookingScheduleAdminRoutes`,
  * `createPaymentPolicyPublicRoutes`, `generatePaymentScheduleForBooking`). This
  * file supplies the deployment-specific cascade resolvers + operator default
- * and exposes:
- *
- *   - `bookingScheduleBundle` — the `booking.confirmed` event subscriber
- *     (a plugin, NOT a route) that regenerates the schedule on confirm. It
- *     bootstraps BEFORE the legal module's auto-generate-contract subscriber so
- *     the contract template sees populated deposit/balance fields.
- *   - `createBookingScheduleExtension()` — the composed HonoExtension on the
- *     `bookings` module (admin route at `/v1/admin/bookings/...`, public route
- *     at `/v1/public/payment-policy/resolve` via the publicPath override).
+ * and exposes `createBookingScheduleExtension()`, the composed HonoExtension on
+ * the `bookings` module (admin route at `/v1/admin/bookings/...`, public route
+ * at `/v1/public/payment-policy/resolve` via the publicPath override).
  *
  * Idempotency, cascade precedence, and the activity-log entry are preserved in
  * the package; this file is now pure glue. See
@@ -23,15 +17,8 @@
 import type { BookingScheduleRoutesOptions } from "@voyant-travel/finance"
 import type { LazyRoutesLoader } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
-import type { HonoBundle } from "@voyant-travel/hono/plugin"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
-
-interface BookingConfirmedPayload {
-  bookingId: string
-  bookingNumber: string
-  actorId: string | null
-}
 
 /**
  * Build the deployment's booking-schedule route options — the cascade
@@ -39,7 +26,7 @@ interface BookingConfirmedPayload {
  * operator default + per-request db resolver. The bookings-schema reads and
  * action-ledger appender are handled inside the package directly.
  */
-async function createBookingScheduleRoutesOptions(): Promise<BookingScheduleRoutesOptions> {
+export async function createBookingScheduleRoutesOptions(): Promise<BookingScheduleRoutesOptions> {
   const [settings, runtime] = await Promise.all([
     import("@voyant-travel/operator-settings"),
     import("../runtime/booking-payment-policy-runtime"),
@@ -58,38 +45,6 @@ async function createBookingScheduleRoutesOptions(): Promise<BookingScheduleRout
   }
 }
 
-export const bookingScheduleBundle: HonoBundle = {
-  name: "booking-schedule",
-  bootstrap: ({ bindings, eventBus }) => {
-    const env = bindings as AppBindings
-    eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
-      try {
-        const [
-          { generatePaymentScheduleForBooking, settleCoveredBookingPaymentSchedules },
-          { withDbFromEnv },
-          runtime,
-          options,
-        ] = await Promise.all([
-          import("@voyant-travel/finance"),
-          import("../lib/db"),
-          import("../runtime/operator-runtime-adapter"),
-          createBookingScheduleRoutesOptions(),
-        ])
-        await withDbFromEnv(env, async (rawDb) => {
-          const db = runtime.operatorPostgresDb(rawDb)
-          await generatePaymentScheduleForBooking(db, data.bookingId, options)
-          await settleCoveredBookingPaymentSchedules(db, data.bookingId)
-        })
-      } catch (err) {
-        console.error("[booking-schedule] failed to generate schedule", {
-          bookingId: data.bookingId,
-          error: err instanceof Error ? err.message : String(err),
-        })
-      }
-    })
-  },
-}
-
 /**
  * Booking payment-schedule routes as a composed extension on the
  * `bookings` module.
@@ -101,9 +56,6 @@ export const bookingScheduleBundle: HonoBundle = {
  * The handler bodies + operator-local policy cascade live in
  * `@voyant-travel/finance`; this file injects the deployment-specific
  * resolvers. See docs/architecture/api-route-ownership-and-composition.md.
- *
- * The event-subscriber bundle (`bookingScheduleBundle`) stays a separate
- * plugin — it carries no routes.
  */
 export function createBookingScheduleExtension(): HonoExtension {
   return {

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -104,6 +104,19 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
         },
       }),
     ])
+    const bookingSchedule = graph.extensions.find(
+      (extension) => extension.id === "@voyant-travel/finance#booking-schedule-extension",
+    )
+    expect(bookingSchedule?.subscribers).toEqual([
+      expect.objectContaining({
+        id: "@voyant-travel/finance#subscriber.booking-schedule-confirmed",
+        eventType: "booking.confirmed",
+        runtime: {
+          entry: "./booking-schedule-subscriber",
+          export: "bookingScheduleConfirmedSubscriber",
+        },
+      }),
+    ])
 
     for (const artifactPath of [
       "admin/project-admin.generated.ts",


### PR DESCRIPTION
## Summary

- activate the Finance booking-schedule subscriber runtime from the package manifest
- resolve only deployment-owned payment-policy options and database lifecycle through an Operator container service registered by generic selected-graph composition
- remove the central `bookingScheduleBundle`, its `app.ts` hand-list entry, and the incorrect ordering claim relative to Legal
- preserve package-owned schedule generation, covered-schedule settlement, and error logging
- add exact-once registration, deselection, generated artifact, and authority checker coverage

## Runtime behavior

Graph lowering owns subscriber descriptor registration. Operator does not call `descriptor.register` or subscribe directly. The event bus runs `booking.confirmed` handlers in parallel, so this change introduces no ordering guarantee relative to Legal or other subscribers.

## Verification

- Finance runtime/manifest/export tests: 3 files, 7 tests passed
- Operator composition/artifact tests: 2 files, 32 tests passed
- Finance typecheck passed with an 8 GB heap
- Finance lint passed with one pre-existing optional-chain warning
- Operator lint passed
- `pnpm --filter operator graph:emit`
- `pnpm exec tsx scripts/check-deployment-graph.ts`
- `pnpm verify:dep-paths`
- changed-file Biome and diff checks passed

The scoped Operator server typecheck was stopped after five minutes without diagnostics while another worktree was concurrently typechecking Operator. CI is authoritative for that lane.

## Stack

Base: #3216 (`feat/finance-booking-schedule-subscriber`).