### PR TITLE
Fix generated starter public API convention

### DIFF
--- a/.changeset/clean-public-api-starter.md
+++ b/.changeset/clean-public-api-starter.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Discover application public API routes from the generated starter's
+`src/api/public` convention and validate that a new starter can build and run a
+route authored there.

--- a/docs/adr/0012-application-authoring-and-product-defaults.md
+++ b/docs/adr/0012-application-authoring-and-product-defaults.md
@@ -31,7 +31,7 @@ the generated graph expresses the complete deployment.**
    plugins.
 3. Application-local contributions are discovered at build time from
    conventional directories:
-   `src/api/{admin,store}`, `src/admin`, `src/workflows`, `src/jobs`,
+   `src/api/{admin,public}`, `src/admin`, `src/workflows`, `src/jobs`,
    `src/subscribers`, `src/links`, and `src/modules`.
 4. Discovery is deterministic and Node-only. It produces normalized stable IDs,
    validates collisions and requirements, and writes the complete result under

--- a/docs/architecture/api-route-authoring.md
+++ b/docs/architecture/api-route-authoring.md
@@ -48,7 +48,7 @@ public surface.
 Applications may author deployment-local API routes in these directories:
 
 - `src/api/admin/**/route.ts` for the authenticated admin surface
-- `src/api/store/**/route.ts` for the authenticated public surface
+- `src/api/public/**/route.ts` for the authenticated public surface
 
 Each route file exports at least one named uppercase HTTP handler: `GET`,
 `POST`, `PUT`, `PATCH`, `DELETE`, `HEAD`, or `OPTIONS`. Route files

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -1401,7 +1401,7 @@ a resolver-private relative import. The operator resolver adapter requires
 `resolveProject({ project, projectRoot, configPath })` and then adds target
 admission, lockfile provenance, and runtime-maintenance schedules.
 
-The same resolver compiles `src/api/{admin,store}/**/route.ts` into individual
+The same resolver compiles `src/api/{admin,public}/**/route.ts` into individual
 graph API facets backed by one generated static Hono adapter, and compiles
 `src/admin/<name>/index.tsx` entries into a deterministic client module. Both
 artifacts use paths relative to `.voyant/`; no runtime filesystem scan or

--- a/packages/framework/src/project-api-conventions.test.ts
+++ b/packages/framework/src/project-api-conventions.test.ts
@@ -25,7 +25,7 @@ describe("project API conventions", () => {
         "export const POST: VoyantRouteHandler = (c) => c.json({ id: c.req.param('orderId') })",
         "export const GET: VoyantRouteHandler = (c) => c.json({ id: c.req.param('orderId') })",
       ].join("\n"),
-      "src/api/store/catalog/(sales)/[...slug]/route.ts":
+      "src/api/public/catalog/(sales)/[...slug]/route.ts":
         "export const OPTIONS = (c: any) => c.body(null, 204)\n",
     })
 
@@ -48,7 +48,7 @@ describe("project API conventions", () => {
       {
         methods: ["OPTIONS"],
         route: "/catalog/*slug",
-        sourcePath: "src/api/store/catalog/(sales)/[...slug]/route.ts",
+        sourcePath: "src/api/public/catalog/(sales)/[...slug]/route.ts",
         surface: "public",
       },
     ])
@@ -71,7 +71,7 @@ describe("project API conventions", () => {
       [
         'import { Hono, type HonoModule, type VoyantBindings, type VoyantVariables } from "@voyant-travel/framework/project-runtime"',
         'import * as route0 from "../../src/api/admin/orders/[orderId]/route.js"',
-        'import * as route1 from "../../src/api/store/catalog/(sales)/[...slug]/route.js"',
+        'import * as route1 from "../../src/api/public/catalog/(sales)/[...slug]/route.js"',
         "",
         "type ProjectApiEnv = { Bindings: VoyantBindings; Variables: VoyantVariables }",
         "const adminRoutes = new Hono<ProjectApiEnv>()",
@@ -98,7 +98,7 @@ describe("project API conventions", () => {
         "export const POST = () => new Response()\n",
       "src/api/admin/(duplicate)/orders/[slug]/route.ts":
         "export const GET = () => new Response()\n",
-      "src/api/store/orders/[id]/route.ts": "export const GET = () => new Response()\n",
+      "src/api/public/orders/[id]/route.ts": "export const GET = () => new Response()\n",
     })
 
     const analysis = await analyzeProjectApiConventions({ projectRoot: root })
@@ -125,7 +125,7 @@ describe("project API conventions", () => {
       "src/api/admin/empty/route.ts": "export type Empty = true\n",
       "src/api/admin/defaulted/route.ts":
         "const handler = () => new Response()\nexport default handler\nexport const GET = handler\n",
-      "src/api/store/unsupported/route.ts":
+      "src/api/public/unsupported/route.ts":
         "export const schema = {}\nexport const PATCH = () => new Response()\n",
     })
 
@@ -151,7 +151,7 @@ describe("project API conventions", () => {
       {
         code: "PROJECT_API_UNSUPPORTED_EXPORT",
         exportName: "schema",
-        sourcePath: "src/api/store/unsupported/route.ts",
+        sourcePath: "src/api/public/unsupported/route.ts",
       },
     ])
     await expect(compileProjectApiConventions({ projectRoot: root })).rejects.toBeInstanceOf(

--- a/packages/framework/src/project-conventions.test.ts
+++ b/packages/framework/src/project-conventions.test.ts
@@ -17,7 +17,7 @@ describe("discoverProjectConventions", () => {
     const root = await projectFixture([
       "src/api/admin/route.ts",
       "src/api/admin/orders/[orderId]/route.ts",
-      "src/api/store/catalog/(sales)/[...slug]/route.ts",
+      "src/api/public/catalog/(sales)/[...slug]/route.ts",
       "src/workflows/booking/confirm.ts",
       "src/jobs/reconcile.ts",
       "src/subscribers/booking/created.ts",
@@ -53,7 +53,7 @@ describe("discoverProjectConventions", () => {
           id: "project.api.public.catalog.all-slug",
           kind: "api-route",
           route: "/catalog/*slug",
-          sourcePath: "src/api/store/catalog/(sales)/[...slug]/route.ts",
+          sourcePath: "src/api/public/catalog/(sales)/[...slug]/route.ts",
           surface: "public",
         },
         {
@@ -227,7 +227,7 @@ describe("discoverProjectConventions", () => {
       "src/api/admin/orders/[id]/route.ts",
       "src/api/admin/orders/[orderId]/route.ts",
       "src/api/admin/(internal)/orders/[slug]/route.ts",
-      "src/api/store/orders/[id]/route.ts",
+      "src/api/public/orders/[id]/route.ts",
     ])
 
     const result = await discoverProjectConventions(root)
@@ -322,7 +322,7 @@ describe("discoverProjectConventions", () => {
   })
 
   it("normalizes optional catch-all routes", async () => {
-    const root = await projectFixture(["src/api/store/docs/[[...parts]]/route.ts"])
+    const root = await projectFixture(["src/api/public/docs/[[...parts]]/route.ts"])
 
     const result = await discoverProjectConventions(root)
 
@@ -331,7 +331,7 @@ describe("discoverProjectConventions", () => {
         id: "project.api.public.docs.all-parts-optional",
         kind: "api-route",
         route: "/docs/*parts?",
-        sourcePath: "src/api/store/docs/[[...parts]]/route.ts",
+        sourcePath: "src/api/public/docs/[[...parts]]/route.ts",
         surface: "public",
       },
     ])

--- a/packages/framework/src/project-conventions.ts
+++ b/packages/framework/src/project-conventions.ts
@@ -110,7 +110,7 @@ export async function discoverProjectConventions(
 
   await Promise.all([
     discoverApiRoutes(projectRoot, "admin", "src/api/admin", contributions),
-    discoverApiRoutes(projectRoot, "public", "src/api/store", contributions),
+    discoverApiRoutes(projectRoot, "public", "src/api/public", contributions),
     ...RECURSIVE_CONVENTIONS.map((convention) =>
       discoverRecursiveConvention(projectRoot, convention, contributions),
     ),

--- a/scripts/check-standard-node-starter.mjs
+++ b/scripts/check-standard-node-starter.mjs
@@ -114,6 +114,14 @@ function inspectGeneratedStarter(starterRoot) {
     inspectPackageJson(packageJsonPath)
   }
 
+  const envExamplePath = join(starterRoot, ".env.example")
+  if (
+    existsSync(envExamplePath) &&
+    !/^DATABASE_URL=postgresql:\/\//m.test(readFileSync(envExamplePath, "utf8"))
+  ) {
+    violations.push("generated .env.example must declare DATABASE_URL")
+  }
+
   const authoredSources = actualFiles
     .filter((path) => !["package.json", "voyant.config.ts"].includes(path))
     .map((path) => [path, readFileSync(join(starterRoot, path), "utf8")])

--- a/scripts/package-starters.mjs
+++ b/scripts/package-starters.mjs
@@ -109,7 +109,7 @@ export default defineConfig({
   )
   writeFileSync(
     join(stagingTemplate, ".env.example"),
-    `${["postgresql", "://postgres:postgres@localhost:5432/voyant"].join("")}\nPORT=8080\n`,
+    `DATABASE_URL=${["postgresql", "://postgres:postgres@localhost:5432/voyant"].join("")}\nPORT=8080\n`,
   )
   writeFileSync(
     join(stagingTemplate, "src/scripts/seed.ts"),

--- a/scripts/tests/check-standard-node-starter.test.mjs
+++ b/scripts/tests/check-standard-node-starter.test.mjs
@@ -19,6 +19,16 @@ test("accepts the strict generated standard Node starter shape", () => {
   assert.match(run(root), /4 authored files, generic Node bootstrap, no product authority/)
 })
 
+test("rejects an environment example without a DATABASE_URL assignment", () => {
+  const root = fixture({
+    extraFiles: { ".env.example": "postgresql://localhost/voyant\nPORT=8080\n" },
+  })
+  assert.throws(
+    () => run(root),
+    (error) => String(error.stderr).includes("generated .env.example must declare DATABASE_URL"),
+  )
+})
+
 test("rejects standard modules, extensions, and plugins in generated config", () => {
   for (const property of ["modules", "extensions", "plugins"]) {
     const root = fixture({

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -47,6 +47,11 @@ test("minimal starter installs, emits its selected graph, and boots the Node hos
       app,
     )
     write(app, "src/api/admin/health/route.ts", "export const GET = (c) => c.json({ ok: true })\n")
+    write(
+      app,
+      "src/api/public/starter-proof/route.ts",
+      'export const GET = (c) => c.json({ route: "public" })\n',
+    )
     write(app, "src/admin/dashboard/index.tsx", 'export default { id: "project.dashboard" }\n')
     write(
       app,
@@ -79,7 +84,17 @@ test("minimal starter installs, emits its selected graph, and boots the Node hos
     const bom = JSON.parse(readFileSync(join(app, ".voyant/product-bom.generated.json"), "utf8"))
     assert.equal(graph.schemaVersion, "voyant.resolved-graph.v1")
     assert.ok(graph.modules.length > 30)
-    assert.ok(graph.modules.some((unit) => unit.localId === "project-api"))
+    const projectApi = graph.modules.find((unit) => unit.localId === "project-api")
+    assert.ok(projectApi)
+    assert.ok(
+      projectApi.api?.some(
+        (api) =>
+          api.id === "project.api.public.starter-proof" &&
+          api.surface === "public" &&
+          api.mount === "/starter-proof" &&
+          api.methods?.includes("GET"),
+      ),
+    )
     assert.ok(graph.modules.some((unit) => unit.localId === "project-workflows"))
     assert.ok(graph.modules.some((unit) => unit.localId === "project-subscribers-links"))
     assert.ok(graph.modules.some((unit) => unit.localId === "concierge"))
@@ -103,6 +118,28 @@ test("minimal starter installs, emits its selected graph, and boots the Node hos
     assert.match(projectRuntime, /GENERATED_GRAPH_RUNTIME_CONTRIBUTORS/)
     assert.match(projectRuntime, /@voyant-travel\/storefront\/runtime-contributor/)
     assert.doesNotMatch(projectRuntime, /createVoyantGraphRuntimePortStubs/)
+    assert.match(
+      readFileSync(join(app, ".voyant/runtime/project-api.generated.ts"), "utf8"),
+      /src\/api\/public\/starter-proof\/route/,
+    )
+    exec(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "--eval",
+        [
+          'import { projectApiHonoModule } from "./.voyant/runtime/project-api.generated.ts"',
+          'const response = await projectApiHonoModule.publicRoutes.request("http://local/starter-proof")',
+          "if (response.status !== 200) throw new Error('Unexpected status: ' + response.status)",
+          "const body = await response.json()",
+          "if (body.route !== 'public') throw new Error('Unexpected body: ' + JSON.stringify(body))",
+        ].join("; "),
+      ],
+      app,
+      { NODE_OPTIONS: "--conditions=development" },
+    )
 
     exec(
       "pnpm",


### PR DESCRIPTION
## Summary
- align project route discovery with the generated `src/api/public` starter directory
- exercise a real public route through graph emission and the generated Hono adapter
- fix the generated `.env.example` so it declares `DATABASE_URL`
- update the active ADR and architecture docs

## Root cause
The packaged starter exposed `src/api/public`, while framework convention discovery scanned `src/api/store`. Existing acceptance only exercised an admin route, so the mismatch passed while consumer-authored public routes were silently omitted.

## Verification
- `pnpm --filter @voyant-travel/framework exec vitest run src/project-conventions.test.ts src/project-api-conventions.test.ts`
- `node --test scripts/tests/check-standard-node-starter.test.mjs scripts/tests/minimal-starter-acceptance.test.mjs`
- `pnpm --filter @voyant-travel/framework typecheck`
- focused Biome check and `git diff --check`