### PR TITLE
fix(runtime): preserve Node output layout

### DIFF
--- a/.changeset/firm-vite-output-layout.md
+++ b/.changeset/firm-vite-output-layout.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/runtime": patch
+---
+
+Keep project Vite configuration from redirecting the lifecycle-owned Node distribution output.

--- a/docs/architecture/standard-node-starter-acceptance.md
+++ b/docs/architecture/standard-node-starter-acceptance.md
@@ -41,6 +41,8 @@ The gate requires:
 - a project may add a standard root `vite.config.ts` only when it needs custom
   Vite plugins or options. Both `voyant develop` and `voyant build` must merge
   that file without requiring custom scripts or a fork of generated metadata.
+  The lifecycle-owned `build.outDir` remains `dist` so server, client, and graph
+  artifact paths cannot diverge.
 
 The product BOM still expands into an explicit `.voyant/` graph during build.
 The checked-in development operator follows the same ownership rule for build

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -47,7 +47,9 @@ Projects may add an optional root `vite.config.ts`. Vite loads and merges it for
 both development and production builds, so project-specific plugins and normal
 Vite options require no lifecycle-script changes. Voyant's inline configuration
 remains authoritative for the generated routes, TanStack Start application,
-React integration, and Node SSR target.
+React integration, Node SSR target, and `dist` output root. Projects must not
+set `build.outDir`: the Node server, client assets, and generated deployment
+artifacts use the fixed `dist/server`, `dist/client`, and `dist/.voyant` layout.
 
 ```bash
 pnpm add -D vite vite-plugin-inspect

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -200,6 +200,11 @@ export function createProjectViteConfig(options: ProjectViteConfigOptions): Inli
       createAnalyzePlugin(options.appRootUrl),
     ],
   })
+  config.build = {
+    ...config.build,
+    // The Node host, admin asset resolver, and deployment artifacts share this layout.
+    outDir: "dist",
+  }
   if (options.bootstrap.stylesEntry || options.bootstrap.aliases) {
     const alias = config.resolve?.alias
     config.resolve = {

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -63,6 +63,20 @@ describe("Voyant project tooling", () => {
     expect((dependencyAlias?.find as RegExp).test("@tanstack/react-router/ssr/server")).toBe(false)
   })
 
+  it("keeps the Node distribution under the lifecycle-owned dist directory", () => {
+    const config = createProjectViteConfig({
+      appRootUrl: pathToFileURL("/workspace/operator/generated-config-anchor.ts").href,
+      generatedRoutes: {
+        plugin: { name: "generated-routes" },
+        routesDirectory: "/workspace/operator/.voyant/routes",
+        generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
+      },
+      bootstrap: {},
+    })
+
+    expect(config.build?.outDir).toBe("dist")
+  })
+
   it("generates, builds, and copies both deployment artifact layouts", async () => {
     const projectRoot = "/workspace/operator"
     const calls: string[] = []

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -90,6 +90,7 @@ test("minimal starter installs, builds, and boots the Node host", {
       [
         'import { writeFileSync } from "node:fs"',
         "export default {",
+        '  build: { outDir: "custom-dist" },',
         "  plugins: [{",
         '    name: "project-vite-config-acceptance",',
         '    configResolved() { writeFileSync(".voyant/project-vite-plugin.loaded", "ok\\n") },',
@@ -98,6 +99,7 @@ test("minimal starter installs, builds, and boots the Node host", {
       ].join("\n"),
     )
     exec("pnpm", ["build"], app)
+    assert.ok(!existsSync(join(app, "custom-dist")))
     assert.ok(existsSync(join(app, "dist/client")))
     assert.ok(existsSync(join(app, "dist/server/server.js")))
     assert.ok(existsSync(join(app, "dist/.voyant/deployment-graph.generated.json")))

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -46,7 +46,8 @@ request compiles the API module graph on demand (a few seconds), then it's warm.
 When the project needs additional Vite plugins or ordinary Vite options, add an
 optional root `vite.config.ts`. `voyant develop` and `voyant build` discover and
 merge it automatically; do not copy or replace Voyant's generated configuration
-under `.voyant/`.
+under `.voyant/`. The `build.outDir` option is reserved because the Node server,
+client assets, and deployment artifacts share the fixed `dist` layout.
 
 ## Production (Node)
 


### PR DESCRIPTION
## Summary
- keep the lifecycle-owned Vite output root fixed at `dist`
- continue loading project Vite plugins and non-structural options
- document that `build.outDir` is reserved by the Node distribution contract
- regress the reported case in packaged-starter acceptance

## Verification
- reproduced the review finding: custom `build.outDir` moved client output and failed starter acceptance
- runtime tests: 32 passed
- runtime typecheck and build
- fresh minimal starter build with custom plugin and attempted `custom-dist` override
- standard Node starter checker