### PR TITLE
Fix admin form accessibility labels

### DIFF
--- a/.changeset/admin-form-accessible-labels.md
+++ b/.changeset/admin-form-accessible-labels.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/ui": patch
+"@voyant-travel/distribution-react": patch
+"@voyant-travel/inventory-react": patch
+---
+
+Associate admin form controls with visible labels and validation messages, and add accessible names to phone, channel, product translation, tag, action-menu, and channel-assignment helpers.

--- a/packages/distribution-react/src/components/channels-page-accessibility.test.tsx
+++ b/packages/distribution-react/src/components/channels-page-accessibility.test.tsx
@@ -4,7 +4,9 @@ import { act } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
 
 const mutationState = vi.hoisted(() => ({
   create: vi.fn(),
@@ -117,7 +119,7 @@ describe("ChannelsPage accessibility", () => {
       ["channel-name", "channel-name-error"],
       ["channel-website", "channel-website-error"],
       ["channel-contact-email", "channel-contact-email-error"],
-    ]) {
+    ] as const) {
       const control = document.getElementById(controlId)
       expect(control?.getAttribute("aria-invalid")).toBe("true")
       expect(control?.getAttribute("aria-describedby")).toBe(errorId)

--- a/packages/distribution-react/src/components/channels-page-accessibility.test.tsx
+++ b/packages/distribution-react/src/components/channels-page-accessibility.test.tsx
@@ -1,0 +1,127 @@
+// @vitest-environment jsdom
+
+import { act } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const mutationState = vi.hoisted(() => ({
+  create: vi.fn(),
+  remove: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock("../index.js", () => ({
+  useChannels: () => ({
+    data: {
+      data: [
+        {
+          id: "channel_1",
+          name: "Website",
+          kind: "direct",
+          status: "active",
+          website: null,
+          contactName: null,
+          contactEmail: null,
+        },
+      ],
+      total: 1,
+    },
+    isPending: false,
+    refetch: vi.fn(),
+  }),
+  useChannelMutation: () => ({
+    create: { isPending: false, mutateAsync: mutationState.create },
+    remove: { isPending: false, mutateAsync: mutationState.remove },
+    update: { isPending: false, mutateAsync: mutationState.update },
+  }),
+}))
+
+import { ChannelsPage } from "./channels-page.js"
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.clearAllMocks()
+})
+
+function buttonNamed(name: string) {
+  return Array.from(document.querySelectorAll("button")).find(
+    (button) => button.textContent?.trim() === name,
+  )
+}
+
+async function openChannelForm() {
+  const addButton = buttonNamed("Add Channel")
+  expect(addButton).toBeDefined()
+  await act(async () => addButton?.dispatchEvent(new MouseEvent("click", { bubbles: true })))
+}
+
+function setNativeInputValue(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set
+  setter?.call(input, value)
+  input.dispatchEvent(new Event("input", { bubbles: true }))
+}
+
+describe("ChannelsPage accessibility", () => {
+  it("names the row action and associates all channel labels", async () => {
+    await act(async () => root.render(<ChannelsPage />))
+
+    const rowAction = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Edit / Delete: Website"]',
+    )
+    expect(rowAction?.title).toBe("Edit / Delete: Website")
+
+    await openChannelForm()
+
+    for (const id of [
+      "channel-name",
+      "channel-kind",
+      "channel-status",
+      "channel-website",
+      "channel-contact-name",
+      "channel-contact-email",
+    ]) {
+      expect(document.querySelector(`label[for="${id}"]`)).not.toBeNull()
+      expect(document.getElementById(id)).not.toBeNull()
+    }
+  })
+
+  it("connects channel validation errors to their controls", async () => {
+    await act(async () => root.render(<ChannelsPage />))
+    await openChannelForm()
+
+    const website = document.getElementById("channel-website") as HTMLInputElement
+    const email = document.getElementById("channel-contact-email") as HTMLInputElement
+    await act(async () => {
+      setNativeInputValue(website, "not-a-url")
+      setNativeInputValue(email, "not-an-email")
+    })
+
+    const form = document.querySelector("form")
+    await act(async () =>
+      form?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true })),
+    )
+
+    for (const [controlId, errorId] of [
+      ["channel-name", "channel-name-error"],
+      ["channel-website", "channel-website-error"],
+      ["channel-contact-email", "channel-contact-email-error"],
+    ]) {
+      const control = document.getElementById(controlId)
+      expect(control?.getAttribute("aria-invalid")).toBe("true")
+      expect(control?.getAttribute("aria-describedby")).toBe(errorId)
+      expect(document.getElementById(errorId)).not.toBeNull()
+    }
+  })
+})

--- a/packages/distribution-react/src/components/channels-page.tsx
+++ b/packages/distribution-react/src/components/channels-page.tsx
@@ -125,8 +125,14 @@ export function ChannelsPage({ className, pageSize = PAGE_SIZE }: ChannelsPagePr
                   </div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground">
-                        <MoreHorizontal className="h-4 w-4" />
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label={`${page.edit} / ${page.delete}: ${channel.name}`}
+                        title={`${page.edit} / ${page.delete}: ${channel.name}`}
+                        className="h-8 w-8 text-muted-foreground"
+                      >
+                        <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
@@ -284,25 +290,38 @@ function ChannelSheet({
         <form onSubmit={onSubmit} className="flex flex-1 flex-col overflow-hidden">
           <SheetBody className="grid gap-4">
             <div className="flex flex-col gap-2">
-              <Label>{page.nameLabel}</Label>
+              <Label htmlFor="channel-name">{page.nameLabel}</Label>
               <Input
+                id="channel-name"
                 value={values.name}
                 onChange={(event) => setValue("name", event.target.value)}
                 placeholder={page.namePlaceholder}
+                aria-invalid={errors.name ? true : undefined}
+                aria-describedby={errors.name ? "channel-name-error" : undefined}
                 autoFocus
               />
-              {errors.name ? <p className="text-xs text-destructive">{errors.name}</p> : null}
+              {errors.name ? (
+                <p id="channel-name-error" className="text-xs text-destructive">
+                  {errors.name}
+                </p>
+              ) : null}
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
-                <Label>{page.kindLabel}</Label>
+                <Label id="channel-kind-label" htmlFor="channel-kind">
+                  {page.kindLabel}
+                </Label>
                 <Select
                   items={channelKinds}
                   value={values.kind}
                   onValueChange={(value) => setValue("kind", value as ChannelRow["kind"])}
                 >
-                  <SelectTrigger className="w-full">
+                  <SelectTrigger
+                    id="channel-kind"
+                    aria-labelledby="channel-kind-label"
+                    className="w-full"
+                  >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -316,12 +335,18 @@ function ChannelSheet({
               </div>
 
               <div className="flex flex-col gap-2">
-                <Label>{page.statusLabel}</Label>
+                <Label id="channel-status-label" htmlFor="channel-status">
+                  {page.statusLabel}
+                </Label>
                 <Select
                   value={values.status}
                   onValueChange={(value) => setValue("status", value as ChannelRow["status"])}
                 >
-                  <SelectTrigger className="w-full">
+                  <SelectTrigger
+                    id="channel-status"
+                    aria-labelledby="channel-status-label"
+                    className="w-full"
+                  >
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
@@ -336,33 +361,46 @@ function ChannelSheet({
             </div>
 
             <div className="flex flex-col gap-2">
-              <Label>{page.websiteLabel}</Label>
+              <Label htmlFor="channel-website">{page.websiteLabel}</Label>
               <Input
+                id="channel-website"
                 value={values.website}
                 onChange={(event) => setValue("website", event.target.value)}
                 placeholder={page.websitePlaceholder}
+                aria-invalid={errors.website ? true : undefined}
+                aria-describedby={errors.website ? "channel-website-error" : undefined}
               />
-              {errors.website ? <p className="text-xs text-destructive">{errors.website}</p> : null}
+              {errors.website ? (
+                <p id="channel-website-error" className="text-xs text-destructive">
+                  {errors.website}
+                </p>
+              ) : null}
             </div>
 
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
-                <Label>{page.primaryContactLabel}</Label>
+                <Label htmlFor="channel-contact-name">{page.primaryContactLabel}</Label>
                 <Input
+                  id="channel-contact-name"
                   value={values.contactName}
                   onChange={(event) => setValue("contactName", event.target.value)}
                   placeholder={page.primaryContactPlaceholder}
                 />
               </div>
               <div className="flex flex-col gap-2">
-                <Label>{page.contactEmailLabel}</Label>
+                <Label htmlFor="channel-contact-email">{page.contactEmailLabel}</Label>
                 <Input
+                  id="channel-contact-email"
                   value={values.contactEmail}
                   onChange={(event) => setValue("contactEmail", event.target.value)}
                   placeholder={page.contactEmailPlaceholder}
+                  aria-invalid={errors.contactEmail ? true : undefined}
+                  aria-describedby={errors.contactEmail ? "channel-contact-email-error" : undefined}
                 />
                 {errors.contactEmail ? (
-                  <p className="text-xs text-destructive">{errors.contactEmail}</p>
+                  <p id="channel-contact-email-error" className="text-xs text-destructive">
+                    {errors.contactEmail}
+                  </p>
                 ) : null}
               </div>
             </div>

--- a/packages/inventory-react/src/components/product-detail/product-detail-accessibility.test.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-accessibility.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import {
+  type OperatorAdminMessages,
+  operatorAdminMessageDefinitions,
+  resolveLocaleMessages,
+} from "@voyant-travel/i18n"
+import { DropdownMenuItem } from "@voyant-travel/ui/components"
+import { act, type ReactNode } from "react"
+import { createRoot, type Root } from "react-dom/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock("@voyant-travel/ui/components/rich-text-editor", () => ({
+  RichTextEditor: ({
+    id,
+    "aria-labelledby": ariaLabelledby,
+    "aria-describedby": ariaDescribedby,
+    "aria-invalid": ariaInvalid,
+  }: {
+    id?: string
+    "aria-labelledby"?: string
+    "aria-describedby"?: string
+    "aria-invalid"?: boolean
+  }) => (
+    <textarea
+      id={id}
+      aria-labelledby={ariaLabelledby}
+      aria-describedby={ariaDescribedby}
+      aria-invalid={ariaInvalid}
+      readOnly
+    />
+  ),
+}))
+
+vi.mock("../../index.js", () => ({
+  useProductTranslations: () => ({ data: { data: [] }, isPending: false }),
+  useProductTranslationMutation: () => ({
+    create: { mutateAsync: vi.fn() },
+    remove: { mutateAsync: vi.fn() },
+    update: { mutateAsync: vi.fn() },
+  }),
+}))
+
+import { type ProductDetailApi, ProductDetailHostProvider } from "./host.js"
+import { ProductChannelsSection } from "./product-detail-channel-section.js"
+import { type ProductData, ProductDetailForm } from "./product-detail-form.js"
+import { ActionMenu } from "./product-detail-section-shell.js"
+import { ContentLanguageSwitcher } from "./product-translation-popover.js"
+
+const messages = resolveLocaleMessages<OperatorAdminMessages>({
+  locale: "en",
+  fallbackLocale: "en",
+  definitions: operatorAdminMessageDefinitions,
+})
+
+const api: ProductDetailApi = {
+  get: async <T,>() => ({ data: [] }) as T,
+  post: async <T,>() => ({ id: "product_1" }) as T,
+  patch: async <T,>() => ({}) as T,
+  delete: async <T,>() => ({}) as T,
+}
+
+const product: ProductData = {
+  id: "product_1",
+  name: "",
+  status: "draft",
+  description: null,
+  inclusionsHtml: null,
+  exclusionsHtml: null,
+  termsHtml: null,
+  bookingMode: "itinerary",
+  visibility: "private",
+  activated: false,
+  productTypeId: null,
+  taxClassId: null,
+  sellCurrency: "E",
+  tags: ["featured"],
+  defaultLanguageTag: "en",
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement("div")
+  document.body.append(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+})
+
+async function renderWithHost(children: ReactNode) {
+  await act(async () => {
+    root.render(
+      <QueryClientProvider client={new QueryClient()}>
+        <ProductDetailHostProvider
+          value={{
+            messages,
+            api,
+            locale: "en",
+            navigate: {
+              toProducts: () => undefined,
+              toProduct: () => undefined,
+              toNewBooking: () => undefined,
+              toAvailability: () => undefined,
+            },
+          }}
+        >
+          {children}
+        </ProductDetailHostProvider>
+      </QueryClientProvider>,
+    )
+  })
+}
+
+describe("product detail accessibility", () => {
+  it("associates labels with all fourteen product controls and validation messages", async () => {
+    await renderWithHost(<ProductDetailForm product={product} onSuccess={() => undefined} />)
+
+    const controlIds = [
+      "product-detail-name",
+      "product-detail-description",
+      "product-detail-slug",
+      "product-detail-inclusions",
+      "product-detail-exclusions",
+      "product-detail-terms",
+      "product-detail-default-language",
+      "product-detail-tags",
+      "product-detail-booking-mode",
+      "product-detail-visibility",
+      "product-detail-product-type",
+      "product-detail-status",
+      "product-detail-tax-class",
+      "product-detail-sell-currency",
+    ]
+
+    expect(controlIds).toHaveLength(14)
+    for (const id of controlIds) {
+      expect(document.querySelector(`label[for="${id}"]`)).not.toBeNull()
+      expect(document.getElementById(id)).not.toBeNull()
+    }
+
+    for (const id of [
+      "product-detail-description",
+      "product-detail-inclusions",
+      "product-detail-exclusions",
+      "product-detail-terms",
+    ]) {
+      expect(document.getElementById(id)?.getAttribute("aria-labelledby")).toBe(`${id}-label`)
+    }
+
+    const form = document.querySelector("form")
+    await act(async () => {
+      form?.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }))
+      await Promise.resolve()
+    })
+
+    for (const [controlId, errorId] of [
+      ["product-detail-name", "product-detail-name-error"],
+      ["product-detail-sell-currency", "product-detail-sell-currency-error"],
+    ]) {
+      const control = document.getElementById(controlId)
+      expect(control?.getAttribute("aria-invalid")).toBe("true")
+      expect(control?.getAttribute("aria-describedby")).toBe(errorId)
+      expect(document.getElementById(errorId)).not.toBeNull()
+    }
+
+    expect(document.querySelector('button[aria-label="Delete: featured"]')).not.toBeNull()
+    expect(document.querySelectorAll('button[aria-label="Not translated"]')).toHaveLength(6)
+  })
+
+  it("names translation, action-menu, and channel helper buttons", async () => {
+    await renderWithHost(
+      <>
+        <ContentLanguageSwitcher
+          activeLanguage="en"
+          defaultLanguageTag="en"
+          languageTags={["fr"]}
+          messages={messages.products.core}
+          onSelect={() => undefined}
+          onAddLanguage={() => undefined}
+          onRemoveLanguage={() => undefined}
+        />
+        <ActionMenu label="Product actions">
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+        </ActionMenu>
+        <ProductChannelsSection
+          allChannels={[{ id: "channel_1", name: "Website", kind: "direct", status: "active" }]}
+          mappings={[
+            { id: "mapping_1", channelId: "channel_1", productId: "product_1", active: true },
+          ]}
+          onAddChannel={() => undefined}
+          onRemoveChannel={() => undefined}
+        />
+      </>,
+    )
+
+    for (const label of ["Remove language: French", "Product actions", "Delete: Website"]) {
+      const button = document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
+      expect(button?.title).toBe(label)
+    }
+  })
+})

--- a/packages/inventory-react/src/components/product-detail/product-detail-accessibility.test.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-accessibility.test.tsx
@@ -11,7 +11,9 @@ import { act, type ReactNode } from "react"
 import { createRoot, type Root } from "react-dom/client"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-globalThis.IS_REACT_ACT_ENVIRONMENT = true
+;(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true
 
 vi.mock("@voyant-travel/ui/components/rich-text-editor", () => ({
   RichTextEditor: ({
@@ -164,7 +166,7 @@ describe("product detail accessibility", () => {
     for (const [controlId, errorId] of [
       ["product-detail-name", "product-detail-name-error"],
       ["product-detail-sell-currency", "product-detail-sell-currency-error"],
-    ]) {
+    ] as const) {
       const control = document.getElementById(controlId)
       expect(control?.getAttribute("aria-invalid")).toBe("true")
       expect(control?.getAttribute("aria-describedby")).toBe(errorId)

--- a/packages/inventory-react/src/components/product-detail/product-detail-accessibility.test.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-accessibility.test.tsx
@@ -46,10 +46,27 @@ vi.mock("../../index.js", () => ({
   }),
 }))
 
+vi.mock("./product-option-price-rule-dialog.js", () => ({
+  OptionPriceRuleDialog: () => null,
+}))
+
+vi.mock("./product-option-pricing-grid.js", () => ({
+  OptionPricingGrid: () => null,
+}))
+
+vi.mock("./product-options-extra-price-rules.js", () => ({
+  ExtraPriceRulesPanel: () => null,
+}))
+
+vi.mock("./product-options-unit-price-matrix.js", () => ({
+  UnitPriceMatrix: () => null,
+}))
+
 import { type ProductDetailApi, ProductDetailHostProvider } from "./host.js"
 import { ProductChannelsSection } from "./product-detail-channel-section.js"
 import { type ProductData, ProductDetailForm } from "./product-detail-form.js"
 import { ActionMenu } from "./product-detail-section-shell.js"
+import { PricingPanel } from "./product-options-pricing-panel.js"
 import { ContentLanguageSwitcher } from "./product-translation-popover.js"
 
 const messages = resolveLocaleMessages<OperatorAdminMessages>({
@@ -97,14 +114,14 @@ afterEach(async () => {
   container.remove()
 })
 
-async function renderWithHost(children: ReactNode) {
+async function renderWithHost(children: ReactNode, hostApi: ProductDetailApi = api) {
   await act(async () => {
     root.render(
       <QueryClientProvider client={new QueryClient()}>
         <ProductDetailHostProvider
           value={{
             messages,
-            api,
+            api: hostApi,
             locale: "en",
             navigate: {
               toProducts: () => undefined,
@@ -207,5 +224,65 @@ describe("product detail accessibility", () => {
       const button = document.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`)
       expect(button?.title).toBe(label)
     }
+  })
+
+  it("names the pricing panel's local action menu for an additional price rule", async () => {
+    const priceRule = {
+      id: "price_rule_2",
+      productId: "product_1",
+      optionId: "option_1",
+      priceCatalogId: "catalog_1",
+      priceScheduleId: null,
+      cancellationPolicyId: null,
+      name: "Flexible rate",
+      code: null,
+      description: null,
+      pricingMode: "per_person" as const,
+      baseSellAmountCents: 12500,
+      baseCostAmountCents: null,
+      minPerBooking: null,
+      maxPerBooking: null,
+      allPricingCategories: true,
+      isDefault: false,
+      active: true,
+      notes: null,
+    }
+    const pricingApi: ProductDetailApi = {
+      ...api,
+      get: async <T,>() =>
+        ({
+          data: [{ ...priceRule, id: "price_rule_1", name: "Default", isDefault: true }, priceRule],
+        }) as T,
+    }
+
+    await renderWithHost(
+      <PricingPanel
+        productId="product_1"
+        optionId="option_1"
+        optionName="Standard"
+        productCurrency="EUR"
+        layout="seats"
+      />,
+      pricingApi,
+    )
+
+    const advancedButton = Array.from(document.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes(messages.products.operations.pricingGrid.advancedToggle),
+    )
+    expect(advancedButton).toBeDefined()
+
+    await act(async () => {
+      advancedButton?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      await vi.waitFor(() => {
+        expect(
+          document.querySelector('button[aria-label="Flexible rate: Edit / Delete"]'),
+        ).not.toBeNull()
+      })
+    })
+
+    const menu = document.querySelector<HTMLButtonElement>(
+      'button[aria-label="Flexible rate: Edit / Delete"]',
+    )
+    expect(menu?.title).toBe("Flexible rate: Edit / Delete")
   })
 })

--- a/packages/inventory-react/src/components/product-detail/product-detail-availability-sections.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-availability-sections.tsx
@@ -40,7 +40,7 @@ export function ProductDeparturesSection({
     <Section
       title={productMessages.departuresTitle}
       actions={
-        <ActionMenu>
+        <ActionMenu label={productMessages.newDeparture}>
           <DropdownMenuItem onClick={onCreate}>
             <Plus className="h-4 w-4" />
             {productMessages.newDeparture}
@@ -118,7 +118,7 @@ export function ProductDeparturesSection({
                   {formatCapacityLabel(slot, messages)}
                 </td>
                 <td className="px-3 py-2.5">
-                  <ActionMenu>
+                  <ActionMenu label={`${productMessages.departuresTitle}: ${slot.dateLocal}`}>
                     <DropdownMenuItem onClick={() => onEdit(slot)}>
                       <Pencil className="h-4 w-4" />
                       {productMessages.edit}
@@ -168,7 +168,7 @@ export function ProductSchedulesSection({
     <Section
       title={productMessages.schedulesTitle}
       actions={
-        <ActionMenu>
+        <ActionMenu label={productMessages.newSchedule}>
           <DropdownMenuItem onClick={onCreate}>
             <Plus className="h-4 w-4" />
             {productMessages.newSchedule}
@@ -207,7 +207,9 @@ export function ProductSchedulesSection({
                   })}
                 </p>
               </div>
-              <ActionMenu>
+              <ActionMenu
+                label={`${productMessages.schedulesTitle}: ${describeRRule(rule.recurrenceRule)}`}
+              >
                 <DropdownMenuItem onClick={() => onEdit(rule)}>
                   <Pencil className="h-4 w-4" />
                   {productMessages.edit}

--- a/packages/inventory-react/src/components/product-detail/product-detail-channel-section.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-channel-section.tsx
@@ -54,10 +54,12 @@ export function ProductChannelsSection({
                     <Button
                       variant="ghost"
                       size="icon"
+                      aria-label={`${productMessages.delete}: ${channel.name}`}
+                      title={`${productMessages.delete}: ${channel.name}`}
                       className="h-7 w-7 text-muted-foreground hover:text-destructive"
                       onClick={() => onRemoveChannel(mapping.id)}
                     >
-                      <Trash2 className="h-3.5 w-3.5" />
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
                     </Button>
                   ) : null}
                 </div>

--- a/packages/inventory-react/src/components/product-detail/product-detail-day-row.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-day-row.tsx
@@ -107,7 +107,11 @@ export function ProductDetailDayRow({
             })}
           </Badge>
         ) : null}
-        <ActionMenu>
+        <ActionMenu
+          label={`${formatMessage(dayRowMessages.title, { dayNumber: day.dayNumber })}${
+            day.title ? `: ${day.title}` : ""
+          }`}
+        >
           <DropdownMenuItem onClick={onEdit}>
             <Pencil className="h-4 w-4" />
             {dayRowMessages.editAction}
@@ -159,7 +163,9 @@ export function ProductDetailDayRow({
                     </td>
                     <td className="px-3 py-2">{service.quantity}</td>
                     <td className="px-3 py-2">
-                      <ActionMenu>
+                      <ActionMenu
+                        label={`${service.name}: ${dayRowMessages.editAction} / ${dayRowMessages.deleteAction}`}
+                      >
                         <DropdownMenuItem onClick={() => onEditService(service)}>
                           <Pencil className="h-4 w-4" />
                           {dayRowMessages.editAction}

--- a/packages/inventory-react/src/components/product-detail/product-detail-form.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-form.tsx
@@ -265,6 +265,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <TranslatableField
+          id="product-detail-name"
           label={productMessages.nameLabel}
           type="text"
           field="name"
@@ -283,6 +284,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <TranslatableField
+          id="product-detail-description"
           label={productMessages.descriptionLabel}
           type="richtext"
           field="description"
@@ -298,6 +300,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <TranslatableField
+          id="product-detail-slug"
           label={productMessages.slugLabel}
           type="text"
           field="slug"
@@ -309,6 +312,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <TranslatableField
+          id="product-detail-inclusions"
           label={productMessages.inclusionsLabel}
           type="richtext"
           field="inclusionsHtml"
@@ -324,6 +328,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <TranslatableField
+          id="product-detail-exclusions"
           label={productMessages.exclusionsLabel}
           type="richtext"
           field="exclusionsHtml"
@@ -339,6 +344,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <TranslatableField
+          id="product-detail-terms"
           label={productMessages.termsLabel}
           type="richtext"
           field="termsHtml"
@@ -354,8 +360,11 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         />
 
         <div className="flex flex-col gap-2">
-          <Label>{productMessages.defaultLanguageLabel}</Label>
+          <Label htmlFor="product-detail-default-language">
+            {productMessages.defaultLanguageLabel}
+          </Label>
           <LanguageCombobox
+            id="product-detail-default-language"
             value={form.watch("defaultLanguageTag")?.trim() || adminBaseLocale}
             onValueChange={(code) =>
               form.setValue("defaultLanguageTag", code, { shouldDirty: true })
@@ -367,13 +376,15 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         </div>
 
         <div className="flex flex-col gap-2">
-          <Label>{productMessages.tagsLabel}</Label>
+          <Label htmlFor="product-detail-tags">{productMessages.tagsLabel}</Label>
           <div className="flex flex-wrap gap-1.5">
             {(form.watch("tags") ?? []).map((tag) => (
               <Badge key={tag} variant="secondary" className="gap-1 text-xs">
                 {tag}
                 <button
                   type="button"
+                  aria-label={`${productMessages.delete}: ${tag}`}
+                  title={`${productMessages.delete}: ${tag}`}
                   className="ml-0.5 rounded-full hover:text-destructive"
                   onClick={() => {
                     const current = form.getValues("tags") ?? []
@@ -390,6 +401,7 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
             ))}
           </div>
           <Input
+            id="product-detail-tags"
             value={tagInput}
             onChange={(e) => setTagInput(e.target.value)}
             onKeyDown={(e) => {
@@ -409,7 +421,9 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
 
         <div className="grid grid-cols-2 gap-4">
           <div className="flex flex-col gap-2">
-            <Label>{productMessages.bookingModeLabel}</Label>
+            <Label id="product-detail-booking-mode-label" htmlFor="product-detail-booking-mode">
+              {productMessages.bookingModeLabel}
+            </Label>
             <Select
               value={form.watch("bookingMode")}
               onValueChange={(v) =>
@@ -417,7 +431,11 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
               }
               items={bookingModes}
             >
-              <SelectTrigger className="w-full">
+              <SelectTrigger
+                id="product-detail-booking-mode"
+                aria-labelledby="product-detail-booking-mode-label"
+                className="w-full"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -430,7 +448,9 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
             </Select>
           </div>
           <div className="flex flex-col gap-2">
-            <Label>{productMessages.visibilityLabel}</Label>
+            <Label id="product-detail-visibility-label" htmlFor="product-detail-visibility">
+              {productMessages.visibilityLabel}
+            </Label>
             <Select
               value={form.watch("visibility")}
               onValueChange={(v) =>
@@ -440,7 +460,11 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
               }
               items={visibilityOptions}
             >
-              <SelectTrigger className="w-full">
+              <SelectTrigger
+                id="product-detail-visibility"
+                aria-labelledby="product-detail-visibility-label"
+                className="w-full"
+              >
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
@@ -456,7 +480,9 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
 
         <div className="grid grid-cols-2 gap-4">
           <div className="flex flex-col gap-2">
-            <Label>{productMessages.productTypeLabel}</Label>
+            <Label id="product-detail-product-type-label" htmlFor="product-detail-product-type">
+              {productMessages.productTypeLabel}
+            </Label>
             <Select
               value={form.watch("productTypeId") ?? ""}
               onValueChange={(v) =>
@@ -469,7 +495,11 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
                 ...productTypes.map((t) => ({ value: t.id, label: t.name })),
               ]}
             >
-              <SelectTrigger className="w-full">
+              <SelectTrigger
+                id="product-detail-product-type"
+                aria-labelledby="product-detail-product-type-label"
+                className="w-full"
+              >
                 <SelectValue placeholder={productMessages.productTypeNone} />
               </SelectTrigger>
               <SelectContent>
@@ -500,13 +530,19 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
         {isEditing && (
           <div className="grid grid-cols-2 gap-4">
             <div className="flex flex-col gap-2">
-              <Label>{productMessages.statusLabel}</Label>
+              <Label id="product-detail-status-label" htmlFor="product-detail-status">
+                {productMessages.statusLabel}
+              </Label>
               <Select
                 value={form.watch("status")}
                 onValueChange={(v) => form.setValue("status", v as ProductFormValues["status"])}
                 items={productStatuses}
               >
-                <SelectTrigger className="w-full">
+                <SelectTrigger
+                  id="product-detail-status"
+                  aria-labelledby="product-detail-status-label"
+                  className="w-full"
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -519,7 +555,9 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
               </Select>
             </div>
             <div className="flex flex-col gap-2">
-              <Label>{productMessages.taxClassLabel}</Label>
+              <Label id="product-detail-tax-class-label" htmlFor="product-detail-tax-class">
+                {productMessages.taxClassLabel}
+              </Label>
               <Select
                 value={form.watch("taxClassId") ?? ""}
                 onValueChange={(v) =>
@@ -535,7 +573,11 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
                   })),
                 ]}
               >
-                <SelectTrigger className="w-full">
+                <SelectTrigger
+                  id="product-detail-tax-class"
+                  aria-labelledby="product-detail-tax-class-label"
+                  className="w-full"
+                >
                   <SelectValue placeholder={productMessages.taxClassNone} />
                 </SelectTrigger>
                 <SelectContent>
@@ -549,14 +591,23 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
               </Select>
             </div>
             <div className="flex flex-col gap-2">
-              <Label>{productMessages.sellCurrencyLabel}</Label>
+              <Label htmlFor="product-detail-sell-currency">
+                {productMessages.sellCurrencyLabel}
+              </Label>
               <CurrencyCombobox
+                id="product-detail-sell-currency"
                 value={form.watch("sellCurrency")}
                 onChange={(v) => form.setValue("sellCurrency", v, { shouldDirty: true })}
                 messages={productMessages}
+                aria-invalid={form.formState.errors.sellCurrency ? true : undefined}
+                aria-describedby={
+                  form.formState.errors.sellCurrency
+                    ? "product-detail-sell-currency-error"
+                    : undefined
+                }
               />
               {form.formState.errors.sellCurrency && (
-                <p className="text-xs text-destructive">
+                <p id="product-detail-sell-currency-error" className="text-xs text-destructive">
                   {form.formState.errors.sellCurrency.message}
                 </p>
               )}
@@ -581,17 +632,30 @@ export function ProductDetailForm({ product, onSuccess, onCancel }: ProductDetai
 }
 
 function CurrencyCombobox({
+  id,
   value,
   onChange,
   messages,
+  "aria-invalid": ariaInvalid,
+  "aria-describedby": ariaDescribedby,
 }: {
+  id: string
   value: string
   onChange: (value: string) => void
   messages: ReturnType<typeof useProductDetailMessages>["products"]["core"]
+  "aria-invalid"?: boolean
+  "aria-describedby"?: string
 }) {
   return (
     <Combobox value={value} onValueChange={(v) => onChange(v ?? "")}>
-      <ComboboxInput placeholder={messages.currencySearchPlaceholder} className="w-full" />
+      <ComboboxInput
+        id={id}
+        aria-label={messages.sellCurrencyLabel}
+        aria-invalid={ariaInvalid}
+        aria-describedby={ariaDescribedby}
+        placeholder={messages.currencySearchPlaceholder}
+        className="w-full"
+      />
       <ComboboxContent>
         <ComboboxList>
           {CURRENCY_OPTIONS.map((c) => (

--- a/packages/inventory-react/src/components/product-detail/product-detail-header.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-header.tsx
@@ -52,7 +52,7 @@ export function ProductDetailHeader({
           <CalendarPlus className="h-4 w-4" />
           {productMessages.addBooking}
         </Button>
-        <ActionMenu>
+        <ActionMenu label={`${productMessages.pageTitle}: ${product.name}`}>
           <DropdownMenuItem disabled={isDuplicating} onClick={onDuplicate}>
             <Copy className="h-4 w-4" />
             {productMessages.duplicate}

--- a/packages/inventory-react/src/components/product-detail/product-detail-itinerary-section.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-itinerary-section.tsx
@@ -164,7 +164,7 @@ export function ProductDetailItinerarySection({ productId }: { productId: string
               <Plus className="mr-2 h-4 w-4" />
               {productMessages.addDay}
             </Button>
-            <ActionMenu>
+            <ActionMenu label={productMessages.itineraryOptionsLabel}>
               <DropdownMenuItem onClick={openCreateItinerary}>
                 <Plus className="h-4 w-4" />
                 {productMessages.newItinerary}

--- a/packages/inventory-react/src/components/product-detail/product-detail-organize-section.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-organize-section.tsx
@@ -30,7 +30,7 @@ export function ProductOrganizeSection({
     <Section
       title={productMessages.organizeTitle}
       actions={
-        <ActionMenu>
+        <ActionMenu label={`${productMessages.organizeTitle}: ${productMessages.edit}`}>
           <DropdownMenuItem onClick={onEdit}>
             <Pencil className="h-4 w-4" />
             {productMessages.edit}

--- a/packages/inventory-react/src/components/product-detail/product-detail-section-shell.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-section-shell.tsx
@@ -40,12 +40,18 @@ export function DetailRow({ label, value }: { label: string; value: ReactNode })
   )
 }
 
-export function ActionMenu({ children }: { children: ReactNode }) {
+export function ActionMenu({ label, children }: { label: string; children: ReactNode }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground">
-          <MoreHorizontal className="h-4 w-4" />
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={label}
+          title={label}
+          className="h-8 w-8 text-muted-foreground"
+        >
+          <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">{children}</DropdownMenuContent>

--- a/packages/inventory-react/src/components/product-detail/product-detail-summary-section.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-summary-section.tsx
@@ -129,7 +129,7 @@ export function ProductDetailsSection({
               ))}
             </ToggleGroup>
           ) : null}
-          <ActionMenu>
+          <ActionMenu label={`${productMessages.detailsTitle}: ${productMessages.edit}`}>
             <DropdownMenuItem onClick={onEdit}>
               <Pencil className="h-4 w-4" />
               {productMessages.edit}

--- a/packages/inventory-react/src/components/product-detail/product-options-pricing-panel.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-options-pricing-panel.tsx
@@ -45,12 +45,18 @@ function getRulePricingModeLabel(
   }
 }
 
-function ActionMenu({ children }: { children: React.ReactNode }) {
+function ActionMenu({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="icon" className="h-8 w-8 text-muted-foreground">
-          <MoreHorizontal className="h-4 w-4" />
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label={label}
+          title={label}
+          className="h-8 w-8 text-muted-foreground"
+        >
+          <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">{children}</DropdownMenuContent>

--- a/packages/inventory-react/src/components/product-detail/product-options-pricing-panel.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-options-pricing-panel.tsx
@@ -285,7 +285,9 @@ function PriceRuleCard({
             {rule.allPricingCategories && <span>{priceRuleMessages.allCategoriesLabel}</span>}
           </div>
         </div>
-        <ActionMenu>
+        <ActionMenu
+          label={`${rule.name}: ${priceRuleMessages.editAction} / ${priceRuleMessages.deleteAction}`}
+        >
           <DropdownMenuItem onClick={onEdit}>
             <Pencil className="h-4 w-4" />
             {priceRuleMessages.editAction}

--- a/packages/inventory-react/src/components/product-detail/product-translation-popover.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-translation-popover.tsx
@@ -368,6 +368,10 @@ function LanguageChip({
   onRemove?: () => void
   removeLabel?: string
 }) {
+  const removeAccessibleLabel = removeLabel
+    ? `${removeLabel}: ${languageLabel(languageTag)}`
+    : languageLabel(languageTag)
+
   return (
     <div
       className={cn(
@@ -390,7 +394,8 @@ function LanguageChip({
         <button
           type="button"
           onClick={onRemove}
-          aria-label={removeLabel}
+          aria-label={removeAccessibleLabel}
+          title={removeAccessibleLabel}
           className="text-muted-foreground hover:text-destructive"
         >
           <X className="size-3" />
@@ -401,6 +406,7 @@ function LanguageChip({
 }
 
 export interface TranslatableFieldProps {
+  id: string
   label: string
   type: "text" | "richtext"
   field: TranslatableField
@@ -422,6 +428,7 @@ export interface TranslatableFieldProps {
  * informational indicator (green when the field has any non-default translation).
  */
 export function TranslatableField({
+  id,
   label,
   type,
   field,
@@ -450,15 +457,23 @@ export function TranslatableField({
   const translatedLanguages = translations.drafts
     .filter((draft) => draft.languageTag !== defaultLanguageTag && fieldHasContent(draft, field))
     .map((draft) => draft.languageTag)
+  const labelId = `${id}-label`
+  const errorId = `${id}-error`
 
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-center gap-1.5">
-        <Label>{label}</Label>
+        <Label id={labelId} htmlFor={id}>
+          {label}
+        </Label>
         <TranslationIndicator languages={translatedLanguages} messages={messages} />
       </div>
       {type === "richtext" ? (
         <RichTextEditor
+          id={id}
+          aria-labelledby={labelId}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
           value={value}
           onChange={handleChange}
           placeholder={placeholder}
@@ -466,13 +481,20 @@ export function TranslatableField({
         />
       ) : (
         <Input
+          id={id}
+          aria-invalid={error ? true : undefined}
+          aria-describedby={error ? errorId : undefined}
           value={value}
           onChange={(event) => handleChange(event.target.value)}
           placeholder={placeholder}
           autoFocus={autoFocus}
         />
       )}
-      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+      {error ? (
+        <p id={errorId} className="text-xs text-destructive">
+          {error}
+        </p>
+      ) : null}
     </div>
   )
 }
@@ -485,13 +507,21 @@ export function TranslationIndicator({
   messages: ProductCoreMessages
 }) {
   const isTranslated = translatedLanguages.length > 0
+  const indicatorLabel = isTranslated
+    ? `${messages.fieldTranslated}: ${translatedLanguages.map((tag) => tag.toUpperCase()).join(", ")}`
+    : messages.fieldNotTranslated
 
   return (
     <TooltipProvider delay={150}>
       <Tooltip>
         <TooltipTrigger
           render={
-            <button type="button" className="inline-flex cursor-help items-center">
+            <button
+              type="button"
+              aria-label={indicatorLabel}
+              title={indicatorLabel}
+              className="inline-flex cursor-help items-center"
+            >
               <Globe
                 className={cn(
                   "size-3.5",
@@ -501,25 +531,21 @@ export function TranslationIndicator({
             </button>
           }
         />
-        <TooltipContent>
-          {isTranslated
-            ? `${messages.fieldTranslated}: ${translatedLanguages
-                .map((tag) => tag.toUpperCase())
-                .join(", ")}`
-            : messages.fieldNotTranslated}
-        </TooltipContent>
+        <TooltipContent>{indicatorLabel}</TooltipContent>
       </Tooltip>
     </TooltipProvider>
   )
 }
 
 export function LanguageCombobox({
+  id,
   value,
   onValueChange,
   exclude = [],
   placeholder,
   emptyLabel,
 }: {
+  id?: string
   value: string
   onValueChange: (languageTag: string) => void
   exclude?: string[]
@@ -549,7 +575,12 @@ export function LanguageCombobox({
         return labelForCode(codeValue).toLowerCase().includes(needle) || codeValue.includes(needle)
       }}
     >
-      <ComboboxInput placeholder={placeholder} className="w-full" />
+      <ComboboxInput
+        id={id}
+        aria-label={id ? undefined : placeholder}
+        placeholder={placeholder}
+        className="w-full"
+      />
       <ComboboxContent>
         <ComboboxList>
           <ComboboxCollection>

--- a/packages/ui/src/components/phone-input.tsx
+++ b/packages/ui/src/components/phone-input.tsx
@@ -61,6 +61,7 @@ InputComponent.displayName = "InputComponent"
 type CountryEntry = { label: string; value: RPNInput.Country | undefined }
 
 type CountrySelectProps = {
+  "aria-label"?: string
   disabled?: boolean
   value: RPNInput.Country
   options: CountryEntry[]
@@ -68,6 +69,7 @@ type CountrySelectProps = {
 }
 
 const CountrySelect = ({
+  "aria-label": ariaLabel,
   disabled,
   value: selectedCountry,
   options: countryList,
@@ -92,18 +94,22 @@ const CountrySelect = ({
           <Button
             type="button"
             variant="outline"
+            aria-label={ariaLabel}
+            title={ariaLabel}
             className="flex gap-1 rounded-e-none rounded-s-lg border-r-0 px-3 focus:z-10"
           />
         }
       >
         <FlagComponent country={selectedCountry} countryName={selectedCountry} />
         <ChevronsUpDown
+          aria-hidden="true"
           className={cn("-mr-2 size-4 opacity-50", disabled ? "hidden" : "opacity-100")}
         />
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0">
         <Command>
           <CommandInput
+            aria-label="Search country"
             value={searchValue}
             onValueChange={(value) => {
               setSearchValue(value)
@@ -169,6 +175,7 @@ const CountrySelectOption = ({
       <span className="flex-1 text-sm">{countryName}</span>
       <span className="text-sm text-foreground/50">{`+${RPNInput.getCountryCallingCode(country)}`}</span>
       <CheckIcon
+        aria-hidden="true"
         className={`ml-auto size-4 ${country === selectedCountry ? "opacity-100" : "opacity-0"}`}
       />
     </CommandItem>

--- a/packages/ui/src/components/rich-text-editor.tsx
+++ b/packages/ui/src/components/rich-text-editor.tsx
@@ -24,6 +24,11 @@ import { RichTextVariable } from "./rich-text-variable-extension.js"
 export type RichTextEditorProps = {
   value: string
   onChange: (value: string) => void
+  id?: string
+  "aria-label"?: string
+  "aria-labelledby"?: string
+  "aria-describedby"?: string
+  "aria-invalid"?: React.AriaAttributes["aria-invalid"]
   placeholder?: string
   disabled?: boolean
   className?: string
@@ -132,6 +137,11 @@ function ToolbarButton({
 export function RichTextEditor({
   value,
   onChange,
+  id,
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledby,
+  "aria-describedby": ariaDescribedby,
+  "aria-invalid": ariaInvalid,
   placeholder = "Write something…",
   disabled = false,
   className,
@@ -177,6 +187,14 @@ export function RichTextEditor({
     extensions.push(RichTextVariable)
   }
 
+  const accessibilityAttributes = {
+    ...(id ? { id } : {}),
+    ...(ariaLabel ? { "aria-label": ariaLabel } : {}),
+    ...(ariaLabelledby ? { "aria-labelledby": ariaLabelledby } : {}),
+    ...(ariaDescribedby ? { "aria-describedby": ariaDescribedby } : {}),
+    ...(ariaInvalid !== undefined ? { "aria-invalid": String(ariaInvalid) } : {}),
+  }
+
   const editor = useEditor({
     immediatelyRender: false,
     editable: !disabled,
@@ -184,6 +202,9 @@ export function RichTextEditor({
     content: normalizeEditorContent(value),
     editorProps: {
       attributes: {
+        role: "textbox",
+        "aria-multiline": "true",
+        ...accessibilityAttributes,
         class:
           "ProseMirror min-h-48 px-3 py-3 text-sm outline-none [&_h2]:mt-6 [&_h2]:text-xl [&_h2]:font-semibold [&_h3]:mt-5 [&_h3]:text-lg [&_h3]:font-semibold [&_blockquote]:border-l-2 [&_blockquote]:border-border [&_blockquote]:pl-4 [&_blockquote]:text-muted-foreground [&_ol]:list-decimal [&_ol]:pl-6 [&_ul]:list-disc [&_ul]:pl-6 [&_li]:my-1 [&_p]:my-2",
       },

--- a/packages/ui/tests/form-control-accessibility.test.tsx
+++ b/packages/ui/tests/form-control-accessibility.test.tsx
@@ -1,0 +1,56 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+const editorState = vi.hoisted(() => ({
+  options: undefined as
+    | {
+        editorProps?: {
+          attributes?: Record<string, unknown>
+        }
+      }
+    | undefined,
+}))
+
+vi.mock("@tiptap/react", () => ({
+  EditorContent: () => null,
+  useEditor: (options: typeof editorState.options) => {
+    editorState.options = options
+    return null
+  },
+}))
+
+import { PhoneInput } from "../src/components/phone-input.js"
+import { RichTextEditor } from "../src/components/rich-text-editor.js"
+
+describe("form control accessibility", () => {
+  it("keeps the phone country helper and search control named", () => {
+    const html = renderToStaticMarkup(
+      <PhoneInput aria-label="Phone" defaultCountry="RO" onChange={() => undefined} value="" />,
+    )
+
+    expect(html).toContain('aria-label="Phone number country"')
+    expect(html).toContain('title="Phone number country"')
+  })
+
+  it("forwards rich-text labeling and validation metadata to the editable element", () => {
+    renderToStaticMarkup(
+      <RichTextEditor
+        id="product-description"
+        aria-labelledby="product-description-label"
+        aria-describedby="product-description-error"
+        aria-invalid="true"
+        value=""
+        onChange={() => undefined}
+      />,
+    )
+
+    expect(editorState.options?.editorProps?.attributes).toMatchObject({
+      id: "product-description",
+      role: "textbox",
+      "aria-labelledby": "product-description-label",
+      "aria-describedby": "product-description-error",
+      "aria-invalid": "true",
+      "aria-multiline": "true",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- associate visible labels and validation errors with the channel and product controls
- expose accessible names for phone-country, rich-text, translation, tag, channel, and action helpers
- add focused accessibility regressions for UI, Distribution, and Inventory

## Verification
- `@voyant-travel/ui`: 21 tests passed
- `@voyant-travel/distribution-react`: 36 tests passed
- `@voyant-travel/inventory-react`: 44 tests passed
- package lint passed; broad checks are delegated to CI because local consumer typechecks exceeded the workstation memory budget

Closes #3346