### PR TITLE
feat(openapi): integrate exact package API authority

### DIFF
--- a/.changeset/package-owned-openapi-authority.md
+++ b/.changeset/package-owned-openapi-authority.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/storage": minor
+"@voyant-travel/realtime": minor
+"@voyant-travel/public-document-delivery": minor
+---
+
+Publish package-owned OpenAPI registries and graph document declarations for storage, realtime, and public document delivery APIs.

--- a/.changeset/package-owned-openapi-authority.md
+++ b/.changeset/package-owned-openapi-authority.md
@@ -2,6 +2,7 @@
 "@voyant-travel/storage": minor
 "@voyant-travel/realtime": minor
 "@voyant-travel/public-document-delivery": minor
+"@voyant-travel/framework": patch
 ---
 
-Publish package-owned OpenAPI registries and graph document declarations for storage, realtime, and public document delivery APIs.
+Publish package-owned OpenAPI registries and graph document declarations for storage, realtime, and public document delivery APIs, with exact operation ownership for overlapping route mounts.

--- a/packages/framework/src/selected-graph-openapi.test.ts
+++ b/packages/framework/src/selected-graph-openapi.test.ts
@@ -208,6 +208,60 @@ describe("buildSelectedGraphOpenApiDocuments", () => {
     ).rejects.toThrow(/path "\/v1\/admin\/identity\/contacts" method "GET" is claimed by both/)
   })
 
+  it("prefers exact operation API ids when route mount prefixes overlap", async () => {
+    const uploadsApiId = "@voyant-travel/storage#api.admin.uploads"
+    const videoApiId = "@voyant-travel/storage#api.admin.video-upload-ticket"
+    const uploadsPath = "/v1/admin/uploads"
+    const videoPath = "/v1/admin/uploads/video"
+    const app = documentedApp([])
+
+    for (const [path, apiId] of [
+      [uploadsPath, uploadsApiId],
+      [videoPath, videoApiId],
+    ] as const) {
+      app.openapi(
+        createRoute({
+          method: "post",
+          path,
+          responses: {
+            200: {
+              content: { "application/json": { schema: z.object({ ok: z.boolean() }) } },
+              description: "OK",
+            },
+          },
+          "x-voyant-api-id": apiId,
+        }),
+        (context) => context.json({ ok: true }),
+      )
+    }
+
+    const storage = unit("@voyant-travel/storage", [
+      route(uploadsApiId, "uploads", "storage-uploads", ["POST"]),
+      route(videoApiId, "uploads/video", "storage-video-upload-ticket", ["POST"]),
+    ])
+    const documents = await buildSelectedGraphOpenApiDocuments({
+      runtime: runtime([storage]),
+      app,
+      options,
+    })
+
+    expect(Object.keys(documents.get("storage-uploads")?.paths ?? {})).toEqual([uploadsPath])
+    expect(Object.keys(documents.get("storage-video-upload-ticket")?.paths ?? {})).toEqual([
+      videoPath,
+    ])
+
+    for (const [path, apiId] of [
+      [uploadsPath, uploadsApiId],
+      [videoPath, videoApiId],
+    ] as const) {
+      const owners = [...documents.values()].flatMap((document) => {
+        const operation = document.paths?.[path]?.post as Record<string, unknown> | undefined
+        return operation ? [operation["x-voyant-api-id"]] : []
+      })
+      expect(owners).toEqual([apiId])
+    }
+  })
+
   it("allows separate bundles to claim different methods on the same path", async () => {
     const path = "/v1/admin/identity/contacts"
     const app = methodSplitApp(path)

--- a/packages/framework/src/selected-graph-openapi.ts
+++ b/packages/framework/src/selected-graph-openapi.ts
@@ -67,6 +67,9 @@ export async function buildSelectedGraphOpenApiDocuments(
         }
         if (!isRecord(value) || !routeClaimsMethod(claim, method)) continue
 
+        const explicitApiId = value["x-voyant-api-id"]
+        if (typeof explicitApiId === "string" && explicitApiId !== claim.route.id) continue
+
         const operation = `${method.toUpperCase()} ${path}`
         const previous = claimedOperations.get(operation)
         if (previous) {

--- a/packages/public-document-delivery/package.json
+++ b/packages/public-document-delivery/package.json
@@ -17,6 +17,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@hono/zod-openapi": "catalog:",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/storage": "workspace:^",

--- a/packages/public-document-delivery/src/index.ts
+++ b/packages/public-document-delivery/src/index.ts
@@ -1,3 +1,4 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
 import type {
   InsertInfraPublicDocumentDeliveryGrant,
   SelectInfraPublicDocumentDeliveryGrant,
@@ -6,13 +7,14 @@ import { infraPublicDocumentDeliveryGrantsTable } from "@voyant-travel/db/schema
 import type { StorageProvider } from "@voyant-travel/storage"
 import { and, eq, isNull, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { Hono } from "hono"
 
 const DEFAULT_PUBLIC_DOCUMENT_TTL_SECONDS = 24 * 60 * 60
 const MAX_PUBLIC_DOCUMENT_TTL_SECONDS = 30 * 24 * 60 * 60
 const PUBLIC_DOCUMENT_TOKEN_BYTES = 32
 const DEFAULT_CONTENT_TYPE = "application/octet-stream"
 const DEFAULT_PUBLIC_DOCUMENT_PATH = "/v1/public/documents"
+export const PUBLIC_DOCUMENT_DELIVERY_OPENAPI_API_ID =
+  "@voyant-travel/public-document-delivery#api.public"
 
 export interface PublicDocumentDeliveryEnvelope {
   grantId: string
@@ -333,7 +335,8 @@ export async function revokePublicDocumentDeliveryGrant(
 export function createPublicDocumentDeliveryRoutes<
   TBindings extends object = Record<string, unknown>,
 >(options: PublicDocumentDeliveryRouteOptions<TBindings> = {}) {
-  return new Hono<Env<TBindings>>().get("/:token", async (c) => {
+  const routes = new OpenAPIHono<Env<TBindings>>()
+  routes.get("/:token", async (c) => {
     const token = c.req.param("token")
     const store = getStore(options, c.env, c.get("db"))
     const resolution = await resolvePublicDocumentDeliveryGrant(store, token)
@@ -370,6 +373,19 @@ export function createPublicDocumentDeliveryRoutes<
       },
     })
   })
+  routes.openAPIRegistry.registerPath({
+    method: "get",
+    path: "/{token}",
+    summary: "Download a public document",
+    responses: {
+      200: { description: "The granted document bytes." },
+      404: { description: "The grant or stored document does not exist." },
+      410: { description: "The grant is expired or revoked." },
+      503: { description: "Document storage is not configured." },
+    },
+    "x-voyant-api-id": PUBLIC_DOCUMENT_DELIVERY_OPENAPI_API_ID,
+  })
+  return routes
 }
 
 export function createPublicDocumentDeliveryHonoModule<

--- a/packages/public-document-delivery/src/voyant.ts
+++ b/packages/public-document-delivery/src/voyant.ts
@@ -14,6 +14,7 @@ export const publicDocumentDeliveryVoyantModule = defineModule({
       surface: "public",
       mount: "documents",
       anonymous: true,
+      openapi: { document: "public-document-delivery" },
       runtime: {
         entry: "@voyant-travel/public-document-delivery",
         export: "createPublicDocumentDeliveryHonoModule",

--- a/packages/public-document-delivery/tests/unit/voyant-manifest.test.ts
+++ b/packages/public-document-delivery/tests/unit/voyant-manifest.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { createPublicDocumentDeliveryHonoModule } from "../../src/index.js"
+import {
+  createPublicDocumentDeliveryHonoModule,
+  PUBLIC_DOCUMENT_DELIVERY_OPENAPI_API_ID,
+} from "../../src/index.js"
 import { publicDocumentDeliveryVoyantModule } from "../../src/voyant.js"
 
 describe("public document delivery deployment manifest", () => {
@@ -16,6 +19,7 @@ describe("public document delivery deployment manifest", () => {
           surface: "public",
           mount: "documents",
           anonymous: true,
+          openapi: { document: "public-document-delivery" },
           runtime: {
             entry: "@voyant-travel/public-document-delivery",
             export: "createPublicDocumentDeliveryHonoModule",
@@ -33,4 +37,24 @@ describe("public document delivery deployment manifest", () => {
     })
     expect(createPublicDocumentDeliveryHonoModule().module.name).toBe("documents")
   })
+
+  it("publishes its anonymous route from a package-owned OpenAPI registry", () => {
+    const routes = createPublicDocumentDeliveryHonoModule().publicRoutes as OpenApiDocumentSource
+    const document = routes.getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: { title: "Public documents", version: "1" },
+    })
+
+    expect(
+      (document.paths?.["/{token}"]?.get as Record<string, unknown> | undefined)?.[
+        "x-voyant-api-id"
+      ],
+    ).toBe(PUBLIC_DOCUMENT_DELIVERY_OPENAPI_API_ID)
+  })
 })
+
+interface OpenApiDocumentSource {
+  getOpenAPI31Document(input: { openapi: "3.1.0"; info: { title: string; version: string } }): {
+    paths?: Record<string, Record<string, unknown>>
+  }
+}

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -24,6 +24,7 @@
     "prepack": "pnpm run build"
   },
   "dependencies": {
+    "@hono/zod-openapi": "catalog:",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "hono": "catalog:"

--- a/packages/realtime/src/index.ts
+++ b/packages/realtime/src/index.ts
@@ -9,6 +9,7 @@ import { createRealtimeBridge } from "./bridge.js"
 import {
   buildRealtimeRouteRuntime,
   createRealtimeRoutes,
+  REALTIME_OPENAPI_API_IDS,
   REALTIME_ROUTE_RUNTIME_CONTAINER_KEY,
   type RealtimeRoutesOptions,
 } from "./routes.js"
@@ -57,6 +58,7 @@ export type {
 export {
   buildRealtimeRouteRuntime,
   createRealtimeRoutes,
+  REALTIME_OPENAPI_API_IDS,
   REALTIME_ROUTE_RUNTIME_CONTAINER_KEY,
 } from "./routes.js"
 export type { RealtimeService } from "./service.js"
@@ -102,7 +104,8 @@ export interface CreateRealtimeHonoModuleOptions extends RealtimeRoutesOptions {
 export function createRealtimeHonoModule(
   options: CreateRealtimeHonoModuleOptions = {},
 ): HonoModule {
-  const routes = createRealtimeRoutes(options)
+  const adminRoutes = createRealtimeRoutes(options, REALTIME_OPENAPI_API_IDS.admin)
+  const publicRoutes = createRealtimeRoutes(options, REALTIME_OPENAPI_API_IDS.public)
 
   const module: Module = {
     ...realtimeModule,
@@ -138,8 +141,8 @@ export function createRealtimeHonoModule(
 
   return {
     module,
-    adminRoutes: routes,
-    publicRoutes: routes,
+    adminRoutes,
+    publicRoutes,
   }
 }
 

--- a/packages/realtime/src/routes.ts
+++ b/packages/realtime/src/routes.ts
@@ -1,6 +1,6 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
 import type { Actor, ModuleContainer } from "@voyant-travel/core"
 import type { Context } from "hono"
-import { Hono } from "hono"
 
 import {
   type PortalScope,
@@ -11,6 +11,10 @@ import { createRealtimeService, type RealtimeService } from "./service.js"
 import type { RealtimeProvider } from "./types.js"
 
 export const REALTIME_ROUTE_RUNTIME_CONTAINER_KEY = "providers.realtime.runtime"
+export const REALTIME_OPENAPI_API_IDS = {
+  admin: "@voyant-travel/realtime#api.admin",
+  public: "@voyant-travel/realtime#api.public",
+} as const
 
 type Env = {
   Bindings: Record<string, unknown>
@@ -79,7 +83,10 @@ function getRuntime(c: Context<Env>): RealtimeRouteRuntime | undefined {
  * customer/partner/supplier actor, and {@link resolveRealtimeCapabilities}
  * scopes the token accordingly.
  */
-export function createRealtimeRoutes(options: RealtimeRoutesOptions = {}): Hono<Env> {
+export function createRealtimeRoutes(
+  options: RealtimeRoutesOptions = {},
+  apiId: (typeof REALTIME_OPENAPI_API_IDS)[keyof typeof REALTIME_OPENAPI_API_IDS] = REALTIME_OPENAPI_API_IDS.admin,
+): OpenAPIHono<Env> {
   // Eager runtime when providers are passed directly; otherwise rely on the
   // container runtime registered at bootstrap (bindings-derived providers).
   const eagerRuntime =
@@ -87,7 +94,8 @@ export function createRealtimeRoutes(options: RealtimeRoutesOptions = {}): Hono<
       ? buildRealtimeRouteRuntime({}, options)
       : undefined
 
-  return new Hono<Env>().post("/token", async (c) => {
+  const routes = new OpenAPIHono<Env>()
+  routes.post("/token", async (c) => {
     const runtime = eagerRuntime ?? getRuntime(c)
     if (!runtime?.service) {
       return c.json({ error: "Realtime provider is not configured" }, 503)
@@ -121,4 +129,16 @@ export function createRealtimeRoutes(options: RealtimeRoutesOptions = {}): Hono<
       },
     })
   })
+  routes.openAPIRegistry.registerPath({
+    method: "post",
+    path: "/token",
+    summary: "Mint a realtime client token",
+    responses: {
+      200: { description: "A short-lived capability-scoped client token." },
+      401: { description: "Authentication is required." },
+      503: { description: "No realtime transport is configured." },
+    },
+    "x-voyant-api-id": apiId,
+  })
+  return routes
 }

--- a/packages/realtime/src/voyant.ts
+++ b/packages/realtime/src/voyant.ts
@@ -15,6 +15,7 @@ export const realtimeVoyantModule = defineModule({
       id: "@voyant-travel/realtime#api.admin",
       surface: "admin",
       mount: "realtime",
+      openapi: { document: "realtime-admin" },
       runtime: {
         entry: "@voyant-travel/realtime",
         export: "createRealtimeVoyantRuntime",
@@ -24,6 +25,7 @@ export const realtimeVoyantModule = defineModule({
       id: "@voyant-travel/realtime#api.public",
       surface: "public",
       mount: "realtime",
+      openapi: { document: "realtime-public" },
       runtime: {
         entry: "@voyant-travel/realtime",
         export: "createRealtimeVoyantRuntime",

--- a/packages/realtime/tests/unit/voyant-manifest.test.ts
+++ b/packages/realtime/tests/unit/voyant-manifest.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY,
   createRealtimeHonoModule,
+  REALTIME_OPENAPI_API_IDS,
   realtimeRuntimePort,
 } from "../../src/index.js"
 import { createLocalRealtimeProvider } from "../../src/providers/local.js"
@@ -23,6 +24,7 @@ describe("realtime deployment manifest", () => {
         {
           id: "@voyant-travel/realtime#api.admin",
           surface: "admin",
+          openapi: { document: "realtime-admin" },
           runtime: {
             entry: "@voyant-travel/realtime",
             export: "createRealtimeVoyantRuntime",
@@ -31,6 +33,7 @@ describe("realtime deployment manifest", () => {
         {
           id: "@voyant-travel/realtime#api.public",
           surface: "public",
+          openapi: { document: "realtime-public" },
           runtime: {
             entry: "@voyant-travel/realtime",
             export: "createRealtimeVoyantRuntime",
@@ -54,6 +57,15 @@ describe("realtime deployment manifest", () => {
         },
       ],
     })
+  })
+
+  it("publishes distinct admin and public OpenAPI registries", () => {
+    const module = createRealtimeHonoModule()
+    const adminDocument = openApiDocument(module.adminRoutes)
+    const publicDocument = openApiDocument(module.publicRoutes)
+
+    expect(readApiId(adminDocument, "/token", "post")).toBe(REALTIME_OPENAPI_API_IDS.admin)
+    expect(readApiId(publicDocument, "/token", "post")).toBe(REALTIME_OPENAPI_API_IDS.public)
   })
 
   it("stages the publication capability without activating domain subscribers", () => {
@@ -100,3 +112,26 @@ describe("realtime deployment manifest", () => {
     expect(container.has(ADMIN_INVALIDATION_PUBLICATION_RUNTIME_KEY)).toBe(true)
   })
 })
+
+function openApiDocument(routes: unknown) {
+  return (routes as OpenApiDocumentSource).getOpenAPI31Document({
+    openapi: "3.1.0",
+    info: { title: "Realtime", version: "1" },
+  })
+}
+
+interface OpenApiDocumentSource {
+  getOpenAPI31Document(input: { openapi: "3.1.0"; info: { title: string; version: string } }): {
+    paths?: Record<string, Record<string, unknown>>
+  }
+}
+
+function readApiId(
+  document: { paths?: Record<string, Record<string, unknown>> },
+  path: string,
+  method: string,
+) {
+  return (document.paths?.[path]?.[method] as Record<string, unknown> | undefined)?.[
+    "x-voyant-api-id"
+  ]
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -78,6 +78,7 @@
     "types": "./dist/index.d.ts"
   },
   "dependencies": {
+    "@hono/zod-openapi": "catalog:",
     "@voyant-travel/core": "workspace:^"
   },
   "peerDependencies": {

--- a/packages/storage/src/routes.ts
+++ b/packages/storage/src/routes.ts
@@ -23,8 +23,9 @@
  * The package never imports the deployment's R2 binding or video provider.
  */
 
+import { OpenAPIHono } from "@hono/zod-openapi"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
-import { type Context, Hono } from "hono"
+import type { Context } from "hono"
 import { z } from "zod"
 import { storageMediaRuntimePort } from "./runtime-port.js"
 import type { StorageProvider } from "./types.js"
@@ -101,12 +102,18 @@ export const STORAGE_MEDIA_ROUTE_PATHS = [
   "/v1/admin/media/*",
 ] as const
 
+export const STORAGE_OPENAPI_API_IDS = {
+  uploads: "@voyant-travel/storage#api.admin.uploads",
+  videoUploadTicket: "@voyant-travel/storage#api.admin.video-upload-ticket",
+  media: "@voyant-travel/storage#api.admin.media",
+} as const
+
 /** Structural module shape kept local so storage does not depend on the Hono adapter package. */
 export interface MediaHonoModule {
   module: { name: "media" }
   lazyRoutes: {
     paths: typeof STORAGE_MEDIA_ROUTE_PATHS
-    load: () => Promise<Hono>
+    load: () => Promise<ReturnType<typeof createMediaRoutes>>
   }
 }
 
@@ -261,8 +268,8 @@ function parseMediaKey(path: string) {
  * root). The deployment supplies the storage provider + video signer via
  * `options`.
  */
-export function createMediaRoutes(options: MediaRoutesOptions): Hono {
-  const hono = new Hono()
+export function createMediaRoutes(options: MediaRoutesOptions) {
+  const hono = new OpenAPIHono()
   const guessServedMimeType = options.guessServedMimeType ?? guessMimeType
 
   function safeServedContentType(key: string) {
@@ -357,6 +364,42 @@ export function createMediaRoutes(options: MediaRoutesOptions): Hono {
   }
 
   hono.get("/v1/admin/media/*", handleMediaServe)
+
+  hono.openAPIRegistry.registerPath({
+    method: "post",
+    path: "/v1/admin/uploads",
+    summary: "Upload media",
+    responses: {
+      200: { description: "The stored media reference." },
+      400: { description: "The multipart request is invalid." },
+      413: { description: "The upload exceeds the configured limit." },
+      415: { description: "The uploaded media type is not supported." },
+      503: { description: "Object storage is not configured." },
+    },
+    "x-voyant-api-id": STORAGE_OPENAPI_API_IDS.uploads,
+  })
+  hono.openAPIRegistry.registerPath({
+    method: "post",
+    path: "/v1/admin/uploads/video",
+    summary: "Create a video upload ticket",
+    responses: {
+      200: { description: "A provider-specific video upload ticket." },
+      400: { description: "The ticket request is invalid." },
+    },
+    "x-voyant-api-id": STORAGE_OPENAPI_API_IDS.videoUploadTicket,
+  })
+  hono.openAPIRegistry.registerPath({
+    method: "get",
+    path: "/v1/admin/media/{key}",
+    summary: "Download stored media",
+    responses: {
+      200: { description: "The stored media bytes." },
+      400: { description: "The storage key is invalid." },
+      404: { description: "The object does not exist." },
+      503: { description: "Object storage is not configured." },
+    },
+    "x-voyant-api-id": STORAGE_OPENAPI_API_IDS.media,
+  })
 
   return hono
 }

--- a/packages/storage/src/voyant.test.ts
+++ b/packages/storage/src/voyant.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from "vitest"
 
 import {
   createMediaHonoModule,
+  createMediaRoutes,
   STORAGE_MEDIA_ROUTE_PATHS,
+  STORAGE_OPENAPI_API_IDS,
   storageMediaRuntimePort,
 } from "./routes.js"
 import { storageVoyantModule } from "./voyant.js"
@@ -30,6 +32,7 @@ describe("storage deployment manifest", () => {
         expect.objectContaining({
           surface: "admin",
           mount,
+          ...(mount === "media" ? { openapi: { document: "storage-media" } } : {}),
           runtime: {
             entry: "@voyant-travel/storage/routes",
             export: "createStorageVoyantRuntime",
@@ -45,6 +48,23 @@ describe("storage deployment manifest", () => {
     expect(module.module.name).toBe("media")
     expect(module.lazyRoutes.paths).toEqual(STORAGE_MEDIA_ROUTE_PATHS)
     expect(module.lazyRoutes.paths).not.toContain("/v1/admin/products/:id/brochure/generate")
+  })
+
+  it("publishes package-owned OpenAPI operations keyed by graph API id", () => {
+    const routes = createMediaRoutes({
+      resolveStorage: () => null,
+      signVideoUploadTicket: async () => null,
+    })
+    const document = routes.getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: { title: "Storage", version: "1" },
+    })
+
+    expect(readApiId(document, "/v1/admin/uploads", "post")).toBe(STORAGE_OPENAPI_API_IDS.uploads)
+    expect(readApiId(document, "/v1/admin/uploads/video", "post")).toBe(
+      STORAGE_OPENAPI_API_IDS.videoUploadTicket,
+    )
+    expect(readApiId(document, "/v1/admin/media/{key}", "get")).toBe(STORAGE_OPENAPI_API_IDS.media)
   })
 
   it("ships a conformance kit for deployment media providers", async () => {
@@ -80,3 +100,8 @@ describe("storage deployment manifest", () => {
     ])
   })
 })
+
+function readApiId(document: unknown, path: string, method: string) {
+  const paths = (document as { paths?: Record<string, Record<string, unknown>> }).paths
+  return (paths?.[path]?.[method] as Record<string, unknown> | undefined)?.["x-voyant-api-id"]
+}

--- a/packages/storage/src/voyant.test.ts
+++ b/packages/storage/src/voyant.test.ts
@@ -28,11 +28,15 @@ describe("storage deployment manifest", () => {
       lifecycle: { uninstall: { default: "retain-data", purge: "not-supported" } },
     })
     expect(storageVoyantModule.api).toEqual(
-      ["uploads", "uploads/video", "media"].map((mount) =>
+      [
+        ["uploads", "storage-uploads"],
+        ["uploads/video", "storage-video-upload-ticket"],
+        ["media", "storage-media"],
+      ].map(([mount, document]) =>
         expect.objectContaining({
           surface: "admin",
           mount,
-          ...(mount === "media" ? { openapi: { document: "storage-media" } } : {}),
+          openapi: { document },
           runtime: {
             entry: "@voyant-travel/storage/routes",
             export: "createStorageVoyantRuntime",

--- a/packages/storage/src/voyant.ts
+++ b/packages/storage/src/voyant.ts
@@ -33,6 +33,7 @@ export const storageVoyantModule = defineModule({
       id: "@voyant-travel/storage#api.admin.media",
       surface: "admin",
       mount: "media",
+      openapi: { document: "storage-media" },
       runtime: {
         entry: "@voyant-travel/storage/routes",
         export: "createStorageVoyantRuntime",

--- a/packages/storage/src/voyant.ts
+++ b/packages/storage/src/voyant.ts
@@ -15,6 +15,7 @@ export const storageVoyantModule = defineModule({
       id: "@voyant-travel/storage#api.admin.uploads",
       surface: "admin",
       mount: "uploads",
+      openapi: { document: "storage-uploads" },
       runtime: {
         entry: "@voyant-travel/storage/routes",
         export: "createStorageVoyantRuntime",
@@ -24,6 +25,7 @@ export const storageVoyantModule = defineModule({
       id: "@voyant-travel/storage#api.admin.video-upload-ticket",
       surface: "admin",
       mount: "uploads/video",
+      openapi: { document: "storage-video-upload-ticket" },
       runtime: {
         entry: "@voyant-travel/storage/routes",
         export: "createStorageVoyantRuntime",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3291,6 +3291,9 @@ importers:
 
   packages/public-document-delivery:
     dependencies:
+      '@hono/zod-openapi':
+        specifier: 'catalog:'
+        version: 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
@@ -3466,6 +3469,9 @@ importers:
 
   packages/realtime:
     dependencies:
+      '@hono/zod-openapi':
+        specifier: 'catalog:'
+        version: 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
@@ -3691,6 +3697,9 @@ importers:
 
   packages/storage:
     dependencies:
+      '@hono/zod-openapi':
+        specifier: 'catalog:'
+        version: 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core

--- a/scripts/check-deployment-graph-openapi-coverage.mjs
+++ b/scripts/check-deployment-graph-openapi-coverage.mjs
@@ -38,36 +38,12 @@ const DEFAULT_ALLOWLIST = new Map([
     "the accommodations content extension public routes do not yet expose committed OpenAPI operations",
   ],
   [
-    "@voyant-travel/public-document-delivery#api.public",
-    "public document delivery routes are currently documented through the operator contract-document surface",
-  ],
-  [
     "@voyant-travel/flights#api",
     "flights declares a graph API bundle before committed operator OpenAPI paths are emitted for it",
   ],
   [
-    "@voyant-travel/realtime#api.admin",
-    "realtime admin routes are not yet emitted as a per-module OpenAPI document",
-  ],
-  [
-    "@voyant-travel/realtime#api.public",
-    "realtime public routes are not yet emitted as a storefront OpenAPI document",
-  ],
-  [
     "@voyant-travel/quotes#proposal-extension.api.public",
     "the quote proposal extension public routes do not yet expose committed OpenAPI operations",
-  ],
-  [
-    "@voyant-travel/storage#api.admin.media",
-    "storage media routes do not yet expose a package OpenAPI registry",
-  ],
-  [
-    "@voyant-travel/storage#api.admin.uploads",
-    "storage upload routes do not yet expose a package OpenAPI registry",
-  ],
-  [
-    "@voyant-travel/storage#api.admin.video-upload-ticket",
-    "storage video upload ticket routes do not yet expose a package OpenAPI registry",
   ],
   [
     "@voyant-travel/plugin-smartbill#api.admin",

--- a/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
+++ b/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
@@ -358,6 +358,52 @@ describe("check-deployment-graph-openapi-coverage", () => {
     assert.match(result.stdout, /1 covered graph API bundles/)
   })
 
+  it("covers overlapping opted-in routes only by their exact operation API ids", async () => {
+    const uploadsApiId = "@voyant-travel/storage#api.admin.uploads"
+    const videoApiId = "@voyant-travel/storage#api.admin.video-upload-ticket"
+    const root = await createFixture({
+      "graph.json": graph([
+        {
+          id: "@voyant-travel/storage",
+          localId: "storage",
+          packageName: "@voyant-travel/storage",
+          api: [
+            {
+              id: uploadsApiId,
+              surface: "admin",
+              mount: "uploads",
+              openapi: { document: "storage-uploads" },
+            },
+            {
+              id: videoApiId,
+              surface: "admin",
+              mount: "uploads/video",
+              openapi: { document: "storage-video-upload-ticket" },
+            },
+          ],
+        },
+      ]),
+      "openapi/admin/storage.json": openapi({
+        "/v1/admin/uploads": {
+          post: {
+            responses: { 200: { description: "OK" } },
+            "x-voyant-api-id": uploadsApiId,
+          },
+        },
+        "/v1/admin/uploads/video": {
+          post: {
+            responses: { 200: { description: "OK" } },
+            "x-voyant-api-id": videoApiId,
+          },
+        },
+      }),
+    })
+
+    const result = await runChecker(root)
+
+    assert.match(result.stdout, /2 covered graph API bundles/)
+  })
+
   it("rejects allowlist exceptions for opted-in bundles", async () => {
     const root = await createFixture({
       "graph.json": graph([


### PR DESCRIPTION
## Summary

- carry forward the complete package-owned OpenAPI work from #3247
- prefer operation-level `x-voyant-api-id` when selected-graph route mount prefixes overlap
- opt Storage uploads and uploads/video into distinct selected-graph documents
- remove the six covered Storage, Realtime, and Public Document Delivery allowlist entries
- add exact-ownership regressions in the framework slicer and coverage checker

## Coverage

Measured against the rollup graph:

- covered graph API bundles: **72 -> 78**
- allowlisted gaps: **10 -> 4**
- migrated exact API ids: **6**

Operator deployment artifacts remain owned by the separate artifact lane and are intentionally not included in this diff.

## Verification

- `@voyant-travel/framework`: selected-graph OpenAPI tests, 7 passed
- `@voyant-travel/storage`: 50 package tests passed; focused manifest rerun passed
- `@voyant-travel/realtime`: 38 package tests passed; focused manifest rerun passed
- `@voyant-travel/public-document-delivery`: 7 package tests passed; focused manifest rerun passed
- OpenAPI coverage checker: 11 tests passed
- scoped Biome lint: 31 files passed
- no full Turbo or repository typecheck, per lane constraints

Supersedes #3247 after preserving its full diff.