### PR TITLE
refactor(admin): complete selected-graph package authority

### DIFF
--- a/.changeset/clean-package-admin-authority.md
+++ b/.changeset/clean-package-admin-authority.md
@@ -1,0 +1,26 @@
+---
+"@voyant-travel/action-ledger": patch
+"@voyant-travel/admin": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/commerce-react": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/distribution-react": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/finance-react": patch
+"@voyant-travel/flights": patch
+"@voyant-travel/flights-react": patch
+"@voyant-travel/legal": patch
+"@voyant-travel/legal-react": patch
+"@voyant-travel/mice": patch
+"@voyant-travel/notifications": patch
+"@voyant-travel/notifications-react": patch
+"@voyant-travel/operations": patch
+"@voyant-travel/operations-react": patch
+"@voyant-travel/quotes": patch
+"@voyant-travel/relationships": patch
+"@voyant-travel/relationships-react": patch
+"@voyant-travel/trips": patch
+"@voyant-travel/trips-react": patch
+---
+
+Move standard first-party admin factories, package copy, slots, contributions, and icons into selected deployment graph composition.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -802,16 +802,17 @@ separate first-party admin catalog.
 
 ### Selected-graph admin bundle cutline
 
-The first Phase 4 admin slices are active for `@voyant-travel/action-ledger`,
-`@voyant-travel/mice`, and `@voyant-travel/quotes`:
+The selected-graph admin bundle is active for Action Ledger, Commerce,
+Distribution, Finance, Flights, Legal, MICE, Notifications, Operations,
+Quotes, Relationships, and Trips:
 
 - the package manifest opts its import-cheap admin extension factory into
   `admin.runtime` and retains its stable route declarations
 - project resolution emits `.voyant/admin/selected-graph-admin.generated.ts`
   from only selected units with `admin.runtime`; package page modules remain
   behind the lazy imports owned by the UI export
-- each selected package adapter owns its Operator nav-copy key and icon; Quotes
-  also owns its existing lazy route message provider
+- each selected package adapter owns its Operator nav-copy keys and icons and
+  attaches its namespaced route-message providers lazily
 - the Operator invokes the generated selected-factory composer with one generic
   localized nav-message map, and the compatibility admin generator removes the
   migrated factory from `admin.extensions.generated.ts`
@@ -823,12 +824,13 @@ The first Phase 4 admin slices are active for `@voyant-travel/action-ledger`,
   from the selected-graph bundle, duplicated in the compatibility registry, or
   present without a selected `admin.runtime` declaration
 
-This cut does not activate admin slots or contributions, generalized namespaced
-copy lowering, or deployment copy overrides. Those remain separate admin
-authorities. The Operator factory wrappers and generated registry entries for
-all other first-party packages also remain compatibility authorities until each
-package proves equivalent nav, route, page, copy, icon, and destination behavior
-through the selected graph.
+Package-owned slots and contributions are active where declared by Finance,
+Distribution, and Relationships. Deployment copy overrides and graph-generated
+copy-provider composition remain separate admin authorities. The compatibility
+registry now contains only Bookings, Catalog, and Inventory because their
+factories still receive deployment-specific page or scope overrides. Those
+overrides must move to generic local contributions before the compatibility
+registry can be deleted.
 
 ## API, OpenAPI, Scopes, And RBAC
 
@@ -1542,14 +1544,15 @@ package surfaces in `voyant#3080`.
   namespaced copy and deployment overrides
 - generate the admin bundle only from selected package exports and graph data
 
-Progress: the action-ledger, MICE, and Quotes nav/route/page factories and their
-lightweight localization/icon adapters are lowered into the selected-graph admin
-bundle. Quotes also owns its lazy route copy provider. The Operator composes
-these selected factories generically, with selection and deselection controlled
-only by the graph. Slots/contributions, generalized copy lowering, and the
-remaining first-party Operator compatibility registry are not part of this
-slice. Identity admin routes are the first package-owned selected-graph OpenAPI
-authority; other API documents remain on the Operator compatibility path.
+Progress: twelve first-party nav/route/page factories, their declared slots and
+contributions, and their lightweight localization/icon adapters are lowered
+into the selected-graph admin bundle. The Operator composes these factories
+generically, with selection and deselection controlled only by the graph.
+Bookings, Catalog, and Inventory remain in the compatibility registry until
+their deployment-specific customization points are represented as local
+contributions. Identity admin routes are the first package-owned selected-graph
+OpenAPI authority; other API documents remain on the Operator compatibility
+path.
 
 Exit: a custom package contributes a secured, documented API and complete admin
 surface without operator edits; all grants and message references validate.

--- a/packages/action-ledger/src/voyant.ts
+++ b/packages/action-ledger/src/voyant.ts
@@ -29,7 +29,7 @@ export const actionLedgerVoyantModule = defineModule({
     },
   ],
   admin: {
-    compositionOrder: 30,
+    compositionOrder: 120,
     runtime: {
       entry: "@voyant-travel/action-ledger-react/admin",
       export: "createSelectedActionLedgerAdminExtension",

--- a/packages/admin/src/admin-route-messages.ts
+++ b/packages/admin/src/admin-route-messages.ts
@@ -1,0 +1,49 @@
+import type * as React from "react"
+
+import type {
+  AdminExtension,
+  AdminRouteMessagesProvider,
+  AdminRouteMessagesProviderModule,
+  AdminUiRouteContribution,
+} from "./extensions.js"
+
+export type AdminRouteMessagesProviderLoader = () => Promise<AdminRouteMessagesProviderModule>
+
+/** Attach one lazy package-copy provider to every rendered route in an extension. */
+export function withAdminRouteMessagesProvider(
+  extension: AdminExtension,
+  routeMessagesProvider: AdminRouteMessagesProviderLoader,
+): AdminExtension {
+  const apply = (route: AdminUiRouteContribution): AdminUiRouteContribution => ({
+    ...route,
+    ...(route.redirectTo
+      ? {}
+      : { routeMessagesProvider: route.routeMessagesProvider ?? routeMessagesProvider }),
+    ...(route.children ? { children: route.children.map(apply) } : {}),
+  })
+
+  return {
+    ...extension,
+    ...(extension.routes ? { routes: extension.routes.map(apply) } : {}),
+  }
+}
+
+/** Compose package-copy providers without pulling React or message tables into shell chrome. */
+export function composeAdminRouteMessagesProviders(
+  ...loaders: readonly AdminRouteMessagesProviderLoader[]
+): AdminRouteMessagesProviderLoader {
+  return async () => {
+    const [{ createElement }, ...modules] = await Promise.all([
+      import("react"),
+      ...loaders.map((load) => load()),
+    ])
+    const providers = modules.map((module) => module.default)
+    const ComposedProvider: AdminRouteMessagesProvider = ({ children, locale }) =>
+      providers.reduceRight<React.ReactNode>(
+        (content, Provider) => createElement(Provider, { children: content, locale }),
+        children,
+      )
+
+    return { default: ComposedProvider }
+  }
+}

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -21,6 +21,11 @@
  */
 
 export {
+  type AdminRouteMessagesProviderLoader,
+  composeAdminRouteMessagesProviders,
+  withAdminRouteMessagesProvider,
+} from "./admin-route-messages.js"
+export {
   type AdminBreadcrumbSegment,
   AdminBreadcrumbsProvider,
   type AdminBreadcrumbsProviderProps,

--- a/packages/admin/tests/unit/extensions.test.tsx
+++ b/packages/admin/tests/unit/extensions.test.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from "react"
 import { describe, expect, it } from "vitest"
 
+import { withAdminRouteMessagesProvider } from "../../src/admin-route-messages.js"
 import {
   type AdminExtension,
   defineAdminExtension,
@@ -131,5 +133,36 @@ describe("admin extensions", () => {
 
     expect(findAdminRouteContribution(extension.routes, "core-settings-team")?.path).toBe("/team")
     expect(requireImplementedAdminRoute(extension, "core-settings-index").redirectTo).toBe("/x")
+  })
+
+  it("attaches package copy lazily to rendered nested routes", () => {
+    const provider = async () => ({ default: ({ children }: { children: ReactNode }) => children })
+    const extension = withAdminRouteMessagesProvider(
+      defineAdminExtension({
+        id: "reports",
+        routes: [
+          { id: "index", path: "/reports", title: "Reports", redirectTo: "/reports/all" },
+          {
+            id: "layout",
+            path: "/reports/all",
+            title: "Reports",
+            page: async () => ({ default: () => null }),
+            children: [
+              {
+                id: "detail",
+                path: "/$id",
+                title: "Report",
+                page: async () => ({ default: () => null }),
+              },
+            ],
+          },
+        ],
+      }),
+      provider,
+    )
+
+    expect(extension.routes?.[0]?.routeMessagesProvider).toBeUndefined()
+    expect(extension.routes?.[1]?.routeMessagesProvider).toBe(provider)
+    expect(extension.routes?.[1]?.children?.[0]?.routeMessagesProvider).toBe(provider)
   })
 })

--- a/packages/commerce-react/src/admin.ts
+++ b/packages/commerce-react/src/admin.ts
@@ -4,7 +4,10 @@ import {
   adminRoutePageModule,
   defineAdminExtension,
   type NavItem,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
+import { Tag } from "lucide-react"
 
 export {
   type CreatePromotionsAdminExtensionOptions,
@@ -58,4 +61,20 @@ export function createCommerceAdminExtension(
       },
     ],
   })
+}
+
+export function createSelectedCommerceAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createCommerceAdminExtension({
+      labels: { promotions: navMessages.promotions },
+      icon: Tag,
+      order: 50,
+    }),
+    () =>
+      import("./promotions/i18n/index.js").then((module) => ({
+        default: module.PromotionsUiMessagesProvider,
+      })),
+  )
 }

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -162,6 +162,11 @@ export const commerceVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 80,
+    runtime: {
+      entry: "@voyant-travel/commerce-react/admin",
+      export: "createSelectedCommerceAdminExtension",
+    },
     copy: [
       {
         id: "@voyant-travel/commerce#admin.copy.promotions",

--- a/packages/distribution-react/src/admin/index.tsx
+++ b/packages/distribution-react/src/admin/index.tsx
@@ -3,7 +3,10 @@ import {
   type AdminRouteLoaderContext,
   type AdminRouteRuntime,
   adminRoutePageModule,
+  composeAdminRouteMessagesProviders,
   defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
 
 import {
@@ -115,4 +118,29 @@ export function createDistributionAdminExtension(
 
 function loaderClient(runtime: AdminRouteRuntime) {
   return { baseUrl: runtime.baseUrl, fetcher: runtime.fetcher ?? defaultFetcher }
+}
+
+const distributionRouteMessagesProvider = composeAdminRouteMessagesProviders(
+  () =>
+    import("../i18n/index.js").then((module) => ({
+      default: module.DistributionUiMessagesProvider,
+    })),
+  () =>
+    import("../suppliers/i18n/index.js").then((module) => ({
+      default: module.SuppliersUiMessagesProvider,
+    })),
+)
+
+export function createSelectedDistributionAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createDistributionAdminExtension({
+      labels: {
+        channelSync: navMessages.channelSync,
+        suppliers: navMessages.suppliers,
+      },
+    }),
+    distributionRouteMessagesProvider,
+  )
 }

--- a/packages/distribution/src/voyant.ts
+++ b/packages/distribution/src/voyant.ts
@@ -72,6 +72,11 @@ export const distributionVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 30,
+    runtime: {
+      entry: "@voyant-travel/distribution-react/admin",
+      export: "createSelectedDistributionAdminExtension",
+    },
     copy: [
       {
         id: "@voyant-travel/distribution#admin.copy",

--- a/packages/finance-react/src/admin/index.tsx
+++ b/packages/finance-react/src/admin/index.tsx
@@ -4,6 +4,8 @@ import {
   type AdminWidgetContribution,
   adminRoutePageModule,
   defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
 // Importing the slot id also binds the bookings-ui `AdminDestinations`
 // augmentation (`booking.detail`, `person.detail`, `organization.detail`,
@@ -408,4 +410,24 @@ export function createFinanceAdminExtension(
       } satisfies AdminWidgetContribution,
     ],
   })
+}
+
+export function createSelectedFinanceAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createFinanceAdminExtension({
+      labels: {
+        invoices: navMessages.invoices,
+        invoiceNumberSeries: navMessages.invoiceNumberSeries,
+        payments: navMessages.payments,
+        supplierInvoices: navMessages.supplierInvoices,
+        profitability: navMessages.profitability,
+      },
+    }),
+    () =>
+      import("../i18n/index.js").then((module) => ({
+        default: module.FinanceUiMessagesProvider,
+      })),
+  )
 }

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -146,6 +146,22 @@ export const financeVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 40,
+    runtime: {
+      entry: "@voyant-travel/finance-react/admin",
+      export: "createSelectedFinanceAdminExtension",
+    },
+    copy: [
+      {
+        id: "@voyant-travel/finance#admin.copy",
+        namespace: "finance.admin",
+        fallbackLocale: "en",
+        runtime: {
+          entry: "@voyant-travel/finance-react/i18n",
+          export: "financeUiMessageDefinitions",
+        },
+      },
+    ],
     routes: (
       [
         ["index", "/finance"],

--- a/packages/flights-react/src/admin/index.tsx
+++ b/packages/flights-react/src/admin/index.tsx
@@ -1,4 +1,9 @@
-import { type AdminExtension, defineAdminExtension } from "@voyant-travel/admin"
+import {
+  type AdminExtension,
+  defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
+} from "@voyant-travel/admin"
 import type { CabinClass } from "@voyant-travel/flights/contract/types"
 import { z } from "zod"
 
@@ -211,4 +216,14 @@ export function createFlightsAdminExtension(
       },
     ],
   })
+}
+
+export function createSelectedFlightsAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createFlightsAdminExtension({ labels: { flights: navMessages.flights } }),
+    () =>
+      import("../i18n/index.js").then((module) => ({ default: module.FlightsUiMessagesProvider })),
+  )
 }

--- a/packages/flights/src/voyant.ts
+++ b/packages/flights/src/voyant.ts
@@ -32,6 +32,11 @@ export const flightsVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 50,
+    runtime: {
+      entry: "@voyant-travel/flights-react/admin",
+      export: "createSelectedFlightsAdminExtension",
+    },
     copy: [
       {
         id: "@voyant-travel/flights#admin.copy",

--- a/packages/legal-react/src/admin/index.tsx
+++ b/packages/legal-react/src/admin/index.tsx
@@ -4,6 +4,8 @@ import {
   type AdminRouteRuntime,
   adminRoutePageModule,
   defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
 // Type-only: binds the bookings-ui `AdminDestinations` augmentation
 // (`booking.detail`, `person.detail`, `organization.detail`, ...) into this
@@ -312,4 +314,21 @@ export function createLegalAdminExtension(
       },
     ],
   })
+}
+
+export function createSelectedLegalAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createLegalAdminExtension({
+      labels: {
+        contracts: navMessages.contracts,
+        contractTemplates: navMessages.contractTemplates,
+        policies: navMessages.policies,
+        numberSeries: navMessages.contractNumberSeries,
+      },
+    }),
+    () =>
+      import("../i18n/index.js").then((module) => ({ default: module.LegalUiMessagesProvider })),
+  )
 }

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -83,6 +83,22 @@ export const legalVoyantModule = defineModule({
     ],
   },
   admin: {
+    compositionOrder: 60,
+    runtime: {
+      entry: "@voyant-travel/legal-react/admin",
+      export: "createSelectedLegalAdminExtension",
+    },
+    copy: [
+      {
+        id: "@voyant-travel/legal#admin.copy",
+        namespace: "legal.admin",
+        fallbackLocale: "en",
+        runtime: {
+          entry: "@voyant-travel/legal-react/i18n",
+          export: "legalUiMessageDefinitions",
+        },
+      },
+    ],
     routes: (
       [
         ["index", "/legal"],

--- a/packages/mice/src/voyant.ts
+++ b/packages/mice/src/voyant.ts
@@ -47,7 +47,7 @@ export const miceVoyantModule = defineModule({
     },
   ],
   admin: {
-    compositionOrder: 20,
+    compositionOrder: 110,
     runtime: {
       entry: "@voyant-travel/mice-react/admin",
       export: "createSelectedMiceAdminExtension",

--- a/packages/notifications-react/src/admin/index.tsx
+++ b/packages/notifications-react/src/admin/index.tsx
@@ -2,6 +2,8 @@ import {
   type AdminExtension,
   adminRoutePageModule,
   defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
 
 /**
@@ -180,4 +182,25 @@ export function createNotificationsAdminExtension(
       },
     ],
   })
+}
+
+export function createSelectedNotificationsAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createNotificationsAdminExtension({
+      labels: {
+        templates: navMessages.notificationTemplates,
+        reminderRules: navMessages.notificationReminderRules,
+        deliveries: navMessages.notificationDeliveries,
+        reminderRuns: navMessages.notificationReminderRuns,
+        preview: navMessages.notificationPreview,
+        settings: navMessages.notificationSettings,
+      },
+    }),
+    () =>
+      import("../i18n/index.js").then((module) => ({
+        default: module.NotificationsUiMessagesProvider,
+      })),
+  )
 }

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -142,6 +142,44 @@ export const notificationsVoyantModule = defineModule({
       requiredScopes: ["notifications:send"],
     },
   ],
+  admin: {
+    compositionOrder: 70,
+    runtime: {
+      entry: "@voyant-travel/notifications-react/admin",
+      export: "createSelectedNotificationsAdminExtension",
+    },
+    copy: [
+      {
+        id: "@voyant-travel/notifications#admin.copy",
+        namespace: "notifications.admin",
+        fallbackLocale: "en",
+        runtime: {
+          entry: "@voyant-travel/notifications-react/i18n",
+          export: "notificationsUiMessageDefinitions",
+        },
+      },
+    ],
+    routes: (
+      [
+        ["index", "/notifications"],
+        ["templates-index", "/notifications/templates"],
+        ["templates-detail", "/notifications/templates/$id"],
+        ["reminder-rules-index", "/notifications/reminder-rules"],
+        ["reminder-rules-detail", "/notifications/reminder-rules/$id"],
+        ["deliveries", "/notifications/deliveries"],
+        ["reminder-runs", "/notifications/reminder-runs"],
+        ["preview", "/notifications/preview"],
+        ["settings", "/notifications/settings"],
+      ] as const
+    ).map(([id, path]) => ({
+      id: `@voyant-travel/notifications#admin.route.${id}`,
+      path,
+      runtime: {
+        entry: "@voyant-travel/notifications-react/admin",
+        export: "createNotificationsAdminExtension",
+      },
+    })),
+  },
   lifecycle: {
     uninstall: { default: "retain-data", purge: "not-supported" },
   },

--- a/packages/operations-react/src/admin.ts
+++ b/packages/operations-react/src/admin.ts
@@ -3,7 +3,10 @@ import {
   type AdminRouteLoaderContext,
   type AdminRouteRuntime,
   adminRoutePageModule,
+  composeAdminRouteMessagesProviders,
   defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
 import type {} from "@voyant-travel/bookings-react/admin"
 
@@ -262,4 +265,33 @@ function availabilityLoaderClient(runtime: AdminRouteRuntime) {
 
 function resourcesLoaderClient(runtime: AdminRouteRuntime) {
   return { baseUrl: runtime.baseUrl, fetcher: runtime.fetcher ?? resourcesDefaultFetcher }
+}
+
+const operationsRouteMessagesProvider = composeAdminRouteMessagesProviders(
+  () =>
+    import("./availability/i18n/index.js").then((module) => ({
+      default: module.AvailabilityUiMessagesProvider,
+    })),
+  () =>
+    import("./availability/allocation/i18n/index.js").then((module) => ({
+      default: module.AllocationUiMessagesProvider,
+    })),
+  () =>
+    import("./resources/i18n/index.js").then((module) => ({
+      default: module.ResourcesUiMessagesProvider,
+    })),
+)
+
+export function createSelectedOperationsAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createOperationsAdminExtension({
+      labels: {
+        availability: navMessages.availability,
+        resources: navMessages.resources,
+      },
+    }),
+    operationsRouteMessagesProvider,
+  )
 }

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -63,6 +63,11 @@ export const operationsVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 10,
+    runtime: {
+      entry: "@voyant-travel/operations-react/admin",
+      export: "createSelectedOperationsAdminExtension",
+    },
     copy: [
       {
         id: "@voyant-travel/operations#admin.copy.availability",

--- a/packages/quotes/src/voyant.ts
+++ b/packages/quotes/src/voyant.ts
@@ -111,7 +111,7 @@ export const quotesVoyantModule = defineModule({
     },
   ],
   admin: {
-    compositionOrder: 10,
+    compositionOrder: 100,
     runtime: {
       entry: "@voyant-travel/quotes-react/admin",
       export: "createSelectedQuotesAdminExtension",

--- a/packages/relationships-react/src/admin/index.tsx
+++ b/packages/relationships-react/src/admin/index.tsx
@@ -4,6 +4,8 @@ import {
   type AdminRouteRuntime,
   adminRoutePageModule,
   defineAdminExtension,
+  type SelectedAdminExtensionFactoryContext,
+  withAdminRouteMessagesProvider,
 } from "@voyant-travel/admin"
 
 // Lean statics only: the client module (fetcher) and the skeletons. Query
@@ -222,4 +224,21 @@ export function createRelationshipsAdminExtension(
  */
 function loaderClient(runtime: AdminRouteRuntime) {
   return { baseUrl: runtime.baseUrl, fetcher: runtime.fetcher ?? defaultFetcher }
+}
+
+const relationshipsRouteMessagesProvider = () =>
+  import("../i18n/index.js").then((module) => ({ default: module.CrmUiMessagesProvider }))
+
+export function createSelectedRelationshipsAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return withAdminRouteMessagesProvider(
+    createRelationshipsAdminExtension({
+      labels: {
+        people: navMessages.people,
+        organizations: navMessages.organizations,
+      },
+    }),
+    relationshipsRouteMessagesProvider,
+  )
 }

--- a/packages/relationships/src/voyant.ts
+++ b/packages/relationships/src/voyant.ts
@@ -121,6 +121,22 @@ export const relationshipsVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 20,
+    runtime: {
+      entry: "@voyant-travel/relationships-react/admin",
+      export: "createSelectedRelationshipsAdminExtension",
+    },
+    copy: [
+      {
+        id: "@voyant-travel/relationships#admin.copy",
+        namespace: "relationships.admin",
+        fallbackLocale: "en",
+        runtime: {
+          entry: "@voyant-travel/relationships-react/i18n",
+          export: "crmUiMessageDefinitions",
+        },
+      },
+    ],
     routes: [
       {
         id: "@voyant-travel/relationships#admin.route.people-index",

--- a/packages/trips-react/src/admin/index.tsx
+++ b/packages/trips-react/src/admin/index.tsx
@@ -5,6 +5,7 @@ import {
   adminRoutePageModule,
   defineAdminExtension,
   type NavItem,
+  type SelectedAdminExtensionFactoryContext,
 } from "@voyant-travel/admin"
 // Type-only: binds the bookings-react `AdminDestinations` augmentation
 // (`booking.detail`, `person.detail`, ...) into this program — the trip
@@ -12,6 +13,7 @@ import {
 // those shared keys, and `booking.detail`'s shape carries bookings-react's
 // own tab union, so re-declaring it here could not stay shape-identical.
 import type {} from "@voyant-travel/bookings-react/admin"
+import { Route } from "lucide-react"
 
 // Lean static only: the client module (fetcher). Query options resolve via
 // dynamic import inside the loaders so the trips data layer
@@ -181,4 +183,17 @@ export function createTripsAdminExtension(
  */
 function loaderClient(runtime: AdminRouteRuntime) {
   return { baseUrl: runtime.baseUrl, fetcher: runtime.fetcher ?? defaultFetcher }
+}
+
+export function createSelectedTripsAdminExtension({
+  navMessages,
+}: SelectedAdminExtensionFactoryContext): AdminExtension {
+  return createTripsAdminExtension({
+    labels: {
+      trips: navMessages.trips,
+      allTrips: navMessages.allTrips,
+      newTrip: navMessages.newTrip,
+    },
+    icon: Route,
+  })
 }

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -132,6 +132,11 @@ export const tripsVoyantModule = defineModule({
     },
   ],
   admin: {
+    compositionOrder: 90,
+    runtime: {
+      entry: "@voyant-travel/trips-react/admin",
+      export: "createSelectedTripsAdminExtension",
+    },
     routes: [
       {
         id: "@voyant-travel/trips#admin.route.trips-index",

--- a/starters/operator/src/admin.extensions.generated.ts
+++ b/starters/operator/src/admin.extensions.generated.ts
@@ -4,16 +4,7 @@
 
 import { createBookingsAdminExtension } from "@voyant-travel/bookings-react/admin"
 import { createCatalogAdminExtension } from "@voyant-travel/catalog-react/admin"
-import { createCommerceAdminExtension } from "@voyant-travel/commerce-react/admin"
-import { createDistributionAdminExtension } from "@voyant-travel/distribution-react/admin"
-import { createFinanceAdminExtension } from "@voyant-travel/finance-react/admin"
-import { createFlightsAdminExtension } from "@voyant-travel/flights-react/admin"
 import { createInventoryAdminExtension } from "@voyant-travel/inventory-react/admin"
-import { createLegalAdminExtension } from "@voyant-travel/legal-react/admin"
-import { createNotificationsAdminExtension } from "@voyant-travel/notifications-react/admin"
-import { createOperationsAdminExtension } from "@voyant-travel/operations-react/admin"
-import { createRelationshipsAdminExtension } from "@voyant-travel/relationships-react/admin"
-import { createTripsAdminExtension } from "@voyant-travel/trips-react/admin"
 
 /**
  * Admin extension factories keyed by module domain. Factories, not
@@ -23,14 +14,5 @@ import { createTripsAdminExtension } from "@voyant-travel/trips-react/admin"
 export const generatedAdminExtensionFactories = {
   bookings: createBookingsAdminExtension,
   catalog: createCatalogAdminExtension,
-  commerce: createCommerceAdminExtension,
-  distribution: createDistributionAdminExtension,
-  finance: createFinanceAdminExtension,
-  flights: createFlightsAdminExtension,
   inventory: createInventoryAdminExtension,
-  legal: createLegalAdminExtension,
-  notifications: createNotificationsAdminExtension,
-  operations: createOperationsAdminExtension,
-  relationships: createRelationshipsAdminExtension,
-  trips: createTripsAdminExtension,
 } as const

--- a/starters/operator/src/deployment-graph-artifacts.test.ts
+++ b/starters/operator/src/deployment-graph-artifacts.test.ts
@@ -99,6 +99,7 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
       }),
       expect.objectContaining({
         eventType: "booking.confirmed",
+        id: "@voyant-travel/distribution#subscriber.channel-push-booking-confirmed",
         runtime: {
           entry: "./channel-push-subscribers",
           export: "channelPushBookingConfirmedSubscriber",
@@ -155,7 +156,7 @@ describe("loadOperatorDeploymentGraphArtifacts", () => {
     expect(notifications?.subscribers).toEqual([
       expect.objectContaining({
         id: "@voyant-travel/notifications#subscriber.booking-confirmation-auto-dispatch",
-        eventType: "booking.confirmed",
+        eventType: "booking.contract.generated",
       }),
       expect.objectContaining({
         id: "@voyant-travel/notifications#subscriber.reminder-booking-cancelled",

--- a/starters/operator/src/lib/admin-extensions.tsx
+++ b/starters/operator/src/lib/admin-extensions.tsx
@@ -13,7 +13,7 @@ import {
 import { createAdminCoreExtension } from "@voyant-travel/admin-app/core-extension"
 import { createOperatorProfileSettingsExtraPage } from "@voyant-travel/operator-settings-react/settings"
 import { Button } from "@voyant-travel/ui/components/button"
-import { Route, SlidersHorizontal, Tag } from "lucide-react"
+import { Route, SlidersHorizontal } from "lucide-react"
 import { generatedAdminExtensionFactories } from "@/admin.extensions.generated"
 import type { AdminMessages } from "@/lib/admin-i18n"
 import { effectiveAccessCatalog } from "../../.voyant/access/selected-access-catalog.generated"
@@ -133,41 +133,13 @@ const distributionMessagesProvider = loadProvider(
   () => import("@voyant-travel/distribution-react/i18n"),
   (module) => module.DistributionUiMessagesProvider,
 )
-const suppliersMessagesProvider = loadProvider(
-  () => import("@voyant-travel/distribution-react/suppliers/i18n"),
-  (module) => module.SuppliersUiMessagesProvider,
-)
 const financeMessagesProvider = loadProvider(
   () => import("@voyant-travel/finance-react/i18n"),
   (module) => module.FinanceUiMessagesProvider,
 )
-const flightsMessagesProvider = loadProvider(
-  () => import("@voyant-travel/flights-react/i18n"),
-  (module) => module.FlightsUiMessagesProvider,
-)
 const productsMessagesProvider = loadProvider(
   () => import("@voyant-travel/inventory-react/i18n"),
   (module) => module.ProductsUiMessagesProvider,
-)
-const legalMessagesProvider = loadProvider(
-  () => import("@voyant-travel/legal-react/i18n"),
-  (module) => module.LegalUiMessagesProvider,
-)
-const notificationsMessagesProvider = loadProvider(
-  () => import("@voyant-travel/notifications-react/i18n"),
-  (module) => module.NotificationsUiMessagesProvider,
-)
-const allocationMessagesProvider = loadProvider(
-  () => import("@voyant-travel/operations-react/availability/allocation/i18n"),
-  (module) => module.AllocationUiMessagesProvider,
-)
-const availabilityMessagesProvider = loadProvider(
-  () => import("@voyant-travel/operations-react/availability/i18n"),
-  (module) => module.AvailabilityUiMessagesProvider,
-)
-const resourcesMessagesProvider = loadProvider(
-  () => import("@voyant-travel/operations-react/resources/i18n"),
-  (module) => module.ResourcesUiMessagesProvider,
 )
 const crmMessagesProvider = loadProvider(
   () => import("@voyant-travel/relationships-react/i18n"),
@@ -180,20 +152,6 @@ const bookingRouteMessagesProvider = composeProviderLoaders(
   productsMessagesProvider,
   catalogMessagesProvider,
 )
-const distributionRouteMessagesProvider = composeProviderLoaders(
-  distributionMessagesProvider,
-  suppliersMessagesProvider,
-)
-const operationsRouteMessagesProvider = composeProviderLoaders(
-  availabilityMessagesProvider,
-  allocationMessagesProvider,
-  resourcesMessagesProvider,
-)
-const relationshipsRouteMessagesProvider = composeProviderLoaders(
-  crmMessagesProvider,
-  bookingsMessagesProvider,
-)
-
 const coreRouteMessagesProviders: Record<string, RouteMessagesProviderLoader | undefined> = {
   "core-account": authMessagesProvider,
   "core-settings-api-tokens": authMessagesProvider,
@@ -210,15 +168,7 @@ const coreRouteMessagesProviders: Record<string, RouteMessagesProviderLoader | u
 const extensionRouteMessagesProviders: Record<string, RouteMessagesProviderLoader | undefined> = {
   bookings: bookingRouteMessagesProvider,
   catalog: catalogMessagesProvider,
-  commerce: commerceMessagesProvider,
-  distribution: distributionRouteMessagesProvider,
-  finance: financeMessagesProvider,
-  flights: flightsMessagesProvider,
   inventory: productsMessagesProvider,
-  legal: legalMessagesProvider,
-  notifications: notificationsMessagesProvider,
-  operations: operationsRouteMessagesProvider,
-  relationships: relationshipsRouteMessagesProvider,
 }
 
 function withRouteMessagesProvider(
@@ -332,20 +282,6 @@ function createCoreExtension() {
   })
 }
 
-// Operations is package-delivered (packaged-admin RFC Phase 3): the owner
-// extension contributes NO navigation — Availability and Resources remain
-// base operator navigation items. The owner admin entry contributes the
-// availability and resource-planning route metadata under
-// /operations/availability and /operations/resources.
-function createOperationsExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.operations({
-    labels: {
-      availability: messages.availability,
-      resources: messages.resources,
-    },
-  })
-}
-
 // App-owned header action on the package-delivered bookings list: composing
 // a trip is an operator concept (the trips pages are app-custom),
 // so the button rides in through the extension factory's
@@ -415,139 +351,6 @@ function createCatalogExtension(messages: AdminExtensionNavMessages) {
   })
 }
 
-// Finance is package-delivered (packaged-admin RFC Phase 3): the extension
-// contributes NO navigation — the Finance group is part of the BASE operator
-// navigation (createOperatorAdminNavigation in @voyant-travel/admin), so entries
-// here would duplicate it. It's registered for the routes seam (metadata for
-// the finance pages; the detail pages are the packaged hosts from
-// @voyant-travel/finance-react/admin) AND for the widgets seam: it contributes the
-// finance-owned booking invoices card on booking UI's
-// `booking.details.invoices-tab` slot — the finance-ui ↔ booking UI cycle
-// resolution (finance-ui depends on booking UI, so the bookings host can't
-// import the card; the widget contribution travels the other way).
-function createFinanceExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.finance({
-    labels: {
-      invoices: messages.invoices,
-      invoiceNumberSeries: messages.invoiceNumberSeries,
-      payments: messages.payments,
-      supplierInvoices: messages.supplierInvoices,
-      profitability: messages.profitability,
-    },
-  })
-}
-
-// Flights is package-delivered (packaged-admin RFC Phase 3 + §4.8): the
-// extension contributes NO navigation — the Flights item is part of the BASE
-// operator navigation (createOperatorAdminNavigation in @voyant-travel/admin), so
-// an entry here would duplicate it. It's registered for the routes seam: the
-// contributions carry the package-owned route implementations + search
-// contracts (flightsIndexSearchSchema / flightsBookSearchSchema), and the
-// host assembles them into its code-based route tree — no route files. The
-// booking wizard mounts as a flat sibling of the search page (the old
-// file-based tree's `flights_.book` escape), and its hand-written
-// `flightBooking.start` resolver lives in src/lib/admin-destinations.ts.
-function createFlightsExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.flights({ labels: { flights: messages.flights } })
-}
-
-// Distribution is package-delivered (packaged-admin RFC Phase 3 + §4.8): the
-// extension contributes NO navigation — the Distribution item is part of the
-// BASE operator navigation (createOperatorAdminNavigation in
-// @voyant-travel/admin), so an entry here would duplicate it. It's registered for
-// the routes seam: the contribution carries the package-owned channel-sync
-// page (no search contract — the page keeps its filters local), and the host
-// assembles it into its code-based route tree — no route file.
-function createDistributionExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.distribution({
-    labels: { channelSync: messages.channelSync, suppliers: messages.suppliers },
-  })
-}
-
-// Relationships is package-delivered (packaged-admin RFC Phase 3): the extension
-// contributes NO navigation — the People and Organizations items are part of
-// the BASE operator navigation (createOperatorAdminNavigation in
-// @voyant-travel/admin), so entries here would duplicate them. It's registered
-// for the routes seam (metadata for the people/organization pages; the pages
-// are the packaged hosts from @voyant-travel/relationships-react/admin — the route files under
-// src/routes/_workspace/people/* and src/routes/_workspace/organizations/*
-// only bind route params onto them). The person detail page's Bookings tab
-// is the relationships-ui ↔ booking UI cycle resolution: booking UI contributes its
-// PersonBookingsWidget on relationships-ui's `person.details.bookings-tab` slot.
-function createRelationshipsExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.relationships({
-    labels: {
-      people: messages.people,
-      organizations: messages.organizations,
-    },
-  })
-}
-
-// Legal is package-delivered (packaged-admin RFC Phase 3): the extension
-// contributes NO navigation — the Legal group is part of the BASE operator
-// navigation (createOperatorAdminNavigation in @voyant-travel/admin), so entries
-// here would duplicate it. It's registered for the routes seam: the
-// contributions carry the package-owned route metadata (the legal pages keep
-// their filter state component-local, so there are no URL search contracts),
-// and the pages are the packaged hosts from @voyant-travel/legal-react/admin — the
-// route files under src/routes/_workspace/legal/* only bind route params
-// onto them.
-function createLegalExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.legal({
-    labels: {
-      contracts: messages.contracts,
-      contractTemplates: messages.contractTemplates,
-      policies: messages.policies,
-      numberSeries: messages.contractNumberSeries,
-    },
-  })
-}
-
-// Notifications is package-delivered (packaged-admin RFC Phase 3): the
-// extension contributes NO navigation — the Notifications group is part of
-// the BASE operator navigation (createOperatorAdminNavigation in
-// @voyant-travel/admin), so entries here would duplicate it. It's registered for
-// the routes seam: the contributions carry the package-owned route metadata
-// (the notifications pages keep their filter state component-local, so
-// there are no URL search contracts), and the pages are the packaged hosts
-// from @voyant-travel/notifications-react/admin — the route files under
-// src/routes/_workspace/notifications/* only bind route params onto them.
-function createNotificationsExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.notifications({
-    labels: {
-      templates: messages.notificationTemplates,
-      reminderRules: messages.notificationReminderRules,
-      deliveries: messages.notificationDeliveries,
-      reminderRuns: messages.notificationReminderRuns,
-      preview: messages.notificationPreview,
-      settings: messages.notificationSettings,
-    },
-  })
-}
-
-// Suppliers is package-delivered (packaged-admin RFC Phase 3): the extension
-// contributes NO navigation — the Suppliers item is part of the BASE operator
-// navigation (createOperatorAdminNavigation in @voyant-travel/admin), so an entry
-// here would duplicate it. It's registered for the routes seam: the
-// contributions carry the package-owned route metadata (no search contracts —
-// the list keeps its filters local), and the pages are the packaged hosts
-// from @voyant-travel/distribution-react/suppliers/admin — the route files under
-// src/routes/_workspace/suppliers/* only bind route params onto them. The
-// detail page's customer-payment-policy card arrives via finance-ui's widget
-// contribution on `supplier.details.payment-policy` (the finance-ui ↔
-// suppliers-ui cycle resolution).
-// Promotions is package-delivered (packaged-admin RFC Phase 2): nav AND the
-// route implementation come from @voyant-travel/commerce-react/promotions/admin. The app only
-// supplies the localized label and icon. Order 50 nudges it past the default
-// admin items so it lands alongside the operator's commercial tools.
-function createPromotionsExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.commerce({
-    labels: { promotions: messages.promotions },
-    icon: Tag,
-    order: 50,
-  })
-}
-
 // Products is package-delivered (packaged-admin RFC Phase 3): the extension
 // contributes NO navigation — the Products item (with its Categories
 // sub-item) is part of the BASE operator navigation
@@ -569,23 +372,6 @@ function createProductsExtension(messages: AdminExtensionNavMessages) {
       import("@/components/voyant/products/product-detail-page").then((module) => ({
         default: module.ProductDetailPage,
       })),
-  })
-}
-
-// Trips is package-delivered (packaged-admin RFC Phase 2): nav AND
-// the route implementations come from @voyant-travel/trips-react/admin —
-// the Trips group (spliced after Bookings via `insertAfter`, with All trips /
-// New trip sub-items), the trips list, and the detail page whose Edit mode
-// lazy-mounts the packaged trips. The app only supplies the localized
-// labels and the icon.
-function createTripsExtension(messages: AdminExtensionNavMessages) {
-  return generatedAdminExtensionFactories.trips({
-    labels: {
-      trips: messages.trips,
-      allTrips: messages.allTrips,
-      newTrip: messages.newTrip,
-    },
-    icon: Route,
   })
 }
 
@@ -648,18 +434,9 @@ export function createOperatorAdminExtensions(
   return withOperatorRouteMessagesProviders(
     createAdminExtensionRegistry(
       createCoreExtension(),
-      createOperationsExtension(messages),
       createBookingsExtension(messages),
       createCatalogExtension(messages),
       createProductsExtension(messages),
-      createRelationshipsExtension(messages),
-      createDistributionExtension(messages),
-      createFinanceExtension(messages),
-      createFlightsExtension(messages),
-      createLegalExtension(messages),
-      createNotificationsExtension(messages),
-      createPromotionsExtension(messages),
-      createTripsExtension(messages),
       ...createSelectedGraphAdminExtensions({ navMessages: messages }),
       ...discoveredAdminExtensions,
     ),

--- a/starters/operator/src/selected-graph-action-ledger-admin.test.ts
+++ b/starters/operator/src/selected-graph-action-ledger-admin.test.ts
@@ -1,5 +1,5 @@
 import { operatorAdminNavMessages } from "@voyant-travel/i18n"
-import { ScrollText } from "lucide-react"
+import { Route, ScrollText, Tag } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
 import {
@@ -18,7 +18,25 @@ describe("selected-graph Action Ledger admin composition", () => {
       createSelectedGraphAdminExtensions({ navMessages: operatorAdminNavMessages.en.nav }).map(
         ({ id }) => id,
       ),
-    ).toEqual(["quotes", "mice", "action-ledger"])
+    ).toEqual([
+      "operations",
+      "relationships",
+      "distribution",
+      "finance",
+      "flights",
+      "legal",
+      "notifications",
+      "commerce",
+      "trips",
+      "quotes",
+      "mice",
+      "action-ledger",
+    ])
+    expect(Object.keys(generatedAdminExtensionFactories)).toEqual([
+      "bookings",
+      "catalog",
+      "inventory",
+    ])
   })
 
   it("preserves localized navigation, route copy, and icon behavior", () => {
@@ -49,5 +67,36 @@ describe("selected-graph Action Ledger admin composition", () => {
         ssr: "data-only",
       },
     ])
+  })
+
+  it("keeps migrated copy providers and icons package-owned", () => {
+    const extensions = createSelectedGraphAdminExtensions({
+      navMessages: operatorAdminNavMessages.ro.nav,
+    })
+
+    for (const id of [
+      "operations",
+      "relationships",
+      "distribution",
+      "finance",
+      "flights",
+      "legal",
+      "notifications",
+      "commerce",
+    ]) {
+      const renderedRoutes = extensions
+        .find((extension) => extension.id === id)
+        ?.routes?.filter((route) => !route.redirectTo)
+      expect(renderedRoutes?.length, id).toBeGreaterThan(0)
+      expect(
+        renderedRoutes?.every((route) => route.routeMessagesProvider),
+        id,
+      ).toBe(true)
+    }
+
+    expect(extensions.find(({ id }) => id === "commerce")?.navigation?.[0]?.items[0]?.icon).toBe(
+      Tag,
+    )
+    expect(extensions.find(({ id }) => id === "trips")?.navigation?.[0]?.items[0]?.icon).toBe(Route)
   })
 })


### PR DESCRIPTION
## Summary
- move Operations, Relationships, Distribution, Finance, Flights, Legal, Notifications, Commerce, and Trips admin factories into selected-graph composition
- move lazy package copy providers, icons, declared slots, and contributions package-side
- reduce the generated Operator compatibility registry to Bookings, Catalog, and Inventory
- document the remaining generic-contribution cutline and add a changeset

## Verification
- 102 focused package/admin tests passed
- 28 Operator selected-graph and artifact tests passed
- `pnpm verify:admin-composition-drift`
- `pnpm lint:changed`
- `pnpm verify:agent-quality:changed`
- `git diff --check`

Full React typecheck exceeded the local Node heap and is delegated to CI. The broader architecture suite reaches the existing Trips subscriber authority failure after all admin-specific gates pass.

## Exact remainder
- Bookings: app header action and detail-page substitution
- Catalog: deployment scope/default overrides
- Inventory: app detail-page substitution

Those three must become generic local contributions before deleting `admin.extensions.generated.ts` and the remaining Operator compatibility provider map.