### PR TITLE
Govern selected graph tools, actions, and webhooks

### DIFF
--- a/.changeset/selected-graph-executable-governance.md
+++ b/.changeset/selected-graph-executable-governance.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Govern tool, action, MCP, and outbound webhook eligibility from selected graph declarations and emit inspectable project manifests.

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -10,6 +10,7 @@ import {
   buildManagedNodeRuntimeEntry,
   buildManagedNodeRuntimeEntryArtifact,
   buildProjectRuntimeModule,
+  buildSelectedGraphExecutableFacetArtifacts,
   VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION,
   VOYANT_MANAGED_NODE_RUNTIME_ENTRY_ID,
 } from "./deployment-artifacts.js"
@@ -78,6 +79,91 @@ async function graphWithSelectedUnits(
 }
 
 describe("deployment graph artifacts", () => {
+  it("emits only selected tool, action, and outbound webhook eligibility metadata", async () => {
+    const selected = defineModule({
+      id: "@acme/selected",
+      access: {
+        resources: [{ id: "selected.access", resource: "selected", actions: ["write"] }],
+      },
+      tools: [
+        {
+          id: "selected.tool",
+          name: "selected_tool",
+          runtime: { entry: "./tools", export: "selectedTool" },
+          requiredScopes: ["selected:write"],
+          context: ["selected"],
+          risk: "high",
+        },
+      ],
+      events: [{ id: "selected.event", eventType: "selected.changed" }],
+      webhooks: [{ id: "selected.webhook", direction: "outbound", eventId: "selected.event" }],
+      actions: [
+        {
+          id: "selected.action",
+          capabilityId: "selected.write",
+          version: "v1",
+          kind: "execute",
+          targetType: "selected-record",
+          requiredScopes: ["selected:write"],
+          risk: "high",
+          ledger: "required",
+          approval: "conditional",
+          policy: "selected-policy",
+          reversible: true,
+          allowedActorTypes: ["staff"],
+          from: { tools: ["selected.tool"], webhooks: ["selected.webhook"] },
+        },
+      ],
+    })
+    const deselected = defineModule({
+      id: "@acme/deselected",
+      tools: [
+        {
+          id: "deselected.tool",
+          name: "deselected_tool",
+          runtime: { entry: "./tools", export: "deselectedTool" },
+        },
+      ],
+    })
+    const graph = await graphWithSelectedUnits([selected])
+
+    const artifacts = buildSelectedGraphExecutableFacetArtifacts(graph)
+    const tools = JSON.parse(artifacts.tools)
+    const actions = JSON.parse(artifacts.actions)
+    const webhooks = JSON.parse(artifacts.outboundWebhooks)
+
+    expect(tools.entries).toEqual([
+      expect.objectContaining({
+        id: "selected.tool",
+        owner: { unitId: "@acme/selected", packageName: "@acme/selected" },
+        requiredScopes: ["selected:write"],
+        context: ["selected"],
+        risk: "high",
+      }),
+    ])
+    expect(actions.entries).toEqual([
+      expect.objectContaining({
+        id: "selected.action",
+        owner: { unitId: "@acme/selected", packageName: "@acme/selected" },
+        kind: "execute",
+        ledger: "required",
+        approval: "conditional",
+        policy: "selected-policy",
+        reversible: true,
+        allowedActorTypes: ["staff"],
+      }),
+    ])
+    expect(webhooks.entries).toEqual([
+      expect.objectContaining({
+        id: "selected.webhook",
+        unitId: "@acme/selected",
+        packageName: "@acme/selected",
+        eventType: "selected.changed",
+      }),
+    ])
+    expect(JSON.stringify(artifacts)).not.toContain(deselected.id)
+  })
+
   it("builds deterministic resolved graph JSON containing the graph hash", async () => {
     const graph = await sampleGraph()
     const first = buildDeploymentGraphJson(graph)

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -61,6 +61,8 @@ export {
 } from "./runtime-values.js"
 
 export const VOYANT_DEPLOYMENT_ARTIFACTS_SCHEMA_VERSION = "voyant.deployment-artifacts.v1" as const
+export const VOYANT_SELECTED_EXECUTABLE_FACETS_SCHEMA_VERSION =
+  "voyant.selected-executable-facets.v1" as const
 export const VOYANT_MANAGED_NODE_RUNTIME_ENTRY_ID = "@voyant-travel/framework#runtime.node" as const
 
 export type VoyantDeploymentRuntimeEntryKind = "managed-profile-node"
@@ -123,6 +125,58 @@ export interface BuildProjectRuntimeModuleInput extends BuildGraphRuntimeModuleI
 export interface BuildGraphWorkflowRuntimeModuleInput extends BuildGraphRuntimeModuleInput {}
 
 export interface BuildGraphAdminBundleModuleInput extends BuildGraphRuntimeModuleInput {}
+
+export interface SelectedGraphExecutableFacetArtifacts {
+  tools: string
+  actions: string
+  outboundWebhooks: string
+}
+
+/** Emit inspectable eligibility metadata from the same selected graph used for runtime lowering. */
+export function buildSelectedGraphExecutableFacetArtifacts(
+  graph: ResolvedVoyantDeploymentGraph,
+): SelectedGraphExecutableFacetArtifacts {
+  assertGraphRuntimeLowerable(graph)
+  const loweredUnits = [
+    ...lowerGraphRuntimeUnits(graph.modules, graph, undefined),
+    ...lowerGraphRuntimeUnits(graph.extensions, graph, undefined),
+    ...lowerGraphRuntimeUnits(graph.plugins, graph, undefined),
+  ]
+  const tools = loweredUnits
+    .flatMap((unit) =>
+      unit.tools.map((tool) => ({
+        owner: { unitId: unit.id, packageName: unit.packageName },
+        ...tool,
+      })),
+    )
+    .sort((left, right) => left.id.localeCompare(right.id))
+  const actions = loweredUnits
+    .flatMap((unit) =>
+      unit.actions.map((action) => ({
+        owner: { unitId: unit.id, packageName: unit.packageName },
+        ...action,
+      })),
+    )
+    .sort(
+      (left, right) => left.id.localeCompare(right.id) || left.version.localeCompare(right.version),
+    )
+  const outboundWebhooks = [...graph.webhookPlan.outbound].sort(
+    (left, right) => left.id.localeCompare(right.id) || left.unitId.localeCompare(right.unitId),
+  )
+  const artifact = (facet: string, entries: readonly unknown[]) =>
+    `${canonicalJson({
+      schemaVersion: VOYANT_SELECTED_EXECUTABLE_FACETS_SCHEMA_VERSION,
+      graphHash: graph.contentHash,
+      facet,
+      entries,
+    })}\n`
+
+  return {
+    tools: artifact("tools.mcp", tools),
+    actions: artifact("actions", actions),
+    outboundWebhooks: artifact("webhooks.outbound", outboundWebhooks),
+  }
+}
 
 export interface BuildGraphAccessCatalogModuleInput {
   graph: ResolvedVoyantDeploymentGraph

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -384,6 +384,40 @@ describe("deployment graph v1", () => {
     )
   })
 
+  it("rejects action bindings that reference the wrong selected facet kind", async () => {
+    const module = defineModule({
+      id: "@acme/voyant-actions",
+      tools: [
+        {
+          id: "@acme/voyant-actions#tool.run",
+          name: "run_action",
+          runtime: { entry: "./tools", export: "runAction" },
+        },
+      ],
+      actions: [
+        {
+          id: "@acme/voyant-actions#action.run",
+          version: "v1",
+          kind: "execute",
+          targetType: "task",
+          risk: "medium",
+          ledger: "required",
+          from: { routes: ["@acme/voyant-actions#tool.run"] },
+        },
+      ],
+    })
+
+    const graph = await resolveDeploymentGraph({ project: defineProject({ modules: [module] }) })
+
+    expect(graph.diagnostics).toContainEqual(
+      expect.objectContaining({
+        code: "VOYANT_GRAPH_UNKNOWN_REFERENCE",
+        facet: "@acme/voyant-actions#action.run.from.routes",
+        message: expect.stringContaining("is not a routes declaration in the selected graph"),
+      }),
+    )
+  })
+
   it("resolves a package-owned module manifest without starter synthesis", async () => {
     expect(validateGraphUnitManifest(bookingsVoyantModule, "module")).toEqual([])
 

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2155,6 +2155,13 @@ function validateFacetReferences(
   const eventById = new Map(
     units.flatMap((unit) => unit.events.map((event) => [event.id, event] as const)),
   )
+  const actionBindings = {
+    routes: new Set(units.flatMap((unit) => unit.api.map((entry) => entry.id))),
+    tools: new Set(units.flatMap((unit) => (unit.tools ?? []).map((entry) => entry.id))),
+    workflows: new Set(units.flatMap((unit) => unit.workflows.map((entry) => entry.id))),
+    events: new Set(units.flatMap((unit) => unit.events.map((entry) => entry.id))),
+    webhooks: new Set(units.flatMap((unit) => (unit.webhooks ?? []).map((entry) => entry.id))),
+  } as const
   const scopes = new Set(
     units.flatMap((unit) =>
       (unit.access?.resources ?? []).flatMap((resource) =>
@@ -2316,8 +2323,18 @@ function validateFacetReferences(
         requireScope(unit.id, `${action.id}.requiredScopes`, scope)
       }
       for (const copy of action.copy ?? []) requireCopy(unit.id, `${action.id}.copy`, copy)
-      for (const [kind, ids] of Object.entries(action.from ?? {})) {
-        for (const id of ids ?? []) reference(unit.id, `${action.id}.from.${kind}`, id)
+      for (const kind of Object.keys(actionBindings) as (keyof typeof actionBindings)[]) {
+        for (const id of action.from?.[kind] ?? []) {
+          if (actionBindings[kind].has(id)) continue
+          diagnostics.push(
+            diagnostic({
+              code: "VOYANT_GRAPH_UNKNOWN_REFERENCE",
+              source: unit.id,
+              facet: `${action.id}.from.${kind}`,
+              message: `Action ${kind} reference "${id}" is not a ${kind} declaration in the selected graph.`,
+            }),
+          )
+        }
       }
     }
   }

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -17,6 +17,7 @@ import {
   buildGraphAdminBundleModule,
   buildGraphWorkflowRuntimeModule,
   buildProjectRuntimeModule,
+  buildSelectedGraphExecutableFacetArtifacts,
 } from "./deployment-artifacts.js"
 import {
   deriveDeploymentRequirements,
@@ -59,6 +60,9 @@ import {
 export const VOYANT_MIGRATION_PLAN_SCHEMA_VERSION = "voyant.migration-plan.v1" as const
 export const VOYANT_PROJECT_RUNTIME_ENTRY = "runtime/project-runtime.generated.ts" as const
 export const VOYANT_PROJECT_MIGRATION_RUNNER = "runtime/project-migrations.generated.mjs" as const
+export const VOYANT_PROJECT_TOOLS_MANIFEST = "manifests/tools.json" as const
+export const VOYANT_PROJECT_ACTIONS_MANIFEST = "manifests/actions.json" as const
+export const VOYANT_PROJECT_WEBHOOKS_MANIFEST = "manifests/webhooks.json" as const
 
 export interface ResolveProjectInput {
   project: unknown
@@ -207,6 +211,7 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
   const workflowRuntimeEntry = VOYANT_PROJECT_WORKFLOW_RUNTIME_ENTRY
   const migrationRunner = VOYANT_PROJECT_MIGRATION_RUNNER
   const migrationPlan = buildMigrationPlan(targetNeutralGraph)
+  const executableFacets = buildSelectedGraphExecutableFacetArtifacts(targetNeutralGraph)
   const runtimeEntryOverrides = await buildLocalRuntimeEntryOverrides(
     targetNeutralGraph,
     materialized.packages,
@@ -233,6 +238,9 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
     },
     ...projectWorkflowJobs.generatedFiles,
     ...projectSubscriberLinks.generatedFiles,
+    { path: VOYANT_PROJECT_TOOLS_MANIFEST, contents: executableFacets.tools },
+    { path: VOYANT_PROJECT_ACTIONS_MANIFEST, contents: executableFacets.actions },
+    { path: VOYANT_PROJECT_WEBHOOKS_MANIFEST, contents: executableFacets.outboundWebhooks },
     {
       path: runtimeEntry,
       contents: buildProjectRuntimeModule({

--- a/packages/framework/src/project.test.ts
+++ b/packages/framework/src/project.test.ts
@@ -63,6 +63,9 @@ describe("framework project resolver", () => {
       "access/selected-access-catalog.generated.ts",
       "admin/project-admin.generated.ts",
       "admin/selected-graph-admin.generated.ts",
+      "manifests/actions.json",
+      "manifests/tools.json",
+      "manifests/webhooks.json",
       "runtime/project-api.generated.ts",
       "runtime/project-jobs.generated.ts",
       "runtime/project-links.generated.ts",
@@ -83,6 +86,18 @@ describe("framework project resolver", () => {
     expect(runtimeSource).toContain('GENERATED_PROJECT_RUNTIME_KIND = "application"')
     expect(runtimeSource).toContain('"database": "postgres"')
     expect(runtimeSource).not.toContain('"target"')
+    for (const path of [
+      "manifests/actions.json",
+      "manifests/tools.json",
+      "manifests/webhooks.json",
+    ]) {
+      expect(
+        JSON.parse(first.artifacts.files.find((file) => file.path === path)?.contents ?? ""),
+      ).toMatchObject({
+        schemaVersion: "voyant.selected-executable-facets.v1",
+        graphHash: expectedHash,
+      })
+    }
     expect(first.artifacts.migrationPlan).toEqual({
       schemaVersion: "voyant.migration-plan.v1",
       contentHash: expectedHash,

--- a/packages/framework/src/runtime-lowering.test.ts
+++ b/packages/framework/src/runtime-lowering.test.ts
@@ -429,6 +429,125 @@ describe("graph runtime lowering", () => {
     expect(importRuntime).not.toHaveBeenCalled()
   })
 
+  it("rejects duplicate actions and undeclared action bindings before imports", () => {
+    const importRuntime = vi.fn(async () => ({}))
+    const action = {
+      id: "loyalty.adjust",
+      unitId: "@acme/loyalty",
+      version: "v1",
+      kind: "execute" as const,
+      targetType: "loyalty-account",
+      requiredScopes: [],
+      risk: "medium" as const,
+      ledger: "required" as const,
+      from: {
+        routes: [],
+        tools: ["loyalty.missing"],
+        workflows: [],
+        events: [],
+        webhooks: [],
+      },
+    }
+
+    expect(() =>
+      createVoyantGraphRuntime({
+        graphHash: "sha256:test",
+        entries: { "@acme/loyalty": importRuntime },
+        modules: [
+          {
+            id: "@acme/loyalty",
+            kind: "module",
+            packageName: "@acme/loyalty",
+            order: 0,
+            actions: [action],
+            routes: [],
+          },
+        ],
+        plugins: [],
+      }),
+    ).toThrow(/action "loyalty.adjust" selects undeclared tools reference "loyalty.missing"/)
+    expect(importRuntime).not.toHaveBeenCalled()
+
+    expect(() =>
+      createVoyantGraphRuntime({
+        graphHash: "sha256:test",
+        entries: {},
+        modules: [
+          {
+            id: "@acme/loyalty",
+            kind: "module",
+            packageName: "@acme/loyalty",
+            order: 0,
+            actions: [
+              { ...action, from: { ...action.from, tools: [] } },
+              { ...action, from: { ...action.from, tools: [] } },
+            ],
+            routes: [],
+          },
+        ],
+        plugins: [],
+      }),
+    ).toThrow(/duplicate action id "loyalty.adjust"/)
+  })
+
+  it("infers declared action bindings when legacy inputs omit selectedIds", () => {
+    const runtime = createVoyantGraphRuntime({
+      graphHash: "sha256:legacy-actions",
+      entries: { "@acme/loyalty/tools": async () => ({ adjustLoyalty: {} }) },
+      modules: [
+        {
+          id: "@acme/loyalty",
+          kind: "module",
+          packageName: "@acme/loyalty",
+          order: 0,
+          references: [
+            {
+              id: "loyalty-tool-runtime",
+              unitId: "@acme/loyalty",
+              facet: "tools.runtime",
+              entityId: "loyalty-tool",
+              runtime: { entry: "./tools", export: "adjustLoyalty" },
+              importEntry: "@acme/loyalty/tools",
+            },
+          ],
+          tools: [
+            {
+              id: "loyalty-tool",
+              unitId: "@acme/loyalty",
+              name: "adjust_loyalty",
+              referenceId: "loyalty-tool-runtime",
+              requiredScopes: [],
+            },
+          ],
+          actions: [
+            {
+              id: "loyalty.adjust",
+              unitId: "@acme/loyalty",
+              version: "v1",
+              kind: "execute",
+              targetType: "loyalty-account",
+              requiredScopes: [],
+              risk: "medium",
+              ledger: "required",
+              from: {
+                routes: [],
+                tools: ["loyalty-tool"],
+                workflows: [],
+                events: [],
+                webhooks: [],
+              },
+            },
+          ],
+          routes: [],
+        },
+      ],
+      plugins: [],
+    })
+
+    expect(runtime.selectedIds.tools).toEqual(["loyalty-tool"])
+    expect(runtime.actions.map(({ id }) => id)).toEqual(["loyalty.adjust"])
+  })
+
   it("rejects unknown reference ids before evaluating package imports", async () => {
     const importRuntime = vi.fn(async () => ({ createLoyaltyModule: {} }))
     const runtime = createVoyantGraphRuntime(runtimeInput(importRuntime))

--- a/packages/framework/src/runtime-lowering.ts
+++ b/packages/framework/src/runtime-lowering.ts
@@ -393,6 +393,9 @@ interface NormalizedVoyantGraphRuntimeInput
 function normalizeRuntimeDefinition(
   input: CreateVoyantGraphRuntimeInput,
 ): NormalizedVoyantGraphRuntimeInput {
+  const webhookPlan = normalizeWebhookPlan(input.webhookPlan)
+  const normalizeUnit = (unit: VoyantGraphRuntimeUnitDefinition) =>
+    normalizeRuntimeUnitDefinition(unit, webhookPlan)
   return {
     ...input,
     accessCatalog: normalizeAccessCatalog(input.accessCatalog, [
@@ -400,10 +403,10 @@ function normalizeRuntimeDefinition(
       ...(input.extensions ?? []),
       ...input.plugins,
     ]),
-    webhookPlan: normalizeWebhookPlan(input.webhookPlan),
-    modules: input.modules.map(normalizeRuntimeUnitDefinition),
-    extensions: (input.extensions ?? []).map(normalizeRuntimeUnitDefinition),
-    plugins: input.plugins.map(normalizeRuntimeUnitDefinition),
+    webhookPlan,
+    modules: input.modules.map(normalizeUnit),
+    extensions: (input.extensions ?? []).map(normalizeUnit),
+    plugins: input.plugins.map(normalizeUnit),
   }
 }
 
@@ -458,6 +461,7 @@ function normalizeAccessCatalog(
 
 function normalizeRuntimeUnitDefinition(
   unit: VoyantGraphRuntimeUnitDefinition,
+  webhookPlan: VoyantGraphWebhookPlan,
 ): NormalizedVoyantGraphRuntimeUnitDefinition {
   const references = [...(unit.references ?? [])]
   const referenceIds = new Set(references.map((reference) => reference.id))
@@ -505,8 +509,31 @@ function normalizeRuntimeUnitDefinition(
     tools: [...(unit.tools ?? [])],
     workflows: [...(unit.workflows ?? [])],
     actions: [...(unit.actions ?? [])],
-    selectedIds: normalizeSelectedIds(unit.selectedIds),
+    selectedIds: normalizeSelectedIds(
+      unit.selectedIds ?? inferLegacySelectedIds(unit, webhookPlan),
+    ),
     routes,
+  }
+}
+
+function inferLegacySelectedIds(
+  unit: VoyantGraphRuntimeUnitDefinition,
+  webhookPlan: VoyantGraphWebhookPlan,
+): VoyantGraphRuntimeSelectedIds {
+  const ownedOutboundWebhooks = webhookPlan.outbound.filter((entry) => entry.unitId === unit.id)
+  return {
+    routes: unit.routes.map(({ route }) => route.id),
+    tools: (unit.tools ?? []).map(({ id }) => id),
+    workflows: (unit.workflows ?? []).map(({ declaration }) => declaration.id),
+    events: sortedUnique([
+      ...(unit.actions ?? []).flatMap(({ from }) => from.events),
+      ...ownedOutboundWebhooks
+        .filter((entry) => entry.eventUnitId === unit.id)
+        .map((entry) => entry.eventId),
+    ]),
+    webhooks: [...webhookPlan.inbound, ...webhookPlan.outbound]
+      .filter((entry) => entry.unitId === unit.id)
+      .map((entry) => entry.id),
   }
 }
 
@@ -559,12 +586,13 @@ function createRuntimeUnitLoader(
     }
   })
   const tools = unit.tools.map((definition) => {
-    const reference = referenceById.get(definition.referenceId)
-    if (reference?.facet !== "tools.runtime") {
-      throw new Error(
-        `createVoyantGraphRuntime: tool "${definition.id}" selects unknown tools.runtime reference "${definition.referenceId}".`,
-      )
-    }
+    const reference = requireDeclarationReference(
+      definition.unitId,
+      definition.id,
+      definition.referenceId,
+      "tools.runtime",
+      referenceById,
+    )
     return {
       ...definition,
       load: <T = unknown>() => loadDeclaredTool<T>(definition, reference),
@@ -750,9 +778,17 @@ function validateRuntimeDefinition(input: NormalizedVoyantGraphRuntimeInput): st
   const declarationIds = new Set<string>()
   const toolIds = new Set<string>()
   const toolNames = new Set<string>()
-  const accessScopes = new Set(
-    [...input.modules, ...input.extensions, ...input.plugins].flatMap((unit) => unit.accessScopes),
-  )
+  const actionIds = new Set<string>()
+  const units = [...input.modules, ...input.extensions, ...input.plugins]
+  const selectedIds = mergeSelectedIds(units.map((unit) => unit.selectedIds))
+  const selectedActionBindings = {
+    routes: new Set(selectedIds.routes),
+    tools: new Set(selectedIds.tools),
+    workflows: new Set(selectedIds.workflows),
+    events: new Set(selectedIds.events),
+    webhooks: new Set(selectedIds.webhooks),
+  } as const
+  const accessScopes = new Set(units.flatMap((unit) => unit.accessScopes))
   const catalogScopes = new Set(
     input.accessCatalog.resources.flatMap((resource) =>
       resource.actions.map((action) => `${resource.resource}:${action.action}`),
@@ -850,6 +886,34 @@ function validateRuntimeDefinition(input: NormalizedVoyantGraphRuntimeInput): st
           }
         }
       }
+      for (const action of unit.actions) {
+        if (action.unitId !== unit.id) {
+          throw new Error(
+            `createVoyantGraphRuntime: action "${action.id}" belongs to unit "${action.unitId}", not "${unit.id}".`,
+          )
+        }
+        if (actionIds.has(action.id)) {
+          throw new Error(`createVoyantGraphRuntime: duplicate action id "${action.id}".`)
+        }
+        actionIds.add(action.id)
+        for (const scope of action.requiredScopes) {
+          if (!accessScopes.has(scope)) {
+            throw new Error(
+              `createVoyantGraphRuntime: action "${action.id}" requires undeclared access scope "${scope}".`,
+            )
+          }
+        }
+        for (const kind of Object.keys(
+          selectedActionBindings,
+        ) as (keyof typeof selectedActionBindings)[]) {
+          for (const id of action.from[kind]) {
+            if (selectedActionBindings[kind].has(id)) continue
+            throw new Error(
+              `createVoyantGraphRuntime: action "${action.id}" selects undeclared ${kind} reference "${id}".`,
+            )
+          }
+        }
+      }
     }
   }
   validateRuntimeWebhookPlan(input)
@@ -889,6 +953,11 @@ function validateRuntimeWebhookPlan(input: NormalizedVoyantGraphRuntimeInput): v
     if (webhookIds.has(entry.id)) {
       throw new Error(`createVoyantGraphRuntime: duplicate webhook plan id "${entry.id}".`)
     }
+    if (!owner.selectedIds.webhooks.includes(entry.id)) {
+      throw new Error(
+        `createVoyantGraphRuntime: webhook "${entry.id}" is not declared by selected owner "${entry.unitId}".`,
+      )
+    }
     webhookIds.add(entry.id)
   }
 
@@ -908,7 +977,8 @@ function validateRuntimeWebhookPlan(input: NormalizedVoyantGraphRuntimeInput): v
   }
   for (const entry of input.webhookPlan.outbound) {
     validateOwner(entry)
-    if (!unitById.has(entry.eventUnitId) || !entry.eventType.trim()) {
+    const eventOwner = unitById.get(entry.eventUnitId)
+    if (!eventOwner?.selectedIds.events.includes(entry.eventId) || !entry.eventType.trim()) {
       throw new Error(
         `createVoyantGraphRuntime: outbound webhook "${entry.id}" selects an invalid event target.`,
       )


### PR DESCRIPTION
## Summary

- validate action bindings against their declared selected facet kind
- fail runtime creation on duplicate actions, undeclared action bindings, invalid tool runtime references, and webhook plans outside selected ownership
- emit deterministic `.voyant/manifests/tools.json`, `actions.json`, and `webhooks.json` eligibility artifacts
- preserve package ownership plus existing scope, context, actor, risk, approval, policy, reversibility, and ledger metadata

## Verification

- Framework focused suites: 90 tests passed
- Core suite: 157 tests passed
- Framework lint passed
- Core lint passed
- `git diff --check` passed

No full Turbo or repository typecheck was run, per the lane's hardware constraints.

## Remaining blockers

- Event declarations still expose only an optional event type; payload schema identity/versioning and compatibility validation are not modeled.
- Outbound webhook delivery still needs subscription/endpoint persistence, visibility policy, payload-schema validation, signing, retries, idempotency, dead-letter handling, and audit outcomes. This PR governs eligibility only.
- Lifecycle declarations describe upgrade compatibility and uninstall retention posture, but there is no graph-lowered execution plan for upgrade hooks, uninstall/resource cleanup, rollback, or retry-safe lifecycle state.
