### PR TITLE
refactor(ui): remove ignored template insertion callbacks

### DIFF
--- a/.changeset/remove-template-insertion-callbacks.md
+++ b/.changeset/remove-template-insertion-callbacks.md
@@ -1,7 +1,11 @@
 ---
-"@voyant-travel/ui": patch
+"@voyant-travel/ui": minor
 "@voyant-travel/notifications-react": patch
 "@voyant-travel/legal-react": patch
 ---
 
-Breaking beta cleanup: remove the deprecated template-authoring insertion callbacks that were ignored by the copy-only helper, along with the inert Legal and Notifications caller wiring.
+Breaking beta cleanup: remove the deprecated `onInsertVariable` and
+`onInsertSnippet` props from `ContractTemplateAuthoringHelp`. The helper only
+supports copying template values and snippets to the clipboard; consumers
+should remove these ignored callbacks. Also remove the inert Legal and
+Notifications caller wiring.

--- a/.changeset/remove-template-insertion-callbacks.md
+++ b/.changeset/remove-template-insertion-callbacks.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/ui": patch
+"@voyant-travel/notifications-react": patch
+"@voyant-travel/legal-react": patch
+---
+
+Breaking beta cleanup: remove the deprecated template-authoring insertion callbacks that were ignored by the copy-only helper, along with the inert Legal and Notifications caller wiring.

--- a/packages/legal-react/package.json
+++ b/packages/legal-react/package.json
@@ -80,7 +80,6 @@
   },
   "devDependencies": {
     "@tanstack/react-query": "^5.101.2",
-    "@tiptap/core": "^3.27.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",

--- a/packages/legal-react/src/admin/template-dialog.tsx
+++ b/packages/legal-react/src/admin/template-dialog.tsx
@@ -1,4 +1,3 @@
-import type { Editor } from "@tiptap/core"
 import { useOperatorAdminMessages } from "@voyant-travel/admin"
 import {
   Button,
@@ -19,15 +18,11 @@ import {
   Textarea,
 } from "@voyant-travel/ui/components"
 import { RichTextEditor } from "@voyant-travel/ui/components/rich-text-editor"
-import {
-  insertPlainText,
-  insertVariableToken,
-} from "@voyant-travel/ui/components/rich-text-variable-extension"
 import { Switch } from "@voyant-travel/ui/components/switch"
 import { zodResolver } from "@voyant-travel/ui/lib/zod-resolver"
 import { languages } from "@voyant-travel/utils"
 import { Loader2 } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
 import {
@@ -88,7 +83,6 @@ export function TemplateDialog({ open, onOpenChange, template, onSuccess }: Temp
   const resolveValidation = (code: string | undefined) =>
     (code && validationByCode[code]) || code || ""
   const { variableCatalog, liquidSnippets } = useLegalContractTemplateAuthoring()
-  const [editorInstance, setEditorInstance] = useState<Editor | null>(null)
   const variableGroups = useMemo(
     () =>
       variableCatalog.map((group) => ({
@@ -243,7 +237,6 @@ export function TemplateDialog({ open, onOpenChange, template, onSuccess }: Temp
                 }
                 placeholder={t.bodyPlaceholder}
                 enableVariables
-                onEditorReady={setEditorInstance}
               />
               {form.formState.errors.body ? (
                 <p className="text-xs text-destructive">
@@ -257,14 +250,6 @@ export function TemplateDialog({ open, onOpenChange, template, onSuccess }: Temp
             <ContractTemplateAuthoringHelp
               variableGroups={variableGroups}
               snippets={liquidSnippets}
-              onInsertVariable={(variable) => {
-                if (!editorInstance) return
-                insertVariableToken(editorInstance, variable.key)
-              }}
-              onInsertSnippet={(snippet) => {
-                if (!editorInstance) return
-                insertPlainText(editorInstance, snippet.code)
-              }}
             />
 
             <div className="flex items-center gap-2">

--- a/packages/legal-react/src/admin/template-version-dialog.tsx
+++ b/packages/legal-react/src/admin/template-version-dialog.tsx
@@ -1,4 +1,3 @@
-import type { Editor } from "@tiptap/core"
 import { useOperatorAdminMessages } from "@voyant-travel/admin"
 import {
   Button,
@@ -13,13 +12,9 @@ import {
   Label,
 } from "@voyant-travel/ui/components"
 import { RichTextEditor } from "@voyant-travel/ui/components/rich-text-editor"
-import {
-  insertPlainText,
-  insertVariableToken,
-} from "@voyant-travel/ui/components/rich-text-variable-extension"
 import { zodResolver } from "@voyant-travel/ui/lib/zod-resolver"
 import { Loader2 } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo } from "react"
 import { useForm } from "react-hook-form"
 import { z } from "zod/v4"
 import {
@@ -52,7 +47,6 @@ export function TemplateVersionDialog({
   const t = useOperatorAdminMessages().legal.templateVersionDialog
   const { create } = useLegalContractTemplateVersionMutation()
   const { variableCatalog, liquidSnippets } = useLegalContractTemplateAuthoring()
-  const [editorInstance, setEditorInstance] = useState<Editor | null>(null)
 
   const resolveValidation = (code: string | undefined) =>
     code === "bodyRequired" ? t.validation.bodyRequired : code || ""
@@ -119,7 +113,6 @@ export function TemplateVersionDialog({
                 }
                 placeholder={t.bodyPlaceholder}
                 enableVariables
-                onEditorReady={setEditorInstance}
               />
               {form.formState.errors.body ? (
                 <p className="text-xs text-destructive">
@@ -131,14 +124,6 @@ export function TemplateVersionDialog({
             <ContractTemplateAuthoringHelp
               variableGroups={variableGroups}
               snippets={liquidSnippets}
-              onInsertVariable={(variable) => {
-                if (!editorInstance) return
-                insertVariableToken(editorInstance, variable.key)
-              }}
-              onInsertSnippet={(snippet) => {
-                if (!editorInstance) return
-                insertPlainText(editorInstance, snippet.code)
-              }}
             />
 
             <div className="grid grid-cols-2 gap-4">

--- a/packages/notifications-react/package.json
+++ b/packages/notifications-react/package.json
@@ -65,7 +65,6 @@
   "devDependencies": {
     "@tanstack/react-query": "^5.101.2",
     "@testing-library/react": "^16.3.2",
-    "@tiptap/core": "^3.27.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",

--- a/packages/notifications-react/src/admin/notification-template-authoring-help.tsx
+++ b/packages/notifications-react/src/admin/notification-template-authoring-help.tsx
@@ -3,13 +3,11 @@
 import type {
   NotificationLiquidSnippet,
   NotificationTemplateVariableCategory,
-  NotificationTemplateVariableDefinition,
 } from "@voyant-travel/notifications/template-authoring"
 
 import {
   ContractTemplateAuthoringHelp,
   type TemplateAuthoringSnippet,
-  type TemplateAuthoringVariable,
   type TemplateAuthoringVariableGroup,
 } from "@voyant-travel/ui/components/contract-template-authoring-help"
 
@@ -18,8 +16,6 @@ import { useNotificationsUiMessagesOrDefault } from "../i18n/index.js"
 type NotificationTemplateAuthoringHelpProps = {
   variableGroups: NotificationTemplateVariableCategory[]
   snippets?: NotificationLiquidSnippet[]
-  onInsertVariable?: (variable: NotificationTemplateVariableDefinition) => void
-  onInsertSnippet?: (snippet: NotificationLiquidSnippet) => void
   className?: string
   messages?: {
     title?: string
@@ -40,8 +36,6 @@ type NotificationTemplateAuthoringHelpProps = {
 export function NotificationTemplateAuthoringHelp({
   variableGroups,
   snippets = [],
-  onInsertVariable,
-  onInsertSnippet,
   className,
   messages,
 }: NotificationTemplateAuthoringHelpProps) {
@@ -55,10 +49,6 @@ export function NotificationTemplateAuthoringHelp({
       messages={messages}
       variableGroups={variableGroups as TemplateAuthoringVariableGroup[]}
       snippets={snippets as TemplateAuthoringSnippet[]}
-      onInsertVariable={
-        onInsertVariable as ((variable: TemplateAuthoringVariable) => void) | undefined
-      }
-      onInsertSnippet={onInsertSnippet as ((snippet: TemplateAuthoringSnippet) => void) | undefined}
     />
   )
 }

--- a/packages/notifications-react/src/admin/notification-template-dialog-utils.ts
+++ b/packages/notifications-react/src/admin/notification-template-dialog-utils.ts
@@ -49,7 +49,6 @@ export const templateFormSchema = z.object({
 export type FormValues = z.input<typeof templateFormSchema>
 export type FormOutput = z.output<typeof templateFormSchema>
 export type TemplateAttachment = z.infer<typeof templateAttachmentSchema>
-export type InsertionTarget = "subject" | "body" | "text"
 
 export function resolveTemplateMutationStatus({
   active,
@@ -156,15 +155,6 @@ export function buildSamplePayload(
 
 export function resolvePreviewDataInput(input: string, fallback: string) {
   return input.trim() ? input : fallback
-}
-
-export function appendTemplateValue(current: string | undefined, addition: string) {
-  if (!current?.trim()) return addition
-  return `${current}${current.endsWith("\n") ? "" : "\n"}${addition}`
-}
-
-export function variableReference(key: string) {
-  return `{{ ${key} }}`
 }
 
 function getMetadataRecord(value: unknown): Record<string, unknown> | null {

--- a/packages/notifications-react/src/admin/notification-template-dialog.tsx
+++ b/packages/notifications-react/src/admin/notification-template-dialog.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import type { Editor } from "@tiptap/core"
 import { formatMessage } from "@voyant-travel/i18n"
 import {
   Button,
@@ -20,10 +19,6 @@ import {
   Textarea,
 } from "@voyant-travel/ui/components"
 import { RichTextEditor } from "@voyant-travel/ui/components/rich-text-editor"
-import {
-  insertPlainText,
-  insertVariableToken,
-} from "@voyant-travel/ui/components/rich-text-variable-extension"
 import { zodResolver } from "@voyant-travel/ui/lib/zod-resolver"
 import { Loader2 } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
@@ -39,14 +34,12 @@ import {
 import { NotificationTemplateAttachmentsField } from "./notification-template-attachments-field.js"
 import { NotificationTemplateAuthoringHelp } from "./notification-template-authoring-help.js"
 import {
-  appendTemplateValue,
   buildSamplePayload,
   buildTemplateMetadata,
   CHANNEL_VALUES,
   channelItemLabel,
   type FormOutput,
   type FormValues,
-  type InsertionTarget,
   nativeSelectClassName,
   readTemplateAttachments,
   resolveTemplateMutationStatus,
@@ -54,7 +47,6 @@ import {
   statusItemLabel,
   type TemplateAttachment,
   templateFormSchema,
-  variableReference,
 } from "./notification-template-dialog-utils.js"
 import { NotificationTemplateRenderedPreview } from "./notification-template-rendered-preview.js"
 
@@ -90,8 +82,6 @@ function NotificationTemplateDialogInner({
   const previewResetRef = useRef(preview.reset)
   const testSendResetRef = useRef(testSend.reset)
   const { variableCatalog, liquidSnippets } = useNotificationTemplateAuthoring()
-  const [editorInstance, setEditorInstance] = useState<Editor | null>(null)
-  const [insertionTarget, setInsertionTarget] = useState<InsertionTarget>("body")
   const [previewDataInput, setPreviewDataInput] = useState("{}")
   const [testRecipient, setTestRecipient] = useState("")
   const variableGroups = useMemo(
@@ -154,14 +144,6 @@ function NotificationTemplateDialogInner({
   }, [open, template, form])
 
   useEffect(() => {
-    if (!open) return
-    setInsertionTarget((current) => {
-      const next = channel === "sms" ? "text" : current === "text" ? "body" : current
-      return next === current ? current : next
-    })
-  }, [channel, open])
-
-  useEffect(() => {
     if (!open || channel === "email" || (form.getValues("attachments") ?? []).length === 0) return
     form.setValue("attachments", [], {
       shouldDirty: true,
@@ -217,30 +199,6 @@ function NotificationTemplateDialogInner({
     } catch (error) {
       throw new Error(error instanceof Error ? error.message : common.previewInvalidJson)
     }
-  }
-
-  const insertIntoTarget = (content: string, kind: "variable" | "snippet") => {
-    if (insertionTarget === "body" && channel === "email" && editorInstance) {
-      if (kind === "variable") {
-        insertVariableToken(editorInstance, content)
-      } else {
-        insertPlainText(editorInstance, content)
-      }
-      return
-    }
-
-    const fieldName = insertionTarget === "subject" ? "subjectTemplate" : "textTemplate"
-    const current = form.getValues(fieldName) ?? ""
-    const nextValue =
-      kind === "variable"
-        ? // i18n-literal-ok single-space joiner between Liquid tokens, not user-facing copy.
-          `${current}${current ? " " : ""}${variableReference(content)}`
-        : appendTemplateValue(current, content)
-    form.setValue(fieldName, nextValue, {
-      shouldDirty: true,
-      shouldTouch: true,
-      shouldValidate: true,
-    })
   }
 
   const handlePreview = async () => {
@@ -409,7 +367,6 @@ function NotificationTemplateDialogInner({
                       }
                       placeholder={t.htmlBodyPlaceholder}
                       enableVariables
-                      onEditorReady={setEditorInstance}
                     />
                   </div>
                 </>
@@ -434,37 +391,9 @@ function NotificationTemplateDialogInner({
                 </TabsList>
 
                 <TabsContent value="authoring" className="mt-4 space-y-4">
-                  <div className="grid grid-cols-1 gap-3 sm:grid-cols-[180px_1fr] sm:items-center">
-                    <div className="flex flex-col gap-1.5">
-                      <Label>{t.insertIntoLabel}</Label>
-                      <select
-                        className={nativeSelectClassName}
-                        value={insertionTarget}
-                        onChange={(event) => {
-                          const nextTarget = event.target.value as InsertionTarget
-                          if (nextTarget === insertionTarget) return
-                          setInsertionTarget(nextTarget)
-                        }}
-                      >
-                        {channel === "email" ? (
-                          <option value="subject">{t.insertTargetSubject}</option>
-                        ) : null}
-                        {channel === "email" ? (
-                          <option value="body">{t.insertTargetHtmlBody}</option>
-                        ) : null}
-                        {channel === "sms" ? (
-                          <option value="text">{t.insertTargetSmsBody}</option>
-                        ) : null}
-                      </select>
-                    </div>
-                    <p className="text-xs text-muted-foreground">{t.insertHint}</p>
-                  </div>
-
                   <NotificationTemplateAuthoringHelp
                     variableGroups={variableGroups}
                     snippets={liquidSnippets}
-                    onInsertVariable={(variable) => insertIntoTarget(variable.key, "variable")}
-                    onInsertSnippet={(snippet) => insertIntoTarget(snippet.code, "snippet")}
                   />
                 </TabsContent>
 

--- a/packages/notifications-react/src/i18n/en.ts
+++ b/packages/notifications-react/src/i18n/en.ts
@@ -217,12 +217,6 @@ export const notificationsUiEn: NotificationsUiMessages = {
         'Hi {{ traveler.firstName | default: "traveler" }}, your booking is confirmed.',
       tabAuthoring: "Authoring",
       tabPreview: "Preview & Test",
-      insertIntoLabel: "Insert into",
-      insertTargetSubject: "Subject",
-      insertTargetHtmlBody: "HTML body",
-      insertTargetSmsBody: "SMS body",
-      insertHint:
-        "Variables insert as Liquid tags in text fields and as inline chips in the rich-text HTML body.",
       previewDataLabel: "Preview data (JSON)",
       previewDataPlaceholder: '{"booking":{"reference":"BKG-2026-00125"}}',
       previewDataHint: "Use sample JSON to preview Liquid rendering and send a safe test message.",

--- a/packages/notifications-react/src/i18n/messages.ts
+++ b/packages/notifications-react/src/i18n/messages.ts
@@ -211,11 +211,6 @@ export type NotificationsUiMessages = {
       smsBodyPlaceholder: string
       tabAuthoring: string
       tabPreview: string
-      insertIntoLabel: string
-      insertTargetSubject: string
-      insertTargetHtmlBody: string
-      insertTargetSmsBody: string
-      insertHint: string
       previewDataLabel: string
       previewDataPlaceholder: string
       previewDataHint: string

--- a/packages/notifications-react/src/i18n/ro.ts
+++ b/packages/notifications-react/src/i18n/ro.ts
@@ -221,12 +221,6 @@ export const notificationsUiRo: NotificationsUiMessages = {
         'Salut {{ traveler.firstName | default: "călător" }}, rezervarea ta este confirmată.',
       tabAuthoring: "Editare",
       tabPreview: "Previzualizare și test",
-      insertIntoLabel: "Inserează în",
-      insertTargetSubject: "Subiect",
-      insertTargetHtmlBody: "Corp HTML",
-      insertTargetSmsBody: "Corp SMS",
-      insertHint:
-        "Variabilele se inserează ca taguri Liquid în câmpurile text și ca etichete inline în corpul HTML.",
       previewDataLabel: "Date de previzualizare (JSON)",
       previewDataPlaceholder: '{"booking":{"reference":"BKG-2026-00125"}}',
       previewDataHint:

--- a/packages/ui/src/components/contract-template-authoring-help.tsx
+++ b/packages/ui/src/components/contract-template-authoring-help.tsx
@@ -36,16 +36,6 @@ export type TemplateAuthoringSnippet = {
 type ContractTemplateAuthoringHelpProps = {
   variableGroups: TemplateAuthoringVariableGroup[]
   snippets?: TemplateAuthoringSnippet[]
-  /**
-   * @deprecated Variables now expose a copy-to-clipboard button instead of
-   * an inline insert. Kept for prop-shape compatibility with older callers.
-   */
-  onInsertVariable?: (variable: TemplateAuthoringVariable) => void
-  /**
-   * @deprecated Snippets now expose a copy-to-clipboard button instead of
-   * an inline insert. Kept for prop-shape compatibility with older callers.
-   */
-  onInsertSnippet?: (snippet: TemplateAuthoringSnippet) => void
   className?: string
   title?: string
   description?: string
@@ -112,8 +102,6 @@ function matchesSearch(haystack: string, query: string) {
 export function ContractTemplateAuthoringHelp({
   variableGroups,
   snippets = [],
-  onInsertVariable: _deprecatedOnInsertVariable,
-  onInsertSnippet: _deprecatedOnInsertSnippet,
   className,
   title = "Template variables",
   description = "Templates render with Liquid. Use output tags for variables and control tags for loops and conditionals.",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2719,9 +2719,6 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.101.2
         version: 5.101.2(react@19.2.7)
-      '@tiptap/core':
-        specifier: ^3.27.1
-        version: 3.27.1(@tiptap/pm@3.27.1)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -3018,9 +3015,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tiptap/core':
-        specifier: ^3.27.1
-        version: 3.27.1(@tiptap/pm@3.27.1)
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17


### PR DESCRIPTION
## Summary

- remove deprecated insertion callback props that the shared authoring help component deliberately ignored
- remove dead Legal and Notifications caller wiring
- delete the inert Notifications insertion selector and messages
- remove now-unused Tiptap development dependencies
- add patch changesets for the affected 0.x packages

## Why

The public props suggested insertion behavior existed, while the implementation discarded every callback. Removing the half-compatible surface makes the actual supported copy-to-clipboard behavior explicit.

## Verification

- UI: 19 tests and typecheck
- Legal React: 24 tests and typecheck
- Notifications React: 25 tests and typecheck
- frozen lockfile check
- focused Biome checks