### PR TITLE
Fix operator starter SSR startup

### DIFF
--- a/.changeset/calm-server-runtime.md
+++ b/.changeset/calm-server-runtime.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/runtime": patch
+"@voyant-travel/vite-config": patch
+---
+
+Start production operator projects through their Vite-built TanStack server
+entry so virtual router imports and the React SSR singleton resolve from the
+generated server graph.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -84,7 +84,9 @@ workload class well. On Node none of it is necessary.
   origin-trust header. During rollout the emitted URL also carries `cron` as a
   compatibility fallback for older runtimes.
 - **CI:** the `node-smoke` job builds the operator, boots it under Node, and
-  asserts `/healthz` + API dispatch — so the first-class target is gated.
+  asserts `/healthz`, API dispatch, and a TanStack SSR page. `/healthz` is only
+  a liveness signal; packaged-starter acceptance gates the complete server
+  graph.
 
 ## Workers host separate edge applications
 

--- a/packages/framework/src/standard-node-starter.json
+++ b/packages/framework/src/standard-node-starter.json
@@ -27,7 +27,8 @@
   "runtimeDependencies": [
     "@voyant-travel/framework",
     "@voyant-travel/runtime",
-    "@voyant-travel/operator-standard"
+    "@voyant-travel/operator-standard",
+    "pg"
   ],
   "developmentDependencies": ["@voyant-travel/cli", "tsx", "typescript"],
   "gitignoreEntries": [".voyant/", "dist/", "node_modules/", ".env", ".env.*", "!.env.example"]

--- a/packages/framework/src/standard-node-starter.test.ts
+++ b/packages/framework/src/standard-node-starter.test.ts
@@ -55,6 +55,7 @@ describe("standard Node starter contract", () => {
           "@voyant-travel/framework",
           "@voyant-travel/runtime",
           "@voyant-travel/operator-standard",
+          "pg",
         ],
         "schemaVersion": "voyant.node-starter.v2",
         "seedEntry": "src/scripts/seed.ts",

--- a/packages/framework/src/standard-node-starter.ts
+++ b/packages/framework/src/standard-node-starter.ts
@@ -30,6 +30,7 @@ type StandardNodeStarterContract = {
     "@voyant-travel/framework",
     "@voyant-travel/runtime",
     "@voyant-travel/operator-standard",
+    "pg",
   ]
   readonly developmentDependencies: readonly ["@voyant-travel/cli", "tsx", "typescript"]
   readonly gitignoreEntries: readonly [

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -43,6 +43,12 @@ SSR build, and copies `.voyant` to both `dist/.voyant` and
 `dist/server/.voyant`. `developVoyantProject()` starts Vite's SSR development
 server and defaults to port `3300`.
 
+The build always uses the project's `src/server.ts` or generates an equivalent
+`.voyant/app/server.ts`. That entry exports both TanStack's request handler and
+the bundled Node `start` function. Production `voyant start` loads this built
+entry so TanStack virtual modules and the React SSR singleton remain inside the
+Vite-generated server graph; it must not reconstruct SSR from package source.
+
 Projects may add an optional root `vite.config.ts`. Vite loads and merges it for
 both development and production builds, so project-specific plugins and normal
 Vite options require no lifecycle-script changes. Voyant's inline configuration

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,10 +35,7 @@ import { tsImport } from "tsx/esm/api"
 import { requireVoyantAuthEnv } from "./auth-env.js"
 import { resolveVoyantCloudAuthEmailSender } from "./cloud-auth-email.js"
 import { createVoyantDeploymentResources } from "./deployment-resources.js"
-import {
-  loadBuiltProjectStart,
-  startVoyantProjectWithDependencies,
-} from "./project-start.js"
+import { loadBuiltProjectStart, startVoyantProjectWithDependencies } from "./project-start.js"
 
 export {
   type CreateVoyantDeploymentResourcesOptions,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,6 +35,10 @@ import { tsImport } from "tsx/esm/api"
 import { requireVoyantAuthEnv } from "./auth-env.js"
 import { resolveVoyantCloudAuthEmailSender } from "./cloud-auth-email.js"
 import { createVoyantDeploymentResources } from "./deployment-resources.js"
+import {
+  loadBuiltProjectStart,
+  startVoyantProjectWithDependencies,
+} from "./project-start.js"
 
 export {
   type CreateVoyantDeploymentResourcesOptions,
@@ -286,8 +290,10 @@ export function createVoyantProjectServerEntry(options: LoadVoyantProjectOptions
 export async function startVoyantProject(
   options: LoadVoyantProjectOptions & { port?: number } = {},
 ): Promise<NodeServerHandle> {
-  const host = await loadVoyantProject(options)
-  return host.start({ port: options.port })
+  return startVoyantProjectWithDependencies(options, {
+    loadBuiltStart: loadBuiltProjectStart,
+    loadProject: loadVoyantProject,
+  })
 }
 
 async function resolveGeneratedArtifactRoot(projectRoot: string): Promise<string> {

--- a/packages/runtime/src/project-start.test.ts
+++ b/packages/runtime/src/project-start.test.ts
@@ -1,0 +1,68 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import type { NodeServerHandle } from "@voyant-travel/runtime-core"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  loadBuiltProjectStart,
+  startVoyantProjectWithDependencies,
+} from "./project-start.js"
+
+const temporaryDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      rm(directory, { recursive: true, force: true }),
+    ),
+  )
+})
+
+describe("production project start", () => {
+  it("uses the bundled start export when the production build provides it", async () => {
+    const handle = {} as NodeServerHandle
+    const builtStart = vi.fn(async () => handle)
+    const loadProject = vi.fn()
+
+    await expect(
+      startVoyantProjectWithDependencies(
+        { port: 4400, preferBuiltAdminAssets: true, projectRoot: "/workspace/operator" },
+        { loadBuiltStart: vi.fn(async () => builtStart), loadProject },
+      ),
+    ).resolves.toBe(handle)
+
+    expect(builtStart).toHaveBeenCalledWith({
+      port: 4400,
+      projectRoot: "/workspace/operator",
+    })
+    expect(loadProject).not.toHaveBeenCalled()
+  })
+
+  it("falls back to source startup when a legacy bundle has no start export", async () => {
+    const projectRoot = await createTemporaryDirectory()
+    const entry = path.join(projectRoot, "dist/server/server.js")
+    await mkdir(path.dirname(entry), { recursive: true })
+    await writeFile(entry, "export default { fetch() {} }\n")
+    const start = vi.fn(() => ({}) as NodeServerHandle)
+    const loadProject = vi.fn(async () => ({ start }))
+
+    await expect(loadBuiltProjectStart(projectRoot)).resolves.toBeUndefined()
+    await startVoyantProjectWithDependencies(
+      { port: 4400, preferBuiltAdminAssets: true, projectRoot },
+      { loadBuiltStart: loadBuiltProjectStart, loadProject },
+    )
+
+    expect(loadProject).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 4400, preferBuiltAdminAssets: true, projectRoot }),
+    )
+    expect(start).toHaveBeenCalledWith({ port: 4400 })
+  })
+})
+
+async function createTemporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), "voyant-project-start-"))
+  temporaryDirectories.push(directory)
+  return directory
+}

--- a/packages/runtime/src/project-start.test.ts
+++ b/packages/runtime/src/project-start.test.ts
@@ -5,18 +5,15 @@ import path from "node:path"
 import type { NodeServerHandle } from "@voyant-travel/runtime-core"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import {
-  loadBuiltProjectStart,
-  startVoyantProjectWithDependencies,
-} from "./project-start.js"
+import { loadBuiltProjectStart, startVoyantProjectWithDependencies } from "./project-start.js"
 
 const temporaryDirectories: string[] = []
 
 afterEach(async () => {
   await Promise.all(
-    temporaryDirectories.splice(0).map((directory) =>
-      rm(directory, { recursive: true, force: true }),
-    ),
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true })),
   )
 })
 

--- a/packages/runtime/src/project-start.test.ts
+++ b/packages/runtime/src/project-start.test.ts
@@ -22,16 +22,29 @@ describe("production project start", () => {
     const handle = {} as NodeServerHandle
     const builtStart = vi.fn(async () => handle)
     const loadProject = vi.fn()
+    const env = { NODE_ENV: "production" }
+    const host = { config: { custom: true } }
 
     await expect(
       startVoyantProjectWithDependencies(
-        { port: 4400, preferBuiltAdminAssets: true, projectRoot: "/workspace/operator" },
+        {
+          adminAssetsDir: "/workspace/operator/dist/client",
+          env,
+          host,
+          port: 4400,
+          preferBuiltAdminAssets: true,
+          projectRoot: "/workspace/operator",
+        },
         { loadBuiltStart: vi.fn(async () => builtStart), loadProject },
       ),
     ).resolves.toBe(handle)
 
     expect(builtStart).toHaveBeenCalledWith({
+      adminAssetsDir: "/workspace/operator/dist/client",
+      env,
+      host,
       port: 4400,
+      preferBuiltAdminAssets: true,
       projectRoot: "/workspace/operator",
     })
     expect(loadProject).not.toHaveBeenCalled()

--- a/packages/runtime/src/project-start.ts
+++ b/packages/runtime/src/project-start.ts
@@ -16,13 +16,12 @@ interface ProjectHost {
   start(options?: { port?: number }): NodeServerHandle
 }
 
-export type BuiltProjectStart = (options: {
-  port?: number
-  projectRoot: string
-}) => Promise<NodeServerHandle>
+export type BuiltProjectStart<TOptions extends ProjectStartOptions = ProjectStartOptions> = (
+  options: TOptions & { projectRoot: string },
+) => Promise<NodeServerHandle>
 
 export interface ProjectStartDependencies<TOptions extends ProjectStartOptions> {
-  loadBuiltStart(projectRoot: string): Promise<BuiltProjectStart | undefined>
+  loadBuiltStart(projectRoot: string): Promise<BuiltProjectStart<TOptions> | undefined>
   loadProject(options: TOptions & { projectRoot: string }): Promise<ProjectHost>
 }
 
@@ -33,16 +32,16 @@ export async function startVoyantProjectWithDependencies<TOptions extends Projec
   const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
   if (options.preferBuiltAdminAssets) {
     const builtStart = await dependencies.loadBuiltStart(projectRoot)
-    if (builtStart) return builtStart({ port: options.port, projectRoot })
+    if (builtStart) return builtStart({ ...options, projectRoot })
   }
 
   const host = await dependencies.loadProject({ ...options, projectRoot })
   return host.start({ port: options.port })
 }
 
-export async function loadBuiltProjectStart(
+export async function loadBuiltProjectStart<TOptions extends ProjectStartOptions>(
   projectRoot: string,
-): Promise<BuiltProjectStart | undefined> {
+): Promise<BuiltProjectStart<TOptions> | undefined> {
   const entry = path.join(projectRoot, BUILT_SERVER_ENTRY)
   try {
     await access(entry)
@@ -51,7 +50,7 @@ export async function loadBuiltProjectStart(
   }
 
   const namespace = (await import(pathToFileURL(entry).href)) as {
-    default?: { start?: BuiltProjectStart }
+    default?: { start?: BuiltProjectStart<TOptions> }
   }
   return typeof namespace.default?.start === "function"
     ? namespace.default.start.bind(namespace.default)

--- a/packages/runtime/src/project-start.ts
+++ b/packages/runtime/src/project-start.ts
@@ -1,0 +1,59 @@
+import { access } from "node:fs/promises"
+import path from "node:path"
+import { pathToFileURL } from "node:url"
+
+import type { NodeServerHandle } from "@voyant-travel/runtime-core"
+
+const BUILT_SERVER_ENTRY = "dist/server/server.js"
+
+interface ProjectStartOptions {
+  projectRoot?: string
+  port?: number
+  preferBuiltAdminAssets?: boolean
+}
+
+interface ProjectHost {
+  start(options?: { port?: number }): NodeServerHandle
+}
+
+export type BuiltProjectStart = (options: {
+  port?: number
+  projectRoot: string
+}) => Promise<NodeServerHandle>
+
+export interface ProjectStartDependencies<TOptions extends ProjectStartOptions> {
+  loadBuiltStart(projectRoot: string): Promise<BuiltProjectStart | undefined>
+  loadProject(options: TOptions & { projectRoot: string }): Promise<ProjectHost>
+}
+
+export async function startVoyantProjectWithDependencies<TOptions extends ProjectStartOptions>(
+  options: TOptions,
+  dependencies: ProjectStartDependencies<TOptions>,
+): Promise<NodeServerHandle> {
+  const projectRoot = path.resolve(options.projectRoot ?? process.cwd())
+  if (options.preferBuiltAdminAssets) {
+    const builtStart = await dependencies.loadBuiltStart(projectRoot)
+    if (builtStart) return builtStart({ port: options.port, projectRoot })
+  }
+
+  const host = await dependencies.loadProject({ ...options, projectRoot })
+  return host.start({ port: options.port })
+}
+
+export async function loadBuiltProjectStart(
+  projectRoot: string,
+): Promise<BuiltProjectStart | undefined> {
+  const entry = path.join(projectRoot, BUILT_SERVER_ENTRY)
+  try {
+    await access(entry)
+  } catch {
+    return undefined
+  }
+
+  const namespace = (await import(pathToFileURL(entry).href)) as {
+    default?: { start?: BuiltProjectStart }
+  }
+  return typeof namespace.default?.start === "function"
+    ? namespace.default.start.bind(namespace.default)
+    : undefined
+}

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -237,9 +237,7 @@ function escapeRegExp(value: string): string {
 }
 
 function relativeEntry(appRootUrl: string, entry: string): string {
-  return `../${path
-    .relative(path.dirname(fileURLToPath(appRootUrl)), entry)
-    .replaceAll("\\", "/")}`
+  return `../${path.relative(path.dirname(fileURLToPath(appRootUrl)), entry).replaceAll("\\", "/")}`
 }
 
 export async function prepareProjectBootstrap(projectRoot: string): Promise<ProjectBootstrap> {

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -264,14 +264,19 @@ export async function prepareProjectBootstrap(projectRoot: string): Promise<Proj
   if (!(await pathExists(authoredServerEntry))) {
     await writeGeneratedFile(
       bootstrap.serverEntry,
-      `import { createVoyantProjectServerEntry } from "@voyant-travel/runtime"
+      `import {
+  createVoyantProjectServerEntry,
+  type LoadVoyantProjectOptions,
+} from "@voyant-travel/runtime"
 
 const server = createVoyantProjectServerEntry()
 
 export default {
   fetch: server.fetch,
-  start: (options: { port?: number; projectRoot?: string } = {}) =>
-    createVoyantProjectServerEntry({ projectRoot: options.projectRoot }).start({ port: options.port }),
+  start: (options: LoadVoyantProjectOptions & { port?: number } = {}) => {
+    const { port, ...projectOptions } = options
+    return createVoyantProjectServerEntry(projectOptions).start({ port })
+  },
 }
 `,
     )

--- a/packages/runtime/src/tooling-internal.ts
+++ b/packages/runtime/src/tooling-internal.ts
@@ -48,6 +48,7 @@ interface ProjectViteConfigOptions {
 }
 
 interface ProjectBootstrap {
+  serverEntry: string
   routerEntry?: string
   stylesEntry?: string
   aliases?: Readonly<Record<string, string>>
@@ -185,10 +186,13 @@ export function createProjectViteConfig(options: ProjectViteConfigOptions): Inli
       devtools(),
       tailwindcss(),
       tanstackStart({
+        server: {
+          entry: relativeEntry(options.appRootUrl, options.bootstrap.serverEntry),
+        },
         router: {
           ...(options.bootstrap.routerEntry
             ? {
-                entry: `../${path.relative(path.dirname(fileURLToPath(options.appRootUrl)), options.bootstrap.routerEntry).replaceAll("\\", "/")}`,
+                entry: relativeEntry(options.appRootUrl, options.bootstrap.routerEntry),
               }
             : {}),
           routesDirectory: options.generatedRoutes.routesDirectory,
@@ -232,10 +236,21 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
+function relativeEntry(appRootUrl: string, entry: string): string {
+  return `../${path
+    .relative(path.dirname(fileURLToPath(appRootUrl)), entry)
+    .replaceAll("\\", "/")}`
+}
+
 export async function prepareProjectBootstrap(projectRoot: string): Promise<ProjectBootstrap> {
   const productBomId = await loadProductBomId(projectRoot)
   const generatedRoot = path.join(projectRoot, ".voyant/app")
-  const bootstrap: ProjectBootstrap = {}
+  const authoredServerEntry = path.join(projectRoot, "src/server.ts")
+  const bootstrap: ProjectBootstrap = {
+    serverEntry: (await pathExists(authoredServerEntry))
+      ? authoredServerEntry
+      : path.join(generatedRoot, "server.ts"),
+  }
   const aliases = resolveProductDependencies(projectRoot, productBomId, [
     "react/jsx-runtime",
     "react/jsx-dev-runtime",
@@ -247,6 +262,22 @@ export async function prepareProjectBootstrap(projectRoot: string): Promise<Proj
     "react",
   ])
   if (Object.keys(aliases).length > 0) bootstrap.aliases = aliases
+
+  if (!(await pathExists(authoredServerEntry))) {
+    await writeGeneratedFile(
+      bootstrap.serverEntry,
+      `import { createVoyantProjectServerEntry } from "@voyant-travel/runtime"
+
+const server = createVoyantProjectServerEntry()
+
+export default {
+  fetch: server.fetch,
+  start: (options: { port?: number; projectRoot?: string } = {}) =>
+    createVoyantProjectServerEntry({ projectRoot: options.projectRoot }).start({ port: options.port }),
+}
+`,
+    )
+  }
 
   if (!(await pathExists(path.join(projectRoot, "src/router.tsx")))) {
     bootstrap.routerEntry = path.join(generatedRoot, "router.tsx")

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -232,7 +232,7 @@ export function createStandardOperatorRouteFiles(options: { presentationIds: rea
       stylesEntry: path.join(projectRoot, ".voyant/app/styles.css"),
     })
     await expect(readText(bootstrap.serverEntry)).resolves.toContain(
-      "createVoyantProjectServerEntry({ projectRoot: options.projectRoot }).start",
+      "createVoyantProjectServerEntry(projectOptions).start",
     )
     await expect(readText(bootstrap.routerEntry!)).resolves.toContain(
       'from "@acme/operator/standard-frontend"',

--- a/packages/runtime/src/tooling.test.ts
+++ b/packages/runtime/src/tooling.test.ts
@@ -49,6 +49,7 @@ describe("Voyant project tooling", () => {
         generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
       },
       bootstrap: {
+        serverEntry: "/workspace/operator/src/server.ts",
         aliases: { "@tanstack/react-router": "/product/react-router/index.cjs" },
       },
     })
@@ -71,7 +72,7 @@ describe("Voyant project tooling", () => {
         routesDirectory: "/workspace/operator/.voyant/routes",
         generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
       },
-      bootstrap: {},
+      bootstrap: { serverEntry: "/workspace/operator/src/server.ts" },
     })
 
     expect(config.build?.outDir).toBe("dist")
@@ -103,7 +104,7 @@ describe("Voyant project tooling", () => {
         routesDirectory: "/workspace/operator/.voyant/routes",
         generatedRouteTree: "/workspace/operator/.voyant/routeTree.gen.ts",
       },
-      bootstrap: {},
+      bootstrap: { serverEntry: "/workspace/operator/src/server.ts" },
     })
     expect(dependencies.buildVite).toHaveBeenCalledWith({
       marker: "voyant-vite-config",
@@ -226,9 +227,13 @@ export function createStandardOperatorRouteFiles(options: { presentationIds: rea
     const bootstrap = await prepareProjectBootstrap(projectRoot)
 
     expect(bootstrap).toEqual({
+      serverEntry: path.join(projectRoot, ".voyant/app/server.ts"),
       routerEntry: path.join(projectRoot, ".voyant/app/router.tsx"),
       stylesEntry: path.join(projectRoot, ".voyant/app/styles.css"),
     })
+    await expect(readText(bootstrap.serverEntry)).resolves.toContain(
+      "createVoyantProjectServerEntry({ projectRoot: options.projectRoot }).start",
+    )
     await expect(readText(bootstrap.routerEntry!)).resolves.toContain(
       'from "@acme/operator/standard-frontend"',
     )
@@ -240,14 +245,17 @@ export function createStandardOperatorRouteFiles(options: { presentationIds: rea
     )
   })
 
-  it("preserves project-authored router and style overrides", async () => {
+  it("preserves project-authored server, router, and style overrides", async () => {
     const projectRoot = await createTemporaryDirectory()
     await writeProductBom(projectRoot, "@acme/operator")
     await mkdir(path.join(projectRoot, "src"), { recursive: true })
+    await writeFile(path.join(projectRoot, "src/server.ts"), "export default { fetch() {} }\n")
     await writeFile(path.join(projectRoot, "src/router.tsx"), "export const projectRouter = true\n")
     await writeFile(path.join(projectRoot, "src/styles.css"), "/* project */\n")
 
-    await expect(prepareProjectBootstrap(projectRoot)).resolves.toEqual({})
+    await expect(prepareProjectBootstrap(projectRoot)).resolves.toEqual({
+      serverEntry: path.join(projectRoot, "src/server.ts"),
+    })
   })
 
   it("fails when the generated product BOM artifact is missing", async () => {
@@ -296,7 +304,9 @@ function createDependencies(calls: string[]): VoyantProjectToolingDependencies {
     loadStandardRouteFiles: vi.fn(async () => [
       { path: "__root.tsx", source: "export const Route = {}" },
     ]),
-    prepareProjectBootstrap: vi.fn(async () => ({})),
+    prepareProjectBootstrap: vi.fn(async () => ({
+      serverEntry: "/workspace/operator/src/server.ts",
+    })),
     materializeRoutes: vi.fn(() => ({
       plugin: { name: "generated-routes" },
       routesDirectory: "/workspace/operator/.voyant/routes",

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -182,6 +182,8 @@ export interface VoyantStartViteConfigOptions {
    * - `ssr.resolve.conditions` with `development` ahead of `node` so those
    *   packages resolve from `./src` and the app build stands alone (no
    *   prebuilt `dist` / `turbo ^build` needed).
+   * - `ssr.external` for the CommonJS `pg` driver so Node loads its native
+   *   constructor exports instead of bundling them into namespace objects.
    *
    * This is the config a Cloud-built hosted admin image would otherwise copy;
    * packaging it keeps it a version bump, not a copy (voyant#3044).
@@ -223,6 +225,7 @@ export function voyantStartViteConfig(options: VoyantStartViteConfigOptions): Us
       ...(nodeSsr
         ? {
             target: "node" as const,
+            external: ["pg"],
             noExternal: [/^@voyant-travel\//, /^@pxmstudio\//],
             resolve: {
               conditions: ["development", "module", "node", "import", "default"],

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -128,6 +128,12 @@ describe("voyantStartViteConfig", () => {
     expect(VOYANT_SSR_OPTIMIZE_DEPS).not.toContain("immer")
   })
 
+  it("keeps the CommonJS Postgres driver external in Node SSR builds", () => {
+    const config = voyantStartViteConfig({ ...base, nodeSsr: true })
+
+    expect(config.ssr?.external).toContain("pg")
+  })
+
   it("allows dev tunnel hosts by default and supports an explicit host list", () => {
     expect(voyantStartViteConfig(base).server?.allowedHosts).toBe(true)
     expect(

--- a/scripts/package-starters.mjs
+++ b/scripts/package-starters.mjs
@@ -21,6 +21,7 @@ const starters = ["operator"]
 const standardNodeStarter = readJson(
   join(repoRoot, "packages", "framework", "src", "standard-node-starter.json"),
 )
+const operatorStarterPackage = readJson(join(repoRoot, "starters", "operator", "package.json"))
 const catalogVersions = readCatalogVersions()
 const workspaceVersions = readWorkspaceVersions()
 
@@ -49,8 +50,12 @@ function stageMinimalOperatorStarter(stagingTemplate, localLinks) {
     mkdirSync(join(stagingTemplate, directory), { recursive: true })
   }
 
-  const dependency = (name) =>
-    localLinks ? `link:${workspacePackageDirectory(name)}` : `^${requiredWorkspaceVersion(name)}`
+  const dependency = (name) => {
+    if (!name.startsWith("@voyant-travel/")) return requiredStarterRuntimeVersion(name)
+    return localLinks
+      ? `link:${workspacePackageDirectory(name)}`
+      : `^${requiredWorkspaceVersion(name)}`
+  }
   const localCliPackage = resolve(repoRoot, "..", "cli", "packages", "cli")
   const cliDependency =
     localLinks && existsSync(join(localCliPackage, "package.json"))
@@ -110,11 +115,16 @@ function requiredCatalogVersion(name) {
   return value
 }
 
+function requiredStarterRuntimeVersion(name) {
+  const value = operatorStarterPackage.dependencies?.[name]
+  if (typeof value !== "string" || /^(?:catalog|workspace|file|link):/.test(value)) {
+    throw new Error(`Missing concrete operator starter dependency version: ${name}`)
+  }
+  return value
+}
+
 function supportedCliRange() {
-  const packageJson = JSON.parse(
-    readFileSync(join(repoRoot, "starters", "operator", "package.json"), "utf8"),
-  )
-  const value = packageJson.devDependencies?.["@voyant-travel/cli"]
+  const value = operatorStarterPackage.devDependencies?.["@voyant-travel/cli"]
   if (typeof value !== "string" || /^(?:workspace|file|link):/.test(value)) {
     throw new Error("starters/operator must declare a released @voyant-travel/cli range")
   }

--- a/scripts/package-starters.mjs
+++ b/scripts/package-starters.mjs
@@ -120,7 +120,7 @@ function requiredStarterRuntimeVersion(name) {
   if (typeof value !== "string" || /^(?:catalog|workspace|file|link):/.test(value)) {
     throw new Error(`Missing concrete operator starter dependency version: ${name}`)
   }
-  return value
+  return value.replace(/^[~^]/, "")
 }
 
 function supportedCliRange() {

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict"
-import { execFileSync } from "node:child_process"
+import { execFileSync, spawn } from "node:child_process"
+import { once } from "node:events"
 import {
   existsSync,
   mkdirSync,
@@ -10,19 +11,21 @@ import {
   writeFileSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
+import { createServer as createNetServer } from "node:net"
 import { dirname, join, resolve } from "node:path"
 import { test } from "node:test"
 import { fileURLToPath } from "node:url"
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../..")
 
-test("minimal starter installs, builds, and boots the Node host", {
-  timeout: 180_000,
-}, () => {
+test("minimal starter installs, builds, and serves API and SSR routes", {
+  timeout: 300_000,
+}, async () => {
   const root = mkdtempSync(join(tmpdir(), "voyant-minimal-starter-acceptance-"))
   const out = join(root, "out")
   const app = join(root, "app")
-  const port = 44_000 + (process.pid % 1_000)
+  const port = await reservePort()
+  let server
   try {
     exec(
       process.execPath,
@@ -183,17 +186,37 @@ test("minimal starter installs, builds, and boots the Node host", {
       { NODE_OPTIONS: "--conditions=development" },
     )
 
-    exec(
-      "pnpm",
-      ["start", "--", "--probe", "--port", String(port)],
-      app,
+    server = spawn(
+      process.execPath,
+      [
+        join(app, "node_modules/@voyant-travel/cli/bin/voyant.mjs"),
+        "start",
+        "--port",
+        String(port),
+      ],
       {
-        DATABASE_URL: ["postgresql", "://postgres:postgres@127.0.0.1:5432/voyant"].join(""),
-        NODE_OPTIONS: "--conditions=development",
+        cwd: app,
+        env: {
+          ...process.env,
+          BETTER_AUTH_SECRET: "starter-acceptance-better-auth-secret",
+          DATABASE_URL: ["postgresql", "://postgres:postgres@127.0.0.1:5432/voyant"].join(""),
+          NODE_OPTIONS: "--conditions=development",
+          SESSION_CLAIMS_SECRET: "starter-acceptance-session-claims-secret",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
       },
-      30_000,
     )
+    const output = captureOutput(server)
+    await waitForOk(`http://127.0.0.1:${port}/healthz`, server, output)
+
+    const apiResponse = await fetch(`http://127.0.0.1:${port}/api/v1/public/starter-proof`)
+    assert.equal(apiResponse.status, 401, output())
+
+    const ssrResponse = await fetch(`http://127.0.0.1:${port}/docs`)
+    assert.equal(ssrResponse.status, 200, output())
+    assert.match(await ssrResponse.text(), /No OpenAPI specs are available/)
   } finally {
+    if (server) await stop(server)
     rmSync(root, { recursive: true, force: true })
   }
 })
@@ -209,7 +232,7 @@ function useInstalledToolingArtifacts(app) {
   writeFileSync(packageJsonPath, `${JSON.stringify(packageJson, null, 2)}\n`)
 }
 
-function exec(command, args, cwd, env = {}, timeout = 120_000) {
+function exec(command, args, cwd, env = {}, timeout = 240_000) {
   return execFileSync(command, args, {
     cwd,
     env: { ...process.env, ...env },
@@ -223,4 +246,61 @@ function write(root, relativePath, contents) {
   const destination = join(root, relativePath)
   mkdirSync(dirname(destination), { recursive: true })
   writeFileSync(destination, contents)
+}
+
+function captureOutput(child) {
+  let output = ""
+  child.stdout.setEncoding("utf8")
+  child.stderr.setEncoding("utf8")
+  child.stdout.on("data", (chunk) => {
+    output += chunk
+  })
+  child.stderr.on("data", (chunk) => {
+    output += chunk
+  })
+  return () => output
+}
+
+async function waitForOk(url, child, output) {
+  const deadline = Date.now() + 30_000
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`Node host exited before it became ready.\n${output()}`)
+    }
+    try {
+      const response = await fetch(url)
+      if (response.ok) return
+    } catch {
+      // The server socket may not be listening yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  throw new Error(`Timed out waiting for ${url}.\n${output()}`)
+}
+
+async function stop(child) {
+  if (child.exitCode !== null) return
+  const exited = once(child, "exit")
+  child.kill("SIGTERM")
+  const stopped = await Promise.race([
+    exited.then(() => true),
+    new Promise((resolve) => setTimeout(() => resolve(false), 5_000)),
+  ])
+  if (stopped) return
+  child.kill("SIGKILL")
+  await exited
+}
+
+async function reservePort() {
+  const listener = createNetServer()
+  await new Promise((resolve, reject) => {
+    listener.once("error", reject)
+    listener.listen(0, "127.0.0.1", resolve)
+  })
+  const address = listener.address()
+  await new Promise((resolve, reject) =>
+    listener.close((error) => (error ? reject(error) : resolve())),
+  )
+  assert.ok(address && typeof address === "object")
+  return address.port
 }

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -10,8 +10,8 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs"
-import { tmpdir } from "node:os"
 import { createServer as createNetServer } from "node:net"
+import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { test } from "node:test"
 import { fileURLToPath } from "node:url"

--- a/scripts/tests/minimal-starter-acceptance.test.mjs
+++ b/scripts/tests/minimal-starter-acceptance.test.mjs
@@ -224,6 +224,9 @@ test("minimal starter installs, builds, and serves API and SSR routes", {
 function useInstalledToolingArtifacts(app) {
   const packageJsonPath = join(app, "package.json")
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+  packageJson.dependencies.pg = `link:${realpathSync(
+    join(repoRoot, "starters/operator/node_modules/pg"),
+  )}`
   for (const dependency of ["@voyant-travel/cli", "tsx", "typescript"]) {
     packageJson.devDependencies[dependency] = `link:${realpathSync(
       join(repoRoot, "starters/operator/node_modules", dependency),

--- a/scripts/tests/package-starters.test.mjs
+++ b/scripts/tests/package-starters.test.mjs
@@ -45,7 +45,7 @@ test("operator release archive contains only the minimal authored project", () =
     assert.equal(packageJson.scripts["graph:emit"], undefined)
     assert.equal(typeof packageJson.dependencies["@voyant-travel/framework"], "string")
     assert.equal(typeof packageJson.dependencies["@voyant-travel/runtime"], "string")
-    assert.equal(typeof packageJson.dependencies.pg, "string")
+    assert.equal(packageJson.dependencies.pg, "8.22.0")
     assert.equal(packageJson.dependencies["@voyant-travel/plugin-smartbill"], undefined)
     assert.equal(packageJson.devDependencies["@voyant-travel/cli"], "^0.40.0")
     const dependencySpecs = Object.values({

--- a/scripts/tests/package-starters.test.mjs
+++ b/scripts/tests/package-starters.test.mjs
@@ -45,6 +45,7 @@ test("operator release archive contains only the minimal authored project", () =
     assert.equal(packageJson.scripts["graph:emit"], undefined)
     assert.equal(typeof packageJson.dependencies["@voyant-travel/framework"], "string")
     assert.equal(typeof packageJson.dependencies["@voyant-travel/runtime"], "string")
+    assert.equal(typeof packageJson.dependencies.pg, "string")
     assert.equal(packageJson.dependencies["@voyant-travel/plugin-smartbill"], undefined)
     assert.equal(packageJson.devDependencies["@voyant-travel/cli"], "^0.40.0")
     const dependencySpecs = Object.values({

--- a/starters/operator/README.md
+++ b/starters/operator/README.md
@@ -147,6 +147,11 @@ exempt). Crons don't run in-process. Deployment tooling derives Cloud Scheduler
 jobs from the admitted graph and POSTs `/__voyant/scheduled?schedule=…`. See
 [docs/architecture/deployment-targets.md](../../docs/architecture/deployment-targets.md).
 
+`voyant start --probe` checks the liveness endpoint and then exits. It proves
+that the Node process can boot, not that TanStack SSR or application API
+dispatch can serve traffic. Release and packaged-starter acceptance must also
+request at least one `/api/*` route and one SSR page such as `/docs`.
+
 ## Routes
 
 Standard frontend routes are emitted from package-owned contributions into the

--- a/starters/operator/src/server.ts
+++ b/starters/operator/src/server.ts
@@ -4,7 +4,13 @@ import { createVoyantProjectServerEntry } from "@voyant-travel/runtime"
 
 const server = createVoyantProjectServerEntry()
 
-export default { fetch: server.fetch }
+export default {
+  fetch: server.fetch,
+  start: (options: { port?: number; projectRoot?: string } = {}) =>
+    createVoyantProjectServerEntry({ projectRoot: options.projectRoot }).start({
+      port: options.port,
+    }),
+}
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   const handle = await server.start({ port: Number.parseInt(process.env.PORT ?? "8080", 10) })

--- a/starters/operator/src/server.ts
+++ b/starters/operator/src/server.ts
@@ -1,15 +1,18 @@
 import { pathToFileURL } from "node:url"
 
-import { createVoyantProjectServerEntry } from "@voyant-travel/runtime"
+import {
+  createVoyantProjectServerEntry,
+  type LoadVoyantProjectOptions,
+} from "@voyant-travel/runtime"
 
 const server = createVoyantProjectServerEntry()
 
 export default {
   fetch: server.fetch,
-  start: (options: { port?: number; projectRoot?: string } = {}) =>
-    createVoyantProjectServerEntry({ projectRoot: options.projectRoot }).start({
-      port: options.port,
-    }),
+  start: (options: LoadVoyantProjectOptions & { port?: number } = {}) => {
+    const { port, ...projectOptions } = options
+    return createVoyantProjectServerEntry(projectOptions).start({ port })
+  },
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {


### PR DESCRIPTION
## Summary

- make the generated/project server entry authoritative for the TanStack Start build and expose its bundled `start` function
- make production `voyant start` use that built entry, while retaining fallback behavior for missing or legacy bundles without a `start` export
- keep the CommonJS `pg` driver external in Node SSR builds and declare it directly in packaged operator starters
- strengthen packaged-starter acceptance to exercise liveness, API dispatch, and a real `/docs` SSR response with deterministic child teardown
- document that `/healthz` and `voyant start --probe` are liveness checks, not full application readiness

## Root cause

`voyant build` emitted a valid TanStack server environment, but `voyant start` reconstructed the SSR handler from package source. That ran outside Vite virtual-module graph, leaving `#tanstack-router-entry` unresolved. Routing startup through the built entry then exposed `pg` being bundled as a namespace object; keeping the Node driver external and installing it at the starter root preserves its CommonJS constructor exports.

The standard product BOM and generated Vite aliases remain responsible for framework-owned UI/runtime dependencies. The packaged starter now declares only the additional app-owned `pg` dependency instead of duplicating the full standard product dependency graph.

## Verification

- `pnpm --filter @voyant-travel/runtime test` (42 tests passed)
- `pnpm --filter @voyant-travel/runtime typecheck`
- `pnpm --filter @voyant-travel/vite-config test` (15 tests passed)
- `node --test scripts/tests/package-starters.test.mjs`
- `node --test scripts/tests/minimal-starter-acceptance.test.mjs` (packages, installs, builds, starts, probes `/healthz`, checks API auth dispatch, and renders `/docs` through SSR)

Closes #3309
Closes #3310