### PR TITLE
fix(ci): raise release build heap limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,9 @@ jobs:
       id-token: write
     env:
       HUSKY: 0
+      # Large declaration builds such as bookings-react exceed Node's 4 GB default heap.
+      # Turbo is serialized below, so one build may safely use the runner's available memory.
+      NODE_OPTIONS: --max-old-space-size=12288
       # Turbo remote cache. Configure in GitHub Settings → Secrets and variables
       # → Actions; without them turbo silently falls back to no remote cache.
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Summary
- give release builds the same 12 GB Node heap used by CI
- retain serialized Turbo execution so only one declaration build consumes that heap at a time

## Root cause
The release run aborted while building `@voyant-travel/bookings-react`: V8 reached the default 4 GB heap limit and exited 134. This is a runner-memory configuration failure, not a TypeScript diagnostic.

## Verification
- `pnpm verify:release-config`
- `git diff --check`