### PR TITLE
refactor(runtime): move booking payment authority package-side

### DIFF
--- a/.changeset/booking-payment-package-authority.md
+++ b/.changeset/booking-payment-package-authority.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/legal": patch
+"@voyant-travel/storefront": patch
+---
+
+Move booking and payment runtime configuration behind package-owned graph factories and typed deployment ports.

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -1,4 +1,5 @@
-import type { Module } from "@voyant-travel/core"
+import type { BootstrapContext, Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
 import { bookingsLinkable } from "./linkables.js"
 import {
@@ -8,6 +9,7 @@ import {
 } from "./route-runtime.js"
 import { bookingRoutes } from "./routes.js"
 import { publicBookingRoutes } from "./routes-public.js"
+import { bookingsRuntimePort } from "./runtime-port.js"
 
 export {
   BOOKING_ACTION_LEDGER_CAPABILITIES,
@@ -134,6 +136,29 @@ export function createBookingsHonoModule(options: BookingsHonoModuleOptions = {}
 
 export const bookingsHonoModule: HonoModule = createBookingsHonoModule()
 
+/** Package-owned adapter from graph ports to the complete Bookings runtime. */
+export const createBookingsVoyantRuntime = defineGraphRuntimeFactory(async ({ api, getPort }) => {
+  const provider = await getPort(bookingsRuntimePort)
+  const configured = createBookingsHonoModule(provider.options)
+  const bootstrap = configured.module.bootstrap
+  const selected: HonoModule = {
+    module: {
+      ...configured.module,
+      bootstrap: async (context: BootstrapContext) => {
+        await provider.registerWorkflowService?.(context)
+        await bootstrap?.(context)
+      },
+    },
+  }
+  if (api.some(({ surface }) => surface === "admin") && configured.adminRoutes) {
+    selected.adminRoutes = configured.adminRoutes
+  }
+  if (api.some(({ surface }) => surface === "public") && configured.publicRoutes) {
+    selected.publicRoutes = configured.publicRoutes
+  }
+  return selected
+})
+
 export type {
   BookingOverviewEnricherItem,
   BookingOverviewItemEnricher,
@@ -156,6 +181,8 @@ export {
 export type { BookingActionLedgerListResponse, BookingRoutes } from "./routes.js"
 export type { PublicBookingRoutes } from "./routes-public.js"
 export { publicBookingRoutes } from "./routes-public.js"
+export type { BookingsRuntimeProvider } from "./runtime-port.js"
+export { bookingRequirementsRuntimePort, bookingsRuntimePort } from "./runtime-port.js"
 export type {
   BookingTravelerBedPreference,
   BookingTravelerDietary,

--- a/packages/bookings/src/requirements/index.ts
+++ b/packages/bookings/src/requirements/index.ts
@@ -1,6 +1,7 @@
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
-
+import { bookingRequirementsRuntimePort } from "../runtime-port.js"
 import { bookingRequirementsRoutes } from "./routes.js"
 import {
   createPublicBookingRequirementsRoutes,
@@ -37,6 +38,22 @@ export function createBookingRequirementsHonoModule(
       : publicBookingRequirementsRoutes,
   }
 }
+
+export const createBookingRequirementsVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) => {
+    const configured = createBookingRequirementsHonoModule(
+      await getPort(bookingRequirementsRuntimePort),
+    )
+    const selected: HonoModule = { module: configured.module }
+    if (api.some(({ surface }) => surface === "admin") && configured.adminRoutes) {
+      selected.adminRoutes = configured.adminRoutes
+    }
+    if (api.some(({ surface }) => surface === "public") && configured.publicRoutes) {
+      selected.publicRoutes = configured.publicRoutes
+    }
+    return selected
+  },
+)
 
 export {
   createPublicBookingRequirementsRoutes,

--- a/packages/bookings/src/runtime-port.ts
+++ b/packages/bookings/src/runtime-port.ts
@@ -1,0 +1,34 @@
+import type { BootstrapContext } from "@voyant-travel/core"
+import { definePort } from "@voyant-travel/core/project"
+
+import type { BookingsHonoModuleOptions } from "./index.js"
+import type { BookingRequirementsHonoModuleOptions } from "./requirements/index.js"
+
+export interface BookingsRuntimeProvider {
+  options: BookingsHonoModuleOptions
+  registerWorkflowService?(context: BootstrapContext): Promise<void> | void
+}
+
+export const bookingsRuntimePort = definePort<BookingsRuntimeProvider>({
+  id: "bookings.runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object" || !provider.options) {
+      throw new Error("bookings.runtime provider must supply module options.")
+    }
+    if (
+      provider.registerWorkflowService !== undefined &&
+      typeof provider.registerWorkflowService !== "function"
+    ) {
+      throw new Error("bookings.runtime registerWorkflowService must be a function.")
+    }
+  },
+})
+
+export const bookingRequirementsRuntimePort = definePort<BookingRequirementsHonoModuleOptions>({
+  id: "bookings.requirements.runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("bookings.requirements.runtime provider must be an options object.")
+    }
+  },
+})

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -1,6 +1,7 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
 
 import { BOOKING_VOYANT_ACTIONS } from "./action-declarations.js"
+import { bookingRequirementsRuntimePort, bookingsRuntimePort } from "./runtime-port.js"
 
 const bookingsAdminRuntime = {
   entry: "@voyant-travel/bookings-react/admin",
@@ -15,6 +16,8 @@ export const bookingsVoyantModule = defineModule({
   id: "@voyant-travel/bookings",
   packageName: "@voyant-travel/bookings",
   localId: "bookings",
+  runtime: { entry: "@voyant-travel/bookings", export: "createBookingsVoyantRuntime" },
+  runtimePorts: [requirePort(bookingsRuntimePort)],
   api: [
     {
       id: "@voyant-travel/bookings#api.admin",
@@ -212,6 +215,11 @@ export const bookingRequirementsVoyantModule = defineModule({
   id: "@voyant-travel/bookings#requirements",
   packageName: "@voyant-travel/bookings",
   localId: "bookings.requirements",
+  runtime: {
+    entry: "@voyant-travel/bookings/requirements",
+    export: "createBookingRequirementsVoyantRuntime",
+  },
+  runtimePorts: [requirePort(bookingRequirementsRuntimePort)],
   api: [
     {
       id: "@voyant-travel/bookings#requirements.api",

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest"
+import { createBookingsVoyantRuntime } from "../../src/index.js"
+import { createBookingRequirementsVoyantRuntime } from "../../src/requirements/index.js"
 import {
   bookingRequirementsVoyantModule,
   bookingsSupplierVoyantPlugin,
@@ -15,6 +17,8 @@ describe("bookings deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/bookings",
       packageName: "@voyant-travel/bookings",
+      runtime: { entry: "@voyant-travel/bookings", export: "createBookingsVoyantRuntime" },
+      runtimePorts: [{ id: "bookings.runtime" }],
       api: [
         {
           id: "@voyant-travel/bookings#api.admin",
@@ -94,6 +98,11 @@ describe("bookings deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/bookings#requirements",
       packageName: "@voyant-travel/bookings",
+      runtime: {
+        entry: "@voyant-travel/bookings/requirements",
+        export: "createBookingRequirementsVoyantRuntime",
+      },
+      runtimePorts: [{ id: "bookings.requirements.runtime" }],
       api: [
         {
           id: "@voyant-travel/bookings#requirements.api",
@@ -132,6 +141,27 @@ describe("bookings deployment manifest", () => {
         },
       ],
     })
+  })
+
+  it("mounts only selected Bookings API surfaces", async () => {
+    const context = {
+      unitId: "@voyant-travel/bookings",
+      projectConfig: {},
+      api: [{ id: "bookings.public", surface: "public" as const }],
+      hasPort: () => true,
+      getPort: async <TProvider>() => ({ options: {} }) as unknown as TProvider,
+    }
+    const bookings = await createBookingsVoyantRuntime(context)
+    const requirements = await createBookingRequirementsVoyantRuntime({
+      ...context,
+      unitId: "@voyant-travel/bookings#requirements",
+      getPort: async <TProvider>() => ({}) as TProvider,
+    })
+
+    expect(bookings.adminRoutes).toBeUndefined()
+    expect(bookings.publicRoutes).toBeDefined()
+    expect(requirements.adminRoutes).toBeUndefined()
+    expect(requirements.publicRoutes).toBeDefined()
   })
 
   it("declares the packaged booking routes, slots, and CRM contribution", () => {

--- a/packages/commerce/src/checkout/index.ts
+++ b/packages/commerce/src/checkout/index.ts
@@ -58,10 +58,12 @@ export {
   type BookingMaintenanceRoutesOptions,
   createBookingMaintenanceHonoExtension,
   createBookingMaintenanceRoutes,
+  createBookingMaintenanceVoyantRuntime,
   createCatalogCheckoutHonoExtension,
   createCatalogCheckoutRoutes,
 } from "./routes.js"
 export {
+  bookingMaintenanceRuntimePort,
   type CatalogCheckoutApiRuntime,
   catalogCheckoutApiRuntimePort,
 } from "./runtime-ports.js"

--- a/packages/commerce/src/checkout/routes.ts
+++ b/packages/commerce/src/checkout/routes.ts
@@ -20,12 +20,14 @@
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { EventBus } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 import { rebuildBookingItemTaxLines } from "./materialization-tax.js"
 import type { CheckoutModuleOptions, CheckoutStartOptions } from "./options.js"
+import { bookingMaintenanceRuntimePort } from "./runtime-ports.js"
 import {
   CatalogCheckoutStartError,
   type CheckoutStartRequestMeta,
@@ -227,6 +229,11 @@ export function createBookingMaintenanceHonoExtension(
     adminRoutes: createBookingMaintenanceRoutes(options),
   }
 }
+
+export const createBookingMaintenanceVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) =>
+    createBookingMaintenanceHonoExtension(await getPort(bookingMaintenanceRuntimePort)),
+)
 
 function checkoutRequestMeta(c: Context): CheckoutStartRequestMeta {
   return {

--- a/packages/commerce/src/checkout/runtime-ports.ts
+++ b/packages/commerce/src/checkout/runtime-ports.ts
@@ -5,8 +5,24 @@ import type { Context } from "hono"
 
 import type { AcceptanceSignatureLegalPort } from "./acceptance-signature.js"
 import type { CheckoutStartOptions } from "./options.js"
+import type { BookingMaintenanceRoutesOptions } from "./routes.js"
 
 export type CatalogCheckoutApiRuntime = (context: Context) => CheckoutStartOptions
+
+export const bookingMaintenanceRuntimePort = definePort<BookingMaintenanceRoutesOptions>({
+  id: "commerce.booking-maintenance.runtime",
+  test(provider) {
+    if (
+      provider === null ||
+      typeof provider !== "object" ||
+      typeof provider.resolveBookingTaxSettings !== "function"
+    ) {
+      throw new Error(
+        "commerce.booking-maintenance.runtime provider must implement resolveBookingTaxSettings().",
+      )
+    }
+  },
+})
 
 export interface CatalogCheckoutDatabaseRuntime {
   withDb<T>(bindings: unknown, operation: (db: PostgresJsDatabase) => Promise<T>): Promise<T>

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -1,6 +1,7 @@
 import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
 import { workflowRunnerRegistryRuntimePort } from "@voyant-travel/workflow-runs/runtime-port"
 import {
+  bookingMaintenanceRuntimePort,
   catalogCheckoutApiRuntimePort,
   catalogCheckoutContractPdfRuntimePort,
   catalogCheckoutDatabaseRuntimePort,
@@ -257,6 +258,11 @@ export const commerceBookingMaintenanceVoyantPlugin = defineExtension({
   id: "@voyant-travel/commerce#booking-maintenance-extension",
   packageName: "@voyant-travel/commerce",
   localId: "commerce.booking-maintenance-extension",
+  runtime: {
+    entry: "@voyant-travel/commerce/checkout",
+    export: "createBookingMaintenanceVoyantRuntime",
+  },
+  runtimePorts: [requirePort(bookingMaintenanceRuntimePort)],
   api: [
     {
       id: "@voyant-travel/commerce#booking-maintenance-extension.api",

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -174,6 +174,11 @@ describe("commerce deployment manifest", () => {
       schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/commerce#booking-maintenance-extension",
       packageName: "@voyant-travel/commerce",
+      runtime: {
+        entry: "@voyant-travel/commerce/checkout",
+        export: "createBookingMaintenanceVoyantRuntime",
+      },
+      runtimePorts: [{ id: "commerce.booking-maintenance.runtime" }],
       api: [
         {
           id: "@voyant-travel/commerce#booking-maintenance-extension.api",

--- a/packages/finance/src/booking-tax.ts
+++ b/packages/finance/src/booking-tax.ts
@@ -1,4 +1,5 @@
 import type { Extension } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { ApiHttpError, parseJsonBody } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import { and, asc, eq, sql } from "drizzle-orm"
@@ -7,6 +8,7 @@ import type { Hono } from "hono"
 import { Hono as HonoApp } from "hono"
 import { z } from "zod"
 
+import { financeBookingTaxRuntimePort } from "./runtime-port.js"
 import { taxClasses, taxPolicyProfiles, taxPolicyRules, taxRegimes } from "./schema.js"
 import { executeBoundaryRows } from "./service-boundary-sql.js"
 
@@ -387,3 +389,7 @@ export function createBookingTaxHonoExtension(options: BookingTaxRouteOptions = 
     adminRoutes: createBookingTaxRoutes(options),
   }
 }
+
+export const createBookingTaxVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) => {
+  return createBookingTaxHonoExtension(await getPort(financeBookingTaxRuntimePort))
+})

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -1,6 +1,7 @@
 // agent-quality: file-size exception -- owner: finance; existing module stays co-located until a dedicated split preserves behavior and tests.
 import { OpenAPIHono } from "@hono/zod-openapi"
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
 import { type BookingTaxRouteOptions, createBookingTaxRoutes } from "./booking-tax.js"
@@ -24,6 +25,7 @@ import { createFinanceAdminDocumentRoutes } from "./routes-documents.js"
 import { createPublicFinanceRoutes, type PublicFinanceRouteOptions } from "./routes-public.js"
 import { createFinanceAdminSettlementRoutes } from "./routes-settlement.js"
 import { supplierInvoiceRoutes } from "./routes-supplier-invoices.js"
+import { financeRuntimePort } from "./runtime-port.js"
 
 export type {
   CheckoutRouteRuntime,
@@ -180,12 +182,25 @@ export function createFinanceHonoModule(options: FinanceHonoModuleOptions = {}):
 
 export const financeHonoModule: HonoModule = createFinanceHonoModule()
 
+export const createFinanceVoyantRuntime = defineGraphRuntimeFactory(async ({ api, getPort }) => {
+  const configured = createFinanceHonoModule(await getPort(financeRuntimePort))
+  const selected: HonoModule = { module: configured.module }
+  if (api.some(({ surface }) => surface === "admin") && configured.adminRoutes) {
+    selected.adminRoutes = configured.adminRoutes
+  }
+  if (api.some(({ surface }) => surface === "public") && configured.publicRoutes) {
+    selected.publicRoutes = configured.publicRoutes
+  }
+  return selected
+})
+
 export {
   type BookingTaxRouteOptions,
   type BookingTaxSettings,
   computeBookingItemTaxLine,
   createBookingTaxHonoExtension,
   createBookingTaxRoutes,
+  createBookingTaxVoyantRuntime,
   loadProductTaxFacts,
   matchesTaxPolicyCondition,
   mountBookingTaxRoutes,
@@ -269,6 +284,7 @@ export {
   type BookingScheduleRoutesOptions,
   createBookingScheduleAdminRoutes,
   createBookingScheduleHonoExtension,
+  createBookingScheduleVoyantRuntime,
   createPaymentPolicyPublicRoutes,
   generatePaymentScheduleForBooking,
   type PaymentPolicyEntityContext,
@@ -289,6 +305,11 @@ export {
   type FinanceSettlementRouteOptions,
   type InvoiceSettlementPoller,
 } from "./routes-settlement.js"
+export {
+  financeBookingScheduleRuntimePort,
+  financeBookingTaxRuntimePort,
+  financeRuntimePort,
+} from "./runtime-port.js"
 export type {
   BookingGuarantee,
   BookingItemCommission,

--- a/packages/finance/src/payment-schedule/routes.ts
+++ b/packages/finance/src/payment-schedule/routes.ts
@@ -27,6 +27,7 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
 import { appendActionLedgerMutation } from "@voyant-travel/action-ledger"
 import { bookingActivityLog, bookings } from "@voyant-travel/bookings/schema"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { openApiValidationHook, parseJsonBody } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import { asc, eq } from "drizzle-orm"
@@ -40,6 +41,7 @@ import {
   resolveEffectivePaymentPolicy,
 } from "../payment-policy.js"
 import type { PaymentPolicyEntityContext } from "../payment-policy-cascade.js"
+import { financeBookingScheduleRuntimePort } from "../runtime-port.js"
 import { bookingPaymentSchedules } from "../schema/booking-billing.js"
 import { financeService } from "../service.js"
 
@@ -501,3 +503,21 @@ export function createBookingScheduleHonoExtension(
     anonymous: true,
   }
 }
+
+export const createBookingScheduleVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ api, getPort }) => {
+    const configured = createBookingScheduleHonoExtension(
+      await getPort(financeBookingScheduleRuntimePort),
+    )
+    const selected: HonoExtension = { extension: configured.extension }
+    if (api.some(({ surface }) => surface === "admin") && configured.lazyAdminRoutes) {
+      selected.lazyAdminRoutes = configured.lazyAdminRoutes
+    }
+    if (api.some(({ surface }) => surface === "public") && configured.lazyPublicRoutes) {
+      selected.lazyPublicRoutes = configured.lazyPublicRoutes
+      if (configured.publicPath !== undefined) selected.publicPath = configured.publicPath
+      if (configured.anonymous !== undefined) selected.anonymous = configured.anonymous
+    }
+    return selected
+  },
+)

--- a/packages/finance/src/runtime-port.ts
+++ b/packages/finance/src/runtime-port.ts
@@ -1,0 +1,24 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { BookingTaxRouteOptions } from "./booking-tax.js"
+import type { FinanceHonoModuleOptions } from "./index.js"
+import type { BookingScheduleRoutesOptions } from "./payment-schedule/routes.js"
+
+function optionsPort<T extends object>(id: string) {
+  return definePort<T>({
+    id,
+    test(provider) {
+      if (provider === null || typeof provider !== "object") {
+        throw new Error(`${id} provider must be an options object.`)
+      }
+    },
+  })
+}
+
+export const financeRuntimePort = optionsPort<FinanceHonoModuleOptions>("finance.runtime")
+export const financeBookingScheduleRuntimePort = optionsPort<BookingScheduleRoutesOptions>(
+  "finance.booking-schedule.runtime",
+)
+export const financeBookingTaxRuntimePort = optionsPort<BookingTaxRouteOptions>(
+  "finance.booking-tax.runtime",
+)

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -1,4 +1,9 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import {
+  financeBookingScheduleRuntimePort,
+  financeBookingTaxRuntimePort,
+  financeRuntimePort,
+} from "./runtime-port.js"
 
 const financeAdminRuntime = {
   entry: "@voyant-travel/finance-react/admin",
@@ -10,6 +15,8 @@ export const financeVoyantModule = defineModule({
   id: "@voyant-travel/finance",
   packageName: "@voyant-travel/finance",
   localId: "finance",
+  runtime: { entry: "@voyant-travel/finance", export: "createFinanceVoyantRuntime" },
+  runtimePorts: [requirePort(financeRuntimePort)],
   provides: { capabilities: ["finance.payment-sessions"] },
   api: [
     {
@@ -188,6 +195,8 @@ export const financeBookingTaxVoyantPlugin = defineExtension({
   id: "@voyant-travel/finance#booking-tax-extension",
   packageName: "@voyant-travel/finance",
   localId: "finance.booking-tax-extension",
+  runtime: { entry: "@voyant-travel/finance", export: "createBookingTaxVoyantRuntime" },
+  runtimePorts: [requirePort(financeBookingTaxRuntimePort)],
   api: [
     {
       id: "@voyant-travel/finance#booking-tax-extension.api",
@@ -230,6 +239,11 @@ export const financeBookingScheduleVoyantPlugin = defineExtension({
   id: "@voyant-travel/finance#booking-schedule-extension",
   packageName: "@voyant-travel/finance",
   localId: "finance.booking-schedule-extension",
+  runtime: {
+    entry: "@voyant-travel/finance",
+    export: "createBookingScheduleVoyantRuntime",
+  },
+  runtimePorts: [requirePort(financeBookingScheduleRuntimePort)],
   api: [
     {
       id: "@voyant-travel/finance#booking-schedule-extension.api.admin",

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { createFinanceVoyantRuntime } from "../../src/index.js"
 import {
   financeBookingScheduleVoyantPlugin,
   financeBookingsCreateVoyantPlugin,
@@ -12,6 +13,8 @@ describe("finance deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/finance",
       packageName: "@voyant-travel/finance",
+      runtime: { entry: "@voyant-travel/finance", export: "createFinanceVoyantRuntime" },
+      runtimePorts: [{ id: "finance.runtime" }],
       api: [
         {
           id: "@voyant-travel/finance#api.admin",
@@ -46,11 +49,26 @@ describe("finance deployment manifest", () => {
     })
   })
 
+  it("mounts only selected Finance API surfaces", async () => {
+    const runtime = await createFinanceVoyantRuntime({
+      unitId: "@voyant-travel/finance",
+      projectConfig: {},
+      api: [{ id: "finance.admin", surface: "admin" }],
+      hasPort: () => true,
+      getPort: async <TProvider>() => ({}) as TProvider,
+    })
+
+    expect(runtime.adminRoutes).toBeDefined()
+    expect(runtime.publicRoutes).toBeUndefined()
+  })
+
   it("owns the finance extensions", () => {
     expect([financeBookingTaxVoyantPlugin, financeBookingsCreateVoyantPlugin]).toMatchObject([
       {
         schemaVersion: "voyant.extension.v1",
         id: "@voyant-travel/finance#booking-tax-extension",
+        runtime: { entry: "@voyant-travel/finance", export: "createBookingTaxVoyantRuntime" },
+        runtimePorts: [{ id: "finance.booking-tax.runtime" }],
         api: [
           {
             runtime: {
@@ -77,6 +95,11 @@ describe("finance deployment manifest", () => {
       schemaVersion: "voyant.extension.v1",
       id: "@voyant-travel/finance#booking-schedule-extension",
       packageName: "@voyant-travel/finance",
+      runtime: {
+        entry: "@voyant-travel/finance",
+        export: "createBookingScheduleVoyantRuntime",
+      },
+      runtimePorts: [{ id: "finance.booking-schedule.runtime" }],
       api: [
         {
           id: "@voyant-travel/finance#booking-schedule-extension.api.admin",

--- a/packages/legal/src/contract-document-routes.ts
+++ b/packages/legal/src/contract-document-routes.ts
@@ -19,9 +19,11 @@
  * `CONTRACT_DOCUMENT_ROUTE_PATHS`.
  */
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { HonoModule } from "@voyant-travel/hono/module"
 import type { Context } from "hono"
+import { legalContractDocumentRuntimePort } from "./contract-document-runtime-port.js"
 
 /** Minimal structural view of the deployment's document storage backend. */
 export interface ContractDocumentStorageLike {
@@ -282,3 +284,7 @@ export function createContractDocumentHonoModule(
     },
   }
 }
+
+export const createContractDocumentVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) =>
+  createContractDocumentHonoModule(await getPort(legalContractDocumentRuntimePort)),
+)

--- a/packages/legal/src/contract-document-runtime-port.ts
+++ b/packages/legal/src/contract-document-runtime-port.ts
@@ -1,0 +1,22 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { ContractDocumentRoutesOptions } from "./contract-document-routes.js"
+
+export const legalContractDocumentRuntimePort = definePort<ContractDocumentRoutesOptions>({
+  id: "legal.contract-document.runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("legal.contract-document.runtime provider must be an options object.")
+    }
+    for (const method of [
+      "generateContract",
+      "previewContract",
+      "resolveStorage",
+      "guessMimeType",
+    ] as const) {
+      if (typeof provider[method] !== "function") {
+        throw new Error(`legal.contract-document.runtime ${method} must be a function.`)
+      }
+    }
+  },
+})

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -92,7 +92,9 @@ export {
   type ContractDocumentStorageLike,
   createContractDocumentHonoModule,
   createContractDocumentRoutes,
+  createContractDocumentVoyantRuntime,
 } from "./contract-document-routes.js"
+export { legalContractDocumentRuntimePort } from "./contract-document-runtime-port.js"
 export {
   createLegalBookingContractSubscriberDescriptor,
   LEGAL_BOOKING_CONTRACT_SUBSCRIBER_ID,

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -1,4 +1,5 @@
 import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import { legalContractDocumentRuntimePort } from "./contract-document-runtime-port.js"
 import { legalBookingContractSubscriberRuntimePort } from "./contracts/booking-contract-subscriber-port.js"
 import { legalRuntimePort } from "./runtime-port.js"
 
@@ -108,6 +109,11 @@ export const legalContractDocumentVoyantModule = defineModule({
   id: "@voyant-travel/legal#contract-document",
   packageName: "@voyant-travel/legal",
   localId: "legal.contract-document",
+  runtime: {
+    entry: "@voyant-travel/legal/contract-document-routes",
+    export: "createContractDocumentVoyantRuntime",
+  },
+  runtimePorts: [requirePort(legalContractDocumentRuntimePort)],
   api: [
     {
       id: "@voyant-travel/legal#contract-document.api",

--- a/packages/legal/tests/unit/voyant-manifest.test.ts
+++ b/packages/legal/tests/unit/voyant-manifest.test.ts
@@ -53,6 +53,11 @@ describe("legal deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/legal#contract-document",
       packageName: "@voyant-travel/legal",
+      runtime: {
+        entry: "@voyant-travel/legal/contract-document-routes",
+        export: "createContractDocumentVoyantRuntime",
+      },
+      runtimePorts: [{ id: "legal.contract-document.runtime" }],
       api: [
         {
           id: "@voyant-travel/legal#contract-document.api",

--- a/packages/storefront/src/customer-portal/index.ts
+++ b/packages/storefront/src/customer-portal/index.ts
@@ -1,5 +1,7 @@
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
+import { storefrontCustomerPortalRuntimePort } from "../runtime-port.js"
 
 import {
   buildPublicCustomerPortalRouteRuntime,
@@ -100,6 +102,10 @@ export function createCustomerPortalHonoModule(
 }
 
 export const customerPortalHonoModule: HonoModule = createCustomerPortalHonoModule()
+
+export const createCustomerPortalVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) => {
+  return createCustomerPortalHonoModule(await getPort(storefrontCustomerPortalRuntimePort))
+})
 
 export type {
   CustomerPortalRouteRuntime,

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -1,9 +1,11 @@
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
 import { registerStorefrontBookingBootstrapRuntime } from "./booking-bootstrap-subscriber-runtime.js"
 import { createStorefrontAdminRoutes } from "./routes-admin.js"
 import { createStorefrontPublicRoutes } from "./routes-public.js"
+import { storefrontRuntimePort } from "./runtime-port.js"
 
 export type {
   GuestBookingGuardOptions,
@@ -202,9 +204,9 @@ export const storefrontModule: Module = {
 
 export const storefrontAnonymousPublicPaths = ["/leads", "/newsletter", "/offers"] as const
 
-export function createStorefrontHonoModule(
-  options?: Parameters<typeof createStorefrontPublicRoutes>[0],
-): HonoModule {
+export type StorefrontHonoModuleOptions = Parameters<typeof createStorefrontPublicRoutes>[0]
+
+export function createStorefrontHonoModule(options?: StorefrontHonoModuleOptions): HonoModule {
   return {
     module: {
       ...storefrontModule,
@@ -222,6 +224,21 @@ export function createStorefrontHonoModule(
     anonymous: storefrontAnonymousPublicPaths,
   }
 }
+
+export const createStorefrontVoyantRuntime = defineGraphRuntimeFactory(async ({ api, getPort }) => {
+  const configured = createStorefrontHonoModule(await getPort(storefrontRuntimePort))
+  const selected: HonoModule = { module: configured.module }
+  if (api.some(({ surface }) => surface === "admin") && configured.adminRoutes) {
+    selected.adminRoutes = configured.adminRoutes
+  }
+  if (api.some(({ surface }) => surface === "public") && configured.publicRoutes) {
+    selected.publicRoutes = configured.publicRoutes
+    if (configured.publicPath !== undefined) selected.publicPath = configured.publicPath
+    if (configured.anonymous !== undefined) selected.anonymous = configured.anonymous
+  }
+  return selected
+})
+
 export {
   registerStorefrontBookingBootstrapRuntime,
   STOREFRONT_BOOKING_BOOTSTRAP_RUNTIME_KEY,
@@ -236,3 +253,9 @@ export {
   type BookingBootstrapIntentPayload,
   createBookingBootstrapIntentHandler,
 } from "./booking-intents.js"
+export {
+  storefrontCustomerPortalRuntimePort,
+  storefrontPaymentLinkRuntimePort,
+  storefrontRuntimePort,
+  storefrontVerificationRuntimePort,
+} from "./runtime-port.js"

--- a/packages/storefront/src/payment-link/routes.ts
+++ b/packages/storefront/src/payment-link/routes.ts
@@ -29,6 +29,7 @@
  */
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { financeService } from "@voyant-travel/finance"
 import { invoices, paymentSessions } from "@voyant-travel/finance/schema"
 import { openApiValidationHook } from "@voyant-travel/hono"
@@ -36,6 +37,7 @@ import type { HonoModule } from "@voyant-travel/hono/module"
 import { and, asc, desc, eq, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
+import { storefrontPaymentLinkRuntimePort } from "../runtime-port.js"
 
 const PUBLIC_PAYMENT_LINK_CONFIG_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=600"
 
@@ -874,6 +876,10 @@ export function createPaymentLinkHonoModule(options: PaymentLinkRoutesOptions): 
     anonymous: ["payment-link-config", "payment-link"],
   }
 }
+
+export const createPaymentLinkVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) => {
+  return createPaymentLinkHonoModule(await getPort(storefrontPaymentLinkRuntimePort))
+})
 
 // ─────────────────────────────────────────────────────────────────
 // Pure schedule resolution helpers

--- a/packages/storefront/src/runtime-port.ts
+++ b/packages/storefront/src/runtime-port.ts
@@ -1,0 +1,28 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { PublicCustomerPortalRouteOptions } from "./customer-portal/routes-public.js"
+import type { StorefrontHonoModuleOptions } from "./index.js"
+import type { PaymentLinkRoutesOptions } from "./payment-link/routes.js"
+import type { StorefrontVerificationRoutesOptions } from "./verification/routes-public.js"
+
+function optionsPort<T extends object>(id: string) {
+  return definePort<T>({
+    id,
+    test(provider) {
+      if (provider === null || typeof provider !== "object") {
+        throw new Error(`${id} provider must be an options object.`)
+      }
+    },
+  })
+}
+
+export const storefrontRuntimePort = optionsPort<StorefrontHonoModuleOptions>("storefront.runtime")
+export const storefrontPaymentLinkRuntimePort = optionsPort<PaymentLinkRoutesOptions>(
+  "storefront.payment-link.runtime",
+)
+export const storefrontCustomerPortalRuntimePort = optionsPort<PublicCustomerPortalRouteOptions>(
+  "storefront.customer-portal.runtime",
+)
+export const storefrontVerificationRuntimePort = optionsPort<StorefrontVerificationRoutesOptions>(
+  "storefront.verification.runtime",
+)

--- a/packages/storefront/src/verification/index.ts
+++ b/packages/storefront/src/verification/index.ts
@@ -1,5 +1,7 @@
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
+import { storefrontVerificationRuntimePort } from "../runtime-port.js"
 import {
   buildStorefrontVerificationSenders,
   createStorefrontVerificationPublicRoutes,
@@ -86,3 +88,8 @@ export function createStorefrontVerificationHonoModule(
     publicRoutes: createStorefrontVerificationPublicRoutes(options),
   }
 }
+
+export const createStorefrontVerificationVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) =>
+    createStorefrontVerificationHonoModule(await getPort(storefrontVerificationRuntimePort)),
+)

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -1,10 +1,18 @@
-import { defineModule } from "@voyant-travel/core/project"
+import { defineModule, requirePort } from "@voyant-travel/core/project"
+import {
+  storefrontCustomerPortalRuntimePort,
+  storefrontPaymentLinkRuntimePort,
+  storefrontRuntimePort,
+  storefrontVerificationRuntimePort,
+} from "./runtime-port.js"
 
 /** Import-cheap deployment declarations owned by the storefront package. */
 export const storefrontVoyantModule = defineModule({
   id: "@voyant-travel/storefront",
   packageName: "@voyant-travel/storefront",
   localId: "storefront",
+  runtime: { entry: "@voyant-travel/storefront", export: "createStorefrontVoyantRuntime" },
+  runtimePorts: [requirePort(storefrontRuntimePort)],
   api: [
     {
       id: "@voyant-travel/storefront#api.admin",
@@ -85,6 +93,11 @@ export const storefrontCustomerPortalVoyantModule = defineModule({
   id: "@voyant-travel/storefront#customer-portal",
   packageName: "@voyant-travel/storefront",
   localId: "storefront.customer-portal",
+  runtime: {
+    entry: "@voyant-travel/storefront/customer-portal",
+    export: "createCustomerPortalVoyantRuntime",
+  },
+  runtimePorts: [requirePort(storefrontCustomerPortalRuntimePort)],
   api: [
     {
       id: "@voyant-travel/storefront#customer-portal.api",
@@ -106,6 +119,11 @@ export const storefrontVerificationVoyantModule = defineModule({
   id: "@voyant-travel/storefront#verification",
   packageName: "@voyant-travel/storefront",
   localId: "storefront.verification",
+  runtime: {
+    entry: "@voyant-travel/storefront/verification",
+    export: "createStorefrontVerificationVoyantRuntime",
+  },
+  runtimePorts: [requirePort(storefrontVerificationRuntimePort)],
   api: [
     {
       id: "@voyant-travel/storefront#verification.api",
@@ -127,6 +145,11 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
   id: "@voyant-travel/storefront#payment-link",
   packageName: "@voyant-travel/storefront",
   localId: "storefront.payment-link",
+  runtime: {
+    entry: "@voyant-travel/storefront/payment-link",
+    export: "createPaymentLinkVoyantRuntime",
+  },
+  runtimePorts: [requirePort(storefrontPaymentLinkRuntimePort)],
   api: [
     {
       id: "@voyant-travel/storefront#payment-link.api",

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { createStorefrontVoyantRuntime } from "../../src/index.js"
 import {
   storefrontCustomerPortalVoyantModule,
   storefrontPaymentLinkVoyantModule,
@@ -12,6 +13,8 @@ describe("storefront deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/storefront",
       packageName: "@voyant-travel/storefront",
+      runtime: { entry: "@voyant-travel/storefront", export: "createStorefrontVoyantRuntime" },
+      runtimePorts: [{ id: "storefront.runtime" }],
       api: [
         {
           id: "@voyant-travel/storefront#api.admin",
@@ -77,6 +80,19 @@ describe("storefront deployment manifest", () => {
     })
   })
 
+  it("mounts only selected Storefront API surfaces", async () => {
+    const runtime = await createStorefrontVoyantRuntime({
+      unitId: "@voyant-travel/storefront",
+      projectConfig: {},
+      api: [{ id: "storefront.public", surface: "public" }],
+      hasPort: () => true,
+      getPort: async <TProvider>() => ({}) as TProvider,
+    })
+
+    expect(runtime.adminRoutes).toBeUndefined()
+    expect(runtime.publicRoutes).toBeDefined()
+  })
+
   it("owns package-namespaced storefront fragments", () => {
     expect([
       storefrontCustomerPortalVoyantModule,
@@ -86,6 +102,11 @@ describe("storefront deployment manifest", () => {
         schemaVersion: "voyant.module.v1",
         id: "@voyant-travel/storefront#customer-portal",
         packageName: "@voyant-travel/storefront",
+        runtime: {
+          entry: "@voyant-travel/storefront/customer-portal",
+          export: "createCustomerPortalVoyantRuntime",
+        },
+        runtimePorts: [{ id: "storefront.customer-portal.runtime" }],
         api: [
           {
             id: "@voyant-travel/storefront#customer-portal.api",
@@ -103,6 +124,11 @@ describe("storefront deployment manifest", () => {
         schemaVersion: "voyant.module.v1",
         id: "@voyant-travel/storefront#verification",
         packageName: "@voyant-travel/storefront",
+        runtime: {
+          entry: "@voyant-travel/storefront/verification",
+          export: "createStorefrontVerificationVoyantRuntime",
+        },
+        runtimePorts: [{ id: "storefront.verification.runtime" }],
         api: [
           {
             id: "@voyant-travel/storefront#verification.api",
@@ -124,6 +150,11 @@ describe("storefront deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/storefront#payment-link",
       packageName: "@voyant-travel/storefront",
+      runtime: {
+        entry: "@voyant-travel/storefront/payment-link",
+        export: "createPaymentLinkVoyantRuntime",
+      },
+      runtimePorts: [{ id: "storefront.payment-link.runtime" }],
       api: [
         {
           id: "@voyant-travel/storefront#payment-link.api",


### PR DESCRIPTION
## Summary
- add package-owned graph factories and typed Node-host ports for Bookings, booking requirements, Finance, booking schedule, booking tax, Commerce booking maintenance, Storefront, payment links, customer portal, verification, and Legal contract documents
- preserve deployment-provided route options and Bookings workflow-service registration behind typed package contracts
- gate multi-surface package factories by the selected admin/public API facets
- declare each factory and required port in its package manifest
- add package-level manifest/runtime coverage and one changeset

## Authority families completed
- `@voyant-travel/bookings`
- `@voyant-travel/bookings#requirements`
- `@voyant-travel/finance`
- `@voyant-travel/finance#booking-schedule-extension`
- `@voyant-travel/finance#booking-tax-extension`
- `@voyant-travel/commerce#booking-maintenance-extension`
- `@voyant-travel/storefront`
- `@voyant-travel/storefront#payment-link`
- `@voyant-travel/storefront#customer-portal`
- `@voyant-travel/storefront#verification`
- `@voyant-travel/legal#contract-document`

## Deferred by lane boundary
`@voyant-travel/catalog#booking-engine` belongs to `packages/catalog`, which is outside this lane's ownership. It needs the same package-owned factory/typed-port treatment in the Catalog/content lane; no generic framework change is required.

This PR intentionally does not perform the central Operator cutover or edit framework catalogs, generated paths, root scripts, or architecture documents.

## Verification
- 8 focused test files, 27 tests passed
- Bookings package typecheck passed
- changed-file Biome and secretlint passed
- changed-file agent quality passed with one existing file-size warning
- Finance, Commerce, Storefront, and Legal package typechecks produced no diagnostics before the three-minute local hardware cutoff; full CI remains required