### PR TITLE
refactor: remove retired preset lineage metadata

### DIFF
--- a/.changeset/remove-preset-lineage.md
+++ b/.changeset/remove-preset-lineage.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+---
+
+Remove retired preset lineage metadata from project authoring and resolved deployment graphs.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -127,8 +127,9 @@ modules, capabilities, product surfaces, and substrate requirements.
 
 Package compatibility should target framework version, the Node runtime
 contract, deployment mode, and required capabilities/surfaces. It should not
-target `profiles: ["operator"]`, expose `presetLineage` as authored runtime
-behavior, or treat a hosting provider as a runtime.
+target `profiles: ["operator"]` or treat a hosting provider as a runtime.
+Compatibility translation must end at explicit graph selections; profile
+lineage is not part of the authored or resolved graph contract.
 
 ### 2. Default to Voyant Cloud, but keep Node substrate lowering separate
 

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -400,7 +400,6 @@ export interface VoyantGraphProjectDeployment {
 
 export interface DefineVoyantGraphProjectInput {
   schemaVersion?: typeof VOYANT_GRAPH_PROJECT_SCHEMA_VERSION
-  presetLineage?: string
   productBom?: VoyantProductBomReference
   modules: readonly DefineVoyantGraphProjectUnitInput[]
   extensions?: readonly DefineVoyantGraphProjectUnitInput[]
@@ -412,7 +411,6 @@ export interface DefineVoyantGraphProjectInput {
 
 export interface VoyantGraphProject {
   schemaVersion: typeof VOYANT_GRAPH_PROJECT_SCHEMA_VERSION
-  presetLineage?: string
   productBom?: VoyantProductBomReference
   modules: readonly VoyantGraphUnitManifest[]
   extensions: readonly VoyantGraphUnitManifest[]
@@ -454,7 +452,6 @@ export function defineProject(input: DefineVoyantGraphProjectInput): VoyantGraph
 
   return {
     schemaVersion,
-    ...(input.presetLineage ? { presetLineage: input.presetLineage } : {}),
     ...(input.productBom ? { productBom: normalizeProductBomReference(input.productBom) } : {}),
     modules: modules.units,
     extensions: extensions.units,

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -365,7 +365,6 @@ export interface ResolvedVoyantDeploymentGraph {
   schemaVersion: typeof VOYANT_RESOLVED_GRAPH_SCHEMA_VERSION
   contentHash: string
   project: {
-    presetLineage?: string
     productBom?: import("@voyant-travel/core/project").VoyantProductBomReference
   }
   deployment: {
@@ -694,7 +693,6 @@ export async function resolveDeploymentGraph(
   const graphWithoutHash: Omit<ResolvedVoyantDeploymentGraph, "contentHash"> = {
     schemaVersion: VOYANT_RESOLVED_GRAPH_SCHEMA_VERSION,
     project: {
-      ...(input.project.presetLineage ? { presetLineage: input.project.presetLineage } : {}),
       ...(input.project.productBom ? { productBom: input.project.productBom } : {}),
     },
     deployment: {

--- a/packages/framework/src/operator-distribution.test.ts
+++ b/packages/framework/src/operator-distribution.test.ts
@@ -48,7 +48,6 @@ describe("standard Operator distribution", () => {
     ])
     expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.modules).size).toBe(38)
     expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.extensions).size).toBe(24)
-    expect(STANDARD_OPERATOR_DISTRIBUTION).not.toHaveProperty("presetLineage")
   })
 
   it("defaults authored differences without treating extensions as plugins", () => {

--- a/packages/framework/src/project-config.test.ts
+++ b/packages/framework/src/project-config.test.ts
@@ -21,7 +21,6 @@ describe("framework project config", () => {
     expect(project.extensions.map((unit) => unit.schemaVersion)).toEqual(
       Array.from({ length: 24 }, () => "voyant.extension.v1"),
     )
-    expect(project).not.toHaveProperty("presetLineage")
   })
 
   it("appends authored differences in their independent unit lanes", () => {

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -188,9 +188,6 @@ async function main(): Promise<void> {
       `expected resolved operator graph runtime target node, got ${operatorGraph.deployment.target}`,
     )
   }
-  if (operatorGraph.project?.presetLineage !== resolvedOperator.project.presetLineage) {
-    failures.push("expected resolved operator graph to preserve declared preset lineage")
-  }
   for (const id of declaredOperatorModuleIds) {
     if (!operatorModuleIds.has(id)) {
       failures.push(`expected resolved operator graph to include declared module ${id}`)

--- a/scripts/lib/operator-deployment-graph-package-records.ts
+++ b/scripts/lib/operator-deployment-graph-package-records.ts
@@ -258,17 +258,14 @@ function requireResolvedProjectArtifacts(value: unknown): ResolvedProjectArtifac
 
 function projectFromResolvedGraph(
   graph: {
-    project: { presetLineage?: string }
     modules: readonly ResolvedVoyantGraphUnit[]
     extensions: readonly ResolvedVoyantGraphUnit[]
     plugins: readonly ResolvedVoyantGraphUnit[]
   },
   authored: OperatorAuthoredProject,
 ): VoyantGraphProject {
-  const presetLineage = graph.project.presetLineage ?? authored.presetLineage
   return {
     schemaVersion: "voyant.project.v1",
-    ...(presetLineage ? { presetLineage } : {}),
     modules: graph.modules.map((unit) => manifestFromResolvedUnit(unit, "voyant.module.v1")),
     extensions: graph.extensions.map((unit) =>
       manifestFromResolvedUnit(unit, "voyant.extension.v1"),
@@ -342,7 +339,6 @@ function isGraphProject(value: unknown): value is VoyantGraphProject {
 }
 
 function isResolvedGraph(value: unknown): value is {
-  project: { presetLineage?: string }
   modules: readonly ResolvedVoyantGraphUnit[]
   extensions: readonly ResolvedVoyantGraphUnit[]
   plugins: readonly ResolvedVoyantGraphUnit[]


### PR DESCRIPTION
## Summary

- remove `presetLineage` from project authoring and generated project metadata
- remove the field from the resolved deployment graph contract and reconstruction tooling
- update graph checks, assertions, and architecture documentation
- add minor 0.x changesets for Core and Framework

## Why

Preset/profile composition has been retired. Keeping lineage metadata in the public graph schema preserved vocabulary and reconstruction logic for an architecture projects can no longer author.

## Verification

- Core tests: 157 passed
- Core typecheck
- Framework affected tests: 51 passed
- Framework typecheck
- deployment graph checker: 38 modules resolved
- focused Biome check
- `git diff --check`