### PR TITLE
Complete Phase 4 selected-admin cutover

### DIFF
--- a/.changeset/calm-mice-admin.md
+++ b/.changeset/calm-mice-admin.md
@@ -1,6 +1,8 @@
 ---
 "@voyant-travel/mice": minor
+"@voyant-travel/mice-react": minor
 ---
 
 Declare the package-owned MICE admin factory as a selected-graph runtime while
-preserving its existing routes and host-supplied navigation options.
+preserving its existing routes, destinations, localized navigation, icon, and
+selection behavior.

--- a/.changeset/calm-quotes-admin.md
+++ b/.changeset/calm-quotes-admin.md
@@ -1,6 +1,8 @@
 ---
 "@voyant-travel/quotes": minor
+"@voyant-travel/quotes-react": minor
 ---
 
 Declare the package-owned Quotes admin factory as a selected-graph runtime while
-preserving its existing routes, copy provider, and host-supplied navigation options.
+preserving its existing routes, destinations, localized navigation, icon, copy
+provider, and selection behavior.

--- a/.changeset/quiet-logs-lower.md
+++ b/.changeset/quiet-logs-lower.md
@@ -1,9 +1,11 @@
 ---
 "@voyant-travel/action-ledger": minor
+"@voyant-travel/action-ledger-react": minor
 "@voyant-travel/core": minor
 "@voyant-travel/framework": minor
 ---
 
 Lower package-owned admin factories from the selected deployment graph into a
 dedicated generated admin bundle, beginning with the action-ledger nav, route,
-and lazy page surface.
+lazy page surface, localized Operator label, and standard icon. Selected admin
+factories compose in stable graph-declared order.

--- a/.changeset/selected-admin-composition.md
+++ b/.changeset/selected-admin-composition.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/admin": minor
+---
+
+Add the uniform selected-admin factory context used by package-owned admin
+cutovers.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -800,21 +800,25 @@ The first Phase 4 admin slices are active for `@voyant-travel/action-ledger`,
 - project resolution emits `.voyant/admin/selected-graph-admin.generated.ts`
   from only selected units with `admin.runtime`; package page modules remain
   behind the lazy imports owned by the UI export
-- the Operator consumes that generated factory while retaining its existing
-  localized label and icon inputs, and the compatibility admin generator removes
-  the migrated factory from `admin.extensions.generated.ts`
+- each selected package adapter owns its Operator nav-copy key and icon; Quotes
+  also owns its existing lazy route message provider
+- the Operator invokes the generated selected-factory composer with one generic
+  localized nav-message map, and the compatibility admin generator removes the
+  migrated factory from `admin.extensions.generated.ts`
+- `admin.compositionOrder` preserves stable ordering for selected contributions
+  that share a host navigation anchor without adding a host-side package list
 - deployment-local `src/admin/*/index.ts[x]` pages remain independently
   discovered and composed; package migration must not remove that local surface
 - `verify:admin-composition-drift` rejects a migrated factory that is missing
   from the selected-graph bundle, duplicated in the compatibility registry, or
   present without a selected `admin.runtime` declaration
 
-This cut does not activate admin slots or contributions, namespaced copy,
-message-provider lowering, or deployment copy overrides. Those remain separate
-admin authorities. The Operator factory wrappers and generated registry entries
-for all other first-party packages also remain compatibility authorities until
-each package proves equivalent nav, route, page, host-option, and destination
-behavior through the selected graph.
+This cut does not activate admin slots or contributions, generalized namespaced
+copy lowering, or deployment copy overrides. Those remain separate admin
+authorities. The Operator factory wrappers and generated registry entries for
+all other first-party packages also remain compatibility authorities until each
+package proves equivalent nav, route, page, copy, icon, and destination behavior
+through the selected graph.
 
 ## API, OpenAPI, Scopes, And RBAC
 
@@ -1468,9 +1472,11 @@ package surfaces in `voyant#3080`.
   namespaced copy and deployment overrides
 - generate the admin bundle only from selected package exports and graph data
 
-Progress: the action-ledger, MICE, and Quotes nav/route/page factories are
-lowered into the selected-graph admin bundle. The Operator still owns their
-lightweight localization/icon wrappers. Slots/contributions, copy, and the
+Progress: the action-ledger, MICE, and Quotes nav/route/page factories and their
+lightweight localization/icon adapters are lowered into the selected-graph admin
+bundle. Quotes also owns its lazy route copy provider. The Operator composes
+these selected factories generically, with selection and deselection controlled
+only by the graph. Slots/contributions, generalized copy lowering, and the
 remaining first-party Operator compatibility registry are not part of this
 slice. Identity admin routes are the first package-owned selected-graph OpenAPI
 authority; other API documents remain on the Operator compatibility path.

--- a/packages/action-ledger-react/src/admin/index.tsx
+++ b/packages/action-ledger-react/src/admin/index.tsx
@@ -5,11 +5,13 @@ import {
   adminRoutePageModule,
   defineAdminExtension,
   type NavItem,
+  type SelectedAdminExtensionFactoryContext,
 } from "@voyant-travel/admin"
 // Lean static only: the shared fetcher fallback. The page-data helpers
 // resolve via dynamic import inside the loader so the admin REST module
 // stays out of the workspace-chrome chunk that evaluates this factory.
 import { defaultFetcher } from "@voyant-travel/react"
+import { ScrollText } from "lucide-react"
 
 /**
  * No destinations declared: nothing navigates TO the Logs page by semantic
@@ -101,6 +103,16 @@ export function createActionLedgerAdminExtension(
         },
       },
     ],
+  })
+}
+
+/** Selected-graph adapter owning the standard Operator copy key and icon. */
+export function createSelectedActionLedgerAdminExtension(
+  { navMessages }: SelectedAdminExtensionFactoryContext = { navMessages: {} },
+): AdminExtension {
+  return createActionLedgerAdminExtension({
+    labels: { actionLedger: navMessages.actionLedger ?? "Logs" },
+    icon: ScrollText,
   })
 }
 

--- a/packages/action-ledger-react/tests/admin-extension.test.ts
+++ b/packages/action-ledger-react/tests/admin-extension.test.ts
@@ -1,7 +1,11 @@
+import { ScrollText } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
 import { actionLedgerVoyantModule } from "../../action-ledger/src/voyant.js"
-import { createActionLedgerAdminExtension } from "../src/admin/index.js"
+import {
+  createActionLedgerAdminExtension,
+  createSelectedActionLedgerAdminExtension,
+} from "../src/admin/index.js"
 
 describe("createActionLedgerAdminExtension", () => {
   it("keeps the package-owned route facet aligned with the admin extension", () => {
@@ -12,9 +16,21 @@ describe("createActionLedgerAdminExtension", () => {
     expect(actionLedgerVoyantModule.admin?.routes?.map((route) => route.runtime)).toEqual([
       {
         entry: "@voyant-travel/action-ledger-react/admin",
-        export: "createActionLedgerAdminExtension",
+        export: "createSelectedActionLedgerAdminExtension",
       },
     ])
+  })
+
+  it("owns the selected Operator label and icon adapter", () => {
+    const extension = createSelectedActionLedgerAdminExtension({
+      navMessages: { actionLedger: "Jurnal actiuni" },
+    })
+
+    expect(extension.navigation?.[0]?.items[0]).toMatchObject({
+      title: "Jurnal actiuni",
+      icon: ScrollText,
+    })
+    expect(extension.routes?.[0]?.title).toBe("Jurnal actiuni")
   })
 
   it("contributes the Logs nav item with the default order", () => {

--- a/packages/action-ledger/src/voyant.ts
+++ b/packages/action-ledger/src/voyant.ts
@@ -29,9 +29,10 @@ export const actionLedgerVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 30,
     runtime: {
       entry: "@voyant-travel/action-ledger-react/admin",
-      export: "createActionLedgerAdminExtension",
+      export: "createSelectedActionLedgerAdminExtension",
     },
     routes: [
       {
@@ -39,7 +40,7 @@ export const actionLedgerVoyantModule = defineModule({
         path: "/action-ledger",
         runtime: {
           entry: "@voyant-travel/action-ledger-react/admin",
-          export: "createActionLedgerAdminExtension",
+          export: "createSelectedActionLedgerAdminExtension",
         },
       },
     ],

--- a/packages/action-ledger/tests/unit/voyant-manifest.test.ts
+++ b/packages/action-ledger/tests/unit/voyant-manifest.test.ts
@@ -22,7 +22,7 @@ describe("action-ledger deployment manifest", () => {
       admin: {
         runtime: {
           entry: "@voyant-travel/action-ledger-react/admin",
-          export: "createActionLedgerAdminExtension",
+          export: "createSelectedActionLedgerAdminExtension",
         },
         routes: [
           {

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -4,6 +4,16 @@ import type * as React from "react"
 import type { AdminDestinationKey, AdminDestinations } from "./navigation/destinations.js"
 import type { NavItem } from "./types.js"
 
+/** Host-localized inputs available to graph-selected package admin factories. */
+export interface SelectedAdminExtensionFactoryContext {
+  navMessages: Readonly<Record<string, string>>
+}
+
+/** Uniform factory shape lowered into the selected-graph admin bundle. */
+export type SelectedAdminExtensionFactory = (
+  context: SelectedAdminExtensionFactoryContext,
+) => AdminExtension
+
 /**
  * App-supplied runtime handed to route loaders: where the API lives and how
  * to reach it (the host's cookie-forwarding fetcher in SSR setups).

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -149,6 +149,8 @@ export {
   requireImplementedAdminRoute,
   resolveAdminNavigation,
   resolveAdminWidgets,
+  type SelectedAdminExtensionFactory,
+  type SelectedAdminExtensionFactoryContext,
 } from "./extensions.js"
 export {
   composeLocaleMessageDefinitions,

--- a/packages/core/src/project-facets.ts
+++ b/packages/core/src/project-facets.ts
@@ -92,6 +92,8 @@ export interface VoyantGraphAdminContribution extends VoyantGraphFacetEntity {
 export interface VoyantGraphAdminDeclaration {
   /** Import-cheap factory for this unit's complete nav/route/page extension. */
   runtime?: VoyantGraphRuntimeReference
+  /** Stable ordering for selected factories that contribute at the same host anchor. */
+  compositionOrder?: number
   copy?: readonly VoyantGraphAdminCopy[]
   routes?: readonly VoyantGraphAdminRoute[]
   nav?: readonly VoyantGraphAdminNavItem[]

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -151,6 +151,9 @@ describe("deployment graph artifacts", () => {
     expect(source).toContain('"@acme/voyant-loyalty": selectedAdminFactory0')
     expect(source).not.toContain("createReportsAdminExtension")
     expect(source).toContain("Page bodies stay lazy in package UI exports")
+    expect(source).toContain("satisfies Readonly<Record<string, SelectedAdminExtensionFactory>>")
+    expect(source).toContain("export function createSelectedGraphAdminExtensions(")
+    expect(source).toContain("Object.values(selectedGraphAdminExtensionFactories)")
   })
 
   it("builds a deployment artifact manifest with relative runtime entries", async () => {

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -133,7 +133,11 @@ export function buildGraphAdminBundleModule(input: BuildGraphAdminBundleModuleIn
 
   const units = [...input.graph.modules, ...input.graph.extensions, ...input.graph.plugins]
     .filter((unit) => unit.admin?.runtime)
-    .sort((left, right) => left.id.localeCompare(right.id))
+    .sort(
+      (left, right) =>
+        (left.admin?.compositionOrder ?? 0) - (right.admin?.compositionOrder ?? 0) ||
+        left.id.localeCompare(right.id),
+    )
   const command = input.command ?? "voyant project resolve"
   const imports = units.map((unit, index) => {
     const runtime = unit.admin?.runtime
@@ -150,6 +154,12 @@ export function buildGraphAdminBundleModule(input: BuildGraphAdminBundleModuleIn
 // Contains only graph-selected, import-cheap admin factories. Page bodies stay lazy in package UI exports.
 
 ${imports.join("\n")}${imports.length > 0 ? "\n" : ""}
+import type {
+  AdminExtension,
+  SelectedAdminExtensionFactory,
+  SelectedAdminExtensionFactoryContext,
+} from "@voyant-travel/admin"
+
 export const GENERATED_SELECTED_GRAPH_ADMIN_HASH = ${quote(input.graph.contentHash)} as const
 export const GENERATED_SELECTED_GRAPH_ADMIN_UNIT_IDS = ${formatConstArray(
     units.map((unit) => unit.id),
@@ -157,7 +167,13 @@ export const GENERATED_SELECTED_GRAPH_ADMIN_UNIT_IDS = ${formatConstArray(
 
 export const selectedGraphAdminExtensionFactories = {
 ${factories.join("\n")}
-} as const
+} as const satisfies Readonly<Record<string, SelectedAdminExtensionFactory>>
+
+export function createSelectedGraphAdminExtensions(
+  context: SelectedAdminExtensionFactoryContext,
+): ReadonlyArray<AdminExtension> {
+  return Object.values(selectedGraphAdminExtensionFactories).map((factory) => factory(context))
+}
 `
 }
 

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -1207,6 +1207,9 @@ function resolveUnit(
       ? {
           admin: {
             ...(unit.admin.runtime ? { runtime: unit.admin.runtime } : {}),
+            ...(unit.admin.compositionOrder !== undefined
+              ? { compositionOrder: unit.admin.compositionOrder }
+              : {}),
             ...(unit.admin.copy?.length ? { copy: sortFacetEntities(unit.admin.copy) } : {}),
             ...(unit.admin.routes?.length ? { routes: sortFacetEntities(unit.admin.routes) } : {}),
             ...(unit.admin.nav?.length ? { nav: sortFacetEntities(unit.admin.nav) } : {}),
@@ -1699,6 +1702,17 @@ function validateAdminFacet(
   }
   if (value.runtime !== undefined) {
     validateRuntimeReference(value.runtime, "admin.runtime", source, diagnostics)
+  }
+  if (
+    value.compositionOrder !== undefined &&
+    (!Number.isInteger(value.compositionOrder) || !Number.isSafeInteger(value.compositionOrder))
+  ) {
+    invalidFacet(
+      "admin.compositionOrder",
+      source,
+      diagnostics,
+      "Admin composition order must be a safe integer.",
+    )
   }
   for (const facet of ["copy", "routes", "nav", "slots", "contributions"] as const) {
     diagnostics.push(...validateFacetEntities(value[facet], `admin.${facet}`, source))

--- a/packages/mice-react/package.json
+++ b/packages/mice-react/package.json
@@ -36,6 +36,7 @@
     "@voyant-travel/mice": "workspace:^",
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
+    "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/mice-react/src/admin/admin-manifest.test.ts
+++ b/packages/mice-react/src/admin/admin-manifest.test.ts
@@ -1,14 +1,15 @@
+import { CalendarRange } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
 import { miceVoyantModule } from "../../../mice/src/voyant.js"
-import { createMiceAdminExtension } from "./index.js"
+import { createMiceAdminExtension, createSelectedMiceAdminExtension } from "./index.js"
 
 describe("MICE admin deployment facets", () => {
   it("tracks the package-owned extension routes", () => {
     const extension = createMiceAdminExtension()
     expect(miceVoyantModule.admin?.runtime).toEqual({
       entry: "@voyant-travel/mice-react/admin",
-      export: "createMiceAdminExtension",
+      export: "createSelectedMiceAdminExtension",
     })
     expect(miceVoyantModule.admin?.routes?.map((route) => route.path)).toEqual(
       extension.routes?.map((route) => route.path),
@@ -20,8 +21,18 @@ describe("MICE admin deployment facets", () => {
     expect(miceVoyantModule.admin?.routes?.map((route) => route.runtime)).toEqual(
       extension.routes?.map(() => ({
         entry: "@voyant-travel/mice-react/admin",
-        export: "createMiceAdminExtension",
+        export: "createSelectedMiceAdminExtension",
       })),
     )
+  })
+
+  it("owns the selected Operator label and icon adapter", () => {
+    const extension = createSelectedMiceAdminExtension({ navMessages: { mice: "Programe" } })
+
+    expect(extension.navigation?.[0]?.items[0]).toMatchObject({
+      title: "Programe",
+      icon: CalendarRange,
+    })
+    expect(extension.routes?.map((route) => route.title)).toEqual(["Programe", "Programe"])
   })
 })

--- a/packages/mice-react/src/admin/index.tsx
+++ b/packages/mice-react/src/admin/index.tsx
@@ -5,11 +5,13 @@ import {
   adminRoutePageModule,
   defineAdminExtension,
   type NavItem,
+  type SelectedAdminExtensionFactoryContext,
 } from "@voyant-travel/admin"
 // Lean static only: the shared fetcher fallback. The page-data helpers resolve
 // via dynamic import inside the loaders so the REST query options stay out of
 // the workspace-chrome chunk that evaluates this factory.
 import { defaultFetcher } from "@voyant-travel/react"
+import { CalendarRange } from "lucide-react"
 
 /**
  * Semantic destinations the MICE admin surfaces navigate to (packaged-admin
@@ -119,6 +121,16 @@ export function createMiceAdminExtension(
         },
       },
     ],
+  })
+}
+
+/** Selected-graph adapter owning the standard Operator copy key and icon. */
+export function createSelectedMiceAdminExtension(
+  { navMessages }: SelectedAdminExtensionFactoryContext = { navMessages: {} },
+): AdminExtension {
+  return createMiceAdminExtension({
+    labels: { programs: navMessages.mice ?? "Programs" },
+    icon: CalendarRange,
   })
 }
 

--- a/packages/mice/src/voyant.ts
+++ b/packages/mice/src/voyant.ts
@@ -47,9 +47,10 @@ export const miceVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 20,
     runtime: {
       entry: "@voyant-travel/mice-react/admin",
-      export: "createMiceAdminExtension",
+      export: "createSelectedMiceAdminExtension",
     },
     routes: [
       {
@@ -57,7 +58,7 @@ export const miceVoyantModule = defineModule({
         path: "/mice",
         runtime: {
           entry: "@voyant-travel/mice-react/admin",
-          export: "createMiceAdminExtension",
+          export: "createSelectedMiceAdminExtension",
         },
       },
       {
@@ -65,7 +66,7 @@ export const miceVoyantModule = defineModule({
         path: "/mice/$id",
         runtime: {
           entry: "@voyant-travel/mice-react/admin",
-          export: "createMiceAdminExtension",
+          export: "createSelectedMiceAdminExtension",
         },
       },
     ],

--- a/packages/mice/tests/unit/voyant-manifest.test.ts
+++ b/packages/mice/tests/unit/voyant-manifest.test.ts
@@ -23,7 +23,7 @@ describe("MICE deployment manifests", () => {
       admin: {
         runtime: {
           entry: "@voyant-travel/mice-react/admin",
-          export: "createMiceAdminExtension",
+          export: "createSelectedMiceAdminExtension",
         },
         routes: [
           {

--- a/packages/quotes-react/package.json
+++ b/packages/quotes-react/package.json
@@ -38,6 +38,7 @@
     "@voyant-travel/quotes": "workspace:^",
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
+    "lucide-react": "^1.23.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/quotes-react/src/admin/admin-manifest.test.ts
+++ b/packages/quotes-react/src/admin/admin-manifest.test.ts
@@ -1,14 +1,15 @@
+import { FileText } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
 import { quotesVoyantModule } from "../../../quotes/src/voyant.js"
-import { createQuotesAdminExtension } from "./index.js"
+import { createQuotesAdminExtension, createSelectedQuotesAdminExtension } from "./index.js"
 
 describe("quotes admin deployment facets", () => {
   it("tracks the package-owned extension routes and copy provider", () => {
     const extension = createQuotesAdminExtension()
     expect(quotesVoyantModule.admin?.runtime).toEqual({
       entry: "@voyant-travel/quotes-react/admin",
-      export: "createQuotesAdminExtension",
+      export: "createSelectedQuotesAdminExtension",
     })
     expect(quotesVoyantModule.admin?.routes?.map((route) => route.path)).toEqual(
       extension.routes?.map((route) => route.path),
@@ -20,7 +21,7 @@ describe("quotes admin deployment facets", () => {
     expect(quotesVoyantModule.admin?.routes?.map((route) => route.runtime)).toEqual(
       extension.routes?.map(() => ({
         entry: "@voyant-travel/quotes-react/admin",
-        export: "createQuotesAdminExtension",
+        export: "createSelectedQuotesAdminExtension",
       })),
     )
     expect(quotesVoyantModule.admin?.copy).toEqual([
@@ -34,5 +35,15 @@ describe("quotes admin deployment facets", () => {
         },
       },
     ])
+    expect(
+      extension.routes?.every((route) => typeof route.routeMessagesProvider === "function"),
+    ).toBe(true)
+  })
+
+  it("owns the selected Operator label and icon adapter", () => {
+    const extension = createSelectedQuotesAdminExtension({ navMessages: { quotes: "Oferte" } })
+
+    expect(extension.navigation?.[0]?.items[0]).toMatchObject({ title: "Oferte", icon: FileText })
+    expect(extension.routes?.map((route) => route.title)).toEqual(["Oferte", "Oferte"])
   })
 })

--- a/packages/quotes-react/src/admin/index.tsx
+++ b/packages/quotes-react/src/admin/index.tsx
@@ -5,11 +5,13 @@ import {
   adminRoutePageModule,
   defineAdminExtension,
   type NavItem,
+  type SelectedAdminExtensionFactoryContext,
 } from "@voyant-travel/admin"
 // Lean static only: the shared fetcher fallback. The page-data helpers
 // resolve via dynamic import inside the loaders so the REST query options stay
 // out of the workspace-chrome chunk that evaluates this factory.
 import { defaultFetcher } from "@voyant-travel/react"
+import { FileText } from "lucide-react"
 
 /**
  * Semantic destinations the quotes admin surfaces navigate to (packaged-admin
@@ -86,6 +88,7 @@ export function createQuotesAdminExtension(
         title: quotes,
         destination: "quote.list",
         ssr: "data-only",
+        routeMessagesProvider: quotesRouteMessagesProvider,
         page: () =>
           import("./quotes-board-host.js").then((module) =>
             adminRoutePageModule(module.QuotesBoardHost),
@@ -107,6 +110,7 @@ export function createQuotesAdminExtension(
         destination: "quote.detail",
         destinationParams: { id: "quoteId" },
         ssr: "data-only",
+        routeMessagesProvider: quotesRouteMessagesProvider,
         page: () => import("./pages/quote-detail-page.js"),
         loader: async ({ queryClient, runtime, params }: AdminRouteLoaderContext) => {
           const id = params.id
@@ -117,6 +121,20 @@ export function createQuotesAdminExtension(
       },
     ],
   })
+}
+
+/** Selected-graph adapter owning the standard Operator copy key and icon. */
+export function createSelectedQuotesAdminExtension(
+  { navMessages }: SelectedAdminExtensionFactoryContext = { navMessages: {} },
+): AdminExtension {
+  return createQuotesAdminExtension({
+    labels: { quotes: navMessages.quotes ?? "Quotes" },
+    icon: FileText,
+  })
+}
+
+function quotesRouteMessagesProvider() {
+  return import("../i18n/index.js").then((module) => ({ default: module.CrmUiMessagesProvider }))
 }
 
 /**

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -111,9 +111,10 @@ export const quotesVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 10,
     runtime: {
       entry: "@voyant-travel/quotes-react/admin",
-      export: "createQuotesAdminExtension",
+      export: "createSelectedQuotesAdminExtension",
     },
     copy: [
       {
@@ -132,7 +133,7 @@ export const quotesVoyantModule = defineModule({
         path: "/quotes",
         runtime: {
           entry: "@voyant-travel/quotes-react/admin",
-          export: "createQuotesAdminExtension",
+          export: "createSelectedQuotesAdminExtension",
         },
       },
       {
@@ -140,7 +141,7 @@ export const quotesVoyantModule = defineModule({
         path: "/quotes/$id",
         runtime: {
           entry: "@voyant-travel/quotes-react/admin",
-          export: "createQuotesAdminExtension",
+          export: "createSelectedQuotesAdminExtension",
         },
       },
     ],

--- a/packages/quotes/tests/unit/voyant-manifest.test.ts
+++ b/packages/quotes/tests/unit/voyant-manifest.test.ts
@@ -26,7 +26,7 @@ describe("quotes deployment manifests", () => {
       admin: {
         runtime: {
           entry: "@voyant-travel/quotes-react/admin",
-          export: "createQuotesAdminExtension",
+          export: "createSelectedQuotesAdminExtension",
         },
         copy: [
           {

--- a/scripts/check-admin-composition-drift.mjs
+++ b/scripts/check-admin-composition-drift.mjs
@@ -35,6 +35,10 @@ const BUNDLE = optionPath(
   "--bundle",
   join(ROOT, "starters/operator/.voyant/admin/selected-graph-admin.generated.ts"),
 )
+const COMPATIBILITY = optionPath(
+  "--compatibility",
+  join(ROOT, "starters/operator/src/lib/admin-extensions.tsx"),
+)
 const DESTINATIONS = join(ROOT, "starters/operator/src/admin.destinations.generated.ts")
 const ROUTES = join(ROOT, "starters/operator/src/admin.routes.generated.tsx")
 
@@ -108,6 +112,19 @@ function adminImportsIn(file) {
   return set
 }
 
+function selectedFactoryReferencesIn(file) {
+  if (!existsSync(file)) return new Set()
+  const src = readFileSync(file, "utf-8")
+  const set = new Set()
+  const re = /selectedGraphAdminExtensionFactories\s*\[\s*["']([^"']+)["']\s*\]/g
+  let match = re.exec(src)
+  while (match) {
+    set.add(match[1])
+    match = re.exec(src)
+  }
+  return set
+}
+
 const violations = []
 
 if (!existsSync(EXTENSIONS)) {
@@ -122,6 +139,7 @@ const expected = selected.filter(hasAdminSurface)
 const actual = adminImportsIn(EXTENSIONS)
 const bundled = new Set(bundledPackages)
 const actualBundle = adminImportsIn(BUNDLE)
+const compatibilitySelectedFactories = selectedFactoryReferencesIn(COMPATIBILITY)
 
 // Silently-dropped admin: graph-selected + has ./admin, but not wired.
 for (const name of expected) {
@@ -141,6 +159,11 @@ for (const name of bundled) {
   if (actual.has(name)) {
     violations.push(
       `${name} is duplicated in admin.extensions.generated.ts after migration to the selected-graph admin bundle`,
+    )
+  }
+  if (compatibilitySelectedFactories.has(name)) {
+    violations.push(
+      `${name} remains package-keyed in the Operator compatibility registry after migration to generic selected-admin composition`,
     )
   }
 }

--- a/scripts/tests/check-admin-composition-drift.test.mjs
+++ b/scripts/tests/check-admin-composition-drift.test.mjs
@@ -13,13 +13,15 @@ test("derives expected admin entries from the resolved graph, not voyant.config"
   const graph = join(dir, "deployment-graph.generated.json")
   const extensions = join(dir, "admin.extensions.generated.ts")
   const bundle = join(dir, "selected-graph-admin.generated.ts")
+  const compatibility = join(dir, "admin-extensions.tsx")
 
   try {
     writeFileSync(graph, JSON.stringify({ modules: [], plugins: [] }))
     writeFileSync(extensions, "export const generatedAdminExtensionFactories = {}\n")
     writeFileSync(bundle, "export const selectedGraphAdminExtensionFactories = {}\n")
+    writeFileSync(compatibility, "export const extensions = []\n")
 
-    assert.doesNotThrow(() => runChecker({ graph, extensions, bundle }))
+    assert.doesNotThrow(() => runChecker({ graph, extensions, bundle, compatibility }))
 
     writeFileSync(
       graph,
@@ -35,7 +37,7 @@ test("derives expected admin entries from the resolved graph, not voyant.config"
     )
 
     assert.throws(
-      () => runChecker({ graph, extensions, bundle }),
+      () => runChecker({ graph, extensions, bundle, compatibility }),
       /selected by the deployment graph.*missing from admin\.extensions\.generated\.ts/s,
     )
   } finally {
@@ -48,6 +50,7 @@ test("requires migrated UI-only admin factories only in the selected-graph bundl
   const graph = join(dir, "deployment-graph.generated.json")
   const extensions = join(dir, "admin.extensions.generated.ts")
   const bundle = join(dir, "selected-graph-admin.generated.ts")
+  const compatibility = join(dir, "admin-extensions.tsx")
 
   try {
     writeFileSync(
@@ -67,26 +70,47 @@ test("requires migrated UI-only admin factories only in the selected-graph bundl
       bundle,
       'import { createActionLedgerAdminExtension } from "@voyant-travel/action-ledger-react/admin"\n',
     )
+    writeFileSync(compatibility, "export const extensions = []\n")
 
-    assert.doesNotThrow(() => runChecker({ graph, extensions, bundle }))
+    assert.doesNotThrow(() => runChecker({ graph, extensions, bundle, compatibility }))
 
     writeFileSync(
       extensions,
       'import { createActionLedgerAdminExtension } from "@voyant-travel/action-ledger-react/admin"\n',
     )
     assert.throws(
-      () => runChecker({ graph, extensions, bundle }),
+      () => runChecker({ graph, extensions, bundle, compatibility }),
       /duplicated in admin\.extensions\.generated\.ts/,
+    )
+
+    writeFileSync(extensions, "export const generatedAdminExtensionFactories = {}\n")
+    writeFileSync(
+      compatibility,
+      'selectedGraphAdminExtensionFactories["@voyant-travel/action-ledger"]({})\n',
+    )
+    assert.throws(
+      () => runChecker({ graph, extensions, bundle, compatibility }),
+      /remains package-keyed in the Operator compatibility registry/,
     )
   } finally {
     rmSync(dir, { force: true, recursive: true })
   }
 })
 
-function runChecker({ graph, extensions, bundle }) {
+function runChecker({ graph, extensions, bundle, compatibility }) {
   return execFileSync(
     process.execPath,
-    [CHECKER, "--graph", graph, "--extensions", extensions, "--bundle", bundle],
+    [
+      CHECKER,
+      "--graph",
+      graph,
+      "--extensions",
+      extensions,
+      "--bundle",
+      bundle,
+      "--compatibility",
+      compatibility,
+    ],
     { encoding: "utf8" },
   )
 }

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -164,7 +164,7 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
       join(process.cwd(), ".voyant", "admin/selected-graph-admin.generated.ts"),
       "utf8",
     )
-    expect(selectedGraphAdmin).toContain('"@voyant-travel/action-ledger": selectedAdminFactory0')
+    expect(selectedGraphAdmin).toMatch(/"@voyant-travel\/action-ledger": selectedAdminFactory\d+/)
     expect(selectedGraphAdmin).not.toContain("createBookingsAdminExtension")
     const projectLinks = readFileSync(
       join(process.cwd(), ".voyant", "runtime/project-links.generated.ts"),

--- a/starters/operator/src/lib/admin-extensions.tsx
+++ b/starters/operator/src/lib/admin-extensions.tsx
@@ -13,10 +13,10 @@ import {
 import { createAdminCoreExtension } from "@voyant-travel/admin-app/core-extension"
 import { createOperatorProfileSettingsExtraPage } from "@voyant-travel/operator-settings-react/settings"
 import { Button } from "@voyant-travel/ui/components/button"
-import { CalendarRange, FileText, Route, ScrollText, SlidersHorizontal, Tag } from "lucide-react"
+import { Route, SlidersHorizontal, Tag } from "lucide-react"
 import { generatedAdminExtensionFactories } from "@/admin.extensions.generated"
 import type { AdminMessages } from "@/lib/admin-i18n"
-import { selectedGraphAdminExtensionFactories } from "../../.voyant/admin/selected-graph-admin.generated"
+import { createSelectedGraphAdminExtensions } from "../../.voyant/admin/selected-graph-admin.generated"
 
 /**
  * Operator admin contributions composed through the shared admin runtime.
@@ -172,11 +172,6 @@ const crmMessagesProvider = loadProvider(
   () => import("@voyant-travel/relationships-react/i18n"),
   (module) => module.CrmUiMessagesProvider,
 )
-const quotesMessagesProvider = loadProvider(
-  () => import("@voyant-travel/quotes-react/i18n"),
-  (module) => module.CrmUiMessagesProvider,
-)
-
 const bookingRouteMessagesProvider = composeProviderLoaders(
   bookingsMessagesProvider,
   financeMessagesProvider,
@@ -222,7 +217,6 @@ const extensionRouteMessagesProviders: Record<string, RouteMessagesProviderLoade
   legal: legalMessagesProvider,
   notifications: notificationsMessagesProvider,
   operations: operationsRouteMessagesProvider,
-  quotes: quotesMessagesProvider,
   relationships: relationshipsRouteMessagesProvider,
 }
 
@@ -593,45 +587,6 @@ function createTripsExtension(messages: AdminExtensionNavMessages) {
   })
 }
 
-// Action ledger is package-delivered (packaged-admin RFC Phase 2): nav AND
-// the route implementation come from @voyant-travel/action-ledger-react/admin —
-// the Logs nav item (order 60, past the default admin items) and the
-// cursor-paginated Logs page. The app only supplies the localized label and
-// the icon.
-function createActionLedgerExtension(messages: AdminExtensionNavMessages) {
-  return selectedGraphAdminExtensionFactories["@voyant-travel/action-ledger"]({
-    labels: { actionLedger: messages.actionLedger },
-    icon: ScrollText,
-  })
-}
-
-// Quotes is package-delivered (packaged-admin RFC Phase 3): nav AND the route
-// implementations come from @voyant-travel/quotes-react/admin — the Quotes nav
-// item (spliced after Bookings via `insertAfter`, since both belong to the
-// quote → accept → book lifecycle), the quotes board (pipelines + stages +
-// quote creation), and the quote detail page where that quote's versions are
-// nested. The app only supplies the localized label and the icon.
-function createQuotesExtension(messages: AdminExtensionNavMessages) {
-  return selectedGraphAdminExtensionFactories["@voyant-travel/quotes"]({
-    labels: { quotes: messages.quotes },
-    icon: FileText,
-  })
-}
-
-// MICE is package-delivered (packaged-admin RFC Phase 3): nav AND the route
-// implementations come from @voyant-travel/mice-react/admin — the Programs nav
-// item (spliced after Bookings via `insertAfter`, since a group program is an
-// operationally-managed booking pipeline of rooms, function space, and
-// delegates), the programs list, and the program detail page where that
-// program's per-currency cost sheet lives. The app only supplies the localized
-// label and the icon.
-function createMiceExtension(messages: AdminExtensionNavMessages) {
-  return selectedGraphAdminExtensionFactories["@voyant-travel/mice"]({
-    labels: { programs: messages.mice },
-    icon: CalendarRange,
-  })
-}
-
 const defaultExtensionNavMessages: AdminExtensionNavMessages = {
   actionLedger: "Logs",
   allTrips: "All trips",
@@ -703,9 +658,7 @@ export function createOperatorAdminExtensions(
       createNotificationsExtension(messages),
       createPromotionsExtension(messages),
       createTripsExtension(messages),
-      createQuotesExtension(messages),
-      createMiceExtension(messages),
-      createActionLedgerExtension(messages),
+      ...createSelectedGraphAdminExtensions({ navMessages: messages }),
       ...discoveredAdminExtensions,
     ),
   )

--- a/starters/operator/src/selected-graph-action-ledger-admin.test.ts
+++ b/starters/operator/src/selected-graph-action-ledger-admin.test.ts
@@ -39,15 +39,15 @@ describe("selected-graph Action Ledger admin composition", () => {
         ],
       },
     ])
-    expect(extension?.routes?.map(({ id, path, title, ssr }) => ({ id, path, title, ssr }))).toEqual(
-      [
-        {
-          id: "action-ledger-index",
-          path: "/action-ledger",
-          title: "Jurnal actiuni",
-          ssr: "data-only",
-        },
-      ],
-    )
+    expect(
+      extension?.routes?.map(({ id, path, title, ssr }) => ({ id, path, title, ssr })),
+    ).toEqual([
+      {
+        id: "action-ledger-index",
+        path: "/action-ledger",
+        title: "Jurnal actiuni",
+        ssr: "data-only",
+      },
+    ])
   })
 })

--- a/starters/operator/src/selected-graph-action-ledger-admin.test.ts
+++ b/starters/operator/src/selected-graph-action-ledger-admin.test.ts
@@ -1,0 +1,53 @@
+import { operatorAdminNavMessages } from "@voyant-travel/i18n"
+import { ScrollText } from "lucide-react"
+import { describe, expect, it } from "vitest"
+
+import {
+  createSelectedGraphAdminExtensions,
+  selectedGraphAdminExtensionFactories,
+} from "../.voyant/admin/selected-graph-admin.generated.js"
+import { generatedAdminExtensionFactories } from "./admin.extensions.generated.js"
+
+describe("selected-graph Action Ledger admin composition", () => {
+  it("uses the selected package factory without compatibility duplication", () => {
+    expect(selectedGraphAdminExtensionFactories["@voyant-travel/action-ledger"]).toBeTypeOf(
+      "function",
+    )
+    expect("actionLedger" in generatedAdminExtensionFactories).toBe(false)
+    expect(
+      createSelectedGraphAdminExtensions({ navMessages: operatorAdminNavMessages.en.nav }).map(
+        ({ id }) => id,
+      ),
+    ).toEqual(["quotes", "mice", "action-ledger"])
+  })
+
+  it("preserves localized navigation, route copy, and icon behavior", () => {
+    const extension = createSelectedGraphAdminExtensions({
+      navMessages: operatorAdminNavMessages.ro.nav,
+    }).find(({ id }) => id === "action-ledger")
+
+    expect(extension?.navigation).toEqual([
+      {
+        order: 60,
+        items: [
+          {
+            id: "action-ledger",
+            title: "Jurnal actiuni",
+            url: "/action-ledger",
+            icon: ScrollText,
+          },
+        ],
+      },
+    ])
+    expect(extension?.routes?.map(({ id, path, title, ssr }) => ({ id, path, title, ssr }))).toEqual(
+      [
+        {
+          id: "action-ledger-index",
+          path: "/action-ledger",
+          title: "Jurnal actiuni",
+          ssr: "data-only",
+        },
+      ],
+    )
+  })
+})

--- a/starters/operator/src/selected-graph-mice-admin.test.ts
+++ b/starters/operator/src/selected-graph-mice-admin.test.ts
@@ -2,9 +2,11 @@ import { operatorAdminNavMessages } from "@voyant-travel/i18n"
 import { CalendarRange } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
-import { selectedGraphAdminExtensionFactories } from "../.voyant/admin/selected-graph-admin.generated.js"
+import {
+  createSelectedGraphAdminExtensions,
+  selectedGraphAdminExtensionFactories,
+} from "../.voyant/admin/selected-graph-admin.generated.js"
 import { generatedAdminExtensionFactories } from "./admin.extensions.generated.js"
-import { createOperatorAdminExtensions } from "./lib/admin-extensions.js"
 
 describe("selected-graph MICE admin composition", () => {
   it("uses the selected package factory without compatibility duplication", () => {
@@ -12,10 +14,10 @@ describe("selected-graph MICE admin composition", () => {
     expect("mice" in generatedAdminExtensionFactories).toBe(false)
   })
 
-  it("preserves MICE navigation, routes, and destinations through host options", () => {
-    const extension = createOperatorAdminExtensions(operatorAdminNavMessages.ro.nav).find(
-      ({ id }) => id === "mice",
-    )
+  it("preserves MICE navigation, routes, and destinations", () => {
+    const extension = createSelectedGraphAdminExtensions({
+      navMessages: operatorAdminNavMessages.ro.nav,
+    }).find(({ id }) => id === "mice")
 
     expect(extension?.navigation).toEqual([
       {

--- a/starters/operator/src/selected-graph-quotes-admin.test.ts
+++ b/starters/operator/src/selected-graph-quotes-admin.test.ts
@@ -2,9 +2,11 @@ import { operatorAdminNavMessages } from "@voyant-travel/i18n"
 import { FileText } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
-import { selectedGraphAdminExtensionFactories } from "../.voyant/admin/selected-graph-admin.generated.js"
+import {
+  createSelectedGraphAdminExtensions,
+  selectedGraphAdminExtensionFactories,
+} from "../.voyant/admin/selected-graph-admin.generated.js"
 import { generatedAdminExtensionFactories } from "./admin.extensions.generated.js"
-import { createOperatorAdminExtensions } from "./lib/admin-extensions.js"
 
 describe("selected-graph Quotes admin composition", () => {
   it("uses the selected package factory without compatibility duplication", () => {
@@ -12,10 +14,10 @@ describe("selected-graph Quotes admin composition", () => {
     expect("quotes" in generatedAdminExtensionFactories).toBe(false)
   })
 
-  it("preserves Quotes navigation, routes, destinations, and host wrappers", () => {
-    const extension = createOperatorAdminExtensions(operatorAdminNavMessages.ro.nav).find(
-      ({ id }) => id === "quotes",
-    )
+  it("preserves Quotes navigation, routes, destinations, and package copy", () => {
+    const extension = createSelectedGraphAdminExtensions({
+      navMessages: operatorAdminNavMessages.ro.nav,
+    }).find(({ id }) => id === "quotes")
 
     expect(extension?.navigation).toEqual([
       {


### PR DESCRIPTION
## Summary
- move Action Ledger, MICE, and Quotes localization/icon adapters into package-owned admin exports
- compose selected admin factories generically from the deployment graph while preserving anchored navigation order and graph selection semantics
- move Quotes route copy-provider ownership into its package and remove the three Operator compatibility entries
- extend admin composition drift coverage, package parity tests, architecture progress, and changesets

## Focused verification
- framework selected-admin bundle tests
- Action Ledger, MICE, and Quotes package admin factory tests
- Operator selected-graph parity tests for all three domains
- generated admin composition drift checker and fixtures
- Biome formatting