### PR TITLE
refactor(auth): remove secure cookie compatibility option

### DIFF
--- a/.changeset/clean-auth-secure-cookie-option.md
+++ b/.changeset/clean-auth-secure-cookie-option.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/auth": minor
+---
+
+Remove the top-level `useSecureCookies` compatibility option from
+`createBetterAuth`. Configure this Better Auth setting through
+`advanced.useSecureCookies` instead. See [Migrating Auth to
+0.128](../../docs/migrations/migrating-to-0.128.md) for the caller rewrite.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -7,6 +7,7 @@ The full history (including patch-level changes and dependency updates) lives in
 ## Available
 
 - [Migrating Framework to 0.42](./migrating-to-0.42.md) - require explicit selected IDs and admitted API runtime reference IDs in hand-authored graph runtime inputs.
+- [Migrating Auth to 0.128](./migrating-to-0.128.md) - move the removed top-level `useSecureCookies` option under Better Auth's `advanced` configuration.
 - [Migrating to 0.11](./migrating-to-0.11.md) — privatize Booking state machine; replace `PATCH /:id/status` with named verbs; `useBookingStatusMutation` requires `currentStatus`; activity-type enum gains three values.
 - [Migrating to 0.10](./migrating-to-0.10.md) — encrypt `accessibility_needs` at rest; explicit Booking state machine + `transitionBooking` guards; drop `redeemed` status; add `bookings.fx_rate_set_id`; `requireActor` fail-closed; `Idempotency-Key` middleware on booking-creation endpoints; mandatory PII redaction + audit on admin booking reads.
 

--- a/docs/migrations/migrating-to-0.128.md
+++ b/docs/migrations/migrating-to-0.128.md
@@ -1,0 +1,66 @@
+# Migrating Auth to 0.128
+
+Breaking-change notes for `@voyant-travel/auth@0.128.0`.
+
+## TL;DR
+
+- Move `createBetterAuth({ useSecureCookies })` to
+  `createBetterAuth({ advanced: { useSecureCookies } })`.
+- Merge the setting into an existing `advanced` object when one is present.
+- Secure cookies remain enabled by default outside explicit local development.
+- Local development remains non-secure by default.
+- No database or HTTP route migration is required.
+
+## Schema changes
+
+None.
+
+## Removed exports
+
+None. This release removes an option from the public `CreateBetterAuthOptions`
+shape rather than removing an exported symbol.
+
+## HTTP route changes
+
+None.
+
+## Hook signature changes
+
+None.
+
+## Caller-code migrations
+
+Move the Better Auth setting under `advanced`:
+
+```ts
+// Before: @voyant-travel/auth@0.127.x
+createBetterAuth({
+  useSecureCookies: false,
+})
+
+// After: @voyant-travel/auth@0.128.x
+createBetterAuth({
+  advanced: {
+    useSecureCookies: false,
+  },
+})
+```
+
+When other advanced options already exist, preserve them in the same object:
+
+```ts
+createBetterAuth({
+  advanced: {
+    ...existingAdvancedOptions,
+    useSecureCookies: false,
+  },
+})
+```
+
+Omitting the option preserves the existing defaults: secure cookies are used
+outside explicit local development, while `NODE_ENV=development` defaults to
+non-secure cookies.
+
+## Per-package CHANGELOGs
+
+- [`@voyant-travel/auth@0.128.0`](../../packages/auth/CHANGELOG.md)

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -233,16 +233,11 @@ export interface CreateBetterAuthOptions<
   /** Better Auth rate-limit config. Defaults to secondary storage when present. */
   rateLimit?: BetterAuthOptions["rateLimit"]
   /**
-   * Additional Better Auth advanced options. Voyant still supplies
-   * `useSecureCookies` by default unless overridden here or via the top-level
-   * `useSecureCookies` compatibility option.
+   * Additional Better Auth advanced options. Voyant supplies secure cookies
+   * by default except in explicit local development. Set
+   * `advanced.useSecureCookies` to override that default.
    */
   advanced?: BetterAuthOptions["advanced"]
-  /**
-   * Controls Better Auth's Secure cookie flag. Defaults to secure except in
-   * explicit local development (`NODE_ENV=development`).
-   */
-  useSecureCookies?: boolean
 }
 
 /**
@@ -432,9 +427,7 @@ export function createBetterAuth<
     advanced: {
       ...options.advanced,
       useSecureCookies:
-        options.useSecureCookies ??
-        options.advanced?.useSecureCookies ??
-        process.env.NODE_ENV !== "development",
+        options.advanced?.useSecureCookies ?? process.env.NODE_ENV !== "development",
     },
   } as ResolvedCreateBetterAuthOptions<UserOptions, Plugins>
 

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { CreateBetterAuthOptions } from "../../src/server.js"
 
@@ -74,6 +74,10 @@ describe("createBetterAuth", () => {
     vi.clearAllMocks()
   })
 
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
   function latestBetterAuthConfig(): BetterAuthConfig {
     return betterAuthMock.mock.calls.at(-1)?.[0] as BetterAuthConfig
   }
@@ -100,6 +104,19 @@ describe("createBetterAuth", () => {
     expect(latestBetterAuthConfig().advanced.useSecureCookies).toBe(true)
   })
 
+  it("defaults secure cookies off in explicit local development", async () => {
+    vi.stubEnv("NODE_ENV", "development")
+    const { createBetterAuth } = await import("../../src/server.js")
+
+    createBetterAuth({
+      db: { id: "db" } as never,
+      secret: "x".repeat(32),
+      baseURL: "http://localhost:3000",
+    })
+
+    expect(latestBetterAuthConfig().advanced.useSecureCookies).toBe(false)
+  })
+
   it("lets consumers override secure cookie handling for local HTTP", async () => {
     const { createBetterAuth } = await import("../../src/server.js")
 
@@ -107,7 +124,9 @@ describe("createBetterAuth", () => {
       db: { id: "db" } as never,
       secret: "x".repeat(32),
       baseURL: "https://auth.example.com",
-      useSecureCookies: false,
+      advanced: {
+        useSecureCookies: false,
+      },
     })
 
     expect(latestBetterAuthConfig().advanced.useSecureCookies).toBe(false)


### PR DESCRIPTION
## Summary
- remove the duplicate top-level `CreateBetterAuthOptions.useSecureCookies` option
- keep `advanced.useSecureCookies` as the sole explicit Better Auth override
- preserve secure-by-default and explicit local-development defaults
- add an Auth minor changeset with migration guidance

Persisted users without a `surfaces` array retain their existing compatibility behavior; this PR does not alter stored-data semantics.

## Verification
- Auth lint
- 97 Auth tests
- Auth typecheck
- Auth build
- `git diff --check`