### PR TITLE
Unblock manifest convergence release

### DIFF
--- a/.changeset/unified-first-party-manifests.md
+++ b/.changeset/unified-first-party-manifests.md
@@ -50,7 +50,6 @@
 "@voyant-travel/trips": patch
 "@voyant-travel/trips-react": patch
 "@voyant-travel/types": patch
-"@voyant-travel/voyant-typescript-config": patch
 "@voyant-travel/workflow-runs": patch
 "@voyant-travel/workflows": patch
 "@voyant-travel/workflows-orchestrator": patch


### PR DESCRIPTION
## Summary
- remove the ignored TypeScript config package from the mixed publishable changeset
- allow the release planner to compute and publish the pending package versions

## Verification
- `node scripts/release-plan.cjs` completes and reports the expected pending publication plan

This unblocks packaged-starter CI, which currently cannot install `@voyant-travel/catalog@0.155.1`.