### PR TITLE
refactor(legal): remove name-based series lookup

### DIFF
--- a/.changeset/legal-series-prefix-scope.md
+++ b/.changeset/legal-series-prefix-scope.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/legal": minor
+---
+
+Remove name-based contract-series selection and require the canonical active
+series identity of `prefix` plus `scope`.

--- a/packages/legal/src/contracts/contract-document-service.ts
+++ b/packages/legal/src/contracts/contract-document-service.ts
@@ -20,9 +20,10 @@
  *     (R2 / browser-rendering / pdf-lib). Returns `null` when storage isn't
  *     configured, which surfaces as a `null` generate result (→ 503).
  *   - `autoGenerateOptions` — the `AutoGenerateContractOptions` carrying the
- *     template slug / scope / series name and the operator-injected
+ *     template slug / scope / series identity and the operator-injected
  *     `resolveVariables` binding (see `buildContractVariableBindings`).
- *   - `defaultSeriesName` — the name seeded by `ensureDefaultContractSeries`.
+ *   - `defaultSeries` — the canonical series identity and display label seeded
+ *     by `ensureDefaultContractSeries`.
  *   - `resolveBindings()` — the runtime env bindings forwarded into
  *     `resolveVariables` (e.g. `DOCUMENTS_BASE_URL`).
  *   - `resolveBookingPiiService()` — the deployment's KMS-backed traveler
@@ -44,7 +45,12 @@ import {
   type AutoGenerateContractOptions,
   autoGenerateContractForBooking,
 } from "./service-auto-generate.js"
+import type { ContractSeriesIdentity } from "./service-auto-generate-types.js"
 import type { ContractDocumentGenerator } from "./service-documents.js"
+
+export interface DefaultContractSeries extends ContractSeriesIdentity {
+  name: string
+}
 
 /**
  * Deployment-supplied dependencies for the contract-document service. Keeps the
@@ -59,12 +65,12 @@ export interface ContractDocumentServiceOptions {
    */
   resolveGenerator(): ContractDocumentGenerator | null
   /**
-   * The auto-generate options (template slug, scope, series name, and the
+   * The auto-generate options (template slug, scope, series identity, and the
    * operator-injected `resolveVariables` binding).
    */
   autoGenerateOptions: AutoGenerateContractOptions
-  /** Name of the default contract number series to lazy-seed on first generate. */
-  defaultSeriesName: string
+  /** Canonical identity and display label of the series to lazy-seed. */
+  defaultSeries: DefaultContractSeries
   /**
    * Runtime env bindings forwarded into `resolveVariables` (e.g.
    * `DOCUMENTS_BASE_URL`, `APP_URL`). Optional.
@@ -104,7 +110,7 @@ export function createContractDocumentService(
   const {
     resolveGenerator,
     autoGenerateOptions,
-    defaultSeriesName,
+    defaultSeries,
     resolveBindings,
     resolveBookingPiiService,
   } = options
@@ -123,7 +129,7 @@ export function createContractDocumentService(
       if (!generator) return null
 
       // Lazy seed — creates the default series on the first contract generation.
-      await ensureDefaultContractSeries(db, defaultSeriesName)
+      await ensureDefaultContractSeries(db, defaultSeries)
 
       const [bookingRow] = await db
         .select({ bookingNumber: bookings.bookingNumber })
@@ -213,24 +219,24 @@ export function createContractDocumentService(
 }
 
 /**
- * Lazy-seed the default customer-contract number series. Idempotent: a no-op
- * when a series with `seriesName` already exists. Swallows insert races so a
- * concurrent first-generate doesn't fail the request.
+ * Lazy-seed the default contract number series by its canonical `(prefix,
+ * scope)` identity. Swallows insert races so concurrent first-generation
+ * requests do not fail.
  */
 export async function ensureDefaultContractSeries(
   db: PostgresJsDatabase,
-  seriesName: string,
+  series: DefaultContractSeries,
 ): Promise<void> {
-  const existing = await contractsService.findSeriesByName(db, seriesName)
+  const existing = await contractsService.findActiveByPrefixScope(db, series.prefix, series.scope)
   if (existing) return
   try {
     await contractsService.createSeries(db, {
-      name: seriesName,
-      prefix: `CTR-${new Date().getFullYear()}-`,
+      name: series.name,
+      prefix: series.prefix,
       separator: "",
       padLength: 5,
       resetStrategy: "never",
-      scope: "customer",
+      scope: series.scope,
       active: true,
     })
   } catch (err) {

--- a/packages/legal/src/contracts/service-auto-generate-types.ts
+++ b/packages/legal/src/contracts/service-auto-generate-types.ts
@@ -358,21 +358,10 @@ export interface AutoGenerateContractOptions {
    */
   scope?: "customer" | "supplier" | "partner" | "channel" | "other"
   /**
-   * When set, the contract tries to allocate a number from the matching
-   * active series on issuance. Without it, the contract issues unnumbered.
-   * @deprecated Prefer `seriesPrefixScope` — `name` has no unique
-   * constraint, so this lookup throws if multiple active rows share the
-   * name. `(prefix, scope)` is the natural key (partial-unique-indexed).
-   */
-  seriesName?: string
-  /**
    * When set, resolves the active series via the `(prefix, scope)`
-   * partial unique index. Takes precedence over `seriesName`.
+   * partial unique index. Without it, the contract issues unnumbered.
    */
-  seriesPrefixScope?: {
-    prefix: string
-    scope: "customer" | "supplier" | "partner" | "channel" | "other"
-  }
+  seriesPrefixScope?: ContractSeriesIdentity
   /**
    * Language code written onto the contract row. Used by the PDF
    * renderer to pick the right locale for date/currency filters.
@@ -397,6 +386,11 @@ export interface AutoGenerateContractOptions {
    * document instead of returning the existing attachment.
    */
   forceRecompute?: boolean
+}
+
+export interface ContractSeriesIdentity {
+  prefix: string
+  scope: "customer" | "supplier" | "partner" | "channel" | "other"
 }
 
 export interface AutoGenerateContractRuntime {

--- a/packages/legal/src/contracts/service-auto-generate-variables.ts
+++ b/packages/legal/src/contracts/service-auto-generate-variables.ts
@@ -34,7 +34,7 @@ export async function resolveContractGenerationVariables(
   event: BookingConfirmedLikeEvent,
   options: AutoGenerateContractOptions,
   runtime: AutoGenerateContractRuntime,
-  template: { id: string; language?: string | null },
+  template: { id: string; language?: string | null; seriesLabel?: string | null },
 ): Promise<Record<string, unknown>> {
   const travelers = await bookingsService.listTravelers(db, event.bookingId)
   const travelerTravelDetails = await resolveTravelerTravelDetails(
@@ -128,7 +128,7 @@ export async function resolveContractGenerationVariables(
       issuedAt: todayIsoDateTime,
       signedAt: "",
       isManual: false,
-      series: options.seriesName ?? "",
+      series: template.seriesLabel ?? "",
       channel: "",
       source: "",
       status: "draft",

--- a/packages/legal/src/contracts/service-auto-generate.ts
+++ b/packages/legal/src/contracts/service-auto-generate.ts
@@ -20,6 +20,7 @@ export type {
   AutoGenerateContractResult,
   AutoGenerateContractRuntime,
   BookingConfirmedLikeEvent,
+  ContractSeriesIdentity,
   DefaultContractVariables,
   GenerateContractForBookingResult,
   ResolveContractVariablesFn,
@@ -179,9 +180,21 @@ export async function autoGenerateContractForBooking(
     return { status: "booking_not_found" }
   }
 
+  // Prefix + scope is the persisted natural identity for an active series.
+  // A missing series remains non-fatal because some operators number
+  // contracts externally.
+  const series = options.seriesPrefixScope
+    ? await contractSeriesService.findActiveByPrefixScope(
+        db,
+        options.seriesPrefixScope.prefix,
+        options.seriesPrefixScope.scope,
+      )
+    : null
+
   const variables = await resolveContractGenerationVariables(db, booking, event, options, runtime, {
     id: template.id,
     language: template.language,
+    seriesLabel: series?.name ?? null,
   })
 
   // Preview branch: render the template body with the freshly-resolved
@@ -205,22 +218,7 @@ export async function autoGenerateContractForBooking(
     }
   }
 
-  // Resolve a series if the consumer gave a (prefix, scope) or a name —
-  // failure to find is non-fatal since a contract can issue without a
-  // number (some operators use templates as standalone records and number
-  // externally). prefix+scope wins when both are set.
-  let seriesId: string | null = null
-  if (options.seriesPrefixScope) {
-    const series = await contractSeriesService.findActiveByPrefixScope(
-      db,
-      options.seriesPrefixScope.prefix,
-      options.seriesPrefixScope.scope,
-    )
-    seriesId = series?.id ?? null
-  } else if (options.seriesName) {
-    const series = await contractSeriesService.findSeriesByName(db, options.seriesName)
-    seriesId = series?.id ?? null
-  }
+  const seriesId = series?.id ?? null
 
   // Branch on whether the storefront pre-created a draft contract
   // at /checkout/start time (carrying the acceptance metadata on

--- a/packages/legal/src/contracts/service-series.ts
+++ b/packages/legal/src/contracts/service-series.ts
@@ -41,8 +41,8 @@ export const contractSeriesService = {
   /**
    * Resolve the single active series for a (prefix, scope) pair. Throws
    * if the partial unique index has been bypassed and >1 active row
-   * exists. Prefer this over `findSeriesByName` — `(prefix, scope)` is
-   * the natural key for the generated number; `name` is just a label.
+   * exists. `(prefix, scope)` is the natural key for the generated number;
+   * `name` is only a display label.
    */
   async findActiveByPrefixScope(db: PostgresJsDatabase, prefix: string, scope: ContractScope) {
     const rows = await db
@@ -108,24 +108,6 @@ export const contractSeriesService = {
    */
   async findSingleActiveByScope(db: PostgresJsDatabase, scope: ContractScope) {
     return contractSeriesService.findDefaultActiveByScope(db, scope)
-  },
-  /**
-   * @deprecated Prefer `findActiveByPrefixScope`. `name` has no unique
-   * constraint, so two active rows can share a name; this method now
-   * throws on multi-match instead of picking the most-recently-updated.
-   */
-  async findSeriesByName(db: PostgresJsDatabase, name: string) {
-    const rows = await db
-      .select()
-      .from(contractNumberSeries)
-      .where(and(eq(contractNumberSeries.name, name), eq(contractNumberSeries.active, true)))
-      .limit(2)
-    if (rows.length > 1) {
-      throw new ContractSeriesAmbiguousError(
-        `Multiple active contract_number_series rows match name=${name}. Resolve by archiving duplicates (active=false) or migrate the caller to findActiveByPrefixScope.`,
-      )
-    }
-    return rows[0] ?? null
   },
   async createSeries(db: PostgresJsDatabase, data: CreateContractNumberSeriesInput) {
     return db.transaction(async (tx) => {

--- a/packages/legal/src/index.ts
+++ b/packages/legal/src/index.ts
@@ -114,6 +114,7 @@ export {
   type ContractDocumentService,
   type ContractDocumentServiceOptions,
   createContractDocumentService,
+  type DefaultContractSeries,
   ensureDefaultContractSeries,
   resetContractDocumentForBooking,
 } from "./contracts/contract-document-service.js"
@@ -136,6 +137,7 @@ export {
   type AutoGenerateContractRuntime,
   autoGenerateContractForBooking,
   type BookingConfirmedLikeEvent,
+  type ContractSeriesIdentity,
   type DefaultContractVariables,
   type GenerateContractForBookingResult,
   generateContractForBookingFromDefaults,

--- a/packages/legal/src/runtime.ts
+++ b/packages/legal/src/runtime.ts
@@ -24,7 +24,11 @@ import {
   createStorageBackedContractDocumentGenerator,
 } from "./index.js"
 
-const DEFAULT_CONTRACT_SERIES_NAME = "customer-contracts"
+const DEFAULT_CONTRACT_SERIES = {
+  name: "customer-contracts",
+  prefix: `CTR-${new Date().getFullYear()}-`,
+  scope: "customer",
+} as const
 const LOCAL_PLACEHOLDER_KEYS = new Set(["local-dev"])
 const CLIENT_CACHE = new WeakMap<object, Map<string, VoyantCloudClient>>()
 
@@ -39,7 +43,10 @@ export const DEFAULT_AUTO_GENERATE_CONTRACT_OPTIONS: AutoGenerateContractOptions
   templateSlug: "customer-sales-agreement",
   scope: "customer",
   language: "en",
-  seriesName: DEFAULT_CONTRACT_SERIES_NAME,
+  seriesPrefixScope: {
+    prefix: DEFAULT_CONTRACT_SERIES.prefix,
+    scope: DEFAULT_CONTRACT_SERIES.scope,
+  },
   resolveVariables: buildContractVariableBindings({
     resolveOperatorProfile: (db) => getOperatorProfile(db),
     resolveOperatorPaymentInstructions: (db) => getOperatorPaymentInstructions(db),
@@ -178,7 +185,7 @@ function createContractDocumentServiceForBindings(
   return createContractDocumentService({
     resolveGenerator: () => resolveContractDocumentGenerator(primitives, bindings) ?? null,
     autoGenerateOptions: DEFAULT_AUTO_GENERATE_CONTRACT_OPTIONS,
-    defaultSeriesName: DEFAULT_CONTRACT_SERIES_NAME,
+    defaultSeries: DEFAULT_CONTRACT_SERIES,
     resolveBindings: () => primitives.env(bindings),
     resolveBookingPiiService: () => resolveBookingPiiService(primitives, bindings),
   })

--- a/packages/legal/tests/integration/auto-generate.test.ts
+++ b/packages/legal/tests/integration/auto-generate.test.ts
@@ -1016,7 +1016,7 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     expect(bodies[0]).toBe("Rooms 1× Twin room")
   })
 
-  it("resolves a series by name and writes seriesId onto the contract", async () => {
+  it("resolves a series by prefix and scope and writes seriesId onto the contract", async () => {
     const { template } = await seedTemplate("cust-series-1")
     const booking = await seedBooking()
     const series = await contractSeriesService.createSeries(db, {
@@ -1032,7 +1032,11 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     const outcome = await autoGenerateContractForBooking(
       db,
       { bookingId: booking.id, bookingNumber: booking.bookingNumber, actorId: null },
-      { enabled: true, templateSlug: template.slug, seriesName: "2026 Customer" },
+      {
+        enabled: true,
+        templateSlug: template.slug,
+        seriesPrefixScope: { prefix: "CS", scope: "customer" },
+      },
       { generator: makeGenerator() },
     )
     expect(outcome.status).toBe("ok")
@@ -1041,6 +1045,9 @@ describe.skipIf(!DB_AVAILABLE)("autoGenerateContractForBooking", () => {
     const contract = await contractRecordsService.getContractById(db, outcome.contractId)
     expect(contract?.seriesId).toBe(series!.id)
     expect(contract?.contractNumber).toBeTruthy() // allocated from series
+    expect((contract?.variables as { contract?: { series?: string } }).contract?.series).toBe(
+      "2026 Customer",
+    )
   })
 
   it("records trigger metadata on the created contract", async () => {

--- a/packages/legal/tests/integration/contract-number-series.test.ts
+++ b/packages/legal/tests/integration/contract-number-series.test.ts
@@ -244,51 +244,6 @@ describe.skipIf(!DB_AVAILABLE)("contract_number_series uniqueness + lookups", ()
     })
   })
 
-  describe("findSeriesByName", () => {
-    it("returns the row when exactly one active match exists", async () => {
-      const created = await contractSeriesService.createSeries(db, {
-        name: "By Name",
-        prefix: "BYN",
-        separator: "-",
-        padLength: 4,
-        resetStrategy: "never",
-        scope: "customer",
-        active: true,
-      })
-
-      const found = await contractSeriesService.findSeriesByName(db, "By Name")
-      expect(found?.id).toBe(created!.id)
-    })
-
-    it("throws when two active rows share a name across different (prefix, scope)", async () => {
-      // Two rows with the same name but different (prefix, scope) — the
-      // partial unique index doesn't catch this, but the lookup should
-      // refuse to silently pick a winner.
-      await contractSeriesService.createSeries(db, {
-        name: "Duplicate Label",
-        prefix: "AAA",
-        separator: "-",
-        padLength: 4,
-        resetStrategy: "never",
-        scope: "customer",
-        active: true,
-      })
-      await contractSeriesService.createSeries(db, {
-        name: "Duplicate Label",
-        prefix: "BBB",
-        separator: "-",
-        padLength: 4,
-        resetStrategy: "never",
-        scope: "supplier",
-        active: true,
-      })
-
-      await expect(
-        contractSeriesService.findSeriesByName(db, "Duplicate Label"),
-      ).rejects.toBeInstanceOf(ContractSeriesAmbiguousError)
-    })
-  })
-
   describe("upsertByPrefixScope", () => {
     it("creates the row on first call and updates it on second", async () => {
       const first = await contractSeriesService.upsertByPrefixScope(db, {

--- a/packages/legal/tests/unit/contract-document-service.test.ts
+++ b/packages/legal/tests/unit/contract-document-service.test.ts
@@ -13,11 +13,11 @@ vi.mock("../../src/contracts/service-auto-generate.js", () => ({
 
 // Mock the contracts service used by ensureDefaultContractSeries +
 // resetContractDocumentForBooking.
-const findSeriesByName = vi.fn()
+const findActiveByPrefixScope = vi.fn()
 const createSeries = vi.fn()
 vi.mock("../../src/contracts/service.js", () => ({
   contractsService: {
-    findSeriesByName: (...args: unknown[]) => findSeriesByName(...args),
+    findActiveByPrefixScope: (...args: unknown[]) => findActiveByPrefixScope(...args),
     createSeries: (...args: unknown[]) => createSeries(...args),
     listContracts: vi.fn(async () => ({ data: [] })),
     listAttachments: vi.fn(async () => []),
@@ -47,14 +47,18 @@ const AUTO_OPTIONS: AutoGenerateContractOptions = {
   enabled: true,
   templateSlug: "customer-sales-agreement",
   scope: "customer",
-  seriesName: "customer-contracts",
+  seriesPrefixScope: { prefix: "CTR-2026-", scope: "customer" },
 }
 
 function makeService(generator: unknown | null) {
   return createContractDocumentService({
     resolveGenerator: () => generator as never,
     autoGenerateOptions: AUTO_OPTIONS,
-    defaultSeriesName: "customer-contracts",
+    defaultSeries: {
+      name: "customer-contracts",
+      prefix: "CTR-2026-",
+      scope: "customer",
+    },
     resolveBindings: () => ({ DOCUMENTS_BASE_URL: "https://docs.example" }),
     resolveBookingPiiService: () => null,
   })
@@ -63,7 +67,7 @@ function makeService(generator: unknown | null) {
 describe("contract document service", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    findSeriesByName.mockResolvedValue({ id: "ser_1" })
+    findActiveByPrefixScope.mockResolvedValue({ id: "ser_1" })
   })
 
   it("generate -> seeds series, persists, returns ids", async () => {
@@ -85,14 +89,23 @@ describe("contract document service", () => {
   })
 
   it("generate -> seeds the default series when missing", async () => {
-    findSeriesByName.mockResolvedValue(null)
+    findActiveByPrefixScope.mockResolvedValue(null)
     autoGenerateContractForBooking.mockResolvedValue({
       status: "ok",
       contractId: "ctr_2",
       attachmentId: "att_2",
     })
     await makeService({}).generate(stubDb("BK-2"), undefined, "bkg_2")
+    expect(findActiveByPrefixScope).toHaveBeenCalledWith(expect.anything(), "CTR-2026-", "customer")
     expect(createSeries).toHaveBeenCalledTimes(1)
+    expect(createSeries).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        name: "customer-contracts",
+        prefix: "CTR-2026-",
+        scope: "customer",
+      }),
+    )
   })
 
   it("preview -> returns rendered html", async () => {


### PR DESCRIPTION
## Summary
- remove deprecated `seriesName` and `findSeriesByName` APIs
- resolve active contract-number series by the canonical partial-unique `(prefix, scope)` identity
- use the same identity for lazy default-series seeding
- preserve the persisted series display label in contract template variables
- update public types/tests and add a Legal minor changeset

## Verification
- 150 Legal tests passed; 52 database-dependent tests skipped
- Biome, changed-file quality, secret, and `git diff --check` passed
- rebased cleanly onto current `origin/main`

The package build remained CPU-active but was terminated by the local execution ceiling after roughly seven minutes (`SIGTERM`), with no TypeScript diagnostic. CI build is the authoritative compile lane for this PR.