### PR TITLE
feat(runtime): load project Vite configuration

### DIFF
--- a/.changeset/tidy-project-vite-config.md
+++ b/.changeset/tidy-project-vite-config.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/runtime": patch
+---
+
+Load an optional project-root Vite configuration during both development and production builds.

--- a/docs/architecture/standard-node-starter-acceptance.md
+++ b/docs/architecture/standard-node-starter-acceptance.md
@@ -38,6 +38,9 @@ The gate requires:
 - no first-party package identifier appears in authored project source.
 - the four-file authored-tree ratchet is exact. New initial files require an
   intentional architecture decision and checker update.
+- a project may add a standard root `vite.config.ts` only when it needs custom
+  Vite plugins or options. Both `voyant develop` and `voyant build` must merge
+  that file without requiring custom scripts or a fork of generated metadata.
 
 The product BOM still expands into an explicit `.voyant/` graph during build.
 The checked-in development operator follows the same ownership rule for build

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -42,3 +42,22 @@ the project-installed `./standard-route-files` export, runs the complete Node
 SSR build, and copies `.voyant` to both `dist/.voyant` and
 `dist/server/.voyant`. `developVoyantProject()` starts Vite's SSR development
 server and defaults to port `3300`.
+
+Projects may add an optional root `vite.config.ts`. Vite loads and merges it for
+both development and production builds, so project-specific plugins and normal
+Vite options require no lifecycle-script changes. Voyant's inline configuration
+remains authoritative for the generated routes, TanStack Start application,
+React integration, and Node SSR target.
+
+```bash
+pnpm add -D vite vite-plugin-inspect
+```
+
+```ts
+import { defineConfig } from "vite"
+import inspect from "vite-plugin-inspect"
+
+export default defineConfig({
+  plugins: [inspect()],
+})
+```

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -108,7 +108,8 @@ export async function buildVoyantProjectWithDependencies(
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
   const config = await prepareProjectViteConfig(projectRoot, dependencies)
 
-  await dependencies.buildVite({ ...config, root: projectRoot, configFile: false })
+  // Undefined configFile lets Vite merge an optional project-root vite.config.*.
+  await dependencies.buildVite({ ...config, root: projectRoot })
   await Promise.all([
     dependencies.replaceDirectory(
       path.join(projectRoot, ".voyant"),
@@ -128,10 +129,10 @@ export async function developVoyantProjectWithDependencies(
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
   const config = await prepareProjectViteConfig(projectRoot, dependencies)
   const port = options.port ?? DEFAULT_DEVELOPMENT_PORT
+  // Keep native config discovery aligned with the production build.
   const server = await dependencies.createViteServer({
     ...config,
     root: projectRoot,
-    configFile: false,
     server: {
       ...config.server,
       ...(options.host === undefined ? {} : { host: options.host }),

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -94,9 +94,9 @@ describe("Voyant project tooling", () => {
     expect(dependencies.buildVite).toHaveBeenCalledWith({
       marker: "voyant-vite-config",
       root: projectRoot,
-      configFile: false,
       server: { allowedHosts: true },
     })
+    expect(vi.mocked(dependencies.buildVite).mock.calls[0]?.[0]).not.toHaveProperty("configFile")
     expect(dependencies.replaceDirectory).toHaveBeenCalledTimes(2)
     expect(dependencies.replaceDirectory).toHaveBeenCalledWith(
       "/workspace/operator/.voyant",
@@ -122,9 +122,11 @@ describe("Voyant project tooling", () => {
     expect(dependencies.createViteServer).toHaveBeenCalledWith({
       marker: "voyant-vite-config",
       root: "/workspace/operator",
-      configFile: false,
       server: { allowedHosts: true, port: 3300 },
     })
+    expect(vi.mocked(dependencies.createViteServer).mock.calls[0]?.[0]).not.toHaveProperty(
+      "configFile",
+    )
     expect(development.url).toBe("http://localhost:3300/")
     expect(calls).toContain("vite-listen")
 

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -84,11 +84,25 @@ test("minimal starter installs, builds, and boots the Node host", {
       "src/subscribers/booking-created.ts",
       'export default { id: "booking.created.health-sync", eventType: "booking.created", manifest: { id: "booking.created.health-sync", eventType: "booking.created", payloadHash: "hash", targetWorkflowId: "health.sync" } }\n',
     )
+    write(
+      app,
+      "vite.config.ts",
+      [
+        'import { writeFileSync } from "node:fs"',
+        "export default {",
+        "  plugins: [{",
+        '    name: "project-vite-config-acceptance",',
+        '    configResolved() { writeFileSync(".voyant/project-vite-plugin.loaded", "ok\\n") },',
+        "  }],",
+        "}",
+      ].join("\n"),
+    )
     exec("pnpm", ["build"], app)
     assert.ok(existsSync(join(app, "dist/client")))
     assert.ok(existsSync(join(app, "dist/server/server.js")))
     assert.ok(existsSync(join(app, "dist/.voyant/deployment-graph.generated.json")))
     assert.ok(existsSync(join(app, "dist/server/.voyant/deployment-graph.generated.json")))
+    assert.equal(readFileSync(join(app, ".voyant/project-vite-plugin.loaded"), "utf8"), "ok\n")
 
     const graph = JSON.parse(
       readFileSync(join(app, ".voyant/deployment-graph.generated.json"), "utf8"),

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -43,6 +43,11 @@ the SSR dashboard, the `/api/*` routes, and Better Auth with hot-reload — the
 same `src/server.ts` handler runs under Vite's dev server. The first `/api/*`
 request compiles the API module graph on demand (a few seconds), then it's warm.
 
+When the project needs additional Vite plugins or ordinary Vite options, add an
+optional root `vite.config.ts`. `voyant develop` and `voyant build` discover and
+merge it automatically; do not copy or replace Voyant's generated configuration
+under `.voyant/`.
+
 ## Production (Node)
 
 ```bash


### PR DESCRIPTION
## Summary
- let Vite discover an optional project-root `vite.config.*` for `voyant develop` and `voyant build`
- retain Voyant inline configuration for required routes, TanStack Start, React, and Node SSR behavior
- document the optional configuration convention without adding a file to fresh starters
- prove a project-owned Vite plugin executes in packaged-starter acceptance

## Verification
- full `pnpm lint`
- runtime tests: 31 passed
- runtime typecheck and build
- standard Node starter checker
- fresh minimal starter install/build/plugin/Node acceptance