### PR TITLE
refactor(runtime): move Quotes and MICE authority package-side

### DIFF
--- a/.changeset/quotes-mice-package-authority.md
+++ b/.changeset/quotes-mice-package-authority.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/quotes": minor
+"@voyant-travel/mice": minor
+---
+
+Move Quotes, proposal, quote-version snapshot, and MICE graph runtime assembly behind package-owned typed ports and factories.

--- a/packages/mice/src/index.ts
+++ b/packages/mice/src/index.ts
@@ -1,9 +1,11 @@
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
 import { miceLinkable } from "./linkables.js"
 import type { MiceRouteRuntimeOptions } from "./route-runtime.js"
 import { createMiceAdminRoutes } from "./routes.js"
+import { miceRuntimePort } from "./runtime-port.js"
 
 /**
  * The MICE spine is operator-local (niche) — registered in the deployment, NOT
@@ -36,6 +38,14 @@ export function createMiceHonoModule(options: MiceHonoModuleOptions = {}): HonoM
     adminRoutes: createMiceAdminRoutes(options),
   }
 }
+
+/** Package-owned adapter from graph runtime ports to the MICE route factory. */
+export const createMiceVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) =>
+  createMiceHonoModule(await getPort(miceRuntimePort)),
+)
+
+export type { MiceRuntime } from "./runtime-port.js"
+export { miceRuntimePort } from "./runtime-port.js"
 
 export const miceHonoModule: HonoModule = createMiceHonoModule()
 

--- a/packages/mice/src/runtime-port.ts
+++ b/packages/mice/src/runtime-port.ts
@@ -1,0 +1,20 @@
+import { definePort } from "@voyant-travel/core/project"
+
+import type { ResolveMiceDelegatePersonById } from "./route-runtime.js"
+
+/** Node-host behavior required by the package-owned MICE runtime factory. */
+export interface MiceRuntime {
+  resolveDelegatePersonById: ResolveMiceDelegatePersonById
+}
+
+export const miceRuntimePort = definePort<MiceRuntime>({
+  id: "mice.runtime",
+  test(provider) {
+    if (provider === null || typeof provider !== "object") {
+      throw new Error("mice.runtime provider must be an options object.")
+    }
+    if (typeof provider.resolveDelegatePersonById !== "function") {
+      throw new Error("mice.runtime provider must implement resolveDelegatePersonById().")
+    }
+  },
+})

--- a/packages/mice/src/voyant.ts
+++ b/packages/mice/src/voyant.ts
@@ -1,10 +1,12 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import { miceRuntimePort } from "./runtime-port.js"
 
 /** Import-cheap deployment declarations owned by the MICE package. */
 export const miceVoyantModule = defineModule({
   id: "@voyant-travel/mice",
   packageName: "@voyant-travel/mice",
   localId: "mice",
+  runtimePorts: [requirePort(miceRuntimePort)],
   api: [
     {
       id: "@voyant-travel/mice#api.admin",
@@ -13,7 +15,7 @@ export const miceVoyantModule = defineModule({
       transactional: true,
       runtime: {
         entry: "@voyant-travel/mice",
-        export: "createMiceHonoModule",
+        export: "createMiceVoyantRuntime",
       },
     },
   ],

--- a/packages/mice/tests/unit/runtime-authority.test.ts
+++ b/packages/mice/tests/unit/runtime-authority.test.ts
@@ -1,0 +1,32 @@
+import { assertPortConforms } from "@voyant-travel/core/project"
+import { describe, expect, it, vi } from "vitest"
+
+import { createMiceVoyantRuntime, miceRuntimePort } from "../../src/index.js"
+import { miceVoyantModule } from "../../src/voyant.js"
+
+describe("MICE deployment authority", () => {
+  it("declares its package-owned runtime factory and port", () => {
+    expect(miceVoyantModule).toMatchObject({
+      runtimePorts: [{ id: "mice.runtime" }],
+      api: [{ runtime: { export: "createMiceVoyantRuntime" } }],
+    })
+  })
+
+  it("assembles the MICE module from its deployment provider", async () => {
+    const provider = { resolveDelegatePersonById: vi.fn(async () => true) }
+    await expect(assertPortConforms(miceRuntimePort, provider)).resolves.toBeUndefined()
+    await expect(assertPortConforms(miceRuntimePort, {} as never)).rejects.toThrow(
+      /resolveDelegatePersonById/,
+    )
+
+    const runtime = await createMiceVoyantRuntime({
+      unitId: miceVoyantModule.id,
+      projectConfig: {},
+      api: miceVoyantModule.api ?? [],
+      hasPort: () => true,
+      getPort: vi.fn(async () => provider) as never,
+    })
+    expect(runtime.module).toMatchObject({ name: "mice", requiresTransactionalDb: true })
+    expect(runtime.adminRoutes).toBeDefined()
+  })
+})

--- a/packages/mice/tests/unit/voyant-manifest.test.ts
+++ b/packages/mice/tests/unit/voyant-manifest.test.ts
@@ -15,7 +15,7 @@ describe("MICE deployment manifests", () => {
           surface: "admin",
           mount: "mice",
           transactional: true,
-          runtime: { entry: "@voyant-travel/mice", export: "createMiceHonoModule" },
+          runtime: { entry: "@voyant-travel/mice", export: "createMiceVoyantRuntime" },
         },
       ],
       schema: [{ id: "@voyant-travel/mice#schema" }],

--- a/packages/quotes/src/index.ts
+++ b/packages/quotes/src/index.ts
@@ -1,9 +1,11 @@
 import type { Module } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
 import { quotesLinkable } from "./linkables.js"
 import type { QuotesRouteRuntimeOptions } from "./route-runtime.js"
 import { createQuotesRoutes } from "./routes/index.js"
+import { quotesRuntimePort } from "./runtime-port.js"
 
 export { quoteLinkable, quotesLinkable, quoteVersionLinkable } from "./linkables.js"
 export type { QuotesRoutes } from "./routes/index.js"
@@ -22,6 +24,22 @@ export function createQuotesHonoModule(options: QuotesHonoModuleOptions = {}): H
     adminRoutes: createQuotesRoutes(options),
   }
 }
+
+/** Package-owned adapter from graph runtime ports to the Quotes route factory. */
+export const createQuotesVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) =>
+  createQuotesHonoModule(await getPort(quotesRuntimePort)),
+)
+
+export type {
+  QuotesProposalRuntime,
+  QuotesRuntime,
+  QuotesSnapshotRuntime,
+} from "./runtime-port.js"
+export {
+  quotesProposalRuntimePort,
+  quotesRuntimePort,
+  quotesSnapshotRuntimePort,
+} from "./runtime-port.js"
 
 export const quotesHonoModule: HonoModule = createQuotesHonoModule()
 

--- a/packages/quotes/src/proposal-routes.ts
+++ b/packages/quotes/src/proposal-routes.ts
@@ -26,6 +26,8 @@
  * profile via `QuoteProposalRoutesOptions` — all generic / structural so this
  * package stays free of operator types and CloudflareBindings.
  */
+
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { parseJsonBody, parseOptionalJsonBody } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import {
@@ -44,7 +46,7 @@ import { sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { type Context, Hono } from "hono"
 import { z } from "zod"
-
+import { quotesProposalRuntimePort, quotesSnapshotRuntimePort } from "./runtime-port.js"
 import type { QuoteVersion, QuoteVersionLine } from "./schema.js"
 import { QuoteVersionConflictError, quotesService } from "./service/index.js"
 import { sendQuoteVersionSchema } from "./validation.js"
@@ -339,6 +341,17 @@ export function createQuoteVersionSnapshotHonoExtension(
     lazyAdminRoutes: async () => createQuoteVersionSnapshotRoutes(options),
   }
 }
+
+/** Package-owned graph adapter for the proposal extension. */
+export const createQuoteProposalVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) =>
+  createQuoteProposalHonoExtension(await getPort(quotesProposalRuntimePort)),
+)
+
+/** Package-owned graph adapter for the quote-version snapshot extension. */
+export const createQuoteVersionSnapshotVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) =>
+    createQuoteVersionSnapshotHonoExtension(await getPort(quotesSnapshotRuntimePort)),
+)
 
 async function handleSendQuoteVersion(
   c: Context<OperatorProposalRouteEnv>,

--- a/packages/quotes/src/runtime-port.ts
+++ b/packages/quotes/src/runtime-port.ts
@@ -1,0 +1,69 @@
+import { definePort } from "@voyant-travel/core/project"
+import type {
+  QuoteProposalRoutesOptions,
+  QuoteVersionSnapshotRoutesOptions,
+} from "./proposal-routes.js"
+import type { ResolveQuoteParticipantPersonById } from "./route-runtime.js"
+
+/** Node-host behavior required by the package-owned Quotes module factory. */
+export interface QuotesRuntime {
+  resolveParticipantPersonById: ResolveQuoteParticipantPersonById
+}
+
+/** Deployment behavior required by the proposal extension. */
+export type QuotesProposalRuntime = QuoteProposalRoutesOptions
+
+/** Deployment behavior required by the quote-version snapshot extension. */
+export type QuotesSnapshotRuntime = QuoteVersionSnapshotRoutesOptions
+
+function requireFunctions(id: string, provider: object, methods: readonly string[]): void {
+  const candidate = provider as Record<string, unknown>
+  for (const method of methods) {
+    if (typeof candidate[method] !== "function") {
+      throw new Error(`${id} provider must implement ${method}().`)
+    }
+  }
+}
+
+function requireObject(id: string, provider: unknown): asserts provider is object {
+  if (provider === null || typeof provider !== "object") {
+    throw new Error(`${id} provider must be an options object.`)
+  }
+}
+
+export const quotesRuntimePort = definePort<QuotesRuntime>({
+  id: "quotes.runtime",
+  test(provider) {
+    requireObject("quotes.runtime", provider)
+    requireFunctions("quotes.runtime", provider, ["resolveParticipantPersonById"])
+  },
+})
+
+export const quotesProposalRuntimePort = definePort<QuotesProposalRuntime>({
+  id: "quotes.proposal-runtime",
+  test(provider) {
+    requireObject("quotes.proposal-runtime", provider)
+    requireFunctions("quotes.proposal-runtime", provider, [
+      "resolveDb",
+      "resolvePublicProposalBaseUrl",
+      "reserveTripDeps",
+      "startCheckoutDeps",
+      "cancelTripComponentsDeps",
+      "resolveOperatorProfile",
+    ])
+    const feedback = (provider as Record<string, unknown>).recordPublicProposalFeedback
+    if (feedback !== undefined && typeof feedback !== "function") {
+      throw new Error(
+        "quotes.proposal-runtime provider recordPublicProposalFeedback must be a function.",
+      )
+    }
+  },
+})
+
+export const quotesSnapshotRuntimePort = definePort<QuotesSnapshotRuntime>({
+  id: "quotes.snapshot-runtime",
+  test(provider) {
+    requireObject("quotes.snapshot-runtime", provider)
+    requireFunctions("quotes.snapshot-runtime", provider, ["resolveDb"])
+  },
+})

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -1,10 +1,16 @@
-import { defineExtension, defineModule } from "@voyant-travel/core/project"
+import { defineExtension, defineModule, requirePort } from "@voyant-travel/core/project"
+import {
+  quotesProposalRuntimePort,
+  quotesRuntimePort,
+  quotesSnapshotRuntimePort,
+} from "./runtime-port.js"
 
 /** Import-cheap deployment declarations owned by the quotes package. */
 export const quotesVoyantModule = defineModule({
   id: "@voyant-travel/quotes",
   packageName: "@voyant-travel/quotes",
   localId: "quotes",
+  runtimePorts: [requirePort(quotesRuntimePort)],
   api: [
     {
       id: "@voyant-travel/quotes#api",
@@ -13,7 +19,7 @@ export const quotesVoyantModule = defineModule({
       transactional: true,
       runtime: {
         entry: "@voyant-travel/quotes",
-        export: "createQuotesHonoModule",
+        export: "createQuotesVoyantRuntime",
       },
     },
   ],
@@ -178,6 +184,7 @@ export const quotesProposalVoyantPlugin = defineExtension({
   id: "@voyant-travel/quotes#proposal-extension",
   packageName: "@voyant-travel/quotes",
   localId: "quotes.proposal-extension",
+  runtimePorts: [requirePort(quotesProposalRuntimePort)],
   api: [
     {
       id: "@voyant-travel/quotes#proposal-extension.api.admin",
@@ -186,7 +193,7 @@ export const quotesProposalVoyantPlugin = defineExtension({
       transactional: true,
       runtime: {
         entry: "@voyant-travel/quotes",
-        export: "createQuoteProposalHonoExtension",
+        export: "createQuoteProposalVoyantRuntime",
       },
     },
     {
@@ -197,7 +204,7 @@ export const quotesProposalVoyantPlugin = defineExtension({
       transactional: true,
       runtime: {
         entry: "@voyant-travel/quotes",
-        export: "createQuoteProposalHonoExtension",
+        export: "createQuoteProposalVoyantRuntime",
       },
     },
   ],
@@ -210,6 +217,7 @@ export const quotesVersionSnapshotVoyantPlugin = defineExtension({
   id: "@voyant-travel/quotes#quote-version-snapshot-extension",
   packageName: "@voyant-travel/quotes",
   localId: "quotes.quote-version-snapshot-extension",
+  runtimePorts: [requirePort(quotesSnapshotRuntimePort)],
   api: [
     {
       id: "@voyant-travel/quotes#quote-version-snapshot-extension.api",
@@ -218,7 +226,7 @@ export const quotesVersionSnapshotVoyantPlugin = defineExtension({
       transactional: true,
       runtime: {
         entry: "@voyant-travel/quotes",
-        export: "createQuoteVersionSnapshotHonoExtension",
+        export: "createQuoteVersionSnapshotVoyantRuntime",
       },
     },
   ],

--- a/packages/quotes/tests/unit/runtime-authority.test.ts
+++ b/packages/quotes/tests/unit/runtime-authority.test.ts
@@ -1,0 +1,105 @@
+import { assertPortConforms } from "@voyant-travel/core/project"
+import { describe, expect, it, vi } from "vitest"
+import {
+  createQuotesVoyantRuntime,
+  quotesProposalRuntimePort,
+  quotesRuntimePort,
+  quotesSnapshotRuntimePort,
+} from "../../src/index.js"
+import {
+  createQuoteProposalVoyantRuntime,
+  createQuoteVersionSnapshotVoyantRuntime,
+} from "../../src/proposal-routes.js"
+import {
+  quotesProposalVoyantPlugin,
+  quotesVersionSnapshotVoyantPlugin,
+  quotesVoyantModule,
+} from "../../src/voyant.js"
+
+function factoryContext<T>(
+  provider: T,
+  api: readonly { id: string; surface: "admin" | "public" }[],
+) {
+  return {
+    unitId: "quotes-test",
+    projectConfig: {},
+    api,
+    hasPort: () => true,
+    getPort: vi.fn(async () => provider) as never,
+  }
+}
+
+describe("quotes deployment authority", () => {
+  it("declares package-owned factories and their narrow ports", () => {
+    expect(quotesVoyantModule).toMatchObject({
+      runtimePorts: [{ id: "quotes.runtime" }],
+      api: [{ runtime: { export: "createQuotesVoyantRuntime" } }],
+    })
+    expect(quotesProposalVoyantPlugin).toMatchObject({
+      runtimePorts: [{ id: "quotes.proposal-runtime" }],
+      api: [
+        { surface: "admin", runtime: { export: "createQuoteProposalVoyantRuntime" } },
+        { surface: "public", runtime: { export: "createQuoteProposalVoyantRuntime" } },
+      ],
+    })
+    expect(quotesVersionSnapshotVoyantPlugin).toMatchObject({
+      runtimePorts: [{ id: "quotes.snapshot-runtime" }],
+      api: [{ runtime: { export: "createQuoteVersionSnapshotVoyantRuntime" } }],
+    })
+  })
+
+  it("assembles the Quotes module from its deployment provider", async () => {
+    const provider = { resolveParticipantPersonById: vi.fn(async () => true) }
+    await expect(assertPortConforms(quotesRuntimePort, provider)).resolves.toBeUndefined()
+    await expect(assertPortConforms(quotesRuntimePort, {} as never)).rejects.toThrow(
+      /resolveParticipantPersonById/,
+    )
+
+    const runtime = await createQuotesVoyantRuntime(
+      factoryContext(provider, quotesVoyantModule.api ?? []),
+    )
+    expect(runtime.module).toMatchObject({ name: "quotes", requiresTransactionalDb: true })
+    expect(runtime.adminRoutes).toBeDefined()
+  })
+
+  it("assembles proposal and snapshot extensions from separate providers", async () => {
+    const proposalProvider = {
+      resolveDb: vi.fn(),
+      resolvePublicProposalBaseUrl: vi.fn(() => null),
+      reserveTripDeps: vi.fn(),
+      startCheckoutDeps: vi.fn(),
+      cancelTripComponentsDeps: vi.fn(),
+      resolveOperatorProfile: vi.fn(async () => null),
+    }
+    const snapshotProvider = { resolveDb: vi.fn() }
+
+    await expect(
+      assertPortConforms(quotesProposalRuntimePort, proposalProvider as never),
+    ).resolves.toBeUndefined()
+    await expect(
+      assertPortConforms(quotesSnapshotRuntimePort, snapshotProvider as never),
+    ).resolves.toBeUndefined()
+    await expect(assertPortConforms(quotesProposalRuntimePort, {} as never)).rejects.toThrow(
+      /resolveDb/,
+    )
+
+    const proposal = await createQuoteProposalVoyantRuntime(
+      factoryContext(proposalProvider, quotesProposalVoyantPlugin.api ?? []),
+    )
+    expect(proposal).toMatchObject({
+      extension: { name: "proposal", module: "quote-versions" },
+      publicPath: "proposals",
+      anonymous: true,
+    })
+    expect(proposal.lazyAdminRoutes).toBeTypeOf("function")
+    expect(proposal.lazyPublicRoutes).toBeTypeOf("function")
+
+    const snapshot = await createQuoteVersionSnapshotVoyantRuntime(
+      factoryContext(snapshotProvider, quotesVersionSnapshotVoyantPlugin.api ?? []),
+    )
+    expect(snapshot).toMatchObject({
+      extension: { name: "quote-version-snapshot", module: "trips" },
+    })
+    expect(snapshot.lazyAdminRoutes).toBeTypeOf("function")
+  })
+})

--- a/packages/quotes/tests/unit/voyant-manifest.test.ts
+++ b/packages/quotes/tests/unit/voyant-manifest.test.ts
@@ -18,7 +18,7 @@ describe("quotes deployment manifests", () => {
           surface: "admin",
           mount: "quotes",
           transactional: true,
-          runtime: { entry: "@voyant-travel/quotes", export: "createQuotesHonoModule" },
+          runtime: { entry: "@voyant-travel/quotes", export: "createQuotesVoyantRuntime" },
         },
       ],
       schema: [{ id: "@voyant-travel/quotes#schema" }],
@@ -81,7 +81,7 @@ describe("quotes deployment manifests", () => {
             mount: "quote-versions",
             runtime: {
               entry: "@voyant-travel/quotes",
-              export: "createQuoteProposalHonoExtension",
+              export: "createQuoteProposalVoyantRuntime",
             },
           },
           {
@@ -90,7 +90,7 @@ describe("quotes deployment manifests", () => {
             anonymous: true,
             runtime: {
               entry: "@voyant-travel/quotes",
-              export: "createQuoteProposalHonoExtension",
+              export: "createQuoteProposalVoyantRuntime",
             },
           },
         ],
@@ -104,7 +104,7 @@ describe("quotes deployment manifests", () => {
             mount: "trips",
             runtime: {
               entry: "@voyant-travel/quotes",
-              export: "createQuoteVersionSnapshotHonoExtension",
+              export: "createQuoteVersionSnapshotVoyantRuntime",
             },
           },
         ],


### PR DESCRIPTION
## Summary

- move Quotes core runtime assembly behind the package-owned `quotes.runtime` port
- move proposal and quote-version snapshot extensions behind separate package-owned runtime ports
- move MICE runtime assembly behind the package-owned `mice.runtime` port
- update package manifests to reference graph runtime factories and add focused authority coverage
- add one changeset for Quotes and MICE

## Scope

This is a package-authority lane stacked on `unified-graph-authority-rollup`. It intentionally does not register deployment providers or modify Operator/framework composition. The later central cutover can provide the declared ports and remove the package-ID compatibility bindings.

## Verification

- `pnpm --filter @voyant-travel/quotes test` (103 passed, 56 skipped)
- `pnpm --filter @voyant-travel/mice test` (49 passed, 9 skipped)
- Biome checks for both package source/test scopes
- `git diff --check`

Package-scoped typechecks were attempted in parallel. Both produced no diagnostics but were stopped after four minutes when local TypeScript processes reached approximately 2.6 GB combined, consistent with the known hardware limitation. CI remains the typecheck authority for this draft.

## Generic blockers

- deployment adapters still need to register the four ports during the central cutover
- Operator/package-ID compatibility bindings remain intentionally untouched
- framework `composition-lazy` remains intentionally untouched
