### PR TITLE
ci: run heavy checks on Depot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,10 @@ permissions:
 jobs:
   checks:
     name: checks
-    runs-on: ubuntu-latest
+    # Depot provides the extra memory needed to typecheck two package graph
+    # nodes concurrently. Keep release.yml on a GitHub-hosted runner: npm
+    # trusted publishing does not accept third-party/self-hosted runners.
+    runs-on: depot-ubuntu-24.04-8
     env:
       HUSKY: 0
       NODE_OPTIONS: --max-old-space-size=12288
@@ -69,15 +72,17 @@ jobs:
       # tsc programs balloon: the operator app and the @voyant-travel/framework
       # composition. Each now needs
       # >8 GB and would either blow its own heap (exit 134) or, run concurrently,
-      # oversubscribe the 16 GB runner and get OOM-killed (exit 137). So the
-      # packages fan out below, then the two heavy programs run one-at-a-time
-      # (concurrency=1), each alone with its own package-script heap.
+      # oversubscribe a standard 16 GB runner and get OOM-killed (exit 137).
+      # The 32 GB Depot runner admits two ordinary package graph nodes, then the
+      # two heavy composition programs still run one-at-a-time, each alone with
+      # its own package-script heap.
       #
       # `typecheck` dependsOn `^build`, so this also executes the same multi-gigabyte
-      # *-react and aggregator builds as the Build job. Keep it serial so only one
-      # process can use the 12 GB heap allowance on the 16 GB runner.
+      # *-react and aggregator builds as the Build job. Concurrency=2 is the
+      # conservative ceiling for the 32 GB runner because individual packages
+      # can still consume 8-12 GB.
       - name: Typecheck (packages)
-        run: NODE_OPTIONS=--max-old-space-size=12288 pnpm turbo run typecheck --continue --concurrency=1 --filter=!./starters/operator --filter=!@voyant-travel/framework --ui=stream --log-order=stream
+        run: NODE_OPTIONS=--max-old-space-size=12288 pnpm turbo run typecheck --continue --concurrency=2 --filter=!./starters/operator --filter=!@voyant-travel/framework --ui=stream --log-order=stream
 
       - name: Typecheck (composition points)
         # Serial (concurrency=1): operator app and framework composition each run
@@ -110,12 +115,12 @@ jobs:
 
   build:
     name: build
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04-8
     env:
       HUSKY: 0
       # The composed framework app's tsc build grows with each module's
       # OpenAPIHono route chain; match the heap the typecheck/db-checks jobs
-      # already use. Serial execution keeps this 12 GB process inside runner RAM.
+      # already use. Bounded concurrency keeps these processes inside runner RAM.
       NODE_OPTIONS: --max-old-space-size=12288
       TEST_DATABASE_URL: postgresql://voyant:voyant@localhost:5432/voyant_starter_acceptance
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
@@ -156,16 +161,16 @@ jobs:
       # cached dist, so only the remaining packages build there.
       - name: Build (framework composition)
         # --filter builds framework AND its whole upstream dep graph; cap at
-        # concurrency=1 because a cold cache can overlap multiple multi-gigabyte
-        # TypeScript builds even inside this dependency slice and exhaust the
-        # 16 GB runner. Framework's own build keeps its package-script heap.
-        run: pnpm turbo build --filter=@voyant-travel/framework --concurrency=1 --ui=stream --log-order=stream
+        # concurrency=2 to use the Depot runner without allowing the dependency
+        # slice to fan out uncontrollably. Framework itself runs after its
+        # dependencies and keeps its package-script heap.
+        run: pnpm turbo build --filter=@voyant-travel/framework --concurrency=2 --ui=stream --log-order=stream
 
       - name: Build
-        # Keep this serial as well: bookings-react alone can approach the 8 GB
-        # package heap, so any concurrent TypeScript build can exceed runner RAM.
-        # Framework already built in the preceding step and should hit cache.
-        run: pnpm turbo build --concurrency=1 --ui=stream --log-order=stream
+        # Keep parallelism bounded: bookings-react alone can approach an 8 GB
+        # heap. Framework already built in the preceding step and should hit
+        # cache, while the remaining graph uses at most two workers.
+        run: pnpm turbo build --concurrency=2 --ui=stream --log-order=stream
 
       - name: Package export checks
         run: pnpm verify:package-exports


### PR DESCRIPTION
## Summary

- move the memory-heavy `checks` and `build` jobs to Depot managed GitHub Actions runners
- use the 8-vCPU/32-GB runner tier
- raise package graph concurrency from 1 to 2
- keep framework/operator composition serialized
- keep database checks, Node smoke, and all release jobs on GitHub-hosted runners

## Why

The standard runner forces the TypeScript package graph to run serially and the latest broad build took 14m30s. Depot provides enough memory for bounded concurrency without changing workflow orchestration, required check names, secrets, or npm trusted publishing.

## Verification

- Depot managed runners GitHub App installed for all Voyant repositories
- workflow YAML parsed locally
- `git diff --check`
- release workflow remains exclusively on `ubuntu-latest`

The PR checks are the dispatch and performance acceptance test.