### PR TITLE
ci: serialize release package builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,11 +114,11 @@ jobs:
         id: release_plan
         run: pnpm release:plan
 
-      # `--concurrency=4` caps peak parallelism so a cold-cache cascade rebuild
-      # can't OOM the runner (kernel SIGKILLs the heaviest tsc — exit 137).
+      # Version bumps can invalidate most workspace build caches. Serialize the
+      # release build to stay within the runner's memory limit.
       - name: Build pending publish workspaces
         if: steps.release_plan.outputs.pending == 'true'
-        run: pnpm turbo build ${{ steps.release_plan.outputs.turbo_filters }} --continue --concurrency=4
+        run: pnpm turbo build ${{ steps.release_plan.outputs.turbo_filters }} --continue --concurrency=1
 
       - name: Verify package exports
         if: steps.release_plan.outputs.pending == 'true'


### PR DESCRIPTION
## Summary
- serialize pending package builds in the release workflow
- match the memory-safe concurrency already used by normal CI

## Context
The release run built 96 of 97 workspaces before `@voyant-travel/bookings-react` exhausted the Node heap under `--concurrency=4`. No packages were published.

## Verification
- `git diff --check`
