### PR TITLE
Add organization and member navigation preferences

### DIFF
--- a/.changeset/atomic-generated-routes.md
+++ b/.changeset/atomic-generated-routes.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/vite-config": patch
+---
+
+Reconcile generated route files atomically so concurrent build, test, and architecture checks can
+share one workspace without deleting routes while another process scans them.

--- a/.changeset/calm-maps-navigate.md
+++ b/.changeset/calm-maps-navigate.md
@@ -1,5 +1,7 @@
 ---
 "@voyant-travel/admin": minor
+"@voyant-travel/admin-app": patch
+"@voyant-travel/admin-host": patch
 "@voyant-travel/core": minor
 "@voyant-travel/framework": minor
 "@voyant-travel/hono": minor
@@ -9,6 +11,7 @@
 ---
 
 Add organization defaults and member overrides for stable admin navigation IDs. Apply visibility
-after selected navigation composition without exposing ineligible routes, retain hidden parents as
-structural containers, and ship the persistence, admin API, provisioning seam, and settings UI in
-standard Operator deployments.
+after selected navigation composition without exposing ineligible routes, inherit hidden parent
+state through navigation subtrees, and retain structural parents only when a child is explicitly
+re-enabled. Ship the persistence, admin API, provisioning seam, and settings UI in standard Operator
+deployments, with duplicate settings contributions normalized at the host and core boundaries.

--- a/.changeset/calm-maps-navigate.md
+++ b/.changeset/calm-maps-navigate.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/admin": minor
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/hono": minor
+"@voyant-travel/navigation-preferences": minor
+"@voyant-travel/navigation-preferences-react": minor
+"@voyant-travel/operator-standard": minor
+---
+
+Add organization defaults and member overrides for stable admin navigation IDs. Apply visibility
+after selected navigation composition without exposing ineligible routes, retain hidden parents as
+structural containers, and ship the persistence, admin API, provisioning seam, and settings UI in
+standard Operator deployments.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -15,6 +15,7 @@
     ["@voyant-travel/identity", "@voyant-travel/identity-react"],
     ["@voyant-travel/legal", "@voyant-travel/legal-react"],
     ["@voyant-travel/notifications", "@voyant-travel/notifications-react"],
+    ["@voyant-travel/navigation-preferences", "@voyant-travel/navigation-preferences-react"],
     [
       "@voyant-travel/storefront",
       "@voyant-travel/storefront-react",

--- a/docs/architecture/api-route-authoring.md
+++ b/docs/architecture/api-route-authoring.md
@@ -43,6 +43,13 @@ Rule:
 Every new package route should declare whether it belongs to the admin or
 public surface.
 
+Selected graph route bundles use coarse method-and-resource authorization by
+default. A bundle may declare `authorization: "route"` only when one mount
+intentionally mixes authorization rules that the coarse guard cannot express,
+such as organization-admin writes and current-member self-service. Surface
+authentication still applies, and every handler in that bundle must enforce
+its own capability or identity rule.
+
 ### Application-local route files
 
 Applications may author deployment-local API routes in these directories:

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -95,6 +95,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1188,6 +1189,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -96,6 +96,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1189,6 +1190,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/admin-app/src/core-extension/index.tsx
+++ b/packages/admin-app/src/core-extension/index.tsx
@@ -168,7 +168,8 @@ export function createAdminCoreExtension(
 }
 
 function createSettingsContribution(options: AdminCoreSettingsOptions): AdminUiRouteContribution {
-  const { basePath = "/settings", omit = [], extraPages = [] } = options
+  const { basePath = "/settings", omit = [] } = options
+  const extraPages = uniqueExtraSettingsPages(options.extraPages ?? [])
   const entries = adminCoreSettingsNavEntries.filter((entry) => !omit.includes(entry.id))
   const indexRedirectTo =
     options.indexRedirectTo ??
@@ -217,6 +218,17 @@ function createSettingsContribution(options: AdminCoreSettingsOptions): AdminUiR
     },
     children,
   }
+}
+
+function uniqueExtraSettingsPages(
+  pages: ReadonlyArray<AdminCoreSettingsExtraPage>,
+): ReadonlyArray<AdminCoreSettingsExtraPage> {
+  const unique = new Map<string, AdminCoreSettingsExtraPage>()
+  for (const page of pages) {
+    const key = `${page.id}\0${page.path}`
+    if (!unique.has(key)) unique.set(key, page)
+  }
+  return [...unique.values()]
 }
 
 function createBuiltInSettingsPage(

--- a/packages/admin-app/tests/admin-app.test.ts
+++ b/packages/admin-app/tests/admin-app.test.ts
@@ -119,7 +119,9 @@ describe("createAdminCoreExtension", async () => {
   it("composes exactly one final team settings route", () => {
     const authTeam = createSelectedAuthTeamAdminExtension()
     const core = createAdminCoreExtensionShim({
-      settings: { extraPages: authTeam.settingsPages },
+      settings: {
+        extraPages: [...(authTeam.settingsPages ?? []), ...(authTeam.settingsPages ?? [])],
+      },
     })
     const rootRoute = createRootRoute()
     const finalRoutes = buildAdminExtensionRoutes([core, authTeam], () => rootRoute, {

--- a/packages/admin-host/src/admin-presentation.ts
+++ b/packages/admin-host/src/admin-presentation.ts
@@ -52,9 +52,22 @@ export function createAdminHostExtensions({
   discovered = [],
 }: CreateAdminHostExtensionsOptions): ReadonlyArray<AdminExtension> {
   const selectedExtensions = uniqueExtensionsById(selected({ navMessages }))
-  const settingsPages = selectedExtensions.flatMap((extension) => extension.settingsPages ?? [])
+  const settingsPages = uniqueSettingsPages(
+    selectedExtensions.flatMap((extension) => extension.settingsPages ?? []),
+  )
 
   return createAdminExtensionRegistry(core(settingsPages), ...selectedExtensions, ...discovered)
+}
+
+function uniqueSettingsPages(
+  pages: ReadonlyArray<AdminSettingsPageContribution>,
+): ReadonlyArray<AdminSettingsPageContribution> {
+  const unique = new Map<string, AdminSettingsPageContribution>()
+  for (const page of pages) {
+    const key = `${page.id}\0${page.path}`
+    if (!unique.has(key)) unique.set(key, page)
+  }
+  return [...unique.values()]
 }
 
 function uniqueExtensionsById(

--- a/packages/admin-host/tests/admin-presentation.test.ts
+++ b/packages/admin-host/tests/admin-presentation.test.ts
@@ -16,6 +16,10 @@ describe("createAdminHostExtensions", () => {
         },
       ],
     })
+    const duplicateTeamContribution = defineAdminExtension({
+      id: "deployment-team",
+      settingsPages: team.settingsPages,
+    })
     let settingsPageIds: ReadonlyArray<string> = []
 
     const extensions = createAdminHostExtensions({
@@ -23,11 +27,11 @@ describe("createAdminHostExtensions", () => {
         settingsPageIds = settingsPages.map(({ id }) => id)
         return defineAdminExtension({ id: "core" })
       },
-      selected: () => [team, team],
+      selected: () => [team, duplicateTeamContribution, team],
       navMessages: {},
     })
 
     expect(settingsPageIds).toEqual(["team"])
-    expect(extensions.map(({ id }) => id)).toEqual(["core", "auth-team"])
+    expect(extensions.map(({ id }) => id)).toEqual(["core", "auth-team", "deployment-team"])
   })
 })

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -27,6 +27,7 @@
     "./extensions": "./src/extensions.ts",
     "./navigation/destinations": "./src/navigation/destinations.tsx",
     "./navigation/operator-navigation": "./src/navigation/operator-navigation.ts",
+    "./navigation/preferences": "./src/navigation/preferences.ts",
     "./providers/admin-extensions": "./src/providers/admin-extensions.tsx",
     "./providers/locale-preferences": "./src/providers/locale-preferences.tsx",
     "./providers/operator-admin-shell": "./src/providers/operator-admin-shell.tsx",
@@ -191,6 +192,11 @@
         "types": "./dist/navigation/operator-navigation.d.ts",
         "import": "./dist/navigation/operator-navigation.js",
         "default": "./dist/navigation/operator-navigation.js"
+      },
+      "./navigation/preferences": {
+        "types": "./dist/navigation/preferences.d.ts",
+        "import": "./dist/navigation/preferences.js",
+        "default": "./dist/navigation/preferences.js"
       },
       "./providers/admin-extensions": {
         "types": "./dist/providers/admin-extensions.d.ts",

--- a/packages/admin/src/app/extension-routes.tsx
+++ b/packages/admin/src/app/extension-routes.tsx
@@ -242,19 +242,19 @@ export function adminExtensionChildRoutes(
   }
   const exclude = new Set(options.exclude ?? [])
 
-  return (parent.children ?? [])
-    .filter((child) => !exclude.has(child.path))
-    .map((child) => {
-      const options = {
-        getParentRoute,
-        path: child.path,
-        validateSearch: child.validateSearch,
-        ...adminRouteOptionsFromContribution(requireChildImplementation(extension, child), runtime),
-      }
-      // Runtime-built routes carry no typed-link contract (they are invisible
-      // to the host's generated typed-link maps), so the loose cast is sound.
-      return createRoute(options)
-    })
+  return uniqueContributionsByPath(
+    (parent.children ?? []).filter((child) => !exclude.has(child.path)),
+  ).map((child) => {
+    const options = {
+      getParentRoute,
+      path: child.path,
+      validateSearch: child.validateSearch,
+      ...adminRouteOptionsFromContribution(requireChildImplementation(extension, child), runtime),
+    }
+    // Runtime-built routes carry no typed-link contract (they are invisible
+    // to the host's generated typed-link maps), so the loose cast is sound.
+    return createRoute(options)
+  })
 }
 
 function requireChildImplementation(
@@ -310,7 +310,7 @@ export function buildAdminExtensionRoutes(
       routes.push(route)
     }
   }
-  return routes
+  return uniqueRoutesByPath(routes)
 }
 
 /**
@@ -373,16 +373,36 @@ export function attachAdminExtensionRoutes<TRouteTree extends AnyRoute>(
   parentRoute: AnyRoute,
   extensionRoutes: ReadonlyArray<AnyRoute>,
 ): TRouteTree {
+  const uniqueExtensionRoutes = uniqueRoutesByPath(extensionRoutes)
   const existing: Array<AnyRoute> = Array.isArray(parentRoute.children)
     ? (parentRoute.children as Array<AnyRoute>)
     : []
   const extensionPaths = new Set(
-    extensionRoutes.map((route) => (route.options as { path?: string }).path),
+    uniqueExtensionRoutes.map((route) => (route.options as { path?: string }).path),
   )
   const children = [
     ...existing.filter((route) => !extensionPaths.has((route.options as { path?: string }).path)),
-    ...extensionRoutes,
+    ...uniqueExtensionRoutes,
   ]
   parentRoute.addChildren(children)
   return routeTree
+}
+
+function uniqueContributionsByPath(
+  contributions: ReadonlyArray<AdminUiRouteContribution>,
+): ReadonlyArray<AdminUiRouteContribution> {
+  const unique = new Map<string, AdminUiRouteContribution>()
+  for (const contribution of contributions) unique.set(contribution.path, contribution)
+  return [...unique.values()]
+}
+
+function uniqueRoutesByPath(routes: ReadonlyArray<AnyRoute>): Array<AnyRoute> {
+  const unique = new Map<string, AnyRoute>()
+  const unkeyed: AnyRoute[] = []
+  for (const route of routes) {
+    const path = (route.options as { path?: string }).path
+    if (typeof path === "string") unique.set(path, route)
+    else unkeyed.push(route)
+  }
+  return [...unkeyed, ...unique.values()]
 }

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -14,10 +14,9 @@ import {
   AdminNavigationProvider,
 } from "../navigation/destinations.js"
 import type { OperatorAdminNavigationIcons } from "../navigation/operator-navigation.js"
-import {
-  type AdminNavigationPreferencesContribution,
-  AdminNavigationPreferencesMemberProvider,
-  type AdminNavigationPreferencesSnapshot,
+import type {
+  AdminNavigationPreferencesContribution,
+  AdminNavigationPreferencesSnapshot,
 } from "../navigation/preferences.js"
 import { AdminLocalePreferenceSync } from "../providers/locale-preferences.js"
 import {
@@ -377,9 +376,5 @@ function SelectedNavigationPreferences({
     queryFn: () => contribution.load(api),
   })
 
-  return (
-    <AdminNavigationPreferencesMemberProvider memberKey={memberKey}>
-      {children(query.data)}
-    </AdminNavigationPreferencesMemberProvider>
-  )
+  return children(query.data)
 }

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -14,6 +14,11 @@ import {
   AdminNavigationProvider,
 } from "../navigation/destinations.js"
 import type { OperatorAdminNavigationIcons } from "../navigation/operator-navigation.js"
+import {
+  type AdminNavigationPreferencesContribution,
+  AdminNavigationPreferencesMemberProvider,
+  type AdminNavigationPreferencesSnapshot,
+} from "../navigation/preferences.js"
 import { AdminLocalePreferenceSync } from "../providers/locale-preferences.js"
 import {
   getOperatorAdminMessageOverridesFromUiPrefs,
@@ -127,6 +132,7 @@ export function AdminWorkspacePendingFallback({ label }: { label?: string }) {
 
 /** Structural slice of the loaded user the shell itself needs. */
 export interface AdminWorkspaceShellUser {
+  id?: string | null
   firstName?: string | null
   lastName?: string | null
   email?: string | null
@@ -259,7 +265,6 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
   children: ReactNode
 }) {
   const router = useRouter()
-  const api = useVoyantReactContext()
   const currentPath = useRouterState({ select: (s) => s.location.pathname })
   const messages = useOperatorAdminMessages()
   const resolvedExtensions = useMemo(
@@ -272,14 +277,6 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
         ?.navigationPreferences,
     [resolvedExtensions],
   )
-  const navigationPreferencesQuery = useQuery({
-    queryKey: navigationPreferencesContribution?.queryKey ?? [
-      "admin-navigation-preferences",
-      "disabled",
-    ],
-    queryFn: () => navigationPreferencesContribution!.load(api),
-    enabled: navigationPreferencesContribution !== undefined,
-  })
   const hasHeaderActionWidgets = useMemo(
     () =>
       resolveAdminWidgets({
@@ -301,41 +298,88 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
     [router],
   )
 
-  const layout = (
-    <OperatorAdminWorkspaceLayout
-      currentPath={currentPath}
-      extensions={resolvedExtensions}
-      headerSlot={headerSlot}
-      headerSlotRight={
-        hasHeaderSlotRight || hasHeaderActionWidgets ? (
-          <>
-            {headerSlotRight}
-            {hasHeaderActionWidgets ? (
-              <AdminWidgetSlotRenderer
-                extensions={resolvedExtensions}
-                slot={adminWorkspaceHeaderActionsSlot}
-              />
-            ) : null}
-          </>
-        ) : undefined
-      }
-      icons={icons}
-      linkComponent={linkComponent}
-      navigationPreferences={navigationPreferencesQuery.data}
-      onSignOut={onSignOut}
-      user={mapUser(user)}
+  return (
+    <OptionalNavigationPreferences
+      contribution={navigationPreferencesContribution}
+      memberKey={user.id ?? user.email ?? "unknown-member"}
     >
-      {children}
-    </OperatorAdminWorkspaceLayout>
-  )
+      {(navigationPreferences) => {
+        const layout = (
+          <OperatorAdminWorkspaceLayout
+            currentPath={currentPath}
+            extensions={resolvedExtensions}
+            headerSlot={headerSlot}
+            headerSlotRight={
+              hasHeaderSlotRight || hasHeaderActionWidgets ? (
+                <>
+                  {headerSlotRight}
+                  {hasHeaderActionWidgets ? (
+                    <AdminWidgetSlotRenderer
+                      extensions={resolvedExtensions}
+                      slot={adminWorkspaceHeaderActionsSlot}
+                    />
+                  ) : null}
+                </>
+              ) : undefined
+            }
+            icons={icons}
+            linkComponent={linkComponent}
+            navigationPreferences={navigationPreferences}
+            onSignOut={onSignOut}
+            user={mapUser(user)}
+          >
+            {children}
+          </OperatorAdminWorkspaceLayout>
+        )
 
-  if (!destinations) {
-    return layout
-  }
+        if (!destinations) return layout
+
+        return (
+          <AdminNavigationProvider resolvers={destinations} navigate={navigateToHref}>
+            {layout}
+          </AdminNavigationProvider>
+        )
+      }}
+    </OptionalNavigationPreferences>
+  )
+}
+
+function OptionalNavigationPreferences({
+  contribution,
+  memberKey,
+  children,
+}: {
+  contribution: AdminNavigationPreferencesContribution | undefined
+  memberKey: string
+  children: (preferences: AdminNavigationPreferencesSnapshot | undefined) => ReactNode
+}) {
+  if (!contribution) return children(undefined)
 
   return (
-    <AdminNavigationProvider resolvers={destinations} navigate={navigateToHref}>
-      {layout}
-    </AdminNavigationProvider>
+    <SelectedNavigationPreferences contribution={contribution} memberKey={memberKey}>
+      {children}
+    </SelectedNavigationPreferences>
+  )
+}
+
+function SelectedNavigationPreferences({
+  contribution,
+  memberKey,
+  children,
+}: {
+  contribution: AdminNavigationPreferencesContribution
+  memberKey: string
+  children: (preferences: AdminNavigationPreferencesSnapshot | undefined) => ReactNode
+}) {
+  const api = useVoyantReactContext()
+  const query = useQuery({
+    queryKey: contribution.queryKey(memberKey),
+    queryFn: () => contribution.load(api),
+  })
+
+  return (
+    <AdminNavigationPreferencesMemberProvider memberKey={memberKey}>
+      {children(query.data)}
+    </AdminNavigationPreferencesMemberProvider>
   )
 }

--- a/packages/admin/src/app/workspace.tsx
+++ b/packages/admin/src/app/workspace.tsx
@@ -1,4 +1,6 @@
+import { useQuery } from "@tanstack/react-query"
 import { Link, redirect, useRouter, useRouterState } from "@tanstack/react-router"
+import { useVoyantReactContext } from "@voyant-travel/react"
 import { Loader2 } from "lucide-react"
 import { forwardRef, type ReactNode, useCallback, useMemo } from "react"
 import type { AdminNavLinkComponent, AdminNavLinkProps } from "../components/admin-nav-link.js"
@@ -257,12 +259,27 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
   children: ReactNode
 }) {
   const router = useRouter()
+  const api = useVoyantReactContext()
   const currentPath = useRouterState({ select: (s) => s.location.pathname })
   const messages = useOperatorAdminMessages()
   const resolvedExtensions = useMemo(
     () => (typeof extensions === "function" ? extensions(messages) : extensions),
     [extensions, messages],
   )
+  const navigationPreferencesContribution = useMemo(
+    () =>
+      resolvedExtensions?.find((extension) => extension.navigationPreferences)
+        ?.navigationPreferences,
+    [resolvedExtensions],
+  )
+  const navigationPreferencesQuery = useQuery({
+    queryKey: navigationPreferencesContribution?.queryKey ?? [
+      "admin-navigation-preferences",
+      "disabled",
+    ],
+    queryFn: () => navigationPreferencesContribution!.load(api),
+    enabled: navigationPreferencesContribution !== undefined,
+  })
   const hasHeaderActionWidgets = useMemo(
     () =>
       resolveAdminWidgets({
@@ -304,6 +321,7 @@ function AdminWorkspaceShellInner<TUser extends AdminWorkspaceShellUser>({
       }
       icons={icons}
       linkComponent={linkComponent}
+      navigationPreferences={navigationPreferencesQuery.data}
       onSignOut={onSignOut}
       user={mapUser(user)}
     >

--- a/packages/admin/src/components/admin-nav-group.tsx
+++ b/packages/admin/src/components/admin-nav-group.tsx
@@ -81,31 +81,43 @@ export function AdminNavGroup({
       {label && <SidebarGroupLabel>{label}</SidebarGroupLabel>}
       <SidebarMenu>
         {items.map((item) => {
-          const key = item.id ?? item.url ?? item.title
+          const key = item.id
           const icon = item.icon ? React.createElement(item.icon, { className: "h-4 w-4" }) : null
 
           if (item.items?.length) {
             const parentActive = isActivePath(currentPath, item.url)
             const anyChildActive = item.items.some((sub) => isActivePath(currentPath, sub.url))
-            const expanded = parentActive || anyChildActive
+            const expanded = item.structural || parentActive || anyChildActive
 
             return (
               <SidebarMenuItem key={key}>
-                <SidebarMenuButton asChild tooltip={item.title} isActive={parentActive}>
-                  <LinkComponent
-                    href={item.url}
-                    onClick={handleLinkClick}
-                    target={item.target ?? "_self"}
-                  >
-                    {icon}
-                    <span>{item.title}</span>
-                    {renderBadge(item.status)}
-                  </LinkComponent>
+                <SidebarMenuButton
+                  asChild={!item.structural}
+                  tooltip={item.title}
+                  isActive={!item.structural && parentActive}
+                >
+                  {item.structural ? (
+                    <span>
+                      {icon}
+                      <span>{item.title}</span>
+                      {renderBadge(item.status)}
+                    </span>
+                  ) : (
+                    <LinkComponent
+                      href={item.url}
+                      onClick={handleLinkClick}
+                      target={item.target ?? "_self"}
+                    >
+                      {icon}
+                      <span>{item.title}</span>
+                      {renderBadge(item.status)}
+                    </LinkComponent>
+                  )}
                 </SidebarMenuButton>
                 {expanded && (
                   <SidebarMenuSub>
                     {item.items.map((subItem) => (
-                      <SidebarMenuSubItem key={subItem.id ?? subItem.url ?? subItem.title}>
+                      <SidebarMenuSubItem key={subItem.id}>
                         {subItem.status === COMING_SOON ? (
                           <SidebarMenuSubButton
                             className={cn(subItem.status === COMING_SOON && "opacity-50")}

--- a/packages/admin/src/components/operator-admin-sidebar.tsx
+++ b/packages/admin/src/components/operator-admin-sidebar.tsx
@@ -23,6 +23,7 @@ import {
   type OperatorAdminNavigationIcons,
   resolveOperatorAdminNavigation,
 } from "../navigation/operator-navigation.js"
+import type { AdminNavigationPreferences } from "../navigation/preferences.js"
 import { AdminExtensionsProvider } from "../providers/admin-extensions.js"
 import { useOperatorAdminMessages } from "../providers/operator-admin-messages.js"
 import type { AdminUser, NavItem, NavSubItem } from "../types.js"
@@ -47,6 +48,7 @@ export interface OperatorAdminSidebarProps
   icons?: OperatorAdminNavigationIcons
   linkComponent?: AdminNavLinkComponent
   navItems?: ReadonlyArray<NavItem>
+  navigationPreferences?: AdminNavigationPreferences
   onSignOut?: () => void | Promise<void>
   user?: AdminUser | null
 }
@@ -92,6 +94,7 @@ export function OperatorAdminSidebar({
   icons,
   linkComponent,
   navItems,
+  navigationPreferences,
   onSignOut,
   user,
   variant = "inset",
@@ -99,7 +102,11 @@ export function OperatorAdminSidebar({
 }: OperatorAdminSidebarProps) {
   const messages = useOperatorAdminMessages()
   const baseItems = navItems ?? createOperatorAdminNavigation({ icons, messages: messages.nav })
-  const resolvedItems = resolveOperatorAdminNavigation({ baseItems, extensions })
+  const resolvedItems = resolveOperatorAdminNavigation({
+    baseItems,
+    extensions,
+    preferences: navigationPreferences,
+  })
   const resolvedBrand = brand ?? <DefaultOperatorAdminBrand linkComponent={linkComponent} />
   const LinkComponent = linkComponent ?? DefaultAdminNavLink
   const SettingsIcon = icons?.settings ?? DefaultSettingsIcon
@@ -160,6 +167,7 @@ export interface OperatorAdminWorkspaceLayoutProps {
   linkComponent?: AdminNavLinkComponent
   mainClassName?: string
   navItems?: ReadonlyArray<NavItem>
+  navigationPreferences?: AdminNavigationPreferences
   onSignOut?: () => void | Promise<void>
   pageHead?: (AdminPageHeadOptions & { titleOverride?: string | null }) | false
   side?: React.ComponentProps<typeof Sidebar>["side"]
@@ -227,6 +235,7 @@ export function OperatorAdminWorkspaceLayout({
   linkComponent,
   mainClassName = "flex-1",
   navItems,
+  navigationPreferences,
   onSignOut,
   pageHead,
   side,
@@ -247,6 +256,7 @@ export function OperatorAdminWorkspaceLayout({
   const resolvedItems = resolveOperatorAdminNavigation({
     baseItems,
     extensions: sidebarExtensions ?? extensions,
+    preferences: navigationPreferences,
   })
   const resolvedSide = sidebarSide ?? side
   let pageTitle: string | null = null

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -2,6 +2,7 @@ import type { QueryClient } from "@tanstack/react-query"
 import type * as React from "react"
 
 import type { AdminDestinationKey, AdminDestinations } from "./navigation/destinations.js"
+import type { AdminNavigationPreferencesContribution } from "./navigation/preferences.js"
 import type { OperatorAdminMessages } from "./providers/operator-admin-messages.js"
 import type { NavItem } from "./types.js"
 
@@ -255,6 +256,8 @@ export const adminWorkspaceHeaderActionsSlot = "workspace.header.actions" satisf
 export interface AdminExtension {
   id: string
   navigation?: ReadonlyArray<AdminNavigationContribution>
+  /** Final navigation-visibility source, evaluated after selected contributions merge. */
+  navigationPreferences?: AdminNavigationPreferencesContribution
   routes?: ReadonlyArray<AdminUiRouteContribution>
   settingsPages?: ReadonlyArray<AdminSettingsPageContribution>
   widgets?: ReadonlyArray<AnyAdminWidgetContribution>

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -190,12 +190,10 @@ export {
   type AdminNavigationPreferences,
   type AdminNavigationPreferencesClient,
   type AdminNavigationPreferencesContribution,
-  AdminNavigationPreferencesMemberProvider,
   type AdminNavigationPreferencesSnapshot,
   type AdminNavigationVisibilityMap,
   type ResolveAdminNavigationPreferencesOptions,
   resolveAdminNavigationPreferences,
-  useAdminNavigationPreferencesMemberKey,
 } from "./navigation/preferences.js"
 export {
   AdminExtensionsProvider,

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -187,6 +187,15 @@ export {
   type OperatorAdminNavigationIcons,
 } from "./navigation/operator-navigation.js"
 export {
+  type AdminNavigationPreferences,
+  type AdminNavigationPreferencesClient,
+  type AdminNavigationPreferencesContribution,
+  type AdminNavigationPreferencesSnapshot,
+  type AdminNavigationVisibilityMap,
+  type ResolveAdminNavigationPreferencesOptions,
+  resolveAdminNavigationPreferences,
+} from "./navigation/preferences.js"
+export {
   AdminExtensionsProvider,
   type AdminExtensionsProviderProps,
   useAdminExtensions,

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -190,10 +190,12 @@ export {
   type AdminNavigationPreferences,
   type AdminNavigationPreferencesClient,
   type AdminNavigationPreferencesContribution,
+  AdminNavigationPreferencesMemberProvider,
   type AdminNavigationPreferencesSnapshot,
   type AdminNavigationVisibilityMap,
   type ResolveAdminNavigationPreferencesOptions,
   resolveAdminNavigationPreferences,
+  useAdminNavigationPreferencesMemberKey,
 } from "./navigation/preferences.js"
 export {
   AdminExtensionsProvider,

--- a/packages/admin/src/navigation/operator-navigation.ts
+++ b/packages/admin/src/navigation/operator-navigation.ts
@@ -18,6 +18,10 @@ import {
 import { type AdminExtension, resolveAdminNavigation } from "../extensions.js"
 import type { OperatorAdminMessages } from "../providers/operator-admin-messages.js"
 import type { NavItem } from "../types.js"
+import {
+  type AdminNavigationPreferences,
+  resolveAdminNavigationPreferences,
+} from "./preferences.js"
 
 export type OperatorAdminNavigationIconName =
   | "availability"
@@ -85,6 +89,7 @@ export function createOperatorAdminNavigation({
 export interface ResolveOperatorAdminNavigationOptions {
   baseItems: ReadonlyArray<NavItem>
   extensions?: ReadonlyArray<AdminExtension>
+  preferences?: AdminNavigationPreferences
 }
 
 /**
@@ -95,6 +100,7 @@ export interface ResolveOperatorAdminNavigationOptions {
 export function resolveOperatorAdminNavigation({
   baseItems,
   extensions = [],
+  preferences,
 }: ResolveOperatorAdminNavigationOptions): NavItem[] {
   const selectContributions = (anchored: boolean): AdminExtension[] =>
     extensions.flatMap((extension) => {
@@ -110,8 +116,12 @@ export function resolveOperatorAdminNavigation({
     extensions: selectContributions(false),
   })
 
-  return resolveAdminNavigation({
+  const mergedItems = resolveAdminNavigation({
     baseItems: packageItems,
     extensions: selectContributions(true),
   })
+
+  return preferences
+    ? resolveAdminNavigationPreferences({ items: mergedItems, ...preferences })
+    : mergedItems
 }

--- a/packages/admin/src/navigation/preferences.ts
+++ b/packages/admin/src/navigation/preferences.ts
@@ -72,10 +72,10 @@ function resolveItem(
   organization: AdminNavigationVisibilityMap,
   member: AdminNavigationVisibilityMap,
 ): NavItem[] {
+  const visible = resolveVisibility(item.id, organization, member, true)
   const children = item.items?.flatMap((child) =>
-    isVisible(child.id, organization, member) ? [child] : [],
+    resolveVisibility(child.id, organization, member, visible) ? [child] : [],
   )
-  const visible = isVisible(item.id, organization, member)
 
   if (!visible && !children?.length) return []
 
@@ -88,12 +88,13 @@ function resolveItem(
   ]
 }
 
-function isVisible(
+function resolveVisibility(
   id: NavItem["id"] | NavSubItem["id"],
   organization: AdminNavigationVisibilityMap,
   member: AdminNavigationVisibilityMap,
+  inherited: boolean,
 ): boolean {
   if (Object.hasOwn(member, id)) return member[id] !== false
   if (Object.hasOwn(organization, id)) return organization[id] !== false
-  return true
+  return inherited
 }

--- a/packages/admin/src/navigation/preferences.ts
+++ b/packages/admin/src/navigation/preferences.ts
@@ -1,5 +1,3 @@
-import { createContext, createElement, type ReactNode, useContext } from "react"
-
 import type { NavItem, NavSubItem } from "../types.js"
 
 export type AdminNavigationVisibilityMap = Readonly<Record<string, boolean>>
@@ -22,32 +20,6 @@ export interface AdminNavigationPreferencesClient {
 export interface AdminNavigationPreferencesContribution {
   queryKey: (memberKey: string) => ReadonlyArray<unknown>
   load: (client: AdminNavigationPreferencesClient) => Promise<AdminNavigationPreferencesSnapshot>
-}
-
-const AdminNavigationPreferencesMemberContext = createContext<string | null>(null)
-
-export function AdminNavigationPreferencesMemberProvider({
-  memberKey,
-  children,
-}: {
-  memberKey: string
-  children: ReactNode
-}) {
-  return createElement(
-    AdminNavigationPreferencesMemberContext.Provider,
-    { value: memberKey },
-    children,
-  )
-}
-
-export function useAdminNavigationPreferencesMemberKey(): string {
-  const memberKey = useContext(AdminNavigationPreferencesMemberContext)
-  if (memberKey === null) {
-    throw new Error(
-      "useAdminNavigationPreferencesMemberKey must be used inside AdminWorkspaceShell",
-    )
-  }
-  return memberKey
 }
 
 export interface ResolveAdminNavigationPreferencesOptions extends AdminNavigationPreferences {

--- a/packages/admin/src/navigation/preferences.ts
+++ b/packages/admin/src/navigation/preferences.ts
@@ -1,0 +1,71 @@
+import type { NavItem, NavSubItem } from "../types.js"
+
+export type AdminNavigationVisibilityMap = Readonly<Record<string, boolean>>
+
+export interface AdminNavigationPreferences {
+  organization: AdminNavigationVisibilityMap
+  member: AdminNavigationVisibilityMap
+}
+
+export interface AdminNavigationPreferencesSnapshot extends AdminNavigationPreferences {
+  effective: AdminNavigationVisibilityMap
+  canManageOrganization: boolean
+}
+
+export interface AdminNavigationPreferencesClient {
+  baseUrl: string
+  fetcher: (url: string, init?: RequestInit) => Promise<Response>
+}
+
+export interface AdminNavigationPreferencesContribution {
+  queryKey: ReadonlyArray<unknown>
+  load: (client: AdminNavigationPreferencesClient) => Promise<AdminNavigationPreferencesSnapshot>
+}
+
+export interface ResolveAdminNavigationPreferencesOptions extends AdminNavigationPreferences {
+  items: ReadonlyArray<NavItem>
+}
+
+/**
+ * Apply visibility only to the already-merged, already-eligible navigation.
+ * Preferences can therefore remove known items, but can never manufacture an
+ * item that graph selection or capability checks excluded.
+ */
+export function resolveAdminNavigationPreferences({
+  items,
+  organization,
+  member,
+}: ResolveAdminNavigationPreferencesOptions): NavItem[] {
+  return items.flatMap((item) => resolveItem(item, organization, member))
+}
+
+function resolveItem(
+  item: NavItem,
+  organization: AdminNavigationVisibilityMap,
+  member: AdminNavigationVisibilityMap,
+): NavItem[] {
+  const children = item.items?.flatMap((child) =>
+    isVisible(child.id, organization, member) ? [child] : [],
+  )
+  const visible = isVisible(item.id, organization, member)
+
+  if (!visible && !children?.length) return []
+
+  return [
+    {
+      ...item,
+      ...(item.items ? { items: children } : {}),
+      ...(!visible ? { structural: true } : {}),
+    },
+  ]
+}
+
+function isVisible(
+  id: NavItem["id"] | NavSubItem["id"],
+  organization: AdminNavigationVisibilityMap,
+  member: AdminNavigationVisibilityMap,
+): boolean {
+  if (Object.hasOwn(member, id)) return member[id] !== false
+  if (Object.hasOwn(organization, id)) return organization[id] !== false
+  return true
+}

--- a/packages/admin/src/navigation/preferences.ts
+++ b/packages/admin/src/navigation/preferences.ts
@@ -1,3 +1,5 @@
+import { createContext, createElement, type ReactNode, useContext } from "react"
+
 import type { NavItem, NavSubItem } from "../types.js"
 
 export type AdminNavigationVisibilityMap = Readonly<Record<string, boolean>>
@@ -18,8 +20,34 @@ export interface AdminNavigationPreferencesClient {
 }
 
 export interface AdminNavigationPreferencesContribution {
-  queryKey: ReadonlyArray<unknown>
+  queryKey: (memberKey: string) => ReadonlyArray<unknown>
   load: (client: AdminNavigationPreferencesClient) => Promise<AdminNavigationPreferencesSnapshot>
+}
+
+const AdminNavigationPreferencesMemberContext = createContext<string | null>(null)
+
+export function AdminNavigationPreferencesMemberProvider({
+  memberKey,
+  children,
+}: {
+  memberKey: string
+  children: ReactNode
+}) {
+  return createElement(
+    AdminNavigationPreferencesMemberContext.Provider,
+    { value: memberKey },
+    children,
+  )
+}
+
+export function useAdminNavigationPreferencesMemberKey(): string {
+  const memberKey = useContext(AdminNavigationPreferencesMemberContext)
+  if (memberKey === null) {
+    throw new Error(
+      "useAdminNavigationPreferencesMemberKey must be used inside AdminWorkspaceShell",
+    )
+  }
+  return memberKey
 }
 
 export interface ResolveAdminNavigationPreferencesOptions extends AdminNavigationPreferences {

--- a/packages/admin/src/types.ts
+++ b/packages/admin/src/types.ts
@@ -25,8 +25,8 @@ export type NavItemStatus = typeof COMING_SOON | typeof BETA
  * or elsewhere) so starters control the icon set.
  */
 export interface NavItem {
-  /** Stable identifier for extension merging and UI keys. */
-  id?: string
+  /** Stable identifier for extension merging and persisted preferences. */
+  id: string
   title: string
   url: string
   icon?: React.ComponentType<{ className?: string }>
@@ -35,10 +35,13 @@ export interface NavItem {
   target?: "_self" | "_blank"
   /** Collapsible sub-items. */
   items?: ReadonlyArray<NavSubItem>
+  /** Retained only as a non-navigable container for visible descendants. */
+  structural?: boolean
 }
 
 export interface NavSubItem {
-  id?: string
+  /** Stable identifier for persisted preferences. */
+  id: string
   title: string
   url: string
   icon?: React.ComponentType<{ className?: string }>

--- a/packages/admin/tests/app/admin-app.test.ts
+++ b/packages/admin/tests/app/admin-app.test.ts
@@ -208,6 +208,12 @@ describe("attachAdminExtensionRoutes", () => {
     const children = layout.children as Array<{ options: { path?: string } }>
     expect(children).toHaveLength(2)
     expect(children.filter((child) => child.options.path === "/bookings")).toHaveLength(1)
+
+    const duplicateRoute = createRoute({ getParentRoute: () => layout, path: "/bookings" })
+    attachAdminExtensionRoutes(tree, layout, [reloadedRoute, duplicateRoute])
+    const deduplicated = layout.children as Array<{ options: { path?: string } }>
+    expect(deduplicated).toHaveLength(2)
+    expect(deduplicated.filter((child) => child.options.path === "/bookings")).toHaveLength(1)
   })
 })
 

--- a/packages/admin/tests/unit/admin-workspace-shell.test.tsx
+++ b/packages/admin/tests/unit/admin-workspace-shell.test.tsx
@@ -1,7 +1,19 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import type { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
 
 import { AdminWorkspaceShell } from "../../src/app/workspace.js"
+import { AdminProvider } from "../../src/providers/admin-provider.js"
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>()
+  return {
+    ...actual,
+    useRouter: () => ({ navigate: vi.fn() }),
+    useRouterState: ({ select }: { select: (state: unknown) => unknown }) =>
+      select({ location: { pathname: "/" } }),
+  }
+})
 
 describe("AdminWorkspaceShell", () => {
   it("renders its bootstrap state without a host-owned messages provider", () => {
@@ -13,5 +25,40 @@ describe("AdminWorkspaceShell", () => {
 
     expect(screen.queryByText("workspace")).toBeNull()
     expect(document.querySelector("svg.animate-spin")).not.toBeNull()
+  })
+
+  it("does not require an API provider when navigation preferences are not selected", () => {
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }))
+    const Link = ({ children, href }: { children: ReactNode; href: string }) => (
+      <a href={href}>{children}</a>
+    )
+
+    render(
+      <AdminProvider
+        defaultTheme="light"
+        localeStorageKey={null}
+        themeStorageKey={null}
+        timeZoneStorageKey={null}
+      >
+        <AdminWorkspaceShell
+          user={{ id: "member-1", email: "member@example.com" }}
+          extensions={[]}
+          linkComponent={Link}
+        >
+          <span>workspace</span>
+        </AdminWorkspaceShell>
+      </AdminProvider>,
+    )
+
+    expect(screen.getByText("workspace")).not.toBeNull()
   })
 })

--- a/packages/admin/tests/unit/navigation-preferences.test.ts
+++ b/packages/admin/tests/unit/navigation-preferences.test.ts
@@ -31,21 +31,24 @@ describe("resolveAdminNavigationPreferences", () => {
         title: "Finance",
         url: "/finance/invoices",
         structural: true,
-        items: [
-          { id: "invoices", title: "Invoices", url: "/finance/invoices" },
-          { id: "payments", title: "Payments", url: "/finance/payments" },
-        ],
+        items: [{ id: "invoices", title: "Invoices", url: "/finance/invoices" }],
       },
     ])
   })
 
-  it("keeps hidden parents as structural containers for visible children", () => {
-    const [finance] = resolveAdminNavigationPreferences({
+  it("hides a parent's subtree unless a child is explicitly re-enabled", () => {
+    const hidden = resolveAdminNavigationPreferences({
       items: navigation,
       organization: { dashboard: false, finance: false, payments: false },
       member: {},
     })
+    const [finance] = resolveAdminNavigationPreferences({
+      items: navigation,
+      organization: { dashboard: false, finance: false },
+      member: { invoices: true },
+    })
 
+    expect(hidden).toEqual([])
     expect(finance).toMatchObject({ id: "finance", structural: true })
     expect(finance?.items?.map((item) => item.id)).toEqual(["invoices"])
   })

--- a/packages/admin/tests/unit/navigation-preferences.test.ts
+++ b/packages/admin/tests/unit/navigation-preferences.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveAdminNavigationPreferences } from "../../src/navigation/preferences.js"
+import type { NavItem } from "../../src/types.js"
+
+const navigation: NavItem[] = [
+  { id: "dashboard", title: "Dashboard", url: "/" },
+  {
+    id: "finance",
+    title: "Finance",
+    url: "/finance/invoices",
+    items: [
+      { id: "invoices", title: "Invoices", url: "/finance/invoices" },
+      { id: "payments", title: "Payments", url: "/finance/payments" },
+    ],
+  },
+]
+
+describe("resolveAdminNavigationPreferences", () => {
+  it("lets member values override organization values while absence inherits", () => {
+    const items = resolveAdminNavigationPreferences({
+      items: navigation,
+      organization: { dashboard: false, finance: false, invoices: false },
+      member: { dashboard: true, invoices: true },
+    })
+
+    expect(items).toEqual([
+      { id: "dashboard", title: "Dashboard", url: "/" },
+      {
+        id: "finance",
+        title: "Finance",
+        url: "/finance/invoices",
+        structural: true,
+        items: [
+          { id: "invoices", title: "Invoices", url: "/finance/invoices" },
+          { id: "payments", title: "Payments", url: "/finance/payments" },
+        ],
+      },
+    ])
+  })
+
+  it("keeps hidden parents as structural containers for visible children", () => {
+    const [finance] = resolveAdminNavigationPreferences({
+      items: navigation,
+      organization: { dashboard: false, finance: false, payments: false },
+      member: {},
+    })
+
+    expect(finance).toMatchObject({ id: "finance", structural: true })
+    expect(finance?.items?.map((item) => item.id)).toEqual(["invoices"])
+  })
+
+  it("ignores unknown preference ids and cannot add ineligible items", () => {
+    const items = resolveAdminNavigationPreferences({
+      items: [navigation[0]!],
+      organization: { unauthorized: true, removed_module: false },
+      member: { another_unknown: true },
+    })
+
+    expect(items.map((item) => item.id)).toEqual(["dashboard"])
+  })
+})

--- a/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
+++ b/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
@@ -109,6 +109,28 @@ describe("OperatorAdminWorkspaceLayout", () => {
     await waitFor(() => expect(document.title).toBe("Invoices · Voyant"))
   })
 
+  it("renders a hidden parent as a non-link container for visible children", () => {
+    renderWithAdminProviders(
+      <OperatorAdminWorkspaceLayout
+        currentPath="/elsewhere"
+        navItems={[
+          {
+            id: "finance",
+            title: "Finance",
+            url: "/finance",
+            items: [{ id: "invoices", title: "Invoices", url: "/finance/invoices" }],
+          },
+        ]}
+        navigationPreferences={{ organization: { finance: false }, member: {} }}
+      >
+        <section>Content</section>
+      </OperatorAdminWorkspaceLayout>,
+    )
+
+    expect(screen.queryByRole("link", { name: "Finance" })).toBeNull()
+    expect(screen.getByRole("link", { name: "Invoices" })).not.toBeNull()
+  })
+
   it("allows workspace consumers to disable automatic page metadata", async () => {
     document.title = "Consumer owned"
 

--- a/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
+++ b/packages/admin/tests/unit/operator-admin-sidebar.test.tsx
@@ -109,7 +109,7 @@ describe("OperatorAdminWorkspaceLayout", () => {
     await waitFor(() => expect(document.title).toBe("Invoices · Voyant"))
   })
 
-  it("renders a hidden parent as a non-link container for visible children", () => {
+  it("renders a hidden parent as a non-link container for an explicitly visible child", () => {
     renderWithAdminProviders(
       <OperatorAdminWorkspaceLayout
         currentPath="/elsewhere"
@@ -121,7 +121,7 @@ describe("OperatorAdminWorkspaceLayout", () => {
             items: [{ id: "invoices", title: "Invoices", url: "/finance/invoices" }],
           },
         ]}
-        navigationPreferences={{ organization: { finance: false }, member: {} }}
+        navigationPreferences={{ organization: { finance: false }, member: { invoices: true } }}
       >
         <section>Content</section>
       </OperatorAdminWorkspaceLayout>,

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -141,6 +141,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1154,6 +1155,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1155,6 +1156,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -148,6 +148,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1141,6 +1142,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1135,6 +1136,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -218,6 +218,8 @@ export interface VoyantGraphRouteBundle {
   mount?: string
   openapi?: VoyantGraphRouteOpenApi
   resource?: string
+  /** Delegate capability checks to handlers while retaining surface authentication. */
+  authorization?: "coarse" | "route"
   requiredScopes?: readonly string[]
   /** Anonymous public access for the whole public mount or route-relative path subsets. */
   anonymous?: boolean | readonly string[]

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -141,6 +141,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1189,6 +1190,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1190,6 +1191,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -141,6 +141,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1210,6 +1211,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1211,6 +1212,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -147,6 +147,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1222,6 +1223,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1217,6 +1218,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1014,6 +1014,7 @@ describe("deployment graph v1", () => {
             mount: "loyalty",
             openapi: { document: "loyalty" },
             resource: "loyalty.points",
+            authorization: "route",
             requiredScopes: ["loyalty:read", "loyalty-points:write"],
             anonymous: ["/status", "health"],
           },
@@ -1040,6 +1041,7 @@ describe("deployment graph v1", () => {
             mount: "",
             openapi: { document: "Loyalty API" },
             resource: "Loyalty Points",
+            authorization: "handler",
             requiredScopes: ["loyalty.points.read", "loyalty:Read"],
             anonymous: true,
             transactional: ["/commit", "commit"],
@@ -1067,6 +1069,10 @@ describe("deployment graph v1", () => {
         expect.objectContaining({
           code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
           facet: "api[0].resource",
+        }),
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          facet: "api[0].authorization",
         }),
         expect.objectContaining({
           code: "VOYANT_GRAPH_INVALID_SCOPE",

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1112,6 +1112,25 @@ describe("deployment graph v1", () => {
         expect.objectContaining({ facet: "api[0].transactional" }),
       ]),
     )
+
+    expect(
+      validateGraphUnitManifest({
+        schemaVersion: "voyant.module.v1",
+        id: "@acme/voyant-route-owned",
+        api: [
+          {
+            id: "@acme/voyant-route-owned#api.admin",
+            surface: "admin",
+            authorization: "route",
+          },
+        ],
+      }),
+    ).toEqual([
+      expect.objectContaining({
+        code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+        facet: "api[0].authorization",
+      }),
+    ])
   })
 
   it("detects duplicate graph ids and missing required capabilities", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2056,6 +2056,17 @@ function validateRouteBundles(value: unknown, source: string | undefined): Voyan
       )
     }
 
+    if (route.authorization === "route" && route.resource === undefined) {
+      diagnostics.push(
+        diagnostic({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          source,
+          facet: `${facet}.authorization`,
+          message: `Route bundle "${route.id ?? index}" must declare a resource when authorization is route-owned.`,
+        }),
+      )
+    }
+
     if (route.requiredScopes !== undefined) {
       if (!Array.isArray(route.requiredScopes)) {
         diagnostics.push(

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2041,6 +2041,21 @@ function validateRouteBundles(value: unknown, source: string | undefined): Voyan
       )
     }
 
+    if (
+      route.authorization !== undefined &&
+      route.authorization !== "coarse" &&
+      route.authorization !== "route"
+    ) {
+      diagnostics.push(
+        diagnostic({
+          code: "VOYANT_GRAPH_INVALID_ROUTE_BUNDLE",
+          source,
+          facet: `${facet}.authorization`,
+          message: `Route bundle "${route.id ?? index}" authorization must be coarse or route.`,
+        }),
+      )
+    }
+
     if (route.requiredScopes !== undefined) {
       if (!Array.isArray(route.requiredScopes)) {
         diagnostics.push(

--- a/packages/framework/src/runtime-composition.test.ts
+++ b/packages/framework/src/runtime-composition.test.ts
@@ -590,6 +590,39 @@ describe("graph runtime composition", () => {
     expect(factory).toHaveBeenCalledTimes(1)
   })
 
+  it("preserves route-owned authorization in selected graph access posture", async () => {
+    const importRuntime = vi.fn(async () => ({
+      createLoyaltyModule: () => ({ module: { name: "loyalty" } }),
+    }))
+    const base = runtimeWithDuplicateFacets(importRuntime)
+    const runtime = {
+      ...base,
+      modules: base.modules.map((unit) => ({
+        ...unit,
+        routes: unit.routes.map((definition) => ({
+          ...definition,
+          route:
+            definition.route.surface === "admin"
+              ? {
+                  ...definition.route,
+                  mount: "navigation-preferences",
+                  resource: "admin-navigation",
+                  authorization: "route" as const,
+                }
+              : definition.route,
+        })),
+      })),
+    }
+
+    const composition = await composeVoyantGraphRuntime({ runtime, capabilities: {} })
+
+    expect(composition.accessResources).toContainEqual({
+      path: "/v1/admin/navigation-preferences",
+      resource: "admin-navigation",
+      authorization: "route",
+    })
+  })
+
   it("preserves a project API root mount when a single public route is selected", async () => {
     const publicRoutes = new Hono().get("/foo", (context) => context.json({ route: "foo" }))
     const runtime = createVoyantGraphRuntime({

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -221,7 +221,11 @@ export interface ComposeVoyantGraphRuntimeInput<TCapabilities> {
 export interface VoyantGraphRuntimeComposition {
   modules: HonoModule[]
   extensions: HonoExtension[]
-  accessResources: { path: string; resource: string }[]
+  accessResources: {
+    path: string
+    resource: string
+    authorization?: "coarse" | "route"
+  }[]
   routePosture: VoyantGraphRuntimeRoutePosture
 }
 
@@ -333,12 +337,22 @@ export async function composeVoyantGraphRuntime<TCapabilities>(
   }
 }
 
-function deriveAccessResources(runtime: VoyantGraphRuntime): { path: string; resource: string }[] {
+function deriveAccessResources(runtime: VoyantGraphRuntime): {
+  path: string
+  resource: string
+  authorization?: "coarse" | "route"
+}[] {
   return [...runtime.modules, ...runtime.extensions, ...runtime.plugins]
     .flatMap((unit) =>
       unit.routes.flatMap(({ route }) =>
         route.resource
-          ? [{ path: resolveVoyantGraphRouteMountPath(unit, route), resource: route.resource }]
+          ? [
+              {
+                path: resolveVoyantGraphRouteMountPath(unit, route),
+                resource: route.resource,
+                ...(route.authorization ? { authorization: route.authorization } : {}),
+              },
+            ]
           : [],
       ),
     )

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -141,6 +141,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1226,6 +1227,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1227,6 +1228,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/hono/src/middleware/require-actor.ts
+++ b/packages/hono/src/middleware/require-actor.ts
@@ -103,7 +103,11 @@ export interface RequireActorOptions {
    */
   basePath?: string
   /** Selected graph mount prefixes whose authorization resource differs from the URL segment. */
-  resources?: readonly { path: string; resource: string }[]
+  resources?: readonly {
+    path: string
+    resource: string
+    authorization?: "coarse" | "route"
+  }[]
   accessCatalog?: AccessCatalog
 }
 
@@ -111,11 +115,17 @@ function isRequireActorOptions(value: unknown): value is RequireActorOptions {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function apiKeyResourceForRequest(pathname: string, options: RequireActorOptions): string | null {
+function authorizationForRequest(
+  pathname: string,
+  options: RequireActorOptions,
+): { resource: string | null; authorization: "coarse" | "route" } {
   const override = [...(options.resources ?? [])]
     .sort((left, right) => right.path.length - left.path.length)
     .find(({ path }) => pathname === path || pathname.startsWith(`${path}/`))
-  return override?.resource ?? apiKeyResourceFromPath(pathname)
+  return {
+    resource: override?.resource ?? apiKeyResourceFromPath(pathname),
+    authorization: override?.authorization ?? "coarse",
+  }
 }
 
 /**
@@ -171,7 +181,7 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       const pathname = normalizePathname(new URL(c.req.url).pathname, {
         basePath: options.basePath,
       })
-      const resource = apiKeyResourceForRequest(pathname, options)
+      const { resource, authorization } = authorizationForRequest(pathname, options)
 
       // Coarse-guard-exempt surfaces. `_meta` (capability discovery) and `mcp`
       // (the agent tool server) are dispatch surfaces where authorization is
@@ -179,7 +189,7 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       // gates each tool by its own `requiredScopes` (voyant#2792, D2). So any
       // authenticated key reaches them; a key with no relevant scopes simply
       // sees an empty tool list. Neither is a real module name.
-      if (isCoarseGuardExempt(resource)) return next()
+      if (authorization === "route" || isCoarseGuardExempt(resource)) return next()
 
       const actions = apiKeyPermissionActionsForMethod(c.req.method, pathname)
 
@@ -220,8 +230,8 @@ export function requireActor<TBindings extends VoyantBindings = VoyantBindings>(
       const pathname = normalizePathname(new URL(c.req.url).pathname, {
         basePath: options.basePath,
       })
-      const resource = apiKeyResourceForRequest(pathname, options)
-      if (resource && !isCoarseGuardExempt(resource)) {
+      const { resource, authorization } = authorizationForRequest(pathname, options)
+      if (resource && authorization !== "route" && !isCoarseGuardExempt(resource)) {
         const actions = apiKeyPermissionActionsForMethod(c.req.method, pathname)
         if (!hasAnyApiKeyPermission(scopes, resource, actions, options.accessCatalog)) {
           return c.json({ error: "Forbidden: missing required permission" }, 403)

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -285,7 +285,11 @@ export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindin
   basePath?: string
   publicPaths?: string[]
   /** Selected graph mount-to-resource authorization overrides. */
-  accessResources?: readonly { path: string; resource: string }[]
+  accessResources?: readonly {
+    path: string
+    resource: string
+    authorization?: "coarse" | "route"
+  }[]
   /** Effective selected-plus-legacy catalog used for wildcard policy. */
   accessCatalog?: AccessCatalog
   logger?: LoggerProvider

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -255,6 +255,29 @@ describe("requireActor", () => {
     expect(response.status).toBe(200)
   })
 
+  it("keeps staff authentication mandatory for route-authorized graph mounts", async () => {
+    const app = makeApp(() => {})
+    app.use(
+      "*",
+      requireActor(
+        {
+          resources: [
+            {
+              path: "/v1/admin/navigation-preferences",
+              resource: "admin-navigation",
+              authorization: "route",
+            },
+          ],
+        },
+        "staff",
+      ),
+    )
+    app.put("/v1/admin/navigation-preferences/me", (c) => c.json({ ok: true }))
+
+    const response = await app.request("/v1/admin/navigation-preferences/me", { method: "PUT" })
+    expect(response.status).toBe(401)
+  })
+
   it("keeps path-derived authorization when no graph override matches", async () => {
     const app = makeApp((c) => {
       c.set("callerType", "api_key")

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -228,6 +228,33 @@ describe("requireActor", () => {
     expect((await app.request("/v1/admin/person-bookings/person_1")).status).toBe(200)
   })
 
+  it("delegates coarse capability checks for route-authorized graph mounts", async () => {
+    const app = makeApp((c) => {
+      c.set("actor", "staff")
+      c.set("callerType", "session")
+      c.set("scopes", ["bookings:read"])
+    })
+    app.use(
+      "*",
+      requireActor(
+        {
+          resources: [
+            {
+              path: "/v1/admin/navigation-preferences",
+              resource: "admin-navigation",
+              authorization: "route",
+            },
+          ],
+        },
+        "staff",
+      ),
+    )
+    app.put("/v1/admin/navigation-preferences/me", (c) => c.json({ ok: true }))
+
+    const response = await app.request("/v1/admin/navigation-preferences/me", { method: "PUT" })
+    expect(response.status).toBe(200)
+  })
+
   it("keeps path-derived authorization when no graph override matches", async () => {
     const app = makeApp((c) => {
       c.set("callerType", "api_key")

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -147,6 +147,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1222,6 +1223,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1217,6 +1218,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -141,6 +141,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1161,6 +1162,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1162,6 +1163,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/navigation-preferences-react/package.json
+++ b/packages/navigation-preferences-react/package.json
@@ -21,6 +21,7 @@
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
     "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/auth-react": "workspace:^",
     "@voyant-travel/navigation-preferences": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
     "lucide-react": "^0.475.0 || ^1.0.0",
@@ -37,6 +38,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/auth-react": "workspace:^",
     "@voyant-travel/navigation-preferences": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
     "@voyant-travel/voyant-typescript-config": "workspace:^",

--- a/packages/navigation-preferences-react/package.json
+++ b/packages/navigation-preferences-react/package.json
@@ -1,0 +1,80 @@
+{
+  "name": "@voyant-travel/navigation-preferences-react",
+  "version": "0.1.0",
+  "description": "React admin settings for Voyant navigation visibility preferences.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./i18n": "./src/i18n/index.ts",
+    "./settings": "./src/settings.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/",
+    "test": "vitest run --passWithNoTests"
+  },
+  "peerDependencies": {
+    "@tanstack/react-query": "^5.0.0",
+    "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/navigation-preferences": "workspace:^",
+    "@voyant-travel/ui": "workspace:^",
+    "lucide-react": "^0.475.0 || ^1.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "sonner": "^2.0.7"
+  },
+  "dependencies": {
+    "@voyant-travel/i18n": "workspace:^",
+    "@voyant-travel/react": "workspace:^"
+  },
+  "devDependencies": {
+    "@tanstack/react-query": "^5.101.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@voyant-travel/admin": "workspace:^",
+    "@voyant-travel/navigation-preferences": "workspace:^",
+    "@voyant-travel/ui": "workspace:^",
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "lucide-react": "^1.23.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "sonner": "^2.0.7",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./i18n": {
+        "types": "./dist/i18n/index.d.ts",
+        "import": "./dist/i18n/index.js",
+        "default": "./dist/i18n/index.js"
+      },
+      "./settings": {
+        "types": "./dist/settings.d.ts",
+        "import": "./dist/settings.js",
+        "default": "./dist/settings.js"
+      }
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/navigation-preferences-react"
+  }
+}

--- a/packages/navigation-preferences-react/src/client.ts
+++ b/packages/navigation-preferences-react/src/client.ts
@@ -4,7 +4,11 @@ import type {
 } from "@voyant-travel/admin/navigation/preferences"
 import { navigationPreferencesSnapshotSchema } from "@voyant-travel/navigation-preferences/contracts"
 
-export const navigationPreferencesQueryKey = ["navigation-preferences"] as const
+export const navigationPreferencesQueryRoot = ["navigation-preferences"] as const
+
+export function navigationPreferencesQueryKey(memberKey: string) {
+  return [...navigationPreferencesQueryRoot, memberKey] as const
+}
 
 export async function loadNavigationPreferences(
   client: AdminNavigationPreferencesClient,

--- a/packages/navigation-preferences-react/src/client.ts
+++ b/packages/navigation-preferences-react/src/client.ts
@@ -1,0 +1,16 @@
+import type {
+  AdminNavigationPreferencesClient,
+  AdminNavigationPreferencesSnapshot,
+} from "@voyant-travel/admin/navigation/preferences"
+import { navigationPreferencesSnapshotSchema } from "@voyant-travel/navigation-preferences/contracts"
+
+export const navigationPreferencesQueryKey = ["navigation-preferences"] as const
+
+export async function loadNavigationPreferences(
+  client: AdminNavigationPreferencesClient,
+): Promise<AdminNavigationPreferencesSnapshot> {
+  const response = await client.fetcher(`${client.baseUrl}/v1/admin/navigation-preferences`)
+  if (!response.ok) throw new Error(`Navigation preferences request failed (${response.status})`)
+  const payload = (await response.json()) as { data?: unknown }
+  return navigationPreferencesSnapshotSchema.parse(payload.data)
+}

--- a/packages/navigation-preferences-react/src/client.ts
+++ b/packages/navigation-preferences-react/src/client.ts
@@ -1,7 +1,7 @@
 import type {
   AdminNavigationPreferencesClient,
   AdminNavigationPreferencesSnapshot,
-} from "@voyant-travel/admin/navigation/preferences"
+} from "@voyant-travel/admin"
 import { navigationPreferencesSnapshotSchema } from "@voyant-travel/navigation-preferences/contracts"
 
 export const navigationPreferencesQueryRoot = ["navigation-preferences"] as const

--- a/packages/navigation-preferences-react/src/i18n/en.ts
+++ b/packages/navigation-preferences-react/src/i18n/en.ts
@@ -1,0 +1,17 @@
+import type { NavigationPreferencesMessages } from "./messages.js"
+
+export const navigationPreferencesEn = {
+  title: "Navigation",
+  personal: "Personal",
+  organization: "Organization",
+  inherit: "Inherit",
+  show: "Show",
+  hide: "Hide",
+  save: "Save changes",
+  reset: "Reset",
+  saved: "Navigation preferences saved",
+  saveFailed: "Could not save navigation preferences",
+  loading: "Loading navigation preferences",
+  loadFailed: "Could not load navigation preferences",
+  retry: "Retry",
+} satisfies NavigationPreferencesMessages

--- a/packages/navigation-preferences-react/src/i18n/index.ts
+++ b/packages/navigation-preferences-react/src/i18n/index.ts
@@ -1,0 +1,9 @@
+export { navigationPreferencesEn } from "./en.js"
+export type { NavigationPreferencesMessages } from "./messages.js"
+export {
+  type NavigationPreferencesMessageOverrides,
+  NavigationPreferencesMessagesProvider,
+  navigationPreferencesMessageDefinitions,
+  useNavigationPreferencesMessages,
+} from "./provider.js"
+export { navigationPreferencesRo } from "./ro.js"

--- a/packages/navigation-preferences-react/src/i18n/messages.ts
+++ b/packages/navigation-preferences-react/src/i18n/messages.ts
@@ -1,0 +1,15 @@
+export type NavigationPreferencesMessages = {
+  title: string
+  personal: string
+  organization: string
+  inherit: string
+  show: string
+  hide: string
+  save: string
+  reset: string
+  saved: string
+  saveFailed: string
+  loading: string
+  loadFailed: string
+  retry: string
+}

--- a/packages/navigation-preferences-react/src/i18n/provider.tsx
+++ b/packages/navigation-preferences-react/src/i18n/provider.tsx
@@ -1,0 +1,47 @@
+"use client"
+
+import {
+  createPackageMessagesContext,
+  type LocaleMessageDefinitions,
+  type LocaleMessageOverrides,
+} from "@voyant-travel/i18n"
+import type { ReactNode } from "react"
+
+import { navigationPreferencesEn } from "./en.js"
+import type { NavigationPreferencesMessages } from "./messages.js"
+import { navigationPreferencesRo } from "./ro.js"
+
+export const navigationPreferencesMessageDefinitions = {
+  en: navigationPreferencesEn,
+  ro: navigationPreferencesRo,
+} satisfies LocaleMessageDefinitions<NavigationPreferencesMessages>
+
+export type NavigationPreferencesMessageOverrides =
+  LocaleMessageOverrides<NavigationPreferencesMessages>
+
+const context = createPackageMessagesContext<NavigationPreferencesMessages>(
+  "NavigationPreferencesMessages",
+)
+
+export function NavigationPreferencesMessagesProvider({
+  children,
+  locale,
+  overrides,
+}: {
+  children: ReactNode
+  locale: string | null | undefined
+  overrides?: NavigationPreferencesMessageOverrides | null
+}) {
+  return (
+    <context.ResolvedMessagesProvider
+      definitions={navigationPreferencesMessageDefinitions}
+      fallbackLocale="en"
+      locale={locale}
+      overrides={overrides}
+    >
+      {children}
+    </context.ResolvedMessagesProvider>
+  )
+}
+
+export const useNavigationPreferencesMessages = context.useMessages

--- a/packages/navigation-preferences-react/src/i18n/ro.ts
+++ b/packages/navigation-preferences-react/src/i18n/ro.ts
@@ -1,0 +1,17 @@
+import type { NavigationPreferencesMessages } from "./messages.js"
+
+export const navigationPreferencesRo = {
+  title: "Navigare",
+  personal: "Personal",
+  organization: "Organizatie",
+  inherit: "Mosteneste",
+  show: "Afiseaza",
+  hide: "Ascunde",
+  save: "Salveaza modificarile",
+  reset: "Reseteaza",
+  saved: "Preferintele de navigare au fost salvate",
+  saveFailed: "Preferintele de navigare nu au putut fi salvate",
+  loading: "Se incarca preferintele de navigare",
+  loadFailed: "Preferintele de navigare nu au putut fi incarcate",
+  retry: "Reincearca",
+} satisfies NavigationPreferencesMessages

--- a/packages/navigation-preferences-react/src/index.ts
+++ b/packages/navigation-preferences-react/src/index.ts
@@ -1,3 +1,7 @@
-export { loadNavigationPreferences, navigationPreferencesQueryKey } from "./client.js"
+export {
+  loadNavigationPreferences,
+  navigationPreferencesQueryKey,
+  navigationPreferencesQueryRoot,
+} from "./client.js"
 export { NavigationPreferencesPage } from "./navigation-preferences-page.js"
 export { createSelectedNavigationPreferencesAdminExtension } from "./settings.js"

--- a/packages/navigation-preferences-react/src/index.ts
+++ b/packages/navigation-preferences-react/src/index.ts
@@ -1,0 +1,3 @@
+export { loadNavigationPreferences, navigationPreferencesQueryKey } from "./client.js"
+export { NavigationPreferencesPage } from "./navigation-preferences-page.js"
+export { createSelectedNavigationPreferencesAdminExtension } from "./settings.js"

--- a/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
+++ b/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
@@ -1,0 +1,244 @@
+"use client"
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import {
+  createOperatorAdminNavigation,
+  resolveOperatorAdminNavigation,
+} from "@voyant-travel/admin/navigation/operator-navigation"
+import { useAdminExtensions } from "@voyant-travel/admin/providers/admin-extensions"
+import { useOperatorAdminMessages } from "@voyant-travel/admin/providers/operator-admin-messages"
+import type { NavItem } from "@voyant-travel/admin/types"
+import type { NavigationVisibilityMap } from "@voyant-travel/navigation-preferences/contracts"
+import { useVoyantReactContext } from "@voyant-travel/react"
+import {
+  Button,
+  Switch,
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
+} from "@voyant-travel/ui/components"
+import { Loader2 } from "lucide-react"
+import type * as React from "react"
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+
+import { loadNavigationPreferences, navigationPreferencesQueryKey } from "./client.js"
+import { useNavigationPreferencesMessages } from "./i18n/provider.js"
+
+type PreferenceMode = "inherit" | "show" | "hide"
+
+export function NavigationPreferencesPage() {
+  const client = useVoyantReactContext()
+  const queryClient = useQueryClient()
+  const messages = useNavigationPreferencesMessages()
+  const adminMessages = useOperatorAdminMessages()
+  const extensions = useAdminExtensions()
+  const navigation = useMemo(
+    () =>
+      resolveOperatorAdminNavigation({
+        baseItems: createOperatorAdminNavigation({ messages: adminMessages.nav }),
+        extensions,
+      }),
+    [adminMessages.nav, extensions],
+  )
+  const rows = useMemo(() => flattenNavigation(navigation), [navigation])
+  const query = useQuery({
+    queryKey: navigationPreferencesQueryKey,
+    queryFn: () => loadNavigationPreferences(client),
+  })
+  const [organization, setOrganization] = useState<NavigationVisibilityMap>({})
+  const [member, setMember] = useState<NavigationVisibilityMap>({})
+
+  useEffect(() => {
+    if (!query.data) return
+    setOrganization(query.data.organization)
+    setMember(query.data.member)
+  }, [query.data])
+
+  const save = useMutation({
+    mutationFn: async ({
+      scope,
+      visibility,
+    }: {
+      scope: "organization" | "me"
+      visibility: NavigationVisibilityMap
+    }) => {
+      const response = await client.fetcher(
+        `${client.baseUrl}/v1/admin/navigation-preferences/${scope}`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ visibility }),
+        },
+      )
+      if (!response.ok) throw new Error(`${messages.saveFailed} (${response.status})`)
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: navigationPreferencesQueryKey })
+      toast.success(messages.saved)
+    },
+    onError: (error) => {
+      toast.error(error instanceof Error ? error.message : messages.saveFailed)
+    },
+  })
+
+  if (query.isPending) {
+    return (
+      <div className="flex h-full items-center justify-center" role="status">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        <span className="sr-only">{messages.loading}</span>
+      </div>
+    )
+  }
+
+  if (query.isError) {
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-3 p-6">
+        <p className="text-sm text-destructive" role="alert">
+          {messages.loadFailed}
+        </p>
+        <Button type="button" variant="outline" onClick={() => query.refetch()}>
+          {messages.retry}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-6 p-6">
+      <h1 className="text-2xl font-bold">{messages.title}</h1>
+      <Tabs defaultValue="personal">
+        <TabsList>
+          <TabsTrigger value="personal">{messages.personal}</TabsTrigger>
+          {query.data?.canManageOrganization ? (
+            <TabsTrigger value="organization">{messages.organization}</TabsTrigger>
+          ) : null}
+        </TabsList>
+        <TabsContent value="personal" className="mt-4">
+          <PreferenceList
+            rows={rows}
+            renderControl={(item) => (
+              <ToggleGroup
+                value={[memberMode(member, item.id)]}
+                onValueChange={(value: string[]) => {
+                  const mode = value[0] as PreferenceMode | undefined
+                  if (mode) setMember(setMemberMode(member, item.id, mode))
+                }}
+                variant="outline"
+                size="sm"
+              >
+                <ToggleGroupItem value="inherit">{messages.inherit}</ToggleGroupItem>
+                <ToggleGroupItem value="show">{messages.show}</ToggleGroupItem>
+                <ToggleGroupItem value="hide">{messages.hide}</ToggleGroupItem>
+              </ToggleGroup>
+            )}
+          />
+          <PreferenceActions
+            resetLabel={messages.reset}
+            saveLabel={messages.save}
+            saving={save.isPending}
+            onReset={() => setMember({})}
+            onSave={() => save.mutate({ scope: "me", visibility: member })}
+          />
+        </TabsContent>
+        {query.data?.canManageOrganization ? (
+          <TabsContent value="organization" className="mt-4">
+            <PreferenceList
+              rows={rows}
+              renderControl={(item) => (
+                <Switch
+                  aria-label={item.title}
+                  checked={organization[item.id] !== false}
+                  onCheckedChange={(checked: boolean) =>
+                    setOrganization({ ...organization, [item.id]: checked })
+                  }
+                />
+              )}
+            />
+            <PreferenceActions
+              resetLabel={messages.reset}
+              saveLabel={messages.save}
+              saving={save.isPending}
+              onReset={() => setOrganization({})}
+              onSave={() => save.mutate({ scope: "organization", visibility: organization })}
+            />
+          </TabsContent>
+        ) : null}
+      </Tabs>
+    </div>
+  )
+}
+
+function PreferenceList({
+  rows,
+  renderControl,
+}: {
+  rows: ReadonlyArray<{ item: NavItem | NonNullable<NavItem["items"]>[number]; depth: number }>
+  renderControl: (item: NavItem | NonNullable<NavItem["items"]>[number]) => React.ReactNode
+}) {
+  return (
+    <div className="divide-y border-y">
+      {rows.map(({ item, depth }) => (
+        <div key={item.id} className="flex min-h-14 items-center justify-between gap-4 py-2">
+          <div className={depth ? "min-w-0 pl-6" : "min-w-0"}>
+            <div className="truncate text-sm font-medium">{item.title}</div>
+            <div className="truncate text-xs text-muted-foreground">{item.url}</div>
+          </div>
+          <div className="shrink-0">{renderControl(item)}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function PreferenceActions({
+  resetLabel,
+  saveLabel,
+  saving,
+  onReset,
+  onSave,
+}: {
+  resetLabel: string
+  saveLabel: string
+  saving: boolean
+  onReset: () => void
+  onSave: () => void
+}) {
+  return (
+    <div className="mt-4 flex justify-end gap-2">
+      <Button type="button" variant="outline" onClick={onReset} disabled={saving}>
+        {resetLabel}
+      </Button>
+      <Button type="button" onClick={onSave} disabled={saving}>
+        {saving ? <Loader2 className="size-4 animate-spin" /> : null}
+        {saveLabel}
+      </Button>
+    </div>
+  )
+}
+
+function flattenNavigation(items: ReadonlyArray<NavItem>) {
+  return items.flatMap((item) => [
+    { item, depth: 0 },
+    ...(item.items?.map((child) => ({ item: child, depth: 1 })) ?? []),
+  ])
+}
+
+function memberMode(visibility: NavigationVisibilityMap, id: string): PreferenceMode {
+  if (!Object.hasOwn(visibility, id)) return "inherit"
+  return visibility[id] === false ? "hide" : "show"
+}
+
+function setMemberMode(
+  visibility: NavigationVisibilityMap,
+  id: string,
+  mode: PreferenceMode,
+): NavigationVisibilityMap {
+  const next = { ...visibility }
+  if (mode === "inherit") delete next[id]
+  else next[id] = mode === "show"
+  return next
+}

--- a/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
+++ b/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
-import { useAdminNavigationPreferencesMemberKey } from "@voyant-travel/admin"
 import {
   createOperatorAdminNavigation,
   resolveOperatorAdminNavigation,
@@ -9,6 +8,7 @@ import {
 import { useAdminExtensions } from "@voyant-travel/admin/providers/admin-extensions"
 import { useOperatorAdminMessages } from "@voyant-travel/admin/providers/operator-admin-messages"
 import type { NavItem } from "@voyant-travel/admin/types"
+import { useCurrentUser } from "@voyant-travel/auth-react"
 import type { NavigationVisibilityMap } from "@voyant-travel/navigation-preferences/contracts"
 import { useVoyantReactContext } from "@voyant-travel/react"
 import {
@@ -37,7 +37,8 @@ type PreferenceMode = "inherit" | "show" | "hide"
 
 export function NavigationPreferencesPage() {
   const client = useVoyantReactContext()
-  const memberKey = useAdminNavigationPreferencesMemberKey()
+  const currentUser = useCurrentUser()
+  const memberKey = currentUser.data?.id ?? "pending-member"
   const queryClient = useQueryClient()
   const messages = useNavigationPreferencesMessages()
   const adminMessages = useOperatorAdminMessages()
@@ -54,6 +55,7 @@ export function NavigationPreferencesPage() {
   const query = useQuery({
     queryKey: navigationPreferencesQueryKey(memberKey),
     queryFn: () => loadNavigationPreferences(client),
+    enabled: currentUser.isSuccess,
   })
   const [organization, setOrganization] = useState<NavigationVisibilityMap>({})
   const [member, setMember] = useState<NavigationVisibilityMap>({})
@@ -91,7 +93,7 @@ export function NavigationPreferencesPage() {
     },
   })
 
-  if (query.isPending) {
+  if (currentUser.isPending || query.isPending) {
     return (
       <div className="flex h-full items-center justify-center" role="status">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />
@@ -100,7 +102,7 @@ export function NavigationPreferencesPage() {
     )
   }
 
-  if (query.isError) {
+  if (currentUser.isError || query.isError) {
     return (
       <div className="flex h-full flex-col items-center justify-center gap-3 p-6">
         <p className="text-sm text-destructive" role="alert">

--- a/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
+++ b/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
@@ -1,11 +1,11 @@
 "use client"
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import { useAdminNavigationPreferencesMemberKey } from "@voyant-travel/admin"
 import {
   createOperatorAdminNavigation,
   resolveOperatorAdminNavigation,
 } from "@voyant-travel/admin/navigation/operator-navigation"
-import { useAdminNavigationPreferencesMemberKey } from "@voyant-travel/admin/navigation/preferences"
 import { useAdminExtensions } from "@voyant-travel/admin/providers/admin-extensions"
 import { useOperatorAdminMessages } from "@voyant-travel/admin/providers/operator-admin-messages"
 import type { NavItem } from "@voyant-travel/admin/types"

--- a/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
+++ b/packages/navigation-preferences-react/src/navigation-preferences-page.tsx
@@ -5,6 +5,7 @@ import {
   createOperatorAdminNavigation,
   resolveOperatorAdminNavigation,
 } from "@voyant-travel/admin/navigation/operator-navigation"
+import { useAdminNavigationPreferencesMemberKey } from "@voyant-travel/admin/navigation/preferences"
 import { useAdminExtensions } from "@voyant-travel/admin/providers/admin-extensions"
 import { useOperatorAdminMessages } from "@voyant-travel/admin/providers/operator-admin-messages"
 import type { NavItem } from "@voyant-travel/admin/types"
@@ -25,13 +26,18 @@ import type * as React from "react"
 import { useEffect, useMemo, useState } from "react"
 import { toast } from "sonner"
 
-import { loadNavigationPreferences, navigationPreferencesQueryKey } from "./client.js"
+import {
+  loadNavigationPreferences,
+  navigationPreferencesQueryKey,
+  navigationPreferencesQueryRoot,
+} from "./client.js"
 import { useNavigationPreferencesMessages } from "./i18n/provider.js"
 
 type PreferenceMode = "inherit" | "show" | "hide"
 
 export function NavigationPreferencesPage() {
   const client = useVoyantReactContext()
+  const memberKey = useAdminNavigationPreferencesMemberKey()
   const queryClient = useQueryClient()
   const messages = useNavigationPreferencesMessages()
   const adminMessages = useOperatorAdminMessages()
@@ -46,7 +52,7 @@ export function NavigationPreferencesPage() {
   )
   const rows = useMemo(() => flattenNavigation(navigation), [navigation])
   const query = useQuery({
-    queryKey: navigationPreferencesQueryKey,
+    queryKey: navigationPreferencesQueryKey(memberKey),
     queryFn: () => loadNavigationPreferences(client),
   })
   const [organization, setOrganization] = useState<NavigationVisibilityMap>({})
@@ -77,7 +83,7 @@ export function NavigationPreferencesPage() {
       if (!response.ok) throw new Error(`${messages.saveFailed} (${response.status})`)
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: navigationPreferencesQueryKey })
+      await queryClient.invalidateQueries({ queryKey: navigationPreferencesQueryRoot })
       toast.success(messages.saved)
     },
     onError: (error) => {

--- a/packages/navigation-preferences-react/src/settings.test.ts
+++ b/packages/navigation-preferences-react/src/settings.test.ts
@@ -20,6 +20,13 @@ describe("navigation preferences admin contribution", () => {
       id: "navigation",
       path: "/navigation",
     })
+    expect(extension.navigationPreferences?.queryKey("member-a")).toEqual([
+      "navigation-preferences",
+      "member-a",
+    ])
+    expect(extension.navigationPreferences?.queryKey("member-b")).not.toEqual(
+      extension.navigationPreferences?.queryKey("member-a"),
+    )
     await expect(
       extension.navigationPreferences?.load({ baseUrl: "/api", fetcher }),
     ).resolves.toEqual({

--- a/packages/navigation-preferences-react/src/settings.test.ts
+++ b/packages/navigation-preferences-react/src/settings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createSelectedNavigationPreferencesAdminExtension } from "./settings.js"
+
+describe("navigation preferences admin contribution", () => {
+  it("contributes the final-stage loader and settings page", async () => {
+    const extension = createSelectedNavigationPreferencesAdminExtension()
+    const fetcher = vi.fn(async () =>
+      Response.json({
+        data: {
+          organization: { finance: false, future: true },
+          member: { finance: true },
+          effective: { finance: true, future: true },
+          canManageOrganization: true,
+        },
+      }),
+    )
+
+    expect(extension.settingsPages?.[0]).toMatchObject({
+      id: "navigation",
+      path: "/navigation",
+    })
+    await expect(
+      extension.navigationPreferences?.load({ baseUrl: "/api", fetcher }),
+    ).resolves.toEqual({
+      organization: { finance: false, future: true },
+      member: { finance: true },
+      effective: { finance: true, future: true },
+      canManageOrganization: true,
+    })
+    expect(fetcher).toHaveBeenCalledWith("/api/v1/admin/navigation-preferences")
+  })
+})

--- a/packages/navigation-preferences-react/src/settings.ts
+++ b/packages/navigation-preferences-react/src/settings.ts
@@ -1,0 +1,37 @@
+import {
+  type AdminExtension,
+  adminRoutePageModule,
+  defineAdminExtension,
+} from "@voyant-travel/admin/extensions"
+import { PanelLeft } from "lucide-react"
+
+import { loadNavigationPreferences, navigationPreferencesQueryKey } from "./client.js"
+
+export function createSelectedNavigationPreferencesAdminExtension(): AdminExtension {
+  return defineAdminExtension({
+    id: "navigation-preferences",
+    navigationPreferences: {
+      queryKey: navigationPreferencesQueryKey,
+      load: loadNavigationPreferences,
+    },
+    settingsPages: [
+      {
+        id: "navigation",
+        path: "/navigation",
+        title: "Navigation",
+        label: "Navigation",
+        icon: PanelLeft,
+        group: "general",
+        order: 15,
+        page: () =>
+          import("./navigation-preferences-page.js").then((module) =>
+            adminRoutePageModule(module.NavigationPreferencesPage),
+          ),
+        routeMessagesProvider: () =>
+          import("./i18n/provider.js").then((module) => ({
+            default: module.NavigationPreferencesMessagesProvider,
+          })),
+      },
+    ],
+  })
+}

--- a/packages/navigation-preferences-react/tsconfig.build.json
+++ b/packages/navigation-preferences-react/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+}

--- a/packages/navigation-preferences-react/tsconfig.json
+++ b/packages/navigation-preferences-react/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/navigation-preferences-react/tsconfig.typecheck.json
+++ b/packages/navigation-preferences-react/tsconfig.typecheck.json
@@ -1,4 +1,6 @@
 {
   "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
-  "compilerOptions": { "noEmit": true }
+  "compilerOptions": {
+    "noEmit": true
+  }
 }

--- a/packages/navigation-preferences-react/tsconfig.typecheck.json
+++ b/packages/navigation-preferences-react/tsconfig.typecheck.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": { "noEmit": true }
+}

--- a/packages/navigation-preferences/drizzle.migrations.config.ts
+++ b/packages/navigation-preferences/drizzle.migrations.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "drizzle-kit"
+
+export default defineConfig({
+  schema: "./src/schema.ts",
+  out: "./migrations",
+  dialect: "postgresql",
+})

--- a/packages/navigation-preferences/migrations/20260715051134_navigation_preferences_baseline.sql
+++ b/packages/navigation-preferences/migrations/20260715051134_navigation_preferences_baseline.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "member_navigation_preferences" (
+	"member_id" text PRIMARY KEY NOT NULL,
+	"visibility" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "organization_navigation_preferences" (
+	"id" text PRIMARY KEY NOT NULL,
+	"visibility" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/navigation-preferences/migrations/meta/20260715051134_snapshot.json
+++ b/packages/navigation-preferences/migrations/meta/20260715051134_snapshot.json
@@ -1,0 +1,99 @@
+{
+  "id": "aea6399f-cc34-4fc5-a47a-e70426d64117",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.member_navigation_preferences": {
+      "name": "member_navigation_preferences",
+      "schema": "",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_navigation_preferences": {
+      "name": "organization_navigation_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/navigation-preferences/migrations/meta/_journal.json
+++ b/packages/navigation-preferences/migrations/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1784092294206,
+      "tag": "20260715051134_navigation_preferences_baseline",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/navigation-preferences/openapi/admin/navigation-preferences.json
+++ b/packages/navigation-preferences/openapi/admin/navigation-preferences.json
@@ -46,17 +46,10 @@
                           "type": "boolean"
                         }
                       },
-                      "required": [
-                        "organization",
-                        "member",
-                        "effective",
-                        "canManageOrganization"
-                      ]
+                      "required": ["organization", "member", "effective", "canManageOrganization"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -97,9 +90,7 @@
                     }
                   }
                 },
-                "required": [
-                  "visibility"
-                ]
+                "required": ["visibility"]
               }
             }
           }
@@ -122,14 +113,10 @@
                           }
                         }
                       },
-                      "required": [
-                        "visibility"
-                      ]
+                      "required": ["visibility"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }
@@ -200,9 +187,7 @@
                     }
                   }
                 },
-                "required": [
-                  "visibility"
-                ]
+                "required": ["visibility"]
               }
             }
           }
@@ -225,14 +210,10 @@
                           }
                         }
                       },
-                      "required": [
-                        "visibility"
-                      ]
+                      "required": ["visibility"]
                     }
                   },
-                  "required": [
-                    "data"
-                  ]
+                  "required": ["data"]
                 }
               }
             }

--- a/packages/navigation-preferences/openapi/admin/navigation-preferences.json
+++ b/packages/navigation-preferences/openapi/admin/navigation-preferences.json
@@ -1,0 +1,274 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Navigation Preferences Admin API",
+    "version": "1.0.0"
+  },
+  "components": {
+    "schemas": {},
+    "parameters": {}
+  },
+  "paths": {
+    "/v1/admin/navigation-preferences": {
+      "get": {
+        "operationId": "getNavigationPreferences",
+        "x-voyant-api-id": "@voyant-travel/navigation-preferences#api.admin",
+        "responses": {
+          "200": {
+            "description": "Navigation preferences",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "organization": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        },
+                        "member": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        },
+                        "effective": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        },
+                        "canManageOrganization": {
+                          "type": "boolean"
+                        }
+                      },
+                      "required": [
+                        "organization",
+                        "member",
+                        "effective",
+                        "canManageOrganization"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/navigation-preferences/organization": {
+      "put": {
+        "operationId": "setOrganizationNavigationPreferences",
+        "x-voyant-api-id": "@voyant-travel/navigation-preferences#api.admin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "visibility": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "required": [
+                  "visibility"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Organization defaults",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "visibility": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "required": [
+                        "visibility"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Organization administrator access required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/admin/navigation-preferences/me": {
+      "put": {
+        "operationId": "setOwnNavigationPreferences",
+        "x-voyant-api-id": "@voyant-travel/navigation-preferences#api.admin",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "visibility": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "required": [
+                  "visibility"
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Member overrides",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "visibility": {
+                          "type": "object",
+                          "additionalProperties": {
+                            "type": "boolean"
+                          }
+                        }
+                      },
+                      "required": [
+                        "visibility"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "data"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "nullable": true
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/navigation-preferences/package.json
+++ b/packages/navigation-preferences/package.json
@@ -1,0 +1,116 @@
+{
+  "name": "@voyant-travel/navigation-preferences",
+  "version": "0.1.0",
+  "description": "Organization and member admin navigation visibility preferences for Voyant.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./contracts": "./src/contracts.ts",
+    "./schema": "./src/schema.ts",
+    "./service": "./src/service.ts",
+    "./routes": "./src/routes.ts",
+    "./hono-module": "./src/hono-module.ts",
+    "./voyant": "./src/voyant.ts",
+    "./openapi/admin": "./openapi/admin/navigation-preferences.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "prepack": "pnpm run build",
+    "typecheck": "tsc -p tsconfig.typecheck.json",
+    "lint": "biome check src/ tests/",
+    "test": "vitest run",
+    "db:generate": "drizzle-kit generate --config=drizzle.migrations.config.ts --prefix=timestamp --name=navigation_preferences_baseline && node ../../scripts/migrations/guard-create-type.mjs ./migrations && node ../../scripts/migrations/ensure-extensions.mjs ./migrations"
+  },
+  "dependencies": {
+    "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/core": "workspace:^",
+    "@voyant-travel/db": "workspace:^",
+    "@voyant-travel/hono": "workspace:^",
+    "@voyant-travel/types": "workspace:^",
+    "drizzle-orm": "catalog:",
+    "hono": "catalog:",
+    "zod": "catalog:"
+  },
+  "devDependencies": {
+    "@voyant-travel/voyant-typescript-config": "workspace:^",
+    "drizzle-kit": "^0.31.10",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "files": [
+    "dist",
+    "openapi",
+    "migrations/*.sql",
+    "migrations/meta/_journal.json"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
+      },
+      "./contracts": {
+        "types": "./dist/contracts.d.ts",
+        "import": "./dist/contracts.js",
+        "default": "./dist/contracts.js"
+      },
+      "./schema": {
+        "types": "./dist/schema.d.ts",
+        "import": "./dist/schema.js",
+        "default": "./dist/schema.js"
+      },
+      "./service": {
+        "types": "./dist/service.d.ts",
+        "import": "./dist/service.js",
+        "default": "./dist/service.js"
+      },
+      "./routes": {
+        "types": "./dist/routes.d.ts",
+        "import": "./dist/routes.js",
+        "default": "./dist/routes.js"
+      },
+      "./hono-module": {
+        "types": "./dist/hono-module.d.ts",
+        "import": "./dist/hono-module.js",
+        "default": "./dist/hono-module.js"
+      },
+      "./voyant": {
+        "types": "./dist/voyant.d.ts",
+        "import": "./dist/voyant.js",
+        "default": "./dist/voyant.js"
+      },
+      "./openapi/admin": "./openapi/admin/navigation-preferences.json"
+    },
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/navigation-preferences"
+  },
+  "voyant": {
+    "schemaVersion": "voyant.package.v1",
+    "kind": "module",
+    "manifest": "./voyant",
+    "compatibleWith": {
+      "framework": ">=0.26.0",
+      "targets": [
+        "node"
+      ],
+      "modes": [
+        "local",
+        "managed-cloud",
+        "self-hosted"
+      ]
+    },
+    "schema": "./schema",
+    "requiresSchemas": [
+      "@voyant-travel/db"
+    ]
+  }
+}

--- a/packages/navigation-preferences/src/contracts.ts
+++ b/packages/navigation-preferences/src/contracts.ts
@@ -1,7 +1,14 @@
 import { z } from "zod"
 
 export const navigationVisibilityMapSchema = z
-  .record(z.string().trim().min(1).max(200), z.boolean())
+  .record(
+    z
+      .string()
+      .min(1)
+      .max(200)
+      .refine((id) => id === id.trim(), "Navigation IDs cannot have surrounding whitespace."),
+    z.boolean(),
+  )
   .superRefine((value, context) => {
     if (Object.keys(value).length > 1_000) {
       context.addIssue({
@@ -22,7 +29,21 @@ export const navigationPreferencesSnapshotSchema = z.object({
   canManageOrganization: z.boolean(),
 })
 
-export type NavigationVisibilityMap = z.infer<typeof navigationVisibilityMapSchema>
-export type UpdateNavigationPreferencesInput = z.infer<typeof updateNavigationPreferencesSchema>
+export type NavigationVisibilityMap = Readonly<z.infer<typeof navigationVisibilityMapSchema>>
 
-export type NavigationPreferencesSnapshot = z.infer<typeof navigationPreferencesSnapshotSchema>
+export interface NavigationPreferencesLayers {
+  readonly organization: NavigationVisibilityMap
+  readonly member: NavigationVisibilityMap
+}
+
+export interface ResolvedNavigationPreferences extends NavigationPreferencesLayers {
+  readonly effective: NavigationVisibilityMap
+}
+
+export interface NavigationPreferencesSnapshot extends ResolvedNavigationPreferences {
+  readonly canManageOrganization: boolean
+}
+
+export interface UpdateNavigationPreferencesInput {
+  readonly visibility: NavigationVisibilityMap
+}

--- a/packages/navigation-preferences/src/contracts.ts
+++ b/packages/navigation-preferences/src/contracts.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+export const navigationVisibilityMapSchema = z
+  .record(z.string().trim().min(1).max(200), z.boolean())
+  .superRefine((value, context) => {
+    if (Object.keys(value).length > 1_000) {
+      context.addIssue({
+        code: "custom",
+        message: "Navigation visibility maps may contain at most 1000 entries.",
+      })
+    }
+  })
+
+export const updateNavigationPreferencesSchema = z.object({
+  visibility: navigationVisibilityMapSchema,
+})
+
+export const navigationPreferencesSnapshotSchema = z.object({
+  organization: navigationVisibilityMapSchema,
+  member: navigationVisibilityMapSchema,
+  effective: navigationVisibilityMapSchema,
+  canManageOrganization: z.boolean(),
+})
+
+export type NavigationVisibilityMap = z.infer<typeof navigationVisibilityMapSchema>
+export type UpdateNavigationPreferencesInput = z.infer<typeof updateNavigationPreferencesSchema>
+
+export type NavigationPreferencesSnapshot = z.infer<typeof navigationPreferencesSnapshotSchema>

--- a/packages/navigation-preferences/src/hono-module.ts
+++ b/packages/navigation-preferences/src/hono-module.ts
@@ -1,0 +1,23 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { openApiValidationHook } from "@voyant-travel/hono"
+import type { HonoModule } from "@voyant-travel/hono/module"
+
+export const NAVIGATION_PREFERENCES_ROUTE_PATHS = [
+  "/v1/admin/navigation-preferences",
+  "/v1/admin/navigation-preferences/*",
+] as const
+
+export function createNavigationPreferencesHonoModule(): HonoModule {
+  return {
+    module: { name: "navigation-preferences" },
+    lazyRoutes: {
+      paths: NAVIGATION_PREFERENCES_ROUTE_PATHS,
+      load: () =>
+        import("./routes.js").then((module) => {
+          const app = new OpenAPIHono({ defaultHook: openApiValidationHook })
+          app.route("/", module.createNavigationPreferencesRoutes())
+          return app
+        }),
+    },
+  }
+}

--- a/packages/navigation-preferences/src/index.ts
+++ b/packages/navigation-preferences/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts.js"
+export * from "./schema.js"
+export * from "./service.js"

--- a/packages/navigation-preferences/src/routes.ts
+++ b/packages/navigation-preferences/src/routes.ts
@@ -1,0 +1,144 @@
+import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
+import {
+  ForbiddenApiError,
+  openApiValidationHook,
+  parseJsonBody,
+  requireUserId,
+  type VoyantDb,
+} from "@voyant-travel/hono"
+import { hasApiKeyPermission, permissionStringsToPermissions } from "@voyant-travel/types/api-keys"
+
+import {
+  navigationPreferencesSnapshotSchema,
+  navigationVisibilityMapSchema,
+  type UpdateNavigationPreferencesInput,
+  updateNavigationPreferencesSchema,
+} from "./contracts.js"
+import {
+  getNavigationPreferences,
+  setMemberNavigationPreferences,
+  setOrganizationNavigationPreferences,
+} from "./service.js"
+
+const apiId = "@voyant-travel/navigation-preferences#api.admin"
+const resource = "admin-navigation"
+
+type Env = {
+  Bindings: Record<string, unknown>
+  Variables: { db: VoyantDb; userId?: string; scopes?: string[] }
+}
+
+export interface NavigationPreferencesRouteService {
+  get: typeof getNavigationPreferences
+  setOrganization: typeof setOrganizationNavigationPreferences
+  setMember: typeof setMemberNavigationPreferences
+}
+
+export interface CreateNavigationPreferencesRoutesOptions {
+  service?: NavigationPreferencesRouteService
+}
+
+const visibilityResponseSchema = z.object({
+  data: z.object({ visibility: navigationVisibilityMapSchema }),
+})
+const snapshotResponseSchema = z.object({ data: navigationPreferencesSnapshotSchema })
+const errorResponseSchema = z.object({ error: z.unknown() })
+
+const jsonContent = <T extends z.ZodTypeAny>(schema: T, description: string) => ({
+  description,
+  content: { "application/json": { schema } },
+})
+const jsonBody = <T extends z.ZodTypeAny>(schema: T) => ({
+  required: true,
+  content: { "application/json": { schema } },
+})
+const errors = {
+  400: jsonContent(errorResponseSchema, "Invalid request"),
+  401: jsonContent(errorResponseSchema, "Authentication required"),
+  403: jsonContent(errorResponseSchema, "Organization administrator access required"),
+} as const
+
+const getPreferencesRoute = createRoute({
+  method: "get",
+  path: "/v1/admin/navigation-preferences",
+  operationId: "getNavigationPreferences",
+  "x-voyant-api-id": apiId,
+  responses: {
+    200: jsonContent(snapshotResponseSchema, "Navigation preferences"),
+    401: errors[401],
+  },
+})
+const putOrganizationRoute = createRoute({
+  method: "put",
+  path: "/v1/admin/navigation-preferences/organization",
+  operationId: "setOrganizationNavigationPreferences",
+  "x-voyant-api-id": apiId,
+  request: { body: jsonBody(updateNavigationPreferencesSchema) },
+  responses: { 200: jsonContent(visibilityResponseSchema, "Organization defaults"), ...errors },
+})
+const putMemberRoute = createRoute({
+  method: "put",
+  path: "/v1/admin/navigation-preferences/me",
+  operationId: "setOwnNavigationPreferences",
+  "x-voyant-api-id": apiId,
+  request: { body: jsonBody(updateNavigationPreferencesSchema) },
+  responses: {
+    200: jsonContent(visibilityResponseSchema, "Member overrides"),
+    400: errors[400],
+    401: errors[401],
+  },
+})
+
+const defaultService: NavigationPreferencesRouteService = {
+  get: getNavigationPreferences,
+  setOrganization: setOrganizationNavigationPreferences,
+  setMember: setMemberNavigationPreferences,
+}
+
+export function createNavigationPreferencesRoutes(
+  options: CreateNavigationPreferencesRoutesOptions = {},
+) {
+  const routes = new OpenAPIHono<Env>({ defaultHook: openApiValidationHook })
+  const service = options.service ?? defaultService
+
+  routes.openapi(getPreferencesRoute, async (c) => {
+    const memberId = requireUserId(c)
+    const preferences = await service.get(c.get("db"), memberId)
+    return c.json(
+      {
+        data: { ...preferences, canManageOrganization: canManageOrganization(c.get("scopes")) },
+      },
+      200,
+    )
+  })
+
+  routes.openapi(putOrganizationRoute, async (c) => {
+    requireOrganizationWrite(c.get("scopes"))
+    const input = (await parseJsonBody(
+      c,
+      updateNavigationPreferencesSchema,
+    )) as UpdateNavigationPreferencesInput
+    const visibility = await service.setOrganization(c.get("db"), input.visibility)
+    return c.json({ data: { visibility } }, 200)
+  })
+
+  routes.openapi(putMemberRoute, async (c) => {
+    const memberId = requireUserId(c)
+    const input = (await parseJsonBody(
+      c,
+      updateNavigationPreferencesSchema,
+    )) as UpdateNavigationPreferencesInput
+    const visibility = await service.setMember(c.get("db"), memberId, input.visibility)
+    return c.json({ data: { visibility } }, 200)
+  })
+
+  return routes
+}
+
+function canManageOrganization(scopes: string[] | undefined): boolean {
+  return hasApiKeyPermission(permissionStringsToPermissions(scopes ?? []), resource, "write")
+}
+
+function requireOrganizationWrite(scopes: string[] | undefined): void {
+  if (!canManageOrganization(scopes)) throw new ForbiddenApiError()
+}

--- a/packages/navigation-preferences/src/routes.ts
+++ b/packages/navigation-preferences/src/routes.ts
@@ -11,7 +11,6 @@ import { hasApiKeyPermission, permissionStringsToPermissions } from "@voyant-tra
 import {
   navigationPreferencesSnapshotSchema,
   navigationVisibilityMapSchema,
-  type UpdateNavigationPreferencesInput,
   updateNavigationPreferencesSchema,
 } from "./contracts.js"
 import {
@@ -114,20 +113,14 @@ export function createNavigationPreferencesRoutes(
 
   routes.openapi(putOrganizationRoute, async (c) => {
     requireOrganizationWrite(c.get("scopes"))
-    const input = (await parseJsonBody(
-      c,
-      updateNavigationPreferencesSchema,
-    )) as UpdateNavigationPreferencesInput
+    const input = await parseJsonBody(c, updateNavigationPreferencesSchema)
     const visibility = await service.setOrganization(c.get("db"), input.visibility)
     return c.json({ data: { visibility } }, 200)
   })
 
   routes.openapi(putMemberRoute, async (c) => {
     const memberId = requireUserId(c)
-    const input = (await parseJsonBody(
-      c,
-      updateNavigationPreferencesSchema,
-    )) as UpdateNavigationPreferencesInput
+    const input = await parseJsonBody(c, updateNavigationPreferencesSchema)
     const visibility = await service.setMember(c.get("db"), memberId, input.visibility)
     return c.json({ data: { visibility } }, 200)
   })

--- a/packages/navigation-preferences/src/schema.ts
+++ b/packages/navigation-preferences/src/schema.ts
@@ -1,0 +1,31 @@
+import { sql } from "drizzle-orm"
+import { jsonb, pgTable, text, timestamp } from "drizzle-orm/pg-core"
+
+import type { NavigationVisibilityMap } from "./contracts.js"
+
+export const ORGANIZATION_NAVIGATION_PREFERENCES_ID = "organization"
+
+export const organizationNavigationPreferences = pgTable("organization_navigation_preferences", {
+  id: text("id").primaryKey(),
+  visibility: jsonb("visibility")
+    .$type<NavigationVisibilityMap>()
+    .notNull()
+    .default(sql`'{}'::jsonb`),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+})
+
+/** `memberId` is an auth-owned user ID kept deliberately free of a cross-package FK. */
+export const memberNavigationPreferences = pgTable("member_navigation_preferences", {
+  memberId: text("member_id").primaryKey(),
+  visibility: jsonb("visibility")
+    .$type<NavigationVisibilityMap>()
+    .notNull()
+    .default(sql`'{}'::jsonb`),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+})
+
+export type OrganizationNavigationPreferences =
+  typeof organizationNavigationPreferences.$inferSelect
+export type MemberNavigationPreferences = typeof memberNavigationPreferences.$inferSelect

--- a/packages/navigation-preferences/src/service.ts
+++ b/packages/navigation-preferences/src/service.ts
@@ -1,0 +1,91 @@
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import type { NavigationVisibilityMap } from "./contracts.js"
+import {
+  memberNavigationPreferences,
+  ORGANIZATION_NAVIGATION_PREFERENCES_ID,
+  organizationNavigationPreferences,
+} from "./schema.js"
+
+const EMPTY_VISIBILITY: NavigationVisibilityMap = {}
+
+export function resolveEffectiveNavigationVisibility(
+  organization: NavigationVisibilityMap,
+  member: NavigationVisibilityMap,
+): NavigationVisibilityMap {
+  return { ...organization, ...member }
+}
+
+export async function getOrganizationNavigationPreferences(
+  db: PostgresJsDatabase,
+): Promise<NavigationVisibilityMap> {
+  const [row] = await db
+    .select({ visibility: organizationNavigationPreferences.visibility })
+    .from(organizationNavigationPreferences)
+    .where(eq(organizationNavigationPreferences.id, ORGANIZATION_NAVIGATION_PREFERENCES_ID))
+    .limit(1)
+  return row?.visibility ?? EMPTY_VISIBILITY
+}
+
+export async function setOrganizationNavigationPreferences(
+  db: PostgresJsDatabase,
+  visibility: NavigationVisibilityMap,
+): Promise<NavigationVisibilityMap> {
+  const [row] = await db
+    .insert(organizationNavigationPreferences)
+    .values({ id: ORGANIZATION_NAVIGATION_PREFERENCES_ID, visibility })
+    .onConflictDoUpdate({
+      target: organizationNavigationPreferences.id,
+      set: { visibility, updatedAt: new Date() },
+    })
+    .returning({ visibility: organizationNavigationPreferences.visibility })
+  return row?.visibility ?? visibility
+}
+
+export async function getMemberNavigationPreferences(
+  db: PostgresJsDatabase,
+  memberId: string,
+): Promise<NavigationVisibilityMap> {
+  const [row] = await db
+    .select({ visibility: memberNavigationPreferences.visibility })
+    .from(memberNavigationPreferences)
+    .where(eq(memberNavigationPreferences.memberId, memberId))
+    .limit(1)
+  return row?.visibility ?? EMPTY_VISIBILITY
+}
+
+export async function setMemberNavigationPreferences(
+  db: PostgresJsDatabase,
+  memberId: string,
+  visibility: NavigationVisibilityMap,
+): Promise<NavigationVisibilityMap> {
+  const [row] = await db
+    .insert(memberNavigationPreferences)
+    .values({ memberId, visibility })
+    .onConflictDoUpdate({
+      target: memberNavigationPreferences.memberId,
+      set: { visibility, updatedAt: new Date() },
+    })
+    .returning({ visibility: memberNavigationPreferences.visibility })
+  return row?.visibility ?? visibility
+}
+
+export async function getNavigationPreferences(
+  db: PostgresJsDatabase,
+  memberId: string,
+): Promise<{
+  organization: NavigationVisibilityMap
+  member: NavigationVisibilityMap
+  effective: NavigationVisibilityMap
+}> {
+  const [organization, member] = await Promise.all([
+    getOrganizationNavigationPreferences(db),
+    getMemberNavigationPreferences(db, memberId),
+  ])
+  return {
+    organization,
+    member,
+    effective: resolveEffectiveNavigationVisibility(organization, member),
+  }
+}

--- a/packages/navigation-preferences/src/service.ts
+++ b/packages/navigation-preferences/src/service.ts
@@ -1,14 +1,12 @@
+import type { VoyantDb } from "@voyant-travel/hono"
 import { eq } from "drizzle-orm"
-import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import type { NavigationVisibilityMap } from "./contracts.js"
+import type { NavigationVisibilityMap, ResolvedNavigationPreferences } from "./contracts.js"
 import {
   memberNavigationPreferences,
   ORGANIZATION_NAVIGATION_PREFERENCES_ID,
   organizationNavigationPreferences,
 } from "./schema.js"
-
-const EMPTY_VISIBILITY: NavigationVisibilityMap = {}
 
 export function resolveEffectiveNavigationVisibility(
   organization: NavigationVisibilityMap,
@@ -18,18 +16,18 @@ export function resolveEffectiveNavigationVisibility(
 }
 
 export async function getOrganizationNavigationPreferences(
-  db: PostgresJsDatabase,
+  db: VoyantDb,
 ): Promise<NavigationVisibilityMap> {
   const [row] = await db
     .select({ visibility: organizationNavigationPreferences.visibility })
     .from(organizationNavigationPreferences)
     .where(eq(organizationNavigationPreferences.id, ORGANIZATION_NAVIGATION_PREFERENCES_ID))
     .limit(1)
-  return row?.visibility ?? EMPTY_VISIBILITY
+  return row?.visibility ?? {}
 }
 
 export async function setOrganizationNavigationPreferences(
-  db: PostgresJsDatabase,
+  db: VoyantDb,
   visibility: NavigationVisibilityMap,
 ): Promise<NavigationVisibilityMap> {
   const [row] = await db
@@ -39,12 +37,12 @@ export async function setOrganizationNavigationPreferences(
       target: organizationNavigationPreferences.id,
       set: { visibility, updatedAt: new Date() },
     })
-    .returning({ visibility: organizationNavigationPreferences.visibility })
+    .returning()
   return row?.visibility ?? visibility
 }
 
 export async function getMemberNavigationPreferences(
-  db: PostgresJsDatabase,
+  db: VoyantDb,
   memberId: string,
 ): Promise<NavigationVisibilityMap> {
   const [row] = await db
@@ -52,11 +50,11 @@ export async function getMemberNavigationPreferences(
     .from(memberNavigationPreferences)
     .where(eq(memberNavigationPreferences.memberId, memberId))
     .limit(1)
-  return row?.visibility ?? EMPTY_VISIBILITY
+  return row?.visibility ?? {}
 }
 
 export async function setMemberNavigationPreferences(
-  db: PostgresJsDatabase,
+  db: VoyantDb,
   memberId: string,
   visibility: NavigationVisibilityMap,
 ): Promise<NavigationVisibilityMap> {
@@ -67,18 +65,14 @@ export async function setMemberNavigationPreferences(
       target: memberNavigationPreferences.memberId,
       set: { visibility, updatedAt: new Date() },
     })
-    .returning({ visibility: memberNavigationPreferences.visibility })
+    .returning()
   return row?.visibility ?? visibility
 }
 
 export async function getNavigationPreferences(
-  db: PostgresJsDatabase,
+  db: VoyantDb,
   memberId: string,
-): Promise<{
-  organization: NavigationVisibilityMap
-  member: NavigationVisibilityMap
-  effective: NavigationVisibilityMap
-}> {
+): Promise<ResolvedNavigationPreferences> {
   const [organization, member] = await Promise.all([
     getOrganizationNavigationPreferences(db),
     getMemberNavigationPreferences(db, memberId),

--- a/packages/navigation-preferences/src/voyant.ts
+++ b/packages/navigation-preferences/src/voyant.ts
@@ -1,0 +1,88 @@
+import { defineModule } from "@voyant-travel/core/project"
+
+const runtime = {
+  entry: "@voyant-travel/navigation-preferences/hono-module",
+  export: "createNavigationPreferencesHonoModule",
+} as const
+
+const adminRuntime = {
+  entry: "@voyant-travel/navigation-preferences-react/settings",
+  export: "createSelectedNavigationPreferencesAdminExtension",
+} as const
+
+export const navigationPreferencesVoyantModule = defineModule({
+  id: "@voyant-travel/navigation-preferences",
+  packageName: "@voyant-travel/navigation-preferences",
+  localId: "navigation-preferences",
+  api: [
+    {
+      id: "@voyant-travel/navigation-preferences#api.admin",
+      surface: "admin",
+      mount: "navigation-preferences",
+      resource: "admin-navigation",
+      authorization: "route",
+      openapi: { document: "navigation-preferences" },
+      runtime,
+    },
+  ],
+  schema: [
+    {
+      id: "@voyant-travel/navigation-preferences#schema",
+      source: "@voyant-travel/navigation-preferences/schema",
+    },
+  ],
+  migrations: [
+    {
+      id: "@voyant-travel/navigation-preferences#migrations",
+      source: "./migrations",
+    },
+  ],
+  resources: [
+    {
+      id: "@voyant-travel/navigation-preferences#resource.database",
+      kind: "database",
+      required: true,
+      config: { engine: "postgres" },
+    },
+  ],
+  access: {
+    resources: [
+      {
+        id: "@voyant-travel/navigation-preferences#access.navigation-preferences",
+        resource: "admin-navigation",
+        label: "Navigation preferences",
+        description: "View and manage organization navigation defaults.",
+        actions: [
+          {
+            action: "read",
+            label: "View navigation preferences",
+            description: "View organization defaults and personal navigation overrides.",
+          },
+          {
+            action: "write",
+            label: "Manage organization navigation",
+            description: "Set or provision organization navigation defaults.",
+            sensitive: true,
+          },
+        ],
+      },
+    ],
+  },
+  admin: {
+    compositionOrder: 15,
+    runtime: adminRuntime,
+    routes: [
+      {
+        id: "@voyant-travel/navigation-preferences#admin.route.settings",
+        path: "/settings/navigation",
+        runtime: adminRuntime,
+      },
+    ],
+  },
+  lifecycle: {
+    uninstall: { default: "retain-data", purge: "not-supported" },
+  },
+  meta: { ownership: "package" },
+})
+
+export default navigationPreferencesVoyantModule

--- a/packages/navigation-preferences/tests/unit/contracts.test.ts
+++ b/packages/navigation-preferences/tests/unit/contracts.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { navigationVisibilityMapSchema } from "../../src/contracts.js"
+
+describe("navigation visibility map contract", () => {
+  it("preserves unknown IDs exactly instead of normalizing their spelling", () => {
+    const visibility = { "Future.Module/v2": false, "removed.module": true }
+
+    expect(navigationVisibilityMapSchema.parse(visibility)).toEqual(visibility)
+  })
+
+  it("rejects malformed IDs without rejecting unknown stable IDs", () => {
+    expect(() => navigationVisibilityMapSchema.parse({ "   ": true })).toThrow()
+    expect(() => navigationVisibilityMapSchema.parse({ " future-module ": true })).toThrow()
+    expect(navigationVisibilityMapSchema.parse({ "future-module": true })).toEqual({
+      "future-module": true,
+    })
+  })
+})

--- a/packages/navigation-preferences/tests/unit/openapi-ownership.test.ts
+++ b/packages/navigation-preferences/tests/unit/openapi-ownership.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs"
+import { describe, expect, it } from "vitest"
+
+import { createNavigationPreferencesRoutes } from "../../src/routes.js"
+
+const committed = JSON.parse(
+  readFileSync(new URL("../../openapi/admin/navigation-preferences.json", import.meta.url), "utf8"),
+) as { paths: Record<string, Record<string, { "x-voyant-api-id"?: string }>> }
+
+describe("navigation preferences OpenAPI ownership", () => {
+  it("claims every committed and live operation", () => {
+    const apiId = "@voyant-travel/navigation-preferences#api.admin"
+    const live = createNavigationPreferencesRoutes().getOpenAPIDocument({
+      info: { title: "test", version: "1" },
+    })
+
+    expect(Object.keys(live.paths ?? {}).sort()).toEqual(Object.keys(committed.paths).sort())
+    for (const path of Object.keys(committed.paths)) {
+      expect(Object.keys(live.paths?.[path] ?? {}).sort()).toEqual(
+        Object.keys(committed.paths[path] ?? {}).sort(),
+      )
+      for (const [method, operation] of Object.entries(committed.paths[path] ?? {})) {
+        expect(operation["x-voyant-api-id"]).toBe(apiId)
+        expect(
+          (live.paths?.[path] as Record<string, { "x-voyant-api-id"?: string }> | undefined)?.[
+            method
+          ]?.["x-voyant-api-id"],
+        ).toBe(apiId)
+      }
+    }
+  })
+})

--- a/packages/navigation-preferences/tests/unit/routes.test.ts
+++ b/packages/navigation-preferences/tests/unit/routes.test.ts
@@ -86,11 +86,26 @@ describe("navigation preference routes", () => {
       {
         method: "PUT",
         headers: { "content-type": "application/json" },
-        body: '{"visibility":{"bookings":false}}',
+        body: '{"memberId":"user_2","visibility":{"bookings":false}}',
       },
     )
 
     expect(response.status).toBe(200)
     expect(service.setMember).toHaveBeenCalledWith({}, "user_1", { bookings: false })
+  })
+
+  it("rejects a member-layer write without an authenticated member", async () => {
+    const service = createService()
+    const response = await createApp(service, ["admin-navigation:write"]).request(
+      "/v1/admin/navigation-preferences/me",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: '{"visibility":{"bookings":false}}',
+      },
+    )
+
+    expect(response.status).toBe(401)
+    expect(service.setMember).not.toHaveBeenCalled()
   })
 })

--- a/packages/navigation-preferences/tests/unit/routes.test.ts
+++ b/packages/navigation-preferences/tests/unit/routes.test.ts
@@ -1,0 +1,96 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import { handleApiError } from "@voyant-travel/hono"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createNavigationPreferencesRoutes,
+  type NavigationPreferencesRouteService,
+} from "../../src/routes.js"
+
+function createService(): NavigationPreferencesRouteService {
+  return {
+    get: vi.fn(async () => ({
+      organization: { finance: false },
+      member: { bookings: true },
+      effective: { finance: false, bookings: true },
+    })),
+    setOrganization: vi.fn(async (_db, visibility) => visibility),
+    setMember: vi.fn(async (_db, _memberId, visibility) => visibility),
+  }
+}
+
+function createApp(
+  service: NavigationPreferencesRouteService,
+  scopes: string[] = [],
+  userId?: string,
+) {
+  const app = new OpenAPIHono()
+  app.use("*", async (c, next) => {
+    c.set("db", {} as never)
+    c.set("scopes", scopes)
+    if (userId) c.set("userId", userId)
+    await next()
+  })
+  app.route("/", createNavigationPreferencesRoutes({ service }))
+  app.onError((error, c) => handleApiError(error, c))
+  return app
+}
+
+describe("navigation preference routes", () => {
+  it("returns organization and current-member maps to an authenticated member", async () => {
+    const service = createService()
+    const response = await createApp(service, ["*:read"], "user_1").request(
+      "/v1/admin/navigation-preferences",
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        organization: { finance: false },
+        member: { bookings: true },
+        effective: { finance: false, bookings: true },
+        canManageOrganization: false,
+      },
+    })
+  })
+
+  it("allows only organization writers to replace organization defaults", async () => {
+    const deniedService = createService()
+    const denied = await createApp(deniedService, ["*:read"], "user_1").request(
+      "/v1/admin/navigation-preferences/organization",
+      { method: "PUT", headers: { "content-type": "application/json" }, body: '{"visibility":{}}' },
+    )
+    expect(denied.status).toBe(403)
+    expect(deniedService.setOrganization).not.toHaveBeenCalled()
+
+    const allowedService = createService()
+    const allowed = await createApp(allowedService, ["admin-navigation:write"]).request(
+      "/v1/admin/navigation-preferences/organization",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: '{"visibility":{"finance":false,"future-module":true}}',
+      },
+    )
+    expect(allowed.status).toBe(200)
+    expect(allowedService.setOrganization).toHaveBeenCalledWith(
+      {},
+      { finance: false, "future-module": true },
+    )
+  })
+
+  it("always writes member preferences for the authenticated member", async () => {
+    const service = createService()
+    const response = await createApp(service, ["*:read"], "user_1").request(
+      "/v1/admin/navigation-preferences/me",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: '{"visibility":{"bookings":false}}',
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(service.setMember).toHaveBeenCalledWith({}, "user_1", { bookings: false })
+  })
+})

--- a/packages/navigation-preferences/tests/unit/service.test.ts
+++ b/packages/navigation-preferences/tests/unit/service.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveEffectiveNavigationVisibility } from "../../src/service.js"
+
+describe("effective navigation preferences", () => {
+  it("lets member values override organization defaults and preserves unknown IDs", () => {
+    expect(
+      resolveEffectiveNavigationVisibility(
+        { finance: false, bookings: true, "future-module": false },
+        { finance: true },
+      ),
+    ).toEqual({ finance: true, bookings: true, "future-module": false })
+  })
+})

--- a/packages/navigation-preferences/tests/unit/voyant-manifest.test.ts
+++ b/packages/navigation-preferences/tests/unit/voyant-manifest.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest"
+
+import navigationPreferencesVoyantModule from "../../src/voyant.js"
+
+describe("navigation preferences manifest", () => {
+  it("owns its API, schema, migrations, access, and admin settings contribution", () => {
+    expect(navigationPreferencesVoyantModule.id).toBe("@voyant-travel/navigation-preferences")
+    expect(navigationPreferencesVoyantModule.api?.map((entry) => entry.id)).toEqual([
+      "@voyant-travel/navigation-preferences#api.admin",
+    ])
+    expect(navigationPreferencesVoyantModule.schema).toHaveLength(1)
+    expect(navigationPreferencesVoyantModule.migrations).toHaveLength(1)
+    expect(navigationPreferencesVoyantModule.api?.[0]).toMatchObject({
+      resource: "admin-navigation",
+      authorization: "route",
+    })
+    expect(navigationPreferencesVoyantModule.access?.resources[0]?.resource).toBe(
+      "admin-navigation",
+    )
+    expect(navigationPreferencesVoyantModule.admin?.routes[0]?.path).toBe("/settings/navigation")
+  })
+})

--- a/packages/navigation-preferences/tsconfig.build.json
+++ b/packages/navigation-preferences/tsconfig.build.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"]
+}

--- a/packages/navigation-preferences/tsconfig.json
+++ b/packages/navigation-preferences/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@voyant-travel/voyant-typescript-config/base.json",
+  "compilerOptions": {
+    "composite": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "Bundler"
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/navigation-preferences/tsconfig.typecheck.json
+++ b/packages/navigation-preferences/tsconfig.typecheck.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../typescript-config/dep-paths.json"],
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -147,6 +147,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1240,6 +1241,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1235,6 +1236,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/operator-standard/package.json
+++ b/packages/operator-standard/package.json
@@ -107,6 +107,8 @@
     "@voyant-travel/mcp": "workspace:*",
     "@voyant-travel/mice": "workspace:*",
     "@voyant-travel/mice-react": "workspace:*",
+    "@voyant-travel/navigation-preferences": "workspace:*",
+    "@voyant-travel/navigation-preferences-react": "workspace:*",
     "@voyant-travel/notifications": "workspace:*",
     "@voyant-travel/notifications-react": "workspace:*",
     "@voyant-travel/operations": "workspace:*",

--- a/packages/operator-standard/src/index.ts
+++ b/packages/operator-standard/src/index.ts
@@ -191,6 +191,7 @@ export const STANDARD_OPERATOR_DISTRIBUTION_POLICY: {
     { resolve: "@voyant-travel/storefront/payment-link" },
     { resolve: "@voyant-travel/trips" },
     { resolve: "@voyant-travel/flights" },
+    { resolve: "@voyant-travel/navigation-preferences", required: true },
     { resolve: "@voyant-travel/operator-settings" },
     { resolve: "@voyant-travel/charters" },
     { resolve: "@voyant-travel/cruises" },

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -1,5 +1,6 @@
 import { bookingsVoyantModule } from "@voyant-travel/bookings/voyant"
 import { financeVoyantModule } from "@voyant-travel/finance/voyant"
+import navigationPreferencesVoyantModule from "@voyant-travel/navigation-preferences/voyant"
 import { storefrontVoyantModule } from "@voyant-travel/storefront/voyant"
 import { describe, expect, it } from "vitest"
 import {
@@ -7,7 +8,10 @@ import {
   resolveDeploymentGraph,
   validateGraphUnitManifest,
 } from "../../framework/src/deployment-graph.js"
-import { STANDARD_OPERATOR_DEPLOYMENT } from "../src/index.js"
+import {
+  STANDARD_OPERATOR_DEPLOYMENT,
+  STANDARD_OPERATOR_DISTRIBUTION_POLICY,
+} from "../src/index.js"
 
 describe("standard package manifests", () => {
   it("selects durable Postgres outbound webhook enqueueing explicitly", () => {
@@ -71,5 +75,14 @@ describe("standard package manifests", () => {
       mode: "self-hosted",
       providers: { workflows: "self-hosted" },
     })
+  })
+
+  it("requires navigation preferences in the standard operator graph", () => {
+    expect(validateGraphUnitManifest(navigationPreferencesVoyantModule, "module")).toEqual([])
+    expect(
+      STANDARD_OPERATOR_DISTRIBUTION_POLICY.modules.find(
+        (selection) => selection.resolve === "@voyant-travel/navigation-preferences",
+      ),
+    ).toEqual({ resolve: "@voyant-travel/navigation-preferences", required: true })
   })
 })

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -140,6 +140,9 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": [
+        "../admin/dist/navigation/preferences.d.ts"
+      ],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1233,6 +1236,36 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": [
+        "../navigation-preferences/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -140,9 +140,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
-      "@voyant-travel/admin/navigation/preferences": [
-        "../admin/dist/navigation/preferences.d.ts"
-      ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1236,9 +1234,7 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
-      "@voyant-travel/navigation-preferences": [
-        "../navigation-preferences/dist/index.d.ts"
-      ],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
       "@voyant-travel/navigation-preferences-react": [
         "../navigation-preferences-react/dist/index.d.ts"
       ],

--- a/packages/vite-config/src/index.ts
+++ b/packages/vite-config/src/index.ts
@@ -1,6 +1,15 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { createRequire } from "node:module"
-import { dirname, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL, URL } from "node:url"
 import type { Alias, Plugin, PluginOption, ResolverFunction, UserConfig } from "vite"
 
@@ -89,6 +98,33 @@ export interface VoyantGeneratedRouteFile {
   readonly source: string
 }
 
+let generatedRouteWriteSequence = 0
+
+function generatedRouteFiles(root: string): string[] {
+  if (!existsSync(root)) return []
+  return readdirSync(root, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(root, entry.name)
+    return entry.isDirectory() ? generatedRouteFiles(path) : [path]
+  })
+}
+
+function removeEmptyGeneratedRouteDirectories(root: string, preserveRoot = true): void {
+  if (!existsSync(root)) return
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      removeEmptyGeneratedRouteDirectories(join(root, entry.name), false)
+    }
+  }
+  if (!preserveRoot) {
+    try {
+      rmdirSync(root)
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== "ENOENT" && code !== "ENOTEMPTY") throw error
+    }
+  }
+}
+
 /**
  * Materialize package-owned route registrations into the ignored project graph.
  * TanStack's file router still receives physical files, while applications do
@@ -103,15 +139,35 @@ export function voyantGeneratedRoutes(options: {
   const generatedRouteTree = resolve(appRoot, ".voyant/routeTree.gen.ts")
 
   const generate = () => {
-    rmSync(routesDirectory, { recursive: true, force: true })
+    const expected = new Map<string, string>()
     for (const file of options.files) {
       if (file.path.startsWith("/") || file.path.includes("..")) {
         throw new Error(`Invalid generated route path: ${file.path}`)
       }
-      const target = resolve(routesDirectory, file.path)
-      mkdirSync(dirname(target), { recursive: true })
-      writeFileSync(target, `${file.source.trim()}\n`)
+      expected.set(resolve(routesDirectory, file.path), `${file.source.trim()}\n`)
     }
+
+    mkdirSync(routesDirectory, { recursive: true })
+    for (const [target, source] of expected) {
+      if (existsSync(target) && readFileSync(target, "utf8") === source) continue
+
+      mkdirSync(dirname(target), { recursive: true })
+      const temporary = resolve(
+        appRoot,
+        `.voyant/.route-write-${process.pid}-${generatedRouteWriteSequence++}.tmp`,
+      )
+      try {
+        writeFileSync(temporary, source)
+        renameSync(temporary, target)
+      } finally {
+        rmSync(temporary, { force: true })
+      }
+    }
+
+    for (const path of generatedRouteFiles(routesDirectory)) {
+      if (!expected.has(path)) rmSync(path, { force: true })
+    }
+    removeEmptyGeneratedRouteDirectories(routesDirectory)
   }
 
   generate()

--- a/packages/vite-config/tests/vite-config.test.ts
+++ b/packages/vite-config/tests/vite-config.test.ts
@@ -68,6 +68,13 @@ describe("voyantGeneratedRoutes", () => {
         "export const Route = true\n",
       )
       expect(existsSync(join(root, "src/routes"))).toBe(false)
+
+      writeFileSync(join(generated.routesDirectory, "stale.tsx"), "stale\n")
+      voyantGeneratedRoutes({
+        appRootUrl: pathToFileURL(join(root, "vite.config.ts")).href,
+        files: [{ path: "(auth)/sign-in.tsx", source: "export const Route = true" }],
+      })
+      expect(existsSync(join(generated.routesDirectory, "stale.tsx"))).toBe(false)
     } finally {
       rmSync(root, { recursive: true, force: true })
     }

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -141,6 +141,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1234,6 +1235,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -142,6 +142,7 @@
       "@voyant-travel/admin/navigation/operator-navigation": [
         "../admin/dist/navigation/operator-navigation.d.ts"
       ],
+      "@voyant-travel/admin/navigation/preferences": ["../admin/dist/navigation/preferences.d.ts"],
       "@voyant-travel/admin/providers/admin-extensions": [
         "../admin/dist/providers/admin-extensions.d.ts"
       ],
@@ -1235,6 +1236,34 @@
       "@voyant-travel/mice/standard-links": ["../mice/dist/standard-links.d.ts"],
       "@voyant-travel/mice/validation": ["../mice/dist/validation.d.ts"],
       "@voyant-travel/mice/voyant": ["../mice/dist/voyant.d.ts"],
+      "@voyant-travel/navigation-preferences": ["../navigation-preferences/dist/index.d.ts"],
+      "@voyant-travel/navigation-preferences-react": [
+        "../navigation-preferences-react/dist/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/i18n": [
+        "../navigation-preferences-react/dist/i18n/index.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences-react/settings": [
+        "../navigation-preferences-react/dist/settings.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/contracts": [
+        "../navigation-preferences/dist/contracts.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/hono-module": [
+        "../navigation-preferences/dist/hono-module.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/routes": [
+        "../navigation-preferences/dist/routes.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/schema": [
+        "../navigation-preferences/dist/schema.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/service": [
+        "../navigation-preferences/dist/service.d.ts"
+      ],
+      "@voyant-travel/navigation-preferences/voyant": [
+        "../navigation-preferences/dist/voyant.d.ts"
+      ],
       "@voyant-travel/notifications": ["../notifications/dist/index.d.ts"],
       "@voyant-travel/notifications-react": ["../notifications-react/dist/index.d.ts"],
       "@voyant-travel/notifications-react/admin": ["../notifications-react/dist/admin/index.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3068,6 +3068,9 @@ importers:
       '@voyant-travel/admin':
         specifier: workspace:^
         version: link:../admin
+      '@voyant-travel/auth-react':
+        specifier: workspace:^
+        version: link:../auth-react
       '@voyant-travel/navigation-preferences':
         specifier: workspace:^
         version: link:../navigation-preferences

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3007,6 +3007,95 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  packages/navigation-preferences:
+    dependencies:
+      '@hono/zod-openapi':
+        specifier: 'catalog:'
+        version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/core':
+        specifier: workspace:^
+        version: link:../core
+      '@voyant-travel/db':
+        specifier: workspace:^
+        version: link:../db
+      '@voyant-travel/hono':
+        specifier: workspace:^
+        version: link:../hono
+      '@voyant-travel/types':
+        specifier: workspace:^
+        version: link:../types
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      hono:
+        specifier: 4.12.25
+        version: 4.12.25
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+    devDependencies:
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
+  packages/navigation-preferences-react:
+    dependencies:
+      '@voyant-travel/i18n':
+        specifier: workspace:^
+        version: link:../i18n
+      '@voyant-travel/react':
+        specifier: workspace:^
+        version: link:../react
+    devDependencies:
+      '@tanstack/react-query':
+        specifier: ^5.101.2
+        version: 5.101.2(react@19.2.7)
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@voyant-travel/admin':
+        specifier: workspace:^
+        version: link:../admin
+      '@voyant-travel/navigation-preferences':
+        specifier: workspace:^
+        version: link:../navigation-preferences
+      '@voyant-travel/ui':
+        specifier: workspace:^
+        version: link:../ui
+      '@voyant-travel/voyant-typescript-config':
+        specifier: workspace:^
+        version: link:../typescript-config
+      lucide-react:
+        specifier: ^1.23.0
+        version: 1.23.0(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      sonner:
+        specifier: ^2.0.7
+        version: 2.0.7(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))
+
   packages/notifications:
     dependencies:
       '@hono/zod-openapi':
@@ -3559,6 +3648,12 @@ importers:
       '@voyant-travel/mice-react':
         specifier: workspace:*
         version: link:../mice-react
+      '@voyant-travel/navigation-preferences':
+        specifier: workspace:*
+        version: link:../navigation-preferences
+      '@voyant-travel/navigation-preferences-react':
+        specifier: workspace:*
+        version: link:../navigation-preferences-react
       '@voyant-travel/notifications':
         specifier: workspace:*
         version: link:../notifications

--- a/starters/operator/tests/selected-graph-action-ledger-admin.test.ts
+++ b/starters/operator/tests/selected-graph-action-ledger-admin.test.ts
@@ -24,6 +24,7 @@ describe("selected-graph Action Ledger admin composition", () => {
       "auth-team",
       "operations",
       "operator-settings",
+      "navigation-preferences",
       "relationships",
       "distribution",
       "finance",

--- a/starters/operator/tests/selected-graph-team-admin.test.ts
+++ b/starters/operator/tests/selected-graph-team-admin.test.ts
@@ -7,6 +7,7 @@ import {
   selectedGraphAdminExtensionFactories,
 } from "../.voyant/admin/selected-graph-admin.generated.js"
 import { operatorFrontend } from "../.voyant/routes/_lib/operator-frontend.js"
+import { getRouter } from "../src/router.js"
 
 describe("selected-graph Team admin composition", () => {
   it("selects the package team extension exactly once", () => {
@@ -26,8 +27,20 @@ describe("selected-graph Team admin composition", () => {
     })
     const routeTree = rootRoute.addChildren([workspaceRoute])
 
-    operatorFrontend.createRouter({ routeTree, workspaceRoute })
+    for (let attempt = 0; attempt < 4; attempt += 1) {
+      operatorFrontend.createRouter({ routeTree, workspaceRoute })
+    }
     const router = operatorFrontend.createRouter({ routeTree, workspaceRoute })
+    const teamRouteIds = Object.keys(router.routesById).filter(
+      (routeId) => routeId === "/_workspace/settings/team",
+    )
+
+    expect(teamRouteIds).toEqual(["/_workspace/settings/team"])
+  })
+
+  it("registers exactly one team route in the generated operator route tree", () => {
+    getRouter()
+    const router = getRouter()
     const teamRouteIds = Object.keys(router.routesById).filter(
       (routeId) => routeId === "/_workspace/settings/team",
     )

--- a/starters/operator/tests/voyant.config.test.ts
+++ b/starters/operator/tests/voyant.config.test.ts
@@ -8,7 +8,7 @@ const operatorRoot = process.cwd()
 
 describe("Operator project config", () => {
   it("authors only deployment differences", () => {
-    expect(config.modules).toHaveLength(40)
+    expect(config.modules).toHaveLength(41)
     expect(config.extensions).toHaveLength(24)
     expect(config.plugins).toHaveLength(0)
     expect(config.productBom).toEqual({
@@ -30,7 +30,7 @@ describe("Operator project config", () => {
       "read-only",
     ])
 
-    expect(config.selections?.modules).toHaveLength(40)
+    expect(config.selections?.modules).toHaveLength(41)
     expect(
       config.selections?.modules.every(({ provenance }) => provenance.kind === "package"),
     ).toBe(true)


### PR DESCRIPTION
## Summary
- add package-owned organization and member navigation preference contracts, persistence, routes, and admin settings
- apply the resolved preferences to operator navigation without coupling them to a specific identity provider
- keep unknown navigation IDs forward-compatible while validating malformed values and graph access authority
- isolate query state per authenticated member and keep the optional extension provider-neutral

## Verification
- pnpm verify:dep-paths
- pnpm --filter @voyant-travel/admin typecheck
- pnpm --filter @voyant-travel/navigation-preferences-react typecheck
- focused navigation settings and workspace tests
- pnpm biome check on changed files

Closes #3354.