### PR TITLE
feat(notifications): stage subscriber runtime contract

### DIFF
--- a/.changeset/notifications-subscriber-runtime.md
+++ b/.changeset/notifications-subscriber-runtime.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/notifications": minor
+---
+
+Publish package-owned subscriber runtime descriptors for reminder rules and booking-confirmation auto-dispatch behind one Notifications runtime service contract.

--- a/docs/architecture/notifications-architecture.md
+++ b/docs/architecture/notifications-architecture.md
@@ -144,6 +144,15 @@ Rule:
 Different trigger points are fine. Delivery should still converge on one shared
 notification model.
 
+Notifications owns executable subscriber descriptors for its reminder rules
+and booking-confirmation auto-dispatch. Deployments supply their database,
+dispatcher, and attachment resolver through the single
+`NotificationsSubscriberRuntime` contract. The package manifest keeps the
+reminder runtime references on an inert extension, and does not reference the
+auto-dispatch descriptor. Selected-graph activation must wait until Legal's
+document generation and Notifications delivery have explicit ordering
+semantics; event-bus registration order is not an ordering contract.
+
 ## Attachments And Documents
 
 ### 8. Sensitive attachments should resolve access at send time

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1015,6 +1015,17 @@ runtime references must move with their domain-owning shards, and the Operator
 bridge must be removed in the same activation change to prevent duplicate
 invalidation hints.
 
+Notifications now stages package-owned executable descriptors for reminder-rule
+handling on `booking.confirmed`, `payment.completed`, `booking.cancelled`, and
+`booking.expired`, plus booking-confirmation auto-dispatch. All five resolve one
+narrow package runtime service for the database, dispatcher, and attachment
+resolver. The four reminder descriptors have runtime references on an inert,
+unselected Notifications extension; existing module bootstrap remains their
+only activation path in this slice. Auto-dispatch deliberately has no manifest
+runtime reference. Moving either path to selected-graph activation remains
+gated on explicit Legal document-ordering semantics for `booking.confirmed`, as
+ordinary event-bus subscribers run independently and provide no ordering.
+
 The broader event catalog is beyond the foundational substrate:
 
 - declared `events.emits` catalogs

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1042,6 +1042,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1037,6 +1037,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1013,6 +1013,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1008,6 +1008,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1077,6 +1077,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1078,6 +1078,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1087,6 +1087,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1088,6 +1088,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1097,6 +1097,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1092,6 +1092,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1101,6 +1101,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1102,6 +1102,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1098,6 +1098,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1093,6 +1093,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -14,6 +14,7 @@
     "./tasks": "./src/tasks/index.ts",
     "./workflows": "./src/workflow-entry.ts",
     "./workflow-runtime": "./src/workflow-runtime.ts",
+    "./subscriber-runtime": "./src/subscriber-runtime.ts",
     "./providers/local": "./src/providers/local.ts",
     "./providers/voyant-cloud-email": "./src/providers/voyant-cloud-email.ts",
     "./providers/voyant-cloud-sms": "./src/providers/voyant-cloud-sms.ts",
@@ -109,6 +110,11 @@
         "types": "./dist/workflow-runtime.d.ts",
         "import": "./dist/workflow-runtime.js",
         "default": "./dist/workflow-runtime.js"
+      },
+      "./subscriber-runtime": {
+        "types": "./dist/subscriber-runtime.d.ts",
+        "import": "./dist/subscriber-runtime.js",
+        "default": "./dist/subscriber-runtime.js"
       },
       "./providers/local": {
         "types": "./dist/providers/local.d.ts",

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -19,11 +19,13 @@ import {
   bookingDocumentBundleLifecycleService,
   type RunBookingDocumentBundleLifecycleInput,
 } from "./service-booking-document-lifecycle.js"
-import { bookingDocumentNotificationsService } from "./service-booking-documents.js"
+import { bookingIsPaidInFullForNotification } from "./service-reminders.js"
 import {
-  bookingIsPaidInFullForNotification,
-  dispatchReminderEventRules,
-} from "./service-reminders.js"
+  createBookingConfirmationAutoDispatchSubscriberRuntime,
+  NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY,
+  type NotificationsAutoConfirmAndDispatchOptions,
+  notificationsReminderSubscriberRuntimeDescriptors,
+} from "./subscriber-runtime.js"
 
 export {
   notificationLiquidEngine,
@@ -113,6 +115,34 @@ export {
   bookingIsPaidInFullForNotification,
   dispatchReminderEventRules,
 } from "./service-reminders.js"
+/**
+ * Auto-dispatch policy for the `booking.confirmed` subscriber. Set `enabled:
+ * false` (or leave the option off entirely) to opt out.
+ */
+export type {
+  NotificationsAutoConfirmAndDispatchOptions,
+  NotificationsSubscriberDependencies,
+  NotificationsSubscriberRuntime,
+} from "./subscriber-runtime.js"
+export {
+  createBookingCancelledReminderSubscriberRuntime,
+  createBookingConfirmationAutoDispatchSubscriberRuntime,
+  createBookingConfirmedReminderSubscriberRuntime,
+  createBookingExpiredReminderSubscriberRuntime,
+  createPaymentCompletedReminderSubscriberRuntime,
+  NOTIFICATIONS_BOOKING_CANCELLED_REMINDER_SUBSCRIBER_ID,
+  NOTIFICATIONS_BOOKING_CONFIRMATION_AUTO_DISPATCH_SUBSCRIBER_ID,
+  NOTIFICATIONS_BOOKING_CONFIRMED_REMINDER_SUBSCRIBER_ID,
+  NOTIFICATIONS_BOOKING_EXPIRED_REMINDER_SUBSCRIBER_ID,
+  NOTIFICATIONS_PAYMENT_COMPLETED_REMINDER_SUBSCRIBER_ID,
+  NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY,
+  notificationsBookingCancelledReminderSubscriber,
+  notificationsBookingConfirmationAutoDispatchSubscriber,
+  notificationsBookingConfirmedReminderSubscriber,
+  notificationsBookingExpiredReminderSubscriber,
+  notificationsPaymentCompletedReminderSubscriber,
+  notificationsReminderSubscriberRuntimeDescriptors,
+} from "./subscriber-runtime.js"
 export type {
   NotificationTaskEnv,
   NotificationTaskRuntime,
@@ -192,18 +222,6 @@ export {
   type SendDueRemindersWorkflowInput,
 } from "./workflow-runtime.js"
 
-/**
- * Auto-dispatch policy for the `booking.confirmed` subscriber. Set `enabled:
- * false` (or leave the option off entirely) to opt out.
- */
-export interface NotificationsAutoConfirmAndDispatchOptions {
-  enabled?: boolean
-  /** Notification template slug used when the handler fires. */
-  templateSlug?: string
-  /** Optional allowlist of document types to attach; defaults to all. */
-  documentTypes?: Array<"contract" | "invoice" | "proforma">
-}
-
 export interface CreateNotificationsHonoModuleOptions extends NotificationsRoutesOptions {
   /**
    * Resolves a database from runtime bindings. Required for
@@ -246,60 +264,24 @@ export function createNotificationsHonoModule(
         buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options),
       )
 
-      // Auto-dispatch wiring — opt-in. When enabled, every `booking.confirmed`
-      // event triggers a `confirmAndDispatchBooking` call so the operator
-      // doesn't have to click a second button. The handler runs in the same
-      // process as the emitter (the in-process event bus) but outside the
-      // request scope, so we resolve our own db handle from bindings.
-      if (options?.autoConfirmAndDispatch?.enabled && options.resolveDb) {
+      if (options?.resolveDb) {
         const resolveDb = options.resolveDb
-        const autoOptions = options.autoConfirmAndDispatch
         const runtime = buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options)
-        const dispatcher = createNotificationService(runtime.providers)
+        container.register(NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY, {
+          resolveDb: (runtimeBindings: unknown) =>
+            resolveDb(runtimeBindings as Record<string, unknown>) as PostgresJsDatabase,
+          dispatcher: createNotificationService(runtime.providers),
+          documentAttachmentResolver: runtime.documentAttachmentResolver,
+          autoConfirmAndDispatch: options.autoConfirmAndDispatch,
+        })
+      }
 
-        eventBus.subscribe(
-          "booking.confirmed",
-          async (event: {
-            data: {
-              bookingId: string
-              bookingNumber: string
-              actorId: string | null
-              suppressNotifications?: boolean
-            }
-          }) => {
-            // Honor caller opt-out — the operator may want to confirm
-            // a booking without firing the customer-facing email/doc
-            // bundle (e.g. data correction, manual hand-off).
-            if (event.data.suppressNotifications === true) return
-            try {
-              // The resolver may return either drizzle flavor; the queries
-              // bookingDocumentNotificationsService runs are compatible with
-              // both at runtime, so we narrow at this internal boundary.
-              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
-              await bookingDocumentNotificationsService.confirmAndDispatchBooking(
-                db,
-                dispatcher,
-                event.data.bookingId,
-                {
-                  templateSlug: autoOptions.templateSlug ?? null,
-                  documentTypes: autoOptions.documentTypes ?? null,
-                },
-                {
-                  attachmentResolver: runtime.documentAttachmentResolver,
-                  eventBus,
-                },
-              )
-            } catch (error) {
-              // Per the EventBus contract, handler failures are logged, not
-              // rethrown. We surface the context so ops can diagnose without
-              // digging through stack traces.
-              const message = error instanceof Error ? error.message : String(error)
-              console.error(
-                `[notifications] auto-dispatch failed for booking ${event.data.bookingId}: ${message}`,
-              )
-            }
-          },
-        )
+      if (options?.autoConfirmAndDispatch?.enabled && options.resolveDb) {
+        createBookingConfirmationAutoDispatchSubscriberRuntime().register({
+          bindings,
+          container,
+          eventBus,
+        })
       }
 
       if (options?.documentBundleLifecycle?.enabled && options.resolveDb) {
@@ -393,148 +375,9 @@ export function createNotificationsHonoModule(
       }
 
       if (options?.resolveDb) {
-        const resolveDb = options.resolveDb
-        const runtime = buildNotificationsRouteRuntime(bindings as Record<string, unknown>, options)
-        const dispatcher = createNotificationService(runtime.providers)
-
-        eventBus.subscribe(
-          "booking.confirmed",
-          async (event: {
-            data: { bookingId: string; bookingNumber: string; actorId: string | null }
-          }) => {
-            try {
-              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
-              await dispatchReminderEventRules(
-                db,
-                dispatcher,
-                {
-                  targetType: "booking_confirmed",
-                  bookingId: event.data.bookingId,
-                  eventData: event.data,
-                },
-                { documentAttachmentResolver: runtime.documentAttachmentResolver },
-              )
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              console.error(
-                `[notifications] booking_confirmed reminder rules failed for booking ${event.data.bookingId}: ${message}`,
-              )
-            }
-          },
-        )
-
-        eventBus.subscribe(
-          "payment.completed",
-          async (event: {
-            data: {
-              paymentSessionId: string
-              bookingId?: string | null
-              orderId?: string | null
-              invoiceId?: string | null
-              amountCents: number
-              currency: string
-              provider: string
-            }
-          }) => {
-            if (!event.data.bookingId) {
-              return
-            }
-
-            try {
-              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
-              const isPaidInFull = await bookingIsPaidInFullForNotification(
-                db,
-                event.data.bookingId,
-              )
-              if (!isPaidInFull) {
-                return
-              }
-
-              await dispatchReminderEventRules(
-                db,
-                dispatcher,
-                {
-                  targetType: "payment_complete",
-                  bookingId: event.data.bookingId,
-                  paymentSessionId: event.data.paymentSessionId,
-                  eventData: event.data,
-                },
-                { documentAttachmentResolver: runtime.documentAttachmentResolver },
-              )
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              console.error(
-                `[notifications] payment_complete reminder rules failed for booking ${event.data.bookingId}: ${message}`,
-              )
-            }
-          },
-        )
-
-        eventBus.subscribe(
-          "booking.cancelled",
-          async (event: {
-            data: {
-              bookingId: string
-              bookingNumber: string
-              previousStatus: "draft" | "on_hold" | "confirmed" | "in_progress"
-              actorId: string | null
-            }
-          }) => {
-            if (event.data.previousStatus !== "on_hold") {
-              return
-            }
-
-            try {
-              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
-              await dispatchReminderEventRules(
-                db,
-                dispatcher,
-                {
-                  targetType: "booking_cancelled_non_payment",
-                  bookingId: event.data.bookingId,
-                  eventData: event.data,
-                },
-                { documentAttachmentResolver: runtime.documentAttachmentResolver },
-              )
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              console.error(
-                `[notifications] booking_cancelled_non_payment reminder rules failed for booking ${event.data.bookingId}: ${message}`,
-              )
-            }
-          },
-        )
-
-        eventBus.subscribe(
-          "booking.expired",
-          async (event: {
-            data: {
-              bookingId: string
-              bookingNumber: string
-              cause: "route" | "sweep"
-              actorId: string | null
-            }
-          }) => {
-            try {
-              const db = resolveDb(bindings as Record<string, unknown>) as PostgresJsDatabase
-              await dispatchReminderEventRules(
-                db,
-                dispatcher,
-                {
-                  targetType: "booking_cancelled_non_payment",
-                  bookingId: event.data.bookingId,
-                  eventData: event.data,
-                },
-                { documentAttachmentResolver: runtime.documentAttachmentResolver },
-              )
-            } catch (error) {
-              const message = error instanceof Error ? error.message : String(error)
-              console.error(
-                `[notifications] booking_cancelled_non_payment reminder rules failed for expired booking ${event.data.bookingId}: ${message}`,
-              )
-            }
-          },
-        )
+        for (const descriptor of notificationsReminderSubscriberRuntimeDescriptors) {
+          descriptor.register({ bindings, container, eventBus })
+        }
       }
     },
   }

--- a/packages/notifications/src/subscriber-runtime.ts
+++ b/packages/notifications/src/subscriber-runtime.ts
@@ -1,0 +1,285 @@
+import type { ModuleContainer, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { NotificationService } from "./service.js"
+import {
+  type BookingDocumentAttachmentResolver,
+  bookingDocumentNotificationsService,
+} from "./service-booking-documents.js"
+import {
+  bookingIsPaidInFullForNotification,
+  dispatchReminderEventRules,
+} from "./service-reminders.js"
+
+export const NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY = "notifications.subscriberRuntime"
+
+export const NOTIFICATIONS_BOOKING_CONFIRMED_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-booking-confirmed"
+export const NOTIFICATIONS_PAYMENT_COMPLETED_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-payment-completed"
+export const NOTIFICATIONS_BOOKING_CANCELLED_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-booking-cancelled"
+export const NOTIFICATIONS_BOOKING_EXPIRED_REMINDER_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.reminder-booking-expired"
+export const NOTIFICATIONS_BOOKING_CONFIRMATION_AUTO_DISPATCH_SUBSCRIBER_ID =
+  "@voyant-travel/notifications#subscriber.booking-confirmation-auto-dispatch"
+
+export interface NotificationsAutoConfirmAndDispatchOptions {
+  enabled?: boolean
+  templateSlug?: string
+  documentTypes?: Array<"contract" | "invoice" | "proforma">
+}
+
+/** Deployment-owned services required by package-owned Notifications subscribers. */
+export interface NotificationsSubscriberRuntime {
+  resolveDb(bindings: unknown): PostgresJsDatabase
+  dispatcher: NotificationService
+  documentAttachmentResolver?: BookingDocumentAttachmentResolver
+  autoConfirmAndDispatch?: NotificationsAutoConfirmAndDispatchOptions
+}
+
+export interface NotificationsSubscriberDependencies {
+  dispatchReminderRules?: typeof dispatchReminderEventRules
+  isPaidInFull?: typeof bookingIsPaidInFullForNotification
+  confirmAndDispatchBooking?: typeof bookingDocumentNotificationsService.confirmAndDispatchBooking
+  logger?: Pick<Console, "error">
+}
+
+interface BookingConfirmedPayload extends Record<string, unknown> {
+  bookingId: string
+  bookingNumber: string
+  actorId: string | null
+  suppressNotifications?: boolean
+}
+
+interface PaymentCompletedPayload extends Record<string, unknown> {
+  paymentSessionId: string
+  bookingId?: string | null
+  orderId?: string | null
+  invoiceId?: string | null
+  amountCents: number
+  currency: string
+  provider: string
+}
+
+interface BookingCancelledPayload extends Record<string, unknown> {
+  bookingId: string
+  bookingNumber: string
+  previousStatus: "draft" | "on_hold" | "confirmed" | "in_progress"
+  actorId: string | null
+}
+
+interface BookingExpiredPayload extends Record<string, unknown> {
+  bookingId: string
+  bookingNumber: string
+  cause: "route" | "sweep"
+  actorId: string | null
+}
+
+function resolveRuntime(container: ModuleContainer): NotificationsSubscriberRuntime {
+  if (!container.has(NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY)) {
+    throw new Error(
+      `Notifications subscriber runtime is not registered at "${NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY}".`,
+    )
+  }
+  return container.resolve<NotificationsSubscriberRuntime>(NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY)
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+export function createBookingConfirmedReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const dispatchReminderRules = dependencies.dispatchReminderRules ?? dispatchReminderEventRules
+  const logger = dependencies.logger ?? console
+
+  return {
+    id: NOTIFICATIONS_BOOKING_CONFIRMED_REMINDER_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
+        try {
+          const runtime = resolveRuntime(container)
+          await dispatchReminderRules(
+            runtime.resolveDb(bindings),
+            runtime.dispatcher,
+            { targetType: "booking_confirmed", bookingId: data.bookingId, eventData: data },
+            { documentAttachmentResolver: runtime.documentAttachmentResolver },
+          )
+        } catch (error) {
+          logger.error(
+            `[notifications] booking_confirmed reminder rules failed for booking ${data.bookingId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+export function createPaymentCompletedReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const dispatchReminderRules = dependencies.dispatchReminderRules ?? dispatchReminderEventRules
+  const isPaidInFull = dependencies.isPaidInFull ?? bookingIsPaidInFullForNotification
+  const logger = dependencies.logger ?? console
+
+  return {
+    id: NOTIFICATIONS_PAYMENT_COMPLETED_REMINDER_SUBSCRIBER_ID,
+    eventType: "payment.completed",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<PaymentCompletedPayload>("payment.completed", async ({ data }) => {
+        if (!data.bookingId) return
+
+        try {
+          const runtime = resolveRuntime(container)
+          const db = runtime.resolveDb(bindings)
+          if (!(await isPaidInFull(db, data.bookingId))) return
+
+          await dispatchReminderRules(
+            db,
+            runtime.dispatcher,
+            {
+              targetType: "payment_complete",
+              bookingId: data.bookingId,
+              paymentSessionId: data.paymentSessionId,
+              eventData: data,
+            },
+            { documentAttachmentResolver: runtime.documentAttachmentResolver },
+          )
+        } catch (error) {
+          logger.error(
+            `[notifications] payment_complete reminder rules failed for booking ${data.bookingId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+export function createBookingCancelledReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const dispatchReminderRules = dependencies.dispatchReminderRules ?? dispatchReminderEventRules
+  const logger = dependencies.logger ?? console
+
+  return {
+    id: NOTIFICATIONS_BOOKING_CANCELLED_REMINDER_SUBSCRIBER_ID,
+    eventType: "booking.cancelled",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<BookingCancelledPayload>("booking.cancelled", async ({ data }) => {
+        if (data.previousStatus !== "on_hold") return
+
+        try {
+          const runtime = resolveRuntime(container)
+          await dispatchReminderRules(
+            runtime.resolveDb(bindings),
+            runtime.dispatcher,
+            {
+              targetType: "booking_cancelled_non_payment",
+              bookingId: data.bookingId,
+              eventData: data,
+            },
+            { documentAttachmentResolver: runtime.documentAttachmentResolver },
+          )
+        } catch (error) {
+          logger.error(
+            `[notifications] booking_cancelled_non_payment reminder rules failed for booking ${data.bookingId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+export function createBookingExpiredReminderSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const dispatchReminderRules = dependencies.dispatchReminderRules ?? dispatchReminderEventRules
+  const logger = dependencies.logger ?? console
+
+  return {
+    id: NOTIFICATIONS_BOOKING_EXPIRED_REMINDER_SUBSCRIBER_ID,
+    eventType: "booking.expired",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<BookingExpiredPayload>("booking.expired", async ({ data }) => {
+        try {
+          const runtime = resolveRuntime(container)
+          await dispatchReminderRules(
+            runtime.resolveDb(bindings),
+            runtime.dispatcher,
+            {
+              targetType: "booking_cancelled_non_payment",
+              bookingId: data.bookingId,
+              eventData: data,
+            },
+            { documentAttachmentResolver: runtime.documentAttachmentResolver },
+          )
+        } catch (error) {
+          logger.error(
+            `[notifications] booking_cancelled_non_payment reminder rules failed for expired booking ${data.bookingId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+export function createBookingConfirmationAutoDispatchSubscriberRuntime(
+  dependencies: NotificationsSubscriberDependencies = {},
+): SubscriberRuntimeDescriptor {
+  const confirmAndDispatchBooking =
+    dependencies.confirmAndDispatchBooking ??
+    bookingDocumentNotificationsService.confirmAndDispatchBooking
+  const logger = dependencies.logger ?? console
+
+  return {
+    id: NOTIFICATIONS_BOOKING_CONFIRMATION_AUTO_DISPATCH_SUBSCRIBER_ID,
+    eventType: "booking.confirmed",
+    register: ({ bindings, container, eventBus }) => {
+      eventBus.subscribe<BookingConfirmedPayload>("booking.confirmed", async ({ data }) => {
+        if (data.suppressNotifications === true) return
+
+        try {
+          const runtime = resolveRuntime(container)
+          const options = runtime.autoConfirmAndDispatch
+          if (!options?.enabled) return
+
+          await confirmAndDispatchBooking(
+            runtime.resolveDb(bindings),
+            runtime.dispatcher,
+            data.bookingId,
+            {
+              templateSlug: options.templateSlug ?? null,
+              documentTypes: options.documentTypes ?? null,
+            },
+            { attachmentResolver: runtime.documentAttachmentResolver, eventBus },
+          )
+        } catch (error) {
+          logger.error(
+            `[notifications] auto-dispatch failed for booking ${data.bookingId}: ${errorMessage(error)}`,
+          )
+        }
+      })
+    },
+  }
+}
+
+export const notificationsBookingConfirmedReminderSubscriber =
+  createBookingConfirmedReminderSubscriberRuntime()
+export const notificationsPaymentCompletedReminderSubscriber =
+  createPaymentCompletedReminderSubscriberRuntime()
+export const notificationsBookingCancelledReminderSubscriber =
+  createBookingCancelledReminderSubscriberRuntime()
+export const notificationsBookingExpiredReminderSubscriber =
+  createBookingExpiredReminderSubscriberRuntime()
+export const notificationsBookingConfirmationAutoDispatchSubscriber =
+  createBookingConfirmationAutoDispatchSubscriberRuntime()
+
+export const notificationsReminderSubscriberRuntimeDescriptors = [
+  notificationsBookingConfirmedReminderSubscriber,
+  notificationsPaymentCompletedReminderSubscriber,
+  notificationsBookingCancelledReminderSubscriber,
+  notificationsBookingExpiredReminderSubscriber,
+] as const

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -1,4 +1,4 @@
-import { defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule } from "@voyant-travel/core/project"
 
 const schemaSource = "@voyant-travel/notifications/schema"
 
@@ -143,6 +143,58 @@ export const notificationsVoyantModule = defineModule({
   lifecycle: {
     uninstall: { default: "retain-data", purge: "not-supported" },
   },
+  meta: {
+    ownership: "package",
+  },
+})
+
+/**
+ * Inert until a deployment explicitly selects the extension and removes the
+ * legacy module-bootstrap registrations. Confirmation auto-dispatch is omitted
+ * until Legal document ordering has an explicit runtime contract.
+ */
+export const notificationsReminderSubscribersVoyantPlugin = defineExtension({
+  id: "@voyant-travel/notifications#reminder-subscribers-extension",
+  packageName: "@voyant-travel/notifications",
+  localId: "notifications.reminder-subscribers-extension",
+  subscribers: [
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-booking-confirmed",
+      eventType: "booking.confirmed",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "./subscriber-runtime",
+        export: "notificationsBookingConfirmedReminderSubscriber",
+      },
+    },
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-payment-completed",
+      eventType: "payment.completed",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "./subscriber-runtime",
+        export: "notificationsPaymentCompletedReminderSubscriber",
+      },
+    },
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-booking-cancelled",
+      eventType: "booking.cancelled",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "./subscriber-runtime",
+        export: "notificationsBookingCancelledReminderSubscriber",
+      },
+    },
+    {
+      id: "@voyant-travel/notifications#subscriber.reminder-booking-expired",
+      eventType: "booking.expired",
+      source: "@voyant-travel/notifications/subscriber-runtime",
+      runtime: {
+        entry: "./subscriber-runtime",
+        export: "notificationsBookingExpiredReminderSubscriber",
+      },
+    },
+  ],
   meta: {
     ownership: "package",
   },

--- a/packages/notifications/tests/unit/subscriber-runtime.test.ts
+++ b/packages/notifications/tests/unit/subscriber-runtime.test.ts
@@ -1,0 +1,217 @@
+import { createContainer, createEventBus } from "@voyant-travel/core"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it, vi } from "vitest"
+
+import type { NotificationService } from "../../src/service.js"
+import {
+  createBookingCancelledReminderSubscriberRuntime,
+  createBookingConfirmationAutoDispatchSubscriberRuntime,
+  createBookingConfirmedReminderSubscriberRuntime,
+  createBookingExpiredReminderSubscriberRuntime,
+  createPaymentCompletedReminderSubscriberRuntime,
+  NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY,
+  type NotificationsSubscriberRuntime,
+  notificationsReminderSubscriberRuntimeDescriptors,
+} from "../../src/subscriber-runtime.js"
+
+const db = {} as PostgresJsDatabase
+const dispatcher = {} as NotificationService
+const attachmentResolver = vi.fn()
+
+function createHarness(runtimeOptions: Partial<NotificationsSubscriberRuntime> = {}) {
+  const bindings = { deployment: "test" }
+  const container = createContainer()
+  const eventBus = createEventBus()
+  container.register(NOTIFICATIONS_SUBSCRIBER_RUNTIME_KEY, {
+    resolveDb: vi.fn(() => db),
+    dispatcher,
+    documentAttachmentResolver: attachmentResolver,
+    ...runtimeOptions,
+  } satisfies NotificationsSubscriberRuntime)
+  return { bindings, container, eventBus }
+}
+
+describe("Notifications subscriber runtime descriptors", () => {
+  it("publishes stable reminder descriptor ids and event types", () => {
+    expect(
+      notificationsReminderSubscriberRuntimeDescriptors.map(({ id, eventType }) => ({
+        id,
+        eventType,
+      })),
+    ).toEqual([
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-booking-confirmed",
+        eventType: "booking.confirmed",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-payment-completed",
+        eventType: "payment.completed",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-booking-cancelled",
+        eventType: "booking.cancelled",
+      },
+      {
+        id: "@voyant-travel/notifications#subscriber.reminder-booking-expired",
+        eventType: "booking.expired",
+      },
+    ])
+  })
+
+  it("dispatches booking-confirmed rules with the runtime attachment resolver", async () => {
+    const dispatchReminderRules = vi.fn().mockResolvedValue(undefined)
+    const harness = createHarness()
+    createBookingConfirmedReminderSubscriberRuntime({ dispatchReminderRules }).register(harness)
+
+    const payload = { bookingId: "book_1", bookingNumber: "BK-1", actorId: null }
+    await harness.eventBus.emit("booking.confirmed", payload)
+
+    expect(dispatchReminderRules).toHaveBeenCalledWith(
+      db,
+      dispatcher,
+      { targetType: "booking_confirmed", bookingId: "book_1", eventData: payload },
+      { documentAttachmentResolver: attachmentResolver },
+    )
+  })
+
+  it("dispatches payment rules only when the booking is paid in full", async () => {
+    const dispatchReminderRules = vi.fn().mockResolvedValue(undefined)
+    const isPaidInFull = vi.fn().mockResolvedValueOnce(false).mockResolvedValueOnce(true)
+    const harness = createHarness()
+    createPaymentCompletedReminderSubscriberRuntime({
+      dispatchReminderRules,
+      isPaidInFull,
+    }).register(harness)
+
+    const payload = {
+      paymentSessionId: "pay_1",
+      bookingId: "book_1",
+      amountCents: 1000,
+      currency: "EUR",
+      provider: "test",
+    }
+    await harness.eventBus.emit("payment.completed", payload)
+    await harness.eventBus.emit("payment.completed", payload)
+
+    expect(isPaidInFull).toHaveBeenCalledTimes(2)
+    expect(dispatchReminderRules).toHaveBeenCalledTimes(1)
+    expect(dispatchReminderRules).toHaveBeenCalledWith(
+      db,
+      dispatcher,
+      expect.objectContaining({
+        targetType: "payment_complete",
+        bookingId: "book_1",
+        paymentSessionId: "pay_1",
+      }),
+      { documentAttachmentResolver: attachmentResolver },
+    )
+  })
+
+  it("dispatches cancellation rules only for a booking leaving on_hold", async () => {
+    const dispatchReminderRules = vi.fn().mockResolvedValue(undefined)
+    const harness = createHarness()
+    createBookingCancelledReminderSubscriberRuntime({ dispatchReminderRules }).register(harness)
+
+    await harness.eventBus.emit("booking.cancelled", {
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+      previousStatus: "confirmed",
+      actorId: null,
+    })
+    await harness.eventBus.emit("booking.cancelled", {
+      bookingId: "book_2",
+      bookingNumber: "BK-2",
+      previousStatus: "on_hold",
+      actorId: null,
+    })
+
+    expect(dispatchReminderRules).toHaveBeenCalledTimes(1)
+    expect(dispatchReminderRules).toHaveBeenCalledWith(
+      db,
+      dispatcher,
+      expect.objectContaining({
+        targetType: "booking_cancelled_non_payment",
+        bookingId: "book_2",
+      }),
+      { documentAttachmentResolver: attachmentResolver },
+    )
+  })
+
+  it("maps booking expiry to non-payment cancellation rules", async () => {
+    const dispatchReminderRules = vi.fn().mockResolvedValue(undefined)
+    const harness = createHarness()
+    createBookingExpiredReminderSubscriberRuntime({ dispatchReminderRules }).register(harness)
+
+    await harness.eventBus.emit("booking.expired", {
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+      cause: "sweep",
+      actorId: null,
+    })
+
+    expect(dispatchReminderRules).toHaveBeenCalledWith(
+      db,
+      dispatcher,
+      expect.objectContaining({
+        targetType: "booking_cancelled_non_payment",
+        bookingId: "book_1",
+      }),
+      { documentAttachmentResolver: attachmentResolver },
+    )
+  })
+
+  it("honors suppression and resolves auto-dispatch attachments from the runtime", async () => {
+    const confirmAndDispatchBooking = vi.fn().mockResolvedValue(undefined)
+    const harness = createHarness({
+      autoConfirmAndDispatch: {
+        enabled: true,
+        templateSlug: "booking-confirmation",
+        documentTypes: ["contract", "invoice"],
+      },
+    })
+    createBookingConfirmationAutoDispatchSubscriberRuntime({
+      confirmAndDispatchBooking,
+    }).register(harness)
+
+    await harness.eventBus.emit("booking.confirmed", {
+      bookingId: "book_suppressed",
+      bookingNumber: "BK-0",
+      actorId: null,
+      suppressNotifications: true,
+    })
+    await harness.eventBus.emit("booking.confirmed", {
+      bookingId: "book_1",
+      bookingNumber: "BK-1",
+      actorId: null,
+    })
+
+    expect(confirmAndDispatchBooking).toHaveBeenCalledTimes(1)
+    expect(confirmAndDispatchBooking).toHaveBeenCalledWith(
+      db,
+      dispatcher,
+      "book_1",
+      { templateSlug: "booking-confirmation", documentTypes: ["contract", "invoice"] },
+      { attachmentResolver, eventBus: harness.eventBus },
+    )
+  })
+
+  it("catches and logs runtime failures without rejecting the event", async () => {
+    const logger = { error: vi.fn() }
+    const harness = createHarness()
+    createBookingConfirmedReminderSubscriberRuntime({
+      dispatchReminderRules: vi.fn().mockRejectedValue(new Error("boom")),
+      logger,
+    }).register(harness)
+
+    await expect(
+      harness.eventBus.emit("booking.confirmed", {
+        bookingId: "book_1",
+        bookingNumber: "BK-1",
+        actorId: null,
+      }),
+    ).resolves.toBeUndefined()
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringMatching(/booking_confirmed reminder rules failed.*book_1.*boom/),
+    )
+  })
+})

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest"
-import { notificationsVoyantModule } from "../../src/voyant.js"
+import {
+  NOTIFICATIONS_BOOKING_CONFIRMATION_AUTO_DISPATCH_SUBSCRIBER_ID,
+  notificationsReminderSubscriberRuntimeDescriptors,
+} from "../../src/subscriber-runtime.js"
+import {
+  notificationsReminderSubscribersVoyantPlugin,
+  notificationsVoyantModule,
+} from "../../src/voyant.js"
 import {
   createNotificationReminderWorkflows,
   notificationsDeliverReminderWorkflow,
@@ -65,6 +72,26 @@ describe("notifications deployment manifest", () => {
     )
     expect(notificationsSendDueRemindersWorkflow.id).toBe(
       notificationsVoyantModule.workflows?.[1]?.id,
+    )
+  })
+
+  it("keeps reminder subscriber runtime references inert and export-compatible", () => {
+    const declarations = notificationsReminderSubscribersVoyantPlugin.subscribers ?? []
+
+    expect(declarations.map(({ id, eventType }) => ({ id, eventType }))).toEqual(
+      notificationsReminderSubscriberRuntimeDescriptors.map(({ id, eventType }) => ({
+        id,
+        eventType,
+      })),
+    )
+    expect(declarations.map((subscriber) => subscriber.runtime?.export)).toEqual([
+      "notificationsBookingConfirmedReminderSubscriber",
+      "notificationsPaymentCompletedReminderSubscriber",
+      "notificationsBookingCancelledReminderSubscriber",
+      "notificationsBookingExpiredReminderSubscriber",
+    ])
+    expect(declarations.map((subscriber) => subscriber.id)).not.toContain(
+      NOTIFICATIONS_BOOKING_CONFIRMATION_AUTO_DISPATCH_SUBSCRIBER_ID,
     )
   })
 

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1107,6 +1107,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1113,6 +1113,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1106,6 +1106,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1107,6 +1107,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1108,6 +1108,9 @@
       "@voyant-travel/notifications/routes": ["../notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../notifications/dist/template-authoring.d.ts"

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1423,6 +1423,9 @@
       "@voyant-travel/notifications/routes": ["../../packages/notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../../packages/notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../../packages/notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../../packages/notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../../packages/notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../../packages/notifications/dist/template-authoring.d.ts"

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1423,6 +1423,9 @@
       "@voyant-travel/notifications/routes": ["../../packages/notifications/dist/routes.d.ts"],
       "@voyant-travel/notifications/schema": ["../../packages/notifications/dist/schema.d.ts"],
       "@voyant-travel/notifications/service": ["../../packages/notifications/dist/service.d.ts"],
+      "@voyant-travel/notifications/subscriber-runtime": [
+        "../../packages/notifications/dist/subscriber-runtime.d.ts"
+      ],
       "@voyant-travel/notifications/tasks": ["../../packages/notifications/dist/tasks/index.d.ts"],
       "@voyant-travel/notifications/template-authoring": [
         "../../packages/notifications/dist/template-authoring.d.ts"


### PR DESCRIPTION
## Summary

- consolidate Notifications reminder-rule and booking confirmation auto-dispatch handlers into package-owned executable subscriber runtime descriptors
- resolve database, dispatcher, and attachment behavior through one narrow Notifications runtime service contract
- stage inert reminder runtime references while keeping auto-dispatch activation gated on explicit Legal document-ordering semantics
- add package tests, export/manifest parity, generated configs, architecture progress, and a changeset

## Behavior preserved

- paid-in-full payment filtering
- `on_hold` cancellation filtering
- `suppressNotifications` handling
- send-time attachment resolution
- catch-and-log subscriber failures

## Verification

- `pnpm --filter @voyant-travel/notifications test` (124 passed, 18 skipped)
- `pnpm --filter @voyant-travel/notifications lint`
- `pnpm verify:dist-configs`
- `git diff --check`

The focused typecheck was terminated during shared-workspace TypeScript contention at the user direction; broad verification is deferred to CI. A pre-push broad test hook was bypassed for publication after an unrelated Framework booking-schedule test failed.