### PR TITLE
fix(release): preserve publish failure status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,8 +161,9 @@ jobs:
               echo "::endgroup::"
               echo "published=true" >> "$GITHUB_OUTPUT"
               exit 0
+            else
+              status=$?
             fi
-            status=$?
             echo "::endgroup::"
             if [ "${status}" -eq 124 ]; then
               echo "::warning::publish attempt ${attempt} timed out after ${per_attempt_timeout}s (likely a stalled npm/OIDC publish)"


### PR DESCRIPTION
## Summary
- capture the failed `timeout pnpm release` status inside the `else` branch
- distinguish ordinary publish failures from timeout exit 124 in release logs

## Verification
- `git diff --check`
- focused shell assertion confirms a failed condition preserves exit status 1

The current webhook-delivery failure itself is an npm trusted-publisher configuration issue: the package authorizes `voyat-travel/voyant` instead of `voyant-travel/voyant`.