### PR TITLE
remove starter storage runtime facade

### DIFF
--- a/packages/storage/src/runtime.test.ts
+++ b/packages/storage/src/runtime.test.ts
@@ -1,15 +1,15 @@
 import { describe, expect, it } from "vitest"
 
-import { resolveDocumentDownloadUrl } from "./storage"
+import { resolveDocumentDownloadUrl, type StorageRuntimeEnv } from "./runtime.js"
 
-function env(overrides: Partial<AppBindings> = {}): AppBindings {
+function env(overrides: StorageRuntimeEnv = {}): StorageRuntimeEnv {
   return {
     DOCUMENTS_BUCKET: {},
     ...overrides,
-  } as AppBindings
+  }
 }
 
-describe("document download URL resolution", () => {
+describe("resolveDocumentDownloadUrl", () => {
   it("uses API_BASE_URL so local admin redirects keep the /api mount prefix", async () => {
     await expect(
       resolveDocumentDownloadUrl(
@@ -24,7 +24,7 @@ describe("document download URL resolution", () => {
     )
   })
 
-  it("derives the mounted API prefix from an origin-only APP_URL when API_BASE_URL is absent", async () => {
+  it("derives the mounted API prefix from an origin-only APP_URL", async () => {
     await expect(
       resolveDocumentDownloadUrl(
         env({

--- a/scripts/check-standard-node-starter.mjs
+++ b/scripts/check-standard-node-starter.mjs
@@ -212,6 +212,7 @@ function inspectRepositoryAuthority(repoRoot) {
 
   for (const relativePath of [
     "starters/operator/src/api/lib/catalog-context.ts",
+    "starters/operator/src/api/lib/storage.ts",
     "starters/operator/src/api/runtime/payment-config.ts",
     "starters/operator/src/api/runtime/booking-payment-policy-runtime.ts",
     "starters/operator/src/api/runtime/media-runtime.ts",

--- a/scripts/check-storage-media-runtime-authority.mjs
+++ b/scripts/check-storage-media-runtime-authority.mjs
@@ -12,7 +12,7 @@ const inventoryContributor = read("packages/inventory/src/runtime-contributor.ts
 const brochureRuntime = read("packages/inventory/src/brochure-runtime.ts")
 const inventoryGraphRuntime = read("packages/inventory/src/graph-runtime.ts")
 const inventoryManifest = read("packages/inventory/src/voyant.ts")
-const storageFacade = read("starters/operator/src/api/lib/storage.ts")
+const operatorRuntimeAdapter = read("starters/operator/src/api/runtime/operator-runtime-adapter.ts")
 const deploymentResources = read("starters/operator/src/api/runtime/deployment-resources.ts")
 const storagePackage = JSON.parse(read("packages/storage/package.json"))
 const inventoryPackage = JSON.parse(read("packages/inventory/package.json"))
@@ -49,11 +49,8 @@ for (const token of policy.brochureRuntimeTokens) {
   if (!brochureRuntime.includes(token)) failures.push(`Brochure runtime must preserve ${token}`)
 }
 
-if (
-  !storageFacade.includes('from "@voyant-travel/storage/runtime"') ||
-  /createR2Provider|MIME_BY_EXT|DOCUMENTS_BUCKET/.test(storageFacade)
-) {
-  failures.push("Operator storage library must remain a package re-export facade")
+if (!operatorRuntimeAdapter.includes('from "@voyant-travel/storage/runtime"')) {
+  failures.push("Operator runtime adapter must consume Storage through its supported runtime API")
 }
 if (
   storagePackage.exports["./runtime"] !== "./src/runtime.ts" ||

--- a/scripts/fixtures/storage-media-runtime-policy.json
+++ b/scripts/fixtures/storage-media-runtime-policy.json
@@ -1,6 +1,7 @@
 {
   "forbiddenStarterPaths": [
-    "starters/operator/src/api/runtime/media-runtime.ts"
+    "starters/operator/src/api/runtime/media-runtime.ts",
+    "starters/operator/src/api/lib/storage.ts"
   ],
   "storageRuntimeTokens": [
     "MEDIA_BUCKET",

--- a/scripts/tests/check-standard-node-starter.test.mjs
+++ b/scripts/tests/check-standard-node-starter.test.mjs
@@ -135,6 +135,7 @@ test("rejects database authority in the checked-in starter", () => {
 test("rejects restored checked-in starter compatibility authority", () => {
   for (const relativePath of [
     "starters/operator/src/api/lib/catalog-context.ts",
+    "starters/operator/src/api/lib/storage.ts",
     "starters/operator/src/api/runtime/payment-config.ts",
     "starters/operator/src/api/runtime/booking-payment-policy-runtime.ts",
     "starters/operator/src/api/runtime/media-runtime.ts",

--- a/scripts/tests/check-storage-media-runtime-authority.test.mjs
+++ b/scripts/tests/check-storage-media-runtime-authority.test.mjs
@@ -16,8 +16,8 @@ const fixturePaths = [
   "packages/inventory/src/graph-runtime.ts",
   "packages/inventory/src/voyant.ts",
   "packages/inventory/package.json",
+  "starters/operator/src/api/runtime/operator-runtime-adapter.ts",
   "starters/operator/src/api/runtime/deployment-resources.ts",
-  "starters/operator/src/api/lib/storage.ts",
   "scripts/fixtures/storage-media-runtime-policy.json",
 ]
 
@@ -68,11 +68,15 @@ test("rejects an Inventory contributor that returns to a starter capability", ()
   assert.throws(() => runChecker(fixtureRoot), /Inventory/)
 })
 
-test("rejects a restored Operator media compatibility facade", () => {
-  const fixtureRoot = createFixture()
-  const facade = "starters/operator/src/api/runtime/media-runtime.ts"
-  const facadePath = path.join(fixtureRoot, facade)
-  mkdirSync(path.dirname(facadePath), { recursive: true })
-  writeFileSync(facadePath, "export const compatibilityFacade = true\n")
-  assert.throws(() => runChecker(fixtureRoot), new RegExp(`${facade} must stay deleted`))
+test("rejects restored Operator storage compatibility facades", () => {
+  for (const facade of [
+    "starters/operator/src/api/runtime/media-runtime.ts",
+    "starters/operator/src/api/lib/storage.ts",
+  ]) {
+    const fixtureRoot = createFixture()
+    const facadePath = path.join(fixtureRoot, facade)
+    mkdirSync(path.dirname(facadePath), { recursive: true })
+    writeFileSync(facadePath, "export const compatibilityFacade = true\n")
+    assert.throws(() => runChecker(fixtureRoot), new RegExp(`${facade} must stay deleted`))
+  }
 })

--- a/starters/operator/src/api/lib/storage.ts
+++ b/starters/operator/src/api/lib/storage.ts
@@ -1,7 +1,0 @@
-export {
-  createDocumentStorage,
-  createMediaStorage,
-  guessMimeType,
-  readDocumentContentBase64,
-  resolveDocumentDownloadUrl,
-} from "@voyant-travel/storage/runtime"

--- a/starters/operator/src/api/runtime/operator-runtime-adapter.ts
+++ b/starters/operator/src/api/runtime/operator-runtime-adapter.ts
@@ -3,17 +3,17 @@ import { resolveNodeDatabase } from "@voyant-travel/db/runtime"
 import type { ResolveInvoiceExchangeRate } from "@voyant-travel/finance"
 import type { VoyantDb } from "@voyant-travel/hono"
 import {
+  createDocumentStorage,
+  readDocumentContentBase64,
+  resolveDocumentDownloadUrl,
+} from "@voyant-travel/storage/runtime"
+import {
   type CloudWorkflowsClientEnv,
   createCloudWorkflowDriver,
 } from "@voyant-travel/workflows/client"
 import { createInMemoryDriver } from "@voyant-travel/workflows-orchestrator/in-memory"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { resolveVoyantDataApiKey } from "../../lib/voyant-cloud"
-import {
-  createDocumentStorage,
-  readDocumentContentBase64,
-  resolveDocumentDownloadUrl,
-} from "../lib/storage"
 
 export function operatorBindings(bindings: unknown): AppBindings & Record<string, unknown> {
   return bindings as unknown as AppBindings & Record<string, unknown>


### PR DESCRIPTION
## Summary
- delete the standard starter storage re-export facade and duplicate tests
- consume the existing supported Storage runtime API directly
- ratchet architecture checks against starter storage authority returning

## Verification
- Storage runtime tests
- storage authority and standard starter checker tests
- both architecture checkers
- Biome and `git diff --check`

Stacked on #3269.