### PR TITLE
Document project-owned inbound webhook modules

### DIFF
--- a/docs/architecture/custom-modules.md
+++ b/docs/architecture/custom-modules.md
@@ -129,6 +129,100 @@ one project-root source using the root package name, and emits a static relative
 import from `.voyant/runtime`. No nested `package.json`, package export, local
 `voyant.ts`, config selection, or deployment binding is required.
 
+## Inbound webhook modules
+
+Inbound webhook routes are graph-governed because they change anonymous route
+posture. A direct `src/modules/<name>/index.ts` convention is runtime-only and
+cannot declare `api` or `webhooks` facets. If it returns `webhookRoutes`,
+`voyant build` fails with `PROJECT_WEBHOOK_DECLARATION_REQUIRED` before runtime.
+
+Use a project-owned workspace package when the module needs inbound webhooks.
+The package must publish its runtime and import-cheap manifest separately:
+
+```jsonc
+// packages/qa-probe/package.json
+{
+  "name": "@acme/qa-probe",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./voyant": "./src/voyant.ts"
+  },
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "manifest": "./voyant",
+    "compatibleWith": {
+      "framework": "*",
+      "targets": ["node"],
+      "modes": ["local", "managed-cloud", "self-hosted"]
+    }
+  }
+}
+```
+
+The runtime owns the concrete Hono routes:
+
+```ts
+// packages/qa-probe/src/index.ts
+import { defineDeploymentModule } from "@voyant-travel/framework"
+import { Hono } from "hono"
+
+const webhookRoutes = new Hono()
+webhookRoutes.post("/demo", (c) => c.json({ ok: true }))
+
+export default defineDeploymentModule({
+  module: { name: "qa-probe" },
+  webhookRoutes,
+})
+```
+
+The manifest declares the executable webhook API and binds an inbound webhook
+to it. Both declarations are required:
+
+```ts
+// packages/qa-probe/src/voyant.ts
+import { defineModule } from "@voyant-travel/core/project"
+
+const runtime = { entry: "@acme/qa-probe", export: "default" } as const
+
+export const qaProbeVoyantModule = defineModule({
+  id: "@acme/qa-probe",
+  packageName: "@acme/qa-probe",
+  localId: "qa-probe",
+  runtime,
+  api: [
+    {
+      id: "@acme/qa-probe#api.webhook",
+      surface: "webhook",
+      mount: "qa-probe",
+      runtime,
+    },
+  ],
+  webhooks: [
+    {
+      id: "@acme/qa-probe#webhook.inbound",
+      direction: "inbound",
+      apiId: "@acme/qa-probe#api.webhook",
+    },
+  ],
+})
+```
+
+Select the local package as an application-owned difference:
+
+```ts
+// voyant.config.ts
+import { defineConfig } from "@voyant-travel/framework/project"
+
+export default defineConfig({
+  modules: [{ resolve: "./packages/qa-probe" }],
+})
+```
+
+The resulting callback is mounted beneath `/v1/qa-probe`. Package-owned schema
+and migrations, if any, follow the persistent-module rules below.
+
 ## Persistent modules
 
 Direct `src/modules` entries are runtime-only. A module that owns tables uses

--- a/starters/operator/src/modules/README.md
+++ b/starters/operator/src/modules/README.md
@@ -38,6 +38,40 @@ export default defineDeploymentModule({
 The resolver creates the graph unit from the project package name and directory
 name, then emits a project-relative static import under `.voyant/runtime`.
 
+## Inbound webhook routes
+
+Direct `src/modules` entries are runtime-only. They can expose admin and public
+routes, but they cannot declare graph-governed inbound webhooks. A module that
+returns `webhookRoutes` must use the project-owned workspace-package shape so
+its manifest can declare both the webhook API and the inbound webhook:
+
+```ts
+// packages/qa-probe/src/voyant.ts
+import { defineModule } from "@voyant-travel/core/project"
+
+export const qaProbeVoyantModule = defineModule({
+  id: "@acme/qa-probe",
+  packageName: "@acme/qa-probe",
+  runtime: { entry: "@acme/qa-probe", export: "default" },
+  api: [{
+    id: "@acme/qa-probe#api.webhook",
+    surface: "webhook",
+    mount: "qa-probe",
+    runtime: { entry: "@acme/qa-probe", export: "default" },
+  }],
+  webhooks: [{
+    id: "@acme/qa-probe#webhook.inbound",
+    direction: "inbound",
+    apiId: "@acme/qa-probe#api.webhook",
+  }],
+})
+```
+
+Select that local package with `modules: [{ resolve:
+"./packages/qa-probe" }]` in `voyant.config.ts`. See the [complete package
+metadata, runtime, and manifest
+pattern](../../../../docs/architecture/custom-modules.md#inbound-webhook-modules).
+
 ## Database migrations
 
 Generate an app-local module's migrations with Drizzle Kit directly; migration


### PR DESCRIPTION
## Summary

- document why direct `src/modules` conventions cannot declare graph-governed inbound webhooks
- show the complete project-owned workspace package metadata, runtime export, module manifest, and config selection
- add the concise declaration pattern to the operator starter module guide

## Dependency

Depends on voyant-travel/cli#80 for the build-time diagnostic. The documented manifest pattern is already supported by the current package graph resolver.

## Validation

- verified all referenced declaration identifiers and the relative architecture-doc link
- `git diff --check`

Related to #3313