### PR TITLE
feat(graph): execute lifecycle plans safely

### DIFF
--- a/.changeset/graph-lifecycle-event-contracts.md
+++ b/.changeset/graph-lifecycle-event-contracts.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+---
+
+Add graph-lowered upgrade and uninstall execution contracts with retry-safe rollback state, explicit resource cleanup, and versioned emitted-event payload schema compatibility validation.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -780,6 +780,15 @@ Rules:
 - setup/seed work is modeled as idempotent data migrations with an applied-work
   ledger
 
+Graph-lowered lifecycle execution uses deterministic, host-executed steps rather
+than package callbacks. Upgrade plans migrate, detach changed runtime units,
+release only explicitly declared non-durable resources, and activate the next
+units. Uninstall plans detach removed units and retain durable data by default.
+Every step carries a stable idempotency key; durable execution state records
+completed steps and rollback progress so a retry resumes execution or rollback
+without inventing a second lifecycle path. Destructive purge remains out of
+scope.
+
 ## Admin Surface
 
 Admin composition is beyond the foundational v1 substrate but required for the
@@ -1124,6 +1133,13 @@ The broader event catalog is beyond the foundational substrate:
 - visibility policy for event fields
 - outbound webhook subscription and delivery policy
 - event-to-OpenAPI or event-to-SDK generation
+
+The first event-contract slice allows an emitted event to carry a semantic
+version and inline JSON payload schema. Graph upgrade tooling rejects
+same-major changes that remove properties or enum values, narrow types, or make
+previously optional properties required. Breaking payload changes require a new
+major contract version. This validates package compatibility only: outbound
+webhook subscription and delivery transport remain a separate later slice.
 
 Inbound webhook routes remain API route declarations. Outbound webhook delivery
 ships after the package-owned event catalog, not inside the foundational slice.

--- a/packages/core/src/project-facets.ts
+++ b/packages/core/src/project-facets.ts
@@ -182,4 +182,15 @@ export interface VoyantGraphLifecycleDeclaration {
     default: "retain-data"
     purge?: "not-supported" | "explicit"
   }
+  /**
+   * Explicit non-durable resources released by graph lifecycle execution.
+   * Durable package data remains retained; destructive purge is not modeled here.
+   */
+  cleanup?: readonly VoyantGraphLifecycleResourceCleanup[]
+}
+
+export interface VoyantGraphLifecycleResourceCleanup extends VoyantGraphFacetEntity {
+  resourceId: string
+  on: readonly ("upgrade" | "uninstall")[]
+  action: "release"
 }

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -152,6 +152,10 @@ export interface VoyantGraphFacetEntity {
 
 export interface VoyantGraphEvent extends VoyantGraphFacetEntity {
   eventType?: string
+  /** Semantic version of the emitted payload contract. Required with payloadSchema. */
+  version?: string
+  /** JSON Schema used by graph tooling to validate payload compatibility before upgrade. */
+  payloadSchema?: VoyantGraphJsonObject
 }
 
 export interface VoyantGraphSubscriber extends VoyantGraphFacetEntity {

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./deployment-artifacts": "./src/deployment-artifacts.ts",
     "./deployment-graph": "./src/deployment-graph.ts",
+    "./graph-lifecycle": "./src/graph-lifecycle.ts",
     "./selected-graph-openapi": "./src/selected-graph-openapi.ts",
     "./operator-distribution": "./src/operator-distribution.ts",
     "./project-api-conventions": "./src/project-api-conventions.ts",
@@ -117,6 +118,10 @@
       "./deployment-graph": {
         "types": "./dist/deployment-graph.d.ts",
         "import": "./dist/deployment-graph.js"
+      },
+      "./graph-lifecycle": {
+        "types": "./dist/graph-lifecycle.d.ts",
+        "import": "./dist/graph-lifecycle.js"
       },
       "./operator-distribution": {
         "types": "./dist/operator-distribution.d.ts",

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -72,6 +72,46 @@ describe("deployment graph v1", () => {
     expect(graph.plugins.map((unit) => unit.id)).toEqual(["@acme/voyant-fiscal#smartbill"])
   })
 
+  it("validates versioned event contracts and declarative lifecycle cleanup", () => {
+    const diagnostics = validateGraphUnitManifest({
+      ...defineModule({
+        id: "@acme/voyant-loyalty",
+        resources: [{ id: "@acme/voyant-loyalty#resource.cache", kind: "cache" }],
+        events: [
+          {
+            id: "@acme/voyant-loyalty#event.changed",
+            eventType: "loyalty.changed",
+            version: "not-semver",
+          },
+        ],
+        lifecycle: {
+          cleanup: [
+            {
+              id: "@acme/voyant-loyalty#cleanup.cache",
+              resourceId: "@acme/voyant-loyalty#resource.cache",
+              on: [],
+              action: "release",
+            },
+          ],
+        },
+      }),
+    })
+
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ facet: "events[0]" }),
+        expect.objectContaining({ facet: "events[0].version" }),
+        expect.objectContaining({ facet: "lifecycle.cleanup[0].on" }),
+      ]),
+    )
+    expect(() =>
+      validateGraphUnitManifest({
+        ...defineModule({ id: "@acme/voyant-loyalty" }),
+        lifecycle: null,
+      }),
+    ).not.toThrow()
+  })
+
   it("resolves the full package-owned facet contract without starter catalogs", async () => {
     const module = defineModule({
       id: "@acme/voyant-loyalty",
@@ -1420,6 +1460,7 @@ describe("deployment graph v1", () => {
       "VOYANT_GRAPH_ARTIFACT_STALE",
       "VOYANT_GRAPH_DUPLICATE_ENTITY_ID",
       "VOYANT_GRAPH_DUPLICATE_ID",
+      "VOYANT_GRAPH_INCOMPATIBLE_EVENT_SCHEMA",
       "VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN",
       "VOYANT_GRAPH_INVALID_ENTITY_ID",
       "VOYANT_GRAPH_INVALID_FACET",

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -148,6 +148,8 @@ export const VOYANT_GRAPH_DIAGNOSTIC_CODE_REGISTRY = {
   VOYANT_GRAPH_ARTIFACT_STALE: "A generated deployment graph artifact is stale.",
   VOYANT_GRAPH_DUPLICATE_ENTITY_ID: "Two v1 graph entities resolved to the same stable entity id.",
   VOYANT_GRAPH_DUPLICATE_ID: "Two selected graph units resolved to the same graph id.",
+  VOYANT_GRAPH_INCOMPATIBLE_EVENT_SCHEMA:
+    "An emitted-event payload schema is incompatible with its previous major-version contract.",
   VOYANT_GRAPH_INVALID_CAPABILITY_TOKEN:
     "A provides/requires capability token does not match v1 namespace rules.",
   VOYANT_GRAPH_INVALID_ENTITY_ID: "A v1 facet entity is missing a stable id or uses an invalid id.",
@@ -1658,22 +1660,84 @@ function validatePromotedFacets(
       )
     }
   })
+  validateEntityArray(input.events, "events", source, diagnostics, (entry, facet) => {
+    if (entry.eventType !== undefined) {
+      requireNonEmptyString(entry.eventType, `${facet}.eventType`, source, diagnostics)
+    }
+    const hasVersion = entry.version !== undefined
+    const hasSchema = entry.payloadSchema !== undefined
+    if (hasVersion !== hasSchema) {
+      invalidFacet(
+        facet,
+        source,
+        diagnostics,
+        "Versioned events must declare both version and payloadSchema.",
+      )
+    }
+    if (hasVersion && (typeof entry.version !== "string" || parseVersion(entry.version) === null)) {
+      invalidFacet(
+        `${facet}.version`,
+        source,
+        diagnostics,
+        "Event contract versions must use semantic versioning.",
+      )
+    }
+    if (hasSchema && !isRecord(entry.payloadSchema)) {
+      invalidFacet(
+        `${facet}.payloadSchema`,
+        source,
+        diagnostics,
+        "Event payloadSchema must be a JSON Schema object.",
+      )
+    }
+  })
 
   validateAccessFacet(input.access, source, diagnostics)
   validateAdminFacet(input.admin, source, diagnostics)
   if (input.lifecycle !== undefined) {
     if (!isRecord(input.lifecycle)) {
       invalidFacet("lifecycle", source, diagnostics, "Lifecycle metadata must be an object.")
-    } else if (input.lifecycle.uninstall !== undefined) {
-      const uninstall = input.lifecycle.uninstall
-      if (!isRecord(uninstall) || uninstall.default !== "retain-data") {
-        invalidFacet(
-          "lifecycle.uninstall.default",
-          source,
-          diagnostics,
-          'Uninstall metadata must default to "retain-data".',
-        )
+    } else {
+      if (input.lifecycle.uninstall !== undefined) {
+        const uninstall = input.lifecycle.uninstall
+        if (!isRecord(uninstall) || uninstall.default !== "retain-data") {
+          invalidFacet(
+            "lifecycle.uninstall.default",
+            source,
+            diagnostics,
+            'Uninstall metadata must default to "retain-data".',
+          )
+        }
       }
+      validateEntityArray(
+        input.lifecycle.cleanup,
+        "lifecycle.cleanup",
+        source,
+        diagnostics,
+        (entry, facet) => {
+          requireNonEmptyString(entry.resourceId, `${facet}.resourceId`, source, diagnostics)
+          if (entry.action !== "release") {
+            invalidFacet(
+              `${facet}.action`,
+              source,
+              diagnostics,
+              'Lifecycle cleanup action must be "release".',
+            )
+          }
+          if (
+            !Array.isArray(entry.on) ||
+            entry.on.length === 0 ||
+            entry.on.some((operation) => operation !== "upgrade" && operation !== "uninstall")
+          ) {
+            invalidFacet(
+              `${facet}.on`,
+              source,
+              diagnostics,
+              "Lifecycle cleanup must name at least one supported operation.",
+            )
+          }
+        },
+      )
     }
   }
   return diagnostics
@@ -2311,6 +2375,9 @@ function validateFacetReferences(
         reference(unit.id, `${migration.id}.dependsOn`, id)
       }
     }
+    for (const cleanup of unit.lifecycle?.cleanup ?? []) {
+      reference(unit.id, `${cleanup.id}.resourceId`, cleanup.resourceId)
+    }
     for (const action of unit.actions ?? []) {
       for (const scope of action.requiredScopes ?? []) {
         requireScope(unit.id, `${action.id}.requiredScopes`, scope)
@@ -2853,6 +2920,7 @@ function unitEntityIds(unit: ResolvedVoyantGraphUnit): string[] {
     ...(unit.tools ?? []).map((entry) => entry.id),
     ...(unit.webhooks ?? []).map((entry) => entry.id),
     ...(unit.actions ?? []).map((entry) => entry.id),
+    ...(unit.lifecycle?.cleanup ?? []).map((entry) => entry.id),
     ...unit.workflows.flatMap((entry) => [
       entry.id,
       ...(entry.schedules ?? []).map((schedule) => schedule.id),

--- a/packages/framework/src/graph-lifecycle.test.ts
+++ b/packages/framework/src/graph-lifecycle.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "vitest"
+
+import { defineModule, defineProject, resolveDeploymentGraph } from "./deployment-graph.js"
+import {
+  createVoyantGraphLifecyclePlan,
+  executeVoyantGraphLifecyclePlan,
+  type VoyantGraphLifecycleExecutionState,
+  type VoyantGraphLifecycleExecutor,
+  VoyantGraphLifecyclePlanError,
+  validateVoyantGraphEventCompatibility,
+} from "./graph-lifecycle.js"
+
+describe("graph lifecycle", () => {
+  it("lowers upgrades into deterministic migration, detach, cleanup, and activation steps", async () => {
+    const previous = await graph({
+      eventVersion: "1.0.0",
+      includeResource: true,
+      cleanupOnUpgrade: true,
+    })
+    const next = await graph({ eventVersion: "1.1.0" })
+
+    const plan = createVoyantGraphLifecyclePlan({
+      operationId: "upgrade-42",
+      operation: "upgrade",
+      previous,
+      next,
+    })
+
+    expect(plan.steps.map((step) => [step.kind, step.unitId, step.resourceId])).toEqual([
+      ["migrate-graph", undefined, undefined],
+      ["detach-unit", "@acme/loyalty", undefined],
+      ["release-resource", "@acme/loyalty", "@acme/loyalty#resource.cache"],
+      ["activate-unit", "@acme/loyalty", undefined],
+    ])
+    expect(plan.steps.every((step) => step.idempotencyKey.startsWith("upgrade-42:"))).toBe(true)
+  })
+
+  it("persists completed steps, rolls back reversible work, and safely retries", async () => {
+    const previous = await graph({ eventVersion: "1.0.0" })
+    const next = await graph({ eventVersion: "1.1.0" })
+    const plan = createVoyantGraphLifecyclePlan({
+      operationId: "upgrade-retry",
+      operation: "upgrade",
+      previous,
+      next,
+    })
+    let state: VoyantGraphLifecycleExecutionState | undefined
+    const calls: string[] = []
+    let failActivation = true
+    const executor: VoyantGraphLifecycleExecutor = {
+      async execute(step) {
+        calls.push(`execute:${step.id}`)
+        if (step.kind === "activate-unit" && failActivation) {
+          failActivation = false
+          throw new Error("activation failed")
+        }
+        return { rollbackToken: step.id }
+      },
+      async rollback(step, context) {
+        calls.push(`rollback:${step.id}:${String(context.rollbackToken)}`)
+      },
+    }
+    const store = {
+      async load() {
+        return state
+      },
+      async save(nextState: VoyantGraphLifecycleExecutionState) {
+        state = structuredClone(nextState)
+      },
+    }
+
+    const failed = await executeVoyantGraphLifecyclePlan(plan, store, executor)
+    expect(failed.status).toBe("rolled-back")
+    expect(failed.error).toBe("activation failed")
+    expect(calls).toEqual([
+      "execute:migrate-graph:graph",
+      "execute:detach-unit:@acme/loyalty",
+      "execute:activate-unit:@acme/loyalty",
+      "rollback:detach-unit:@acme/loyalty:detach-unit:@acme/loyalty",
+    ])
+
+    const completed = await executeVoyantGraphLifecyclePlan(plan, store, executor)
+    expect(completed.status).toBe("completed")
+    expect(completed.attempt).toBe(2)
+  })
+
+  it("uninstalls only removed units when surviving unit order changes", async () => {
+    const removed = defineModule({ id: "@acme/alpha" })
+    const retained = defineModule({ id: "@acme/loyalty" })
+    const previous = await resolveDeploymentGraph({
+      project: defineProject({ modules: [removed, retained] }),
+    })
+    const next = await resolveDeploymentGraph({ project: defineProject({ modules: [retained] }) })
+
+    const plan = createVoyantGraphLifecyclePlan({
+      operationId: "uninstall-alpha",
+      operation: "uninstall",
+      previous,
+      next,
+    })
+
+    expect(plan.steps.map((step) => step.id)).toEqual(["detach-unit:@acme/alpha"])
+  })
+
+  it("resumes rollback before executing more work after an interrupted rollback", async () => {
+    const previous = await graph({ eventVersion: "1.0.0" })
+    const next = await graph({ eventVersion: "1.1.0" })
+    const plan = createVoyantGraphLifecyclePlan({
+      operationId: "upgrade-rollback-resume",
+      operation: "upgrade",
+      previous,
+      next,
+    })
+    let state: VoyantGraphLifecycleExecutionState | undefined
+    let rollbackFails = true
+    const calls: string[] = []
+    const executor: VoyantGraphLifecycleExecutor = {
+      async execute(step) {
+        calls.push(`execute:${step.id}`)
+        if (step.kind === "activate-unit") throw new Error("activate failed")
+      },
+      async rollback(step) {
+        calls.push(`rollback:${step.id}`)
+        if (rollbackFails) {
+          rollbackFails = false
+          throw new Error("rollback interrupted")
+        }
+      },
+    }
+    const store = {
+      async load() {
+        return state
+      },
+      async save(nextState: VoyantGraphLifecycleExecutionState) {
+        state = structuredClone(nextState)
+      },
+    }
+
+    await expect(executeVoyantGraphLifecyclePlan(plan, store, executor)).rejects.toThrow(
+      "rollback interrupted",
+    )
+    expect(state?.status).toBe("rolling-back")
+    const resumed = await executeVoyantGraphLifecyclePlan(plan, store, executor)
+    expect(resumed.status).toBe("rolled-back")
+    expect(calls.filter((call) => call.startsWith("execute:"))).toHaveLength(3)
+  })
+
+  it("rejects same-major event payload narrowing and accepts additive evolution", async () => {
+    const previous = await graph({ eventVersion: "1.0.0" })
+    const additive = await graph({ eventVersion: "1.1.0", addOptionalField: true })
+    const breaking = await graph({ eventVersion: "1.1.0", requireCurrency: true })
+    const nextMajor = await graph({ eventVersion: "2.0.0", requireCurrency: true })
+    const downgrade = await graph({ eventVersion: "0.9.0" })
+    const removedContract = await graph({ eventVersion: "1.1.0", omitContract: true })
+
+    expect(validateVoyantGraphEventCompatibility(previous, additive)).toEqual([])
+    expect(validateVoyantGraphEventCompatibility(previous, breaking)).toEqual([
+      expect.objectContaining({
+        code: "VOYANT_GRAPH_INCOMPATIBLE_EVENT_SCHEMA",
+        facet: "@acme/loyalty#event.changed",
+        message: expect.stringContaining("$.currency became required"),
+      }),
+    ])
+    expect(() =>
+      createVoyantGraphLifecyclePlan({
+        operationId: "breaking-upgrade",
+        operation: "upgrade",
+        previous,
+        next: breaking,
+      }),
+    ).toThrow(VoyantGraphLifecyclePlanError)
+    expect(validateVoyantGraphEventCompatibility(previous, nextMajor)).toEqual([])
+    expect(validateVoyantGraphEventCompatibility(previous, downgrade)[0]?.message).toContain(
+      "version 0.9.0 is older than 1.0.0",
+    )
+    expect(validateVoyantGraphEventCompatibility(previous, removedContract)[0]?.message).toContain(
+      "versioned payload contract was removed",
+    )
+  })
+})
+
+async function graph(options: {
+  eventVersion: string
+  addOptionalField?: boolean
+  requireCurrency?: boolean
+  includeResource?: boolean
+  cleanupOnUpgrade?: boolean
+  omitContract?: boolean
+}) {
+  const module = defineModule({
+    id: "@acme/loyalty",
+    events: [
+      {
+        id: "@acme/loyalty#event.changed",
+        eventType: "loyalty.changed",
+        ...(options.omitContract
+          ? {}
+          : {
+              version: options.eventVersion,
+              payloadSchema: {
+                type: "object",
+                properties: {
+                  accountId: { type: "string" },
+                  ...(options.addOptionalField || options.requireCurrency
+                    ? { currency: { type: "string" } }
+                    : {}),
+                },
+                required: ["accountId", ...(options.requireCurrency ? ["currency"] : [])],
+              },
+            }),
+      },
+    ],
+    ...(options.includeResource
+      ? {
+          resources: [{ id: "@acme/loyalty#resource.cache", kind: "cache", required: false }],
+          lifecycle: {
+            uninstall: { default: "retain-data" as const },
+            cleanup: [
+              {
+                id: "@acme/loyalty#cleanup.cache",
+                resourceId: "@acme/loyalty#resource.cache",
+                on: options.cleanupOnUpgrade
+                  ? (["upgrade", "uninstall"] as const)
+                  : (["uninstall"] as const),
+                action: "release" as const,
+              },
+            ],
+          },
+        }
+      : {}),
+  })
+  return resolveDeploymentGraph({ project: defineProject({ modules: [module] }) })
+}

--- a/packages/framework/src/graph-lifecycle.ts
+++ b/packages/framework/src/graph-lifecycle.ts
@@ -1,0 +1,430 @@
+import type { VoyantGraphJsonValue } from "@voyant-travel/core/project"
+
+import {
+  canonicalJson,
+  type ResolvedVoyantDeploymentGraph,
+  type ResolvedVoyantGraphUnit,
+  type VoyantGraphDiagnostic,
+} from "./deployment-graph.js"
+
+export type VoyantGraphLifecycleOperation = "upgrade" | "uninstall"
+
+export interface VoyantGraphLifecycleStep {
+  id: string
+  idempotencyKey: string
+  kind: "migrate-graph" | "detach-unit" | "release-resource" | "activate-unit"
+  unitId?: string
+  resourceId?: string
+  fromGraphHash: string
+  toGraphHash: string
+  reversible: boolean
+}
+
+export interface VoyantGraphLifecyclePlan {
+  schemaVersion: "voyant.graph-lifecycle-plan.v1"
+  operationId: string
+  operation: VoyantGraphLifecycleOperation
+  fromGraphHash: string
+  toGraphHash: string
+  steps: readonly VoyantGraphLifecycleStep[]
+}
+
+export interface CreateVoyantGraphLifecyclePlanInput {
+  operationId: string
+  operation: VoyantGraphLifecycleOperation
+  previous: ResolvedVoyantDeploymentGraph
+  next: ResolvedVoyantDeploymentGraph
+}
+
+export interface VoyantGraphLifecycleStepState {
+  stepId: string
+  status: "completed" | "rolled-back"
+  rollbackToken?: VoyantGraphJsonValue
+}
+
+export interface VoyantGraphLifecycleExecutionState {
+  schemaVersion: "voyant.graph-lifecycle-state.v1"
+  operationId: string
+  planFingerprint: string
+  attempt: number
+  status: "running" | "rolling-back" | "completed" | "rolled-back"
+  steps: readonly VoyantGraphLifecycleStepState[]
+  error?: string
+}
+
+export interface VoyantGraphLifecycleStateStore {
+  load(operationId: string): Promise<VoyantGraphLifecycleExecutionState | undefined>
+  save(state: VoyantGraphLifecycleExecutionState): Promise<void>
+}
+
+export interface VoyantGraphLifecycleExecutor {
+  execute(
+    step: VoyantGraphLifecycleStep,
+    context: { operationId: string; attempt: number },
+  ): Promise<{ rollbackToken?: VoyantGraphJsonValue } | undefined>
+  rollback(
+    step: VoyantGraphLifecycleStep,
+    context: { operationId: string; attempt: number; rollbackToken?: VoyantGraphJsonValue },
+  ): Promise<void>
+}
+
+export class VoyantGraphLifecyclePlanError extends Error {
+  readonly diagnostics: readonly VoyantGraphDiagnostic[]
+
+  constructor(diagnostics: readonly VoyantGraphDiagnostic[]) {
+    super(
+      `Cannot lower graph lifecycle plan with ${diagnostics.length} incompatible event contract(s)`,
+    )
+    this.name = "VoyantGraphLifecyclePlanError"
+    this.diagnostics = diagnostics
+  }
+}
+
+export function createVoyantGraphLifecyclePlan(
+  input: CreateVoyantGraphLifecyclePlanInput,
+): VoyantGraphLifecyclePlan {
+  requireText(input.operationId, "operationId")
+  if (input.previous.contentHash === input.next.contentHash) {
+    return plan(input, [])
+  }
+  if (input.operation === "upgrade") {
+    const diagnostics = validateVoyantGraphEventCompatibility(input.previous, input.next)
+    if (diagnostics.length > 0) throw new VoyantGraphLifecyclePlanError(diagnostics)
+  }
+
+  const previous = unitsById(input.previous)
+  const next = unitsById(input.next)
+  const removedOrChanged = [...previous.values()]
+    .filter((unit) => !sameUnit(unit, next.get(unit.id)))
+    .sort(compareUnits)
+  const addedOrChanged = [...next.values()]
+    .filter((unit) => !sameUnit(unit, previous.get(unit.id)))
+    .sort(compareUnits)
+
+  if (input.operation === "uninstall" && addedOrChanged.length > 0) {
+    throw new Error("Uninstall lifecycle plans cannot add or change graph units")
+  }
+
+  const steps: VoyantGraphLifecycleStep[] = []
+  if (input.operation === "upgrade") {
+    steps.push(step(input, "migrate-graph", "graph", false))
+  }
+  for (const unit of removedOrChanged) {
+    steps.push(step(input, "detach-unit", unit.id, true, { unitId: unit.id }))
+  }
+  for (const unit of removedOrChanged) {
+    for (const cleanup of unit.lifecycle?.cleanup ?? []) {
+      if (!cleanup.on.includes(input.operation)) continue
+      steps.push(
+        step(input, "release-resource", `${unit.id}:${cleanup.resourceId}`, true, {
+          unitId: unit.id,
+          resourceId: cleanup.resourceId,
+        }),
+      )
+    }
+  }
+  for (const unit of addedOrChanged) {
+    steps.push(step(input, "activate-unit", unit.id, true, { unitId: unit.id }))
+  }
+  return plan(input, steps)
+}
+
+export async function executeVoyantGraphLifecyclePlan(
+  plan: VoyantGraphLifecyclePlan,
+  store: VoyantGraphLifecycleStateStore,
+  executor: VoyantGraphLifecycleExecutor,
+): Promise<VoyantGraphLifecycleExecutionState> {
+  const fingerprint = canonicalJson(plan)
+  const stored = await store.load(plan.operationId)
+  if (stored?.planFingerprint !== undefined && stored.planFingerprint !== fingerprint) {
+    throw new Error(
+      `Lifecycle operation ${plan.operationId} was already started with a different plan`,
+    )
+  }
+  if (stored?.status === "completed") return stored
+
+  let state: VoyantGraphLifecycleExecutionState = stored
+    ? { ...stored, attempt: stored.attempt + 1, error: undefined }
+    : {
+        schemaVersion: "voyant.graph-lifecycle-state.v1",
+        operationId: plan.operationId,
+        planFingerprint: fingerprint,
+        attempt: 1,
+        status: "running",
+        steps: [],
+      }
+
+  if (state.status === "rolling-back") {
+    return rollback(plan, state, store, executor)
+  }
+  if (state.status === "rolled-back") state = { ...state, status: "running", steps: [] }
+  await store.save(state)
+
+  try {
+    for (const lifecycleStep of plan.steps) {
+      if (
+        state.steps.some(
+          (entry) => entry.stepId === lifecycleStep.id && entry.status === "completed",
+        )
+      ) {
+        continue
+      }
+      const result = await executor.execute(lifecycleStep, {
+        operationId: plan.operationId,
+        attempt: state.attempt,
+      })
+      state = {
+        ...state,
+        steps: [
+          ...state.steps,
+          {
+            stepId: lifecycleStep.id,
+            status: "completed",
+            ...(result?.rollbackToken !== undefined ? { rollbackToken: result.rollbackToken } : {}),
+          },
+        ],
+      }
+      await store.save(state)
+    }
+    state = { ...state, status: "completed" }
+    await store.save(state)
+    return state
+  } catch (error) {
+    state = { ...state, status: "rolling-back", error: errorMessage(error) }
+    await store.save(state)
+    return rollback(plan, state, store, executor)
+  }
+}
+
+export function validateVoyantGraphEventCompatibility(
+  previous: ResolvedVoyantDeploymentGraph,
+  next: ResolvedVoyantDeploymentGraph,
+): VoyantGraphDiagnostic[] {
+  const diagnostics: VoyantGraphDiagnostic[] = []
+  const oldEvents = new Map(
+    allUnits(previous).flatMap((unit) => unit.events.map((event) => [event.id, event])),
+  )
+  const nextEventIds = new Set(
+    allUnits(next).flatMap((unit) => unit.events.map((event) => event.id)),
+  )
+  for (const unit of allUnits(previous)) {
+    for (const event of unit.events) {
+      if (event.version && event.payloadSchema && !nextEventIds.has(event.id)) {
+        diagnostics.push(
+          eventCompatibilityDiagnostic(unit, event, "the versioned event contract was removed"),
+        )
+      }
+    }
+  }
+  for (const unit of allUnits(next)) {
+    for (const event of unit.events) {
+      const oldEvent = oldEvents.get(event.id)
+      if (!oldEvent?.version || !oldEvent.payloadSchema) continue
+      if (!event.version || !event.payloadSchema) {
+        diagnostics.push(
+          eventCompatibilityDiagnostic(unit, event, "the versioned payload contract was removed"),
+        )
+        continue
+      }
+      const oldVersion = semverParts(oldEvent.version)
+      const newVersion = semverParts(event.version)
+      if (!oldVersion || !newVersion) continue
+      if (compareSemver(newVersion, oldVersion) < 0) {
+        diagnostics.push(
+          eventCompatibilityDiagnostic(
+            unit,
+            event,
+            `version ${event.version} is older than ${oldEvent.version}`,
+          ),
+        )
+        continue
+      }
+      if (newVersion[0] !== oldVersion[0]) continue
+      for (const issue of incompatibleSchemaChanges(oldEvent.payloadSchema, event.payloadSchema)) {
+        diagnostics.push(eventCompatibilityDiagnostic(unit, event, issue))
+      }
+    }
+  }
+  return diagnostics
+}
+
+async function rollback(
+  plan: VoyantGraphLifecyclePlan,
+  initial: VoyantGraphLifecycleExecutionState,
+  store: VoyantGraphLifecycleStateStore,
+  executor: VoyantGraphLifecycleExecutor,
+): Promise<VoyantGraphLifecycleExecutionState> {
+  let state = initial
+  const steps = new Map(plan.steps.map((entry) => [entry.id, entry]))
+  for (const completed of [...state.steps].reverse()) {
+    if (completed.status === "rolled-back") continue
+    const lifecycleStep = steps.get(completed.stepId)
+    if (!lifecycleStep?.reversible) continue
+    await executor.rollback(lifecycleStep, {
+      operationId: plan.operationId,
+      attempt: state.attempt,
+      ...(completed.rollbackToken !== undefined ? { rollbackToken: completed.rollbackToken } : {}),
+    })
+    state = {
+      ...state,
+      steps: state.steps.map((entry) =>
+        entry.stepId === completed.stepId ? { ...entry, status: "rolled-back" } : entry,
+      ),
+    }
+    await store.save(state)
+  }
+  state = { ...state, status: "rolled-back" }
+  await store.save(state)
+  return state
+}
+
+function incompatibleSchemaChanges(
+  previous: Record<string, VoyantGraphJsonValue>,
+  next: Record<string, VoyantGraphJsonValue>,
+  path = "$",
+): string[] {
+  const issues: string[] = []
+  const previousTypes = schemaTypes(previous.type)
+  const nextTypes = schemaTypes(next.type)
+  if (previousTypes.some((type) => !nextTypes.includes(type))) {
+    issues.push(`${path} narrows type ${previousTypes.join("|")} to ${nextTypes.join("|")}`)
+  }
+  const previousEnum = stringValues(previous.enum)
+  const nextEnum = stringValues(next.enum)
+  if (previousEnum.some((value) => !nextEnum.includes(value)))
+    issues.push(`${path} removes enum values`)
+
+  const oldProperties = recordValue(previous.properties)
+  const newProperties = recordValue(next.properties)
+  const oldRequired = new Set(stringValues(previous.required))
+  const newRequired = new Set(stringValues(next.required))
+  for (const [name, schema] of Object.entries(oldProperties)) {
+    const replacement = newProperties[name]
+    if (replacement === undefined) {
+      issues.push(`${path}.${name} was removed`)
+      continue
+    }
+    if (isJsonObject(schema) && isJsonObject(replacement)) {
+      issues.push(...incompatibleSchemaChanges(schema, replacement, `${path}.${name}`))
+    }
+  }
+  for (const name of newRequired) {
+    if (!oldRequired.has(name)) issues.push(`${path}.${name} became required`)
+  }
+  return issues
+}
+
+function plan(
+  input: CreateVoyantGraphLifecyclePlanInput,
+  steps: VoyantGraphLifecycleStep[],
+): VoyantGraphLifecyclePlan {
+  return {
+    schemaVersion: "voyant.graph-lifecycle-plan.v1",
+    operationId: input.operationId,
+    operation: input.operation,
+    fromGraphHash: input.previous.contentHash,
+    toGraphHash: input.next.contentHash,
+    steps,
+  }
+}
+
+function step(
+  input: CreateVoyantGraphLifecyclePlanInput,
+  kind: VoyantGraphLifecycleStep["kind"],
+  identity: string,
+  reversible: boolean,
+  extra: Pick<VoyantGraphLifecycleStep, "unitId" | "resourceId"> = {},
+): VoyantGraphLifecycleStep {
+  const id = `${kind}:${identity}`
+  return {
+    id,
+    idempotencyKey: `${input.operationId}:${id}`,
+    kind,
+    fromGraphHash: input.previous.contentHash,
+    toGraphHash: input.next.contentHash,
+    reversible,
+    ...extra,
+  }
+}
+
+function unitsById(graph: ResolvedVoyantDeploymentGraph): Map<string, ResolvedVoyantGraphUnit> {
+  return new Map(allUnits(graph).map((unit) => [unit.id, unit]))
+}
+
+function allUnits(graph: ResolvedVoyantDeploymentGraph): ResolvedVoyantGraphUnit[] {
+  return [...graph.modules, ...graph.extensions, ...graph.plugins]
+}
+
+function sameUnit(
+  left: ResolvedVoyantGraphUnit,
+  right: ResolvedVoyantGraphUnit | undefined,
+): boolean {
+  if (!right) return false
+  const { order: _leftOrder, ...leftContract } = left
+  const { order: _rightOrder, ...rightContract } = right
+  return canonicalJson(leftContract) === canonicalJson(rightContract)
+}
+
+function compareUnits(left: ResolvedVoyantGraphUnit, right: ResolvedVoyantGraphUnit): number {
+  return left.order - right.order || left.id.localeCompare(right.id)
+}
+
+function eventCompatibilityDiagnostic(
+  unit: ResolvedVoyantGraphUnit,
+  event: ResolvedVoyantGraphUnit["events"][number],
+  issue: string,
+): VoyantGraphDiagnostic {
+  return {
+    code: "VOYANT_GRAPH_INCOMPATIBLE_EVENT_SCHEMA",
+    severity: "error",
+    source: unit.id,
+    facet: event.id,
+    message: `Event ${event.eventType ?? event.id} ${event.version ?? "(unversioned)"} is not backward compatible: ${issue}`,
+    hint: "Preserve the existing payload shape or publish the breaking contract under a new major version.",
+  }
+}
+
+function semverParts(value: string): readonly [number, number, number] | undefined {
+  const match = /^(?:v)?(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value)
+  return match ? [Number(match[1]), Number(match[2]), Number(match[3])] : undefined
+}
+
+function compareSemver(
+  left: readonly [number, number, number],
+  right: readonly [number, number, number],
+): number {
+  return left[0] - right[0] || left[1] - right[1] || left[2] - right[2]
+}
+
+function schemaTypes(value: VoyantGraphJsonValue | undefined): string[] {
+  if (typeof value === "string") return [value]
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : []
+}
+
+function stringValues(value: VoyantGraphJsonValue | undefined): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : []
+}
+
+function recordValue(
+  value: VoyantGraphJsonValue | undefined,
+): Record<string, VoyantGraphJsonValue> {
+  return isJsonObject(value) ? value : {}
+}
+
+function isJsonObject(
+  value: VoyantGraphJsonValue | undefined,
+): value is Record<string, VoyantGraphJsonValue> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function requireText(value: string, field: string): void {
+  if (!value.trim()) throw new Error(`${field} must be a non-empty string`)
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -35,6 +35,20 @@ export {
   type VoyantGraphActionRiskEvaluator,
 } from "./graph-action-ledger.js"
 export {
+  type CreateVoyantGraphLifecyclePlanInput,
+  createVoyantGraphLifecyclePlan,
+  executeVoyantGraphLifecyclePlan,
+  type VoyantGraphLifecycleExecutionState,
+  type VoyantGraphLifecycleExecutor,
+  type VoyantGraphLifecycleOperation,
+  type VoyantGraphLifecyclePlan,
+  VoyantGraphLifecyclePlanError,
+  type VoyantGraphLifecycleStateStore,
+  type VoyantGraphLifecycleStep,
+  type VoyantGraphLifecycleStepState,
+  validateVoyantGraphEventCompatibility,
+} from "./graph-lifecycle.js"
+export {
   FRAMEWORK_CAPABILITY_GRAPH,
   FRAMEWORK_EXTENSION_OWNERSHIP,
   FRAMEWORK_RUNTIME_MANIFEST,


### PR DESCRIPTION
## Summary

- lower graph upgrades and uninstalls into deterministic host-executed lifecycle plans
- persist retry-safe execution and rollback state with explicit non-durable resource cleanup
- validate versioned emitted-event payload schemas and reject same-major breaking changes
- expose the lifecycle API from Framework and document transport as a separate concern

## Verification

- `@voyant-travel/framework`: 45 focused lifecycle/deployment-graph tests
- `@voyant-travel/framework`: lint
- `@voyant-travel/core`: typecheck
- `@voyant-travel/core`: 157 tests
- `@voyant-travel/core`: lint
- `git diff --check`

Framework package typecheck was stopped after sustained high memory use; CI is authoritative for that lane.

## Remaining scope

- outbound webhook persistence, visibility policy, signing, retries, idempotency, dead letters, and delivery audit outcomes
- destructive data purge remains intentionally unsupported
- concrete deployment hosts must implement durable lifecycle state storage and step executors