### PR TITLE
Harden the self-host export contract

### DIFF
--- a/.changeset/harden-self-host-export-contract.md
+++ b/.changeset/harden-self-host-export-contract.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": minor
+---
+
+Version the self-host export and starter contracts with exact dependency
+coordinates, deterministic registry install provenance, explicit secret-free
+config validation, and machine-readable migration no-replay/drift policy.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -64,7 +64,7 @@ workload class well. On Node none of it is necessary.
   missing. Local `.env` loading is only a source for satisfying the same graph
   contract; it is not a parallel deployment shape.
 - **Cloud export:** a managed deployment exits through a validated
-  `voyant.self-host-export-bundle.v1` containing its admitted resolved graph and
+  `voyant.self-host-export-bundle.v2` containing its admitted resolved graph and
   data manifests. The framework projects that same graph to self-hosted
   `deployment.providers`; an external generator consumes the projection and
   `STANDARD_NODE_STARTER`. It does not boot a profile snapshot or select a

--- a/docs/architecture/standard-node-starter-acceptance.md
+++ b/docs/architecture/standard-node-starter-acceptance.md
@@ -32,6 +32,9 @@ The gate requires:
   Node bootstrap implementation details.
 - The project names only the CLI, framework, standard product distribution, and
   runtime as Voyant dependencies.
+- `voyant.node-starter.v3` provides exact, key-complete runtime and development
+  dependency coordinate maps. Self-host generators consume those coordinates
+  directly and must never fall back to mutable registry tags such as `latest`.
 - Packaged starters inherit the supported CLI semver range from the checked-in
   starter; the starter archive version never doubles as the CLI version.
 - `.gitignore` protects `.voyant/`, `dist/`, `node_modules/`, and local env files

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -284,19 +284,26 @@ restored as an export format.
 
 `@voyant-travel/framework/self-host-export` validates the duplicated graph/hash/
 BOM evidence and projects deployment authority to self-hosted Node. Projection
-preserves selected graph IDs and package-scoped config, remaps Cloud substrate
-providers through `deployment.providers`, recomputes resource requirements and
-the graph hash, and reports unsupported providers or non-portable packages as
-explicit diagnostics. It does not rediscover package facets or maintain a
-central package catalog.
+preserves selected graph IDs and package-scoped config only after recursively
+rejecting secret-like fields and values. It remaps Cloud substrate providers
+through `deployment.providers`, recomputes resource requirements and the graph
+hash, and reports unsupported providers or non-portable packages as explicit
+diagnostics. It does not rediscover package facets or maintain a central package
+catalog.
 
 External generators consume that projection and the versioned
-`STANDARD_NODE_STARTER` contract. They generate selection intent and install the
-admitted package versions; package manifests remain the sole composition path.
-The restored database retains the shared `drizzle._voyant_migrations` lineage,
-so standard package migrations already applied in Cloud are not replayed and
-self-host-only additions continue in the same journal. Operational steps live
-in [Exporting From Voyant Cloud](../exporting-from-voyant-cloud.md).
+`STANDARD_NODE_STARTER` contract. The starter carries exact coordinates for
+every runtime and development dependency; generators may not resolve absent
+coordinates through registry tags. Projected registry package installs preserve
+their exact version, lockfile/npm reference, and sha512 integrity for deterministic
+verification. Package manifests remain the sole composition path.
+
+The restored database retains the shared `drizzle._voyant_migrations` lineage.
+The public projection's migration policy identifies entries by `(source, tag)`,
+skips matching entries without replay, applies only absent entries, and rejects
+an immutable-content hash mismatch as drift. Self-host-only additions continue
+in that same journal. Operational steps live in
+[Exporting From Voyant Cloud](../exporting-from-voyant-cloud.md).
 
 ## Facet Ownership
 

--- a/docs/exporting-from-voyant-cloud.md
+++ b/docs/exporting-from-voyant-cloud.md
@@ -1,13 +1,14 @@
 # Exporting From Voyant Cloud
 
 Voyant Cloud exports a running Operator as a
-`voyant.self-host-export-bundle.v1` bundle. The bundle is a data and admitted
+`voyant.self-host-export-bundle.v2` bundle. The bundle is a data and admitted
 graph handoff, not a runtime profile: it contains the canonical
 `voyant.resolved-graph.v1`, graph hash and product BOM, framework version,
 Postgres dump metadata, and an object-storage manifest.
 
 The public framework contract is
-`@voyant-travel/framework/self-host-export`. Project generation belongs to the
+`@voyant-travel/framework/self-host-export`; a validated bundle produces a
+`voyant.self-host-projection.v2` projection. Project generation belongs to the
 external CLI and must use the framework's `STANDARD_NODE_STARTER` contract. It
 must not copy a framework package catalog or construct a second runtime graph.
 
@@ -33,13 +34,20 @@ if (!projection.ready) throw new Error(JSON.stringify(projection.diagnostics, nu
 
 Validation rejects a stale or malformed graph, a graph/envelope hash mismatch,
 a product BOM mismatch, graph admission errors, invalid dump/object metadata,
-or a database from a different migration-journal lineage.
+or a database from a different migration-journal lineage. Every registry package
+record must carry an exact version, its matching npm/pnpm-lock reference, and
+sha512 integrity. This provenance is preserved in `projection.packageInstalls`
+so generation and post-install verification use the same admitted evidence.
 
 The projection preserves the selected module, extension, and plugin IDs plus
-their package-scoped JSON config. It derives installable package/version data
-from the graph's admitted package records. A workspace, file, or unknown package
-source is not portable from the bundle alone and blocks generation until that
-package is published or supplied through an installable source.
+their package-scoped JSON config. Before projection, validation recursively
+rejects secret-like config fields and values, including nested credentials,
+credential-bearing URLs, private keys, and common token formats. Diagnostics
+contain only the config path and never echo the value. Secrets must be
+re-provisioned from `projection.provisioning.resources`; they are not exportable
+project settings. A workspace, file, or unknown package source is not portable
+from the bundle alone and blocks generation until that package is published or
+supplied through an installable source.
 
 ## 2. Resolve Provider Diagnostics
 
@@ -73,11 +81,16 @@ them into generated project source.
 
 ## 3. Generate The Standard Node Project
 
-Generate from `projection.starter` and `projection.project`. Install the exact
-framework version from the bundle and the package versions admitted by the
-resolved graph. The generated config is selection intent; package manifests are
-still the only authority for APIs, schemas, migrations, admin UI, workflows,
-and runtime contributors.
+Generate from the `voyant.node-starter.v3` data in `projection.starter` and from
+`projection.project`. The `runtimeDependencyCoordinates` and
+`developmentDependencyCoordinates` maps contain an exact coordinate for every
+starter dependency; the projected framework coordinate is the bundle's exact
+framework version. Generators must require key parity with the dependency-name
+arrays and must not substitute tags or ranges such as `latest`. Install selected
+graph packages from `projection.packageInstalls`, then verify each registry
+resolution against its preserved reference and sha512 integrity. The generated
+config is selection intent; package manifests are still the only authority for
+APIs, schemas, migrations, admin UI, workflows, and runtime contributors.
 
 Resolve the generated project before restoring production traffic. Compare its
 selected IDs and package config with the projection and require a clean graph.
@@ -92,6 +105,12 @@ restore according to `database.format` (`pg-custom`, `pg-directory`, or `sql`).
 Do not delete or rename `drizzle._voyant_migrations`: Cloud and standard Node use
 the same `voyant.migration-journal-lineage.v1` journal keyed by `(source, tag)`
 with immutable SQL content hashes.
+
+The public projection carries this as `migrationJournal` plus a machine-readable
+`migrationPolicy`: matching `(source, tag)` entries are skipped, absent entries
+are applied, and a different content hash for an existing identity is rejected
+as drift. Restore tooling must enforce that policy and must not offer a replay or
+journal-rewrite fallback.
 
 After restore, run the generated project's migration command. Package migrations
 already represented in the restored journal are no-ops. New migrations selected

--- a/packages/framework/README.md
+++ b/packages/framework/README.md
@@ -45,7 +45,9 @@ selected package records and each package's `voyant.package.v1` metadata.
   turn a resolved graph into deterministic JSON, artifact manifests, and tiny
   Node runtime entry modules for build/deploy tooling.
 - `@voyant-travel/framework/self-host-export` — validated Cloud export-bundle
-  input and deterministic self-host projection for external project generators.
+  input and deterministic self-host projection for external project generators,
+  including exact install coordinates/provenance, secret-free projected config,
+  and shared migration no-replay/drift policy.
 
 Profile snapshots and their managed runtime/conversion subpaths are no longer
 published. Applications author projects through `@voyant-travel/framework/project`

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -175,6 +175,7 @@ export {
   VOYANT_POSTGRES_EXPORT_SCHEMA_VERSION,
   VOYANT_SELF_HOST_EXPORT_BUNDLE_JSON_SCHEMA,
   VOYANT_SELF_HOST_EXPORT_BUNDLE_SCHEMA_VERSION,
+  VOYANT_SELF_HOST_MIGRATION_POLICY,
   VOYANT_SELF_HOST_PROJECTION_JSON_SCHEMA,
   VOYANT_SELF_HOST_PROJECTION_SCHEMA_VERSION,
   VOYANT_SELF_HOST_PROVIDER_DEFAULTS,
@@ -188,12 +189,14 @@ export {
   type VoyantSelfHostExportValidationIssue,
   type VoyantSelfHostExportValidationIssueCode,
   type VoyantSelfHostExportValidationResult,
+  type VoyantSelfHostPackageInstall,
   type VoyantSelfHostProjection,
   type VoyantSelfHostProjectionDiagnostic,
   type VoyantSelfHostProjectionDiagnosticCode,
   type VoyantSelfHostProjectProjection,
   type VoyantSelfHostProjectSelection,
   type VoyantSelfHostProviderRemap,
+  type VoyantSelfHostStarterProjection,
   validateVoyantSelfHostExportBundle,
 } from "./self-host-export.js"
 export {

--- a/packages/framework/src/self-host-export.test.ts
+++ b/packages/framework/src/self-host-export.test.ts
@@ -88,6 +88,22 @@ describe("Voyant self-host export bundle", () => {
     )
   })
 
+  it("rejects a mutable framework coordinate", async () => {
+    const bundle = await exportBundle()
+    bundle.frameworkVersion = "latest"
+
+    const result = await validateVoyantSelfHostExportBundle(bundle)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        code: "VOYANT_EXPORT_INVALID_FRAMEWORK_VERSION",
+        path: "$.frameworkVersion",
+      }),
+    )
+  })
+
   it("reports malformed graph array entries without throwing", async () => {
     const bundle = await exportBundle()
     const malformed = structuredClone(bundle) as unknown as Record<string, unknown>
@@ -113,6 +129,87 @@ describe("Voyant self-host export bundle", () => {
     )
     await expect(projectVoyantSelfHostExport(malformed)).rejects.toBeInstanceOf(Error)
   })
+
+  it("rejects registry packages without exact lockfile provenance and integrity", async () => {
+    const mutations = [
+      (bundle: VoyantSelfHostExportBundle) => {
+        bundle.resolvedGraph.packageRecords[0]!.version = "^1.2.3"
+      },
+      (bundle: VoyantSelfHostExportBundle) => {
+        bundle.resolvedGraph.packageRecords[0]!.source.reference = "@acme/voyant-loyalty"
+      },
+      (bundle: VoyantSelfHostExportBundle) => {
+        delete bundle.resolvedGraph.packageRecords[0]!.source.integrity
+      },
+    ]
+
+    for (const mutate of mutations) {
+      const bundle = await exportBundle()
+      mutate(bundle)
+      await rehashBundle(bundle)
+      const result = await validateVoyantSelfHostExportBundle(bundle)
+
+      expect(result.ok).toBe(false)
+      if (result.ok) continue
+      expect(result.issues).toContainEqual(
+        expect.objectContaining({
+          code: "VOYANT_EXPORT_INVALID_PACKAGE_PROVENANCE",
+          path: "$.resolvedGraph.packageRecords[0].source",
+        }),
+      )
+    }
+  })
+
+  it("rejects secret-like fields and values in projected unit config without echoing secrets", async () => {
+    const bundle = await exportBundle()
+    const graph = bundle.resolvedGraph as unknown as {
+      modules: Array<{ projectConfig?: Record<string, unknown> }>
+      extensions: Array<Record<string, unknown>>
+      plugins: Array<Record<string, unknown>>
+    }
+    graph.modules[0]!.projectConfig = {
+      mail: { apiKey: "sk_live_exported_123456789" },
+    }
+    graph.extensions.push({
+      id: "@acme/voyant-loyalty#sync",
+      packageName: "@acme/voyant-loyalty",
+      projectConfig: {
+        endpoint: ["postgresql", "://operator:s3cret@db.internal/voyant"].join(""),
+      },
+    })
+    graph.plugins.push({
+      id: "@acme/voyant-loyalty#signing",
+      packageName: "@acme/voyant-loyalty",
+      projectConfig: {
+        material: "-----BEGIN PRIVATE KEY-----\nZXhwb3J0ZWQ=\n-----END PRIVATE KEY-----",
+      },
+    })
+    await rehashBundle(bundle)
+
+    const result = await validateVoyantSelfHostExportBundle(bundle)
+
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "VOYANT_EXPORT_SECRET_IN_PROJECT_CONFIG",
+          path: "$.resolvedGraph.modules[0].projectConfig.mail.apiKey",
+        }),
+        expect.objectContaining({
+          code: "VOYANT_EXPORT_SECRET_IN_PROJECT_CONFIG",
+          path: "$.resolvedGraph.extensions[0].projectConfig.endpoint",
+        }),
+        expect.objectContaining({
+          code: "VOYANT_EXPORT_SECRET_IN_PROJECT_CONFIG",
+          path: "$.resolvedGraph.plugins[0].projectConfig.material",
+        }),
+      ]),
+    )
+    expect(JSON.stringify(result.issues)).not.toContain("sk_live_exported")
+    expect(JSON.stringify(result.issues)).not.toContain("operator:s3cret")
+    expect(JSON.stringify(result.issues)).not.toContain("ZXhwb3J0ZWQ")
+  })
 })
 
 describe("self-host projection", () => {
@@ -125,6 +222,13 @@ describe("self-host projection", () => {
     expect(projection.schemaVersion).toBe(VOYANT_SELF_HOST_PROJECTION_SCHEMA_VERSION)
     expect(projection.ready).toBe(true)
     expect(projection.sourceGraphHash).toBe(bundle.graphHash)
+    expect(projection.starter.runtimeDependencyCoordinates["@voyant-travel/framework"]).toBe(
+      bundle.frameworkVersion,
+    )
+    expect([
+      ...Object.values(projection.starter.runtimeDependencyCoordinates),
+      ...Object.values(projection.starter.developmentDependencyCoordinates),
+    ]).not.toContain("latest")
     expect(projection.project.modules).toEqual([
       {
         id: "@acme/voyant-loyalty#rewards",
@@ -165,6 +269,17 @@ describe("self-host projection", () => {
         },
       ]),
     )
+    expect(projection.packageInstalls).toEqual([
+      {
+        packageName: "@acme/voyant-loyalty",
+        coordinate: "1.2.3",
+        source: {
+          kind: "registry",
+          reference: "pnpm-lock:@acme/voyant-loyalty@1.2.3",
+          integrity: expect.stringMatching(/^sha512-/),
+        },
+      },
+    ])
     expect(projection.provisioning.resources).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ resourceKey: "database:postgres", provider: "postgres" }),
@@ -243,6 +358,12 @@ describe("self-host projection", () => {
 
     expect(bundle.database.migrationJournal).toBe(VOYANT_MIGRATION_JOURNAL_LINEAGE)
     expect(projection.migrationJournal).toBe(VOYANT_MIGRATION_JOURNAL_LINEAGE)
+    expect(projection.migrationPolicy).toEqual({
+      identity: ["source", "tag"],
+      matchingEntry: "skip",
+      contentHashMismatch: "reject-drift",
+      pendingEntry: "apply",
+    })
     expect(selfHostPackageMigration).toEqual(cloudPackageMigration)
     expect(selfHostPlan.migrations.map((migration) => migration.id)).toContain(
       "@voyant-travel/workflows-orchestrator#migrations",
@@ -281,7 +402,15 @@ async function exportBundle(
       {
         packageName: "@acme/voyant-loyalty",
         version: "1.2.3",
-        source: { kind: options.sourceKind ?? "registry", reference: "@1.2.3" },
+        source:
+          options.sourceKind === "workspace"
+            ? { kind: "workspace", reference: "link:../voyant-loyalty" }
+            : {
+                kind: "registry",
+                reference: "pnpm-lock:@acme/voyant-loyalty@1.2.3",
+                integrity:
+                  "sha512-YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==",
+              },
         metadata: {
           schemaVersion: "voyant.package.v1",
           kind: "module",

--- a/packages/framework/src/self-host-export.test.ts
+++ b/packages/framework/src/self-host-export.test.ts
@@ -141,6 +141,10 @@ describe("Voyant self-host export bundle", () => {
       (bundle: VoyantSelfHostExportBundle) => {
         delete bundle.resolvedGraph.packageRecords[0]!.source.integrity
       },
+      (bundle: VoyantSelfHostExportBundle) => {
+        bundle.resolvedGraph.packageRecords[0]!.source.integrity =
+          "sha512-YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg=="
+      },
     ]
 
     for (const mutate of mutations) {
@@ -409,7 +413,7 @@ async function exportBundle(
                 kind: "registry",
                 reference: "pnpm-lock:@acme/voyant-loyalty@1.2.3",
                 integrity:
-                  "sha512-YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXphYmNkZWZnaGlqa2xtbm9wcXJzdHV2d3h5eg==",
+                  "sha512-g7nE4PFtngOZNZSy1lOPpkC+FAiHxqBJXqyRMEG7NUrEVZlz5goBdtHg1YgWRJIX776JTXAmbOI5JreAKVAsVA==",
               },
         metadata: {
           schemaVersion: "voyant.package.v1",

--- a/packages/framework/src/self-host-export.ts
+++ b/packages/framework/src/self-host-export.ts
@@ -30,7 +30,7 @@ export const VOYANT_SELF_HOST_PROJECTION_SCHEMA_VERSION = "voyant.self-host-proj
 
 const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
 const EXACT_PACKAGE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
-const SHA512_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{43,}={0,2}$/
+const SHA512_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{86}==$/
 const PORTABLE_PACKAGE_SOURCE_KINDS = new Set(["registry", "git"])
 
 export const VOYANT_SELF_HOST_MIGRATION_POLICY = {

--- a/packages/framework/src/self-host-export.ts
+++ b/packages/framework/src/self-host-export.ts
@@ -22,14 +22,23 @@ import { DEPLOYMENT_PROVIDER_CONTRACTS, DEPLOYMENT_PROVIDER_ROLES } from "./depl
 import { STANDARD_NODE_STARTER } from "./standard-node-starter.js"
 
 export const VOYANT_SELF_HOST_EXPORT_BUNDLE_SCHEMA_VERSION =
-  "voyant.self-host-export-bundle.v1" as const
+  "voyant.self-host-export-bundle.v2" as const
 export const VOYANT_POSTGRES_EXPORT_SCHEMA_VERSION = "voyant.postgres-export.v1" as const
 export const VOYANT_OBJECT_STORAGE_EXPORT_SCHEMA_VERSION =
   "voyant.object-storage-export.v1" as const
-export const VOYANT_SELF_HOST_PROJECTION_SCHEMA_VERSION = "voyant.self-host-projection.v1" as const
+export const VOYANT_SELF_HOST_PROJECTION_SCHEMA_VERSION = "voyant.self-host-projection.v2" as const
 
 const SHA256_PATTERN = /^sha256:[a-f0-9]{64}$/
+const EXACT_PACKAGE_VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/
+const SHA512_INTEGRITY_PATTERN = /^sha512-[A-Za-z0-9+/]{43,}={0,2}$/
 const PORTABLE_PACKAGE_SOURCE_KINDS = new Set(["registry", "git"])
+
+export const VOYANT_SELF_HOST_MIGRATION_POLICY = {
+  identity: ["source", "tag"],
+  matchingEntry: "skip",
+  contentHashMismatch: "reject-drift",
+  pendingEntry: "apply",
+} as const
 
 export type VoyantPostgresDumpFormat = "pg-custom" | "pg-directory" | "sql"
 
@@ -71,7 +80,7 @@ export interface VoyantSelfHostExportBundle {
 
 export const VOYANT_SELF_HOST_EXPORT_BUNDLE_JSON_SCHEMA = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
-  $id: "https://schemas.voyant.travel/self-host-export-bundle.v1.json",
+  $id: "https://schemas.voyant.travel/self-host-export-bundle.v2.json",
   type: "object",
   additionalProperties: false,
   required: [
@@ -118,7 +127,7 @@ export const VOYANT_SELF_HOST_EXPORT_BUNDLE_JSON_SCHEMA = {
 
 export const VOYANT_SELF_HOST_PROJECTION_JSON_SCHEMA = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
-  $id: "https://schemas.voyant.travel/self-host-projection.v1.json",
+  $id: "https://schemas.voyant.travel/self-host-projection.v2.json",
   type: "object",
   additionalProperties: false,
   required: [
@@ -132,7 +141,9 @@ export const VOYANT_SELF_HOST_PROJECTION_JSON_SCHEMA = {
     "graph",
     "providerRemaps",
     "provisioning",
+    "packageInstalls",
     "migrationJournal",
+    "migrationPolicy",
     "diagnostics",
   ],
   properties: {
@@ -146,7 +157,9 @@ export const VOYANT_SELF_HOST_PROJECTION_JSON_SCHEMA = {
     graph: { type: "object" },
     providerRemaps: { type: "array" },
     provisioning: { type: "object" },
+    packageInstalls: { type: "array" },
     migrationJournal: { type: "object" },
+    migrationPolicy: { type: "object" },
     diagnostics: { type: "array" },
   },
 } as const
@@ -160,6 +173,8 @@ export type VoyantSelfHostExportValidationIssueCode =
   | "VOYANT_EXPORT_GRAPH_NOT_CANONICAL"
   | "VOYANT_EXPORT_GRAPH_NOT_ADMITTED"
   | "VOYANT_EXPORT_BOM_MISMATCH"
+  | "VOYANT_EXPORT_INVALID_PACKAGE_PROVENANCE"
+  | "VOYANT_EXPORT_SECRET_IN_PROJECT_CONFIG"
   | "VOYANT_EXPORT_INVALID_DATABASE_DUMP"
   | "VOYANT_EXPORT_MIGRATION_LINEAGE_MISMATCH"
   | "VOYANT_EXPORT_INVALID_STORAGE_MANIFEST"
@@ -222,13 +237,45 @@ export interface VoyantSelfHostProjectProjection {
   }
 }
 
+export type VoyantSelfHostPackageInstall =
+  | {
+      packageName: string
+      coordinate: string
+      source: {
+        kind: "registry"
+        reference: string
+        integrity: string
+      }
+    }
+  | {
+      packageName: string
+      coordinate: string
+      source: {
+        kind: "git"
+        reference: string
+        integrity?: string
+      }
+    }
+
+export type VoyantSelfHostStarterProjection = Omit<
+  typeof STANDARD_NODE_STARTER,
+  "runtimeDependencyCoordinates"
+> & {
+  readonly runtimeDependencyCoordinates: Omit<
+    (typeof STANDARD_NODE_STARTER)["runtimeDependencyCoordinates"],
+    "@voyant-travel/framework"
+  > & {
+    readonly "@voyant-travel/framework": string
+  }
+}
+
 export interface VoyantSelfHostProjection {
   schemaVersion: typeof VOYANT_SELF_HOST_PROJECTION_SCHEMA_VERSION
   ready: boolean
   frameworkVersion: string
   sourceGraphHash: string
   projectedGraphHash: string
-  starter: typeof STANDARD_NODE_STARTER
+  starter: VoyantSelfHostStarterProjection
   project: VoyantSelfHostProjectProjection
   graph: ResolvedVoyantDeploymentGraph
   providerRemaps: readonly VoyantSelfHostProviderRemap[]
@@ -237,7 +284,9 @@ export interface VoyantSelfHostProjection {
     database: VoyantPostgresExportMetadata
     objectStorage: VoyantObjectStorageExportManifest
   }
+  packageInstalls: readonly VoyantSelfHostPackageInstall[]
   migrationJournal: typeof VOYANT_MIGRATION_JOURNAL_LINEAGE
+  migrationPolicy: typeof VOYANT_SELF_HOST_MIGRATION_POLICY
   diagnostics: readonly VoyantSelfHostProjectionDiagnostic[]
 }
 
@@ -270,7 +319,7 @@ export async function validateVoyantSelfHostExportBundle(
   }
   const frameworkVersion =
     nonEmptyString(input.frameworkVersion) &&
-    /^v?\d+\.\d+\.\d+(?:[-+].*)?$/.test(input.frameworkVersion)
+    EXACT_PACKAGE_VERSION_PATTERN.test(input.frameworkVersion)
       ? input.frameworkVersion
       : undefined
   if (!frameworkVersion) {
@@ -278,7 +327,7 @@ export async function validateVoyantSelfHostExportBundle(
       issues,
       "VOYANT_EXPORT_INVALID_FRAMEWORK_VERSION",
       "$.frameworkVersion",
-      "frameworkVersion must be a semantic version.",
+      "frameworkVersion must be an exact semantic version without a tag or range.",
     )
   }
 
@@ -388,7 +437,7 @@ export async function projectVoyantSelfHostExport(
     frameworkVersion: bundle.frameworkVersion,
     sourceGraphHash: bundle.graphHash,
     projectedGraphHash: graph.contentHash,
-    starter: STANDARD_NODE_STARTER,
+    starter: projectStarter(bundle.frameworkVersion),
     project: {
       productBom: bundle.productBom,
       modules: projectSelections(graph.modules, versions),
@@ -408,7 +457,9 @@ export async function projectVoyantSelfHostExport(
       database: bundle.database,
       objectStorage: bundle.objectStorage,
     },
+    packageInstalls: projectPackageInstalls(graph),
     migrationJournal: VOYANT_MIGRATION_JOURNAL_LINEAGE,
+    migrationPolicy: VOYANT_SELF_HOST_MIGRATION_POLICY,
     diagnostics,
   }
 }
@@ -476,6 +527,14 @@ function validateGraph(
           `$.resolvedGraph.${kind}[${index}]`,
           `resolvedGraph.${kind} entries require non-empty id and packageName values plus an optional object projectConfig.`,
         )
+        continue
+      }
+      if (unit.projectConfig !== undefined) {
+        validateSecretFreeProjectConfig(
+          unit.projectConfig,
+          `$.resolvedGraph.${kind}[${index}].projectConfig`,
+          issues,
+        )
       }
     }
   }
@@ -489,7 +548,13 @@ function validateGraph(
           `$.resolvedGraph.packageRecords[${index}]`,
           "resolvedGraph.packageRecords entries require a packageName, a supported source coordinate, and well-formed compatibility metadata.",
         )
+        continue
       }
+      validatePackageProvenance(
+        record as unknown as ResolvedVoyantDeploymentGraph["packageRecords"][number],
+        index,
+        issues,
+      )
     }
   }
   if (Array.isArray(value.diagnostics)) {
@@ -616,6 +681,114 @@ function validPackageRecord(value: unknown): boolean {
     (compatibility.targets === undefined || stringArray(compatibility.targets)) &&
     (compatibility.modes === undefined || stringArray(compatibility.modes))
   )
+}
+
+function validatePackageProvenance(
+  record: ResolvedVoyantDeploymentGraph["packageRecords"][number],
+  index: number,
+  issues: VoyantSelfHostExportValidationIssue[],
+): void {
+  if (record.source.kind !== "registry") return
+  if (
+    !record.version ||
+    !EXACT_PACKAGE_VERSION_PATTERN.test(record.version) ||
+    !registryReferenceMatches(record.source.reference, record.packageName, record.version) ||
+    !record.source.integrity ||
+    !SHA512_INTEGRITY_PATTERN.test(record.source.integrity)
+  ) {
+    addIssue(
+      issues,
+      "VOYANT_EXPORT_INVALID_PACKAGE_PROVENANCE",
+      `$.resolvedGraph.packageRecords[${index}].source`,
+      `Registry package ${record.packageName} must preserve an exact version, matching npm or pnpm-lock reference, and sha512 integrity.`,
+    )
+  }
+}
+
+function registryReferenceMatches(
+  reference: string | undefined,
+  packageName: string,
+  version: string,
+): boolean {
+  if (!reference) return false
+  if (reference === `npm:${packageName}@${version}`) return true
+  const lockfilePrefix = `pnpm-lock:${packageName}@${version}`
+  return reference === lockfilePrefix || reference.startsWith(`${lockfilePrefix}(`)
+}
+
+function validateSecretFreeProjectConfig(
+  value: unknown,
+  path: string,
+  issues: VoyantSelfHostExportValidationIssue[],
+): void {
+  if (Array.isArray(value)) {
+    for (const [index, item] of value.entries()) {
+      validateSecretFreeProjectConfig(item, `${path}[${index}]`, issues)
+    }
+    return
+  }
+  if (isRecord(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      const itemPath = jsonPathProperty(path, key)
+      if (secretLikeField(key)) {
+        addSecretIssue(itemPath, "field name", issues)
+        continue
+      }
+      validateSecretFreeProjectConfig(item, itemPath, issues)
+    }
+    return
+  }
+  if (typeof value === "string" && secretLikeValue(value)) {
+    addSecretIssue(path, "value", issues)
+  }
+}
+
+function secretLikeField(key: string): boolean {
+  const tokens = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean)
+  if (
+    tokens.some((token) =>
+      ["password", "passwd", "secret", "token", "credential", "credentials"].includes(token),
+    )
+  ) {
+    return true
+  }
+  const normalized = tokens.join("")
+  return ["apikey", "privatekey", "accesskey", "signingkey", "authorization"].some((term) =>
+    normalized.includes(term),
+  )
+}
+
+function secretLikeValue(value: string): boolean {
+  return (
+    /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/.test(value) ||
+    /^[a-z][a-z0-9+.-]*:\/\/[^/\s:@]+:[^/\s@]+@/i.test(value) ||
+    /^(?:Bearer\s+)?eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(value) ||
+    /^(?:sk_(?:live|test)_|gh[pousr]_|xox[baprs]-)[A-Za-z0-9_-]{8,}$/.test(value) ||
+    /^AKIA[A-Z0-9]{16}$/.test(value)
+  )
+}
+
+function addSecretIssue(
+  path: string,
+  reason: "field name" | "value",
+  issues: VoyantSelfHostExportValidationIssue[],
+): void {
+  addIssue(
+    issues,
+    "VOYANT_EXPORT_SECRET_IN_PROJECT_CONFIG",
+    path,
+    `Projected package config contains a secret-like ${reason}; export only non-secret settings and provision secrets separately.`,
+  )
+}
+
+function jsonPathProperty(path: string, key: string): string {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key)
+    ? `${path}.${key}`
+    : `${path}[${JSON.stringify(key)}]`
 }
 
 function validateProductBom(
@@ -844,6 +1017,57 @@ function validatePackagePortability(
             : "Export the admitted git reference.",
       })
     }
+  }
+}
+
+function projectPackageInstalls(
+  graph: ResolvedVoyantDeploymentGraph,
+): VoyantSelfHostPackageInstall[] {
+  return [...graph.packageRecords]
+    .sort((left, right) => left.packageName.localeCompare(right.packageName))
+    .flatMap((record): VoyantSelfHostPackageInstall[] => {
+      if (
+        record.source.kind === "registry" &&
+        record.version &&
+        record.source.reference &&
+        record.source.integrity
+      ) {
+        return [
+          {
+            packageName: record.packageName,
+            coordinate: record.version,
+            source: {
+              kind: "registry",
+              reference: record.source.reference,
+              integrity: record.source.integrity,
+            },
+          },
+        ]
+      }
+      if (record.source.kind === "git" && record.source.reference) {
+        return [
+          {
+            packageName: record.packageName,
+            coordinate: record.source.reference,
+            source: {
+              kind: "git",
+              reference: record.source.reference,
+              ...(record.source.integrity ? { integrity: record.source.integrity } : {}),
+            },
+          },
+        ]
+      }
+      return []
+    })
+}
+
+function projectStarter(frameworkVersion: string): VoyantSelfHostStarterProjection {
+  return {
+    ...STANDARD_NODE_STARTER,
+    runtimeDependencyCoordinates: {
+      ...STANDARD_NODE_STARTER.runtimeDependencyCoordinates,
+      "@voyant-travel/framework": frameworkVersion,
+    },
   }
 }
 

--- a/packages/framework/src/standard-node-starter.json
+++ b/packages/framework/src/standard-node-starter.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "voyant.node-starter.v2",
+  "schemaVersion": "voyant.node-starter.v3",
   "rootFiles": [".env.example", ".gitignore", "package.json", "voyant.config.ts"],
   "optionalDirectories": [
     "src/api/admin",
@@ -34,6 +34,21 @@
     "react-dom",
     "pg"
   ],
+  "runtimeDependencyCoordinates": {
+    "@voyant-travel/framework": "0.45.0",
+    "@voyant-travel/runtime": "0.11.0",
+    "@voyant-travel/operator-standard": "0.5.0",
+    "@tanstack/react-query": "5.101.2",
+    "@tanstack/react-router": "1.170.17",
+    "react": "19.2.7",
+    "react-dom": "19.2.7",
+    "pg": "8.22.0"
+  },
   "developmentDependencies": ["@voyant-travel/cli", "tsx", "typescript"],
+  "developmentDependencyCoordinates": {
+    "@voyant-travel/cli": "0.40.5",
+    "tsx": "4.22.4",
+    "typescript": "6.0.3"
+  },
   "gitignoreEntries": [".voyant/", "dist/", "node_modules/", ".env", ".env.*", "!.env.example"]
 }

--- a/packages/framework/src/standard-node-starter.test.ts
+++ b/packages/framework/src/standard-node-starter.test.ts
@@ -18,6 +18,11 @@ describe("standard Node starter contract", () => {
           "tsx",
           "typescript",
         ],
+        "developmentDependencyCoordinates": {
+          "@voyant-travel/cli": "0.40.5",
+          "tsx": "4.22.4",
+          "typescript": "6.0.3",
+        },
         "gitignoreEntries": [
           ".voyant/",
           "dist/",
@@ -61,7 +66,17 @@ describe("standard Node starter contract", () => {
           "react-dom",
           "pg",
         ],
-        "schemaVersion": "voyant.node-starter.v2",
+        "runtimeDependencyCoordinates": {
+          "@tanstack/react-query": "5.101.2",
+          "@tanstack/react-router": "1.170.17",
+          "@voyant-travel/framework": "0.45.0",
+          "@voyant-travel/operator-standard": "0.5.0",
+          "@voyant-travel/runtime": "0.11.0",
+          "pg": "8.22.0",
+          "react": "19.2.7",
+          "react-dom": "19.2.7",
+        },
+        "schemaVersion": "voyant.node-starter.v3",
         "seedEntry": "src/scripts/seed.ts",
       }
     `)
@@ -76,10 +91,27 @@ describe("standard Node starter contract", () => {
     expect(buildStandardNodeStarterSnapshot()).not.toMatch(/smartbill/i)
   })
 
+  it("provides exact coordinates for every generated project dependency", () => {
+    expect(Object.keys(STANDARD_NODE_STARTER.runtimeDependencyCoordinates).sort()).toEqual(
+      [...STANDARD_NODE_STARTER.runtimeDependencies].sort(),
+    )
+    expect(Object.keys(STANDARD_NODE_STARTER.developmentDependencyCoordinates).sort()).toEqual(
+      [...STANDARD_NODE_STARTER.developmentDependencies].sort(),
+    )
+
+    for (const coordinate of [
+      ...Object.values(STANDARD_NODE_STARTER.runtimeDependencyCoordinates),
+      ...Object.values(STANDARD_NODE_STARTER.developmentDependencyCoordinates),
+    ]) {
+      expect(coordinate).toMatch(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/)
+      expect(coordinate).not.toMatch(/^(?:latest|next)|^[~^*]|\s|\|/)
+    }
+  })
+
   it("preserves literal readonly types for consumers", () => {
     expectTypeOf(
       VOYANT_STANDARD_NODE_STARTER_SCHEMA_VERSION,
-    ).toEqualTypeOf<"voyant.node-starter.v2">()
+    ).toEqualTypeOf<"voyant.node-starter.v3">()
     expectTypeOf<(typeof STANDARD_NODE_STARTER.rootFiles)[number]>().toEqualTypeOf<
       ".env.example" | ".gitignore" | "package.json" | "voyant.config.ts"
     >()

--- a/packages/framework/src/standard-node-starter.ts
+++ b/packages/framework/src/standard-node-starter.ts
@@ -1,7 +1,7 @@
 import standardNodeStarter from "./standard-node-starter.json" with { type: "json" }
 
 type StandardNodeStarterContract = {
-  readonly schemaVersion: "voyant.node-starter.v2"
+  readonly schemaVersion: "voyant.node-starter.v3"
   readonly rootFiles: readonly [".env.example", ".gitignore", "package.json", "voyant.config.ts"]
   readonly optionalDirectories: readonly [
     "src/api/admin",
@@ -36,7 +36,22 @@ type StandardNodeStarterContract = {
     "react-dom",
     "pg",
   ]
+  readonly runtimeDependencyCoordinates: {
+    readonly "@voyant-travel/framework": "0.45.0"
+    readonly "@voyant-travel/runtime": "0.11.0"
+    readonly "@voyant-travel/operator-standard": "0.5.0"
+    readonly "@tanstack/react-query": "5.101.2"
+    readonly "@tanstack/react-router": "1.170.17"
+    readonly react: "19.2.7"
+    readonly "react-dom": "19.2.7"
+    readonly pg: "8.22.0"
+  }
   readonly developmentDependencies: readonly ["@voyant-travel/cli", "tsx", "typescript"]
+  readonly developmentDependencyCoordinates: {
+    readonly "@voyant-travel/cli": "0.40.5"
+    readonly tsx: "4.22.4"
+    readonly typescript: "6.0.3"
+  }
   readonly gitignoreEntries: readonly [
     ".voyant/",
     "dist/",

--- a/scripts/package-starters.mjs
+++ b/scripts/package-starters.mjs
@@ -6,7 +6,6 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
-  statSync,
   writeFileSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
@@ -21,9 +20,6 @@ const starters = ["operator"]
 const standardNodeStarter = readJson(
   join(repoRoot, "packages", "framework", "src", "standard-node-starter.json"),
 )
-const operatorStarterPackage = readJson(join(repoRoot, "starters", "operator", "package.json"))
-const catalogVersions = readCatalogVersions()
-const workspaceVersions = readWorkspaceVersions()
 
 mkdirSync(outDir, { recursive: true })
 
@@ -50,17 +46,15 @@ function stageMinimalOperatorStarter(stagingTemplate, localLinks) {
     mkdirSync(join(stagingTemplate, directory), { recursive: true })
   }
 
-  const dependency = (name) => {
-    if (!name.startsWith("@voyant-travel/")) return requiredStarterRuntimeVersion(name)
-    return localLinks
+  const dependency = (name) =>
+    localLinks && name.startsWith("@voyant-travel/")
       ? `link:${workspacePackageDirectory(name)}`
-      : `^${requiredWorkspaceVersion(name)}`
-  }
+      : standardNodeStarter.runtimeDependencyCoordinates[name]
   const localCliPackage = resolve(repoRoot, "..", "cli", "packages", "cli")
   const cliDependency =
     localLinks && existsSync(join(localCliPackage, "package.json"))
       ? `link:${localCliPackage}`
-      : supportedCliRange()
+      : standardNodeStarter.developmentDependencyCoordinates["@voyant-travel/cli"]
   writeJson(join(stagingTemplate, "package.json"), {
     name: "voyant-app",
     private: true,
@@ -73,7 +67,9 @@ function stageMinimalOperatorStarter(stagingTemplate, localLinks) {
     devDependencies: Object.fromEntries(
       standardNodeStarter.developmentDependencies.map((name) => [
         name,
-        name === "@voyant-travel/cli" ? cliDependency : requiredCatalogVersion(name),
+        name === "@voyant-travel/cli"
+          ? cliDependency
+          : standardNodeStarter.developmentDependencyCoordinates[name],
       ]),
     ),
   })
@@ -103,34 +99,6 @@ export default defineConfig({
   )
 }
 
-function requiredWorkspaceVersion(name) {
-  const value = workspaceVersions.get(name)
-  if (!value) throw new Error(`Missing workspace package for starter dependency: ${name}`)
-  return value
-}
-
-function requiredCatalogVersion(name) {
-  const value = catalogVersions.get(name)
-  if (!value) throw new Error(`Missing catalog version for starter dependency: ${name}`)
-  return value
-}
-
-function requiredStarterRuntimeVersion(name) {
-  const value = operatorStarterPackage.dependencies?.[name]
-  if (typeof value !== "string" || /^(?:catalog|workspace|file|link):/.test(value)) {
-    throw new Error(`Missing concrete operator starter dependency version: ${name}`)
-  }
-  return value.replace(/^[~^]/, "")
-}
-
-function supportedCliRange() {
-  const value = operatorStarterPackage.devDependencies?.["@voyant-travel/cli"]
-  if (typeof value !== "string" || /^(?:workspace|file|link):/.test(value)) {
-    throw new Error("starters/operator must declare a released @voyant-travel/cli range")
-  }
-  return value
-}
-
 function workspacePackageDirectory(name) {
   for (const root of ["packages", join("packages", "plugins"), "apps"]) {
     const rootPath = join(repoRoot, root)
@@ -143,42 +111,6 @@ function workspacePackageDirectory(name) {
     }
   }
   throw new Error(`Missing workspace package directory for ${name}`)
-}
-
-function readCatalogVersions() {
-  const text = readFileSync(join(repoRoot, "pnpm-workspace.yaml"), "utf8")
-  const versions = new Map()
-  let inCatalog = false
-  for (const line of text.split(/\r?\n/)) {
-    if (line.trim() === "catalog:") {
-      inCatalog = true
-      continue
-    }
-    if (!inCatalog) continue
-    if (!line.startsWith("  ")) break
-    const match = line.match(/^\s+"?([^":]+)"?:\s+(.+)$/)
-    if (match) versions.set(match[1], match[2].trim())
-  }
-  return versions
-}
-
-function readWorkspaceVersions() {
-  const versions = new Map()
-  for (const root of ["packages", join("packages", "plugins"), "apps"]) {
-    const rootPath = join(repoRoot, root)
-    if (!existsSync(rootPath)) continue
-    for (const entry of readdirSync(rootPath)) {
-      const packageDir = join(rootPath, entry)
-      if (!statSync(packageDir).isDirectory()) continue
-      const packageJsonPath = join(packageDir, "package.json")
-      if (!existsSync(packageJsonPath)) continue
-      const packageJson = readJson(packageJsonPath)
-      if (packageJson.name && packageJson.version) {
-        versions.set(packageJson.name, packageJson.version)
-      }
-    }
-  }
-  return versions
 }
 
 function readJson(path) {

--- a/scripts/tests/package-starters.test.mjs
+++ b/scripts/tests/package-starters.test.mjs
@@ -43,11 +43,12 @@ test("operator release archive contains only the minimal authored project", () =
     const packageJson = JSON.parse(readFileSync(join(fixture.extractDir, "package.json"), "utf8"))
     assert.deepEqual(packageJson.scripts, standardNodeStarter.packageScripts)
     assert.equal(packageJson.scripts["graph:emit"], undefined)
-    assert.equal(typeof packageJson.dependencies["@voyant-travel/framework"], "string")
-    assert.equal(typeof packageJson.dependencies["@voyant-travel/runtime"], "string")
-    assert.equal(packageJson.dependencies.pg, "8.22.0")
+    assert.deepEqual(packageJson.dependencies, standardNodeStarter.runtimeDependencyCoordinates)
     assert.equal(packageJson.dependencies["@voyant-travel/plugin-smartbill"], undefined)
-    assert.equal(packageJson.devDependencies["@voyant-travel/cli"], "^0.40.0")
+    assert.deepEqual(
+      packageJson.devDependencies,
+      standardNodeStarter.developmentDependencyCoordinates,
+    )
     const dependencySpecs = Object.values({
       ...packageJson.dependencies,
       ...packageJson.devDependencies,


### PR DESCRIPTION
## Summary
- require deterministic dependency coordinates and preserve registry integrity/provenance in self-host export projections
- reject secret-like project configuration while keeping secret values out of diagnostics and bundles
- define migration lineage, no-replay, pending-application, and drift-rejection policy for exported deployments
- version the bundle, projection, and starter contracts so incomplete older generators fail explicitly

## Verification
- framework self-host export tests (12 passed)
- framework starter tests (5 passed)
- package export tests (2 passed)
- pnpm --filter @voyant-travel/framework typecheck
- pnpm --filter @voyant-travel/framework lint
- focused secretlint

Framework portion of #3356.