### PR TITLE
Fix catalog offer index scope

### DIFF
--- a/.changeset/fix-catalog-offer-index-scope.md
+++ b/.changeset/fix-catalog-offer-index-scope.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Fix catalog-offer index enrichment and dynamic hotel lookup for deployments whose default catalog scope uses a non-default locale, market, or channel.

--- a/packages/catalog/src/runtime-support.test.ts
+++ b/packages/catalog/src/runtime-support.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { createCatalogOffersTypesenseResolvers } from "./runtime-support.js"
+
+const resolvers = createCatalogOffersTypesenseResolvers(
+  () => ({ TYPESENSE_HOST: "typesense.example.test", TYPESENSE_API_KEY: "test-key" }),
+  () => ({ locale: "ro-RO", audience: "staff", market: "ro", channel: "website" }),
+)
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("catalog offer Typesense resolvers", () => {
+  it("uses the configured scope collection for index-field enrichment", async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ hits: [] })))
+    vi.stubGlobal("fetch", fetch)
+
+    await resolvers.fetchIndexFields({}, ["product-1"])
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/collections/products__ro-RO__staff__ro__website/documents/search"),
+      { headers: { "X-TYPESENSE-API-KEY": "test-key" } },
+    )
+  })
+
+  it("uses the configured scope collection for dynamic hotel resolution", async () => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ hits: [] })))
+    vi.stubGlobal("fetch", fetch)
+
+    await resolvers.resolveDynamicHotelIds({}, { countryCode: "RO", city: "Bucharest" }, 10)
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/collections/products__ro-RO__staff__ro__website/documents/search"),
+      { headers: { "X-TYPESENSE-API-KEY": "test-key" } },
+    )
+  })
+})

--- a/packages/catalog/src/runtime-support.ts
+++ b/packages/catalog/src/runtime-support.ts
@@ -20,6 +20,7 @@ import type { EmbeddingProvider } from "./embeddings/contract.js"
 import { createGeminiEmbeddingProvider } from "./embeddings/gemini.js"
 import type { IndexerAdapter, IndexerDocument, IndexerSlice } from "./indexer/contract.js"
 import {
+  collectionName,
   createTypesenseIndexer,
   type TypesenseClient,
   type TypesenseCollectionSchema,
@@ -162,6 +163,13 @@ export interface CatalogOffersTypesenseEnv {
   TYPESENSE_API_KEY?: string
 }
 
+export interface CatalogOffersTypesenseScope {
+  locale: string
+  audience: IndexerSlice["audience"]
+  market: string
+  channel?: string
+}
+
 export interface CatalogRuntimeEnv extends CatalogOffersTypesenseEnv {
   VOYANT_API_KEY?: string
   VOYANT_CLOUD_API_KEY?: string
@@ -296,18 +304,20 @@ function typesenseConfig(env: CatalogOffersTypesenseEnv) {
 
 export function createCatalogOffersTypesenseResolvers(
   resolveEnv: (context: unknown) => CatalogOffersTypesenseEnv,
+  resolveScope: (context: unknown) => CatalogOffersTypesenseScope,
 ) {
   return {
     async fetchIndexFields(context: unknown, ids: string[]) {
       const config = typesenseConfig(resolveEnv(context))
       const output = new Map<string, CatalogOffersIndexFields>()
       if (!config || ids.length === 0) return output
+      const collection = collectionName({ vertical: "products", ...resolveScope(context) })
       const distinct = [...new Set(ids)]
       for (let index = 0; index < distinct.length; index += 80) {
         const batch = distinct.slice(index, index + 80)
         const filter = `id:=[${batch.map((id) => `\`${id}\``).join(",")}]`
         const url =
-          `${config.base}/collections/products__en-GB__staff__default/documents/search` +
+          `${config.base}/collections/${encodeURIComponent(collection)}/documents/search` +
           `?q=*&query_by=name&filter_by=${encodeURIComponent(filter)}&per_page=${batch.length}` +
           "&include_fields=id,name,thumbnailUrl,stars,destinations,countryCodes"
         try {
@@ -332,11 +342,12 @@ export function createCatalogOffersTypesenseResolvers(
     ) {
       const config = typesenseConfig(resolveEnv(context))
       if (!config) return []
+      const collection = collectionName({ vertical: "products", ...resolveScope(context) })
       const filters = ["supplyModel:=dynamic"]
       if (destination.countryCode) filters.push(`countryCodes:=[\`${destination.countryCode}\`]`)
       if (destination.city) filters.push(`destinations:=[\`${destination.city}\`]`)
       const url =
-        `${config.base}/collections/products__en-GB__staff__default/documents/search` +
+        `${config.base}/collections/${encodeURIComponent(collection)}/documents/search` +
         `?q=*&query_by=name&filter_by=${encodeURIComponent(filters.join(" && "))}` +
         `&per_page=${Math.min(limit, 250)}&include_fields=id`
       try {

--- a/packages/catalog/src/runtime.ts
+++ b/packages/catalog/src/runtime.ts
@@ -72,7 +72,9 @@ export function createCatalogRuntime(
   return {
     search: { resolveRuntime: createCatalogSearchRuntime },
     booking: createOperatorCatalogBookingRouteModuleOptions(),
-    offers: createOperatorCatalogOffersRouteModuleOptions(),
+    offers: createOperatorCatalogOffersRouteModuleOptions((context) =>
+      resolveCatalogDefaultScope(context),
+    ),
     content: { resolveRegistry: getBookingEngineRegistryFromContext },
     projection: {
       createRuntime(bindings) {
@@ -86,23 +88,30 @@ export function createCatalogRuntime(
 }
 
 function createCatalogSearchRuntime(context: unknown): CatalogSearchRuntime {
+  const env = (context as { env: Record<string, unknown> }).env
+  const embeddings = buildEmbeddingProvider(env)
+  const defaultScope = resolveCatalogDefaultScope(context)
+  return {
+    indexer: buildTypesenseIndexer(env, embeddings),
+    embeddings,
+    defaultScope,
+  }
+}
+
+function resolveCatalogDefaultScope(context: unknown): CatalogSearchRuntime["defaultScope"] {
   const requestContext = context as { env: Record<string, unknown>; var?: { actor?: string } }
   const env = requestContext.env
-  const embeddings = buildEmbeddingProvider(env)
   const actor = requestContext.var?.actor ?? "staff"
   const audience: CatalogSearchRuntime["defaultScope"]["audience"] =
     actor === "staff" ? "staff" : (actor as CatalogSearchRuntime["defaultScope"]["audience"])
   return {
-    indexer: buildTypesenseIndexer(env, embeddings),
-    embeddings,
-    defaultScope: {
-      locale: "en-GB",
-      audience,
-      market: "default",
-      channel:
-        typeof env.VOYANT_STOREFRONT_CHANNEL_ID === "string"
-          ? env.VOYANT_STOREFRONT_CHANNEL_ID
-          : undefined,
-    },
+    locale: stringValue(env.DEFAULT_LOCALE) ?? "en-GB",
+    audience,
+    market: stringValue(env.DEFAULT_MARKET) ?? "default",
+    channel: stringValue(env.VOYANT_STOREFRONT_CHANNEL_ID),
   }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
 }

--- a/packages/catalog/src/runtime/offers-runtime.ts
+++ b/packages/catalog/src/runtime/offers-runtime.ts
@@ -3,7 +3,10 @@ import type {
   CatalogOffersConnectClient,
   CatalogOffersRouteModuleOptions,
 } from "@voyant-travel/catalog/offers"
-import { createCatalogOffersTypesenseResolvers } from "@voyant-travel/catalog/runtime-support"
+import {
+  type CatalogOffersTypesenseScope,
+  createCatalogOffersTypesenseResolvers,
+} from "@voyant-travel/catalog/runtime-support"
 import { createVoyantConnectClient } from "@voyant-travel/connect-sdk"
 import { createDestinationNameResolver } from "@voyant-travel/plugin-voyant-connect"
 import type { Context } from "hono"
@@ -35,10 +38,6 @@ function resolveConnectClient(c: Context): CatalogOffersConnectClient | null {
   }) as CatalogOffersConnectClient
 }
 
-const typesenseResolvers = createCatalogOffersTypesenseResolvers(
-  (context) => (context as Context).env as PackageOffersEnv,
-)
-
 async function resolveAirportLabels(
   c: Context,
   codes: string[],
@@ -66,7 +65,13 @@ async function resolveAirportLabels(
   )
 }
 
-export function createOperatorCatalogOffersRouteModuleOptions(): CatalogOffersRouteModuleOptions {
+export function createOperatorCatalogOffersRouteModuleOptions(
+  resolveScope: (context: Context) => CatalogOffersTypesenseScope,
+): CatalogOffersRouteModuleOptions {
+  const typesenseResolvers = createCatalogOffersTypesenseResolvers(
+    (context) => (context as Context).env as PackageOffersEnv,
+    (context) => resolveScope(context as Context),
+  )
   return {
     resolveConnectClient,
     fetchIndexFields: typesenseResolvers.fetchIndexFields,


### PR DESCRIPTION
## Summary
- derive catalog-offer Typesense collection names from the request default catalog scope
- honor deployment `DEFAULT_LOCALE` and `DEFAULT_MARKET` defaults in the catalog runtime
- cover non-default locale, market, and channel collection resolution

## Root cause
Offer enrichment and dynamic hotel lookup hardcoded the `products__en-GB__staff__default` collection, so deployments indexed under another slice silently received no enrichment or dynamic hotel ids.

## Validation
- `pnpm exec vitest run packages/catalog/src/runtime-support.test.ts`
- `pnpm --filter @voyant-travel/catalog lint`
- `pnpm --filter @voyant-travel/catalog typecheck` remains blocked by pre-existing unresolved workspace package exports and links.

Closes #3262