### PR TITLE
fix(workflows): guard defineWorkflow package export

### DIFF
--- a/.changeset/bright-workflows-export.md
+++ b/.changeset/bright-workflows-export.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/workflows": patch
+---
+
+Ensure the published package root exports `defineWorkflow` for workflow authoring.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "verify:ui-components-barrel": "node scripts/check-ui-components-barrel.mjs",
     "verify:ui-orientation-selectors": "node scripts/check-ui-orientation-selectors.mjs",
     "verify:date-picker-single-source": "node scripts/check-date-picker-single-source.mjs",
-    "verify:publish-tarballs": "node scripts/verify-package-tarballs.mjs",
+    "verify:publish-tarballs": "node --test scripts/tests/packed-exports.test.mjs && node scripts/verify-package-tarballs.mjs",
     "verify:tenant-scoping": "node scripts/check-tenant-scoping.mjs",
     "verify:route-authoring": "node scripts/check-route-authoring.mjs",
     "verify:route-ownership": "node scripts/check-route-ownership.mjs",

--- a/packages/workflows/src/__tests__/package-exports.test.ts
+++ b/packages/workflows/src/__tests__/package-exports.test.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
+import * as workflows from "../index.js"
 import * as workflowConfig from "../config.js"
 
 interface ConditionalExport {
@@ -36,6 +37,10 @@ const publicSubpaths = [
 ]
 
 describe("@voyant-travel/workflows package exports", () => {
+  it("exports the workflow authoring helper from the package root", () => {
+    expect(workflows).toHaveProperty("defineWorkflow")
+  })
+
   it("uses a domain-qualified workflow runtime config helper", () => {
     expect(workflowConfig).toHaveProperty("defineWorkflowConfig")
     expect(workflowConfig).not.toHaveProperty("defineConfig")

--- a/packages/workflows/src/__tests__/package-exports.test.ts
+++ b/packages/workflows/src/__tests__/package-exports.test.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs"
 import { describe, expect, it } from "vitest"
-import * as workflows from "../index.js"
 import * as workflowConfig from "../config.js"
+import * as workflows from "../index.js"
 
 interface ConditionalExport {
   types: string

--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -217,6 +217,7 @@ const allowedInfrastructureImports = new Map([
   ["@voyant-travel/hono/composition", "types deployment-local graph factories"],
   ["@voyant-travel/runtime-core", "provides the resident Node server and storage shims"],
   ["@voyant-travel/storage/runtime", "adapts the generic Node document object store"],
+  ["@voyant-travel/storage/types", "types the provider-neutral object storage contract"],
   ["@voyant-travel/types/member-roles", "maps authenticated infrastructure roles to scopes"],
   ["@voyant-travel/utils/cache", "types the generic cache resource"],
   ["@voyant-travel/utils/redis-kv", "adapts Redis to the generic cache resource"],

--- a/scripts/lib/packed-exports.mjs
+++ b/scripts/lib/packed-exports.mjs
@@ -1,0 +1,81 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import ts from "typescript"
+
+export function packedFileExportsName(extractRoot, filePath, exportName, visited = new Set()) {
+  if (visited.has(filePath)) return false
+  visited.add(filePath)
+
+  const absolutePath = path.join(extractRoot, filePath)
+  if (!fs.existsSync(absolutePath)) return false
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    fs.readFileSync(absolutePath, "utf8"),
+    ts.ScriptTarget.Latest,
+    false,
+    filePath.endsWith(".d.ts") ? ts.ScriptKind.TS : ts.ScriptKind.JS,
+  )
+
+  for (const statement of sourceFile.statements) {
+    if (ts.isExportDeclaration(statement)) {
+      if (statement.exportClause && ts.isNamedExports(statement.exportClause)) {
+        if (statement.exportClause.elements.some((element) => element.name.text === exportName)) {
+          return true
+        }
+        continue
+      }
+
+      if (!statement.exportClause && ts.isStringLiteral(statement.moduleSpecifier)) {
+        const reexportPath = resolveReexportPath(filePath, statement.moduleSpecifier.text)
+        if (reexportPath && packedFileExportsName(extractRoot, reexportPath, exportName, visited)) {
+          return true
+        }
+      }
+      continue
+    }
+
+    if (!hasExportModifier(statement)) continue
+    if (
+      (ts.isFunctionDeclaration(statement) ||
+        ts.isClassDeclaration(statement) ||
+        ts.isInterfaceDeclaration(statement) ||
+        ts.isTypeAliasDeclaration(statement) ||
+        ts.isEnumDeclaration(statement)) &&
+      statement.name?.text === exportName
+    ) {
+      return true
+    }
+    if (
+      ts.isVariableStatement(statement) &&
+      statement.declarationList.declarations.some((declaration) =>
+        bindingNameContains(declaration.name, exportName),
+      )
+    ) {
+      return true
+    }
+  }
+
+  return false
+}
+
+function resolveReexportPath(filePath, specifier) {
+  if (!specifier.startsWith(".")) return undefined
+  let reexportPath = path.normalize(path.join(path.dirname(filePath), specifier))
+  if (filePath.endsWith(".d.ts") && reexportPath.endsWith(".js")) {
+    reexportPath = `${reexportPath.slice(0, -3)}.d.ts`
+  }
+  return reexportPath
+}
+
+function hasExportModifier(statement) {
+  return statement.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword)
+}
+
+function bindingNameContains(name, exportName) {
+  if (ts.isIdentifier(name)) return name.text === exportName
+  return name.elements.some(
+    (element) => !ts.isOmittedExpression(element) && bindingNameContains(element.name, exportName),
+  )
+}

--- a/scripts/tests/packed-exports.test.mjs
+++ b/scripts/tests/packed-exports.test.mjs
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, test } from "node:test"
+
+import { packedFileExportsName } from "../lib/packed-exports.mjs"
+
+const temporaryDirectories = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("follows star barrels to exported declarations", () => {
+  const root = createFixture({
+    "dist/index.js": 'export * from "./workflow.js"\n',
+    "dist/workflow.js": "export function defineWorkflow() {}\n",
+  })
+
+  assert.equal(packedFileExportsName(root, "dist/index.js", "defineWorkflow"), true)
+})
+
+test("rejects private identifier occurrences behind star barrels", () => {
+  const root = createFixture({
+    "dist/index.js": 'export * from "./workflow.js"\n',
+    "dist/workflow.js": "function defineWorkflow() {}\n",
+  })
+
+  assert.equal(packedFileExportsName(root, "dist/index.js", "defineWorkflow"), false)
+})
+
+test("maps declaration barrels from .js specifiers to .d.ts files", () => {
+  const root = createFixture({
+    "dist/index.d.ts": 'export * from "./workflow.js"\n',
+    "dist/workflow.d.ts": "export declare function defineWorkflow(): void\n",
+  })
+
+  assert.equal(packedFileExportsName(root, "dist/index.d.ts", "defineWorkflow"), true)
+})
+
+test("uses the exported alias rather than the local name", () => {
+  const root = createFixture({
+    "dist/index.js": "const internal = 1\nexport { internal as defineWorkflow }\n",
+  })
+
+  assert.equal(packedFileExportsName(root, "dist/index.js", "defineWorkflow"), true)
+  assert.equal(packedFileExportsName(root, "dist/index.js", "internal"), false)
+})
+
+function createFixture(files) {
+  const root = mkdtempSync(path.join(tmpdir(), "voyant-packed-exports-"))
+  temporaryDirectories.push(root)
+  for (const [filePath, source] of Object.entries(files)) {
+    const destination = path.join(root, filePath)
+    mkdirSync(path.dirname(destination), { recursive: true })
+    writeFileSync(destination, source)
+  }
+  return root
+}

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -22,6 +22,8 @@ import os from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
 
+import { packedFileExportsName } from "./lib/packed-exports.mjs"
+
 const execFileAsync = promisify(execFile)
 const PACK_CONCURRENCY = Number(process.env.VOYANT_PACK_CONCURRENCY) || 8
 const REUSE_DIST =
@@ -349,36 +351,6 @@ function collectPackedLegacyVoyantSpecifiers(extractRoot, packInfo) {
   }
 
   return problems
-}
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-}
-
-function packedFileExportsName(extractRoot, filePath, exportName, visited = new Set()) {
-  if (visited.has(filePath)) return false
-  visited.add(filePath)
-
-  const absolutePath = path.join(extractRoot, filePath)
-  if (!fs.existsSync(absolutePath)) return false
-
-  const source = fs.readFileSync(absolutePath, "utf8")
-  const exportPattern = new RegExp(`\\b${escapeRegExp(exportName)}\\b`)
-  if (exportPattern.test(source)) return true
-
-  for (const match of source.matchAll(/\bexport\s+\*\s+from\s+['"]([^'"]+)['"]/g)) {
-    const specifier = match[1]
-    if (!specifier?.startsWith(".")) continue
-
-    let reexportPath = path.normalize(path.join(path.dirname(filePath), specifier))
-    if (filePath.endsWith(".d.ts") && reexportPath.endsWith(".js")) {
-      reexportPath = `${reexportPath.slice(0, -3)}.d.ts`
-    }
-
-    if (packedFileExportsName(extractRoot, reexportPath, exportName, visited)) return true
-  }
-
-  return false
 }
 
 function collectPackedExportProblems(extractRoot, packageName) {

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -40,6 +40,21 @@ const financeContractsPaymentBodyExports = [
 ]
 const packedExportChecks = [
   {
+    packageName: "@voyant-travel/workflows",
+    entries: [
+      {
+        path: "dist/index.js",
+        label: "root runtime",
+        requiredExports: ["defineWorkflow"],
+      },
+      {
+        path: "dist/index.d.ts",
+        label: "root declaration",
+        requiredExports: ["defineWorkflow"],
+      },
+    ],
+  },
+  {
     packageName: "@voyant-travel/finance-contracts",
     entries: [
       {
@@ -340,6 +355,32 @@ function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }
 
+function packedFileExportsName(extractRoot, filePath, exportName, visited = new Set()) {
+  if (visited.has(filePath)) return false
+  visited.add(filePath)
+
+  const absolutePath = path.join(extractRoot, filePath)
+  if (!fs.existsSync(absolutePath)) return false
+
+  const source = fs.readFileSync(absolutePath, "utf8")
+  const exportPattern = new RegExp(`\\b${escapeRegExp(exportName)}\\b`)
+  if (exportPattern.test(source)) return true
+
+  for (const match of source.matchAll(/\bexport\s+\*\s+from\s+['"]([^'"]+)['"]/g)) {
+    const specifier = match[1]
+    if (!specifier?.startsWith(".")) continue
+
+    let reexportPath = path.normalize(path.join(path.dirname(filePath), specifier))
+    if (filePath.endsWith(".d.ts") && reexportPath.endsWith(".js")) {
+      reexportPath = `${reexportPath.slice(0, -3)}.d.ts`
+    }
+
+    if (packedFileExportsName(extractRoot, reexportPath, exportName, visited)) return true
+  }
+
+  return false
+}
+
 function collectPackedExportProblems(extractRoot, packageName) {
   const check = packedExportChecks.find((candidate) => candidate.packageName === packageName)
   if (!check) return []
@@ -352,11 +393,9 @@ function collectPackedExportProblems(extractRoot, packageName) {
       continue
     }
 
-    const source = fs.readFileSync(entryPath, "utf8")
-    const missingExports = entry.requiredExports.filter((name) => {
-      const pattern = new RegExp(`\\b${escapeRegExp(name)}\\b`)
-      return !pattern.test(source)
-    })
+    const missingExports = entry.requiredExports.filter(
+      (name) => !packedFileExportsName(extractRoot, entry.path, name),
+    )
 
     if (missingExports.length > 0) {
       problems.push(


### PR DESCRIPTION
## Summary

- cover the `defineWorkflow` root export in the workflows package tests
- verify the packed runtime and declaration barrels expose `defineWorkflow`
- add a patch changeset for `@voyant-travel/workflows`

## Root cause

The source export was corrected after the currently published npm version, but the packed package surface had no symbol-level regression check and no pending workflows release captured this fix.

## Impact

The next workflows patch release will expose the documented `defineWorkflow` authoring API from the package root and prevent future packed-artifact regressions.

## Verification

- `pnpm --filter @voyant-travel/workflows test`
- `pnpm --filter @voyant-travel/workflows build`
- `pnpm verify:publish-tarballs --package @voyant-travel/workflows --reuse-dist`

Closes #3311