### PR TITLE
Fix public package dependency protocols

### DIFF
--- a/.changeset/safe-tools-zod-manifest.md
+++ b/.changeset/safe-tools-zod-manifest.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/tools": patch
+---
+
+Publish an external-consumer-safe Zod peer range instead of a workspace catalog protocol.

--- a/.changeset/safe-tools-zod-manifest.md
+++ b/.changeset/safe-tools-zod-manifest.md
@@ -1,5 +1,7 @@
 ---
 "@voyant-travel/tools": patch
+"@voyant-travel/bookings": patch
 ---
 
-Publish an external-consumer-safe Zod peer range instead of a workspace catalog protocol.
+Publish an external-consumer-safe Zod peer range and refresh Bookings so its public dependency
+range no longer selects the historical `@voyant-travel/tools@0.0.0` manifest.

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -29,13 +29,14 @@
     "clean": "rm -rf dist tsconfig.tsbuildinfo",
     "prepack": "pnpm run build"
   },
-  "dependencies": {
-    "zod": "catalog:"
-  },
   "devDependencies": {
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "typescript": "catalog:",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "^4.4.3"
   },
   "repository": {
     "type": "git",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4487,10 +4487,6 @@ importers:
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
 
   packages/tools:
-    dependencies:
-      zod:
-        specifier: 'catalog:'
-        version: 4.4.3
     devDependencies:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
@@ -4501,6 +4497,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
 
   packages/trips:
     dependencies:

--- a/scripts/lib/packed-manifest.mjs
+++ b/scripts/lib/packed-manifest.mjs
@@ -1,0 +1,28 @@
+const dependencyFields = [
+  "dependencies",
+  "peerDependencies",
+  "optionalDependencies",
+  "devDependencies",
+]
+
+const internalProtocols = ["catalog:", "workspace:"]
+
+export function collectPackedManifestProtocolDependencies(pkg) {
+  const problems = []
+
+  for (const field of dependencyFields) {
+    const dependencies = pkg[field]
+    if (!dependencies || typeof dependencies !== "object") continue
+
+    for (const [name, version] of Object.entries(dependencies)) {
+      if (
+        typeof version === "string" &&
+        internalProtocols.some((protocol) => version.startsWith(protocol))
+      ) {
+        problems.push(`${field}.${name}=${version}`)
+      }
+    }
+  }
+
+  return problems
+}

--- a/scripts/tests/packed-exports.test.mjs
+++ b/scripts/tests/packed-exports.test.mjs
@@ -5,6 +5,7 @@ import path from "node:path"
 import { afterEach, test } from "node:test"
 
 import { packedFileExportsName } from "../lib/packed-exports.mjs"
+import { collectPackedManifestProtocolDependencies } from "../lib/packed-manifest.mjs"
 
 const temporaryDirectories = []
 
@@ -48,6 +49,31 @@ test("uses the exported alias rather than the local name", () => {
 
   assert.equal(packedFileExportsName(root, "dist/index.js", "defineWorkflow"), true)
   assert.equal(packedFileExportsName(root, "dist/index.js", "internal"), false)
+})
+
+test("rejects package-manager protocols from packed manifest dependencies", () => {
+  const manifest = {
+    dependencies: { zod: "catalog:" },
+    peerDependencies: { react: "^19.0.0" },
+    optionalDependencies: { internal: "workspace:^" },
+    devDependencies: { typescript: "catalog:build" },
+  }
+
+  assert.deepEqual(collectPackedManifestProtocolDependencies(manifest), [
+    "dependencies.zod=catalog:",
+    "optionalDependencies.internal=workspace:^",
+    "devDependencies.typescript=catalog:build",
+  ])
+})
+
+test("accepts external-consumer dependency ranges in packed manifests", () => {
+  const manifest = {
+    dependencies: { zod: "^4.4.3" },
+    peerDependencies: { react: ">=18" },
+    optionalDependencies: { sharp: "npm:@img/sharp@^0.34.0" },
+  }
+
+  assert.deepEqual(collectPackedManifestProtocolDependencies(manifest), [])
 })
 
 function createFixture(files) {

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -23,6 +23,7 @@ import path from "node:path"
 import { promisify } from "node:util"
 
 import { packedFileExportsName } from "./lib/packed-exports.mjs"
+import { collectPackedManifestProtocolDependencies } from "./lib/packed-manifest.mjs"
 import { collectPackedSourceMapProblems } from "./lib/packed-sourcemaps.mjs"
 
 const execFileAsync = promisify(execFile)
@@ -380,29 +381,6 @@ function collectPackedExportProblems(extractRoot, packageName) {
   return problems
 }
 
-function collectWorkspaceProtocolDependencies(pkg) {
-  const problems = []
-  const dependencyFields = [
-    "dependencies",
-    "peerDependencies",
-    "optionalDependencies",
-    "devDependencies",
-  ]
-
-  for (const field of dependencyFields) {
-    const dependencies = pkg[field]
-    if (!dependencies || typeof dependencies !== "object") continue
-
-    for (const [name, version] of Object.entries(dependencies)) {
-      if (typeof version === "string" && version.startsWith("workspace:")) {
-        problems.push(`${field}.${name}=${version}`)
-      }
-    }
-  }
-
-  return problems
-}
-
 function getPublishedTargets(pkg) {
   const targets = new Set()
   const publishedMain = pkg.publishConfig?.main ?? pkg.main
@@ -534,10 +512,10 @@ function collectTarballProblems(
     problems.push(`missing packed exports: ${missingPackedExports.join("; ")}`)
   }
   problems.push(...packedSourceMapProblems)
-  const workspaceProtocolDependencies = collectWorkspaceProtocolDependencies(packedManifest)
-  if (workspaceProtocolDependencies.length > 0) {
+  const internalProtocolDependencies = collectPackedManifestProtocolDependencies(packedManifest)
+  if (internalProtocolDependencies.length > 0) {
     problems.push(
-      `packed manifest contains workspace protocol dependencies: ${workspaceProtocolDependencies.join(
+      `packed manifest contains package-manager protocol dependencies: ${internalProtocolDependencies.join(
         ", ",
       )}`,
     )


### PR DESCRIPTION
## Summary
- publish `@voyant-travel/tools` with an external Zod peer range
- refresh Bookings so its public dependency range moves off historical `@voyant-travel/tools@0.0.0`
- reject `catalog:` and `workspace:` protocols in packed public manifests
- cover the manifest guard with regression tests

## Verification
- packed-manifest tests
- tools tests and typecheck
- filtered publish-tarball verification
- dependency-version policy and frozen filtered install
- external tarball install/import

This unblocks external installation of the released framework dependency chain used by the self-host export CLI.