### PR TITLE
refactor(framework): unify deployment resource API

### DIFF
--- a/.changeset/clean-framework-resource-api.md
+++ b/.changeset/clean-framework-resource-api.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Rename deployment-local `createVoyantApp` factory inputs from `providers` to `resources`, remove the deprecated Node runtime `providers` aliases, and remove the retired `FrameworkProviders` and `generateCustomSourcePluginManifests` exports. Graph runtime providers and deployment provider selections are unchanged. See [Migrating to Framework 0.42](../../docs/migrations/migrating-to-0.42.md) for caller rewrites.

--- a/docs/architecture/managed-profile-contract.md
+++ b/docs/architecture/managed-profile-contract.md
@@ -116,7 +116,7 @@ import { toCreateVoyantAppProfileConfig } from "@voyant-travel/framework/profile
 const profileConfig = toCreateVoyantAppProfileConfig(snapshot)
 
 createVoyantApp({
-  providers,
+  resources,
   ...profileConfig,
   modules: customModules,
   extensions: customExtensions,

--- a/docs/architecture/operator-settings-extraction.md
+++ b/docs/architecture/operator-settings-extraction.md
@@ -3,7 +3,7 @@
 - **Status:** Superseded by package manifests, typed runtime ports, and generated graph composition
 - **Date:** 2026-06-17
 - **Feeds:** `consolidated-deployments-rfc.md` Workstream B step 4 · `operator-registry-classification.md` ("Recommendation: extract operator-settings")
-- **Prereq met:** the registry relocation + `createVoyantApp` convergence (Workstream B steps 1–3) are merged. The deployment is now config + injected `providers` + two deployment-local module families (`invitations`, `operator-settings`). This note assesses turning the second one into a standard package.
+- **Prereq met:** the registry relocation + `createVoyantApp` convergence (Workstream B steps 1–3) are merged. The deployment is now config + injected resources + two deployment-local module families (`invitations`, `operator-settings`). This note assesses turning the second one into a standard package.
 
 ## Summary
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -6,6 +6,7 @@ The full history (including patch-level changes and dependency updates) lives in
 
 ## Available
 
+- [Migrating to Framework 0.42](./migrating-to-0.42.md) - rename deployment-local factory `providers` to `resources` and replace removed Framework compatibility exports.
 - [Migrating to 0.11](./migrating-to-0.11.md) — privatize Booking state machine; replace `PATCH /:id/status` with named verbs; `useBookingStatusMutation` requires `currentStatus`; activity-type enum gains three values.
 - [Migrating to 0.10](./migrating-to-0.10.md) — encrypt `accessibility_needs` at rest; explicit Booking state machine + `transitionBooking` guards; drop `redeemed` status; add `bookings.fx_rate_set_id`; `requireActor` fail-closed; `Idempotency-Key` middleware on booking-creation endpoints; mandatory PII redaction + audit on admin booking reads.
 

--- a/docs/migrations/migrating-to-0.42.md
+++ b/docs/migrations/migrating-to-0.42.md
@@ -1,0 +1,142 @@
+# Migrating Framework to 0.42
+
+Consolidated breaking-change notes for `@voyant-travel/framework@0.42.0`.
+These changes remove deprecated beta compatibility names for deployment-local
+factory resources. Graph runtime providers and deployment provider selections
+keep their existing names and behavior.
+
+## TL;DR
+
+- Rename `createVoyantApp({ providers })` to `createVoyantApp({ resources })`.
+- Rename the top-level Node runtime `providers` option to `resources`.
+- Replace the removed `FrameworkProviders` marker with an application-owned resource type or typed runtime ports.
+- Replace `generateCustomSourcePluginManifests` with `generateCustomSourceExtensionManifests`.
+- Do not rename graph manifest `providers` or `deployment.providers`; those are separate, supported concepts.
+
+## Schema changes
+
+None. This release does not require a database migration.
+
+## Removed exports
+
+| Removed | Replacement |
+|---|---|
+| `FrameworkProviders` | Define a type for deployment-local resources, or use package-owned typed runtime ports for package behavior. |
+| `generateCustomSourcePluginManifests` | `generateCustomSourceExtensionManifests` |
+
+## HTTP route changes
+
+None.
+
+## Hook signature changes
+
+None.
+
+## Caller-code migrations
+
+### `createVoyantApp`
+
+The deployment-local factory container is now named `resources`. Factories
+still receive that value as their low-level Hono `capabilities` argument.
+
+```ts
+// Before: @voyant-travel/framework@0.41.x
+const app = createVoyantApp({
+  providers: localResources,
+  modules: localModules,
+  extensions: localExtensions,
+  db,
+})
+
+// After: @voyant-travel/framework@0.42.x
+const app = createVoyantApp({
+  resources: localResources,
+  modules: localModules,
+  extensions: localExtensions,
+  db,
+})
+```
+
+### Node runtime resources
+
+Rename only the top-level deployment-local input. Keep the nested deployment
+provider selections unchanged.
+
+```ts
+// Before: @voyant-travel/framework@0.41.x
+await loadVoyantNodeRuntime({
+  graphRuntime,
+  deployment: {
+    mode: "self-hosted",
+    providers: deploymentProviderSelections,
+  },
+  deploymentRequirements,
+  providers: deploymentResources,
+})
+
+// After: @voyant-travel/framework@0.42.x
+await loadVoyantNodeRuntime({
+  graphRuntime,
+  deployment: {
+    mode: "self-hosted",
+    providers: deploymentProviderSelections,
+  },
+  deploymentRequirements,
+  resources: deploymentResources,
+})
+```
+
+The same top-level rename applies when calling `createVoyantNodeApp` directly:
+
+```ts
+createVoyantNodeApp({
+  applicationId,
+  activeModules,
+  resources: deploymentResources,
+})
+```
+
+### `FrameworkProviders`
+
+`FrameworkProviders` was an empty compatibility marker. Applications should
+declare the concrete resources their local factories use:
+
+```ts
+// Before: @voyant-travel/framework@0.41.x
+import type { FrameworkProviders } from "@voyant-travel/framework"
+
+interface AppResources extends FrameworkProviders {
+  customFields: CustomFieldRegistry
+}
+
+// After: @voyant-travel/framework@0.42.x
+interface AppResources {
+  customFields: CustomFieldRegistry
+}
+```
+
+Package behavior should use package-owned typed runtime ports instead of adding
+package-specific fields to the deployment-local resource container.
+
+### Custom source extension manifests
+
+The deprecated plugin-named alias is removed. The graph vocabulary consistently
+uses `extension` for this unit kind:
+
+```ts
+// Before: @voyant-travel/framework@0.41.x
+import { generateCustomSourcePluginManifests } from "@voyant-travel/framework/deployment-graph"
+
+const extensions = generateCustomSourcePluginManifests(specifiers)
+
+// After: @voyant-travel/framework@0.42.x
+import { generateCustomSourceExtensionManifests } from "@voyant-travel/framework/deployment-graph"
+
+const extensions = generateCustomSourceExtensionManifests(specifiers)
+```
+
+## Per-package CHANGELOGs
+
+For full detail, including patch-level changes and dependency updates:
+
+- [`@voyant-travel/framework@0.42.0`](../../packages/framework/CHANGELOG.md)

--- a/packages/framework/src/create-app.test.ts
+++ b/packages/framework/src/create-app.test.ts
@@ -5,7 +5,7 @@ import { createVoyantApp } from "./create-app.js"
 describe("createVoyantApp", () => {
   it("composes only explicitly supplied local factories", () => {
     const app = createVoyantApp({
-      providers: { value: "local" },
+      resources: { value: "local" },
       db: {} as never,
       modules: {
         local: ({ capabilities }) => ({
@@ -22,7 +22,7 @@ describe("createVoyantApp", () => {
   })
 
   it("does not mount a framework-owned standard set", () => {
-    const app = createVoyantApp({ providers: {}, db: {} as never })
+    const app = createVoyantApp({ resources: {}, db: {} as never })
     expect(app.moduleMounts).toEqual([])
   })
 })

--- a/packages/framework/src/create-app.ts
+++ b/packages/framework/src/create-app.ts
@@ -6,45 +6,39 @@ import type {
 } from "@voyant-travel/hono/composition"
 
 /**
- * Deprecated compatibility marker for deployment capability containers.
- * Product packages own their provider types through declared runtime ports.
- */
-export type FrameworkProviders = Record<never, never>
-
-/**
- * Config for {@link createVoyantApp}: the injected providers + deployment-local
+ * Config for {@link createVoyantApp}: the deployment-local resources and
  * additions, plus everything else `createApp` takes (db, auth, workflows,
  * outbox, publicPaths, …) — minus the `manifest`/`registry`/`capabilities` the
  * framework now assembles for you.
  */
-export interface CreateVoyantAppConfig<TBindings extends VoyantBindings, TProviders>
-  extends Omit<CreateAppConfig<TBindings, TProviders>, "manifest" | "registry" | "capabilities"> {
+export interface CreateVoyantAppConfig<TBindings extends VoyantBindings, TResources>
+  extends Omit<CreateAppConfig<TBindings, TResources>, "manifest" | "registry" | "capabilities"> {
   /** Capabilities passed only to the explicitly supplied local factories. */
-  providers: TProviders
+  resources: TResources
   /** Explicit module factories. Standard product units come from the generated graph runtime. */
-  modules?: Record<string, ModuleFactory<TProviders>>
+  modules?: Record<string, ModuleFactory<TResources>>
   /** Explicit extension factories. */
-  extensions?: Record<string, ExtensionFactory<TProviders>>
+  extensions?: Record<string, ExtensionFactory<TResources>>
 }
 
 /** Compose only explicitly supplied factories through the generic Hono machinery. */
-export function createVoyantApp<TBindings extends VoyantBindings, TProviders>(
-  config: CreateVoyantAppConfig<TBindings, TProviders>,
+export function createVoyantApp<TBindings extends VoyantBindings, TResources>(
+  config: CreateVoyantAppConfig<TBindings, TResources>,
 ) {
-  const { providers, modules = {}, extensions = {}, ...rest } = config
+  const { resources, modules = {}, extensions = {}, ...rest } = config
 
-  const registry: CompositionRegistry<TProviders> = {
+  const registry: CompositionRegistry<TResources> = {
     modules,
     extensions,
   }
 
-  return createApp<TBindings, TProviders>({
+  return createApp<TBindings, TResources>({
     ...rest,
     manifest: {
       modules: Object.keys(modules),
       extensions: Object.keys(extensions),
     },
     registry,
-    capabilities: providers,
-  } as CreateAppConfig<TBindings, TProviders>)
+    capabilities: resources,
+  } as CreateAppConfig<TBindings, TResources>)
 }

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -900,9 +900,6 @@ export function generateCustomSourceExtensionManifests(
   )
 }
 
-/** @deprecated Use generateCustomSourceExtensionManifests. */
-export const generateCustomSourcePluginManifests = generateCustomSourceExtensionManifests
-
 export function graphIdFromSpecifier(specifier: string): string {
   const { packageName, subpath } = splitPackageSpecifier(specifier)
   if (!subpath) return packageName

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -20,7 +20,6 @@
 export {
   type CreateVoyantAppConfig,
   createVoyantApp,
-  type FrameworkProviders,
 } from "./create-app.js"
 export {
   DEFAULT_MANAGED_CLOUD_PROVIDERS,

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -193,10 +193,8 @@ export interface VoyantNodeRuntimeOptions {
   applicationId?: string
   env?: Record<string, unknown> | VoyantNodeRuntimeEnv
   auth?: VoyantAuthIntegration<VoyantNodeRuntimeEnv>
-  /** @deprecated Use `resources`; package behavior belongs behind `runtimePorts`. */
-  providers?: VoyantNodeRuntimeResources
   app?: Partial<
-    Omit<CreateVoyantAppConfig<VoyantNodeRuntimeEnv, VoyantNodeRuntimeResources>, "providers">
+    Omit<CreateVoyantAppConfig<VoyantNodeRuntimeEnv, VoyantNodeRuntimeResources>, "resources">
   >
 }
 
@@ -259,7 +257,7 @@ export async function loadVoyantNodeRuntime(
     auth: options.app?.auth ?? options.auth,
     activeModules,
   })
-  const resources = { ...(options.providers ?? {}), ...(options.resources ?? {}) }
+  const resources = { ...(options.resources ?? {}) }
   const graphComposition = await composeVoyantGraphRuntime({
     runtime: options.graphRuntime,
     capabilities: resources,
@@ -364,10 +362,8 @@ export function createVoyantNodeApp(options: {
   env?: VoyantNodeRuntimeEnv
   auth?: VoyantAuthIntegration<VoyantNodeRuntimeEnv>
   resources?: VoyantNodeRuntimeResources
-  /** @deprecated Use `resources`; package behavior belongs behind graph runtime ports. */
-  providers?: VoyantNodeRuntimeResources
   app?: Partial<
-    Omit<CreateVoyantAppConfig<VoyantNodeRuntimeEnv, VoyantNodeRuntimeResources>, "providers">
+    Omit<CreateVoyantAppConfig<VoyantNodeRuntimeEnv, VoyantNodeRuntimeResources>, "resources">
   >
   modules?: Record<string, ModuleFactory<VoyantNodeRuntimeResources>>
   extensions?: Record<string, ExtensionFactory<VoyantNodeRuntimeResources>>
@@ -398,7 +394,7 @@ export function createVoyantNodeApp(options: {
     },
     basePath: options.app?.basePath ?? "/api",
     auth,
-    providers: { ...(options.providers ?? {}), ...(options.resources ?? {}) },
+    resources: { ...(options.resources ?? {}) },
   })
 }
 

--- a/packages/hono/src/create-app.ts
+++ b/packages/hono/src/create-app.ts
@@ -33,7 +33,7 @@ export interface CreateAppConfig<TBindings extends VoyantBindings, TCapabilities
  *       db, auth, plugins, ...
  *     })
  *
- * Framework callers may use `createVoyantApp({ providers, modules })` for an
+ * Framework callers may use `createVoyantApp({ resources, modules })` for an
  * explicit local registry. Standard product units are composed from the
  * generated deployment graph instead of this registry path.
  */


### PR DESCRIPTION
## Summary
- rename deployment-local `createVoyantApp` factory inputs from `providers` to `resources`
- remove the empty `FrameworkProviders` marker and Node runtime `providers` aliases
- remove the retired `generateCustomSourcePluginManifests` export
- leave graph runtime providers and deployment provider selections unchanged
- update focused tests/docs and add a Framework minor changeset

## Verification
- Framework focused tests
- Framework lint
- Framework typecheck
- Framework build
- Biome and `git diff --check`

## Stack
This PR is stacked on #3302 because that PR deletes the aggregate OpenAPI package and its final `createVoyantApp({ providers })` caller. Once #3302 merges, this PR can target `main` without a modify/delete conflict.