### PR TITLE
feat(legal): stage booking contract subscriber

### DIFF
--- a/.changeset/legal-booking-contract-subscriber.md
+++ b/.changeset/legal-booking-contract-subscriber.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/legal": patch
+---
+
+Stage the package-owned Legal booking-confirmed contract generation subscriber descriptor and narrow runtime service contract for a later selected-graph activation.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1058,6 +1058,16 @@ runtime reference. Moving either path to selected-graph activation remains
 gated on explicit Legal document-ordering semantics for `booking.confirmed`, as
 ordinary event-bus subscribers run independently and provide no ordering.
 
+Legal now stages its booking-contract auto-generation handler as an executable
+package-owned subscriber descriptor on the unselected
+`@voyant-travel/legal#booking-contract-extension`. The existing Legal module
+bootstrap remains the compatibility activation path until a separate graph
+cutover removes it. That activation must coordinate contract generation with
+Notifications through explicit ordering semantics, such as a durable workflow
+dependency or a follow-up document-generated event. Registration order is not
+an ordering contract: the in-process event bus runs `booking.confirmed`
+subscribers independently and in parallel.
+
 The broader event catalog is beyond the foundational substrate:
 
 - declared `events.emits` catalogs

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -969,6 +969,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -964,6 +964,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -940,6 +940,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -935,6 +935,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1004,6 +1004,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1005,6 +1005,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1014,6 +1014,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1015,6 +1015,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1024,6 +1024,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1019,6 +1019,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1026,6 +1026,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1027,6 +1027,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1025,6 +1025,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1020,6 +1020,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -9,6 +9,7 @@
     "./contract-document-routes": "./src/contract-document-routes.ts",
     "./contract-document": "./src/contracts/contract-document-service.ts",
     "./contract-variables": "./src/contracts/contract-variables.ts",
+    "./booking-contract-subscriber": "./src/contracts/booking-contract-subscriber-runtime.ts",
     "./schema": "./src/schema.ts",
     "./contracts": "./src/contracts/index.ts",
     "./contracts/linkables": "./src/contracts/linkables.ts",
@@ -94,6 +95,11 @@
         "types": "./dist/contracts/contract-variables.d.ts",
         "import": "./dist/contracts/contract-variables.js",
         "default": "./dist/contracts/contract-variables.js"
+      },
+      "./booking-contract-subscriber": {
+        "types": "./dist/contracts/booking-contract-subscriber-runtime.d.ts",
+        "import": "./dist/contracts/booking-contract-subscriber-runtime.js",
+        "default": "./dist/contracts/booking-contract-subscriber-runtime.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/legal/src/contracts/booking-contract-subscriber-runtime.ts
+++ b/packages/legal/src/contracts/booking-contract-subscriber-runtime.ts
@@ -1,0 +1,130 @@
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
+import type { BookingPiiService } from "@voyant-travel/bookings"
+import type { ModuleContainer, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { StorageProvider } from "@voyant-travel/storage"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { ContractLifecycleHook } from "./lifecycle.js"
+import {
+  type AutoGenerateContractOptions,
+  type AutoGenerateContractResult,
+  autoGenerateContractForBooking,
+} from "./service-auto-generate.js"
+import type {
+  BookingConfirmedLikeEvent,
+  ResolveContractVariablesFn,
+} from "./service-auto-generate-types.js"
+import type { ContractDocumentGenerator } from "./service-documents.js"
+
+export const LEGAL_BOOKING_CONTRACT_SUBSCRIBER_ID =
+  "@voyant-travel/legal#subscriber.booking-contract-confirmed"
+export const LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY =
+  "legal.bookingContractSubscriberRuntime"
+
+export interface LegalBookingConfirmedEvent extends BookingConfirmedLikeEvent {
+  /** Notification suppression does not suppress the independently owned Legal artifact. */
+  suppressNotifications?: boolean
+}
+
+export interface LegalBookingContractSubscriberRuntime<TBindings = unknown> {
+  options: AutoGenerateContractOptions
+  /** Own the deployment database lifecycle for the complete generation operation. */
+  withDb<TResult>(
+    bindings: TBindings,
+    operation: (db: PostgresJsDatabase) => Promise<TResult>,
+  ): Promise<TResult>
+  documentGenerator: ContractDocumentGenerator
+  /** Storage is exposed for deployment adapters; generation consumes its storage-backed generator. */
+  documentStorage?: StorageProvider | null
+  bookingPiiService?: BookingPiiService | null
+  resolveBookingPiiService?: () =>
+    | BookingPiiService
+    | Promise<BookingPiiService | null | undefined>
+    | null
+    | undefined
+  lifecycleHooks?: readonly ContractLifecycleHook[]
+  resolveVariables?: ResolveContractVariablesFn
+  resolveActionLedgerContext(
+    event: LegalBookingConfirmedEvent,
+  ): ActionLedgerRequestContextValues | null
+}
+
+export interface LegalBookingContractSubscriberDependencies {
+  generateContract?: typeof autoGenerateContractForBooking
+  logger?: Pick<Console, "error">
+}
+
+/** Build the package-owned descriptor while leaving graph activation to a later cutover. */
+export function createLegalBookingContractSubscriberDescriptor(
+  dependencies: LegalBookingContractSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const generateContract = dependencies.generateContract ?? autoGenerateContractForBooking
+  const logger = dependencies.logger ?? console
+
+  return {
+    id: LEGAL_BOOKING_CONTRACT_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<LegalBookingConfirmedEvent>("booking.confirmed", async ({ data }) => {
+        const runtime = resolveLegalBookingContractSubscriberRuntime(container)
+        if (!runtime.options.enabled) return
+
+        try {
+          const result = await runtime.withDb(bindings, async (db) =>
+            generateContract(
+              db,
+              data,
+              {
+                ...runtime.options,
+                resolveVariables: runtime.resolveVariables ?? runtime.options.resolveVariables,
+              },
+              {
+                generator: runtime.documentGenerator,
+                eventBus,
+                lifecycleHooks: runtime.lifecycleHooks,
+                bindings: bindings as Record<string, unknown>,
+                bookingPiiService:
+                  runtime.bookingPiiService ?? (await runtime.resolveBookingPiiService?.()) ?? null,
+                actionLedgerContext: runtime.resolveActionLedgerContext(data),
+              },
+            ),
+          )
+          logNonSuccessResult(logger, data.bookingId, result)
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          logger.error(
+            `[legal] auto-generate contract failed for booking ${data.bookingId}: ${message}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+function resolveLegalBookingContractSubscriberRuntime(
+  container: ModuleContainer,
+): LegalBookingContractSubscriberRuntime {
+  if (!container.has(LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY)) {
+    throw new Error(
+      `Legal booking-contract subscriber runtime is not registered at "${LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY}".`,
+    )
+  }
+  return container.resolve<LegalBookingContractSubscriberRuntime>(
+    LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY,
+  )
+}
+
+function logNonSuccessResult(
+  logger: Pick<Console, "error">,
+  bookingId: string,
+  result: AutoGenerateContractResult,
+) {
+  if (result.status !== "ok") {
+    logger.error(
+      `[legal] auto-generate contract skipped for booking ${bookingId}: ${result.status}`,
+    )
+  }
+}
+
+export const legalBookingContractConfirmedSubscriber =
+  createLegalBookingContractSubscriberDescriptor()

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -5,6 +5,12 @@ import { openApiValidationHook } from "@voyant-travel/hono"
 import type { HonoModule } from "@voyant-travel/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
+  LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY,
+  type LegalBookingConfirmedEvent,
+  type LegalBookingContractSubscriberRuntime,
+  legalBookingContractConfirmedSubscriber,
+} from "./contracts/booking-contract-subscriber-runtime.js"
+import {
   buildContractsRouteRuntime,
   CONTRACTS_ROUTE_RUNTIME_CONTAINER_KEY,
 } from "./contracts/route-runtime.js"
@@ -13,10 +19,7 @@ import {
   createContractsAdminRoutes,
   createContractsPublicRoutes,
 } from "./contracts/routes.js"
-import {
-  type AutoGenerateContractOptions,
-  autoGenerateContractForBooking,
-} from "./contracts/service-auto-generate.js"
+import type { AutoGenerateContractOptions } from "./contracts/service-auto-generate.js"
 import { legalLinkable } from "./linkables.js"
 import { policiesAdminRoutes, policiesPublicRoutes } from "./policies/routes.js"
 import { legalTermsAdminRoutes, legalTermsPublicRoutes } from "./terms/routes.js"
@@ -76,8 +79,8 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
       // autoConfirmAndDispatch subscriber pattern. Both fire on the same
       // booking.confirmed event; legal's handler just needs to run first
       // so the contract attachment exists before notifications looks it
-      // up via listLegalBookingDocuments. Module-registration order in the
-      // template controls this.
+      // up via listLegalBookingDocuments. The selected-graph cutover must
+      // replace this compatibility path with explicit ordering semantics.
       const auto = options.autoGenerateContractOnConfirmed
       if (auto?.enabled && options.resolveDb) {
         const resolveDb = options.resolveDb
@@ -89,47 +92,30 @@ export function createLegalHonoModule(options: CreateLegalHonoModuleOptions = {}
           )
           return
         }
-        const generator = contractsRuntime.documentGenerator
-
-        eventBus.subscribe(
-          "booking.confirmed",
-          async (event: {
-            data: { bookingId: string; bookingNumber: string; actorId: string | null }
-          }) => {
-            try {
-              // The resolver may return either drizzle flavor; the queries
-              // autoGenerateContractForBooking runs are compatible with both
-              // at runtime, so we narrow at this internal boundary.
-              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
-              const result = await autoGenerateContractForBooking(db, event.data, auto, {
-                generator,
-                eventBus,
-                lifecycleHooks: contractsRuntime.lifecycleHooks,
-                bindings: bindingsRecord,
-                bookingPiiService:
-                  contractsRuntime.bookingPiiService ??
-                  (await contractsRuntime.resolveBookingPiiService?.(bindingsRecord)) ??
-                  null,
-                actionLedgerContext: {
-                  userId: event.data.actorId,
-                  actor: event.data.actorId ? "staff" : "system",
-                  callerType: "internal",
-                  isInternalRequest: true,
-                },
-              })
-              if (result.status !== "ok") {
-                console.error(
-                  `[legal] auto-generate contract skipped for booking ${event.data.bookingId}: ${result.status}`,
-                )
-              }
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              console.error(
-                `[legal] auto-generate contract failed for booking ${event.data.bookingId}: ${message}`,
-              )
-            }
-          },
-        )
+        const subscriberRuntime: LegalBookingContractSubscriberRuntime = {
+          options: auto,
+          withDb: async (runtimeBindings, operation) =>
+            operation(
+              // The generator queries support both deployed drizzle flavors;
+              // this legacy resolver narrows at the package-owned boundary.
+              resolveDb(runtimeBindings as Record<string, unknown>) as PostgresJsDatabase,
+            ),
+          documentGenerator: contractsRuntime.documentGenerator,
+          documentStorage: contractsRuntime.documentStorage,
+          bookingPiiService: contractsRuntime.bookingPiiService,
+          resolveBookingPiiService: () =>
+            contractsRuntime.resolveBookingPiiService?.(bindingsRecord),
+          lifecycleHooks: contractsRuntime.lifecycleHooks,
+          resolveVariables: auto.resolveVariables,
+          resolveActionLedgerContext: (event: LegalBookingConfirmedEvent) => ({
+            userId: event.actorId,
+            actor: event.actorId ? "staff" : "system",
+            callerType: "internal",
+            isInternalRequest: true,
+          }),
+        }
+        container.register(LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY, subscriberRuntime)
+        legalBookingContractConfirmedSubscriber.register({ bindings, container, eventBus })
       }
     },
   }
@@ -150,6 +136,15 @@ export {
   createContractDocumentHonoModule,
   createContractDocumentRoutes,
 } from "./contract-document-routes.js"
+export {
+  createLegalBookingContractSubscriberDescriptor,
+  LEGAL_BOOKING_CONTRACT_SUBSCRIBER_ID,
+  LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY,
+  type LegalBookingConfirmedEvent,
+  type LegalBookingContractSubscriberDependencies,
+  type LegalBookingContractSubscriberRuntime,
+  legalBookingContractConfirmedSubscriber,
+} from "./contracts/booking-contract-subscriber-runtime.js"
 export {
   type ContractDocumentService,
   type ContractDocumentServiceOptions,

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 const legalAdminRuntime = {
   entry: "@voyant-travel/legal-react/admin",
@@ -112,6 +112,27 @@ export const legalContractDocumentVoyantModule = defineModule({
       runtime: {
         entry: "@voyant-travel/legal/contract-document-routes",
         export: "createContractDocumentHonoModule",
+      },
+    },
+  ],
+  meta: {
+    ownership: "package",
+  },
+})
+
+/** Staged declaration; standard composition does not select this extension yet. */
+export const legalBookingContractVoyantExtension = defineExtension({
+  id: "@voyant-travel/legal#booking-contract-extension",
+  packageName: "@voyant-travel/legal",
+  localId: "legal.booking-contract-extension",
+  subscribers: [
+    {
+      id: "@voyant-travel/legal#subscriber.booking-contract-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/legal/booking-contract-subscriber",
+      runtime: {
+        entry: "./booking-contract-subscriber",
+        export: "legalBookingContractConfirmedSubscriber",
       },
     },
   ],

--- a/packages/legal/tests/unit/booking-contract-subscriber-runtime.test.ts
+++ b/packages/legal/tests/unit/booking-contract-subscriber-runtime.test.ts
@@ -1,0 +1,176 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import type { StorageProvider } from "@voyant-travel/storage"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createLegalBookingContractSubscriberDescriptor,
+  LEGAL_BOOKING_CONTRACT_SUBSCRIBER_ID,
+  LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY,
+  type LegalBookingContractSubscriberRuntime,
+} from "../../src/contracts/booking-contract-subscriber-runtime.js"
+import type { ResolveContractVariablesFn } from "../../src/contracts/service-auto-generate.js"
+import type { ContractDocumentGenerator } from "../../src/contracts/service-documents.js"
+
+const bookingEvent = {
+  name: "booking.confirmed",
+  data: {
+    bookingId: "booking_1",
+    bookingNumber: "BK-1",
+    actorId: "user_1",
+    suppressNotifications: true,
+  },
+  emittedAt: new Date().toISOString(),
+  metadata: undefined,
+} satisfies EventEnvelope
+
+function harness(options: { enabled?: boolean } = {}) {
+  const db = {} as PostgresJsDatabase
+  const bindings = { DATABASE_URL: "postgres://legal" }
+  const documentGenerator = vi.fn() as unknown as ContractDocumentGenerator
+  const documentStorage = { name: "documents" } as StorageProvider
+  const bookingPiiService = {} as never
+  const lifecycleHooks = [vi.fn()]
+  const resolveVariables = vi.fn() as ResolveContractVariablesFn
+  const actionLedgerContext = {
+    userId: "user_1",
+    actor: "staff" as const,
+    callerType: "internal" as const,
+    isInternalRequest: true,
+  }
+  const withDb = vi.fn(async (_bindings, operation) => operation(db))
+  const runtime: LegalBookingContractSubscriberRuntime<typeof bindings> = {
+    options: {
+      enabled: options.enabled ?? true,
+      templateSlug: "customer-sales-agreement",
+    },
+    withDb,
+    documentGenerator,
+    documentStorage,
+    bookingPiiService,
+    lifecycleHooks,
+    resolveVariables,
+    resolveActionLedgerContext: vi.fn(() => actionLedgerContext),
+  }
+  const container = createContainer()
+  const eventBus = createEventBus()
+  container.register(LEGAL_BOOKING_CONTRACT_SUBSCRIBER_RUNTIME_KEY, runtime)
+  let handler: ((event: EventEnvelope) => Promise<void> | void) | undefined
+  vi.spyOn(eventBus, "subscribe").mockImplementation((_eventType, registeredHandler) => {
+    handler = registeredHandler as typeof handler
+    return { unsubscribe: vi.fn() }
+  })
+  return { bindings, db, eventBus, handler: () => handler, runtime, withDb, container }
+}
+
+describe("Legal booking-contract subscriber runtime", () => {
+  it("registers the package descriptor and forwards the complete Legal runtime context", async () => {
+    const test = harness()
+    const generateContract = vi.fn(async () => ({
+      status: "ok" as const,
+      contractId: "contract_1",
+      attachmentId: "attachment_1",
+    }))
+    const descriptor = createLegalBookingContractSubscriberDescriptor({ generateContract })
+
+    await descriptor.register({
+      bindings: test.bindings,
+      container: test.container,
+      eventBus: test.eventBus,
+    })
+    await test.handler()?.(bookingEvent)
+
+    expect({ id: descriptor.id, eventType: descriptor.eventType }).toEqual({
+      id: LEGAL_BOOKING_CONTRACT_SUBSCRIBER_ID,
+      eventType: "booking.confirmed",
+    })
+    expect(test.withDb).toHaveBeenCalledWith(test.bindings, expect.any(Function))
+    expect(generateContract).toHaveBeenCalledWith(
+      test.db,
+      bookingEvent.data,
+      expect.objectContaining({
+        enabled: true,
+        templateSlug: "customer-sales-agreement",
+        resolveVariables: test.runtime.resolveVariables,
+      }),
+      expect.objectContaining({
+        generator: test.runtime.documentGenerator,
+        eventBus: test.eventBus,
+        lifecycleHooks: test.runtime.lifecycleHooks,
+        bookingPiiService: test.runtime.bookingPiiService,
+        actionLedgerContext: expect.objectContaining({ userId: "user_1", actor: "staff" }),
+        bindings: test.bindings,
+      }),
+    )
+  })
+
+  it("filters disabled generation without opening a database context", async () => {
+    const test = harness({ enabled: false })
+    const generateContract = vi.fn()
+    const descriptor = createLegalBookingContractSubscriberDescriptor({ generateContract })
+    await descriptor.register({
+      bindings: test.bindings,
+      container: test.container,
+      eventBus: test.eventBus,
+    })
+
+    await test.handler()?.(bookingEvent)
+
+    expect(test.withDb).not.toHaveBeenCalled()
+    expect(generateContract).not.toHaveBeenCalled()
+  })
+
+  it("does not treat notification suppression as Legal contract suppression", async () => {
+    const test = harness()
+    const generateContract = vi.fn(async () => ({
+      status: "ok" as const,
+      contractId: "contract_1",
+      attachmentId: "attachment_1",
+    }))
+    const descriptor = createLegalBookingContractSubscriberDescriptor({ generateContract })
+    await descriptor.register({
+      bindings: test.bindings,
+      container: test.container,
+      eventBus: test.eventBus,
+    })
+
+    await test.handler()?.(bookingEvent)
+
+    expect(generateContract).toHaveBeenCalledWith(
+      test.db,
+      expect.objectContaining({ suppressNotifications: true }),
+      expect.any(Object),
+      expect.any(Object),
+    )
+  })
+
+  it("logs ineligible generation outcomes and thrown failures without rejecting delivery", async () => {
+    const skipped = harness()
+    const logger = { error: vi.fn() }
+    const generateContract = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "template_not_found" })
+      .mockRejectedValueOnce(new Error("database unavailable"))
+    const descriptor = createLegalBookingContractSubscriberDescriptor({
+      generateContract,
+      logger,
+    })
+    await descriptor.register({
+      bindings: skipped.bindings,
+      container: skipped.container,
+      eventBus: skipped.eventBus,
+    })
+
+    await expect(skipped.handler()?.(bookingEvent)).resolves.toBeUndefined()
+    await expect(skipped.handler()?.(bookingEvent)).resolves.toBeUndefined()
+    expect(logger.error).toHaveBeenNthCalledWith(
+      1,
+      "[legal] auto-generate contract skipped for booking booking_1: template_not_found",
+    )
+    expect(logger.error).toHaveBeenNthCalledWith(
+      2,
+      "[legal] auto-generate contract failed for booking booking_1: database unavailable",
+    )
+  })
+})

--- a/packages/legal/tests/unit/package-exports.test.ts
+++ b/packages/legal/tests/unit/package-exports.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, { types: string; import: string; default: string }>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/legal package exports", () => {
+  it("publishes the booking-contract subscriber runtime subpath", () => {
+    expect(packageJson.exports["./booking-contract-subscriber"]).toBe(
+      "./src/contracts/booking-contract-subscriber-runtime.ts",
+    )
+    expect(packageJson.publishConfig.exports["./booking-contract-subscriber"]).toEqual({
+      types: "./dist/contracts/booking-contract-subscriber-runtime.d.ts",
+      import: "./dist/contracts/booking-contract-subscriber-runtime.js",
+      default: "./dist/contracts/booking-contract-subscriber-runtime.js",
+    })
+  })
+})

--- a/packages/legal/tests/unit/voyant-manifest.test.ts
+++ b/packages/legal/tests/unit/voyant-manifest.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { legalContractDocumentVoyantModule, legalVoyantModule } from "../../src/voyant.js"
+import {
+  legalBookingContractVoyantExtension,
+  legalContractDocumentVoyantModule,
+  legalVoyantModule,
+} from "../../src/voyant.js"
 
 describe("legal deployment manifest", () => {
   it("owns the selected legal package surfaces", () => {
@@ -55,6 +59,26 @@ describe("legal deployment manifest", () => {
           runtime: {
             entry: "@voyant-travel/legal/contract-document-routes",
             export: "createContractDocumentHonoModule",
+          },
+        },
+      ],
+    })
+  })
+
+  it("stages the inert booking-contract subscriber on its package-owned extension", () => {
+    expect(legalVoyantModule.subscribers).toBeUndefined()
+    expect(legalBookingContractVoyantExtension).toMatchObject({
+      schemaVersion: "voyant.extension.v1",
+      id: "@voyant-travel/legal#booking-contract-extension",
+      packageName: "@voyant-travel/legal",
+      subscribers: [
+        {
+          id: "@voyant-travel/legal#subscriber.booking-contract-confirmed",
+          eventType: "booking.confirmed",
+          source: "@voyant-travel/legal/booking-contract-subscriber",
+          runtime: {
+            entry: "./booking-contract-subscriber",
+            export: "legalBookingContractConfirmedSubscriber",
           },
         },
       ],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1034,6 +1034,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1035,6 +1035,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1035,6 +1035,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1040,6 +1040,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1035,6 +1035,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1033,6 +1033,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1034,6 +1034,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1035,6 +1035,9 @@
       "@voyant-travel/legal-react/provider": ["../legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1322,6 +1322,9 @@
       "@voyant-travel/legal-react/provider": ["../../packages/legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../../packages/legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../../packages/legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../../packages/legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../../packages/legal/dist/contracts/contract-document-service.d.ts"
       ],

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1322,6 +1322,9 @@
       "@voyant-travel/legal-react/provider": ["../../packages/legal-react/dist/provider.d.ts"],
       "@voyant-travel/legal-react/query-keys": ["../../packages/legal-react/dist/query-keys.d.ts"],
       "@voyant-travel/legal-react/ui": ["../../packages/legal-react/dist/ui.d.ts"],
+      "@voyant-travel/legal/booking-contract-subscriber": [
+        "../../packages/legal/dist/contracts/booking-contract-subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/legal/contract-document": [
         "../../packages/legal/dist/contracts/contract-document-service.d.ts"
       ],


### PR DESCRIPTION
## Summary

- extract Legal booking-confirmed contract generation into a package-owned executable subscriber descriptor
- define a narrow Legal runtime service for database lifecycle, document generation/storage, booking PII, lifecycle/action-ledger context, and variable resolution
- stage an inert runtime reference on an unselected Legal extension and publish the subscriber subpath
- preserve compatibility bootstrap eligibility, notification-suppression isolation, and failure logging
- document explicit ordering semantics for future Notifications coordination

## Verification

- `pnpm --filter @voyant-travel/legal test -- tests/unit/booking-contract-subscriber-runtime.test.ts tests/unit/voyant-manifest.test.ts tests/unit/package-exports.test.ts` (package runner: 18 files / 144 tests passed; 9 files / 54 database-dependent tests skipped)
- `pnpm exec biome check --write` on changed Legal source and test files
- `pnpm generate:dist-configs`
- `git diff --cached --check`

Package typecheck was attempted twice but terminated under shared-workspace compiler pressure, first by SIGTERM and then by explicit cancellation. Broad verification is deferred to CI per request.