### PR TITLE
refactor(graph): move catalog and content authority package-side

### DIFF
--- a/.changeset/catalog-content-package-authority.md
+++ b/.changeset/catalog-content-package-authority.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/catalog": minor
+"@voyant-travel/inventory": minor
+"@voyant-travel/accommodations": minor
+"@voyant-travel/cruises": minor
+"@voyant-travel/action-ledger": minor
+---
+
+Add package-owned graph runtime factories and typed deployment ports for Catalog search, booking, and offers; Inventory core, content, and brochures; Accommodations and Cruises content; and Action Ledger health.

--- a/packages/accommodations/package.json
+++ b/packages/accommodations/package.json
@@ -17,6 +17,7 @@
     "./draft-shape": "./src/draft-shape.ts",
     "./booking-engine": "./src/booking-engine/index.ts",
     "./routes-content": "./src/routes-content.ts",
+    "./graph-runtime": "./src/graph-runtime.ts",
     "./voyant": "./src/voyant.ts"
   },
   "scripts": {
@@ -120,6 +121,11 @@
         "types": "./dist/routes-content.d.ts",
         "import": "./dist/routes-content.js",
         "default": "./dist/routes-content.js"
+      },
+      "./graph-runtime": {
+        "types": "./dist/graph-runtime.d.ts",
+        "import": "./dist/graph-runtime.js",
+        "default": "./dist/graph-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/accommodations/src/graph-runtime.ts
+++ b/packages/accommodations/src/graph-runtime.ts
@@ -1,0 +1,19 @@
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+
+import { createAccommodationContentHonoExtension } from "./routes-content.js"
+import { accommodationsContentRuntimePort } from "./runtime-port.js"
+
+export const createAccommodationsContentVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) => {
+    const configured = createAccommodationContentHonoExtension(
+      await getPort(accommodationsContentRuntimePort),
+    )
+    return {
+      ...configured,
+      ...(api.some(({ surface }) => surface === "admin") ? {} : { adminRoutes: undefined }),
+      ...(api.some(({ surface }) => surface === "public") ? {} : { publicRoutes: undefined }),
+    }
+  },
+)
+
+export { accommodationsContentRuntimePort } from "./runtime-port.js"

--- a/packages/accommodations/src/runtime-port.ts
+++ b/packages/accommodations/src/runtime-port.ts
@@ -1,0 +1,20 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { AccommodationContentHonoExtensionOptions } from "./routes-content.js"
+
+export const accommodationsContentRuntimePort =
+  definePort<AccommodationContentHonoExtensionOptions>({
+    id: "accommodations.content-runtime",
+    test(provider) {
+      if (provider === null || typeof provider !== "object") {
+        throw new Error("accommodations.content-runtime provider must be an options object.")
+      }
+      for (const surface of ["admin", "public"] as const) {
+        if (typeof provider[surface]?.resolveRegistry !== "function") {
+          throw new Error(
+            `accommodations.content-runtime provider must configure ${surface}.resolveRegistry().`,
+          )
+        }
+      }
+    },
+  })

--- a/packages/accommodations/src/voyant.ts
+++ b/packages/accommodations/src/voyant.ts
@@ -1,4 +1,5 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import { accommodationsContentRuntimePort } from "./runtime-port.js"
 
 /** Import-cheap deployment declaration owned by the accommodations package. */
 export const accommodationsVoyantModule = defineModule({
@@ -47,14 +48,15 @@ export const accommodationsContentVoyantPlugin = defineExtension({
   id: "@voyant-travel/accommodations#content-extension",
   packageName: "@voyant-travel/accommodations",
   localId: "accommodations.content-extension",
+  runtimePorts: [requirePort(accommodationsContentRuntimePort)],
   api: [
     {
       id: "@voyant-travel/accommodations#content-extension.api.admin",
       surface: "admin",
       mount: "accommodations",
       runtime: {
-        entry: "@voyant-travel/accommodations/routes-content",
-        export: "createAccommodationContentHonoExtension",
+        entry: "@voyant-travel/accommodations/graph-runtime",
+        export: "createAccommodationsContentVoyantRuntime",
       },
     },
     {
@@ -63,8 +65,8 @@ export const accommodationsContentVoyantPlugin = defineExtension({
       mount: "accommodations",
       anonymous: true,
       runtime: {
-        entry: "@voyant-travel/accommodations/routes-content",
-        export: "createAccommodationContentHonoExtension",
+        entry: "@voyant-travel/accommodations/graph-runtime",
+        export: "createAccommodationsContentVoyantRuntime",
       },
     },
   ],

--- a/packages/accommodations/tests/unit/voyant-manifest.test.ts
+++ b/packages/accommodations/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,6 @@
+import { isGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
+import { createAccommodationsContentVoyantRuntime } from "../../src/graph-runtime.js"
 import { createAccommodationContentHonoExtension } from "../../src/routes-content.js"
 import { accommodationsContentVoyantPlugin, accommodationsVoyantModule } from "../../src/voyant.js"
 
@@ -44,15 +46,16 @@ describe("accommodations deployment manifest", () => {
         {
           surface: "admin",
           mount: "accommodations",
-          runtime: { export: "createAccommodationContentHonoExtension" },
+          runtime: { export: "createAccommodationsContentVoyantRuntime" },
         },
         {
           surface: "public",
           mount: "accommodations",
           anonymous: true,
-          runtime: { export: "createAccommodationContentHonoExtension" },
+          runtime: { export: "createAccommodationsContentVoyantRuntime" },
         },
       ],
+      runtimePorts: [{ id: "accommodations.content-runtime" }],
     })
 
     const resolveRegistry = () => ({}) as never
@@ -63,5 +66,6 @@ describe("accommodations deployment manifest", () => {
     expect(extension.extension).toMatchObject({ name: "content", module: "accommodations" })
     expect(extension.adminRoutes).toBeDefined()
     expect(extension.publicRoutes).toBeDefined()
+    expect(isGraphRuntimeFactory(createAccommodationsContentVoyantRuntime)).toBe(true)
   })
 })

--- a/packages/action-ledger/package.json
+++ b/packages/action-ledger/package.json
@@ -12,6 +12,7 @@
     "./service": "./src/service.ts",
     "./fingerprint": "./src/fingerprint.ts",
     "./health": "./src/health-routes.ts",
+    "./graph-runtime": "./src/graph-runtime.ts",
     "./timeline": "./src/timeline.ts",
     "./request-context": "./src/request-context.ts",
     "./routes": "./src/routes.ts",
@@ -100,6 +101,11 @@
         "types": "./dist/routes.d.ts",
         "import": "./dist/routes.js",
         "default": "./dist/routes.js"
+      },
+      "./graph-runtime": {
+        "types": "./dist/graph-runtime.d.ts",
+        "import": "./dist/graph-runtime.js",
+        "default": "./dist/graph-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/action-ledger/src/graph-runtime.ts
+++ b/packages/action-ledger/src/graph-runtime.ts
@@ -1,0 +1,11 @@
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+
+import { createActionLedgerHealthHonoExtension } from "./health-routes.js"
+import { actionLedgerHealthRuntimePort } from "./runtime-port.js"
+
+export const createActionLedgerHealthVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) =>
+    createActionLedgerHealthHonoExtension(await getPort(actionLedgerHealthRuntimePort)),
+)
+
+export { actionLedgerHealthRuntimePort } from "./runtime-port.js"

--- a/packages/action-ledger/src/runtime-port.ts
+++ b/packages/action-ledger/src/runtime-port.ts
@@ -1,0 +1,17 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { ActionLedgerHealthRoutesOptions } from "./health-routes.js"
+
+export const actionLedgerHealthRuntimePort = definePort<ActionLedgerHealthRoutesOptions>({
+  id: "action-ledger.health-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("action-ledger.health-runtime provider must be an options object.")
+    }
+    for (const method of ["checkBookingDrift", "checkFinanceDrift", "checkProductDrift"] as const) {
+      if (typeof provider[method] !== "function") {
+        throw new Error(`action-ledger.health-runtime provider must implement ${method}().`)
+      }
+    }
+  },
+})

--- a/packages/action-ledger/src/voyant.ts
+++ b/packages/action-ledger/src/voyant.ts
@@ -1,4 +1,5 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import { actionLedgerHealthRuntimePort } from "./runtime-port.js"
 
 /** Import-cheap deployment declaration owned by the action-ledger package. */
 export const actionLedgerVoyantModule = defineModule({
@@ -57,14 +58,15 @@ export const actionLedgerHealthVoyantPlugin = defineExtension({
   id: "@voyant-travel/action-ledger#health-extension",
   packageName: "@voyant-travel/action-ledger",
   localId: "action-ledger.health-extension",
+  runtimePorts: [requirePort(actionLedgerHealthRuntimePort)],
   api: [
     {
       id: "@voyant-travel/action-ledger#health-extension.api",
       surface: "admin",
       mount: "action-ledger",
       runtime: {
-        entry: "@voyant-travel/action-ledger/health",
-        export: "createActionLedgerHealthHonoExtension",
+        entry: "@voyant-travel/action-ledger/graph-runtime",
+        export: "createActionLedgerHealthVoyantRuntime",
       },
     },
   ],

--- a/packages/action-ledger/tests/unit/voyant-manifest.test.ts
+++ b/packages/action-ledger/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,6 @@
+import { isGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
+import { createActionLedgerHealthVoyantRuntime } from "../../src/graph-runtime.js"
 import { actionLedgerHealthVoyantPlugin, actionLedgerVoyantModule } from "../../src/voyant.js"
 
 describe("action-ledger deployment manifest", () => {
@@ -45,11 +47,13 @@ describe("action-ledger deployment manifest", () => {
           surface: "admin",
           mount: "action-ledger",
           runtime: {
-            entry: "@voyant-travel/action-ledger/health",
-            export: "createActionLedgerHealthHonoExtension",
+            entry: "@voyant-travel/action-ledger/graph-runtime",
+            export: "createActionLedgerHealthVoyantRuntime",
           },
         },
       ],
+      runtimePorts: [{ id: "action-ledger.health-runtime" }],
     })
+    expect(isGraphRuntimeFactory(createActionLedgerHealthVoyantRuntime)).toBe(true)
   })
 })

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -41,6 +41,7 @@
     "./offers": "./src/offers/operator-routes.ts",
     "./index-subscribers": "./src/index-subscriber-runtime.ts",
     "./projection-runtime": "./src/projection-runtime.ts",
+    "./graph-runtime": "./src/graph-runtime.ts",
     "./voyant": "./src/voyant.ts"
   },
   "voyant": {
@@ -264,6 +265,11 @@
         "types": "./dist/projection-runtime.d.ts",
         "import": "./dist/projection-runtime.js",
         "default": "./dist/projection-runtime.js"
+      },
+      "./graph-runtime": {
+        "types": "./dist/graph-runtime.d.ts",
+        "import": "./dist/graph-runtime.js",
+        "default": "./dist/graph-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/catalog/src/api-runtime-ports.ts
+++ b/packages/catalog/src/api-runtime-ports.ts
@@ -1,0 +1,60 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { CatalogBookingRouteModuleOptions } from "./booking-engine/operator-routes.js"
+import type { CatalogOffersRouteModuleOptions } from "./offers/operator-routes.js"
+import type { CatalogSearchRoutesOptions } from "./search/routes.js"
+
+export type CatalogSearchRuntimeOptions = Pick<CatalogSearchRoutesOptions, "resolveRuntime">
+
+export const catalogSearchRuntimePort = definePort<CatalogSearchRuntimeOptions>({
+  id: "catalog.search-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("catalog.search-runtime provider must be an options object.")
+    }
+    if (typeof provider.resolveRuntime !== "function") {
+      throw new Error("catalog.search-runtime provider must implement resolveRuntime().")
+    }
+  },
+})
+
+export const catalogBookingRuntimePort = definePort<CatalogBookingRouteModuleOptions>({
+  id: "catalog.booking-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("catalog.booking-runtime provider must be an options object.")
+    }
+    if (provider.booking === null || typeof provider.booking !== "object") {
+      throw new Error("catalog.booking-runtime provider must configure booking options.")
+    }
+    for (const method of [
+      "resolveRegistry",
+      "getProductContent",
+      "listAvailabilitySlots",
+      "getOwnedProductById",
+    ] as const) {
+      if (typeof provider[method] !== "function") {
+        throw new Error(`catalog.booking-runtime provider must implement ${method}().`)
+      }
+    }
+  },
+})
+
+export const catalogOffersRuntimePort = definePort<CatalogOffersRouteModuleOptions>({
+  id: "catalog.offers-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("catalog.offers-runtime provider must be an options object.")
+    }
+    for (const method of [
+      "resolveConnectClient",
+      "fetchIndexFields",
+      "resolveDynamicHotelIds",
+      "resolveAirportLabels",
+    ] as const) {
+      if (typeof provider[method] !== "function") {
+        throw new Error(`catalog.offers-runtime provider must implement ${method}().`)
+      }
+    }
+  },
+})

--- a/packages/catalog/src/graph-runtime.ts
+++ b/packages/catalog/src/graph-runtime.ts
@@ -1,0 +1,84 @@
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { HonoExtension, HonoModule } from "@voyant-travel/hono/module"
+
+import {
+  catalogBookingRuntimePort,
+  catalogOffersRuntimePort,
+  catalogSearchRuntimePort,
+} from "./api-runtime-ports.js"
+import { createCatalogBookingEngineHonoModule } from "./booking-engine/operator-routes.js"
+import { createCatalogOffersHonoExtension } from "./offers/operator-routes.js"
+import { createCatalogSearchHonoModule } from "./search/routes.js"
+import { executeSemanticSearch } from "./search/semantic.js"
+
+function selectedModuleSurfaces(
+  configured: HonoModule,
+  api: readonly { surface: string }[],
+): HonoModule {
+  return {
+    ...configured,
+    ...(api.some(({ surface }) => surface === "admin")
+      ? {}
+      : { adminRoutes: undefined, lazyAdminRoutes: undefined }),
+    ...(api.some(({ surface }) => surface === "public")
+      ? {}
+      : { publicRoutes: undefined, lazyPublicRoutes: undefined }),
+  }
+}
+
+function selectedExtensionSurfaces(
+  configured: HonoExtension,
+  api: readonly { surface: string }[],
+): HonoExtension {
+  return {
+    ...configured,
+    ...(api.some(({ surface }) => surface === "admin")
+      ? {}
+      : { adminRoutes: undefined, lazyAdminRoutes: undefined }),
+    ...(api.some(({ surface }) => surface === "public")
+      ? {}
+      : { publicRoutes: undefined, lazyPublicRoutes: undefined }),
+  }
+}
+
+export const createCatalogSearchVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) => {
+    const runtime = await getPort(catalogSearchRuntimePort)
+    return selectedModuleSurfaces(
+      createCatalogSearchHonoModule({
+        ...runtime,
+        executeSearch: ({ adapter, embeddings, slice, request }) =>
+          executeSemanticSearch({
+            adapter,
+            embeddings: embeddings as Parameters<typeof executeSemanticSearch>[0]["embeddings"],
+            slice,
+            request,
+          }),
+      }),
+      api,
+    )
+  },
+)
+
+export const createCatalogBookingVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) =>
+    selectedModuleSurfaces(
+      createCatalogBookingEngineHonoModule(await getPort(catalogBookingRuntimePort)),
+      api,
+    ),
+)
+
+export const createCatalogOffersVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) =>
+    selectedExtensionSurfaces(
+      createCatalogOffersHonoExtension(await getPort(catalogOffersRuntimePort)),
+      api,
+    ),
+)
+
+export type { CatalogSearchRuntimeOptions } from "./api-runtime-ports.js"
+export {
+  catalogBookingRuntimePort,
+  catalogOffersRuntimePort,
+  catalogSearchRuntimePort,
+} from "./api-runtime-ports.js"

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -1,4 +1,9 @@
 import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import {
+  catalogBookingRuntimePort,
+  catalogOffersRuntimePort,
+  catalogSearchRuntimePort,
+} from "./api-runtime-ports.js"
 import { catalogBookingSnapshotSubscriberDeclaration } from "./booking-snapshot-subscriber-declaration.js"
 import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
 import {
@@ -28,6 +33,7 @@ export const catalogVoyantModule = defineModule({
   packageName: "@voyant-travel/catalog",
   localId: "catalog",
   runtimePorts: [
+    requirePort(catalogSearchRuntimePort),
     requirePort(catalogProjectionRuntimePort),
     requirePort(catalogBookingSnapshotRuntimePort),
   ],
@@ -37,8 +43,8 @@ export const catalogVoyantModule = defineModule({
       surface: "admin",
       mount: "catalog",
       runtime: {
-        entry: "@voyant-travel/catalog",
-        export: "createCatalogSearchHonoModule",
+        entry: "@voyant-travel/catalog/graph-runtime",
+        export: "createCatalogSearchVoyantRuntime",
       },
     },
     {
@@ -47,8 +53,8 @@ export const catalogVoyantModule = defineModule({
       mount: "catalog",
       anonymous: true,
       runtime: {
-        entry: "@voyant-travel/catalog",
-        export: "createCatalogSearchHonoModule",
+        entry: "@voyant-travel/catalog/graph-runtime",
+        export: "createCatalogSearchVoyantRuntime",
       },
     },
   ],
@@ -235,6 +241,7 @@ export const catalogBookingEngineVoyantModule = defineModule({
   id: "@voyant-travel/catalog#booking-engine",
   packageName: "@voyant-travel/catalog",
   localId: "catalog.booking-engine",
+  runtimePorts: [requirePort(catalogBookingRuntimePort)],
   api: [
     {
       id: "@voyant-travel/catalog#booking-engine.api.admin",
@@ -242,8 +249,8 @@ export const catalogBookingEngineVoyantModule = defineModule({
       mount: "catalog",
       transactional: ["/book", "/holds", "/orders", "/quote", "/quotes/batch"],
       runtime: {
-        entry: "@voyant-travel/catalog/booking-engine",
-        export: "createCatalogBookingEngineHonoModule",
+        entry: "@voyant-travel/catalog/graph-runtime",
+        export: "createCatalogBookingVoyantRuntime",
       },
     },
     {
@@ -252,8 +259,8 @@ export const catalogBookingEngineVoyantModule = defineModule({
       mount: "catalog",
       transactional: ["/book", "/holds", "/quote", "/quotes/batch"],
       runtime: {
-        entry: "@voyant-travel/catalog/booking-engine",
-        export: "createCatalogBookingEngineHonoModule",
+        entry: "@voyant-travel/catalog/graph-runtime",
+        export: "createCatalogBookingVoyantRuntime",
       },
     },
   ],
@@ -266,14 +273,15 @@ export const catalogOffersVoyantPlugin = defineExtension({
   id: "@voyant-travel/catalog#offers-extension",
   packageName: "@voyant-travel/catalog",
   localId: "catalog.offers-extension",
+  runtimePorts: [requirePort(catalogOffersRuntimePort)],
   api: [
     {
       id: "@voyant-travel/catalog#offers-extension.api",
       surface: "admin",
       mount: "catalog",
       runtime: {
-        entry: "@voyant-travel/catalog/offers",
-        export: "createCatalogOffersHonoExtension",
+        entry: "@voyant-travel/catalog/graph-runtime",
+        export: "createCatalogOffersVoyantRuntime",
       },
     },
   ],

--- a/packages/catalog/tests/unit/package-exports.test.ts
+++ b/packages/catalog/tests/unit/package-exports.test.ts
@@ -19,6 +19,14 @@ const packageJson = JSON.parse(
 ) as PackageJson
 
 describe("@voyant-travel/catalog package exports", () => {
+  it("publishes package-owned API graph runtimes", () => {
+    expect(packageJson.exports["./graph-runtime"]).toBe("./src/graph-runtime.ts")
+    expect(packageJson.publishConfig.exports["./graph-runtime"]).toEqual({
+      types: "./dist/graph-runtime.d.ts",
+      import: "./dist/graph-runtime.js",
+      default: "./dist/graph-runtime.js",
+    })
+  })
   it("publishes the projection subscriber runtime contract", () => {
     expect(packageJson.exports["./projection-runtime"]).toBe("./src/projection-runtime.ts")
     expect(packageJson.publishConfig.exports["./projection-runtime"]).toEqual({

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,10 @@
+import { isGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
+import {
+  createCatalogBookingVoyantRuntime,
+  createCatalogOffersVoyantRuntime,
+  createCatalogSearchVoyantRuntime,
+} from "../../src/graph-runtime.js"
 import {
   catalogBookingEngineVoyantModule,
   catalogOffersVoyantPlugin,
@@ -16,8 +22,8 @@ describe("catalog deployment manifest", () => {
           id: "@voyant-travel/catalog#api.admin",
           surface: "admin",
           runtime: {
-            entry: "@voyant-travel/catalog",
-            export: "createCatalogSearchHonoModule",
+            entry: "@voyant-travel/catalog/graph-runtime",
+            export: "createCatalogSearchVoyantRuntime",
           },
         },
         {
@@ -25,8 +31,8 @@ describe("catalog deployment manifest", () => {
           surface: "public",
           anonymous: true,
           runtime: {
-            entry: "@voyant-travel/catalog",
-            export: "createCatalogSearchHonoModule",
+            entry: "@voyant-travel/catalog/graph-runtime",
+            export: "createCatalogSearchVoyantRuntime",
           },
         },
       ],
@@ -67,6 +73,7 @@ describe("catalog deployment manifest", () => {
       })),
     )
     expect(catalogVoyantModule.runtimePorts).toEqual([
+      { id: "catalog.search-runtime" },
       { id: "catalog.projection-runtime" },
       { id: "catalog.booking-snapshot-runtime" },
     ])
@@ -84,8 +91,8 @@ describe("catalog deployment manifest", () => {
           mount: "catalog",
           transactional: ["/book", "/holds", "/orders", "/quote", "/quotes/batch"],
           runtime: {
-            entry: "@voyant-travel/catalog/booking-engine",
-            export: "createCatalogBookingEngineHonoModule",
+            entry: "@voyant-travel/catalog/graph-runtime",
+            export: "createCatalogBookingVoyantRuntime",
           },
         },
         {
@@ -94,11 +101,12 @@ describe("catalog deployment manifest", () => {
           mount: "catalog",
           transactional: ["/book", "/holds", "/quote", "/quotes/batch"],
           runtime: {
-            entry: "@voyant-travel/catalog/booking-engine",
-            export: "createCatalogBookingEngineHonoModule",
+            entry: "@voyant-travel/catalog/graph-runtime",
+            export: "createCatalogBookingVoyantRuntime",
           },
         },
       ],
+      runtimePorts: [{ id: "catalog.booking-runtime" }],
     })
 
     expect(catalogOffersVoyantPlugin).toMatchObject({
@@ -111,12 +119,17 @@ describe("catalog deployment manifest", () => {
           surface: "admin",
           mount: "catalog",
           runtime: {
-            entry: "@voyant-travel/catalog/offers",
-            export: "createCatalogOffersHonoExtension",
+            entry: "@voyant-travel/catalog/graph-runtime",
+            export: "createCatalogOffersVoyantRuntime",
           },
         },
       ],
+      runtimePorts: [{ id: "catalog.offers-runtime" }],
     })
+
+    expect(isGraphRuntimeFactory(createCatalogSearchVoyantRuntime)).toBe(true)
+    expect(isGraphRuntimeFactory(createCatalogBookingVoyantRuntime)).toBe(true)
+    expect(isGraphRuntimeFactory(createCatalogOffersVoyantRuntime)).toBe(true)
   })
 
   it("declares every route in the packaged catalog admin extension", () => {

--- a/packages/cruises/package.json
+++ b/packages/cruises/package.json
@@ -20,6 +20,7 @@
     "./service-external-refresh": "./src/service-external-refresh.ts",
     "./service-content-synthesizer": "./src/service-content-synthesizer.ts",
     "./routes-content": "./src/routes-content.ts",
+    "./graph-runtime": "./src/graph-runtime.ts",
     "./draft-shape": "./src/draft-shape.ts",
     "./booking-engine": "./src/booking-engine/index.ts",
     "./service-pricing": "./src/service-pricing.ts",
@@ -156,6 +157,11 @@
         "types": "./dist/service-pricing.d.ts",
         "import": "./dist/service-pricing.js",
         "default": "./dist/service-pricing.js"
+      },
+      "./graph-runtime": {
+        "types": "./dist/graph-runtime.d.ts",
+        "import": "./dist/graph-runtime.js",
+        "default": "./dist/graph-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/cruises/src/graph-runtime.ts
+++ b/packages/cruises/src/graph-runtime.ts
@@ -1,0 +1,17 @@
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+
+import { createCruiseContentHonoExtension } from "./routes-content.js"
+import { cruisesContentRuntimePort } from "./runtime-port.js"
+
+export const createCruisesContentVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) => {
+    const configured = createCruiseContentHonoExtension(await getPort(cruisesContentRuntimePort))
+    return {
+      ...configured,
+      ...(api.some(({ surface }) => surface === "admin") ? {} : { adminRoutes: undefined }),
+      ...(api.some(({ surface }) => surface === "public") ? {} : { publicRoutes: undefined }),
+    }
+  },
+)
+
+export { cruisesContentRuntimePort } from "./runtime-port.js"

--- a/packages/cruises/src/runtime-port.ts
+++ b/packages/cruises/src/runtime-port.ts
@@ -1,0 +1,19 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { CruiseContentHonoExtensionOptions } from "./routes-content.js"
+
+export const cruisesContentRuntimePort = definePort<CruiseContentHonoExtensionOptions>({
+  id: "cruises.content-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("cruises.content-runtime provider must be an options object.")
+    }
+    for (const surface of ["admin", "public"] as const) {
+      if (typeof provider[surface]?.resolveRegistry !== "function") {
+        throw new Error(
+          `cruises.content-runtime provider must configure ${surface}.resolveRegistry().`,
+        )
+      }
+    }
+  },
+})

--- a/packages/cruises/src/voyant.ts
+++ b/packages/cruises/src/voyant.ts
@@ -1,4 +1,5 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import { cruisesContentRuntimePort } from "./runtime-port.js"
 
 /** Import-cheap deployment declaration owned by the cruises package. */
 export const cruisesVoyantModule = defineModule({
@@ -78,14 +79,15 @@ export const cruisesContentVoyantPlugin = defineExtension({
   id: "@voyant-travel/cruises#content-extension",
   packageName: "@voyant-travel/cruises",
   localId: "cruises.content-extension",
+  runtimePorts: [requirePort(cruisesContentRuntimePort)],
   api: [
     {
       id: "@voyant-travel/cruises#content-extension.api.admin",
       surface: "admin",
       mount: "cruises",
       runtime: {
-        entry: "@voyant-travel/cruises/routes-content",
-        export: "createCruiseContentHonoExtension",
+        entry: "@voyant-travel/cruises/graph-runtime",
+        export: "createCruisesContentVoyantRuntime",
       },
     },
     {
@@ -93,8 +95,8 @@ export const cruisesContentVoyantPlugin = defineExtension({
       surface: "public",
       mount: "cruises",
       runtime: {
-        entry: "@voyant-travel/cruises/routes-content",
-        export: "createCruiseContentHonoExtension",
+        entry: "@voyant-travel/cruises/graph-runtime",
+        export: "createCruisesContentVoyantRuntime",
       },
     },
   ],

--- a/packages/cruises/tests/unit/voyant-manifest.test.ts
+++ b/packages/cruises/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,6 @@
+import { isGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
+import { createCruisesContentVoyantRuntime } from "../../src/graph-runtime.js"
 import { createCruisesHonoModule } from "../../src/index.js"
 import { createCruiseContentHonoExtension } from "../../src/routes-content.js"
 import {
@@ -47,14 +49,15 @@ describe("cruises deployment manifest", () => {
         {
           surface: "admin",
           mount: "cruises",
-          runtime: { export: "createCruiseContentHonoExtension" },
+          runtime: { export: "createCruisesContentVoyantRuntime" },
         },
         {
           surface: "public",
           mount: "cruises",
-          runtime: { export: "createCruiseContentHonoExtension" },
+          runtime: { export: "createCruisesContentVoyantRuntime" },
         },
       ],
+      runtimePorts: [{ id: "cruises.content-runtime" }],
     })
     expect(cruisesBookingVoyantPlugin).toMatchObject({
       schemaVersion: "voyant.extension.v1",
@@ -72,6 +75,7 @@ describe("cruises deployment manifest", () => {
     expect(extension.extension).toMatchObject({ name: "content", module: "cruises" })
     expect(extension.adminRoutes).toBeDefined()
     expect(extension.publicRoutes).toBeDefined()
+    expect(isGraphRuntimeFactory(createCruisesContentVoyantRuntime)).toBe(true)
   })
 
   it("preserves deployment-injected lazy route bridges", () => {

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -40,6 +40,7 @@
     "./authoring/schema": "./src/authoring/schema.ts",
     "./authoring/spec": "./src/authoring/spec.ts",
     "./authoring/extension": "./src/authoring/extension.ts",
+    "./graph-runtime": "./src/graph-runtime.ts",
     "./voyant": "./src/voyant.ts"
   },
   "scripts": {
@@ -268,6 +269,11 @@
         "types": "./dist/authoring/extension.d.ts",
         "import": "./dist/authoring/extension.js",
         "default": "./dist/authoring/extension.js"
+      },
+      "./graph-runtime": {
+        "types": "./dist/graph-runtime.d.ts",
+        "import": "./dist/graph-runtime.js",
+        "default": "./dist/graph-runtime.js"
       },
       "./voyant": {
         "types": "./dist/voyant.d.ts",

--- a/packages/inventory/src/graph-runtime.ts
+++ b/packages/inventory/src/graph-runtime.ts
@@ -1,0 +1,63 @@
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { HonoExtension, HonoModule } from "@voyant-travel/hono/module"
+
+import { inventoryHonoModule } from "./interface.js"
+import { createProductBrochureHonoExtension } from "./routes-brochure.js"
+import { createProductContentHonoExtension } from "./routes-content.js"
+import {
+  inventoryBrochureRuntimePort,
+  inventoryContentRuntimePort,
+  inventoryRuntimePort,
+} from "./runtime-ports.js"
+
+function selectedModuleSurfaces(
+  configured: HonoModule,
+  api: readonly { surface: string }[],
+): HonoModule {
+  return {
+    ...configured,
+    ...(api.some(({ surface }) => surface === "admin") ? {} : { adminRoutes: undefined }),
+    ...(api.some(({ surface }) => surface === "public") ? {} : { publicRoutes: undefined }),
+  }
+}
+
+function selectedExtensionSurfaces(
+  configured: HonoExtension,
+  api: readonly { surface: string }[],
+): HonoExtension {
+  return {
+    ...configured,
+    ...(api.some(({ surface }) => surface === "admin") ? {} : { adminRoutes: undefined }),
+    ...(api.some(({ surface }) => surface === "public") ? {} : { publicRoutes: undefined }),
+  }
+}
+
+export const createInventoryVoyantRuntime = defineGraphRuntimeFactory(async ({ api, getPort }) => {
+  const runtime = await getPort(inventoryRuntimePort)
+  return selectedModuleSurfaces(
+    {
+      ...inventoryHonoModule,
+      module: { ...inventoryHonoModule.module, bootstrap: runtime.bootstrap },
+    },
+    api,
+  )
+})
+
+export const createInventoryContentVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) =>
+    selectedExtensionSurfaces(
+      createProductContentHonoExtension(await getPort(inventoryContentRuntimePort)),
+      api,
+    ),
+)
+
+export const createInventoryBrochureVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) =>
+  createProductBrochureHonoExtension(await getPort(inventoryBrochureRuntimePort)),
+)
+
+export type { InventoryRuntime } from "./runtime-ports.js"
+export {
+  inventoryBrochureRuntimePort,
+  inventoryContentRuntimePort,
+  inventoryRuntimePort,
+} from "./runtime-ports.js"

--- a/packages/inventory/src/runtime-ports.ts
+++ b/packages/inventory/src/runtime-ports.ts
@@ -1,0 +1,51 @@
+import type { Module } from "@voyant-travel/core"
+import { definePort } from "@voyant-travel/core/project"
+
+import type { ProductBrochureRoutesOptions } from "./routes-brochure.js"
+import type { ProductContentHonoExtensionOptions } from "./routes-content.js"
+
+export interface InventoryRuntime {
+  bootstrap: NonNullable<Module["bootstrap"]>
+}
+
+export const inventoryRuntimePort = definePort<InventoryRuntime>({
+  id: "inventory.runtime",
+  test(provider) {
+    if (
+      provider === null ||
+      typeof provider !== "object" ||
+      typeof provider.bootstrap !== "function"
+    ) {
+      throw new Error("inventory.runtime provider must implement bootstrap().")
+    }
+  },
+})
+
+export const inventoryContentRuntimePort = definePort<ProductContentHonoExtensionOptions>({
+  id: "inventory.content-runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("inventory.content-runtime provider must be an options object.")
+    }
+    for (const surface of ["admin", "public"] as const) {
+      if (typeof provider[surface]?.resolveRegistry !== "function") {
+        throw new Error(
+          `inventory.content-runtime provider must configure ${surface}.resolveRegistry().`,
+        )
+      }
+    }
+  },
+})
+
+export const inventoryBrochureRuntimePort = definePort<ProductBrochureRoutesOptions>({
+  id: "inventory.brochure-runtime",
+  test(provider) {
+    if (
+      provider === null ||
+      typeof provider !== "object" ||
+      typeof provider.resolveStorage !== "function"
+    ) {
+      throw new Error("inventory.brochure-runtime provider must implement resolveStorage().")
+    }
+  },
+})

--- a/packages/inventory/src/voyant.ts
+++ b/packages/inventory/src/voyant.ts
@@ -1,18 +1,24 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import {
+  inventoryBrochureRuntimePort,
+  inventoryContentRuntimePort,
+  inventoryRuntimePort,
+} from "./runtime-ports.js"
 
 /** Import-cheap deployment declarations owned by the inventory package. */
 export const inventoryVoyantModule = defineModule({
   id: "@voyant-travel/inventory",
   packageName: "@voyant-travel/inventory",
   localId: "inventory",
+  runtimePorts: [requirePort(inventoryRuntimePort)],
   api: [
     {
       id: "@voyant-travel/inventory#api.admin",
       surface: "admin",
       mount: "products",
       runtime: {
-        entry: "@voyant-travel/inventory",
-        export: "inventoryHonoModule",
+        entry: "@voyant-travel/inventory/graph-runtime",
+        export: "createInventoryVoyantRuntime",
       },
     },
     {
@@ -21,8 +27,8 @@ export const inventoryVoyantModule = defineModule({
       mount: "products",
       anonymous: true,
       runtime: {
-        entry: "@voyant-travel/inventory",
-        export: "inventoryHonoModule",
+        entry: "@voyant-travel/inventory/graph-runtime",
+        export: "createInventoryVoyantRuntime",
       },
     },
   ],
@@ -242,14 +248,15 @@ export const inventoryContentVoyantPlugin = defineExtension({
   id: "@voyant-travel/inventory#content-extension",
   packageName: "@voyant-travel/inventory",
   localId: "inventory.content-extension",
+  runtimePorts: [requirePort(inventoryContentRuntimePort)],
   api: [
     {
       id: "@voyant-travel/inventory#content-extension.api.admin",
       surface: "admin",
       mount: "products",
       runtime: {
-        entry: "@voyant-travel/inventory/routes-content",
-        export: "createProductContentHonoExtension",
+        entry: "@voyant-travel/inventory/graph-runtime",
+        export: "createInventoryContentVoyantRuntime",
       },
     },
     {
@@ -258,8 +265,8 @@ export const inventoryContentVoyantPlugin = defineExtension({
       mount: "products",
       anonymous: true,
       runtime: {
-        entry: "@voyant-travel/inventory/routes-content",
-        export: "createProductContentHonoExtension",
+        entry: "@voyant-travel/inventory/graph-runtime",
+        export: "createInventoryContentVoyantRuntime",
       },
     },
   ],
@@ -272,14 +279,15 @@ export const inventoryBrochureVoyantPlugin = defineExtension({
   id: "@voyant-travel/inventory#brochure-extension",
   packageName: "@voyant-travel/inventory",
   localId: "inventory.brochure-extension",
+  runtimePorts: [requirePort(inventoryBrochureRuntimePort)],
   api: [
     {
       id: "@voyant-travel/inventory#brochure-extension.api.admin",
       surface: "admin",
       mount: "products",
       runtime: {
-        entry: "@voyant-travel/inventory/routes-brochure",
-        export: "createProductBrochureHonoExtension",
+        entry: "@voyant-travel/inventory/graph-runtime",
+        export: "createInventoryBrochureVoyantRuntime",
       },
     },
   ],

--- a/packages/inventory/tests/unit/voyant-manifest.test.ts
+++ b/packages/inventory/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,10 @@
+import { isGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { describe, expect, it } from "vitest"
+import {
+  createInventoryBrochureVoyantRuntime,
+  createInventoryContentVoyantRuntime,
+  createInventoryVoyantRuntime,
+} from "../../src/graph-runtime.js"
 import { createProductBrochureHonoExtension } from "../../src/routes-brochure.js"
 import { createProductContentHonoExtension } from "../../src/routes-content.js"
 import {
@@ -24,15 +30,22 @@ describe("inventory deployment manifests", () => {
         {
           id: "@voyant-travel/inventory#api.admin",
           surface: "admin",
-          runtime: { entry: "@voyant-travel/inventory", export: "inventoryHonoModule" },
+          runtime: {
+            entry: "@voyant-travel/inventory/graph-runtime",
+            export: "createInventoryVoyantRuntime",
+          },
         },
         {
           id: "@voyant-travel/inventory#api.public",
           surface: "public",
           anonymous: true,
-          runtime: { entry: "@voyant-travel/inventory", export: "inventoryHonoModule" },
+          runtime: {
+            entry: "@voyant-travel/inventory/graph-runtime",
+            export: "createInventoryVoyantRuntime",
+          },
         },
       ],
+      runtimePorts: [{ id: "inventory.runtime" }],
       schema: [{ id: "@voyant-travel/inventory#schema" }],
       migrations: [{ id: "@voyant-travel/inventory#migrations" }],
       links: [{ id: "@voyant-travel/inventory#linkable.product" }],
@@ -102,15 +115,16 @@ describe("inventory deployment manifests", () => {
         {
           surface: "admin",
           mount: "products",
-          runtime: { export: "createProductContentHonoExtension" },
+          runtime: { export: "createInventoryContentVoyantRuntime" },
         },
         {
           surface: "public",
           mount: "products",
           anonymous: true,
-          runtime: { export: "createProductContentHonoExtension" },
+          runtime: { export: "createInventoryContentVoyantRuntime" },
         },
       ],
+      runtimePorts: [{ id: "inventory.content-runtime" }],
     })
     expect(inventoryBrochureVoyantPlugin).toMatchObject({
       schemaVersion: "voyant.extension.v1",
@@ -119,9 +133,10 @@ describe("inventory deployment manifests", () => {
         {
           surface: "admin",
           mount: "products",
-          runtime: { export: "createProductBrochureHonoExtension" },
+          runtime: { export: "createInventoryBrochureVoyantRuntime" },
         },
       ],
+      runtimePorts: [{ id: "inventory.brochure-runtime" }],
     })
 
     const resolveRegistry = () => ({}) as never
@@ -134,6 +149,9 @@ describe("inventory deployment manifests", () => {
     expect(content.adminRoutes).toBeDefined()
     expect(content.publicRoutes).toBeDefined()
     expect(brochure.extension).toMatchObject({ name: "brochure", module: "products" })
+    expect(isGraphRuntimeFactory(createInventoryVoyantRuntime)).toBe(true)
+    expect(isGraphRuntimeFactory(createInventoryContentVoyantRuntime)).toBe(true)
+    expect(isGraphRuntimeFactory(createInventoryBrochureVoyantRuntime)).toBe(true)
   })
 
   it("exposes a configurable PDF workflow factory", () => {


### PR DESCRIPTION
## Summary
- add package-owned graph runtime factories for Catalog search, booking engine, and offers
- add package-owned graph runtime factories for Inventory core, content, and brochures
- add typed content runtime ports for Accommodations and Cruises
- add a typed health runtime port for Action Ledger
- preserve deployment adapters behind typed ports and honor selected API surfaces

## Authority families
- Catalog search
- Catalog booking engine
- Catalog offers
- Inventory core and workflow bootstrap
- Inventory content
- Inventory brochures
- Accommodations content
- Cruises content
- Action Ledger health

## Verification
- Catalog manifest/export tests: 8 passed
- Inventory manifest tests: 5 passed
- Accommodations manifest tests: 2 passed
- Cruises manifest tests: 3 passed
- Action Ledger manifest tests: 2 passed
- package lint passed for all five owned packages
- Catalog, Cruises, and Action Ledger typechecks passed
- Inventory and Accommodations full typechecks exceeded the local 4 GB Node heap without emitting diagnostics; CI remains authoritative for those two

## Scope
This stack intentionally does not modify Operator composition, app wiring, framework composition catalogs, root scripts, generated dependency paths, or architecture documentation. The central cutover can register deployment adapters against these ports and delete the corresponding package-ID bindings and compatibility extension entries.