### PR TITLE
feat(quotes): lower selected graph admin runtime

### DIFF
--- a/.changeset/calm-quotes-admin.md
+++ b/.changeset/calm-quotes-admin.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/quotes": minor
+---
+
+Declare the package-owned Quotes admin factory as a selected-graph runtime while
+preserving its existing routes, copy provider, and host-supplied navigation options.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -792,8 +792,8 @@ separate first-party admin catalog.
 
 ### Selected-graph admin bundle cutline
 
-The first Phase 4 admin slices are active for `@voyant-travel/action-ledger` and
-`@voyant-travel/mice`:
+The first Phase 4 admin slices are active for `@voyant-travel/action-ledger`,
+`@voyant-travel/mice`, and `@voyant-travel/quotes`:
 
 - the package manifest opts its import-cheap admin extension factory into
   `admin.runtime` and retains its stable route declarations
@@ -1399,10 +1399,11 @@ package surfaces in `voyant#3080`.
   namespaced copy and deployment overrides
 - generate the admin bundle only from selected package exports and graph data
 
-Progress: the action-ledger and MICE nav/route/page factories are lowered into
-the selected-graph admin bundle. The Operator still owns their lightweight
-localization/icon wrappers. Slots/contributions, copy, and the remaining
-first-party Operator compatibility registry are not part of this slice.
+Progress: the action-ledger, MICE, and Quotes nav/route/page factories are
+lowered into the selected-graph admin bundle. The Operator still owns their
+lightweight localization/icon wrappers. Slots/contributions, copy, and the
+remaining first-party Operator compatibility registry are not part of this
+slice.
 
 Exit: a custom package contributes a secured, documented API and complete admin
 surface without operator edits; all grants and message references validate.

--- a/packages/quotes-react/src/admin/admin-manifest.test.ts
+++ b/packages/quotes-react/src/admin/admin-manifest.test.ts
@@ -6,9 +6,17 @@ import { createQuotesAdminExtension } from "./index.js"
 describe("quotes admin deployment facets", () => {
   it("tracks the package-owned extension routes and copy provider", () => {
     const extension = createQuotesAdminExtension()
+    expect(quotesVoyantModule.admin?.runtime).toEqual({
+      entry: "@voyant-travel/quotes-react/admin",
+      export: "createQuotesAdminExtension",
+    })
     expect(quotesVoyantModule.admin?.routes?.map((route) => route.path)).toEqual(
       extension.routes?.map((route) => route.path),
     )
+    expect(extension.routes?.map((route) => route.destination)).toEqual([
+      "quote.list",
+      "quote.detail",
+    ])
     expect(quotesVoyantModule.admin?.routes?.map((route) => route.runtime)).toEqual(
       extension.routes?.map(() => ({
         entry: "@voyant-travel/quotes-react/admin",

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -111,6 +111,10 @@ export const quotesVoyantModule = defineModule({
     },
   ],
   admin: {
+    runtime: {
+      entry: "@voyant-travel/quotes-react/admin",
+      export: "createQuotesAdminExtension",
+    },
     copy: [
       {
         id: "@voyant-travel/quotes#admin.copy",

--- a/packages/quotes/tests/unit/voyant-manifest.test.ts
+++ b/packages/quotes/tests/unit/voyant-manifest.test.ts
@@ -23,6 +23,28 @@ describe("quotes deployment manifests", () => {
       ],
       schema: [{ id: "@voyant-travel/quotes#schema" }],
       migrations: [{ id: "@voyant-travel/quotes#migrations" }],
+      admin: {
+        runtime: {
+          entry: "@voyant-travel/quotes-react/admin",
+          export: "createQuotesAdminExtension",
+        },
+        copy: [
+          {
+            id: "@voyant-travel/quotes#admin.copy",
+            namespace: "quotes.admin",
+          },
+        ],
+        routes: [
+          {
+            id: "@voyant-travel/quotes#admin.route.quotes-index",
+            path: "/quotes",
+          },
+          {
+            id: "@voyant-travel/quotes#admin.route.quotes-detail",
+            path: "/quotes/$id",
+          },
+        ],
+      },
       links: [
         { id: "@voyant-travel/quotes#linkable.quote" },
         { id: "@voyant-travel/quotes#linkable.quoteVersion" },

--- a/starters/operator/src/admin.extensions.generated.ts
+++ b/starters/operator/src/admin.extensions.generated.ts
@@ -12,7 +12,6 @@ import { createInventoryAdminExtension } from "@voyant-travel/inventory-react/ad
 import { createLegalAdminExtension } from "@voyant-travel/legal-react/admin"
 import { createNotificationsAdminExtension } from "@voyant-travel/notifications-react/admin"
 import { createOperationsAdminExtension } from "@voyant-travel/operations-react/admin"
-import { createQuotesAdminExtension } from "@voyant-travel/quotes-react/admin"
 import { createRelationshipsAdminExtension } from "@voyant-travel/relationships-react/admin"
 import { createTripsAdminExtension } from "@voyant-travel/trips-react/admin"
 
@@ -32,7 +31,6 @@ export const generatedAdminExtensionFactories = {
   legal: createLegalAdminExtension,
   notifications: createNotificationsAdminExtension,
   operations: createOperationsAdminExtension,
-  quotes: createQuotesAdminExtension,
   relationships: createRelationshipsAdminExtension,
   trips: createTripsAdminExtension,
 } as const

--- a/starters/operator/src/lib/admin-extensions.tsx
+++ b/starters/operator/src/lib/admin-extensions.tsx
@@ -612,7 +612,7 @@ function createActionLedgerExtension(messages: AdminExtensionNavMessages) {
 // quote creation), and the quote detail page where that quote's versions are
 // nested. The app only supplies the localized label and the icon.
 function createQuotesExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.quotes({
+  return selectedGraphAdminExtensionFactories["@voyant-travel/quotes"]({
     labels: { quotes: messages.quotes },
     icon: FileText,
   })

--- a/starters/operator/src/selected-graph-quotes-admin.test.ts
+++ b/starters/operator/src/selected-graph-quotes-admin.test.ts
@@ -1,0 +1,66 @@
+import { operatorAdminNavMessages } from "@voyant-travel/i18n"
+import { FileText } from "lucide-react"
+import { describe, expect, it } from "vitest"
+
+import { selectedGraphAdminExtensionFactories } from "../.voyant/admin/selected-graph-admin.generated.js"
+import { generatedAdminExtensionFactories } from "./admin.extensions.generated.js"
+import { createOperatorAdminExtensions } from "./lib/admin-extensions.js"
+
+describe("selected-graph Quotes admin composition", () => {
+  it("uses the selected package factory without compatibility duplication", () => {
+    expect(selectedGraphAdminExtensionFactories["@voyant-travel/quotes"]).toBeTypeOf("function")
+    expect("quotes" in generatedAdminExtensionFactories).toBe(false)
+  })
+
+  it("preserves Quotes navigation, routes, destinations, and host wrappers", () => {
+    const extension = createOperatorAdminExtensions(operatorAdminNavMessages.ro.nav).find(
+      ({ id }) => id === "quotes",
+    )
+
+    expect(extension?.navigation).toEqual([
+      {
+        insertAfter: "bookings",
+        items: [
+          {
+            id: "quotes",
+            title: "Oferte",
+            url: "/quotes",
+            icon: FileText,
+          },
+        ],
+      },
+    ])
+    expect(
+      extension?.routes?.map(
+        ({ id, path, title, destination, destinationParams, ssr, routeMessagesProvider }) => ({
+          id,
+          path,
+          title,
+          destination,
+          destinationParams,
+          ssr,
+          hasRouteMessagesProvider: typeof routeMessagesProvider === "function",
+        }),
+      ),
+    ).toEqual([
+      {
+        id: "quotes-index",
+        path: "/quotes",
+        title: "Oferte",
+        destination: "quote.list",
+        destinationParams: undefined,
+        ssr: "data-only",
+        hasRouteMessagesProvider: true,
+      },
+      {
+        id: "quotes-detail",
+        path: "/quotes/$id",
+        title: "Oferte",
+        destination: "quote.detail",
+        destinationParams: { id: "quoteId" },
+        ssr: "data-only",
+        hasRouteMessagesProvider: true,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

- declare the Quotes admin runtime in the package-owned Voyant manifest
- lower Quotes navigation, routes, destinations, and UI factory through the selected graph
- remove the Quotes compatibility entry from the Operator admin registry
- preserve existing copy, icons, paths, and destination parameters with parity coverage

## Validation

- Quotes and Quotes React manifest/admin tests
- dedicated Operator selected-graph Quotes test
- package typechecks and admin composition checks
