### PR TITLE
fix unified Operator review regressions

### DIFF
--- a/.changeset/resolve-operator-review-findings.md
+++ b/.changeset/resolve-operator-review-findings.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/framework-migrations": patch
+"@voyant-travel/operator-runtime": patch
+"@voyant-travel/relationships": patch
+---
+
+Preserve legacy migration and route behavior in the unified Node host, align generated admin assets with their graph artifacts, restore auth email and media compatibility, and publish the selected-graph OpenAPI entry.

--- a/packages/framework-migrations/src/collector.test.ts
+++ b/packages/framework-migrations/src/collector.test.ts
@@ -142,6 +142,81 @@ describe("migration hash compatibility", () => {
   })
 })
 
+describe("migration source aliases", () => {
+  it("adopts a matching legacy ledger row under the stable source without replaying SQL", async () => {
+    const migrationSource: MigrationSource = {
+      name: "finance",
+      legacyNames: ["schema:@voyant-travel/finance#migrations"],
+      priority: 0,
+      migrations: [{ tag: "0000_finance", sql: "CREATE TABLE finance_records (id text);" }],
+    }
+    const [migration] = planMigrations([migrationSource])
+    const ledger = new Map([
+      ["schema:@voyant-travel/finance#migrations/0000_finance", migration?.contentHash ?? ""],
+    ])
+    const queries: string[] = []
+    const client: MigrationClient = {
+      async query(sql, params = []) {
+        queries.push(sql)
+        if (sql.includes('SELECT "content_hash", "source"')) {
+          const sources = params[0] as string[]
+          const tag = String(params[1])
+          return {
+            rows: sources.flatMap((source) => {
+              const hash = ledger.get(`${source}/${tag}`)
+              return hash ? [{ source, content_hash: hash }] : []
+            }),
+          }
+        }
+        if (sql.startsWith("INSERT INTO") && sql.includes("ON CONFLICT")) {
+          ledger.set(`${String(params[0])}/${String(params[1])}`, String(params[2]))
+        }
+        return { rows: [] }
+      },
+    }
+
+    const result = await applyMigrations(client, [migrationSource], ledgerOpts)
+
+    expect(result).toEqual({ executed: [], baselined: [] })
+    expect(ledger.get("finance/0000_finance")).toBe(migration?.contentHash)
+    expect(ledger.has("schema:@voyant-travel/finance#migrations/0000_finance")).toBe(true)
+    expect(queries).not.toContain("BEGIN")
+  })
+
+  it("rejects changed SQL recorded under a legacy source name", async () => {
+    const client: MigrationClient = {
+      async query(sql) {
+        if (sql.includes('SELECT "content_hash", "source"')) {
+          return {
+            rows: [
+              {
+                source: "schema:@voyant-travel/finance#migrations",
+                content_hash: "stale-hash",
+              },
+            ],
+          }
+        }
+        return { rows: [] }
+      },
+    }
+
+    await expect(
+      applyMigrations(
+        client,
+        [
+          {
+            name: "finance",
+            legacyNames: ["schema:@voyant-travel/finance#migrations"],
+            priority: 0,
+            migrations: [{ tag: "0000_finance", sql: "SELECT 1" }],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).rejects.toBeInstanceOf(MigrationImmutabilityError)
+  })
+})
+
 // ---- applyMigrations: execute path (integration) ----------------------------
 
 function sources(): { db: MigrationSource; deployment: MigrationSource } {

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -25,6 +25,8 @@ export interface MigrationStatement {
 export interface MigrationSource {
   /** Name recorded in the ledger, e.g. `framework` / `deployment`. */
   name: string
+  /** Prior ledger source names that should be adopted without replaying SQL. */
+  legacyNames?: readonly string[]
   /**
    * Apply order across sources within a run (lower first). Framework < deployment
    * is load-bearing — deployment link tables FK into framework tables.
@@ -36,6 +38,7 @@ export interface MigrationSource {
 
 export interface PlannedMigration {
   source: string
+  legacySources?: readonly string[]
   tag: string
   sql: string
   /** sha256 of the raw SQL (immutability key). */
@@ -176,6 +179,7 @@ export function planMigrations(sources: MigrationSource[]): PlannedMigration[] {
     .flatMap((source) =>
       source.migrations.map((m, seq) => ({
         source: source.name,
+        ...(source.legacyNames?.length ? { legacySources: source.legacyNames } : {}),
         priority: source.priority,
         seq,
         tag: m.tag,
@@ -184,7 +188,13 @@ export function planMigrations(sources: MigrationSource[]): PlannedMigration[] {
       })),
     )
     .sort((a, b) => a.priority - b.priority || a.seq - b.seq)
-    .map(({ source, tag, sql, contentHash: hash }) => ({ source, tag, sql, contentHash: hash }))
+    .map(({ source, legacySources, tag, sql, contentHash: hash }) => ({
+      source,
+      ...(legacySources?.length ? { legacySources } : {}),
+      tag,
+      sql,
+      contentHash: hash,
+    }))
 }
 
 function qualifiedLedger(options?: ApplyMigrationsOptions): string {
@@ -244,14 +254,28 @@ export async function applyMigrations(
   const executed: string[] = []
   const baselined: string[] = []
   for (const m of planMigrations(sources)) {
+    const ledgerSources = [...new Set([m.source, ...(m.legacySources ?? [])])]
     const seen = await client.query(
-      `SELECT "content_hash" FROM ${ledger} WHERE "source" = $1 AND "tag" = $2`,
-      [m.source, m.tag],
+      `SELECT "content_hash", "source" FROM ${ledger}
+        WHERE "source" = ANY($1::text[]) AND "tag" = $2`,
+      [ledgerSources, m.tag],
     )
     if (seen.rows.length > 0) {
-      const ledgerHash = String(seen.rows[0]?.content_hash ?? "")
-      if (ledgerHash !== m.contentHash && !isEquivalentMigrationHash(m, ledgerHash)) {
-        throw new MigrationImmutabilityError(m.source, m.tag, ledgerHash, m.contentHash)
+      for (const row of seen.rows) {
+        const ledgerHash = String(row.content_hash ?? "")
+        if (ledgerHash !== m.contentHash && !isEquivalentMigrationHash(m, ledgerHash)) {
+          throw new MigrationImmutabilityError(m.source, m.tag, ledgerHash, m.contentHash)
+        }
+      }
+      const hasStableRow = seen.rows.some(
+        (row) => row.source === undefined || String(row.source) === m.source,
+      )
+      if (!hasStableRow) {
+        await client.query(
+          `INSERT INTO ${ledger} ("source", "tag", "content_hash") VALUES ($1, $2, $3)
+           ON CONFLICT ("source", "tag") DO NOTHING`,
+          [m.source, m.tag, m.contentHash],
+        )
       }
       continue // already applied, identical → no-op
     }

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-import type { MigrationSource } from "./collector.js"
-import { expectedSchema } from "./deployment-runner.js"
+import type { MigrationClient, MigrationSource } from "./collector.js"
+import { detectExisting, expectedSchema } from "./deployment-runner.js"
 
 const src = (name: string, sqls: string[]): MigrationSource => ({
   name,
@@ -59,5 +59,23 @@ describe("expectedSchema", () => {
     expect(e.tables.has("tmp")).toBe(false)
     expect(e.dropped.has("tmp")).toBe(true)
     expect([...e.columns].some((c) => c.startsWith("tmp."))).toBe(false)
+  })
+})
+
+describe("detectExisting", () => {
+  it("recognizes graph-era package ledger source names", async () => {
+    const client: MigrationClient = {
+      async query(sql, params = []) {
+        if (sql.startsWith("SELECT to_regclass")) {
+          return { rows: [{ reg: String(params[0]) }] }
+        }
+        if (sql.includes(`"source" LIKE 'schema:%#migrations'`)) {
+          return { rows: [{ n: "1" }] }
+        }
+        return { rows: [{ n: "0" }] }
+      },
+    }
+
+    await expect(detectExisting(client)).resolves.toBe(true)
   })
 })

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -54,6 +54,12 @@ export async function detectExisting(client: MigrationClient): Promise<boolean> 
     `"source" = 'framework'`,
   )
   if (frameworkRows > 0) return true
+  const graphSchemaRows = await ledgerRowCount(
+    client,
+    `"drizzle"."_voyant_migrations"`,
+    `"source" LIKE 'schema:%#migrations'`,
+  )
+  if (graphSchemaRows > 0) return true
   const legacyRows = await ledgerRowCount(client, `"drizzle"."__drizzle_migrations"`)
   return legacyRows > 0
 }

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -105,6 +105,10 @@
         "types": "./dist/graph-lifecycle.d.ts",
         "import": "./dist/graph-lifecycle.js"
       },
+      "./selected-graph-openapi": {
+        "types": "./dist/selected-graph-openapi.d.ts",
+        "import": "./dist/selected-graph-openapi.js"
+      },
       "./operator-distribution": {
         "types": "./dist/operator-distribution.d.ts",
         "import": "./dist/operator-distribution.js"

--- a/packages/framework/src/node-migration-runner.test.ts
+++ b/packages/framework/src/node-migration-runner.test.ts
@@ -142,6 +142,7 @@ describe("Node migration runner", () => {
     )
 
     expect(source.name).toBe("finance")
+    expect(source.legacyNames).toEqual(["schema:@voyant-travel/finance#migrations"])
     expect(source.priority).toBe(9)
     expect(source.migrations.length).toBeGreaterThan(0)
   })

--- a/packages/framework/src/node-migration-runner.ts
+++ b/packages/framework/src/node-migration-runner.ts
@@ -189,7 +189,10 @@ export async function loadNodeSchemaMigrationSource(
       `Package ${migration.source.packageName} does not publish migrations/meta/_journal.json`,
     )
   }
-  return source
+  return {
+    ...source,
+    legacyNames: [migration.idempotencyKey],
+  }
 }
 
 function deploymentPackageRoot(resolveFrom: string | URL): string {

--- a/packages/framework/src/node-workflow-runtime.test.ts
+++ b/packages/framework/src/node-workflow-runtime.test.ts
@@ -60,6 +60,50 @@ describe("loadVoyantNodeWorkflowRuntime", () => {
     })
     expect(contribution.create).toHaveBeenCalledOnce()
   })
+
+  it("reuses graph services when scheduled loads share a container", async () => {
+    const services = createContainer()
+    const serviceHost = { services, eventBus: createEventBus() }
+    const contribution = {
+      serviceId: "example.workflow.runtime",
+      create: vi.fn(() => ({ selected: true })),
+    }
+    const options = {
+      graphRuntime: graphWithUnit(unitWithRuntime({ id: "example" } as never)),
+      environment: {},
+      runtimePorts: {
+        [VOYANT_WORKFLOW_SERVICE_CONTRIBUTIONS_PORT_ID]: [contribution],
+      },
+      createServices: async () => serviceHost,
+    }
+
+    await loadVoyantNodeWorkflowRuntime(options)
+    await loadVoyantNodeWorkflowRuntime(options)
+
+    expect(contribution.create).toHaveBeenCalledOnce()
+    expect(services.resolve("example.workflow.runtime")).toEqual({ selected: true })
+  })
+
+  it("rejects duplicate workflow services within one contribution batch", async () => {
+    const contribution = (selected: string) => ({
+      serviceId: "example.workflow.runtime",
+      create: vi.fn(() => ({ selected })),
+    })
+
+    await expect(
+      loadVoyantNodeWorkflowRuntime({
+        graphRuntime: graphWithUnit(unitWithRuntime({ id: "example" } as never)),
+        environment: {},
+        runtimePorts: {
+          [VOYANT_WORKFLOW_SERVICE_CONTRIBUTIONS_PORT_ID]: [
+            contribution("first"),
+            contribution("second"),
+          ],
+        },
+        createServices: async () => ({ services: createContainer(), eventBus: createEventBus() }),
+      }),
+    ).rejects.toThrow('Workflow service "example.workflow.runtime" is registered more than once.')
+  })
 })
 
 function unitWithRuntime(

--- a/packages/framework/src/node-workflow-runtime.ts
+++ b/packages/framework/src/node-workflow-runtime.ts
@@ -44,6 +44,8 @@ export interface VoyantNodeWorkflowServiceHost {
   reportFailure?(error: unknown, context: Readonly<Record<string, unknown>>): void
 }
 
+const graphRegisteredWorkflowServices = new WeakMap<ModuleContainer, Set<string>>()
+
 /** Load workflow behavior exclusively from units selected by the generated graph. */
 export async function loadVoyantNodeWorkflowRuntime<TEnvironment>(
   options: LoadVoyantNodeWorkflowRuntimeOptions<TEnvironment>,
@@ -103,10 +105,21 @@ async function registerWorkflowServiceContributions<TEnvironment>(
   const seen = new Set<string>()
   for (const contribution of contributions as VoyantWorkflowServiceContribution[]) {
     await voyantWorkflowServiceContributionsPort.test(contribution)
-    if (seen.has(contribution.serviceId) || value.services.has(contribution.serviceId)) {
+    if (seen.has(contribution.serviceId)) {
       throw new Error(`Workflow service "${contribution.serviceId}" is registered more than once.`)
     }
     seen.add(contribution.serviceId)
+  }
+  let registered = graphRegisteredWorkflowServices.get(value.services)
+  if (!registered) {
+    registered = new Set()
+    graphRegisteredWorkflowServices.set(value.services, registered)
+  }
+  for (const contribution of contributions as VoyantWorkflowServiceContribution[]) {
+    if (registered.has(contribution.serviceId)) continue
+    if (value.services.has(contribution.serviceId)) {
+      throw new Error(`Workflow service "${contribution.serviceId}" is registered more than once.`)
+    }
     value.services.register(
       contribution.serviceId,
       await contribution.create({
@@ -116,6 +129,7 @@ async function registerWorkflowServiceContributions<TEnvironment>(
         reportFailure: value.reportFailure ?? defaultWorkflowFailureReporter,
       }),
     )
+    registered.add(contribution.serviceId)
   }
   return value.services
 }

--- a/packages/framework/src/package-exports.test.ts
+++ b/packages/framework/src/package-exports.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+interface PackageJson {
+  exports: Record<string, string>
+  publishConfig: {
+    exports: Record<string, { types: string; import: string }>
+  }
+}
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as PackageJson
+
+describe("@voyant-travel/framework package exports", () => {
+  it("publishes the selected graph OpenAPI authority used by the Node host", () => {
+    expect(packageJson.exports["./selected-graph-openapi"]).toBe("./src/selected-graph-openapi.ts")
+    expect(packageJson.publishConfig.exports["./selected-graph-openapi"]).toEqual({
+      types: "./dist/selected-graph-openapi.d.ts",
+      import: "./dist/selected-graph-openapi.js",
+    })
+  })
+})

--- a/packages/framework/src/runtime-composition.test.ts
+++ b/packages/framework/src/runtime-composition.test.ts
@@ -1,6 +1,8 @@
 // agent-quality: file-size exception -- owner: framework; graph unit, facet, port, route posture, and plugin output contracts share one composition harness.
 import { createEventBus } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory, definePort } from "@voyant-travel/core/project"
+import { mountApp } from "@voyant-travel/hono"
+import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 import {
   composeVoyantGraphRuntime,
@@ -526,6 +528,58 @@ describe("graph runtime composition", () => {
     expect(composition.modules.map((module) => module.module.name)).toEqual(["loyalty"])
     expect(importRuntime).toHaveBeenCalledTimes(1)
     expect(factory).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves a project API root mount when a single public route is selected", async () => {
+    const publicRoutes = new Hono().get("/foo", (context) => context.json({ route: "foo" }))
+    const runtime = createVoyantGraphRuntime({
+      graphHash: "sha256:project-api-public-route",
+      entries: {
+        "./.voyant/runtime/project-api.generated.js": async () => ({
+          projectApiHonoModule: {
+            module: { name: "project-api" },
+            publicRoutes,
+            publicPath: "/",
+          },
+        }),
+      },
+      modules: [
+        {
+          id: "project/api",
+          localId: "project-api",
+          kind: "module",
+          packageName: "project",
+          order: 0,
+          routes: [
+            {
+              route: {
+                id: "project.api.public.foo",
+                surface: "public",
+                mount: "/foo",
+                runtime: {
+                  entry: "./.voyant/runtime/project-api.generated.js",
+                  export: "projectApiHonoModule",
+                },
+              },
+              importEntry: "./.voyant/runtime/project-api.generated.js",
+            },
+          ],
+        },
+      ],
+      plugins: [],
+    })
+
+    const composition = await composeVoyantGraphRuntime({ runtime, capabilities: {} })
+    const app = mountApp({
+      db: () => ({}) as never,
+      modules: composition.modules,
+      auth: { resolve: () => ({ userId: "user_1", actor: "customer" }) },
+    })
+
+    expect(composition.modules[0]?.publicPath).toBe("/")
+    const bindings = { DATABASE_URL: "postgres://test" }
+    expect((await app.request("/v1/public/foo", {}, bindings)).status).toBe(200)
+    expect((await app.request("/v1/public/foo/foo", {}, bindings)).status).toBe(404)
   })
 
   it("passes only selected API facets to a package runtime factory", async () => {

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -417,7 +417,9 @@ function anonymousForPublicMount(
 function applyModuleRoutePosture(output: HonoModule, posture: UnitRoutePosture): HonoModule {
   return {
     ...output,
-    ...(posture.publicMount ? { publicPath: publicPathFromMount(posture.publicMount) } : {}),
+    ...(output.publicPath === undefined && posture.publicMount
+      ? { publicPath: publicPathFromMount(posture.publicMount) }
+      : {}),
     ...(posture.anonymous !== undefined ? { anonymous: posture.anonymous } : {}),
     ...(posture.transactionalPaths.length > 0
       ? {
@@ -436,7 +438,9 @@ function applyExtensionRoutePosture(
 ): HonoExtension {
   return {
     ...output,
-    ...(posture.publicMount ? { publicPath: publicPathFromMount(posture.publicMount) } : {}),
+    ...(output.publicPath === undefined && posture.publicMount
+      ? { publicPath: publicPathFromMount(posture.publicMount) }
+      : {}),
     ...(posture.anonymous !== undefined ? { anonymous: posture.anonymous } : {}),
     ...(posture.transactionalPaths.length > 0
       ? {

--- a/packages/operator-runtime/package.json
+++ b/packages/operator-runtime/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@voyant-travel/admin-host": "workspace:^",
     "@voyant-travel/auth": "workspace:^",
+    "@voyant-travel/cloud-sdk": "^0.11.0",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/framework": "workspace:^",

--- a/packages/operator-runtime/src/cli.ts
+++ b/packages/operator-runtime/src/cli.ts
@@ -10,7 +10,7 @@ if (command !== "start") {
   process.exit(2)
 }
 
-const handle = await startOperatorProject({ port })
+const handle = await startOperatorProject({ port, preferBuiltArtifacts: true })
 console.info(`[operator-runtime] Node host listening on :${handle.port}`)
 
 if (probe) {

--- a/packages/operator-runtime/src/cli.ts
+++ b/packages/operator-runtime/src/cli.ts
@@ -10,7 +10,7 @@ if (command !== "start") {
   process.exit(2)
 }
 
-const handle = await startOperatorProject({ port, preferBuiltArtifacts: true })
+const handle = await startOperatorProject({ port, preferBuiltAdminAssets: true })
 console.info(`[operator-runtime] Node host listening on :${handle.port}`)
 
 if (probe) {

--- a/packages/operator-runtime/src/cloud-auth-email.test.ts
+++ b/packages/operator-runtime/src/cloud-auth-email.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  getVoyantCloudClient: vi.fn(),
+  sendMessage: vi.fn(async () => ({ id: "message-1" })),
+}))
+
+vi.mock("@voyant-travel/cloud-sdk", () => ({
+  getVoyantCloudClient: mocks.getVoyantCloudClient,
+}))
+
+import { resolveOperatorCloudAuthEmailSender } from "./cloud-auth-email.js"
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getVoyantCloudClient.mockReturnValue({ email: { sendMessage: mocks.sendMessage } })
+})
+
+describe("Operator cloud auth email", () => {
+  it("stays disabled when no cloud API key is configured", () => {
+    expect(resolveOperatorCloudAuthEmailSender({})).toBeNull()
+    expect(resolveOperatorCloudAuthEmailSender({ VOYANT_API_KEY: "local-dev" })).toBeNull()
+    expect(mocks.getVoyantCloudClient).not.toHaveBeenCalled()
+  })
+
+  it("sends password reset and verification messages through Voyant Cloud", async () => {
+    const sender = resolveOperatorCloudAuthEmailSender({
+      VOYANT_API_KEY: "vc_test",
+      VOYANT_CLOUD_API_URL: "https://cloud.example.test",
+      VOYANT_CLOUD_USER_AGENT: "operator-test",
+      EMAIL_FROM: "Support <support@example.test>",
+      EMAIL_REPLY_TO: "help@example.test, owner@example.test",
+    })
+
+    expect(mocks.getVoyantCloudClient).toHaveBeenCalledWith(
+      {
+        VOYANT_CLOUD_API_KEY: "vc_test",
+        VOYANT_CLOUD_API_URL: "https://cloud.example.test",
+        VOYANT_CLOUD_USER_AGENT: "operator-test",
+      },
+      { apiKey: "vc_test" },
+    )
+    await sender?.sendResetPassword({
+      user: { email: "ana@example.test", name: "Ana <Admin>" },
+      url: "https://operator.example.test/reset?token=a&next=/admin",
+    })
+    await sender?.sendVerificationOtp({
+      email: "ana@example.test",
+      otp: "123456",
+      type: "email-verification",
+    })
+
+    expect(mocks.sendMessage).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        from: "Support <support@example.test>",
+        to: ["ana@example.test"],
+        replyTo: ["help@example.test", "owner@example.test"],
+        subject: "Reset your password",
+        html: expect.stringContaining("Ana &lt;Admin&gt;"),
+      }),
+    )
+    expect(mocks.sendMessage.mock.calls[0]?.[0]?.html).toContain("token=a&amp;next=/admin")
+    expect(mocks.sendMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        from: "Support <support@example.test>",
+        to: ["ana@example.test"],
+        replyTo: ["help@example.test", "owner@example.test"],
+        subject: "Verify your email",
+        html: expect.stringContaining("<strong>123456</strong>"),
+      }),
+    )
+  })
+
+  it("uses the standard sender and generic OTP subject defaults", async () => {
+    const sender = resolveOperatorCloudAuthEmailSender({ VOYANT_CLOUD_API_KEY: "vc_other" })
+    await sender?.sendVerificationOtp({
+      email: "user@example.test",
+      otp: "654321",
+      type: "sign-in",
+    })
+
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        from: "Voyant <noreply@voyantcloud.app>",
+        subject: "Your verification code",
+      }),
+    )
+  })
+})

--- a/packages/operator-runtime/src/cloud-auth-email.test.ts
+++ b/packages/operator-runtime/src/cloud-auth-email.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   getVoyantCloudClient: vi.fn(),
-  sendMessage: vi.fn(async () => ({ id: "message-1" })),
+  sendMessage: vi.fn(async (_message: { html: string }) => ({ id: "message-1" })),
 }))
 
 vi.mock("@voyant-travel/cloud-sdk", () => ({

--- a/packages/operator-runtime/src/cloud-auth-email.ts
+++ b/packages/operator-runtime/src/cloud-auth-email.ts
@@ -1,0 +1,99 @@
+import type { OperatorAuthEmailSender } from "@voyant-travel/auth/operator-node-runtime"
+import { getVoyantCloudClient, type VoyantCloudClient } from "@voyant-travel/cloud-sdk"
+
+type CloudAuthEmailEnv = object
+
+const DEFAULT_EMAIL_FROM = "Voyant <noreply@voyantcloud.app>"
+const LOCAL_PLACEHOLDER_KEYS = new Set(["local-dev"])
+const CLIENT_CACHE = new WeakMap<object, Map<string, VoyantCloudClient>>()
+
+function nonEmpty(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 && !LOCAL_PLACEHOLDER_KEYS.has(trimmed) ? trimmed : undefined
+}
+
+function readEnv(env: CloudAuthEmailEnv, key: string): unknown {
+  return Reflect.get(env, key)
+}
+
+function resolveApiKey(env: CloudAuthEmailEnv): string | undefined {
+  return nonEmpty(readEnv(env, "VOYANT_API_KEY")) ?? nonEmpty(readEnv(env, "VOYANT_CLOUD_API_KEY"))
+}
+
+function resolveCloudClient(env: CloudAuthEmailEnv, apiKey: string): VoyantCloudClient {
+  const clients = CLIENT_CACHE.get(env)
+  const cached = clients?.get(apiKey)
+  if (cached) return cached
+
+  const baseUrl = nonEmpty(readEnv(env, "VOYANT_CLOUD_API_URL"))
+  const userAgent = nonEmpty(readEnv(env, "VOYANT_CLOUD_USER_AGENT"))
+  const client = getVoyantCloudClient(
+    {
+      VOYANT_CLOUD_API_KEY: apiKey,
+      ...(baseUrl ? { VOYANT_CLOUD_API_URL: baseUrl } : {}),
+      ...(userAgent ? { VOYANT_CLOUD_USER_AGENT: userAgent } : {}),
+    },
+    { apiKey },
+  )
+  const nextClients = clients ?? new Map<string, VoyantCloudClient>()
+  nextClients.set(apiKey, client)
+  CLIENT_CACHE.set(env, nextClients)
+  return client
+}
+
+function resolveReplyTo(env: CloudAuthEmailEnv): string[] | undefined {
+  const value = nonEmpty(readEnv(env, "EMAIL_REPLY_TO"))
+  if (!value) return undefined
+  const addresses = value
+    .split(",")
+    .map((address) => address.trim())
+    .filter(Boolean)
+  return addresses.length > 0 ? addresses : undefined
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[character]!,
+  )
+}
+
+/** Resolve the standard Operator auth mail transport from Node environment values. */
+export function resolveOperatorCloudAuthEmailSender(
+  env: CloudAuthEmailEnv,
+): OperatorAuthEmailSender | null {
+  const apiKey = resolveApiKey(env)
+  if (!apiKey) return null
+
+  const cloud = resolveCloudClient(env, apiKey)
+  const from = nonEmpty(readEnv(env, "EMAIL_FROM")) ?? DEFAULT_EMAIL_FROM
+  const replyTo = resolveReplyTo(env)
+  return {
+    async sendResetPassword({ user, url }) {
+      await cloud.email.sendMessage({
+        from,
+        to: [user.email],
+        subject: "Reset your password",
+        html: `<p>Hi ${escapeHtml(user.name)},</p><p>Click <a href="${escapeHtml(url)}">here</a> to reset your password.</p><p>If you didn&#39;t request this, you can safely ignore this email.</p>`,
+        ...(replyTo ? { replyTo } : {}),
+      })
+    },
+    async sendVerificationOtp({ email, otp, type }) {
+      await cloud.email.sendMessage({
+        from,
+        to: [email],
+        subject: type === "email-verification" ? "Verify your email" : "Your verification code",
+        html: `<p>Your verification code is: <strong>${escapeHtml(otp)}</strong></p><p>This code expires in 10 minutes.</p>`,
+        ...(replyTo ? { replyTo } : {}),
+      })
+    },
+  }
+}

--- a/packages/operator-runtime/src/index.ts
+++ b/packages/operator-runtime/src/index.ts
@@ -23,6 +23,7 @@ import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyant-tr
 import { tsImport } from "tsx/esm/api"
 
 import { requireOperatorAuthEnv } from "./auth-env.js"
+import { resolveOperatorCloudAuthEmailSender } from "./cloud-auth-email.js"
 import { createOperatorDeploymentResources } from "./deployment-resources.js"
 
 export {
@@ -111,6 +112,7 @@ export async function loadOperatorProject(
     accessCatalog: generated.graphRuntime.accessCatalog,
     appName: path.basename(projectRoot),
     reporter: consoleReporter(),
+    resolveEmailSender: resolveOperatorCloudAuthEmailSender,
   })
   const runtime = await loadVoyantNodeRuntime({
     applicationId: path.basename(projectRoot),
@@ -153,12 +155,12 @@ export async function loadOperatorProject(
       },
     },
   })
-  const clientAssetsDir = await resolveAdminAssetsDir(projectRoot, options.adminAssetsDir)
+  const clientAssetsDir = resolveAdminAssetsDir(projectRoot, artifactRoot, options.adminAssetsDir)
   const web = serveAdminHost<VoyantNodeRuntimeEnv>({
     clientAssetsDir,
     app: async (request, bindings, ctx) => {
       if (new URL(request.url).pathname.startsWith("/api")) {
-        return runtime.app.fetch(request, bindings, ctx)
+        return runtime.app.fetch(rewriteLegacyMediaRequest(request), bindings, ctx)
       }
       const { createAdminSsrHandler } = await import("@voyant-travel/admin-host/ssr")
       return createAdminSsrHandler<VoyantNodeRuntimeEnv>()(request, bindings, ctx)
@@ -347,21 +349,22 @@ async function loadGeneratedProjectLinks(artifactRoot: string) {
   }
 }
 
-async function resolveAdminAssetsDir(projectRoot: string, explicit?: string): Promise<string> {
+function resolveAdminAssetsDir(
+  projectRoot: string,
+  artifactRoot: string,
+  explicit?: string,
+): string {
   if (explicit) return path.resolve(explicit)
-  const candidates = [
-    path.join(projectRoot, "dist/client"),
-    path.join(projectRoot, ".voyant/admin/client"),
-  ]
-  for (const candidate of candidates) {
-    try {
-      await access(candidate)
-      return candidate
-    } catch {}
-  }
-  // Vite serves assets itself in development; the static middleware may point
-  // at the future build directory without creating project-owned artifacts.
-  return candidates[0]!
+  return artifactRoot === path.join(projectRoot, "dist/.voyant")
+    ? path.join(projectRoot, "dist/client")
+    : path.join(artifactRoot, "admin/client")
+}
+
+function rewriteLegacyMediaRequest(request: Request): Request {
+  const url = new URL(request.url)
+  if (!url.pathname.startsWith("/api/v1/media/")) return request
+  url.pathname = url.pathname.replace("/api/v1/media/", "/api/v1/admin/media/")
+  return new Request(url, request)
 }
 
 async function pathExists(candidate: string): Promise<boolean> {

--- a/packages/operator-runtime/src/index.ts
+++ b/packages/operator-runtime/src/index.ts
@@ -42,6 +42,7 @@ export interface LoadOperatorProjectOptions {
   projectRoot?: string
   env?: Record<string, string | undefined>
   adminAssetsDir?: string
+  preferBuiltArtifacts?: boolean
   host?: {
     config?: Readonly<Record<string, unknown>>
     deliverEvent?: (event: unknown, bindings: unknown) => Promise<unknown>
@@ -85,7 +86,9 @@ export async function loadOperatorProject(
   options: LoadOperatorProjectOptions = {},
 ): Promise<OperatorProjectHost> {
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
-  const artifactRoot = await resolveGeneratedArtifactRoot(projectRoot)
+  const preferBuiltArtifacts =
+    options.preferBuiltArtifacts ?? (options.env?.NODE_ENV ?? process.env.NODE_ENV) === "production"
+  const artifactRoot = await resolveGeneratedArtifactRoot(projectRoot, preferBuiltArtifacts)
   const generated = await loadGeneratedProjectRuntime(artifactRoot)
   const graph = await readGeneratedDeploymentGraph(artifactRoot, generated)
   const env = createVoyantNodeEnv(options.env ?? process.env)
@@ -222,8 +225,14 @@ export async function startOperatorProject(
   return host.start({ port: options.port })
 }
 
-async function resolveGeneratedArtifactRoot(projectRoot: string): Promise<string> {
-  for (const layout of GENERATED_ARTIFACT_LAYOUTS) {
+async function resolveGeneratedArtifactRoot(
+  projectRoot: string,
+  preferBuiltArtifacts = false,
+): Promise<string> {
+  const layouts = preferBuiltArtifacts
+    ? (["dist/.voyant", ".voyant"] as const)
+    : GENERATED_ARTIFACT_LAYOUTS
+  for (const layout of layouts) {
     const artifactRoot = path.join(projectRoot, layout)
     if (
       (await pathExists(path.join(artifactRoot, PROJECT_GRAPH_ENTRY))) &&

--- a/packages/operator-runtime/src/index.ts
+++ b/packages/operator-runtime/src/index.ts
@@ -42,7 +42,7 @@ export interface LoadOperatorProjectOptions {
   projectRoot?: string
   env?: Record<string, string | undefined>
   adminAssetsDir?: string
-  preferBuiltArtifacts?: boolean
+  preferBuiltAdminAssets?: boolean
   host?: {
     config?: Readonly<Record<string, unknown>>
     deliverEvent?: (event: unknown, bindings: unknown) => Promise<unknown>
@@ -86,9 +86,7 @@ export async function loadOperatorProject(
   options: LoadOperatorProjectOptions = {},
 ): Promise<OperatorProjectHost> {
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
-  const preferBuiltArtifacts =
-    options.preferBuiltArtifacts ?? (options.env?.NODE_ENV ?? process.env.NODE_ENV) === "production"
-  const artifactRoot = await resolveGeneratedArtifactRoot(projectRoot, preferBuiltArtifacts)
+  const artifactRoot = await resolveGeneratedArtifactRoot(projectRoot)
   const generated = await loadGeneratedProjectRuntime(artifactRoot)
   const graph = await readGeneratedDeploymentGraph(artifactRoot, generated)
   const env = createVoyantNodeEnv(options.env ?? process.env)
@@ -158,7 +156,13 @@ export async function loadOperatorProject(
       },
     },
   })
-  const clientAssetsDir = resolveAdminAssetsDir(projectRoot, artifactRoot, options.adminAssetsDir)
+  const clientAssetsDir = await resolveAdminAssetsDir(
+    projectRoot,
+    artifactRoot,
+    options.adminAssetsDir,
+    options.preferBuiltAdminAssets ??
+      (options.env?.NODE_ENV ?? process.env.NODE_ENV) === "production",
+  )
   const web = serveAdminHost<VoyantNodeRuntimeEnv>({
     clientAssetsDir,
     app: async (request, bindings, ctx) => {
@@ -225,14 +229,8 @@ export async function startOperatorProject(
   return host.start({ port: options.port })
 }
 
-async function resolveGeneratedArtifactRoot(
-  projectRoot: string,
-  preferBuiltArtifacts = false,
-): Promise<string> {
-  const layouts = preferBuiltArtifacts
-    ? (["dist/.voyant", ".voyant"] as const)
-    : GENERATED_ARTIFACT_LAYOUTS
-  for (const layout of layouts) {
+async function resolveGeneratedArtifactRoot(projectRoot: string): Promise<string> {
+  for (const layout of GENERATED_ARTIFACT_LAYOUTS) {
     const artifactRoot = path.join(projectRoot, layout)
     if (
       (await pathExists(path.join(artifactRoot, PROJECT_GRAPH_ENTRY))) &&
@@ -358,15 +356,48 @@ async function loadGeneratedProjectLinks(artifactRoot: string) {
   }
 }
 
-function resolveAdminAssetsDir(
+async function resolveAdminAssetsDir(
   projectRoot: string,
   artifactRoot: string,
   explicit?: string,
-): string {
+  preferBuiltAssets = false,
+): Promise<string> {
   if (explicit) return path.resolve(explicit)
-  return artifactRoot === path.join(projectRoot, "dist/.voyant")
-    ? path.join(projectRoot, "dist/client")
-    : path.join(artifactRoot, "admin/client")
+  const sourceArtifactRoot = path.join(projectRoot, ".voyant")
+  const builtArtifactRoot = path.join(projectRoot, "dist/.voyant")
+  const builtClientDir = path.join(projectRoot, "dist/client")
+  if (artifactRoot === builtArtifactRoot) return builtClientDir
+  if (
+    preferBuiltAssets &&
+    artifactRoot === sourceArtifactRoot &&
+    (await pathExists(builtClientDir)) &&
+    (await generatedArtifactGraphsMatch(sourceArtifactRoot, builtArtifactRoot))
+  ) {
+    return builtClientDir
+  }
+  return path.join(artifactRoot, "admin/client")
+}
+
+async function generatedArtifactGraphsMatch(
+  sourceArtifactRoot: string,
+  builtArtifactRoot: string,
+): Promise<boolean> {
+  const [sourceHash, builtHash] = await Promise.all([
+    readGeneratedArtifactGraphHash(sourceArtifactRoot),
+    readGeneratedArtifactGraphHash(builtArtifactRoot),
+  ])
+  return sourceHash !== undefined && sourceHash === builtHash
+}
+
+async function readGeneratedArtifactGraphHash(artifactRoot: string): Promise<string | undefined> {
+  try {
+    const graph = JSON.parse(
+      await readFile(path.join(artifactRoot, PROJECT_GRAPH_ENTRY), "utf8"),
+    ) as { contentHash?: unknown }
+    return typeof graph.contentHash === "string" ? graph.contentHash : undefined
+  } catch {
+    return undefined
+  }
 }
 
 function rewriteLegacyMediaRequest(request: Request): Request {

--- a/packages/operator-runtime/src/runtime-composition.test.ts
+++ b/packages/operator-runtime/src/runtime-composition.test.ts
@@ -176,6 +176,34 @@ describe("Operator runtime composition", () => {
     )
   })
 
+  it("prefers packaged artifacts and client assets for production start", async () => {
+    const projectRoot = await createGeneratedProject()
+    const builtArtifactRoot = path.join(projectRoot, "dist/.voyant")
+    await mkdir(path.join(builtArtifactRoot, "runtime"), { recursive: true })
+    await writeFile(
+      path.join(builtArtifactRoot, "runtime/project-runtime.generated.ts"),
+      "export {}\n",
+    )
+    await writeFile(
+      path.join(builtArtifactRoot, "deployment-graph.generated.json"),
+      JSON.stringify({
+        contentHash: "graph-hash",
+        requirements: { resources: [] },
+        provisioning: { scheduledJobs: [] },
+      }),
+    )
+    await mkdir(path.join(projectRoot, "dist/client"), { recursive: true })
+
+    const project = await loadOperatorProject({
+      projectRoot,
+      preferBuiltArtifacts: true,
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+
+    expect(project.graphHash).toBe("graph-hash")
+    expect(mocks.adminHostOptions[0]?.clientAssetsDir).toBe(path.join(projectRoot, "dist/client"))
+  })
+
   it("rewrites persisted legacy media URLs before API dispatch", async () => {
     const projectRoot = await createGeneratedProject()
     const project = await loadOperatorProject({

--- a/packages/operator-runtime/src/runtime-composition.test.ts
+++ b/packages/operator-runtime/src/runtime-composition.test.ts
@@ -1,7 +1,7 @@
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import path from "node:path"
-
+import { tsImport } from "tsx/esm/api"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => {
@@ -176,14 +176,10 @@ describe("Operator runtime composition", () => {
     )
   })
 
-  it("prefers packaged artifacts and client assets for production start", async () => {
+  it("uses current source runtime artifacts with matching built admin assets in production", async () => {
     const projectRoot = await createGeneratedProject()
     const builtArtifactRoot = path.join(projectRoot, "dist/.voyant")
-    await mkdir(path.join(builtArtifactRoot, "runtime"), { recursive: true })
-    await writeFile(
-      path.join(builtArtifactRoot, "runtime/project-runtime.generated.ts"),
-      "export {}\n",
-    )
+    await mkdir(builtArtifactRoot, { recursive: true })
     await writeFile(
       path.join(builtArtifactRoot, "deployment-graph.generated.json"),
       JSON.stringify({
@@ -196,12 +192,34 @@ describe("Operator runtime composition", () => {
 
     const project = await loadOperatorProject({
       projectRoot,
-      preferBuiltArtifacts: true,
-      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+      env: { DATABASE_URL: "postgres://example.invalid/voyant", NODE_ENV: "production" },
     })
 
     expect(project.graphHash).toBe("graph-hash")
     expect(mocks.adminHostOptions[0]?.clientAssetsDir).toBe(path.join(projectRoot, "dist/client"))
+    expect(vi.mocked(tsImport).mock.calls[0]?.[0]).toContain(
+      path.join(projectRoot, ".voyant/runtime/project-runtime.generated.ts"),
+    )
+  })
+
+  it("does not serve built admin assets from a stale deployment graph", async () => {
+    const projectRoot = await createGeneratedProject()
+    const builtArtifactRoot = path.join(projectRoot, "dist/.voyant")
+    await mkdir(builtArtifactRoot, { recursive: true })
+    await writeFile(
+      path.join(builtArtifactRoot, "deployment-graph.generated.json"),
+      JSON.stringify({ contentHash: "stale-graph-hash" }),
+    )
+    await mkdir(path.join(projectRoot, "dist/client"), { recursive: true })
+
+    await loadOperatorProject({
+      projectRoot,
+      env: { DATABASE_URL: "postgres://example.invalid/voyant", NODE_ENV: "production" },
+    })
+
+    expect(mocks.adminHostOptions[0]?.clientAssetsDir).toBe(
+      path.join(projectRoot, ".voyant/admin/client"),
+    )
   })
 
   it("rewrites persisted legacy media URLs before API dispatch", async () => {

--- a/packages/operator-runtime/src/runtime-composition.test.ts
+++ b/packages/operator-runtime/src/runtime-composition.test.ts
@@ -15,18 +15,25 @@ const mocks = vi.hoisted(() => {
   const runtimePorts = { "voyant.workflow-services": [{ serviceId: "package.service" }] }
   const services = { has: vi.fn(() => false), register: vi.fn(), resolve: vi.fn() }
   const eventBus = { emit: vi.fn(), subscribe: vi.fn() }
+  const runtimeFetch = vi.fn(async (request: Request) => new Response(request.url))
   const nodeRuntime = {
     env: { DATABASE_URL: "postgres://example.invalid/voyant" },
-    app: { ready: vi.fn(), services, eventBus },
+    app: { ready: vi.fn(), fetch: runtimeFetch, services, eventBus },
   }
 
   return {
+    adminHostOptions: [] as Array<{
+      clientAssetsDir: string
+      app(request: Request, env: unknown, ctx: unknown): Promise<Response>
+    }>,
+    authRuntimeOptions: [] as Array<Record<string, unknown>>,
     createNodeServer: vi.fn((_options: unknown) => ({ close: vi.fn(), port: 8080 })),
     enqueuePostgresWebhookEvent: vi.fn(async () => ["queued"]),
     loadVoyantNodeRuntime: vi.fn(async (_options: unknown) => nodeRuntime),
     loadVoyantNodeWorkflowRuntime: vi.fn(async (_options: unknown) => ({ workflows: [] })),
     nodeRuntime,
     resolveNodeDatabase: vi.fn(() => ({ kind: "database" })),
+    runtimeFetch,
     runScheduledWorkflow: vi.fn(
       async (_job: unknown, _event: unknown, runtime: { load(): Promise<unknown> }) =>
         runtime.load(),
@@ -37,18 +44,30 @@ const mocks = vi.hoisted(() => {
 })
 
 vi.mock("@voyant-travel/admin-host/serve", () => ({
-  serveAdminHost: () => ({ fetch: vi.fn(async () => new Response("ok")) }),
+  serveAdminHost: (options: (typeof mocks.adminHostOptions)[number]) => {
+    mocks.adminHostOptions.push(options)
+    return {
+      fetch: (request: Request, env: unknown, ctx: unknown) => options.app(request, env, ctx),
+    }
+  },
 }))
 
 vi.mock("@voyant-travel/auth/operator-node-runtime", () => ({
-  createOperatorAuthNodeRuntime: () => ({
-    handler: vi.fn(),
-    getBootstrapStatusForRequest: vi.fn(),
-    getCurrentUserForRequest: vi.fn(),
-    hasAuthPermission: vi.fn(),
-    resolveAuthRequest: vi.fn(),
-    validateApiTokenAccess: vi.fn(),
-  }),
+  createOperatorAuthNodeRuntime: (options: Record<string, unknown>) => {
+    mocks.authRuntimeOptions.push(options)
+    return {
+      handler: vi.fn(),
+      getBootstrapStatusForRequest: vi.fn(),
+      getCurrentUserForRequest: vi.fn(),
+      hasAuthPermission: vi.fn(),
+      resolveAuthRequest: vi.fn(),
+      validateApiTokenAccess: vi.fn(),
+    }
+  },
+}))
+
+vi.mock("@voyant-travel/cloud-sdk", () => ({
+  getVoyantCloudClient: vi.fn(),
 }))
 
 vi.mock("@voyant-travel/db/runtime", () => ({
@@ -124,6 +143,8 @@ const temporaryRoots: string[] = []
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mocks.adminHostOptions.length = 0
+  mocks.authRuntimeOptions.length = 0
 })
 
 afterEach(async () => {
@@ -131,6 +152,62 @@ afterEach(async () => {
 })
 
 describe("Operator runtime composition", () => {
+  it("selects admin assets from the same generated artifact layout", async () => {
+    const developmentRoot = await createGeneratedProject()
+    await mkdir(path.join(developmentRoot, ".voyant/admin/client"), { recursive: true })
+    await mkdir(path.join(developmentRoot, "dist/client"), { recursive: true })
+    await loadOperatorProject({
+      projectRoot: developmentRoot,
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+    expect(mocks.adminHostOptions[0]?.clientAssetsDir).toBe(
+      path.join(developmentRoot, ".voyant/admin/client"),
+    )
+
+    const distributionRoot = await createGeneratedProject([], "dist/.voyant")
+    await mkdir(path.join(distributionRoot, ".voyant/admin/client"), { recursive: true })
+    await mkdir(path.join(distributionRoot, "dist/client"), { recursive: true })
+    await loadOperatorProject({
+      projectRoot: distributionRoot,
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+    expect(mocks.adminHostOptions[1]?.clientAssetsDir).toBe(
+      path.join(distributionRoot, "dist/client"),
+    )
+  })
+
+  it("rewrites persisted legacy media URLs before API dispatch", async () => {
+    const projectRoot = await createGeneratedProject()
+    const project = await loadOperatorProject({
+      projectRoot,
+      adminAssetsDir: path.join(projectRoot, "admin"),
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+
+    await project.fetch(
+      new Request("http://localhost:3300/api/v1/media/uploads/example.pdf?download=1"),
+    )
+
+    const dispatched = mocks.runtimeFetch.mock.calls[0]?.[0] as Request
+    expect(new URL(dispatched.url)).toMatchObject({
+      pathname: "/api/v1/admin/media/uploads/example.pdf",
+      search: "?download=1",
+    })
+  })
+
+  it("provides the standard cloud email resolver to the auth runtime", async () => {
+    const projectRoot = await createGeneratedProject()
+    await loadOperatorProject({
+      projectRoot,
+      adminAssetsDir: path.join(projectRoot, "admin"),
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+
+    expect(mocks.authRuntimeOptions[0]).toMatchObject({
+      resolveEmailSender: expect.any(Function),
+    })
+  })
+
   it("wires graph outbound webhooks through the neutral Node delivery helper", async () => {
     const projectRoot = await createGeneratedProject()
     await loadOperatorProject({
@@ -220,14 +297,16 @@ describe("Operator runtime composition", () => {
 
 async function createGeneratedProject(
   scheduledJobs: readonly Readonly<Record<string, unknown>>[] = [],
+  layout = ".voyant",
 ): Promise<string> {
   const projectRoot = await mkdtemp(path.join(tmpdir(), "voyant-operator-runtime-"))
   temporaryRoots.push(projectRoot)
-  const runtimeDir = path.join(projectRoot, ".voyant", "runtime")
+  const artifactRoot = path.join(projectRoot, layout)
+  const runtimeDir = path.join(artifactRoot, "runtime")
   await mkdir(runtimeDir, { recursive: true })
   await writeFile(path.join(runtimeDir, "project-runtime.generated.ts"), "export {}\n")
   await writeFile(
-    path.join(projectRoot, ".voyant", "deployment-graph.generated.json"),
+    path.join(artifactRoot, "deployment-graph.generated.json"),
     JSON.stringify({
       contentHash: "graph-hash",
       requirements: { resources: [] },

--- a/packages/relationships/migrations/20260713000600_backfill_custom_field_values.sql
+++ b/packages/relationships/migrations/20260713000600_backfill_custom_field_values.sql
@@ -6,6 +6,7 @@ DECLARE
   entity record;
   legacy_count bigint;
   missing_count bigint;
+  mismatched_count bigint;
   unknown_types text;
 BEGIN
   IF to_regclass('public.custom_field_values') IS NULL THEN
@@ -33,6 +34,18 @@ BEGIN
     RAISE EXCEPTION
       'Cannot retire custom_field_values: % row(s) reference missing definitions',
       missing_count;
+  END IF;
+
+  SELECT count(*)
+    INTO mismatched_count
+    FROM custom_field_values v
+    JOIN custom_field_definitions d ON d.id = v.definition_id
+   WHERE d.entity_type::text IS DISTINCT FROM v.entity_type::text;
+
+  IF mismatched_count > 0 THEN
+    RAISE EXCEPTION
+      'Cannot retire custom_field_values: % row(s) have a definition entity type that does not match the value entity type',
+      mismatched_count;
   END IF;
 
   FOR entity IN
@@ -114,7 +127,9 @@ BEGIN
                     END
                   ) AS backfilled
              FROM custom_field_values v
-             JOIN custom_field_definitions d ON d.id = v.definition_id
+             JOIN custom_field_definitions d
+               ON d.id = v.definition_id
+              AND d.entity_type::text = v.entity_type::text
             WHERE v.entity_type::text = $1
             GROUP BY v.entity_id
          ) sub

--- a/packages/relationships/tests/unit/custom-fields-backfill-migration.test.ts
+++ b/packages/relationships/tests/unit/custom-fields-backfill-migration.test.ts
@@ -21,7 +21,12 @@ describe("legacy custom-field value migration", () => {
     expect(migration).toContain("sub.backfilled || COALESCE(t.custom_fields, ''{}''::jsonb)")
     expect(migration).toContain("unsupported entity types")
     expect(migration).toContain("reference missing definitions")
+    expect(migration).toContain("definition entity type that does not match")
+    expect(migration).toContain("d.entity_type::text = v.entity_type::text")
     expect(migration).toContain("reference missing %.id values")
+    expect(migration.indexOf("definition entity type that does not match")).toBeLessThan(
+      migration.indexOf("UPDATE %I t"),
+    )
     expect(migration.indexOf("reference missing %.id values")).toBeLessThan(
       migration.indexOf("DROP TABLE custom_field_values;"),
     )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5252,6 +5252,9 @@ importers:
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -5418,9 +5421,6 @@ importers:
       '@voyant-travel/workflow-runs':
         specifier: workspace:^
         version: link:../../packages/workflow-runs
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.2.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3267,6 +3267,9 @@ importers:
       '@voyant-travel/auth':
         specifier: workspace:^
         version: link:../auth
+      '@voyant-travel/cloud-sdk':
+        specifier: ^0.11.0
+        version: 0.11.0(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core

--- a/scripts/check-standard-node-starter.mjs
+++ b/scripts/check-standard-node-starter.mjs
@@ -384,7 +384,10 @@ function inspectCheckedInStarterDependencies(repoRoot) {
   if (!existsSync(packageJsonPath)) return
 
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
-  if (packageJson.scripts?.start !== "node --require=dotenv/config dist/server/server.js") {
+  if (
+    packageJson.scripts?.start !==
+    "NODE_ENV=production node --require=dotenv/config dist/server/server.js"
+  ) {
     violations.push(
       "checked-in starter start must load optional .env through the Node 20 bootstrap",
     )

--- a/scripts/check-standard-node-starter.mjs
+++ b/scripts/check-standard-node-starter.mjs
@@ -384,6 +384,22 @@ function inspectCheckedInStarterDependencies(repoRoot) {
   if (!existsSync(packageJsonPath)) return
 
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  if (packageJson.scripts?.start !== "node --require=dotenv/config dist/server/server.js") {
+    violations.push(
+      "checked-in starter start must load optional .env through the Node 20 bootstrap",
+    )
+  }
+  if (
+    packageJson.scripts?.["db:migrate"] !==
+    "pnpm run graph:emit && NODE_OPTIONS=--require=dotenv/config voyant migrate"
+  ) {
+    violations.push(
+      "checked-in starter db:migrate must load optional .env before invoking the external CLI",
+    )
+  }
+  if (!packageJson.dependencies?.dotenv || packageJson.devDependencies?.dotenv) {
+    violations.push("checked-in starter must provide dotenv as a production bootstrap dependency")
+  }
   const declared = new Set([
     ...Object.keys(packageJson.dependencies ?? {}),
     ...Object.keys(packageJson.devDependencies ?? {}),

--- a/scripts/check-standard-node-starter.mjs
+++ b/scripts/check-standard-node-starter.mjs
@@ -391,10 +391,11 @@ function inspectCheckedInStarterDependencies(repoRoot) {
   }
   if (
     packageJson.scripts?.["db:migrate"] !==
-    "pnpm run graph:emit && NODE_OPTIONS=--require=dotenv/config voyant migrate"
+    'pnpm run graph:emit && NODE_OPTIONS="$' +
+      '{NODE_OPTIONS:+$NODE_OPTIONS }--require=dotenv/config" voyant migrate'
   ) {
     violations.push(
-      "checked-in starter db:migrate must load optional .env before invoking the external CLI",
+      "checked-in starter db:migrate must preserve NODE_OPTIONS and load optional .env before invoking the external CLI",
     )
   }
   if (!packageJson.dependencies?.dotenv || packageJson.devDependencies?.dotenv) {

--- a/scripts/tests/check-standard-node-starter.test.mjs
+++ b/scripts/tests/check-standard-node-starter.test.mjs
@@ -308,10 +308,39 @@ test("rejects checked-in starter commands that do not load optional .env on Node
       const stderr = String(error.stderr)
       return (
         stderr.includes("start must load optional .env through the Node 20 bootstrap") &&
-        stderr.includes("db:migrate must load optional .env before invoking the external CLI") &&
+        stderr.includes(
+          "db:migrate must preserve NODE_OPTIONS and load optional .env before invoking the external CLI",
+        ) &&
         stderr.includes("dotenv as a production bootstrap dependency")
       )
     },
+  )
+})
+
+test("rejects db:migrate commands that replace existing NODE_OPTIONS", () => {
+  const starter = fixture()
+  const root = mkdtempSync(join(tmpdir(), "voyant-standard-node-repository-"))
+  roots.push(root)
+  const packageJsonPath = join(root, "starters/operator/package.json")
+  mkdirSync(dirname(packageJsonPath), { recursive: true })
+  writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify({
+      scripts: {
+        start: "node --require=dotenv/config dist/server/server.js",
+        "db:migrate": "pnpm run graph:emit && NODE_OPTIONS=--require=dotenv/config voyant migrate",
+      },
+      dependencies: { dotenv: "1.0.0" },
+      devDependencies: {},
+    })}\n`,
+  )
+
+  assert.throws(
+    () => run(starter, root),
+    (error) =>
+      String(error.stderr).includes(
+        "db:migrate must preserve NODE_OPTIONS and load optional .env before invoking the external CLI",
+      ),
   )
 })
 

--- a/scripts/tests/check-standard-node-starter.test.mjs
+++ b/scripts/tests/check-standard-node-starter.test.mjs
@@ -284,6 +284,37 @@ test("rejects undeclared first-party imports in checked-in starter tests", () =>
   )
 })
 
+test("rejects checked-in starter commands that do not load optional .env on Node 20", () => {
+  const starter = fixture()
+  const root = mkdtempSync(join(tmpdir(), "voyant-standard-node-repository-"))
+  roots.push(root)
+  const packageJsonPath = join(root, "starters/operator/package.json")
+  mkdirSync(dirname(packageJsonPath), { recursive: true })
+  writeFileSync(
+    packageJsonPath,
+    `${JSON.stringify({
+      scripts: {
+        start: "node --env-file-if-exists=.env dist/server/server.js",
+        "db:migrate": "pnpm run graph:emit && voyant migrate",
+      },
+      dependencies: {},
+      devDependencies: { dotenv: "1.0.0" },
+    })}\n`,
+  )
+
+  assert.throws(
+    () => run(starter, root),
+    (error) => {
+      const stderr = String(error.stderr)
+      return (
+        stderr.includes("start must load optional .env through the Node 20 bootstrap") &&
+        stderr.includes("db:migrate must load optional .env before invoking the external CLI") &&
+        stderr.includes("dotenv as a production bootstrap dependency")
+      )
+    },
+  )
+})
+
 function run(starterDir, root = repoRoot) {
   if (root !== repoRoot) {
     const gitignore = join(root, "starters/operator/.gitignore")

--- a/scripts/tests/check-standard-node-starter.test.mjs
+++ b/scripts/tests/check-standard-node-starter.test.mjs
@@ -327,7 +327,7 @@ test("rejects db:migrate commands that replace existing NODE_OPTIONS", () => {
     packageJsonPath,
     `${JSON.stringify({
       scripts: {
-        start: "node --require=dotenv/config dist/server/server.js",
+        start: "NODE_ENV=production node --require=dotenv/config dist/server/server.js",
         "db:migrate": "pnpm run graph:emit && NODE_OPTIONS=--require=dotenv/config voyant migrate",
       },
       dependencies: { dotenv: "1.0.0" },

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -9,7 +9,7 @@
     "copy:deployment-artifacts": "rm -rf dist/.voyant dist/server/.voyant && mkdir -p dist/server && cp -R .voyant dist/.voyant && cp -R .voyant dist/server/.voyant",
     "preview": "pnpm run build && vite preview --config .voyant/vite.config.ts",
     "measure": "node ../../scripts/measure-standard-node-starter.mjs --require-build",
-    "start": "node --require=dotenv/config dist/server/server.js",
+    "start": "NODE_ENV=production node --require=dotenv/config dist/server/server.js",
     "typecheck": "pnpm run graph:emit && NODE_OPTIONS=--max-old-space-size=6144 tsc -p .voyant/tsconfig.server.json && NODE_OPTIONS=--max-old-space-size=6144 tsc -p .voyant/tsconfig.tests-smoke.json && NODE_OPTIONS=--max-old-space-size=6144 tsc -p .voyant/tsconfig.client.json",
     "test": "pnpm run graph:emit && vitest run --config .voyant/vitest.config.ts --passWithNoTests",
     "graph:check": "node ../../scripts/generate-operator-starter-metadata.mjs --check && voyant db doctor --fail-on-drift",

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -17,7 +17,7 @@
     "dev:worker": "voyant dev --file ../../packages/operator-runtime/src/workflow-entry.ts --port 3310",
     "workflows:build": "voyant workflows build --file ../../packages/operator-runtime/src/workflow-entry.ts --out dist/workflows",
     "workflows:doctor": "voyant workflows doctor --target entry --file ../../packages/operator-runtime/src/workflow-entry.ts",
-    "db:migrate": "pnpm run graph:emit && NODE_OPTIONS=--require=dotenv/config voyant migrate",
+    "db:migrate": "pnpm run graph:emit && NODE_OPTIONS=\"${NODE_OPTIONS:+$NODE_OPTIONS }--require=dotenv/config\" voyant migrate",
     "lint": "biome check src/ tests/"
   },
   "dependencies": {

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -9,7 +9,7 @@
     "copy:deployment-artifacts": "rm -rf dist/.voyant dist/server/.voyant && mkdir -p dist/server && cp -R .voyant dist/.voyant && cp -R .voyant dist/server/.voyant",
     "preview": "pnpm run build && vite preview --config .voyant/vite.config.ts",
     "measure": "node ../../scripts/measure-standard-node-starter.mjs --require-build",
-    "start": "node --env-file-if-exists=.env dist/server/server.js",
+    "start": "node --require=dotenv/config dist/server/server.js",
     "typecheck": "pnpm run graph:emit && NODE_OPTIONS=--max-old-space-size=6144 tsc -p .voyant/tsconfig.server.json && NODE_OPTIONS=--max-old-space-size=6144 tsc -p .voyant/tsconfig.tests-smoke.json && NODE_OPTIONS=--max-old-space-size=6144 tsc -p .voyant/tsconfig.client.json",
     "test": "pnpm run graph:emit && vitest run --config .voyant/vitest.config.ts --passWithNoTests",
     "graph:check": "node ../../scripts/generate-operator-starter-metadata.mjs --check && voyant db doctor --fail-on-drift",
@@ -17,7 +17,7 @@
     "dev:worker": "voyant dev --file ../../packages/operator-runtime/src/workflow-entry.ts --port 3310",
     "workflows:build": "voyant workflows build --file ../../packages/operator-runtime/src/workflow-entry.ts --out dist/workflows",
     "workflows:doctor": "voyant workflows doctor --target entry --file ../../packages/operator-runtime/src/workflow-entry.ts",
-    "db:migrate": "pnpm run graph:emit && voyant migrate",
+    "db:migrate": "pnpm run graph:emit && NODE_OPTIONS=--require=dotenv/config voyant migrate",
     "lint": "biome check src/ tests/"
   },
   "dependencies": {
@@ -71,6 +71,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.4.0",
     "drizzle-orm": "catalog:",
+    "dotenv": "^17.4.2",
     "embla-carousel-react": "^8.6.0",
     "hono": "catalog:",
     "input-otp": "^1.4.2",
@@ -127,7 +128,6 @@
     "@voyant-travel/trips": "workspace:^",
     "@voyant-travel/vite-config": "workspace:^",
     "@voyant-travel/workflow-runs": "workspace:^",
-    "dotenv": "^17.4.2",
     "jsdom": "^29.1.1",
     "rollup-plugin-visualizer": "^7.0.1",
     "tsx": "catalog:",


### PR DESCRIPTION
## Summary
- preserve explicit project API mounts and adopt legacy migration ledger identities without replaying SQL
- make scheduled workflow service registration repeat-safe and align admin assets with the selected artifact layout
- restore legacy media dispatch and Voyant Cloud auth email behavior in the package-owned Node host
- publish the selected-graph OpenAPI subpath, validate custom-field entity types before destructive backfill, and load optional `.env` on Node 20

Addresses valid review findings left on the superseded #3263, #3265, #3267, #3272, #3275, #3277, #3278, and #3280 branches after #3281 merged.

## Verification
- affected package tests: 514 passed, expected integration skips only
- affected package typechecks and builds: framework, framework-migrations, operator-runtime, relationships
- `pnpm verify:architecture` passed through deployment-graph validation; the remaining local graph resolution requires unrelated package `dist` outputs that CI builds first
- push hook full repository test lane: 103/103 tasks successful
- clean standard Node starter tests and checker
- changeset status and frozen offline lockfile validation
- Biome and `git diff --check`