### PR TITLE
feat(realtime): stage admin invalidation runtime

### DIFF
--- a/.changeset/realtime-admin-invalidation-runtime.md
+++ b/.changeset/realtime-admin-invalidation-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/realtime": patch
+---
+
+Stage the package-owned deferred admin invalidation subscriber runtime contract and narrow publication capability for selected-graph activation.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1000,6 +1000,17 @@ intentionally omits a runtime reference while the central Operator bundle
 remains active; direct selected-graph activation must remove that central
 registration in the same change to avoid duplicate event handling.
 
+Realtime now publishes a package-owned admin-invalidation subscriber runtime
+contract from `@voyant-travel/realtime/admin-invalidation-subscriber`. The
+contract resolves a narrow publication capability from the runtime container,
+registers deferred handlers exactly once per event bus, filters before routing,
+deduplicates channels per delivery, and reports transport failures without
+rejecting event delivery. The Realtime manifest advertises that capability but
+does not yet activate domain subscribers: event declarations and executable
+runtime references must move with their domain-owning shards, and the Operator
+bridge must be removed in the same activation change to prevent duplicate
+invalidation hints.
+
 The broader event catalog is beyond the foundational substrate:
 
 - declared `events.emits` catalogs

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1265,6 +1265,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1260,6 +1260,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1236,6 +1236,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1231,6 +1231,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1300,6 +1300,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1301,6 +1301,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1310,6 +1310,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1311,6 +1311,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1320,6 +1320,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1315,6 +1315,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1324,6 +1324,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1325,6 +1325,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1321,6 +1321,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1316,6 +1316,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1329,6 +1329,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1330,6 +1330,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1331,6 +1331,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1217,6 +1217,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1212,6 +1212,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -8,6 +8,7 @@
     "./types": "./src/types.ts",
     "./service": "./src/service.ts",
     "./bridge": "./src/bridge.ts",
+    "./admin-invalidation-subscriber": "./src/admin-invalidation-subscriber.ts",
     "./capabilities": "./src/capabilities.ts",
     "./routes": "./src/routes.ts",
     "./providers/local": "./src/providers/local.ts",
@@ -57,6 +58,11 @@
         "types": "./dist/bridge.d.ts",
         "import": "./dist/bridge.js",
         "default": "./dist/bridge.js"
+      },
+      "./admin-invalidation-subscriber": {
+        "types": "./dist/admin-invalidation-subscriber.d.ts",
+        "import": "./dist/admin-invalidation-subscriber.js",
+        "default": "./dist/admin-invalidation-subscriber.js"
       },
       "./capabilities": {
         "types": "./dist/capabilities.d.ts",

--- a/packages/realtime/src/admin-invalidation-subscriber.ts
+++ b/packages/realtime/src/admin-invalidation-subscriber.ts
@@ -1,0 +1,166 @@
+import type {
+  EventEnvelope,
+  ModuleContainer,
+  Subscriber,
+  SubscriberRuntimeDescriptor,
+} from "@voyant-travel/core"
+
+import type {
+  RealtimeInvalidationHint,
+  RealtimeMessage,
+  RealtimeProvider,
+  RealtimeRouteResult,
+} from "./types.js"
+
+export const ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY =
+  "realtime.admin-invalidation-publication" as const
+
+export interface AdminInvalidationPublishErrorContext {
+  readonly event: string
+  readonly channel: string
+}
+
+/** Narrow runtime capability consumed by package-owned invalidation subscribers. */
+export interface AdminInvalidationPublicationPort {
+  publish(channel: string, message: RealtimeMessage): Promise<void>
+  reportError(error: unknown, context: AdminInvalidationPublishErrorContext): void
+}
+
+export type AdminInvalidationRoute<TData = unknown> = (
+  data: TData,
+  envelope: EventEnvelope<TData>,
+) => ReadonlyArray<string> | RealtimeRouteResult | undefined
+
+export interface CreateAdminInvalidationSubscriberRuntimeOptions<TData = unknown> {
+  /** Stable id matching the owning selected-graph subscriber declaration. */
+  readonly id: string
+  readonly eventType: string
+  /** Returning `undefined` filters the event without publishing. */
+  readonly route: AdminInvalidationRoute<TData>
+}
+
+export interface CreateAdminInvalidationSubscriberOptions<TData = unknown>
+  extends Omit<CreateAdminInvalidationSubscriberRuntimeOptions<TData>, "id"> {
+  readonly port: AdminInvalidationPublicationPort
+}
+
+export interface CreateAdminInvalidationPublicationPortOptions {
+  provider: Pick<RealtimeProvider, "publish">
+  onError?: (error: unknown, context: AdminInvalidationPublishErrorContext) => void
+}
+
+function isRouteResult(
+  value: ReadonlyArray<string> | RealtimeRouteResult,
+): value is RealtimeRouteResult {
+  return !Array.isArray(value)
+}
+
+function resourceOf(event: string): string {
+  const dot = event.indexOf(".")
+  return dot === -1 ? event : event.slice(0, dot)
+}
+
+export function createAdminInvalidationPublicationPort(
+  options: CreateAdminInvalidationPublicationPortOptions,
+): AdminInvalidationPublicationPort {
+  const reportError =
+    options.onError ??
+    ((error, context) => {
+      const message = error instanceof Error ? error.message : String(error)
+      console.warn(
+        `[realtime] publish failed for ${context.event} -> ${context.channel}: ${message}`,
+      )
+    })
+
+  return {
+    publish: (channel, message) => options.provider.publish(channel, message),
+    reportError,
+  }
+}
+
+export function registerAdminInvalidationPublicationPort(
+  container: ModuleContainer,
+  port: AdminInvalidationPublicationPort,
+): void {
+  container.register(ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY, port)
+}
+
+async function publishAdminInvalidation<TData>(
+  port: AdminInvalidationPublicationPort,
+  eventType: string,
+  route: AdminInvalidationRoute<TData>,
+  envelope: EventEnvelope<TData>,
+): Promise<void> {
+  const result = route(envelope.data, envelope)
+  if (result === undefined) return
+
+  const channels = isRouteResult(result) ? result.channels : result
+  const uniqueChannels = [...new Set(channels)]
+  if (uniqueChannels.length === 0) return
+
+  const hint: RealtimeInvalidationHint = {
+    event: eventType,
+    entity: resourceOf(eventType),
+    ...(isRouteResult(result) ? result.hint : undefined),
+  }
+
+  await Promise.all(
+    uniqueChannels.map(async (channel) => {
+      try {
+        await port.publish(channel, { event: eventType, data: hint })
+      } catch (error) {
+        try {
+          port.reportError(error, { event: eventType, channel })
+        } catch {
+          // Error reporting is best-effort and must not reject event delivery.
+        }
+      }
+    }),
+  )
+}
+
+export function createAdminInvalidationSubscriber<TData>(
+  options: CreateAdminInvalidationSubscriberOptions<TData>,
+): Subscriber<TData> {
+  return {
+    event: options.eventType,
+    inline: false,
+    handler: async (envelope) => {
+      if (envelope.name !== options.eventType) return
+      await publishAdminInvalidation(options.port, options.eventType, options.route, envelope)
+    },
+  }
+}
+
+/**
+ * Build one executable selected-graph subscriber descriptor. The descriptor is
+ * inert until its owning graph declaration receives a runtime reference and a
+ * realtime module bootstrap registers the publication port.
+ */
+export function createAdminInvalidationSubscriberRuntime<TData = unknown>(
+  options: CreateAdminInvalidationSubscriberRuntimeOptions<TData>,
+): SubscriberRuntimeDescriptor {
+  const registeredEventBuses = new WeakSet<object>()
+
+  return {
+    id: options.id,
+    eventType: options.eventType,
+    register: ({ container, eventBus }) => {
+      if (registeredEventBuses.has(eventBus)) return
+
+      eventBus.subscribe<TData>(
+        options.eventType,
+        async (envelope) => {
+          if (envelope.name !== options.eventType) return
+          if (!container.has(ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY)) return
+          const port = container.resolve<AdminInvalidationPublicationPort>(
+            ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY,
+          )
+          await publishAdminInvalidation(port, options.eventType, options.route, envelope)
+        },
+        { inline: false },
+      )
+      registeredEventBuses.add(eventBus)
+    },
+  }
+}

--- a/packages/realtime/src/bridge.ts
+++ b/packages/realtime/src/bridge.ts
@@ -1,12 +1,9 @@
 import type { Subscriber } from "@voyant-travel/core"
-
-import type {
-  RealtimeInvalidationHint,
-  RealtimeProvider,
-  RealtimeRoute,
-  RealtimeRouteResult,
-  RealtimeRoutes,
-} from "./types.js"
+import {
+  createAdminInvalidationPublicationPort,
+  createAdminInvalidationSubscriber,
+} from "./admin-invalidation-subscriber.js"
+import type { RealtimeProvider, RealtimeRoute, RealtimeRoutes } from "./types.js"
 
 export interface CreateRealtimeBridgeOptions {
   /** Transport to publish through. */
@@ -19,18 +16,6 @@ export interface CreateRealtimeBridgeOptions {
    * blip must not break the emitting transaction.
    */
   onError?: (error: unknown, context: { event: string; channel: string }) => void
-}
-
-function isRouteResult(
-  value: ReadonlyArray<string> | RealtimeRouteResult,
-): value is RealtimeRouteResult {
-  return !Array.isArray(value)
-}
-
-/** Derive the entity family from an event name (`booking.confirmed` → `booking`). */
-function resourceOf(event: string): string {
-  const dot = event.indexOf(".")
-  return dot === -1 ? event : event.slice(0, dot)
 }
 
 /**
@@ -46,37 +31,16 @@ function resourceOf(event: string): string {
  * client refetch.
  */
 export function createRealtimeBridge(options: CreateRealtimeBridgeOptions): Subscriber[] {
-  const { provider, routes } = options
-  const onError =
-    options.onError ??
-    ((error, context) => {
-      const message = error instanceof Error ? error.message : String(error)
-      console.warn(
-        `[realtime] publish failed for ${context.event} → ${context.channel}: ${message}`,
-      )
-    })
+  const port = createAdminInvalidationPublicationPort({
+    provider: options.provider,
+    onError: options.onError,
+  })
 
-  return Object.entries(routes).map(([event, route]) => ({
-    event,
-    inline: false,
-    handler: async (envelope) => {
-      const result = (route as RealtimeRoute)(envelope.data, envelope)
-      const channels = isRouteResult(result) ? result.channels : result
-      if (channels.length === 0) return
-
-      const hint: RealtimeInvalidationHint = {
-        event,
-        entity: resourceOf(event),
-        ...(isRouteResult(result) ? result.hint : undefined),
-      }
-
-      await Promise.all(
-        channels.map((channel) =>
-          provider
-            .publish(channel, { event, data: hint })
-            .catch((error: unknown) => onError(error, { event, channel })),
-        ),
-      )
-    },
-  }))
+  return Object.entries(options.routes).map(([event, route]) =>
+    createAdminInvalidationSubscriber({
+      port,
+      eventType: event,
+      route: route as RealtimeRoute,
+    }),
+  )
 }

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -1,7 +1,10 @@
 import type { Module } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
-
+import {
+  createAdminInvalidationPublicationPort,
+  registerAdminInvalidationPublicationPort,
+} from "./admin-invalidation-subscriber.js"
 import { createRealtimeBridge } from "./bridge.js"
 import {
   buildRealtimeRouteRuntime,
@@ -12,6 +15,21 @@ import {
 import { realtimeRuntimePort } from "./runtime-port.js"
 import type { RealtimeRoutes } from "./types.js"
 
+export type {
+  AdminInvalidationPublicationPort,
+  AdminInvalidationPublishErrorContext,
+  AdminInvalidationRoute,
+  CreateAdminInvalidationPublicationPortOptions,
+  CreateAdminInvalidationSubscriberOptions,
+  CreateAdminInvalidationSubscriberRuntimeOptions,
+} from "./admin-invalidation-subscriber.js"
+export {
+  ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY,
+  createAdminInvalidationPublicationPort,
+  createAdminInvalidationSubscriber,
+  createAdminInvalidationSubscriberRuntime,
+  registerAdminInvalidationPublicationPort,
+} from "./admin-invalidation-subscriber.js"
 export type { CreateRealtimeBridgeOptions } from "./bridge.js"
 export { createRealtimeBridge } from "./bridge.js"
 export type {
@@ -91,6 +109,16 @@ export function createRealtimeHonoModule(
     bootstrap: ({ bindings, container, eventBus }) => {
       const runtime = buildRealtimeRouteRuntime(bindings as Record<string, unknown>, options)
       container.register(REALTIME_ROUTE_RUNTIME_CONTAINER_KEY, runtime)
+
+      if (runtime.service) {
+        registerAdminInvalidationPublicationPort(
+          container,
+          createAdminInvalidationPublicationPort({
+            provider: runtime.service.defaultProvider,
+            onError: options.onPublishError,
+          }),
+        )
+      }
 
       // No provider configured → nothing to publish to; stay inert.
       if (runtime.service && options.bridgeRoutes && Object.keys(options.bridgeRoutes).length > 0) {

--- a/packages/realtime/src/voyant.ts
+++ b/packages/realtime/src/voyant.ts
@@ -7,7 +7,7 @@ export const realtimeVoyantModule = defineModule({
   packageName: "@voyant-travel/realtime",
   localId: "realtime",
   provides: {
-    ports: [{ id: "realtime.transport" }],
+    ports: [{ id: "realtime.transport" }, { id: "realtime.admin-invalidation-publication" }],
   },
   runtimePorts: [requirePort(realtimeRuntimePort)],
   api: [

--- a/packages/realtime/tests/unit/admin-invalidation-subscriber.test.ts
+++ b/packages/realtime/tests/unit/admin-invalidation-subscriber.test.ts
@@ -1,0 +1,133 @@
+import type { EventEnvelope, EventHandler } from "@voyant-travel/core"
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createAdminInvalidationSubscriberRuntime,
+  registerAdminInvalidationPublicationPort,
+} from "../../src/admin-invalidation-subscriber.js"
+
+function envelope(name: string, data: { bookingId: string }): EventEnvelope {
+  return { name, data, emittedAt: new Date().toISOString() }
+}
+
+function captureHandler() {
+  const eventBus = createEventBus()
+  let handler: EventHandler | undefined
+  const subscribe = vi.spyOn(eventBus, "subscribe").mockImplementation((_event, candidate) => {
+    handler = candidate as EventHandler
+    return { unsubscribe: vi.fn() }
+  })
+  return { eventBus, subscribe, getHandler: () => handler }
+}
+
+describe("admin invalidation subscriber runtime", () => {
+  it("registers exactly once per event bus as a deferred subscriber", async () => {
+    const { eventBus, subscribe } = captureHandler()
+    const descriptor = createAdminInvalidationSubscriberRuntime({
+      id: "@voyant-travel/bookings#subscriber.admin-invalidation-confirmed",
+      eventType: "booking.confirmed",
+      route: () => ["admin"],
+    })
+    const context = { bindings: {}, container: createContainer(), eventBus }
+
+    await descriptor.register(context)
+    await descriptor.register(context)
+
+    expect({ id: descriptor.id, eventType: descriptor.eventType }).toEqual({
+      id: "@voyant-travel/bookings#subscriber.admin-invalidation-confirmed",
+      eventType: "booking.confirmed",
+    })
+    expect(subscribe).toHaveBeenCalledTimes(1)
+    expect(subscribe).toHaveBeenCalledWith("booking.confirmed", expect.any(Function), {
+      inline: false,
+    })
+  })
+
+  it("filters mismatched and explicitly ignored events before publication", async () => {
+    const publish = vi.fn(async () => undefined)
+    const route = vi.fn(() => undefined)
+    const container = createContainer()
+    registerAdminInvalidationPublicationPort(container, { publish, reportError: vi.fn() })
+    const { eventBus, getHandler } = captureHandler()
+    const descriptor = createAdminInvalidationSubscriberRuntime({
+      id: "@voyant-travel/bookings#subscriber.admin-invalidation-confirmed",
+      eventType: "booking.confirmed",
+      route,
+    })
+    await descriptor.register({ bindings: {}, container, eventBus })
+
+    await getHandler()?.(envelope("booking.cancelled", { bookingId: "booking_1" }))
+    await getHandler()?.(envelope("booking.confirmed", { bookingId: "booking_1" }))
+
+    expect(route).toHaveBeenCalledTimes(1)
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it("publishes each selected channel exactly once with the routed hint", async () => {
+    const publish = vi.fn(async () => undefined)
+    const container = createContainer()
+    registerAdminInvalidationPublicationPort(container, { publish, reportError: vi.fn() })
+    const { eventBus, getHandler } = captureHandler()
+    const descriptor = createAdminInvalidationSubscriberRuntime({
+      id: "@voyant-travel/bookings#subscriber.admin-invalidation-confirmed",
+      eventType: "booking.confirmed",
+      route: ({ bookingId }: { bookingId: string }) => ({
+        channels: ["admin", `booking:${bookingId}`, "admin"],
+        hint: { entity: "booking", id: bookingId },
+      }),
+    })
+    await descriptor.register({ bindings: {}, container, eventBus })
+
+    await getHandler()?.(envelope("booking.confirmed", { bookingId: "booking_1" }))
+
+    expect(publish).toHaveBeenCalledTimes(2)
+    expect(publish).toHaveBeenCalledWith("admin", {
+      event: "booking.confirmed",
+      data: { event: "booking.confirmed", entity: "booking", id: "booking_1" },
+    })
+    expect(publish).toHaveBeenCalledWith("booking:booking_1", expect.any(Object))
+  })
+
+  it("reports publication errors without rejecting the deferred handler", async () => {
+    const error = new Error("transport unavailable")
+    const reportError = vi.fn()
+    const container = createContainer()
+    registerAdminInvalidationPublicationPort(container, {
+      publish: vi.fn().mockRejectedValue(error),
+      reportError,
+    })
+    const { eventBus, getHandler } = captureHandler()
+    const descriptor = createAdminInvalidationSubscriberRuntime({
+      id: "@voyant-travel/bookings#subscriber.admin-invalidation-confirmed",
+      eventType: "booking.confirmed",
+      route: () => ["admin"],
+    })
+    await descriptor.register({ bindings: {}, container, eventBus })
+
+    await expect(
+      getHandler()?.(envelope("booking.confirmed", { bookingId: "booking_1" })),
+    ).resolves.toBeUndefined()
+    expect(reportError).toHaveBeenCalledOnce()
+    expect(reportError).toHaveBeenCalledWith(error, {
+      event: "booking.confirmed",
+      channel: "admin",
+    })
+  })
+
+  it("stays inert until the publication port is available", async () => {
+    const route = vi.fn(() => ["admin"])
+    const { eventBus, getHandler } = captureHandler()
+    const descriptor = createAdminInvalidationSubscriberRuntime({
+      id: "@voyant-travel/bookings#subscriber.admin-invalidation-confirmed",
+      eventType: "booking.confirmed",
+      route,
+    })
+    await descriptor.register({ bindings: {}, container: createContainer(), eventBus })
+
+    await expect(
+      getHandler()?.(envelope("booking.confirmed", { bookingId: "booking_1" })),
+    ).resolves.toBeUndefined()
+    expect(route).not.toHaveBeenCalled()
+  })
+})

--- a/packages/realtime/tests/unit/package-exports.test.ts
+++ b/packages/realtime/tests/unit/package-exports.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, { types: string; import: string; default: string }>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/realtime package exports", () => {
+  it("publishes the admin invalidation subscriber runtime contract", () => {
+    expect(packageJson.exports["./admin-invalidation-subscriber"]).toBe(
+      "./src/admin-invalidation-subscriber.ts",
+    )
+    expect(packageJson.publishConfig.exports["./admin-invalidation-subscriber"]).toEqual({
+      types: "./dist/admin-invalidation-subscriber.d.ts",
+      import: "./dist/admin-invalidation-subscriber.js",
+      default: "./dist/admin-invalidation-subscriber.js",
+    })
+  })
+})

--- a/packages/realtime/tests/unit/voyant-manifest.test.ts
+++ b/packages/realtime/tests/unit/voyant-manifest.test.ts
@@ -1,7 +1,12 @@
 import { createContainer, createEventBus } from "@voyant-travel/core"
 import { assertPortConforms } from "@voyant-travel/core/project"
 import { describe, expect, it, vi } from "vitest"
-import { createRealtimeHonoModule, realtimeRuntimePort } from "../../src/index.js"
+import {
+  ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY,
+  createRealtimeHonoModule,
+  realtimeRuntimePort,
+} from "../../src/index.js"
+import { createLocalRealtimeProvider } from "../../src/providers/local.js"
 import { realtimeVoyantModule } from "../../src/voyant.js"
 
 describe("realtime deployment manifest", () => {
@@ -10,7 +15,9 @@ describe("realtime deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/realtime",
       packageName: "@voyant-travel/realtime",
-      provides: { ports: [{ id: "realtime.transport" }] },
+      provides: {
+        ports: [{ id: "realtime.transport" }, { id: "realtime.admin-invalidation-publication" }],
+      },
       runtimePorts: [{ id: "realtime.runtime" }],
       api: [
         {
@@ -49,6 +56,13 @@ describe("realtime deployment manifest", () => {
     })
   })
 
+  it("stages the publication capability without activating domain subscribers", () => {
+    expect(realtimeVoyantModule.provides?.ports).toContainEqual({
+      id: "realtime.admin-invalidation-publication",
+    })
+    expect(realtimeVoyantModule.subscribers).toBeUndefined()
+  })
+
   it("ships a conformance kit for deployment realtime providers", async () => {
     await expect(
       assertPortConforms(realtimeRuntimePort, { resolveProviders: () => [] }),
@@ -69,5 +83,20 @@ describe("realtime deployment manifest", () => {
     })
 
     expect(resolveProviders).toHaveBeenCalledWith({ REALTIME_API_KEY: "test" })
+  })
+
+  it("binds admin invalidation publication without activating bridge routes", async () => {
+    const container = createContainer()
+    const module = createRealtimeHonoModule({
+      resolveProviders: () => [createLocalRealtimeProvider()],
+    })
+
+    await module.module.bootstrap?.({
+      bindings: {},
+      container,
+      eventBus: createEventBus(),
+    })
+
+    expect(container.has(ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY)).toBe(true)
   })
 })

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1329,6 +1329,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1330,6 +1330,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1331,6 +1331,9 @@
       ],
       "@voyant-travel/realtime-react/provider": ["../realtime-react/dist/provider.d.ts"],
       "@voyant-travel/realtime-react/query-keys": ["../realtime-react/dist/query-keys.d.ts"],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": ["../realtime/dist/providers/local.d.ts"],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1702,6 +1702,9 @@
       "@voyant-travel/realtime-react/query-keys": [
         "../../packages/realtime-react/dist/query-keys.d.ts"
       ],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../../packages/realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../../packages/realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../../packages/realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": [

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1702,6 +1702,9 @@
       "@voyant-travel/realtime-react/query-keys": [
         "../../packages/realtime-react/dist/query-keys.d.ts"
       ],
+      "@voyant-travel/realtime/admin-invalidation-subscriber": [
+        "../../packages/realtime/dist/admin-invalidation-subscriber.d.ts"
+      ],
       "@voyant-travel/realtime/bridge": ["../../packages/realtime/dist/bridge.d.ts"],
       "@voyant-travel/realtime/capabilities": ["../../packages/realtime/dist/capabilities.d.ts"],
       "@voyant-travel/realtime/providers/local": [


### PR DESCRIPTION
## Summary

- add a package-owned admin invalidation publication port and executable subscriber descriptor factory
- preserve the existing deferred, best-effort bridge behavior while filtering mismatched events and deduplicating channels per delivery
- advertise the staged capability in the Realtime manifest without activating domain subscribers
- publish the runtime subpath and regenerate dependency-resolution configs
- document the duplicate-free selected-graph activation boundary

## Why

The Operator currently owns the realtime invalidation route map and subscriber registration. This stages the reusable Realtime runtime contract required for domain-owned subscriber shards to move to selected-graph lowering before `starters/operator/src/lib/realtime.ts` can be removed.

## Validation

- `pnpm --filter @voyant-travel/realtime test` (9 files, 37 tests)
- `pnpm --filter @voyant-travel/realtime typecheck`
- `pnpm --filter @voyant-travel/realtime build`
- `pnpm --filter @voyant-travel/realtime lint`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `node scripts/check-package-dist-configs.mjs`
- package-owned manifest and export parity tests
