### PR TITLE
feat(webhooks): add durable delivery engine

### DIFF
--- a/.changeset/durable-webhook-delivery.md
+++ b/.changeset/durable-webhook-delivery.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/webhook-delivery": minor
+---
+
+Add the generic Node outbound webhook delivery engine with Postgres persistence, visibility policy admission, HMAC signing, idempotent attempts, bounded retries, terminal dead-letter state, and auditable outcomes.

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1492,6 +1492,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1487,6 +1487,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1463,6 +1463,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1458,6 +1458,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1527,6 +1527,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1528,6 +1528,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1537,6 +1537,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1538,6 +1538,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1547,6 +1547,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1542,6 +1542,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1549,6 +1549,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1550,6 +1550,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1548,6 +1548,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1543,6 +1543,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1556,6 +1556,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1557,6 +1557,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1558,6 +1558,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1444,6 +1444,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1439,6 +1439,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1556,6 +1556,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/webhook-delivery/README.md
+++ b/packages/webhook-delivery/README.md
@@ -1,0 +1,10 @@
+# @voyant-travel/webhook-delivery
+
+Node-host outbound webhook delivery behind the Framework's selected-event
+enqueue boundary. The package owns subscription fan-out, visibility policy,
+HMAC signing, persisted attempts, idempotency, bounded retries, terminal
+dead-letter state, and delivery audit outcomes.
+
+The audit tables intentionally contain only redacted, bounded excerpts. The
+original event payload remains at the host enqueue boundary and is never used
+as an audit-storage surrogate.

--- a/packages/webhook-delivery/package.json
+++ b/packages/webhook-delivery/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@voyant-travel/webhook-delivery",
+  "version": "0.1.0",
+  "description": "Durable, policy-aware outbound webhook delivery for Voyant Node deployments.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./postgres": "./src/postgres-store.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/ tests/",
+    "test": "vitest run",
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build"
+  },
+  "dependencies": {
+    "@voyant-travel/core": "workspace:^",
+    "@voyant-travel/db": "workspace:^",
+    "drizzle-orm": "catalog:"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./postgres": {
+        "types": "./dist/postgres-store.d.ts",
+        "import": "./dist/postgres-store.js",
+        "default": "./dist/postgres-store.js"
+      }
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/webhook-delivery"
+  }
+}

--- a/packages/webhook-delivery/src/engine.ts
+++ b/packages/webhook-delivery/src/engine.ts
@@ -1,0 +1,402 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import type { InfraWebhookDelivery } from "@voyant-travel/db/schema/infra"
+
+import {
+  hashWebhookPayload,
+  redactWebhookHeaders,
+  signWebhookPayload,
+  webhookBodyExcerpt,
+} from "./security.js"
+import type {
+  CreateWebhookDeliveryEngineOptions,
+  WebhookDeliveryAuditEvent,
+  WebhookDeliveryEngine,
+  WebhookDeliveryOutcome,
+  WebhookSubscription,
+} from "./types.js"
+
+const DEFAULT_BASE_DELAY_MS = 1_000
+const DEFAULT_MAX_DELAY_MS = 60_000
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000
+const DEFAULT_CLAIM_TIMEOUT_MS = 60_000
+const MAX_RESPONSE_BODY_BYTES = 4 * 1024
+const MAX_ERROR_MESSAGE_LENGTH = 1_000
+
+export function createWebhookDeliveryEngine(
+  options: CreateWebhookDeliveryEngineOptions,
+): WebhookDeliveryEngine {
+  const fetchImpl = options.fetch ?? globalThis.fetch
+  const now = options.now ?? (() => new Date())
+  const sleep =
+    options.sleep ?? ((milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds)))
+  const baseDelayMs = positiveInteger(options.retry?.baseDelayMs, DEFAULT_BASE_DELAY_MS)
+  const maxDelayMs = positiveInteger(options.retry?.maxDelayMs, DEFAULT_MAX_DELAY_MS)
+  const requestTimeoutMs = positiveInteger(
+    options.retry?.requestTimeoutMs,
+    DEFAULT_REQUEST_TIMEOUT_MS,
+  )
+  const claimTimeoutMs = positiveInteger(options.retry?.claimTimeoutMs, DEFAULT_CLAIM_TIMEOUT_MS)
+
+  return {
+    async enqueue(event) {
+      const eventId = requireEventId(event)
+      const subscriptions = await options.store.listActiveSubscriptions(event.name)
+      return Promise.all(
+        subscriptions.map(async (subscription) => {
+          const decision = await options.visibilityPolicy.authorize({
+            event,
+            eventId,
+            category: stringMetadata(event, "category"),
+            source: stringMetadata(event, "source"),
+            subscription: publicSubscription(subscription),
+          })
+          if (!decision.allowed) {
+            const outcome: WebhookDeliveryOutcome = {
+              status: "filtered",
+              subscriptionId: subscription.id,
+              reason: decision.reason,
+            }
+            await audit(options, event, outcome)
+            return outcome
+          }
+          const payload = decision.payload ?? event
+          const body = JSON.stringify(payload)
+          return deliverToSubscription(event, eventId, subscription, body)
+        }),
+      )
+    },
+  }
+
+  async function deliverToSubscription(
+    event: EventEnvelope,
+    eventId: string,
+    subscription: WebhookSubscription,
+    body: string,
+  ): Promise<WebhookDeliveryOutcome> {
+    assertWebhookUrl(subscription.url)
+    const idempotencyKey = `graph-webhook:${eventId}:${subscription.id}`
+    const maxAttempts = Math.max(1, subscription.maxRetries + 1)
+    let parentDeliveryId: string | null = null
+
+    for (let attemptNumber = 1; attemptNumber <= maxAttempts; attemptNumber += 1) {
+      const delayMs =
+        attemptNumber === 1 ? 0 : retryDelay(attemptNumber - 1, baseDelayMs, maxDelayMs)
+      const scheduledFor = new Date(now().getTime() + delayMs)
+      const timestamp = Math.floor(scheduledFor.getTime() / 1_000).toString()
+      const requestHeaders = signedHeaders(
+        subscription,
+        event,
+        eventId,
+        idempotencyKey,
+        timestamp,
+        body,
+      )
+      const enqueued = await options.store.enqueueAttempt({
+        sourceModule: "graph-outbound-webhooks",
+        sourceEvent: event.name,
+        ...sourceEntity(event.data),
+        subscriptionId: subscription.id,
+        targetUrl: subscription.url,
+        requestMethod: "POST",
+        requestHeaders: redactWebhookHeaders(requestHeaders) ?? {},
+        requestBodyHash: hashWebhookPayload(body),
+        requestBodyExcerpt: webhookBodyExcerpt(body),
+        attemptNumber,
+        parentDeliveryId,
+        idempotencyKey,
+        scheduledFor,
+      })
+
+      if (!enqueued.created && isTerminal(enqueued.attempt)) {
+        const outcome: WebhookDeliveryOutcome = {
+          status: "already_completed",
+          subscriptionId: subscription.id,
+          delivery: enqueued.attempt,
+          attempts: attemptNumber,
+        }
+        await audit(options, event, outcome)
+        return outcome
+      }
+      if (!enqueued.created && enqueued.attempt.status === "failed") {
+        parentDeliveryId = enqueued.attempt.id
+        continue
+      }
+      if (delayMs > 0) await sleep(delayMs)
+      const startedAt = now()
+      const staleBefore = new Date(startedAt.getTime() - claimTimeoutMs)
+      const claimed = await options.store.claimAttempt(enqueued.attempt.id, startedAt, staleBefore)
+      if (!claimed) {
+        const replay = await options.store.enqueueAttempt({
+          sourceModule: "graph-outbound-webhooks",
+          sourceEvent: event.name,
+          ...sourceEntity(event.data),
+          subscriptionId: subscription.id,
+          targetUrl: subscription.url,
+          requestMethod: "POST",
+          requestHeaders: redactWebhookHeaders(requestHeaders) ?? {},
+          requestBodyHash: hashWebhookPayload(body),
+          requestBodyExcerpt: webhookBodyExcerpt(body),
+          attemptNumber,
+          parentDeliveryId,
+          idempotencyKey,
+          scheduledFor,
+        })
+        if (isTerminal(replay.attempt)) {
+          const outcome: WebhookDeliveryOutcome = {
+            status: "already_completed",
+            subscriptionId: subscription.id,
+            delivery: replay.attempt,
+            attempts: attemptNumber,
+          }
+          await audit(options, event, outcome)
+          return outcome
+        }
+        const outcome: WebhookDeliveryOutcome = {
+          status: "already_active",
+          subscriptionId: subscription.id,
+          delivery: replay.attempt,
+          attempts: attemptNumber,
+        }
+        await audit(options, event, outcome)
+        return outcome
+      }
+
+      const result = await dispatch(
+        fetchImpl,
+        subscription.url,
+        requestHeaders,
+        body,
+        requestTimeoutMs,
+      )
+      const retryable = result.retryable && attemptNumber < maxAttempts
+      const terminalStatus = result.succeeded ? "succeeded" : retryable ? "failed" : "abandoned"
+      const completed = await options.store.completeAttempt({
+        id: claimed.id,
+        status: terminalStatus,
+        responseStatus: result.responseStatus,
+        responseHeaders: redactWebhookHeaders(result.responseHeaders),
+        responseBodyExcerpt: webhookBodyExcerpt(result.responseBody),
+        errorClass: result.errorClass,
+        errorMessage: result.errorMessage,
+        finishedAt: now(),
+        durationMs: Math.max(0, now().getTime() - startedAt.getTime()),
+      })
+
+      if (result.succeeded) {
+        await options.store.recordSubscriptionOutcome(subscription.id, true, now())
+        const outcome: WebhookDeliveryOutcome = {
+          status: "succeeded",
+          subscriptionId: subscription.id,
+          delivery: completed,
+          attempts: attemptNumber,
+        }
+        await audit(options, event, outcome)
+        return outcome
+      }
+
+      if (!retryable) {
+        await options.store.recordSubscriptionOutcome(subscription.id, false, now())
+        const outcome: WebhookDeliveryOutcome = {
+          status: "dead_lettered",
+          subscriptionId: subscription.id,
+          delivery: completed,
+          attempts: attemptNumber,
+        }
+        await audit(options, event, outcome)
+        return outcome
+      }
+      parentDeliveryId = completed.id
+    }
+
+    throw new Error("Webhook delivery exhausted retries without a terminal outcome")
+  }
+}
+
+interface DispatchResult {
+  succeeded: boolean
+  retryable: boolean
+  responseStatus: number | null
+  responseHeaders?: Record<string, string>
+  responseBody?: string
+  errorClass: InfraWebhookDelivery["errorClass"]
+  errorMessage: string | null
+}
+
+async function dispatch(
+  fetchImpl: typeof globalThis.fetch,
+  url: string,
+  headers: Record<string, string>,
+  body: string,
+  timeoutMs: number,
+): Promise<DispatchResult> {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers,
+      body,
+      signal: controller.signal,
+    })
+    const responseBody = await readBoundedResponseBody(response, MAX_RESPONSE_BODY_BYTES)
+    const responseHeaders = Object.fromEntries(response.headers.entries())
+    if (response.ok) {
+      return {
+        succeeded: true,
+        retryable: false,
+        responseStatus: response.status,
+        responseHeaders,
+        responseBody,
+        errorClass: null,
+        errorMessage: null,
+      }
+    }
+    const rateLimited = response.status === 429
+    const retryable = rateLimited || response.status === 408 || response.status >= 500
+    return {
+      succeeded: false,
+      retryable,
+      responseStatus: response.status,
+      responseHeaders,
+      responseBody,
+      errorClass: rateLimited ? "rate_limited" : response.status >= 500 ? "5xx" : "4xx",
+      errorMessage: boundedMessage(`HTTP ${response.status}`),
+    }
+  } catch (error) {
+    const timedOut = controller.signal.aborted
+    return {
+      succeeded: false,
+      retryable: true,
+      responseStatus: null,
+      errorClass: timedOut ? "timeout" : "network",
+      errorMessage: boundedMessage(error instanceof Error ? error.message : String(error)),
+    }
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function readBoundedResponseBody(response: Response, maxBytes: number): Promise<string> {
+  const reader = response.body?.getReader()
+  if (!reader) return ""
+
+  const buffer = new Uint8Array(maxBytes)
+  let offset = 0
+  let complete = false
+  try {
+    while (offset < maxBytes) {
+      const chunk = await reader.read()
+      if (chunk.done) {
+        complete = true
+        break
+      }
+      const remaining = maxBytes - offset
+      const length = Math.min(remaining, chunk.value.byteLength)
+      buffer.set(chunk.value.subarray(0, length), offset)
+      offset += length
+      if (length < chunk.value.byteLength) break
+    }
+  } finally {
+    if (!complete) await reader.cancel().catch(() => undefined)
+  }
+  return new TextDecoder().decode(buffer.subarray(0, offset))
+}
+
+function signedHeaders(
+  subscription: WebhookSubscription,
+  event: EventEnvelope,
+  eventId: string,
+  idempotencyKey: string,
+  timestamp: string,
+  body: string,
+): Record<string, string> {
+  return {
+    ...(subscription.headers ?? {}),
+    "content-type": "application/json",
+    "idempotency-key": idempotencyKey,
+    "x-voyant-event": event.name,
+    "x-voyant-event-id": eventId,
+    "x-voyant-timestamp": timestamp,
+    "x-voyant-signature": signWebhookPayload(subscription.secret, timestamp, body),
+  }
+}
+
+function requireEventId(event: EventEnvelope): string {
+  const eventId = event.metadata?.eventId
+  if (typeof eventId !== "string" || eventId.trim().length === 0) {
+    throw new Error(`Webhook event "${event.name}" requires metadata.eventId`)
+  }
+  return eventId
+}
+
+function stringMetadata(event: EventEnvelope, key: string): string | null {
+  const value = event.metadata?.[key]
+  return typeof value === "string" ? value : null
+}
+
+function publicSubscription(
+  subscription: WebhookSubscription,
+): Omit<WebhookSubscription, "secret"> {
+  const { secret: _secret, ...visible } = subscription
+  return visible
+}
+
+function sourceEntity(data: unknown): {
+  sourceEntityModule: string | null
+  sourceEntityId: string | null
+} {
+  if (data === null || typeof data !== "object" || Array.isArray(data)) {
+    return { sourceEntityModule: null, sourceEntityId: null }
+  }
+  const record = data as Record<string, unknown>
+  const module = record.entityModule ?? record.entity_module
+  const id = record.entityId ?? record.entity_id
+  return {
+    sourceEntityModule: typeof module === "string" ? module : null,
+    sourceEntityId: typeof id === "string" ? id : null,
+  }
+}
+
+function retryDelay(retryNumber: number, baseDelayMs: number, maxDelayMs: number): number {
+  return Math.min(maxDelayMs, baseDelayMs * 2 ** Math.max(0, retryNumber - 1))
+}
+
+function positiveInteger(value: number | undefined, fallback: number): number {
+  return value !== undefined && Number.isInteger(value) && value > 0 ? value : fallback
+}
+
+function boundedMessage(message: string): string {
+  return message.slice(0, MAX_ERROR_MESSAGE_LENGTH)
+}
+
+function isTerminal(delivery: InfraWebhookDelivery): boolean {
+  return delivery.status === "succeeded" || delivery.status === "abandoned"
+}
+
+function assertWebhookUrl(value: string): void {
+  const url = new URL(value)
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`Webhook URL must use HTTP(S): ${value}`)
+  }
+}
+
+async function audit(
+  options: CreateWebhookDeliveryEngineOptions,
+  event: EventEnvelope,
+  outcome: WebhookDeliveryOutcome,
+): Promise<void> {
+  if (!options.onAudit) return
+  const auditEvent: WebhookDeliveryAuditEvent = {
+    eventId: requireEventId(event),
+    eventName: event.name,
+    subscriptionId: outcome.subscriptionId,
+    outcome: outcome.status,
+    ...(outcome.status === "filtered"
+      ? { reason: outcome.reason }
+      : {
+          deliveryId: outcome.delivery.id,
+          attemptNumber: outcome.delivery.attemptNumber,
+        }),
+  }
+  await options.onAudit(auditEvent)
+}

--- a/packages/webhook-delivery/src/index.ts
+++ b/packages/webhook-delivery/src/index.ts
@@ -1,0 +1,22 @@
+export { createWebhookDeliveryEngine } from "./engine.js"
+export {
+  hashWebhookPayload,
+  redactWebhookHeaders,
+  signWebhookPayload,
+  webhookBodyExcerpt,
+} from "./security.js"
+export type {
+  CompleteWebhookAttemptInput,
+  CreateWebhookDeliveryEngineOptions,
+  EnqueuedWebhookAttempt,
+  EnqueueWebhookAttemptInput,
+  WebhookDeliveryAuditEvent,
+  WebhookDeliveryEngine,
+  WebhookDeliveryOutcome,
+  WebhookDeliveryStore,
+  WebhookRetryOptions,
+  WebhookSubscription,
+  WebhookVisibilityDecision,
+  WebhookVisibilityPolicy,
+  WebhookVisibilityPolicyInput,
+} from "./types.js"

--- a/packages/webhook-delivery/src/postgres-store.ts
+++ b/packages/webhook-delivery/src/postgres-store.ts
@@ -1,0 +1,159 @@
+import { newId } from "@voyant-travel/db/lib/typeid"
+import {
+  infraWebhookDeliveriesTable,
+  infraWebhookDeliverySelectSchema,
+  infraWebhookSubscriptionsTable,
+} from "@voyant-travel/db/schema/infra"
+import { and, arrayContains, eq, lte, or, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type {
+  CompleteWebhookAttemptInput,
+  EnqueuedWebhookAttempt,
+  EnqueueWebhookAttemptInput,
+  WebhookDeliveryStore,
+} from "./types.js"
+
+/**
+ * Postgres implementation for the Node delivery host. Transaction-scoped
+ * advisory locks make `(idempotencyKey, attemptNumber)` atomic even though the
+ * legacy audit table has an index rather than a unique constraint.
+ */
+export function createPostgresWebhookDeliveryStore(db: PostgresJsDatabase): WebhookDeliveryStore {
+  return {
+    async listActiveSubscriptions(eventName) {
+      const rows = await db
+        .select()
+        .from(infraWebhookSubscriptionsTable)
+        .where(
+          and(
+            eq(infraWebhookSubscriptionsTable.active, true),
+            arrayContains(infraWebhookSubscriptionsTable.events, [eventName]),
+          ),
+        )
+      return rows.map((row) => ({
+        id: row.id,
+        url: row.url,
+        secret: row.secret,
+        headers: row.headers ?? null,
+        maxRetries: row.maxRetries,
+      }))
+    },
+
+    async enqueueAttempt(input): Promise<EnqueuedWebhookAttempt> {
+      return db.transaction(async (tx) => {
+        const lockKey = `webhook-delivery:${input.idempotencyKey}:${input.attemptNumber}`
+        await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${lockKey}, 0))`)
+        const existing = await tx
+          .select()
+          .from(infraWebhookDeliveriesTable)
+          .where(
+            and(
+              eq(infraWebhookDeliveriesTable.idempotencyKey, input.idempotencyKey),
+              eq(infraWebhookDeliveriesTable.attemptNumber, input.attemptNumber),
+            ),
+          )
+          .limit(1)
+        if (existing[0]) {
+          return {
+            attempt: infraWebhookDeliverySelectSchema.parse(existing[0]),
+            created: false,
+          }
+        }
+
+        const inserted = await tx
+          .insert(infraWebhookDeliveriesTable)
+          .values(pendingAttemptValues(input))
+          .returning()
+        const row = inserted[0]
+        if (!row) throw new Error("Webhook attempt insert returned no row")
+        return {
+          attempt: infraWebhookDeliverySelectSchema.parse(row),
+          created: true,
+        }
+      })
+    },
+
+    async claimAttempt(id, now, staleBefore) {
+      const rows = await db
+        .update(infraWebhookDeliveriesTable)
+        .set({ status: "in_flight", startedAt: now, updatedAt: now })
+        .where(
+          and(
+            eq(infraWebhookDeliveriesTable.id, id),
+            or(
+              eq(infraWebhookDeliveriesTable.status, "pending"),
+              and(
+                eq(infraWebhookDeliveriesTable.status, "in_flight"),
+                lte(infraWebhookDeliveriesTable.startedAt, staleBefore),
+              ),
+            ),
+            lte(infraWebhookDeliveriesTable.scheduledFor, now),
+          ),
+        )
+        .returning()
+      return rows[0] ? infraWebhookDeliverySelectSchema.parse(rows[0]) : null
+    },
+
+    async completeAttempt(input: CompleteWebhookAttemptInput) {
+      const rows = await db
+        .update(infraWebhookDeliveriesTable)
+        .set({
+          status: input.status,
+          responseStatus: input.responseStatus,
+          responseHeaders: input.responseHeaders,
+          responseBodyExcerpt: input.responseBodyExcerpt,
+          errorClass: input.errorClass,
+          errorMessage: input.errorMessage,
+          finishedAt: input.finishedAt,
+          durationMs: input.durationMs,
+          updatedAt: input.finishedAt,
+        })
+        .where(
+          and(
+            eq(infraWebhookDeliveriesTable.id, input.id),
+            eq(infraWebhookDeliveriesTable.status, "in_flight"),
+          ),
+        )
+        .returning()
+      const row = rows[0]
+      if (!row) throw new Error(`Webhook attempt ${input.id} was not in flight`)
+      return infraWebhookDeliverySelectSchema.parse(row)
+    },
+
+    async recordSubscriptionOutcome(subscriptionId, succeeded, at) {
+      await db
+        .update(infraWebhookSubscriptionsTable)
+        .set({
+          lastDeliveryAt: at,
+          failureCount: succeeded ? 0 : sql`${infraWebhookSubscriptionsTable.failureCount} + 1`,
+          updatedAt: at,
+        })
+        .where(eq(infraWebhookSubscriptionsTable.id, subscriptionId))
+    },
+  }
+}
+
+function pendingAttemptValues(input: EnqueueWebhookAttemptInput) {
+  return {
+    id: newId("webhook_deliveries"),
+    sourceModule: input.sourceModule,
+    sourceEvent: input.sourceEvent,
+    sourceEntityModule: input.sourceEntityModule,
+    sourceEntityId: input.sourceEntityId,
+    subscriptionId: input.subscriptionId,
+    targetUrl: input.targetUrl,
+    targetKind: "subscription",
+    targetRef: input.subscriptionId,
+    requestMethod: input.requestMethod,
+    requestHeaders: input.requestHeaders,
+    requestBodyHash: input.requestBodyHash,
+    requestBodyExcerpt: input.requestBodyExcerpt,
+    attemptNumber: input.attemptNumber,
+    parentDeliveryId: input.parentDeliveryId,
+    idempotencyKey: input.idempotencyKey,
+    status: "pending",
+    scheduledFor: input.scheduledFor,
+    startedAt: null,
+  } as const
+}

--- a/packages/webhook-delivery/src/security.ts
+++ b/packages/webhook-delivery/src/security.ts
@@ -1,0 +1,112 @@
+import { createHash, createHmac } from "node:crypto"
+
+const DEFAULT_EXCERPT_BYTES = 4 * 1024
+const REDACTION_MARKER = "[REDACTED]"
+const REDACTED_HEADERS = new Set([
+  "authorization",
+  "proxy-authorization",
+  "cookie",
+  "set-cookie",
+  "x-api-key",
+  "x-api-token",
+  "x-auth-token",
+  "x-access-token",
+  "x-voyant-signature",
+  "api-key",
+  "apikey",
+])
+const REDACTED_BODY_KEYS = new Set([
+  "password",
+  "secret",
+  "token",
+  "accesstoken",
+  "refreshtoken",
+  "apikey",
+  "apitoken",
+  "authorization",
+  "email",
+  "phone",
+  "phonenumber",
+  "mobile",
+  "ssn",
+  "passport",
+  "passportnumber",
+  "documentnumber",
+  "nationalid",
+  "taxid",
+  "dob",
+  "dateofbirth",
+  "birthdate",
+  "cardnumber",
+  "pan",
+  "cvv",
+  "cvc",
+  "iban",
+  "bic",
+  "accountnumber",
+  "firstname",
+  "lastname",
+  "fullname",
+  "middlename",
+])
+const EMAIL_PATTERN = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/gi
+const PHONE_PATTERN = /\+?\d[\d\s().-]{6,}\d/g
+
+export function signWebhookPayload(secret: string, timestamp: string, body: string): string {
+  return `sha256=${createHmac("sha256", secret).update(`${timestamp}.${body}`).digest("hex")}`
+}
+
+export function hashWebhookPayload(body: string): string {
+  return createHash("sha256").update(body).digest("hex")
+}
+
+export function redactWebhookHeaders(
+  headers: Record<string, string> | undefined,
+): Record<string, string> | null {
+  if (!headers) return null
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      REDACTED_HEADERS.has(name.toLowerCase()) ? REDACTION_MARKER : value,
+    ]),
+  )
+}
+
+export function webhookBodyExcerpt(body: unknown, maxBytes = DEFAULT_EXCERPT_BYTES): string | null {
+  if (body == null) return null
+  let text: string
+  if (typeof body === "string") {
+    try {
+      text = JSON.stringify(redactValue(JSON.parse(body)))
+    } catch {
+      text = redactString(body)
+    }
+  } else {
+    try {
+      text = JSON.stringify(redactValue(body))
+    } catch {
+      text = "[unserializable]"
+    }
+  }
+  if (Buffer.byteLength(text, "utf8") <= maxBytes) return text
+  return `${Buffer.from(text, "utf8")
+    .subarray(0, Math.max(0, maxBytes - 3))
+    .toString("utf8")}...`
+}
+
+function redactValue(value: unknown): unknown {
+  if (value == null) return value
+  if (typeof value === "string") return redactString(value)
+  if (typeof value !== "object") return value
+  if (Array.isArray(value)) return value.map(redactValue)
+  const output: Record<string, unknown> = {}
+  for (const [key, item] of Object.entries(value as Record<string, unknown>)) {
+    const normalized = key.toLowerCase().replace(/[_-]/g, "")
+    output[key] = REDACTED_BODY_KEYS.has(normalized) ? REDACTION_MARKER : redactValue(item)
+  }
+  return output
+}
+
+function redactString(value: string): string {
+  return value.replace(EMAIL_PATTERN, REDACTION_MARKER).replace(PHONE_PATTERN, REDACTION_MARKER)
+}

--- a/packages/webhook-delivery/src/types.ts
+++ b/packages/webhook-delivery/src/types.ts
@@ -1,0 +1,114 @@
+import type { EventEnvelope } from "@voyant-travel/core"
+import type { InfraWebhookDelivery } from "@voyant-travel/db/schema/infra"
+
+export interface WebhookSubscription {
+  id: string
+  url: string
+  secret: string
+  headers: Record<string, string> | null
+  maxRetries: number
+}
+
+export interface WebhookVisibilityPolicyInput {
+  event: EventEnvelope
+  eventId: string
+  category: string | null
+  source: string | null
+  subscription: Readonly<Omit<WebhookSubscription, "secret">>
+}
+
+export type WebhookVisibilityDecision =
+  | { allowed: true; payload?: unknown }
+  | { allowed: false; reason: string }
+
+export interface WebhookVisibilityPolicy {
+  authorize(
+    input: WebhookVisibilityPolicyInput,
+  ): WebhookVisibilityDecision | Promise<WebhookVisibilityDecision>
+}
+
+export interface EnqueueWebhookAttemptInput {
+  sourceModule: string
+  sourceEvent: string
+  sourceEntityModule: string | null
+  sourceEntityId: string | null
+  subscriptionId: string
+  targetUrl: string
+  requestMethod: string
+  requestHeaders: Record<string, string>
+  requestBodyHash: string
+  requestBodyExcerpt: string | null
+  attemptNumber: number
+  parentDeliveryId: string | null
+  idempotencyKey: string
+  scheduledFor: Date
+}
+
+export interface CompleteWebhookAttemptInput {
+  id: string
+  status: "succeeded" | "failed" | "abandoned"
+  responseStatus: number | null
+  responseHeaders: Record<string, string> | null
+  responseBodyExcerpt: string | null
+  errorClass: InfraWebhookDelivery["errorClass"]
+  errorMessage: string | null
+  finishedAt: Date
+  durationMs: number
+}
+
+export interface EnqueuedWebhookAttempt {
+  attempt: InfraWebhookDelivery
+  created: boolean
+}
+
+export interface WebhookDeliveryStore {
+  listActiveSubscriptions(eventName: string): Promise<WebhookSubscription[]>
+  enqueueAttempt(input: EnqueueWebhookAttemptInput): Promise<EnqueuedWebhookAttempt>
+  claimAttempt(id: string, now: Date, staleBefore: Date): Promise<InfraWebhookDelivery | null>
+  completeAttempt(input: CompleteWebhookAttemptInput): Promise<InfraWebhookDelivery>
+  recordSubscriptionOutcome(subscriptionId: string, succeeded: boolean, at: Date): Promise<void>
+}
+
+export type WebhookDeliveryOutcome =
+  | {
+      status: "filtered"
+      subscriptionId: string
+      reason: string
+    }
+  | {
+      status: "succeeded" | "dead_lettered" | "already_completed" | "already_active"
+      subscriptionId: string
+      delivery: InfraWebhookDelivery
+      attempts: number
+    }
+
+export interface WebhookDeliveryAuditEvent {
+  eventId: string
+  eventName: string
+  subscriptionId: string
+  outcome: WebhookDeliveryOutcome["status"]
+  deliveryId?: string
+  attemptNumber?: number
+  reason?: string
+}
+
+export interface WebhookRetryOptions {
+  baseDelayMs?: number
+  maxDelayMs?: number
+  requestTimeoutMs?: number
+  claimTimeoutMs?: number
+}
+
+export interface CreateWebhookDeliveryEngineOptions {
+  store: WebhookDeliveryStore
+  visibilityPolicy: WebhookVisibilityPolicy
+  fetch?: typeof globalThis.fetch
+  now?: () => Date
+  sleep?: (milliseconds: number) => Promise<void>
+  retry?: WebhookRetryOptions
+  onAudit?: (event: WebhookDeliveryAuditEvent) => void | Promise<void>
+}
+
+export interface WebhookDeliveryEngine {
+  enqueue(event: EventEnvelope, _bindings?: unknown): Promise<WebhookDeliveryOutcome[]>
+}

--- a/packages/webhook-delivery/tests/engine.test.ts
+++ b/packages/webhook-delivery/tests/engine.test.ts
@@ -1,0 +1,291 @@
+import { createHmac } from "node:crypto"
+import type { EventEnvelope } from "@voyant-travel/core"
+import { newId } from "@voyant-travel/db/lib/typeid"
+import type { InfraWebhookDelivery } from "@voyant-travel/db/schema/infra"
+import { describe, expect, it, vi } from "vitest"
+
+import { createWebhookDeliveryEngine } from "../src/engine.js"
+import type {
+  CompleteWebhookAttemptInput,
+  EnqueueWebhookAttemptInput,
+  WebhookDeliveryStore,
+  WebhookSubscription,
+} from "../src/types.js"
+
+const EVENT: EventEnvelope = {
+  name: "booking.created",
+  data: {
+    entityModule: "bookings",
+    entityId: "book_1",
+    email: "private@example.test",
+  },
+  metadata: {
+    eventId: "evt_1",
+    category: "domain",
+    source: "workflow",
+  },
+  emittedAt: "2026-07-11T12:00:00.000Z",
+}
+
+const SUBSCRIPTION: WebhookSubscription = {
+  id: newId("webhook_subscriptions"),
+  url: "https://partner.example.test/hooks",
+  secret: "a-secret-that-is-at-least-thirty-two-characters",
+  headers: { Authorization: "Bearer private", "x-partner": "voyant" },
+  maxRetries: 2,
+}
+
+describe("createWebhookDeliveryEngine", () => {
+  it("signs and delivers a policy-approved event while persisting redacted audit data", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const request = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      const headers = new Headers(init?.headers)
+      const body = String(init?.body)
+      const timestamp = headers.get("x-voyant-timestamp") ?? ""
+      expect(headers.get("authorization")).toBe("Bearer private")
+      expect(headers.get("x-voyant-signature")).toBe(
+        `sha256=${createHmac("sha256", SUBSCRIPTION.secret)
+          .update(`${timestamp}.${body}`)
+          .digest("hex")}`,
+      )
+      return new Response("accepted", { status: 202, headers: { "x-request-id": "req_1" } })
+    }) as typeof fetch
+    const engine = createWebhookDeliveryEngine({
+      store,
+      fetch: request,
+      visibilityPolicy: { authorize: () => ({ allowed: true }) },
+      now: () => new Date("2026-07-11T12:00:00.000Z"),
+    })
+
+    await expect(engine.enqueue(EVENT)).resolves.toMatchObject([
+      { status: "succeeded", attempts: 1, subscriptionId: SUBSCRIPTION.id },
+    ])
+    expect(request).toHaveBeenCalledOnce()
+    expect(store.inputs[0]?.requestHeaders.Authorization).toBe("[REDACTED]")
+    expect(store.inputs[0]?.requestHeaders["x-voyant-signature"]).toBe("[REDACTED]")
+    expect(store.inputs[0]?.requestBodyHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(store.inputs[0]?.requestBodyExcerpt).not.toContain("private@example.test")
+    expect(store.outcomes).toEqual([{ subscriptionId: SUBSCRIPTION.id, succeeded: true }])
+  })
+
+  it("passes event visibility inputs to a deny-by-default policy without dispatching", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const request = vi.fn()
+    const authorize = vi.fn(() => ({ allowed: false as const, reason: "internal event" }))
+    const engine = createWebhookDeliveryEngine({
+      store,
+      fetch: request as typeof fetch,
+      visibilityPolicy: { authorize },
+    })
+
+    await expect(engine.enqueue(EVENT)).resolves.toEqual([
+      { status: "filtered", subscriptionId: SUBSCRIPTION.id, reason: "internal event" },
+    ])
+    expect(authorize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: "evt_1",
+        category: "domain",
+        source: "workflow",
+        subscription: expect.not.objectContaining({ secret: expect.anything() }),
+      }),
+    )
+    expect(request).not.toHaveBeenCalled()
+    expect(store.inputs).toHaveLength(0)
+  })
+
+  it("persists bounded exponential retries and succeeds without duplicating attempts", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce(new Response("down", { status: 503 }))
+      .mockResolvedValueOnce(new Response("limited", { status: 429 }))
+      .mockResolvedValueOnce(new Response("ok", { status: 200 }))
+    let clock = new Date("2026-07-11T12:00:00.000Z").getTime()
+    const sleep = vi.fn(async (milliseconds: number) => {
+      clock += milliseconds
+    })
+    const engine = createWebhookDeliveryEngine({
+      store,
+      fetch: request as typeof fetch,
+      visibilityPolicy: { authorize: () => ({ allowed: true }) },
+      retry: { baseDelayMs: 10, maxDelayMs: 15 },
+      sleep,
+      now: () => new Date(clock),
+    })
+
+    await expect(engine.enqueue(EVENT)).resolves.toMatchObject([
+      { status: "succeeded", attempts: 3 },
+    ])
+    expect(store.inputs.map((input) => input.attemptNumber)).toEqual([1, 2, 3])
+    expect(store.records.map((record) => record.status)).toEqual(["failed", "failed", "succeeded"])
+    expect(sleep).toHaveBeenNthCalledWith(1, 10)
+    expect(sleep).toHaveBeenNthCalledWith(2, 15)
+
+    await expect(engine.enqueue(EVENT)).resolves.toMatchObject([
+      { status: "already_completed", attempts: 3 },
+    ])
+    expect(request).toHaveBeenCalledTimes(3)
+    expect(store.records).toHaveLength(3)
+  })
+
+  it("dead-letters a non-retryable response and records the failed subscription outcome", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const request = vi.fn(async () => new Response("invalid", { status: 422 }))
+    const engine = createWebhookDeliveryEngine({
+      store,
+      fetch: request as typeof fetch,
+      visibilityPolicy: { authorize: () => ({ allowed: true }) },
+    })
+
+    await expect(engine.enqueue(EVENT)).resolves.toMatchObject([
+      {
+        status: "dead_lettered",
+        attempts: 1,
+        delivery: { status: "abandoned", errorClass: "4xx", responseStatus: 422 },
+      },
+    ])
+    expect(request).toHaveBeenCalledOnce()
+    expect(store.outcomes).toEqual([{ subscriptionId: SUBSCRIPTION.id, succeeded: false }])
+  })
+
+  it("reclaims an abandoned in-flight attempt after the claim lease expires", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const seeded = await store.enqueueAttempt({
+      sourceModule: "graph-outbound-webhooks",
+      sourceEvent: EVENT.name,
+      sourceEntityModule: "bookings",
+      sourceEntityId: "book_1",
+      subscriptionId: SUBSCRIPTION.id,
+      targetUrl: SUBSCRIPTION.url,
+      requestMethod: "POST",
+      requestHeaders: {},
+      requestBodyHash: "stale",
+      requestBodyExcerpt: null,
+      attemptNumber: 1,
+      parentDeliveryId: null,
+      idempotencyKey: `graph-webhook:evt_1:${SUBSCRIPTION.id}`,
+      scheduledFor: new Date("2026-07-11T12:00:00.000Z"),
+    })
+    seeded.attempt.status = "in_flight"
+    seeded.attempt.startedAt = new Date("2026-07-11T12:00:00.000Z")
+    const request = vi.fn(async () => new Response("ok", { status: 200 }))
+    const engine = createWebhookDeliveryEngine({
+      store,
+      fetch: request as typeof fetch,
+      visibilityPolicy: { authorize: () => ({ allowed: true }) },
+      retry: { claimTimeoutMs: 30_000 },
+      now: () => new Date("2026-07-11T12:01:00.000Z"),
+    })
+
+    await expect(engine.enqueue(EVENT)).resolves.toMatchObject([{ status: "succeeded" }])
+    expect(request).toHaveBeenCalledOnce()
+  })
+
+  it("bounds response reads before persisting excerpts", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const engine = createWebhookDeliveryEngine({
+      store,
+      fetch: vi.fn(async () => new Response("x".repeat(100_000), { status: 200 })) as typeof fetch,
+      visibilityPolicy: { authorize: () => ({ allowed: true }) },
+    })
+
+    await engine.enqueue(EVENT)
+
+    expect(
+      Buffer.byteLength(store.records[0]?.responseBodyExcerpt ?? "", "utf8"),
+    ).toBeLessThanOrEqual(4 * 1024)
+  })
+
+  it("requires a stable event id before subscription lookup", async () => {
+    const store = new MemoryWebhookDeliveryStore([SUBSCRIPTION])
+    const engine = createWebhookDeliveryEngine({
+      store,
+      visibilityPolicy: { authorize: () => ({ allowed: true }) },
+    })
+
+    await expect(engine.enqueue({ ...EVENT, metadata: {} })).rejects.toThrow(
+      /requires metadata\.eventId/,
+    )
+  })
+})
+
+class MemoryWebhookDeliveryStore implements WebhookDeliveryStore {
+  readonly inputs: EnqueueWebhookAttemptInput[] = []
+  readonly records: InfraWebhookDelivery[] = []
+  readonly outcomes: Array<{ subscriptionId: string; succeeded: boolean }> = []
+
+  constructor(private readonly subscriptions: WebhookSubscription[]) {}
+
+  async listActiveSubscriptions(): Promise<WebhookSubscription[]> {
+    return this.subscriptions
+  }
+
+  async enqueueAttempt(input: EnqueueWebhookAttemptInput) {
+    const existing = this.records.find(
+      (record) =>
+        record.idempotencyKey === input.idempotencyKey &&
+        record.attemptNumber === input.attemptNumber,
+    )
+    if (existing) return { attempt: existing, created: false }
+    this.inputs.push(input)
+    const timestamp = new Date()
+    const attempt: InfraWebhookDelivery = {
+      id: newId("webhook_deliveries"),
+      sourceModule: input.sourceModule,
+      sourceEvent: input.sourceEvent,
+      sourceEntityModule: input.sourceEntityModule,
+      sourceEntityId: input.sourceEntityId,
+      subscriptionId: input.subscriptionId,
+      targetUrl: input.targetUrl,
+      targetKind: "subscription",
+      targetRef: input.subscriptionId,
+      requestMethod: input.requestMethod,
+      requestHeaders: input.requestHeaders,
+      requestBodyHash: input.requestBodyHash,
+      requestBodyExcerpt: input.requestBodyExcerpt,
+      responseStatus: null,
+      responseHeaders: null,
+      responseBodyExcerpt: null,
+      attemptNumber: input.attemptNumber,
+      parentDeliveryId: input.parentDeliveryId,
+      idempotencyKey: input.idempotencyKey,
+      status: "pending",
+      scheduledFor: input.scheduledFor,
+      startedAt: null,
+      finishedAt: null,
+      durationMs: null,
+      errorClass: null,
+      errorMessage: null,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    }
+    this.records.push(attempt)
+    return { attempt, created: true }
+  }
+
+  async claimAttempt(id: string, now: Date, staleBefore: Date) {
+    const attempt = this.records.find((record) => record.id === id)
+    const pending = attempt?.status === "pending"
+    const stale =
+      attempt?.status === "in_flight" &&
+      attempt.startedAt !== null &&
+      attempt.startedAt.getTime() <= staleBefore.getTime()
+    if ((!pending && !stale) || (attempt.scheduledFor?.getTime() ?? 0) > now.getTime()) {
+      return null
+    }
+    attempt.status = "in_flight"
+    attempt.startedAt = now
+    return attempt
+  }
+
+  async completeAttempt(input: CompleteWebhookAttemptInput) {
+    const attempt = this.records.find((record) => record.id === input.id)
+    if (!attempt) throw new Error("missing attempt")
+    Object.assign(attempt, input)
+    return attempt
+  }
+
+  async recordSubscriptionOutcome(subscriptionId: string, succeeded: boolean) {
+    this.outcomes.push({ subscriptionId, succeeded })
+  }
+}

--- a/packages/webhook-delivery/tests/security.test.ts
+++ b/packages/webhook-delivery/tests/security.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  hashWebhookPayload,
+  redactWebhookHeaders,
+  signWebhookPayload,
+  webhookBodyExcerpt,
+} from "../src/security.js"
+
+describe("webhook delivery security", () => {
+  it("uses a versioned SHA-256 HMAC signature", () => {
+    expect(signWebhookPayload("secret", "123", '{"ok":true}')).toMatch(/^sha256=[a-f0-9]{64}$/)
+  })
+
+  it("uses a cryptographic body fingerprint", () => {
+    expect(hashWebhookPayload("hello")).toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    )
+  })
+
+  it("redacts credentials and PII from persisted audit fields", () => {
+    expect(
+      redactWebhookHeaders({ Authorization: "secret", "x-voyant-signature": "signature" }),
+    ).toEqual({ Authorization: "[REDACTED]", "x-voyant-signature": "[REDACTED]" })
+    expect(webhookBodyExcerpt('{"email":"private@example.test","bookingId":"book_1"}')).toBe(
+      '{"email":"[REDACTED]","bookingId":"book_1"}',
+    )
+  })
+
+  it("bounds persisted excerpts", () => {
+    expect(
+      Buffer.byteLength(webhookBodyExcerpt("x".repeat(10_000)) ?? "", "utf8"),
+    ).toBeLessThanOrEqual(4 * 1024)
+  })
+})

--- a/packages/webhook-delivery/tsconfig.build.json
+++ b/packages/webhook-delivery/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+}

--- a/packages/webhook-delivery/tsconfig.json
+++ b/packages/webhook-delivery/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["node"]
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/webhook-delivery/tsconfig.typecheck.json
+++ b/packages/webhook-delivery/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/webhook-delivery/vitest.config.ts
+++ b/packages/webhook-delivery/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+})

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1557,6 +1557,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1558,6 +1558,8 @@
       "@voyant-travel/utils/tiered-kv": ["../utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": ["../webhook-delivery/dist/postgres-store.d.ts"],
       "@voyant-travel/workflow-runs": ["../workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": ["../workflow-runs/dist/hono-module.d.ts"],
       "@voyant-travel/workflow-runs/recorder": ["../workflow-runs/dist/recorder.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4242,6 +4242,31 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
 
+  packages/webhook-delivery:
+    dependencies:
+      '@voyant-travel/core':
+        specifier: workspace:^
+        version: link:../core
+      '@voyant-travel/db':
+        specifier: workspace:^
+        version: link:../db
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.35.6)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+    devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.5.2
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/workflow-runs:
     dependencies:
       '@hono/zod-openapi':

--- a/starters/operator/tsconfig.client.json
+++ b/starters/operator/tsconfig.client.json
@@ -1993,6 +1993,10 @@
       "@voyant-travel/utils/tiered-kv": ["../../packages/utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../../packages/utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../../packages/vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../../packages/webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": [
+        "../../packages/webhook-delivery/dist/postgres-store.d.ts"
+      ],
       "@voyant-travel/workflow-runs": ["../../packages/workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": [
         "../../packages/workflow-runs/dist/hono-module.d.ts"

--- a/starters/operator/tsconfig.server.json
+++ b/starters/operator/tsconfig.server.json
@@ -1993,6 +1993,10 @@
       "@voyant-travel/utils/tiered-kv": ["../../packages/utils/dist/tiered-kv.d.ts"],
       "@voyant-travel/utils/timezones": ["../../packages/utils/dist/timezones.d.ts"],
       "@voyant-travel/vite-config": ["../../packages/vite-config/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery": ["../../packages/webhook-delivery/dist/index.d.ts"],
+      "@voyant-travel/webhook-delivery/postgres": [
+        "../../packages/webhook-delivery/dist/postgres-store.d.ts"
+      ],
       "@voyant-travel/workflow-runs": ["../../packages/workflow-runs/dist/index.d.ts"],
       "@voyant-travel/workflow-runs/hono-module": [
         "../../packages/workflow-runs/dist/hono-module.d.ts"


### PR DESCRIPTION
## Summary

- add a generic Node-host outbound webhook delivery engine behind the selected-event enqueue boundary
- persist subscriptions and delivery attempts through the existing infra webhook tables
- enforce injected visibility policy, HMAC-SHA256 signatures, idempotent attempt claims, bounded exponential retries, terminal abandonment, and audit callbacks
- keep full event payloads out of audit storage while redacting credentials and PII from bounded excerpts

## Package API

- `createWebhookDeliveryEngine(options)` returns the Framework-compatible `enqueue(event, bindings?)` boundary
- `createPostgresWebhookDeliveryStore(db)` provides atomic Postgres persistence using transaction-scoped advisory locks
- `WebhookVisibilityPolicy` receives event taxonomy and subscription inputs and may deny or transform the outbound payload
- signing, hashing, header redaction, and body-excerpt helpers are exported for host and integration use

## Verification

- 9 focused tests
- package lint
- package typecheck
- package build
- package tarball inspection
- `git diff --check`

## Follow-up integration

- wire the package to Framework `outboundWebhooks.enqueue` in the generic Node bootstrap
- provide the selected-event visibility policy from emitted-event schema metadata
- choose the durable host wake-up/queue adapter; audit rows intentionally do not store the raw payload
- remove the legacy Distribution enqueue/delivery helpers after consumers migrate
