### PR TITLE
feat(openapi): close first-party authority gaps

### DIFF
--- a/.changeset/final-package-openapi-authority.md
+++ b/.changeset/final-package-openapi-authority.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/accommodations": minor
+"@voyant-travel/flights": minor
+"@voyant-travel/quotes": minor
+---
+
+Publish package-owned OpenAPI registries and selected-graph documents for accommodation content, Flights, and public quote proposal APIs.

--- a/packages/accommodations/src/routes-content.ts
+++ b/packages/accommodations/src/routes-content.ts
@@ -9,12 +9,12 @@
  * fallback.
  */
 
+import { OpenAPIHono } from "@hono/zod-openapi"
 import type { SourceAdapterRegistry } from "@voyant-travel/catalog/booking-engine"
 import type { Extension } from "@voyant-travel/core"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import type { Context } from "hono"
-import { Hono } from "hono"
 
 import { type AccommodationContentScope, getAccommodationContent } from "./service-content.js"
 
@@ -30,10 +30,17 @@ export interface CreateAccommodationContentRoutesOptions {
   defaultAcceptMachineTranslated?: boolean
 }
 
+export const ACCOMMODATION_CONTENT_OPENAPI_API_IDS = {
+  admin: "@voyant-travel/accommodations#content-extension.api.admin",
+  public: "@voyant-travel/accommodations#content-extension.api.public",
+} as const
+
 export function createAccommodationContentRoutes(
   options: CreateAccommodationContentRoutesOptions,
-): Hono<AccommodationContentRoutesEnv> {
-  return new Hono<AccommodationContentRoutesEnv>().get("/:id/content", async (c) => {
+  apiId?: (typeof ACCOMMODATION_CONTENT_OPENAPI_API_IDS)[keyof typeof ACCOMMODATION_CONTENT_OPENAPI_API_IDS],
+): OpenAPIHono<AccommodationContentRoutesEnv> {
+  const routes = new OpenAPIHono<AccommodationContentRoutesEnv>()
+  routes.get("/:id/content", async (c) => {
     const entityId = c.req.param("id")
     const scope = parseScope(c)
     const registry = options.resolveRegistry(c)
@@ -66,6 +73,18 @@ export function createAccommodationContentRoutes(
       },
     })
   })
+  routes.openAPIRegistry.registerPath({
+    method: "get",
+    path: "/{id}/content",
+    summary: "Get accommodation content",
+    responses: {
+      200: { description: "Localized accommodation content and provenance." },
+      404: { description: "Accommodation content was not found." },
+    },
+    ...(apiId ? { "x-voyant-api-id": apiId } : {}),
+  })
+
+  return routes
 
   function parseScope(c: Context): AccommodationContentScope {
     const localeParams = c.req.queries("locale") ?? c.req.queries("locales") ?? []
@@ -111,8 +130,14 @@ export function createAccommodationContentHonoExtension(
 ): HonoExtension {
   return {
     extension: accommodationContentExtension,
-    adminRoutes: createAccommodationContentRoutes(options.admin),
-    publicRoutes: createAccommodationContentRoutes(options.public),
+    adminRoutes: createAccommodationContentRoutes(
+      options.admin,
+      ACCOMMODATION_CONTENT_OPENAPI_API_IDS.admin,
+    ),
+    publicRoutes: createAccommodationContentRoutes(
+      options.public,
+      ACCOMMODATION_CONTENT_OPENAPI_API_IDS.public,
+    ),
   }
 }
 

--- a/packages/accommodations/src/voyant.ts
+++ b/packages/accommodations/src/voyant.ts
@@ -62,6 +62,7 @@ export const accommodationsContentVoyantPlugin = defineExtension({
       surface: "public",
       mount: "accommodations",
       anonymous: true,
+      openapi: { document: "accommodations-content-public" },
       runtime: {
         entry: "@voyant-travel/accommodations/routes-content",
         export: "createAccommodationContentHonoExtension",

--- a/packages/accommodations/tests/unit/voyant-manifest.test.ts
+++ b/packages/accommodations/tests/unit/voyant-manifest.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest"
-import { createAccommodationContentHonoExtension } from "../../src/routes-content.js"
+import {
+  ACCOMMODATION_CONTENT_OPENAPI_API_IDS,
+  createAccommodationContentHonoExtension,
+} from "../../src/routes-content.js"
 import { accommodationsContentVoyantPlugin, accommodationsVoyantModule } from "../../src/voyant.js"
 
 describe("accommodations deployment manifest", () => {
@@ -50,6 +53,7 @@ describe("accommodations deployment manifest", () => {
           surface: "public",
           mount: "accommodations",
           anonymous: true,
+          openapi: { document: "accommodations-content-public" },
           runtime: { export: "createAccommodationContentHonoExtension" },
         },
       ],
@@ -63,5 +67,33 @@ describe("accommodations deployment manifest", () => {
     expect(extension.extension).toMatchObject({ name: "content", module: "accommodations" })
     expect(extension.adminRoutes).toBeDefined()
     expect(extension.publicRoutes).toBeDefined()
+
+    const document = openApiDocument(extension.publicRoutes)
+    expect(readApiId(document, "/{id}/content", "get")).toBe(
+      ACCOMMODATION_CONTENT_OPENAPI_API_IDS.public,
+    )
   })
 })
+
+function openApiDocument(routes: unknown) {
+  return (routes as OpenApiDocumentSource).getOpenAPI31Document({
+    openapi: "3.1.0",
+    info: { title: "Accommodation content", version: "1" },
+  })
+}
+
+interface OpenApiDocumentSource {
+  getOpenAPI31Document(input: { openapi: "3.1.0"; info: { title: string; version: string } }): {
+    paths?: Record<string, Record<string, unknown>>
+  }
+}
+
+function readApiId(
+  document: { paths?: Record<string, Record<string, unknown>> },
+  path: string,
+  method: string,
+) {
+  return (document.paths?.[path]?.[method] as Record<string, unknown> | undefined)?.[
+    "x-voyant-api-id"
+  ]
+}

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -126,6 +126,7 @@
     "types": "./dist/index.d.ts"
   },
   "dependencies": {
+    "@hono/zod-openapi": "catalog:",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/finance": "workspace:^",

--- a/packages/flights/src/hono.ts
+++ b/packages/flights/src/hono.ts
@@ -23,12 +23,13 @@
  * `/v1/admin/flights` via `createFlightsHonoModule(...)`.
  */
 
+import { OpenAPIHono } from "@hono/zod-openapi"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 import { createOrderPaymentSessions } from "@voyant-travel/finance/order-payment-sessions"
 import type { HonoModule } from "@voyant-travel/hono"
 import { ilike, or } from "drizzle-orm"
-import { type Context, Hono } from "hono"
+import type { Context } from "hono"
 
 import type {
   FlightCancelReason,
@@ -89,6 +90,23 @@ export interface FlightsRouteOptions {
 }
 
 export type FlightsHonoModuleOptions = FlightsRouteOptions
+
+export const FLIGHTS_OPENAPI_API_ID = "@voyant-travel/flights#api"
+
+const FLIGHT_OPENAPI_OPERATIONS = [
+  ["post", "/search", "Search flights"],
+  ["post", "/ancillaries", "Get flight ancillaries"],
+  ["post", "/seatmap", "Get a flight seat map"],
+  ["post", "/price", "Price a flight offer"],
+  ["post", "/book", "Book a flight offer"],
+  ["get", "/orders", "List flight orders"],
+  ["get", "/orders/{orderId}", "Get a flight order"],
+  ["post", "/orders/{orderId}/ticket", "Ticket a flight order"],
+  ["post", "/orders/{orderId}/cancel", "Cancel a flight order"],
+  ["get", "/reference/airports", "List reference airports"],
+  ["get", "/reference/airlines", "List reference airlines"],
+  ["get", "/reference/aircraft", "List reference aircraft"],
+] as const
 
 function buildContext(c: Context): { connectionId: string; correlationId?: string } {
   return {
@@ -154,9 +172,9 @@ function adapterBookingRequestForIntent(body: FlightBookRequest): FlightBookRequ
 }
 
 /** Build the flight admin routes (relative paths; mount at `/v1/admin/flights`). */
-export function createFlightAdminRoutes(options: FlightsRouteOptions): Hono {
+export function createFlightAdminRoutes(options: FlightsRouteOptions): OpenAPIHono {
   const { resolveAdapter, payment } = options
-  const hono = new Hono()
+  const hono = new OpenAPIHono()
 
   // ── Search ──────────────────────────────────────────────────────────────
   hono.post("/search", async (c) => {
@@ -415,6 +433,16 @@ export function createFlightAdminRoutes(options: FlightsRouteOptions): Hono {
     const rows = await getDb(c).select().from(referenceAircraft)
     return c.json({ data: rows })
   })
+
+  for (const [method, path, summary] of FLIGHT_OPENAPI_OPERATIONS) {
+    hono.openAPIRegistry.registerPath({
+      method,
+      path,
+      summary,
+      responses: { 200: { description: "Successful response." } },
+      "x-voyant-api-id": FLIGHTS_OPENAPI_API_ID,
+    })
+  }
 
   return hono
 }

--- a/packages/flights/src/voyant.test.ts
+++ b/packages/flights/src/voyant.test.ts
@@ -1,7 +1,12 @@
 import { assertPortConforms } from "@voyant-travel/core/project"
 import { describe, expect, it, vi } from "vitest"
 import type { FlightConnectorAdapter } from "./contract/adapter.js"
-import { createFlightsHonoModule, createFlightsVoyantRuntime, flightsRuntimePort } from "./hono.js"
+import {
+  createFlightsHonoModule,
+  createFlightsVoyantRuntime,
+  FLIGHTS_OPENAPI_API_ID,
+  flightsRuntimePort,
+} from "./hono.js"
 import { flightsVoyantModule } from "./voyant.js"
 
 describe("flights deployment manifest", () => {
@@ -17,6 +22,7 @@ describe("flights deployment manifest", () => {
           id: "@voyant-travel/flights#api",
           surface: "admin",
           mount: "flights",
+          openapi: { document: "flights" },
           runtime: {
             entry: "@voyant-travel/flights/hono",
             export: "createFlightsVoyantRuntime",
@@ -51,6 +57,7 @@ describe("flights deployment manifest", () => {
         id: "@voyant-travel/flights#api",
         surface: "admin",
         mount: "flights",
+        openapi: { document: "flights" },
         runtime: {
           entry: "@voyant-travel/flights/hono",
           export: "createFlightsVoyantRuntime",
@@ -67,6 +74,18 @@ describe("flights deployment manifest", () => {
     expect(runtime.adminRoutes).toBeDefined()
     expect(runtime.publicRoutes).toBeUndefined()
     expect(runtime.webhookRoutes).toBeUndefined()
+
+    const document = (runtime.adminRoutes as OpenApiDocumentSource).getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: { title: "Flights", version: "1" },
+    })
+    const operations = Object.values(document.paths ?? {}).flatMap((path) =>
+      Object.values(path).filter((operation) => typeof operation === "object"),
+    ) as Array<Record<string, unknown>>
+    expect(operations).toHaveLength(12)
+    expect(
+      operations.every((operation) => operation["x-voyant-api-id"] === FLIGHTS_OPENAPI_API_ID),
+    ).toBe(true)
   })
 
   it("owns runtime assembly and validates Node-host providers", async () => {
@@ -99,3 +118,9 @@ describe("flights deployment manifest", () => {
     expect(runtime.adminRoutes).toBeDefined()
   })
 })
+
+interface OpenApiDocumentSource {
+  getOpenAPI31Document(input: { openapi: "3.1.0"; info: { title: string; version: string } }): {
+    paths?: Record<string, Record<string, unknown>>
+  }
+}

--- a/packages/flights/src/voyant.ts
+++ b/packages/flights/src/voyant.ts
@@ -13,6 +13,7 @@ export const flightsVoyantModule = defineModule({
       id: "@voyant-travel/flights#api",
       surface: "admin",
       mount: "flights",
+      openapi: { document: "flights" },
       runtime: {
         entry: "@voyant-travel/flights/hono",
         export: "createFlightsVoyantRuntime",

--- a/packages/quotes/src/proposal-routes.ts
+++ b/packages/quotes/src/proposal-routes.ts
@@ -26,6 +26,7 @@
  * profile via `QuoteProposalRoutesOptions` — all generic / structural so this
  * package stays free of operator types and CloudflareBindings.
  */
+import { OpenAPIHono } from "@hono/zod-openapi"
 import { parseJsonBody, parseOptionalJsonBody } from "@voyant-travel/hono"
 import type { HonoExtension } from "@voyant-travel/hono/module"
 import {
@@ -89,6 +90,18 @@ export interface QuoteProposalRoutesOptions {
     c: Context,
   ): Promise<PublicProposalFeedbackRecord | null>
 }
+
+export const QUOTE_PROPOSAL_OPENAPI_API_IDS = {
+  admin: "@voyant-travel/quotes#proposal-extension.api.admin",
+  public: "@voyant-travel/quotes#proposal-extension.api.public",
+} as const
+
+const PUBLIC_PROPOSAL_OPENAPI_OPERATIONS = [
+  ["get", "/{quoteVersionId}", "Get a public quote proposal"],
+  ["post", "/{quoteVersionId}/accept", "Accept a public quote proposal"],
+  ["post", "/{quoteVersionId}/decline", "Decline a public quote proposal"],
+  ["post", "/{quoteVersionId}/request-edits", "Request quote proposal edits"],
+] as const
 
 export interface QuoteVersionSnapshotRoutesOptions {
   /** Resolve the concrete transactional db for a request. */
@@ -297,12 +310,21 @@ export function createQuoteProposalAdminRoutes(
 /** Build the public proposal routes (relative paths; mount at `/v1/public/proposals`). */
 export function createQuoteProposalPublicRoutes(
   options: QuoteProposalRoutesOptions,
-): Hono<OperatorProposalRouteEnv> {
-  const app = new Hono<OperatorProposalRouteEnv>()
+): OpenAPIHono<OperatorProposalRouteEnv> {
+  const app = new OpenAPIHono<OperatorProposalRouteEnv>()
   app.get("/:quoteVersionId", (c) => handleGetPublicProposal(c, options))
   app.post("/:quoteVersionId/accept", (c) => handleAcceptPublicProposal(c, options))
   app.post("/:quoteVersionId/decline", (c) => handleDeclinePublicProposal(c, options))
   app.post("/:quoteVersionId/request-edits", (c) => handleRequestPublicProposalEdits(c, options))
+  for (const [method, path, summary] of PUBLIC_PROPOSAL_OPENAPI_OPERATIONS) {
+    app.openAPIRegistry.registerPath({
+      method,
+      path,
+      summary,
+      responses: { 200: { description: "Successful response." } },
+      "x-voyant-api-id": QUOTE_PROPOSAL_OPENAPI_API_IDS.public,
+    })
+  }
   return app
 }
 

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -195,6 +195,7 @@ export const quotesProposalVoyantPlugin = defineExtension({
       mount: "proposals",
       anonymous: true,
       transactional: true,
+      openapi: { document: "quotes-proposal-public" },
       runtime: {
         entry: "@voyant-travel/quotes",
         export: "createQuoteProposalHonoExtension",

--- a/packages/quotes/tests/unit/voyant-manifest.test.ts
+++ b/packages/quotes/tests/unit/voyant-manifest.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
 import {
+  createQuoteProposalPublicRoutes,
+  QUOTE_PROPOSAL_OPENAPI_API_IDS,
+} from "../../src/proposal-routes.js"
+import {
   quotesBookingVoyantPlugin,
   quotesProposalVoyantPlugin,
   quotesVersionSnapshotVoyantPlugin,
@@ -88,6 +92,7 @@ describe("quotes deployment manifests", () => {
             surface: "public",
             mount: "proposals",
             anonymous: true,
+            openapi: { document: "quotes-proposal-public" },
             runtime: {
               entry: "@voyant-travel/quotes",
               export: "createQuoteProposalHonoExtension",
@@ -110,5 +115,27 @@ describe("quotes deployment manifests", () => {
         ],
       },
     ])
+
+    const document = (
+      createQuoteProposalPublicRoutes({} as never) as OpenApiDocumentSource
+    ).getOpenAPI31Document({
+      openapi: "3.1.0",
+      info: { title: "Public quote proposals", version: "1" },
+    })
+    const operations = Object.values(document.paths ?? {}).flatMap((path) =>
+      Object.values(path).filter((operation) => typeof operation === "object"),
+    ) as Array<Record<string, unknown>>
+    expect(operations).toHaveLength(4)
+    expect(
+      operations.every(
+        (operation) => operation["x-voyant-api-id"] === QUOTE_PROPOSAL_OPENAPI_API_IDS.public,
+      ),
+    ).toBe(true)
   })
 })
+
+interface OpenApiDocumentSource {
+  getOpenAPI31Document(input: { openapi: "3.1.0"; info: { title: string; version: string } }): {
+    paths?: Record<string, Record<string, unknown>>
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1854,6 +1854,9 @@ importers:
 
   packages/flights:
     dependencies:
+      '@hono/zod-openapi':
+        specifier: 'catalog:'
+        version: 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/catalog':
         specifier: workspace:^
         version: link:../catalog

--- a/scripts/check-deployment-graph-openapi-coverage.mjs
+++ b/scripts/check-deployment-graph-openapi-coverage.mjs
@@ -34,18 +34,6 @@ const HTTP_METHODS = new Set([
 
 const DEFAULT_ALLOWLIST = new Map([
   [
-    "@voyant-travel/accommodations#content-extension.api.public",
-    "the accommodations content extension public routes do not yet expose committed OpenAPI operations",
-  ],
-  [
-    "@voyant-travel/flights#api",
-    "flights declares a graph API bundle before committed operator OpenAPI paths are emitted for it",
-  ],
-  [
-    "@voyant-travel/quotes#proposal-extension.api.public",
-    "the quote proposal extension public routes do not yet expose committed OpenAPI operations",
-  ],
-  [
     "@voyant-travel/plugin-smartbill#api.admin",
     "SmartBill 0.138.0 publishes a plain Hono admin route and does not yet expose a package OpenAPI registry",
   ],

--- a/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
+++ b/scripts/tests/check-deployment-graph-openapi-coverage.test.mjs
@@ -404,6 +404,83 @@ describe("check-deployment-graph-openapi-coverage", () => {
     assert.match(result.stdout, /2 covered graph API bundles/)
   })
 
+  it("covers the final first-party package documents by exact operation API id", async () => {
+    const apiIds = {
+      accommodations: "@voyant-travel/accommodations#content-extension.api.public",
+      flights: "@voyant-travel/flights#api",
+      quotes: "@voyant-travel/quotes#proposal-extension.api.public",
+    }
+    const root = await createFixture({
+      "graph.json": graph(
+        [
+          {
+            id: "@voyant-travel/flights",
+            localId: "flights",
+            packageName: "@voyant-travel/flights",
+            api: [
+              {
+                id: apiIds.flights,
+                surface: "admin",
+                mount: "flights",
+                openapi: { document: "flights" },
+              },
+            ],
+          },
+        ],
+        [
+          {
+            id: "@voyant-travel/accommodations#content-extension",
+            localId: "accommodations.content-extension",
+            packageName: "@voyant-travel/accommodations",
+            api: [
+              {
+                id: apiIds.accommodations,
+                surface: "public",
+                mount: "accommodations",
+                openapi: { document: "accommodations-content-public" },
+              },
+            ],
+          },
+          {
+            id: "@voyant-travel/quotes#proposal-extension",
+            localId: "quotes.proposal-extension",
+            packageName: "@voyant-travel/quotes",
+            api: [
+              {
+                id: apiIds.quotes,
+                surface: "public",
+                mount: "proposals",
+                openapi: { document: "quotes-proposal-public" },
+              },
+            ],
+          },
+        ],
+      ),
+      "openapi/admin/flights.json": openapi({
+        "/v1/admin/flights/search": {
+          post: { responses: { 200: { description: "OK" } }, "x-voyant-api-id": apiIds.flights },
+        },
+      }),
+      "openapi/storefront/accommodations-content-public.json": openapi({
+        "/v1/public/accommodations/{id}/content": {
+          get: {
+            responses: { 200: { description: "OK" } },
+            "x-voyant-api-id": apiIds.accommodations,
+          },
+        },
+      }),
+      "openapi/storefront/quotes-proposal-public.json": openapi({
+        "/v1/public/proposals/{quoteVersionId}": {
+          get: { responses: { 200: { description: "OK" } }, "x-voyant-api-id": apiIds.quotes },
+        },
+      }),
+    })
+
+    const result = await runChecker(root)
+
+    assert.match(result.stdout, /3 covered graph API bundles, 0 allowlisted gaps/)
+  })
+
   it("rejects allowlist exceptions for opted-in bundles", async () => {
     const root = await createFixture({
       "graph.json": graph([


### PR DESCRIPTION
## Summary

- publish exact operation-level package OpenAPI registries for accommodations content, Flights, and public quote proposals
- opt the three graph API bundles into named selected-graph documents
- remove their temporary coverage allowlist entries and add checker regression coverage
- leave SmartBill and Operator compatibility files unchanged

## Coverage

- covered graph API bundles: 78 -> 81
- allowlisted gaps: 4 -> 1
- remaining gap: `@voyant-travel/plugin-smartbill#api.admin`

## Verification

- 45 focused package tests passed
- 7 selected-graph Framework tests passed
- 12 deployment graph OpenAPI checker tests passed
- scoped package and changed-file lint passed
- `git diff --check` passed

## Stack note

The full Operator OpenAPI generator reaches the known compatibility boundary: the new accommodations document duplicates the legacy Operator `accommodations` partition. That compatibility surface is intentionally excluded here and is removed by the central package-authority cutover; this PR does not modify `starters/operator`.