### PR TITLE
fix operator runtime project layout

### DIFF
--- a/.changeset/fair-operator-layout-parity.md
+++ b/.changeset/fair-operator-layout-parity.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operator-runtime": patch
+---
+
+Resolve generated runtime artifacts and admin assets across source and packaged operator layouts, while allowing API-only projects to boot without creating an empty admin directory.

--- a/packages/operator-runtime/src/index.ts
+++ b/packages/operator-runtime/src/index.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import path from "node:path"
 import { pathToFileURL } from "node:url"
 
@@ -15,8 +15,24 @@ import {
 import { createNodeServer, type NodeServerHandle } from "@voyant-travel/runtime"
 import { tsImport } from "tsx/esm/api"
 
-const PROJECT_RUNTIME_ENTRY = ".voyant/runtime/project-runtime.generated.ts"
-const PROJECT_GRAPH_ENTRY = ".voyant/deployment-graph.generated.json"
+const GENERATED_ARTIFACT_LAYOUTS = [".voyant", "dist/.voyant"] as const
+const PROJECT_RUNTIME_ENTRY = "runtime/project-runtime.generated.ts"
+const PROJECT_GRAPH_ENTRY = "deployment-graph.generated.json"
+
+export type OperatorProjectLayoutErrorCode =
+  | "MISSING_GENERATED_ARTIFACTS"
+  | "MISSING_ADMIN_ASSETS"
+
+export class OperatorProjectLayoutError extends Error {
+  override readonly name = "OperatorProjectLayoutError"
+
+  constructor(
+    readonly code: OperatorProjectLayoutErrorCode,
+    message: string,
+  ) {
+    super(message)
+  }
+}
 
 export interface LoadOperatorProjectOptions {
   projectRoot?: string
@@ -53,8 +69,9 @@ export async function loadOperatorProject(
   options: LoadOperatorProjectOptions = {},
 ): Promise<OperatorProjectHost> {
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
-  const generated = await loadGeneratedProjectRuntime(projectRoot)
-  const graph = await readGeneratedDeploymentGraph(projectRoot, generated)
+  const artifacts = await resolveGeneratedArtifacts(projectRoot)
+  const generated = await loadGeneratedProjectRuntime(artifacts.runtimeEntry)
+  const graph = await readGeneratedDeploymentGraph(artifacts.graphEntry, generated)
   const env = createVoyantNodeEnv(options.env ?? process.env)
   const primitives = createVoyantNodeRuntimeHostPrimitives({
     env,
@@ -71,10 +88,7 @@ export async function loadOperatorProject(
     runtimePorts: generated.createRuntimePorts({ primitives }),
     env,
   })
-  const clientAssetsDir = path.resolve(
-    options.adminAssetsDir ?? path.join(projectRoot, ".voyant/admin/client"),
-  )
-  await mkdir(clientAssetsDir, { recursive: true })
+  const clientAssetsDir = await resolveAdminAssetsDir(projectRoot, options.adminAssetsDir)
   const web = serveAdminHost<VoyantNodeRuntimeEnv>({
     clientAssetsDir,
     app: (request, env, ctx) => runtime.app.fetch(request, env, ctx),
@@ -103,31 +117,53 @@ export async function startOperatorProject(
   return host.start({ port: options.port })
 }
 
-async function loadGeneratedProjectRuntime(projectRoot: string): Promise<GeneratedProjectRuntime> {
-  const entry = path.join(projectRoot, PROJECT_RUNTIME_ENTRY)
+async function resolveGeneratedArtifacts(projectRoot: string): Promise<{
+  runtimeEntry: string
+  graphEntry: string
+}> {
+  const candidates = GENERATED_ARTIFACT_LAYOUTS.map((layout) => ({
+    runtimeEntry: path.join(projectRoot, layout, PROJECT_RUNTIME_ENTRY),
+    graphEntry: path.join(projectRoot, layout, PROJECT_GRAPH_ENTRY),
+  }))
+
+  for (const candidate of candidates) {
+    if ((await isFile(candidate.runtimeEntry)) && (await isFile(candidate.graphEntry))) {
+      return candidate
+    }
+  }
+
+  throw new OperatorProjectLayoutError(
+    "MISSING_GENERATED_ARTIFACTS",
+    `Generated operator runtime artifacts were not found. Expected both runtime and graph files in one of: ${candidates
+      .map(({ runtimeEntry, graphEntry }) => `${runtimeEntry} and ${graphEntry}`)
+      .join("; ")}.`,
+  )
+}
+
+async function loadGeneratedProjectRuntime(entry: string): Promise<GeneratedProjectRuntime> {
   const namespace = (await tsImport(pathToFileURL(entry).href, {
     parentURL: import.meta.url,
   })) as { createGeneratedProjectRuntime?: () => GeneratedProjectRuntime }
   if (typeof namespace.createGeneratedProjectRuntime !== "function") {
-    throw new Error(`${PROJECT_RUNTIME_ENTRY} does not export createGeneratedProjectRuntime().`)
+    throw new Error(`${entry} does not export createGeneratedProjectRuntime().`)
   }
   const generated = namespace.createGeneratedProjectRuntime()
   if (generated.kind !== "application") {
-    throw new Error(`${PROJECT_RUNTIME_ENTRY} is not a Voyant application runtime.`)
+    throw new Error(`${entry} is not a Voyant application runtime.`)
   }
   if (typeof generated.createRuntimePorts !== "function") {
-    throw new Error(`${PROJECT_RUNTIME_ENTRY} does not expose static runtime port composition.`)
+    throw new Error(`${entry} does not expose static runtime port composition.`)
   }
   return generated
 }
 
 async function readGeneratedDeploymentGraph(
-  projectRoot: string,
+  graphEntry: string,
   runtime: GeneratedProjectRuntime,
 ): Promise<{
   requirements: VoyantGraphDeploymentRequirements
 }> {
-  const graph = JSON.parse(await readFile(path.join(projectRoot, PROJECT_GRAPH_ENTRY), "utf8")) as {
+  const graph = JSON.parse(await readFile(graphEntry, "utf8")) as {
     contentHash?: unknown
     requirements?: unknown
   }
@@ -144,6 +180,62 @@ async function readGeneratedDeploymentGraph(
   }
   return {
     requirements: graph.requirements as VoyantGraphDeploymentRequirements,
+  }
+}
+
+async function resolveAdminAssetsDir(
+  projectRoot: string,
+  explicitAdminAssetsDir: string | undefined,
+): Promise<string> {
+  if (explicitAdminAssetsDir) {
+    const explicit = path.resolve(explicitAdminAssetsDir)
+    if (await directoryContainsFile(explicit)) {
+      return explicit
+    }
+    throw new OperatorProjectLayoutError(
+      "MISSING_ADMIN_ASSETS",
+      `The configured operator admin assets directory is missing or empty: ${explicit}.`,
+    )
+  }
+
+  const candidates = [
+    path.join(projectRoot, "dist/client"),
+    path.join(projectRoot, ".voyant/admin/client"),
+  ]
+
+  for (const candidate of candidates) {
+    if (await directoryContainsFile(candidate)) {
+      return candidate
+    }
+  }
+
+  // API-only projects do not need to produce an admin bundle. The static host
+  // treats this absent default directory as a miss and delegates to the API.
+  return candidates.at(-1)!
+}
+
+async function isFile(candidate: string): Promise<boolean> {
+  try {
+    return (await stat(candidate)).isFile()
+  } catch {
+    return false
+  }
+}
+
+async function directoryContainsFile(directory: string): Promise<boolean> {
+  try {
+    const entries = await readdir(directory, { withFileTypes: true })
+    for (const entry of entries) {
+      if (entry.isFile()) {
+        return true
+      }
+      if (entry.isDirectory() && (await directoryContainsFile(path.join(directory, entry.name)))) {
+        return true
+      }
+    }
+    return false
+  } catch {
+    return false
   }
 }
 

--- a/packages/operator-runtime/src/layout-parity.test.ts
+++ b/packages/operator-runtime/src/layout-parity.test.ts
@@ -1,0 +1,226 @@
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import type { AddressInfo } from "node:net"
+import os from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  loadVoyantNodeRuntime: vi.fn(async (options: unknown) => ({
+    app: {
+      fetch: () => new Response("runtime fallback", { status: 418 }),
+    },
+    env: {},
+    options,
+  })),
+}))
+
+vi.mock("@voyant-travel/framework/node-runtime", () => ({
+  createVoyantNodeEnv: (env: Record<string, string | undefined>) => env,
+  createVoyantNodeRuntimeHostPrimitives: () => ({}),
+  loadVoyantNodeRuntime: mocks.loadVoyantNodeRuntime,
+}))
+
+import { loadOperatorProject, OperatorProjectLayoutError } from "./index.js"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  mocks.loadVoyantNodeRuntime.mockClear()
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  )
+})
+
+describe("operator project layout resolution", () => {
+  it("loads generated artifacts from the source .voyant layout", async () => {
+    const projectRoot = await createProject()
+    await writeArtifacts(projectRoot, ".voyant", "source-hash")
+    await writeAsset(projectRoot, ".voyant/admin/client/source.txt", "source asset")
+
+    const host = await loadOperatorProject({ projectRoot })
+
+    expect(host.graphHash).toBe("source-hash")
+    expect(mocks.loadVoyantNodeRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deploymentRequirements: { resources: [{ id: "source-hash" }] },
+      }),
+    )
+  })
+
+  it("falls back to generated artifacts in dist/.voyant", async () => {
+    const projectRoot = await createProject()
+    await writeArtifacts(projectRoot, "dist/.voyant", "dist-hash")
+    await writeAsset(projectRoot, "dist/client/dist.txt", "dist asset")
+
+    const host = await loadOperatorProject({ projectRoot })
+
+    expect(host.graphHash).toBe("dist-hash")
+    expect(mocks.loadVoyantNodeRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deploymentRequirements: { resources: [{ id: "dist-hash" }] },
+      }),
+    )
+  })
+
+  it.each([
+    {
+      name: "an explicit directory",
+      explicit: true,
+      expected: "explicit asset",
+    },
+    {
+      name: "dist/client",
+      explicit: false,
+      expected: "dist asset",
+    },
+    {
+      name: ".voyant/admin/client",
+      explicit: false,
+      expected: "generated asset",
+      omitDist: true,
+    },
+  ])("selects and serves admin assets from $name", async ({ explicit, expected, omitDist }) => {
+    const projectRoot = await createProject()
+    await writeArtifacts(projectRoot, ".voyant", "asset-hash")
+    await writeAsset(projectRoot, ".voyant/admin/client/selected.txt", "generated asset")
+    if (!omitDist) {
+      await writeAsset(projectRoot, "dist/client/selected.txt", "dist asset")
+    }
+    const explicitDir = path.join(projectRoot, "custom-admin")
+    if (explicit) {
+      await writeAsset(projectRoot, "custom-admin/selected.txt", "explicit asset")
+    }
+
+    const host = await loadOperatorProject({
+      projectRoot,
+      ...(explicit ? { adminAssetsDir: explicitDir } : {}),
+    })
+    const server = host.start({ port: 0 })
+
+    try {
+      const port = await listeningPort(server)
+      const response = await fetch(`http://127.0.0.1:${port}/selected.txt`)
+      expect(response.status).toBe(200)
+      expect(await response.text()).toBe(expected)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it("preserves generated runtime and graph hash validation", async () => {
+    const projectRoot = await createProject()
+    await writeArtifacts(projectRoot, ".voyant", "runtime-hash", "graph-hash")
+    await writeAsset(projectRoot, "dist/client/admin.txt", "admin")
+
+    await expect(loadOperatorProject({ projectRoot })).rejects.toThrow(
+      "Generated project runtime and deployment graph hashes do not match.",
+    )
+  })
+
+  it("fails clearly when neither generated artifact layout is complete", async () => {
+    const projectRoot = await createProject()
+    await writeFileAt(projectRoot, ".voyant/runtime/project-runtime.generated.ts", "export {}")
+    await writeFileAt(projectRoot, "dist/.voyant/deployment-graph.generated.json", "{}")
+
+    await expect(loadOperatorProject({ projectRoot })).rejects.toMatchObject({
+      name: "OperatorProjectLayoutError",
+      code: "MISSING_GENERATED_ARTIFACTS",
+      message: expect.stringContaining("dist/.voyant/runtime/project-runtime.generated.ts"),
+    })
+  })
+
+  it("boots an API-only project without creating an empty admin client directory", async () => {
+    const projectRoot = await createProject()
+    await writeArtifacts(projectRoot, ".voyant", "missing-admin-hash")
+
+    const host = await loadOperatorProject({ projectRoot })
+    const server = host.start({ port: 0 })
+
+    try {
+      const port = await listeningPort(server)
+      const response = await fetch(`http://127.0.0.1:${port}/api-only`)
+      expect(response.status).toBe(418)
+      expect(await response.text()).toBe("runtime fallback")
+      await expect(
+        import("node:fs/promises").then(({ stat }) =>
+          stat(path.join(projectRoot, ".voyant/admin/client")),
+        ),
+      ).rejects.toMatchObject({ code: "ENOENT" })
+    } finally {
+      await server.close()
+    }
+  })
+
+  it("fails clearly when an explicit admin assets directory is empty", async () => {
+    const projectRoot = await createProject()
+    await writeArtifacts(projectRoot, ".voyant", "missing-admin-hash")
+    const explicit = path.join(projectRoot, "custom-admin")
+    await mkdir(explicit, { recursive: true })
+
+    const error = (await loadOperatorProject({
+      projectRoot,
+      adminAssetsDir: explicit,
+    }).catch((caught: unknown) => caught)) as OperatorProjectLayoutError
+
+    expect(error).toBeInstanceOf(OperatorProjectLayoutError)
+    expect(error).toMatchObject({ code: "MISSING_ADMIN_ASSETS" })
+    expect(error.message).toContain(explicit)
+  })
+})
+
+async function createProject(): Promise<string> {
+  const projectRoot = await mkdtemp(path.join(os.tmpdir(), "voyant-operator-runtime-"))
+  temporaryDirectories.push(projectRoot)
+  return projectRoot
+}
+
+async function listeningPort(
+  handle: ReturnType<Awaited<ReturnType<typeof loadOperatorProject>>["start"]>,
+): Promise<number> {
+  if (!handle.server.listening) {
+    await new Promise<void>((resolve) => handle.server.once("listening", resolve))
+  }
+  return (handle.server.address() as AddressInfo).port
+}
+
+async function writeArtifacts(
+  projectRoot: string,
+  layout: ".voyant" | "dist/.voyant",
+  runtimeHash: string,
+  graphHash = runtimeHash,
+): Promise<void> {
+  await writeFileAt(
+    projectRoot,
+    `${layout}/runtime/project-runtime.generated.ts`,
+    `export function createGeneratedProjectRuntime() {
+  return {
+    kind: "application",
+    graphHash: ${JSON.stringify(runtimeHash)},
+    deployment: { providers: {} },
+    graphRuntime: {},
+    createRuntimePorts: () => ({}),
+  }
+}
+`,
+  )
+  await writeFileAt(
+    projectRoot,
+    `${layout}/deployment-graph.generated.json`,
+    JSON.stringify({ contentHash: graphHash, requirements: { resources: [{ id: graphHash }] } }),
+  )
+}
+
+async function writeAsset(projectRoot: string, relativePath: string, contents: string): Promise<void> {
+  await writeFileAt(projectRoot, relativePath, contents)
+}
+
+async function writeFileAt(
+  projectRoot: string,
+  relativePath: string,
+  contents: string,
+): Promise<void> {
+  const file = path.join(projectRoot, relativePath)
+  await mkdir(path.dirname(file), { recursive: true })
+  await writeFile(file, contents)
+}


### PR DESCRIPTION
## Summary
- resolve generated graph/runtime artifacts from source and packaged project layouts
- prefer built admin assets while allowing API-only projects to boot without generated empty directories
- add focused layout and host behavior coverage

## Verification
- `pnpm --filter @voyant-travel/operator-runtime test`
- `pnpm --filter @voyant-travel/operator-runtime typecheck`
- `node --test scripts/tests/minimal-starter-acceptance.test.mjs`

Stacked on #3265.