### PR TITLE
Fix staff catalog offer channel scope

### DIFF
--- a/.changeset/fix-staff-catalog-offer-scope.md
+++ b/.changeset/fix-staff-catalog-offer-scope.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": patch
+---
+
+Keep staff catalog-offer index lookups on the unscoped staff collection when a storefront channel is configured.

--- a/packages/catalog/src/runtime-support.test.ts
+++ b/packages/catalog/src/runtime-support.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { createCatalogOffersTypesenseResolvers } from "./runtime-support.js"
+import {
+  createCatalogOffersTypesenseResolvers,
+  withoutCatalogScopeChannel,
+} from "./runtime-support.js"
 
 const resolvers = createCatalogOffersTypesenseResolvers(
   () => ({ TYPESENSE_HOST: "typesense.example.test", TYPESENSE_API_KEY: "test-key" }),
-  () => ({ locale: "ro-RO", audience: "staff", market: "ro", channel: "website" }),
+  () =>
+    withoutCatalogScopeChannel({
+      locale: "ro-RO",
+      audience: "staff",
+      market: "ro",
+      channel: "website",
+    }),
 )
 
 afterEach(() => {
@@ -19,7 +28,7 @@ describe("catalog offer Typesense resolvers", () => {
     await resolvers.fetchIndexFields({}, ["product-1"])
 
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/collections/products__ro-RO__staff__ro__website/documents/search"),
+      expect.stringContaining("/collections/products__ro-RO__staff__ro/documents/search"),
       { headers: { "X-TYPESENSE-API-KEY": "test-key" } },
     )
   })
@@ -31,7 +40,7 @@ describe("catalog offer Typesense resolvers", () => {
     await resolvers.resolveDynamicHotelIds({}, { countryCode: "RO", city: "Bucharest" }, 10)
 
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/collections/products__ro-RO__staff__ro__website/documents/search"),
+      expect.stringContaining("/collections/products__ro-RO__staff__ro/documents/search"),
       { headers: { "X-TYPESENSE-API-KEY": "test-key" } },
     )
   })

--- a/packages/catalog/src/runtime-support.ts
+++ b/packages/catalog/src/runtime-support.ts
@@ -170,6 +170,13 @@ export interface CatalogOffersTypesenseScope {
   channel?: string
 }
 
+export function withoutCatalogScopeChannel(
+  scope: CatalogOffersTypesenseScope,
+): CatalogOffersTypesenseScope {
+  const { channel: _, ...unscoped } = scope
+  return unscoped
+}
+
 export interface CatalogRuntimeEnv extends CatalogOffersTypesenseEnv {
   VOYANT_API_KEY?: string
   VOYANT_CLOUD_API_KEY?: string

--- a/packages/catalog/src/runtime.ts
+++ b/packages/catalog/src/runtime.ts
@@ -19,6 +19,7 @@ import {
   getFieldPolicyRegistries,
   loadCatalogSlices,
   withEmbedding,
+  withoutCatalogScopeChannel,
 } from "./runtime/catalog-runtime.js"
 import { configureCatalogRuntimeHost } from "./runtime/host.js"
 import { createOperatorCatalogOffersRouteModuleOptions } from "./runtime/offers-runtime.js"
@@ -73,7 +74,7 @@ export function createCatalogRuntime(
     search: { resolveRuntime: createCatalogSearchRuntime },
     booking: createOperatorCatalogBookingRouteModuleOptions(),
     offers: createOperatorCatalogOffersRouteModuleOptions((context) =>
-      resolveCatalogDefaultScope(context),
+      withoutCatalogScopeChannel(resolveCatalogDefaultScope(context)),
     ),
     content: { resolveRegistry: getBookingEngineRegistryFromContext },
     projection: {

--- a/packages/catalog/src/runtime/catalog-runtime.ts
+++ b/packages/catalog/src/runtime/catalog-runtime.ts
@@ -19,6 +19,7 @@ import {
   DEFAULT_CATALOG_SLICES,
   DEFAULT_CATALOG_VERTICALS,
   withCatalogEmbedding,
+  withoutCatalogScopeChannel,
 } from "@voyant-travel/catalog/runtime-support"
 import type { DocumentBuilder } from "@voyant-travel/catalog/services/indexer"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
@@ -60,6 +61,7 @@ export type CatalogRuntimeEnv = {
 }
 
 export const buildEmbeddingProvider = buildCatalogEmbeddingProvider
+export { withoutCatalogScopeChannel }
 
 export function buildTypesenseIndexer(
   env: CatalogRuntimeEnv,


### PR DESCRIPTION
## Summary
- remove storefront channel scope from admin catalog-offer index lookups
- keep offer enrichment and dynamic hotel resolution on the indexed staff collection
- add a patch changeset and regression coverage for channel-bearing deployment scopes

## Root cause
The catalog runtime propagated `VOYANT_STOREFRONT_CHANNEL_ID` into staff offer lookups. Channel collections are only indexed for customer slices, so the resolver queried a staff collection that does not exist.

## Validation
- `pnpm exec vitest run packages/catalog/src/runtime-support.test.ts`
- `pnpm --filter @voyant-travel/catalog lint`

Closes #3262