### PR TITLE
feat(runtime): add clean project lifecycle tooling

### DIFF
--- a/.changeset/clean-runtime-project-tooling.md
+++ b/.changeset/clean-runtime-project-tooling.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/runtime": minor
+"@voyant-travel/operator-standard": minor
+---
+
+Add the versioned `@voyant-travel/runtime/tooling` project build and development server API for external CLI consumers, and keep generated standard frontend routes resolvable through the selected product distribution.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1516,6 +1516,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1517,6 +1517,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/admin/tsconfig.build.json
+++ b/packages/admin/tsconfig.build.json
@@ -1497,6 +1497,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/admin/tsconfig.typecheck.json
+++ b/packages/admin/tsconfig.typecheck.json
@@ -1492,6 +1492,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1487,6 +1487,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1488,6 +1488,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1468,6 +1468,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1463,6 +1463,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1517,6 +1517,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1518,6 +1518,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1538,6 +1538,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1539,6 +1539,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1550,6 +1550,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1545,6 +1545,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1554,6 +1554,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1555,6 +1555,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1550,6 +1550,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1545,6 +1545,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1489,6 +1489,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1490,6 +1490,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/observability-sentry/tsconfig.build.json
+++ b/packages/observability-sentry/tsconfig.build.json
@@ -1561,6 +1561,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/observability-sentry/tsconfig.typecheck.json
+++ b/packages/observability-sentry/tsconfig.typecheck.json
@@ -1562,6 +1562,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/openapi/tsconfig.typecheck.json
+++ b/packages/openapi/tsconfig.typecheck.json
@@ -1563,6 +1563,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1449,6 +1449,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1444,6 +1444,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -55,6 +55,13 @@ import { createAuthClient } from "better-auth/react"
 import type { ComponentType, ReactNode } from "react"
 import { createApiDocsRouteOptions, type OpenApiSpecLoaders } from "./standard-api-docs.js"
 
+export {
+  AdminRootErrorBoundary,
+  AdminRootShell,
+  adminRootHead,
+} from "@voyant-travel/admin/app/root"
+export { Toaster } from "@voyant-travel/ui/components"
+
 export interface StandardOperatorCurrentUser {
   id: string
   email: string

--- a/packages/operator-standard/src/standard-route-files.ts
+++ b/packages/operator-standard/src/standard-route-files.ts
@@ -61,10 +61,14 @@ export const operatorFrontend = createStandardOperatorFrontend({
   {
     path: "__root.tsx",
     source: `
+import {
+  AdminRootErrorBoundary,
+  AdminRootShell,
+  adminRootHead,
+  Toaster,
+} from ${JSON.stringify(standardFrontendImport)}
 import type { QueryClient } from "@tanstack/react-query"
 import { createRootRouteWithContext, Outlet, useRouteContext } from "@tanstack/react-router"
-import { AdminRootErrorBoundary, AdminRootShell, adminRootHead } from "@voyant-travel/admin/app/root"
-import { Toaster } from "@voyant-travel/ui/components"
 import { operatorFrontend } from "./_lib/operator-frontend.js"
 import "@/styles.css"
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -11,3 +11,34 @@ should not depend on that package directly.
 
 Command parsing and executable entry points belong to
 [`voyant-travel/cli`](https://github.com/voyant-travel/cli), not this package.
+
+## Project tooling
+
+The versioned `@voyant-travel/runtime/tooling` subpath owns the standard
+operator application's Vite and TanStack Start lifecycle. CLI packages provide
+command parsing, prepare the project graph under `.voyant`, and call this API.
+
+```ts
+import {
+  buildVoyantProject,
+  developVoyantProject,
+} from "@voyant-travel/runtime/tooling"
+
+await buildVoyantProject({ projectRoot: process.cwd() })
+
+const development = await developVoyantProject({
+  projectRoot: process.cwd(),
+  host: "127.0.0.1",
+  port: 3300,
+})
+
+console.log(development.url)
+await development.close()
+```
+
+`buildVoyantProject()` reads the selected product distribution from
+`.voyant/product-bom.generated.json`, generates its package-owned routes from
+the project-installed `./standard-route-files` export, runs the complete Node
+SSR build, and copies `.voyant` to both `dist/.voyant` and
+`dist/server/.voyant`. `developVoyantProject()` starts Vite's SSR development
+server and defaults to port `3300`.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -8,7 +8,8 @@
     ".": "./src/index.ts",
     "./deployment-resources": "./src/deployment-resources.ts",
     "./workflow-entry": "./src/workflow-entry.ts",
-    "./openapi": "./src/openapi.ts"
+    "./openapi": "./src/openapi.ts",
+    "./tooling": "./src/tooling.ts"
   },
   "scripts": {
     "build": "pnpm run clean && NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.build.json",
@@ -19,6 +20,11 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@tailwindcss/vite": "^4.3.2",
+    "@tanstack/devtools-vite": "^0.8.1",
+    "@tanstack/react-start": "^1.168.27",
+    "@tanstack/router-generator": "1.167.18",
+    "@vitejs/plugin-react": "^6.0.3",
     "@voyant-travel/admin-host": "workspace:^",
     "@voyant-travel/auth": "workspace:^",
     "@voyant-travel/cloud-sdk": "^0.11.0",
@@ -27,10 +33,12 @@
     "@voyant-travel/framework": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/runtime-core": "workspace:^",
+    "@voyant-travel/vite-config": "workspace:^",
     "@voyant-travel/webhook-delivery": "workspace:^",
     "@voyant-travel/workflow-runs": "workspace:^",
     "hono": "catalog:",
-    "tsx": "catalog:"
+    "tsx": "catalog:",
+    "vite": "catalog:"
   },
   "devDependencies": {
     "@hono/zod-openapi": "catalog:",
@@ -69,6 +77,11 @@
         "types": "./dist/openapi.d.ts",
         "import": "./dist/openapi.js",
         "default": "./dist/openapi.js"
+      },
+      "./tooling": {
+        "types": "./dist/tooling.d.ts",
+        "import": "./dist/tooling.js",
+        "default": "./dist/tooling.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -1,0 +1,423 @@
+import { access, cp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
+import path from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import tailwindcss from "@tailwindcss/vite"
+import { devtools } from "@tanstack/devtools-vite"
+import { tanstackStart } from "@tanstack/react-start/plugin/vite"
+import { Generator, getConfig } from "@tanstack/router-generator"
+import viteReact from "@vitejs/plugin-react"
+import {
+  createAnalyzePlugin,
+  VOYANT_ROUTE_FILE_IGNORE_PATTERN,
+  type VoyantGeneratedRouteFile,
+  voyantGeneratedRoutes,
+  voyantStartViteConfig,
+} from "@voyant-travel/vite-config"
+import { register } from "tsx/esm/api"
+import {
+  createServer as createViteServer,
+  type InlineConfig,
+  type PluginOption,
+  type ViteDevServer,
+  build as viteBuild,
+} from "vite"
+
+import type {
+  BuildVoyantProjectOptions,
+  DevelopVoyantProjectOptions,
+  VoyantProjectDevelopmentServer,
+} from "./tooling.js"
+
+const DEFAULT_DEVELOPMENT_PORT = 3300
+const PRODUCT_BOM_ARTIFACT = ".voyant/product-bom.generated.json"
+const PRODUCT_ROUTE_FILES_EXPORT = "standard-route-files"
+
+interface GeneratedRoutes {
+  plugin: PluginOption
+  routesDirectory: string
+  generatedRouteTree: string
+}
+
+interface ProjectViteConfigOptions {
+  appRootUrl: string
+  generatedRoutes: GeneratedRoutes
+  bootstrap: ProjectBootstrap
+}
+
+interface ProjectBootstrap {
+  routerEntry?: string
+  stylesEntry?: string
+  aliases?: Readonly<Record<string, string>>
+}
+
+interface ProjectRouteGenerationOptions {
+  projectRoot: string
+  routesDirectory: string
+  generatedRouteTree: string
+}
+
+interface ProjectViteServer {
+  resolvedUrls: ViteDevServer["resolvedUrls"]
+  listen(): Promise<unknown>
+  close(): Promise<void>
+}
+
+export interface VoyantProjectToolingDependencies {
+  loadStandardRouteFiles(projectRoot: string): Promise<readonly VoyantGeneratedRouteFile[]>
+  prepareProjectBootstrap(projectRoot: string): Promise<ProjectBootstrap>
+  materializeRoutes(options: {
+    appRootUrl: string
+    files: readonly VoyantGeneratedRouteFile[]
+  }): GeneratedRoutes
+  createViteConfig(options: ProjectViteConfigOptions): InlineConfig
+  generateRouteTree(options: ProjectRouteGenerationOptions): Promise<void>
+  buildVite(config: InlineConfig): Promise<unknown>
+  createViteServer(config: InlineConfig): Promise<ProjectViteServer>
+  replaceDirectory(source: string, destination: string): Promise<void>
+}
+
+const defaultDependencies: VoyantProjectToolingDependencies = {
+  loadStandardRouteFiles,
+  prepareProjectBootstrap,
+  materializeRoutes: voyantGeneratedRoutes,
+  createViteConfig: createProjectViteConfig,
+  generateRouteTree,
+  buildVite: viteBuild,
+  createViteServer,
+  replaceDirectory,
+}
+
+export async function buildVoyantProjectWithDependencies(
+  options: BuildVoyantProjectOptions,
+  dependencies: VoyantProjectToolingDependencies = defaultDependencies,
+): Promise<void> {
+  const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
+  const config = await prepareProjectViteConfig(projectRoot, dependencies)
+
+  await dependencies.buildVite({ ...config, root: projectRoot, configFile: false })
+  await Promise.all([
+    dependencies.replaceDirectory(
+      path.join(projectRoot, ".voyant"),
+      path.join(projectRoot, "dist/.voyant"),
+    ),
+    dependencies.replaceDirectory(
+      path.join(projectRoot, ".voyant"),
+      path.join(projectRoot, "dist/server/.voyant"),
+    ),
+  ])
+}
+
+export async function developVoyantProjectWithDependencies(
+  options: DevelopVoyantProjectOptions,
+  dependencies: VoyantProjectToolingDependencies = defaultDependencies,
+): Promise<VoyantProjectDevelopmentServer> {
+  const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
+  const config = await prepareProjectViteConfig(projectRoot, dependencies)
+  const port = options.port ?? DEFAULT_DEVELOPMENT_PORT
+  const server = await dependencies.createViteServer({
+    ...config,
+    root: projectRoot,
+    configFile: false,
+    server: {
+      ...config.server,
+      ...(options.host === undefined ? {} : { host: options.host }),
+      port,
+    },
+  })
+
+  try {
+    await server.listen()
+  } catch (error) {
+    await server.close().catch(() => undefined)
+    throw error
+  }
+
+  let closed = false
+  return {
+    url: resolveDevelopmentUrl(server, options.host, port),
+    close: async () => {
+      if (closed) return
+      closed = true
+      await server.close()
+    },
+  }
+}
+
+async function prepareProjectViteConfig(
+  projectRoot: string,
+  dependencies: VoyantProjectToolingDependencies,
+): Promise<InlineConfig> {
+  const appRootUrl = pathToFileURL(path.join(projectRoot, "generated-config-anchor.ts")).href
+  const files = await dependencies.loadStandardRouteFiles(projectRoot)
+  const bootstrap = await dependencies.prepareProjectBootstrap(projectRoot)
+  const generatedRoutes = dependencies.materializeRoutes({ appRootUrl, files })
+
+  await dependencies.generateRouteTree({
+    projectRoot,
+    routesDirectory: generatedRoutes.routesDirectory,
+    generatedRouteTree: generatedRoutes.generatedRouteTree,
+  })
+
+  return dependencies.createViteConfig({ appRootUrl, generatedRoutes, bootstrap })
+}
+
+export function createProjectViteConfig(options: ProjectViteConfigOptions): InlineConfig {
+  const config = voyantStartViteConfig({
+    appRootUrl: options.appRootUrl,
+    nodeSsr: true,
+    plugins: [
+      options.generatedRoutes.plugin,
+      devtools(),
+      tailwindcss(),
+      tanstackStart({
+        router: {
+          ...(options.bootstrap.routerEntry
+            ? {
+                entry: `../${path.relative(path.dirname(fileURLToPath(options.appRootUrl)), options.bootstrap.routerEntry).replaceAll("\\", "/")}`,
+              }
+            : {}),
+          routesDirectory: options.generatedRoutes.routesDirectory,
+          generatedRouteTree: options.generatedRoutes.generatedRouteTree,
+          routeFileIgnorePattern: VOYANT_ROUTE_FILE_IGNORE_PATTERN,
+        },
+      }),
+      viteReact(),
+      createAnalyzePlugin(options.appRootUrl),
+    ],
+  })
+  if (options.bootstrap.stylesEntry || options.bootstrap.aliases) {
+    const alias = config.resolve?.alias
+    config.resolve = {
+      ...config.resolve,
+      alias: {
+        ...options.bootstrap.aliases,
+        ...(options.bootstrap.stylesEntry ? { "@/styles.css": options.bootstrap.stylesEntry } : {}),
+        ...(alias && !Array.isArray(alias) ? alias : {}),
+      },
+    }
+  }
+  return config
+}
+
+export async function prepareProjectBootstrap(projectRoot: string): Promise<ProjectBootstrap> {
+  const productBomId = await loadProductBomId(projectRoot)
+  const generatedRoot = path.join(projectRoot, ".voyant/app")
+  const bootstrap: ProjectBootstrap = {}
+  const aliases = resolveProductDependencies(projectRoot, productBomId, [
+    "react/jsx-runtime",
+    "react/jsx-dev-runtime",
+    "react-dom/client",
+    "react-dom/server",
+    "@tanstack/react-query",
+    "@tanstack/react-router",
+    "react-dom",
+    "react",
+  ])
+  if (Object.keys(aliases).length > 0) bootstrap.aliases = aliases
+
+  if (!(await pathExists(path.join(projectRoot, "src/router.tsx")))) {
+    bootstrap.routerEntry = path.join(generatedRoot, "router.tsx")
+    await writeGeneratedFile(
+      bootstrap.routerEntry,
+      `import type { StandardOperatorRouterContext } from ${JSON.stringify(`${productBomId}/standard-frontend`)}
+import { operatorFrontend } from "../routes/_lib/operator-frontend"
+import { Route as workspaceRoute } from "../routes/_workspace/route"
+import { routeTree } from "../routeTree.gen"
+
+export type RouterContext = StandardOperatorRouterContext
+
+export function getRouter() {
+  return operatorFrontend.createRouter({ routeTree, workspaceRoute })
+}
+
+declare module "@tanstack/react-router" {
+  interface Register {
+    router: ReturnType<typeof getRouter>
+  }
+}
+`,
+    )
+  }
+
+  if (!(await pathExists(path.join(projectRoot, "src/styles.css")))) {
+    bootstrap.stylesEntry = path.join(generatedRoot, "styles.css")
+    await writeGeneratedFile(
+      bootstrap.stylesEntry,
+      `@import ${JSON.stringify(`${productBomId}/standard-styles.css`)};\n`,
+    )
+  }
+  return bootstrap
+}
+
+async function generateRouteTree(options: ProjectRouteGenerationOptions): Promise<void> {
+  const config = getConfig(
+    {
+      target: "react",
+      routesDirectory: options.routesDirectory,
+      generatedRouteTree: options.generatedRouteTree,
+      routeFileIgnorePattern: VOYANT_ROUTE_FILE_IGNORE_PATTERN,
+      disableLogging: true,
+    },
+    options.projectRoot,
+  )
+  await new Generator({ config, root: options.projectRoot }).run()
+}
+
+export async function loadStandardRouteFiles(
+  projectRoot: string,
+): Promise<readonly VoyantGeneratedRouteFile[]> {
+  const productBomId = await loadProductBomId(projectRoot)
+  const routeFilesExport = `${productBomId}/${PRODUCT_ROUTE_FILES_EXPORT}`
+  const resolveFromProject = createRequire(path.join(projectRoot, "package.json"))
+  let resolved: string
+  try {
+    resolved = resolveFromProject.resolve(routeFilesExport)
+  } catch (error) {
+    throw new Error(
+      `Voyant product BOM ${productBomId} does not provide ${routeFilesExport}: ${errorMessage(error)}`,
+      { cause: error },
+    )
+  }
+
+  const module = (await importProjectModule(resolved)) as {
+    standardOperatorRouteFiles?: unknown
+  }
+
+  if (!isGeneratedRouteFileArray(module.standardOperatorRouteFiles)) {
+    throw new TypeError(`${routeFilesExport} must export standardOperatorRouteFiles as an array`)
+  }
+  return module.standardOperatorRouteFiles
+}
+
+export async function loadProductBomId(projectRoot: string): Promise<string> {
+  const artifactPath = path.join(projectRoot, PRODUCT_BOM_ARTIFACT)
+  let source: string
+  try {
+    source = await readFile(artifactPath, "utf8")
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new Error(
+        `Voyant product BOM artifact is missing at ${artifactPath}. Run voyant build first.`,
+        {
+          cause: error,
+        },
+      )
+    }
+    throw error
+  }
+
+  let artifact: unknown
+  try {
+    artifact = JSON.parse(source)
+  } catch (error) {
+    throw new Error(`Voyant product BOM artifact at ${artifactPath} is not valid JSON.`, {
+      cause: error,
+    })
+  }
+
+  const productBomId = (artifact as { productBom?: { id?: unknown } })?.productBom?.id
+  if (typeof productBomId !== "string" || !isPackageName(productBomId)) {
+    throw new TypeError(
+      `Voyant product BOM artifact at ${artifactPath} must declare productBom.id as a canonical package name.`,
+    )
+  }
+  return productBomId
+}
+
+async function pathExists(file: string): Promise<boolean> {
+  try {
+    await access(file)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function writeGeneratedFile(file: string, source: string): Promise<void> {
+  await mkdir(path.dirname(file), { recursive: true })
+  await writeFile(file, source)
+}
+
+async function importProjectModule(resolved: string): Promise<unknown> {
+  const moduleUrl = pathToFileURL(resolved).href
+  if (/\.[cm]?tsx?$/.test(resolved)) {
+    const unregister = register()
+    try {
+      return await import(moduleUrl)
+    } finally {
+      await unregister()
+    }
+  }
+  return import(moduleUrl)
+}
+
+function resolveProductDependencies(
+  projectRoot: string,
+  productBomId: string,
+  dependencies: readonly string[],
+): Readonly<Record<string, string>> {
+  try {
+    const projectRequire = createRequire(path.join(projectRoot, "package.json"))
+    const productEntry = projectRequire.resolve(`${productBomId}/standard-frontend`)
+    const productRequire = createRequire(productEntry)
+    return Object.fromEntries(
+      dependencies.flatMap((dependency) => {
+        try {
+          return [[dependency, productRequire.resolve(dependency)]]
+        } catch {
+          return []
+        }
+      }),
+    )
+  } catch {
+    return {}
+  }
+}
+
+function isPackageName(value: string): boolean {
+  return (
+    /^@[a-z0-9][a-z0-9._-]*\/[a-z0-9][a-z0-9._-]*$/.test(value) ||
+    /^[a-z0-9][a-z0-9._-]*$/.test(value)
+  )
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function isGeneratedRouteFileArray(value: unknown): value is readonly VoyantGeneratedRouteFile[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (file) =>
+        typeof file === "object" &&
+        file !== null &&
+        typeof (file as { path?: unknown }).path === "string" &&
+        typeof (file as { source?: unknown }).source === "string",
+    )
+  )
+}
+
+async function replaceDirectory(source: string, destination: string): Promise<void> {
+  await rm(destination, { recursive: true, force: true })
+  await mkdir(path.dirname(destination), { recursive: true })
+  await cp(source, destination, { recursive: true })
+}
+
+function resolveDevelopmentUrl(
+  server: Pick<ProjectViteServer, "resolvedUrls">,
+  host: string | undefined,
+  port: number,
+): string {
+  const resolved = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+  if (resolved) return resolved
+
+  const fallbackHost = host && host !== "0.0.0.0" && host !== "::" ? host : "localhost"
+  return `http://${formatUrlHost(fallbackHost)}:${port}`
+}
+
+function formatUrlHost(host: string): string {
+  return host.includes(":") && !host.startsWith("[") ? `[${host}]` : host
+}

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -222,9 +222,9 @@ export async function prepareProjectBootstrap(projectRoot: string): Promise<Proj
     await writeGeneratedFile(
       bootstrap.routerEntry,
       `import type { StandardOperatorRouterContext } from ${JSON.stringify(`${productBomId}/standard-frontend`)}
-import { operatorFrontend } from "../routes/_lib/operator-frontend"
-import { Route as workspaceRoute } from "../routes/_workspace/route"
-import { routeTree } from "../routeTree.gen"
+import { operatorFrontend } from "../routes/_lib/operator-frontend.js"
+import { Route as workspaceRoute } from "../routes/_workspace/route.js"
+import { routeTree } from "../routeTree.gen.js"
 
 export type RouterContext = StandardOperatorRouterContext
 

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -175,6 +175,9 @@ export const standardOperatorRouteFiles: readonly RouteFile[] = [
     await expect(readText(bootstrap.routerEntry!)).resolves.toContain(
       'from "@acme/operator/standard-frontend"',
     )
+    await expect(readText(bootstrap.routerEntry!)).resolves.toContain(
+      'from "../routes/_lib/operator-frontend.js"',
+    )
     await expect(readText(bootstrap.stylesEntry!)).resolves.toBe(
       '@import "@acme/operator/standard-styles.css";\n',
     )

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -1,0 +1,297 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  buildVoyantProjectWithDependencies,
+  developVoyantProjectWithDependencies,
+  loadStandardRouteFiles,
+  prepareProjectBootstrap,
+  type VoyantProjectToolingDependencies,
+} from "./tooling-internal.js"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, {
+        recursive: true,
+        force: true,
+      }),
+    ),
+  )
+})
+
+describe("Voyant project tooling", () => {
+  it("generates, builds, and copies both deployment artifact layouts", async () => {
+    const projectRoot = "/workspace/operator"
+    const calls: string[] = []
+    const dependencies = createDependencies(calls)
+
+    await buildVoyantProjectWithDependencies({ projectRoot }, dependencies)
+
+    const appRootUrl = pathToFileURL(path.join(projectRoot, "generated-config-anchor.ts")).href
+    expect(dependencies.loadStandardRouteFiles).toHaveBeenCalledWith(projectRoot)
+    expect(dependencies.materializeRoutes).toHaveBeenCalledWith({
+      appRootUrl,
+      files: [{ path: "__root.tsx", source: "export const Route = {}" }],
+    })
+    expect(dependencies.prepareProjectBootstrap).toHaveBeenCalledWith(projectRoot)
+    expect(dependencies.generateRouteTree).toHaveBeenCalledWith({
+      projectRoot,
+      routesDirectory: "/workspace/operator/.voyant/routes",
+      generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
+    })
+    expect(dependencies.createViteConfig).toHaveBeenCalledWith({
+      appRootUrl,
+      generatedRoutes: {
+        plugin: { name: "generated-routes" },
+        routesDirectory: "/workspace/operator/.voyant/routes",
+        generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
+      },
+      bootstrap: {},
+    })
+    expect(dependencies.buildVite).toHaveBeenCalledWith({
+      marker: "voyant-vite-config",
+      root: projectRoot,
+      configFile: false,
+      server: { allowedHosts: true },
+    })
+    expect(dependencies.replaceDirectory).toHaveBeenCalledTimes(2)
+    expect(dependencies.replaceDirectory).toHaveBeenCalledWith(
+      "/workspace/operator/.voyant",
+      "/workspace/operator/dist/.voyant",
+    )
+    expect(dependencies.replaceDirectory).toHaveBeenCalledWith(
+      "/workspace/operator/.voyant",
+      "/workspace/operator/dist/server/.voyant",
+    )
+    expect(calls.indexOf("generate-route-tree")).toBeLessThan(calls.indexOf("vite-build"))
+    expect(calls.indexOf("vite-build")).toBeLessThan(calls.indexOf("replace-directory"))
+  })
+
+  it("starts Vite SSR on port 3300 and closes the server once", async () => {
+    const calls: string[] = []
+    const dependencies = createDependencies(calls)
+
+    const development = await developVoyantProjectWithDependencies(
+      { projectRoot: "/workspace/operator" },
+      dependencies,
+    )
+
+    expect(dependencies.createViteServer).toHaveBeenCalledWith({
+      marker: "voyant-vite-config",
+      root: "/workspace/operator",
+      configFile: false,
+      server: { allowedHosts: true, port: 3300 },
+    })
+    expect(development.url).toBe("http://localhost:3300/")
+    expect(calls).toContain("vite-listen")
+
+    await development.close()
+    await development.close()
+    expect(calls.filter((call) => call === "vite-close")).toHaveLength(1)
+  })
+
+  it("passes explicit host and port to Vite and provides a fallback URL", async () => {
+    const dependencies = createDependencies([])
+    vi.mocked(dependencies.createViteServer).mockResolvedValue({
+      resolvedUrls: null,
+      listen: vi.fn(async () => {}),
+      close: vi.fn(async () => {}),
+    })
+
+    const development = await developVoyantProjectWithDependencies(
+      { projectRoot: "/workspace/operator", host: "127.0.0.1", port: 4400 },
+      dependencies,
+    )
+
+    expect(dependencies.createViteServer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        server: { allowedHosts: true, host: "127.0.0.1", port: 4400 },
+      }),
+    )
+    expect(development.url).toBe("http://127.0.0.1:4400")
+  })
+
+  it("closes Vite when the server cannot start listening", async () => {
+    const dependencies = createDependencies([])
+    const close = vi.fn(async () => {})
+    vi.mocked(dependencies.createViteServer).mockResolvedValue({
+      resolvedUrls: null,
+      listen: vi.fn(async () => {
+        throw new Error("port unavailable")
+      }),
+      close,
+    })
+
+    await expect(
+      developVoyantProjectWithDependencies({ projectRoot: "/workspace/operator" }, dependencies),
+    ).rejects.toThrow("port unavailable")
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it("loads a linked TypeScript route export from the product BOM package", async () => {
+    const projectRoot = await createTemporaryDirectory()
+    await writeProductBom(projectRoot, "@voyant-travel/operator-standard")
+    const packageRoot = path.join(projectRoot, "node_modules/@voyant-travel/operator-standard")
+    await mkdir(packageRoot, { recursive: true })
+    await writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "@voyant-travel/operator-standard",
+        type: "module",
+        exports: { "./standard-route-files": "./standard-route-files.ts" },
+      }),
+    )
+    await writeFile(
+      path.join(packageRoot, "standard-route-files.ts"),
+      `interface RouteFile { readonly path: string; readonly source: string }
+export const standardOperatorRouteFiles: readonly RouteFile[] = [
+  { path: "project.tsx", source: "project-owned" },
+]
+`,
+    )
+
+    await expect(loadStandardRouteFiles(projectRoot)).resolves.toEqual([
+      { path: "project.tsx", source: "project-owned" },
+    ])
+  })
+
+  it("materializes hidden router and style fallbacks for a minimal project", async () => {
+    const projectRoot = await createTemporaryDirectory()
+    await writeProductBom(projectRoot, "@acme/operator")
+
+    const bootstrap = await prepareProjectBootstrap(projectRoot)
+
+    expect(bootstrap).toEqual({
+      routerEntry: path.join(projectRoot, ".voyant/app/router.tsx"),
+      stylesEntry: path.join(projectRoot, ".voyant/app/styles.css"),
+    })
+    await expect(readText(bootstrap.routerEntry!)).resolves.toContain(
+      'from "@acme/operator/standard-frontend"',
+    )
+    await expect(readText(bootstrap.stylesEntry!)).resolves.toBe(
+      '@import "@acme/operator/standard-styles.css";\n',
+    )
+  })
+
+  it("preserves project-authored router and style overrides", async () => {
+    const projectRoot = await createTemporaryDirectory()
+    await writeProductBom(projectRoot, "@acme/operator")
+    await mkdir(path.join(projectRoot, "src"), { recursive: true })
+    await writeFile(path.join(projectRoot, "src/router.tsx"), "export const projectRouter = true\n")
+    await writeFile(path.join(projectRoot, "src/styles.css"), "/* project */\n")
+
+    await expect(prepareProjectBootstrap(projectRoot)).resolves.toEqual({})
+  })
+
+  it("fails when the generated product BOM artifact is missing", async () => {
+    const projectRoot = await createTemporaryDirectory()
+
+    await expect(loadStandardRouteFiles(projectRoot)).rejects.toThrow(
+      `Voyant product BOM artifact is missing at ${path.join(
+        projectRoot,
+        ".voyant/product-bom.generated.json",
+      )}`,
+    )
+  })
+
+  it("fails when productBom.id is not a canonical package name", async () => {
+    const projectRoot = await createTemporaryDirectory()
+    await writeProductBom(projectRoot, "../operator-standard")
+
+    await expect(loadStandardRouteFiles(projectRoot)).rejects.toThrow(
+      "must declare productBom.id as a canonical package name",
+    )
+  })
+
+  it("fails when the selected product package has no route tooling export", async () => {
+    const projectRoot = await createTemporaryDirectory()
+    await writeProductBom(projectRoot, "@acme/operator")
+    const packageRoot = path.join(projectRoot, "node_modules/@acme/operator")
+    await mkdir(packageRoot, { recursive: true })
+    await writeFile(
+      path.join(packageRoot, "package.json"),
+      JSON.stringify({
+        name: "@acme/operator",
+        type: "module",
+        exports: { ".": "./index.js" },
+      }),
+    )
+    await writeFile(path.join(packageRoot, "index.js"), "export default {}\n")
+
+    await expect(loadStandardRouteFiles(projectRoot)).rejects.toThrow(
+      "Voyant product BOM @acme/operator does not provide @acme/operator/standard-route-files",
+    )
+  })
+})
+
+function createDependencies(calls: string[]): VoyantProjectToolingDependencies {
+  return {
+    loadStandardRouteFiles: vi.fn(async () => [
+      { path: "__root.tsx", source: "export const Route = {}" },
+    ]),
+    prepareProjectBootstrap: vi.fn(async () => ({})),
+    materializeRoutes: vi.fn(() => ({
+      plugin: { name: "generated-routes" },
+      routesDirectory: "/workspace/operator/.voyant/routes",
+      generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
+    })),
+    generateRouteTree: vi.fn(async () => {
+      calls.push("generate-route-tree")
+    }),
+    createViteConfig: vi.fn(() => ({
+      marker: "voyant-vite-config",
+      server: { allowedHosts: true as const },
+    })),
+    buildVite: vi.fn(async () => {
+      calls.push("vite-build")
+    }),
+    createViteServer: vi.fn(async () => ({
+      resolvedUrls: {
+        local: ["http://localhost:3300/"],
+        network: [],
+      },
+      listen: vi.fn(async () => {
+        calls.push("vite-listen")
+      }),
+      close: vi.fn(async () => {
+        calls.push("vite-close")
+      }),
+    })),
+    replaceDirectory: vi.fn(async () => {
+      calls.push("replace-directory")
+    }),
+  }
+}
+
+async function readText(file: string): Promise<string> {
+  return readFile(file, "utf8")
+}
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "voyant-runtime-tooling-"))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+async function writeProductBom(projectRoot: string, id: string): Promise<void> {
+  const artifactDirectory = path.join(projectRoot, ".voyant")
+  await mkdir(artifactDirectory, { recursive: true })
+  await writeFile(
+    path.join(artifactDirectory, "product-bom.generated.json"),
+    JSON.stringify({
+      schemaVersion: "voyant.product-bom-expansion.v1",
+      productBom: {
+        schemaVersion: "voyant.product-bom-reference.v1",
+        id,
+        version: "1",
+      },
+    }),
+  )
+}

--- a/packages/runtime/src/tooling.ts
+++ b/packages/runtime/src/tooling.ts
@@ -1,0 +1,33 @@
+import {
+  buildVoyantProjectWithDependencies,
+  developVoyantProjectWithDependencies,
+} from "./tooling-internal.js"
+
+export interface BuildVoyantProjectOptions {
+  /** Voyant application root. Defaults to the current working directory. */
+  projectRoot?: string
+}
+
+export interface DevelopVoyantProjectOptions extends BuildVoyantProjectOptions {
+  /** Host passed to Vite. */
+  host?: string
+  /** Development server port. Defaults to 3300. */
+  port?: number
+}
+
+export interface VoyantProjectDevelopmentServer {
+  url: string
+  close(): Promise<void>
+}
+
+/** Build the complete TanStack Start Node application and its deployment artifacts. */
+export async function buildVoyantProject(options: BuildVoyantProjectOptions = {}): Promise<void> {
+  await buildVoyantProjectWithDependencies(options)
+}
+
+/** Start the complete TanStack Start application in Vite's SSR development mode. */
+export async function developVoyantProject(
+  options: DevelopVoyantProjectOptions = {},
+): Promise<VoyantProjectDevelopmentServer> {
+  return developVoyantProjectWithDependencies(options)
+}

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1561,6 +1561,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1562,6 +1562,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1563,6 +1563,7 @@
       "@voyant-travel/runtime-core/worker-fetch": ["../runtime-core/dist/worker-fetch.d.ts"],
       "@voyant-travel/runtime/deployment-resources": ["../runtime/dist/deployment-resources.d.ts"],
       "@voyant-travel/runtime/openapi": ["../runtime/dist/openapi.d.ts"],
+      "@voyant-travel/runtime/tooling": ["../runtime/dist/tooling.d.ts"],
       "@voyant-travel/runtime/workflow-entry": ["../runtime/dist/workflow-entry.d.ts"],
       "@voyant-travel/schema-kit": ["../schema-kit/dist/index.d.ts"],
       "@voyant-travel/schema-kit/kms": ["../schema-kit/dist/kms.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4045,6 +4045,21 @@ importers:
 
   packages/runtime:
     dependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.3.2
+        version: 4.3.2(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+      '@tanstack/devtools-vite':
+        specifier: ^0.8.1
+        version: 0.8.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+      '@tanstack/react-start':
+        specifier: ^1.168.27
+        version: 1.168.27(esbuild@0.28.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(rolldown@1.1.3)(rollup@4.60.2)(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+      '@tanstack/router-generator':
+        specifier: 1.167.18
+        version: 1.167.18
+      '@vitejs/plugin-react':
+        specifier: ^6.0.3
+        version: 6.0.3(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
       '@voyant-travel/admin-host':
         specifier: workspace:^
         version: link:../admin-host
@@ -4069,6 +4084,9 @@ importers:
       '@voyant-travel/runtime-core':
         specifier: workspace:^
         version: link:../runtime-core
+      '@voyant-travel/vite-config':
+        specifier: workspace:^
+        version: link:../vite-config
       '@voyant-travel/webhook-delivery':
         specifier: workspace:^
         version: link:../webhook-delivery
@@ -4081,6 +4099,9 @@ importers:
       tsx:
         specifier: 'catalog:'
         version: 4.22.4
+      vite:
+        specifier: 'catalog:'
+        version: 8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3)
     devDependencies:
       '@hono/zod-openapi':
         specifier: 'catalog:'


### PR DESCRIPTION
## What changed

- adds the public runtime tooling API used by the CLI for full project builds and development
- generates hidden router and stylesheet bootstrap only when a project does not author overrides
- resolves generated frontend dependencies through the selected product BOM
- copies deployment artifacts into both server build locations

## Why

Consumer projects should use clean lifecycle commands without owning Vite, graph emission, artifact copying, or standard frontend bootstrap details.

## Validation

- runtime typecheck and 29 runtime tests
- operator-standard typecheck
- minimal packaged starter install, full build, artifact assertions, custom API probe, and Node host probe
- repository pre-push suite: 103 tasks passed