### PR TITLE
refactor(workflow-runs): own selected graph runtime

### DIFF
--- a/.changeset/workflow-runs-graph-authority.md
+++ b/.changeset/workflow-runs-graph-authority.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/workflow-runs": minor
+"@voyant-travel/runtime": minor
+---
+
+Move Workflow Runs registry and route composition behind its selected-graph runtime port. The generic Node runtime no longer mounts Workflow Runs routes when the module is not selected.
+
+Direct applications can continue to instantiate `WorkflowRunnerRegistry` and call `mountWorkflowRunsAdminRoutes`. Runtime-port implementations must now expose both `register()` and `get()`.
+
+See the [Workflow Runs 0.119 migration guide](../docs/migrations/migrating-to-0.119.md) for the custom provider update.

--- a/docs/architecture/api-route-ownership-and-composition.md
+++ b/docs/architecture/api-route-ownership-and-composition.md
@@ -13,16 +13,16 @@ Related:
 - [Catalog Booking Route Module Plan](./catalog-booking-route-module-plan.md)
 - [Route Ownership Inventory](./route-ownership-inventory.md)
 
-## Status update (2026-06-15)
+## Status update (2026-07-13)
 
 Implemented for the operator starter. The route-ownership checker (Phase 0),
 first-class context-preserving lazy contributions including the multi-prefix
 `lazyRoutes` variant (Phase 1), and the full route-family migration (Phases 3–4)
-have landed: `app.ts`'s `additionalRoutes` now contains only the workflow-runs
-admin surface, and every other route family composes through the registry. See
+have landed. Workflow Runs was the final generic Node host mount and now composes
+through its package-owned selected-graph runtime port. The Operator starter and
+generic Runtime contain no `additionalRoutes` product composition. See
 [Route Ownership Inventory](./route-ownership-inventory.md) for the per-family
-result. The remaining open work is promoting deployment-local route definitions
-into shared packages where a second deployment would reuse them.
+result.
 
 ## Summary
 

--- a/docs/architecture/route-ownership-inventory.md
+++ b/docs/architecture/route-ownership-inventory.md
@@ -1,6 +1,14 @@
 # Route Ownership Inventory — `starters/operator/src/api`
 
-Status: living document (baseline 2026-06-15)
+Status: migration record (completed 2026-07-13)
+
+The Operator starter no longer owns product API routes. The table below records
+the original migration inventory; its files have since moved to package-owned
+selected-graph runtime factories.
+
+The separate federated compatibility starter still has two explicitly annotated
+deployment-owned route files. They are outside the Operator starter migration
+and remain until that direct app adopts generated graph composition.
 
 This is the Phase 0 inventory called for by
 [API Route Ownership And Runtime Composition](./api-route-ownership-and-composition.md).
@@ -50,9 +58,10 @@ honest.
 ## Final state (migration complete)
 
 Every route family above now composes through `OPERATOR_RUNTIME_MANIFEST` /
-`operatorComposition` as a module or extension. `app.ts`'s `additionalRoutes`
-contains only the **workflow-runs** admin surface, which is genuinely coupled to
-the app-level runner registry that bundle bootstraps populate at construction.
+`operatorComposition` as a module or extension. Workflow Runs now creates its
+registry through its package runtime contributor and mounts its routes through
+its selected-graph factory. The generic Runtime and Operator starter contain no
+Workflow Runs-specific route mount.
 
 - Package-owned extensions: `channel-push` (distribution), `booking-tax`
   (finance).

--- a/docs/architecture/storefront-checkout-flow.md
+++ b/docs/architecture/storefront-checkout-flow.md
@@ -409,7 +409,7 @@ for in-process workflows. The catalog-checkout subscriber wraps the
 booking id, payment session id, and payment intent. The
 `WorkflowRunsPage` UI from `@voyant-travel/workflows-react/ui` reads
 the admin routes (`/v1/admin/workflow-runs[/:id]`) the operator
-starter mounts via `additionalRoutes`, and can be embedded in any
+runtime mounts from the selected Workflow Runs graph module, and can be embedded in any
 host or pointed at a separate-origin API via its `apiBase` option.
 
 This observability sits beside the durable `@voyant-travel/workflows`

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -8,6 +8,7 @@ The full history (including patch-level changes and dependency updates) lives in
 
 - [Migrating Framework to 0.42](./migrating-to-0.42.md) - require explicit selected IDs and admitted API runtime reference IDs in hand-authored graph runtime inputs.
 - [Migrating Auth to 0.128](./migrating-to-0.128.md) - move the removed top-level `useSecureCookies` option under Better Auth's `advanced` configuration.
+- [Workflow Runs 0.119](./migrating-to-0.119.md) — custom `workflows.runner-registry` providers must implement both `register()` and `get()`; direct registry and route composition APIs remain available.
 - [Migrating to 0.11](./migrating-to-0.11.md) — privatize Booking state machine; replace `PATCH /:id/status` with named verbs; `useBookingStatusMutation` requires `currentStatus`; activity-type enum gains three values.
 - [Migrating to 0.10](./migrating-to-0.10.md) — encrypt `accessibility_needs` at rest; explicit Booking state machine + `transitionBooking` guards; drop `redeemed` status; add `bookings.fx_rate_set_id`; `requireActor` fail-closed; `Idempotency-Key` middleware on booking-creation endpoints; mandatory PII redaction + audit on admin booking reads.
 

--- a/docs/migrations/migrating-to-0.119.md
+++ b/docs/migrations/migrating-to-0.119.md
@@ -1,0 +1,77 @@
+# Workflow Runs 0.119
+
+## TL;DR
+
+- Custom `workflows.runner-registry` providers must implement both `register()` and `get()`.
+- The selected Workflow Runs package now creates the standard registry and mounts its own routes.
+- The generic Node runtime no longer mounts Workflow Runs routes when the module is not selected.
+- `WorkflowRunnerRegistry` and `mountWorkflowRunsAdminRoutes` remain available for direct composition.
+- There are no schema or HTTP path changes in this release.
+
+## Runtime Port Contract
+
+This migration only affects applications or packages that supply a custom
+`WorkflowRunnerRegistryRuntime` implementation. The `get()` reader is required
+so the package-owned trigger, rerun, and resume routes can resolve registered
+workflows through the selected runtime port.
+
+Before:
+
+```ts
+import type {
+  WorkflowRunner,
+  WorkflowRunnerRegistryRuntime,
+} from "@voyant-travel/workflow-runs"
+
+const runners = new Map<string, WorkflowRunner>()
+
+export const workflowRunnerRegistry: WorkflowRunnerRegistryRuntime = {
+  register(runner) {
+    runners.set(runner.name, runner)
+  },
+}
+```
+
+After:
+
+```ts
+import type {
+  WorkflowRunner,
+  WorkflowRunnerRegistryRuntime,
+} from "@voyant-travel/workflow-runs"
+
+const runners = new Map<string, WorkflowRunner>()
+
+export const workflowRunnerRegistry: WorkflowRunnerRegistryRuntime = {
+  register(runner) {
+    runners.set(runner.name, runner)
+  },
+  get(name) {
+    return runners.get(name) ?? null
+  },
+}
+```
+
+## Direct Composition
+
+Direct applications do not need to adopt the selected deployment graph in this
+release. The existing registry and route APIs remain supported:
+
+```ts
+import {
+  mountWorkflowRunsAdminRoutes,
+  WorkflowRunnerRegistry,
+} from "@voyant-travel/workflow-runs"
+
+const runners = new WorkflowRunnerRegistry()
+mountWorkflowRunsAdminRoutes(app, { runners })
+```
+
+Selected-graph applications should not mount these routes in their generic Node
+host. Selecting `@voyant-travel/workflow-runs` now supplies the registry and
+route composition through the package manifest.
+
+## Full Changelogs
+
+- [`@voyant-travel/workflow-runs`](../../packages/workflow-runs/CHANGELOG.md)
+- [`@voyant-travel/runtime`](../../packages/runtime/CHANGELOG.md)

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,7 +19,6 @@ import {
 import { consoleReporter } from "@voyant-travel/hono/observability/reporter"
 import { createNodeServer, type NodeServerHandle } from "@voyant-travel/runtime-core"
 import { enqueuePostgresWebhookEvent } from "@voyant-travel/webhook-delivery/postgres"
-import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyant-travel/workflow-runs"
 import { tsImport } from "tsx/esm/api"
 
 import { requireVoyantAuthEnv } from "./auth-env.js"
@@ -90,7 +89,6 @@ export async function loadVoyantProject(
   const generated = await loadGeneratedProjectRuntime(artifactRoot)
   const graph = await readGeneratedDeploymentGraph(artifactRoot, generated)
   const env = createVoyantNodeEnv(options.env ?? process.env)
-  const workflowRunnerRegistry = new WorkflowRunnerRegistry()
   const primitives = createVoyantNodeRuntimeHostPrimitives({
     env,
     ...options.host,
@@ -144,15 +142,6 @@ export async function loadVoyantProject(
           authRuntime.hasAuthPermission(request, requireVoyantAuthEnv(requestEnv)),
         validateApiKey: ({ env: requestEnv, db, apiKey }) =>
           authRuntime.validateApiTokenAccess(requireVoyantAuthEnv(requestEnv), db, apiKey),
-      },
-      additionalRoutes: (app) => {
-        mountWorkflowRunsAdminRoutes(app, {
-          runners: workflowRunnerRegistry,
-          resolveUserId: (context) => {
-            const userId = (context as { get(key: string): unknown }).get("userId")
-            return typeof userId === "string" ? userId : null
-          },
-        })
       },
     },
   })

--- a/packages/runtime/src/runtime-composition.test.ts
+++ b/packages/runtime/src/runtime-composition.test.ts
@@ -106,11 +106,6 @@ vi.mock("@voyant-travel/webhook-delivery/postgres", () => ({
   enqueuePostgresWebhookEvent: mocks.enqueuePostgresWebhookEvent,
 }))
 
-vi.mock("@voyant-travel/workflow-runs", () => ({
-  mountWorkflowRunsAdminRoutes: vi.fn(),
-  WorkflowRunnerRegistry: class {},
-}))
-
 vi.mock("@voyant-travel/workflow-runs/scheduled-workflow", () => ({
   isGraphWorkflowScheduledJob: () => true,
   runScheduledWorkflow: mocks.runScheduledWorkflow,
@@ -276,6 +271,20 @@ describe("Voyant project runtime composition", () => {
     await expect(options?.outboundWebhooks.enqueue(event, bindings)).resolves.toEqual(["queued"])
     expect(mocks.resolveNodeDatabase).toHaveBeenCalledWith(bindings)
     expect(mocks.enqueuePostgresWebhookEvent).toHaveBeenCalledWith({ kind: "database" }, event)
+  })
+
+  it("leaves Workflow Runs route composition to the selected graph", async () => {
+    const projectRoot = await createGeneratedProject()
+    await loadVoyantProject({
+      projectRoot,
+      adminAssetsDir: path.join(projectRoot, "admin"),
+      env: { DATABASE_URL: "postgres://example.invalid/voyant" },
+    })
+
+    const options = mocks.loadVoyantNodeRuntime.mock.calls[0]?.[0] as {
+      app?: { additionalRoutes?: unknown }
+    }
+    expect(options.app?.additionalRoutes).toBeUndefined()
   })
 
   it("passes graph runtime ports into scheduled package workflow composition", async () => {

--- a/packages/workflow-runs/README.md
+++ b/packages/workflow-runs/README.md
@@ -27,9 +27,20 @@ export function WorkflowsRoute() {
 }
 ```
 
-## Mount the admin routes
+## Selected graph composition
+
+When `@voyant-travel/workflow-runs` is selected in a Voyant project, its package
+contributor creates the runner registry and its graph runtime mounts the admin
+routes. Other selected packages register executable workflows through the
+`workflows.runner-registry` runtime port; the generic Node host does not need
+Workflow Runs-specific wiring.
+
+## Direct composition
 
 `mountWorkflowRunsAdminRoutes` adds the workflow-run list, detail, rerun, and resume endpoints under `/v1/admin/workflow-runs`, plus an explicit trigger endpoint at `POST /v1/admin/workflows/:name/runs`.
+
+Applications that do not use the selected deployment graph can still compose
+the registry and routes directly:
 
 ```ts
 import { mountWorkflowRunsAdminRoutes, WorkflowRunnerRegistry } from "@voyant-travel/workflow-runs"

--- a/packages/workflow-runs/src/hono-module.ts
+++ b/packages/workflow-runs/src/hono-module.ts
@@ -1,8 +1,10 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { openApiValidationHook } from "@voyant-travel/hono"
 import type { HonoModule } from "@voyant-travel/hono/module"
 
 import type { MountWorkflowRunsAdminRoutesOptions } from "./routes.js"
+import { workflowRunnerRegistryRuntimePort } from "./runtime-port.js"
 
 export const WORKFLOW_RUNS_ADMIN_ROUTE_PATHS = [
   "/v1/admin/workflow-runs",
@@ -27,3 +29,14 @@ export function createWorkflowRunsHonoModule(
     },
   }
 }
+
+/** Package-owned adapter from the selected runner-registry port to admin routes. */
+export const createWorkflowRunsVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) =>
+  createWorkflowRunsHonoModule({
+    runners: await getPort(workflowRunnerRegistryRuntimePort),
+    resolveUserId: (context) => {
+      const userId = (context as { get(key: string): unknown }).get("userId")
+      return typeof userId === "string" ? userId : null
+    },
+  }),
+)

--- a/packages/workflow-runs/src/index.ts
+++ b/packages/workflow-runs/src/index.ts
@@ -20,6 +20,7 @@
 
 export {
   createWorkflowRunsHonoModule,
+  createWorkflowRunsVoyantRuntime,
   WORKFLOW_RUNS_ADMIN_ROUTE_PATHS,
 } from "./hono-module.js"
 export {

--- a/packages/workflow-runs/src/routes.ts
+++ b/packages/workflow-runs/src/routes.ts
@@ -38,7 +38,7 @@ import { handleApiError, openApiValidationHook, parseJsonBody } from "@voyant-tr
 import { listResponseSchema } from "@voyant-travel/types"
 import type { Context, Hono } from "hono"
 
-import type { WorkflowRunnerRegistry } from "./runner.js"
+import type { WorkflowRunnerRegistryRuntime } from "./runtime-port.js"
 import { workflowRunsService } from "./service.js"
 
 /**
@@ -122,7 +122,7 @@ export interface MountWorkflowRunsAdminRoutesOptions {
    * for the rerun/resume endpoints; bundles register their runners
    * on bootstrap.
    */
-  runners?: WorkflowRunnerRegistry
+  runners?: WorkflowRunnerRegistryRuntime
   /**
    * Resolves the acting user id from the request context — used to
    * stamp `triggered_by_user_id` on rerun runs. When omitted, runs

--- a/packages/workflow-runs/src/runner.ts
+++ b/packages/workflow-runs/src/runner.ts
@@ -104,8 +104,8 @@ export interface WorkflowRunner {
 let activeWorkflowRunnerRegistry: WorkflowRunnerRegistry | undefined
 
 /**
- * Package-owned registration service used by graph-selected workflow runtimes.
- * The app-level registry remains the read authority for admin dispatch.
+ * Compatibility registration service for direct/manual composition. The
+ * graph-selected runtime reads the concrete registry through its runtime port.
  */
 export const workflowRunnerRegistryService = {
   register(runner: WorkflowRunner): void {
@@ -117,9 +117,8 @@ export const workflowRunnerRegistryService = {
 }
 
 /**
- * Process-wide registry. Templates instantiate one and pass it to
- * `mountWorkflowRunsAdminRoutes(hono, { runners })`. Bundles register
- * their runners on bootstrap.
+ * Process-wide registry. Graph composition creates one through the package
+ * contributor; direct applications may still instantiate and mount one.
  */
 export class WorkflowRunnerRegistry {
   private readonly runners = new Map<string, WorkflowRunner>()

--- a/packages/workflow-runs/src/runtime-contributor.ts
+++ b/packages/workflow-runs/src/runtime-contributor.ts
@@ -1,9 +1,9 @@
-import { workflowRunnerRegistryService } from "./runner.js"
+import { WorkflowRunnerRegistry } from "./runner.js"
 import { workflowRunnerRegistryRuntimePort } from "./runtime-port.js"
 
-/** Package-owned registration for the process-local workflow runner registry service. */
+/** Package-owned provider for the process-local workflow runner registry. */
 export function createWorkflowRunsRuntimePortContribution(
   _host: unknown,
 ): Readonly<Record<string, unknown>> {
-  return { [workflowRunnerRegistryRuntimePort.id]: workflowRunnerRegistryService }
+  return { [workflowRunnerRegistryRuntimePort.id]: new WorkflowRunnerRegistry() }
 }

--- a/packages/workflow-runs/src/runtime-port.ts
+++ b/packages/workflow-runs/src/runtime-port.ts
@@ -1,21 +1,4 @@
-import { definePort } from "@voyant-travel/core/project"
-
-import type { WorkflowRunner } from "./runner.js"
-
-export interface WorkflowRunnerRegistryRuntime {
-  register(runner: WorkflowRunner): void
-}
-
-/** Process-owned registry used by package runtimes to expose rerun/resume handlers. */
-export const workflowRunnerRegistryRuntimePort = definePort<WorkflowRunnerRegistryRuntime>({
-  id: "workflows.runner-registry",
-  test(provider) {
-    if (
-      provider === null ||
-      typeof provider !== "object" ||
-      typeof provider.register !== "function"
-    ) {
-      throw new Error("workflows.runner-registry provider must implement register().")
-    }
-  },
-})
+export {
+  type WorkflowRunnerRegistryRuntime,
+  workflowRunnerRegistryRuntimePort,
+} from "./voyant.js"

--- a/packages/workflow-runs/src/voyant.ts
+++ b/packages/workflow-runs/src/voyant.ts
@@ -1,10 +1,33 @@
-import { defineModule } from "@voyant-travel/core/project"
+import { defineModule, definePort, requirePort } from "@voyant-travel/core/project"
+
+import type { WorkflowRunner } from "./runner.js"
+
+export interface WorkflowRunnerRegistryRuntime {
+  register(runner: WorkflowRunner): void
+  get(name: string): WorkflowRunner | null
+}
+
+/** Process-owned registry used by package runtimes to expose rerun/resume handlers. */
+export const workflowRunnerRegistryRuntimePort = definePort<WorkflowRunnerRegistryRuntime>({
+  id: "workflows.runner-registry",
+  test(provider) {
+    if (
+      provider === null ||
+      typeof provider !== "object" ||
+      typeof provider.register !== "function" ||
+      typeof provider.get !== "function"
+    ) {
+      throw new Error("workflows.runner-registry provider must implement register() and get().")
+    }
+  },
+})
 
 /** Import-cheap deployment declaration owned by the workflow-runs package. */
 export const workflowRunsVoyantModule = defineModule({
   id: "@voyant-travel/workflow-runs",
   packageName: "@voyant-travel/workflow-runs",
   localId: "workflow-runs",
+  runtimePorts: [requirePort(workflowRunnerRegistryRuntimePort)],
   api: [
     {
       id: "@voyant-travel/workflow-runs#api.admin",
@@ -13,7 +36,7 @@ export const workflowRunsVoyantModule = defineModule({
       openapi: { document: "workflow-runs" },
       runtime: {
         entry: "@voyant-travel/workflow-runs/hono-module",
-        export: "createWorkflowRunsHonoModule",
+        export: "createWorkflowRunsVoyantRuntime",
       },
     },
   ],

--- a/packages/workflow-runs/tests/unit/graph-runtime.test.ts
+++ b/packages/workflow-runs/tests/unit/graph-runtime.test.ts
@@ -1,0 +1,44 @@
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+
+import { createWorkflowRunsVoyantRuntime } from "../../src/hono-module.js"
+import { WorkflowRunnerRegistry } from "../../src/runner.js"
+import { workflowRunnerRegistryRuntimePort } from "../../src/runtime-port.js"
+
+describe("Workflow Runs selected graph runtime", () => {
+  it("dispatches through the graph-provided registry and preserves the request actor", async () => {
+    const registry = new WorkflowRunnerRegistry()
+    const trigger = vi.fn(async () => ({ runId: "run_selected" }))
+    registry.register({
+      name: "selected-workflow",
+      idempotency: "safe",
+      trigger,
+      rerun: async () => ({ runId: "run_rerun" }),
+      resume: async () => ({ runId: "run_resume" }),
+    })
+    const getPort = vi.fn(async () => registry)
+    const runtime = await createWorkflowRunsVoyantRuntime({ getPort } as never)
+    const routes = await runtime.lazyRoutes?.load()
+    if (!routes) throw new Error("Workflow Runs graph runtime did not expose lazy routes")
+
+    const app = new Hono()
+    app.use("*", async (context, next) => {
+      context.set("userId" as never, "user_selected")
+      await next()
+    })
+    app.route("/", routes)
+
+    const response = await app.request("/v1/admin/workflows/selected-workflow/runs", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: { bookingId: "booking_1" } }),
+    })
+
+    expect(response.status).toBe(202)
+    expect(getPort).toHaveBeenCalledWith(workflowRunnerRegistryRuntimePort)
+    expect(trigger).toHaveBeenCalledWith(
+      { bookingId: "booking_1" },
+      expect.objectContaining({ triggeredByUserId: "user_selected" }),
+    )
+  })
+})

--- a/packages/workflow-runs/tests/unit/runtime-contributor.test.ts
+++ b/packages/workflow-runs/tests/unit/runtime-contributor.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+
+import { WorkflowRunnerRegistry, workflowRunnerRegistryService } from "../../src/runner.js"
+import { createWorkflowRunsRuntimePortContribution } from "../../src/runtime-contributor.js"
+import {
+  type WorkflowRunnerRegistryRuntime,
+  workflowRunnerRegistryRuntimePort,
+} from "../../src/runtime-port.js"
+
+describe("Workflow Runs runtime contributor", () => {
+  it("owns the concrete selected-graph runner registry", () => {
+    const contribution = createWorkflowRunsRuntimePortContribution(undefined)
+    const registry = contribution[
+      workflowRunnerRegistryRuntimePort.id
+    ] as WorkflowRunnerRegistryRuntime
+    const runner = createRunner("selected")
+
+    expect(registry).toBeInstanceOf(WorkflowRunnerRegistry)
+    registry.register(runner)
+    expect(registry.get("selected")).toBe(runner)
+    expect(() => workflowRunnerRegistryRuntimePort.test?.(registry)).not.toThrow()
+  })
+
+  it("keeps direct registration bridged to the active package registry", () => {
+    const contribution = createWorkflowRunsRuntimePortContribution(undefined)
+    const registry = contribution[
+      workflowRunnerRegistryRuntimePort.id
+    ] as WorkflowRunnerRegistryRuntime
+    const runner = createRunner("manual-bridge")
+
+    workflowRunnerRegistryService.register(runner)
+
+    expect(registry.get("manual-bridge")).toBe(runner)
+  })
+})
+
+function createRunner(name: string) {
+  return {
+    name,
+    idempotency: "safe" as const,
+    rerun: async () => ({ runId: `${name}-rerun` }),
+    resume: async () => ({ runId: `${name}-resume` }),
+  }
+}

--- a/packages/workflow-runs/tests/unit/voyant-manifest.test.ts
+++ b/packages/workflow-runs/tests/unit/voyant-manifest.test.ts
@@ -4,6 +4,7 @@ import {
   createWorkflowRunsHonoModule,
   WORKFLOW_RUNS_ADMIN_ROUTE_PATHS,
 } from "../../src/hono-module.js"
+import { workflowRunnerRegistryRuntimePort } from "../../src/runtime-port.js"
 import { workflowRunsVoyantModule } from "../../src/voyant.js"
 
 describe("workflow-runs deployment manifest", () => {
@@ -12,6 +13,7 @@ describe("workflow-runs deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/workflow-runs",
       packageName: "@voyant-travel/workflow-runs",
+      runtimePorts: [{ id: workflowRunnerRegistryRuntimePort.id }],
       api: [
         {
           id: "@voyant-travel/workflow-runs#api.admin",
@@ -20,7 +22,7 @@ describe("workflow-runs deployment manifest", () => {
           openapi: { document: "workflow-runs" },
           runtime: {
             entry: "@voyant-travel/workflow-runs/hono-module",
-            export: "createWorkflowRunsHonoModule",
+            export: "createWorkflowRunsVoyantRuntime",
           },
         },
       ],

--- a/scripts/check-action-distribution-workflow-runtime-authority.mjs
+++ b/scripts/check-action-distribution-workflow-runtime-authority.mjs
@@ -21,7 +21,10 @@ const sources = {
   distributionPackage: read("packages/distribution/package.json"),
   distributionContributor: read("packages/distribution/src/runtime-contributor.ts"),
   distributionRuntime: read("packages/distribution/src/runtime.ts"),
+  runtime: read("packages/runtime/src/index.ts"),
   workflowContributor: read("packages/workflow-runs/src/runtime-contributor.ts"),
+  workflowHonoModule: read("packages/workflow-runs/src/hono-module.ts"),
+  workflowManifest: read("packages/workflow-runs/src/voyant.ts"),
   workflowRunner: read("packages/workflow-runs/src/runner.ts"),
 }
 
@@ -77,10 +80,20 @@ if (existsSync(path.join(root, "packages/distribution-node"))) {
   violations.push("packages/distribution-node must stay deleted")
 }
 if (
-  !sources.workflowContributor.includes("workflowRunnerRegistryService") ||
+  !sources.workflowContributor.includes("new WorkflowRunnerRegistry()") ||
+  !sources.workflowHonoModule.includes("defineGraphRuntimeFactory") ||
+  !sources.workflowHonoModule.includes("getPort(workflowRunnerRegistryRuntimePort)") ||
+  !sources.workflowManifest.includes("requirePort(workflowRunnerRegistryRuntimePort)") ||
   !sources.workflowRunner.includes("activeWorkflowRunnerRegistry = this")
 ) {
-  violations.push("Workflow Runs must bind its package registry service to the app registry")
+  violations.push(
+    "Workflow Runs must create and resolve its registry through selected-graph package authority",
+  )
+}
+for (const forbidden of ["mountWorkflowRunsAdminRoutes", "WorkflowRunnerRegistry"]) {
+  if (sources.runtime.includes(forbidden)) {
+    violations.push(`generic runtime must not retain Workflow Runs route authority: ${forbidden}`)
+  }
 }
 for (const compatibilityPath of [
   "starters/operator/src/api/runtime/action-ledger-health-runtime.ts",
@@ -98,5 +111,5 @@ if (violations.length > 0) {
 }
 
 console.log(
-  "check-action-distribution-workflow-runtime-authority: OK (Action Ledger static ports, Distribution domain runtime, and package registry authority)",
+  "check-action-distribution-workflow-runtime-authority: OK (Action Ledger static ports, Distribution domain runtime, and selected-graph Workflow Runs authority)",
 )

--- a/scripts/check-runtime-binding-final.mjs
+++ b/scripts/check-runtime-binding-final.mjs
@@ -20,7 +20,7 @@ const contributorRequirements = {
   legal: "createLegalRuntime",
   notifications: "createNotificationsRuntime",
   quotes: "createQuotesRuntime",
-  "workflow-runs": "workflowRunnerRegistryService",
+  "workflow-runs": "new WorkflowRunnerRegistry()",
 }
 
 const [deploymentResources, ...contributors] = await Promise.all([

--- a/scripts/route-ownership-baseline.json
+++ b/scripts/route-ownership-baseline.json
@@ -1,8 +1,5 @@
 {
   "_comment": "Baseline for scripts/check-route-ownership.mjs. Generated from the state of starters/*/src/api at the time docs/architecture/api-route-ownership-and-composition.md Phase 0 landed. Each entry records the number of direct `/v1/...` route definitions a starter file carried at baseline. The checker fails when a NEW route-bearing starter file appears without a `// voyant-route-owner:` annotation, or when an allowlisted file's `/v1/` route count grows above its baseline. As route families are extracted into packages (RFC Phases 3-4), lower these counts; never raise them. See docs/architecture/route-ownership-inventory.md for per-file ownership.",
-  "files": {
-    "starters/operator/src/api/app.ts": 1,
-    "starters/operator/src/api/routes/settings.ts": 10
-  },
-  "additionalRoutesAllowed": ["starters/operator/src/api/app.ts"]
+  "files": {},
+  "additionalRoutesAllowed": []
 }

--- a/scripts/tests/check-action-distribution-workflow-runtime-authority.test.mjs
+++ b/scripts/tests/check-action-distribution-workflow-runtime-authority.test.mjs
@@ -25,7 +25,10 @@ const fixturePaths = [
   "packages/distribution/package.json",
   "packages/distribution/src/runtime-contributor.ts",
   "packages/distribution/src/runtime.ts",
+  "packages/runtime/src/index.ts",
   "packages/workflow-runs/src/runtime-contributor.ts",
+  "packages/workflow-runs/src/hono-module.ts",
+  "packages/workflow-runs/src/voyant.ts",
   "packages/workflow-runs/src/runner.ts",
 ]
 
@@ -69,5 +72,15 @@ test("rejects a restored host capability", async () => {
   await assert.rejects(
     execFileAsync(process.execPath, [checker, "--root", root]),
     /workflowContributor retains resolveWorkflowRunnerRegistry/,
+  )
+})
+
+test("rejects restored generic runtime Workflow Runs route authority", async () => {
+  const root = await fixture()
+  const target = path.join(root, "packages/runtime/src/index.ts")
+  await writeFile(target, `${await readFile(target, "utf8")}\nmountWorkflowRunsAdminRoutes\n`)
+  await assert.rejects(
+    execFileAsync(process.execPath, [checker, "--root", root]),
+    /generic runtime must not retain Workflow Runs route authority/,
   )
 })

--- a/scripts/tests/check-runtime-binding-final.test.mjs
+++ b/scripts/tests/check-runtime-binding-final.test.mjs
@@ -21,7 +21,7 @@ const contributors = {
   legal: "createLegalRuntime",
   notifications: "createNotificationsRuntime",
   quotes: "createQuotesRuntime",
-  "workflow-runs": "workflowRunnerRegistryService",
+  "workflow-runs": "new WorkflowRunnerRegistry()",
 }
 
 async function fixture(generatedArguments) {

--- a/starters/federated-operator/src/api/app.ts
+++ b/starters/federated-operator/src/api/app.ts
@@ -1,3 +1,4 @@
+// voyant-route-owner: federated host compatibility until this direct app adopts generated graph composition.
 import { actionLedgerHonoModule } from "@voyant-travel/action-ledger"
 import { mountApp } from "@voyant-travel/hono/app"
 import { identityHonoModule } from "@voyant-travel/identity"

--- a/starters/federated-operator/src/api/routes/source-connections.ts
+++ b/starters/federated-operator/src/api/routes/source-connections.ts
@@ -1,3 +1,4 @@
+// voyant-route-owner: federated deployment probe pending a package-owned source-connections module.
 import { Hono } from "hono"
 
 type Env = {


### PR DESCRIPTION
## Summary
- create the concrete Workflow Runs registry in its package-owned runtime contributor
- resolve that registry through the selected graph port for package-owned admin routes
- remove unconditional Workflow Runs registry construction and route mounting from generic Runtime
- extend the runtime-port contract with the `get()` reader used by trigger/rerun/resume routes
- add authority ratchets, focused graph/dispatch coverage, minor changesets, and a 0.119 migration guide

Direct/federated applications may continue using `WorkflowRunnerRegistry` and `mountWorkflowRunsAdminRoutes`. The process-global compatibility bridge and Runtime dependency for scheduled workflow execution remain intentionally; this PR only removes generic route/registry authority.

## Verification
- Workflow Runs: 25 tests, typecheck, build
- Runtime: 33 tests, build
- six architecture checker tests
- Runtime authority, final bindings, Operator authority, and route ownership checks
- migration link and `git diff --check`

Runtime typecheck was stopped after 5m12 with no diagnostics at the local hardware limit; CI is the full cross-package typecheck.