### PR TITLE
Fix provider authority regression tests

### DIFF
--- a/packages/finance/tests/unit/storage-generator.test.ts
+++ b/packages/finance/tests/unit/storage-generator.test.ts
@@ -29,7 +29,7 @@ describe("createStorageBackedInvoiceDocumentGenerator", () => {
     expect(result.format).toBe("html")
     expect(result.storageKey).toBe("invoices/inv_123/rendition.html")
     expect(result.metadata).toMatchObject({
-      storageProvider: "local",
+      storageProvider: "memory",
       url: "https://files.example/invoices/inv_123/rendition.html",
     })
 

--- a/packages/legal/tests/unit/storage-generator.test.ts
+++ b/packages/legal/tests/unit/storage-generator.test.ts
@@ -25,7 +25,7 @@ describe("createStorageBackedContractDocumentGenerator", () => {
     expect(result.mimeType).toBe("text/html; charset=utf-8")
     expect(result.storageKey).toBe("contracts/cont_123/contract-cont_123.html")
     expect(result.metadata).toMatchObject({
-      storageProvider: "local",
+      storageProvider: "memory",
       url: "https://files.example/contracts/cont_123/contract-cont_123.html",
     })
 

--- a/starters/operator/tests/api/selected-graph-runtime.test.ts
+++ b/starters/operator/tests/api/selected-graph-runtime.test.ts
@@ -79,7 +79,10 @@ import {
 import { STOREFRONT_BOOKING_BOOTSTRAP_RUNTIME_KEY } from "@voyant-travel/storefront/booking-bootstrap-subscriber"
 import { TRIPS_PAYMENT_SUBSCRIBER_RUNTIME_KEY } from "@voyant-travel/trips/payment-subscribers"
 import { tripsDatabaseRuntimePort, tripsRoutesRuntimePort } from "@voyant-travel/trips/voyant"
-import { WorkflowRunnerRegistry } from "@voyant-travel/workflow-runs"
+import {
+  WorkflowRunnerRegistry,
+  workflowRunnerRegistryRuntimePort,
+} from "@voyant-travel/workflow-runs"
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -509,11 +512,16 @@ describe("selected Operator graph runtime composition", () => {
     const checkout = runtime.extensions.find(
       (unit) => unit.id === "@voyant-travel/commerce#catalog-checkout-extension",
     )
-    const registry = new WorkflowRunnerRegistry()
+    const ports = buildOperatorRuntimePorts()
+    const registry = await ports[workflowRunnerRegistryRuntimePort.id]
+    expect(registry).toBeInstanceOf(WorkflowRunnerRegistry)
+    if (!(registry instanceof WorkflowRunnerRegistry)) {
+      throw new TypeError("The selected graph did not contribute a workflow runner registry.")
+    }
     const composed = await composeVoyantGraphRuntime({
       runtime,
       capabilities: buildOperatorProviders(),
-      ports: buildOperatorRuntimePorts(registry),
+      ports,
     })
     const runtimeModule = composed.modules.find(
       (module) => module.module.name === "commerce.catalog-checkout-extension.graph-runtime",

--- a/starters/operator/tests/api/selected-graph-runtime.test.ts
+++ b/starters/operator/tests/api/selected-graph-runtime.test.ts
@@ -105,25 +105,21 @@ const createDeploymentResources = () => {
   })
 }
 const buildOperatorProviders = () => createDeploymentResources().capabilities
-const buildOperatorRuntimePorts = (_registry?: WorkflowRunnerRegistry) =>
-  createDeploymentResources().ports
+const buildOperatorRuntimePorts = () => createDeploymentResources().ports
 
 async function composeOperatorGraph(runtime = createGeneratedGraphRuntime()) {
-  const workflowRunnerRegistry = new WorkflowRunnerRegistry()
   return composeVoyantGraphRuntime({
     runtime,
     capabilities: buildOperatorProviders(),
-    ports: buildOperatorRuntimePorts(workflowRunnerRegistry),
+    ports: buildOperatorRuntimePorts(),
   })
 }
 
 describe("selected Operator graph runtime composition", () => {
   it("supplies request-scoped checkout options through the declared runtime port", async () => {
-    expect(
-      await buildOperatorRuntimePorts(new WorkflowRunnerRegistry())[
-        catalogCheckoutApiRuntimePort.id
-      ],
-    ).toEqual(expect.any(Function))
+    expect(await buildOperatorRuntimePorts()[catalogCheckoutApiRuntimePort.id]).toEqual(
+      expect.any(Function),
+    )
   })
 
   it("mounts selected package exports once in graph order", async () => {
@@ -184,9 +180,7 @@ describe("selected Operator graph runtime composition", () => {
         (module) => module.module.name === "distribution.channel-push-extension.graph-runtime",
       ),
     ).toHaveLength(1)
-    expect(buildOperatorRuntimePorts(new WorkflowRunnerRegistry())).toHaveProperty(
-      channelPushRuntimePort.id,
-    )
+    expect(buildOperatorRuntimePorts()).toHaveProperty(channelPushRuntimePort.id)
 
     const eventBus = createEventBus()
     const subscribe = vi.spyOn(eventBus, "subscribe")
@@ -217,7 +211,7 @@ describe("selected Operator graph runtime composition", () => {
         ),
       },
       capabilities: buildOperatorProviders(),
-      ports: buildOperatorRuntimePorts(new WorkflowRunnerRegistry()),
+      ports: buildOperatorRuntimePorts(),
     })
 
     expect(
@@ -264,7 +258,7 @@ describe("selected Operator graph runtime composition", () => {
         ),
       },
       capabilities: buildOperatorProviders(),
-      ports: buildOperatorRuntimePorts(new WorkflowRunnerRegistry()),
+      ports: buildOperatorRuntimePorts(),
     })
 
     expect(
@@ -347,7 +341,7 @@ describe("selected Operator graph runtime composition", () => {
       runtime,
       capabilities: buildOperatorProviders(),
       ports: {
-        ...buildOperatorRuntimePorts(new WorkflowRunnerRegistry()),
+        ...buildOperatorRuntimePorts(),
         [legalBookingContractSubscriberRuntimePort.id]: {
           createRuntime: () => ({
             options: { enabled: true, templateSlug: "customer-sales-agreement" },
@@ -395,7 +389,7 @@ describe("selected Operator graph runtime composition", () => {
         ),
       },
       capabilities: buildOperatorProviders(),
-      ports: buildOperatorRuntimePorts(new WorkflowRunnerRegistry()),
+      ports: buildOperatorRuntimePorts(),
     })
 
     expect(
@@ -409,9 +403,7 @@ describe("selected Operator graph runtime composition", () => {
   })
 
   it("binds Legal runtime services by declared ports instead of package id", () => {
-    expect(buildOperatorRuntimePorts(new WorkflowRunnerRegistry())).toHaveProperty(
-      legalBookingContractSubscriberRuntimePort.id,
-    )
+    expect(buildOperatorRuntimePorts()).toHaveProperty(legalBookingContractSubscriberRuntimePort.id)
   })
 
   it("graph-gates the Trips payment subscriber and its runtime service", async () => {
@@ -604,7 +596,7 @@ describe("selected Operator graph runtime composition", () => {
   })
 
   it("fails composition when selected Commerce promotions omit a required host port", async () => {
-    const ports = buildOperatorRuntimePorts(new WorkflowRunnerRegistry())
+    const ports = buildOperatorRuntimePorts()
     const missingDatabase = Object.fromEntries(
       Object.entries(ports).filter(([id]) => id !== promotionRedemptionDatabaseRuntimePort.id),
     )
@@ -628,7 +620,7 @@ describe("selected Operator graph runtime composition", () => {
         ),
       },
       capabilities: buildOperatorProviders(),
-      ports: buildOperatorRuntimePorts(new WorkflowRunnerRegistry()),
+      ports: buildOperatorRuntimePorts(),
     })
 
     expect(
@@ -697,7 +689,7 @@ describe("selected Operator graph runtime composition", () => {
   })
 
   it("binds host runtimes by package-declared ports instead of package ids", async () => {
-    const ports = buildOperatorRuntimePorts(new WorkflowRunnerRegistry())
+    const ports = buildOperatorRuntimePorts()
 
     expect(Object.keys(ports)).toEqual(
       expect.arrayContaining([


### PR DESCRIPTION
## Summary

- assert Commerce checkout runner registration against the workflow registry contributed by the generated selected graph
- align Legal and Finance storage metadata assertions with the canonical `memory` provider identity
- keep the fix test-only because the provider-authority runtime behavior is correct

## Root cause

The selected-graph test still injected an external `WorkflowRunnerRegistry` through a helper that no longer accepts host-owned registries; generated runtime contributors now own that port. The storage tests also retained the former `local` provider name after the in-memory provider was intentionally renamed to `memory`.

## Verification

- `pnpm exec vitest run starters/operator/tests/api/selected-graph-runtime.test.ts` (26 passed)
- `pnpm exec vitest run packages/legal/tests/unit/storage-generator.test.ts` (2 passed)
- `pnpm exec vitest run packages/finance/tests/unit/storage-generator.test.ts` (3 passed)
- `pnpm exec biome check starters/operator/tests/api/selected-graph-runtime.test.ts packages/legal/tests/unit/storage-generator.test.ts packages/finance/tests/unit/storage-generator.test.ts`
- `git diff --check`