### PR TITLE
fix(auth): enforce local member access invariants

### DIFF
--- a/.changeset/quiet-owners-guard.md
+++ b/.changeset/quiet-owners-guard.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Enforce local member deactivation across every Better Auth sign-in path and serialize owner mutations so concurrent requests cannot remove the final active owner.

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -45,6 +45,20 @@ return auth.handler(request)
 Auth provider wiring is starter-owned — core Voyant packages only depend on
 the normalized `{ userId, actor }` contract, not on Better Auth specifically.
 
+## Local Team Access
+
+Local team deactivation is durable auth state. It revokes the member's current
+sessions and API keys, blocks cached-session reuse and new Better Auth sessions,
+and suppresses email OTP flows for the deactivated address. Reactivation
+restores the member's sign-in providers so new password, social, or OTP sessions
+can be created; previously revoked sessions and API keys remain revoked.
+
+Local role changes, activation, and deactivation require an interactive
+transaction. Owner-removing mutations serialize and recheck the active-owner
+count inside that transaction, so concurrent requests cannot remove the last
+active owner. Deployments mounting the team API must therefore select a
+transaction-capable database adapter.
+
 `createBetterAuth` forwards Better Auth's `user` options, including
 `user.additionalFields`, while preserving Voyant's default change-email support.
 When using additional user fields with the Drizzle adapter, the consuming app is

--- a/packages/auth/src/local-member-access.ts
+++ b/packages/auth/src/local-member-access.ts
@@ -1,4 +1,4 @@
-import { authAccount, authUser } from "@voyant-travel/db/schema/iam"
+import { authAccount, authSession, authUser } from "@voyant-travel/db/schema/iam"
 import type { VoyantDb } from "@voyant-travel/hono"
 import { APIError, createAuthMiddleware, getSessionFromCtx } from "better-auth/api"
 import { deleteSessionCookie } from "better-auth/cookies"
@@ -48,8 +48,22 @@ export async function isLocalMemberEmailDeactivated(db: VoyantDb, email: string)
   )
 }
 
+export async function isLocalMemberSessionActive(
+  db: VoyantDb,
+  sessionId: string,
+  userId: string,
+): Promise<boolean> {
+  const sessions = await db
+    .select({ id: authSession.id })
+    .from(authSession)
+    .where(and(eq(authSession.id, sessionId), eq(authSession.userId, userId)))
+    .limit(1)
+  return sessions.length > 0
+}
+
 export interface LocalMemberAccessResolver {
   isEmailDeactivated(email: string): Promise<boolean>
+  isSessionActive(sessionId: string, userId: string): Promise<boolean>
   isUserDeactivated(userId: string): Promise<boolean>
 }
 
@@ -108,10 +122,16 @@ export function createLocalMemberAccessPlugin(
           matcher: () => true,
           handler: createAuthMiddleware(async (context) => {
             const session = await getSessionFromCtx(context)
-            if (session && (await resolver.isUserDeactivated(session.user.id))) {
-              deleteSessionCookie(context)
-              if (context.path === "/get-session") return context.json(null)
-              denyAccess()
+            if (session) {
+              const [isDeactivated, isSessionActive] = await Promise.all([
+                resolver.isUserDeactivated(session.user.id),
+                resolver.isSessionActive(session.session.id, session.user.id),
+              ])
+              if (isDeactivated || !isSessionActive) {
+                deleteSessionCookie(context)
+                if (context.path === "/get-session") return context.json(null)
+                denyAccess()
+              }
             }
 
             const email = requestEmail(context)

--- a/packages/auth/src/local-member-access.ts
+++ b/packages/auth/src/local-member-access.ts
@@ -1,0 +1,124 @@
+import { authAccount, authUser } from "@voyant-travel/db/schema/iam"
+import type { VoyantDb } from "@voyant-travel/hono"
+import { APIError, createAuthMiddleware, getSessionFromCtx } from "better-auth/api"
+import { deleteSessionCookie } from "better-auth/cookies"
+import type { BetterAuthPlugin } from "better-auth/types"
+import { and, eq } from "drizzle-orm"
+
+import type { TeamMemberStatus } from "./team-management-runtime-port.js"
+
+export const DEACTIVATED_PROVIDER_PREFIX = "voyant-deactivated:"
+
+export function localProviderIdForStatus(providerId: string, status: TeamMemberStatus): string {
+  if (status === "deactivated") {
+    return providerId.startsWith(DEACTIVATED_PROVIDER_PREFIX)
+      ? providerId
+      : `${DEACTIVATED_PROVIDER_PREFIX}${providerId}`
+  }
+  return providerId.startsWith(DEACTIVATED_PROVIDER_PREFIX)
+    ? providerId.slice(DEACTIVATED_PROVIDER_PREFIX.length)
+    : providerId
+}
+
+export function isDeactivatedProviderId(providerId: string): boolean {
+  return providerId.startsWith(DEACTIVATED_PROVIDER_PREFIX)
+}
+
+async function accountProvidersForUser(db: VoyantDb, userId: string): Promise<string[]> {
+  const accounts = await db
+    .select({ providerId: authAccount.providerId })
+    .from(authAccount)
+    .where(eq(authAccount.userId, userId))
+  return accounts.map((account) => account.providerId)
+}
+
+export async function isLocalMemberDeactivated(db: VoyantDb, userId: string): Promise<boolean> {
+  const providerIds = await accountProvidersForUser(db, userId)
+  return providerIds.length > 0 && providerIds.every(isDeactivatedProviderId)
+}
+
+export async function isLocalMemberEmailDeactivated(db: VoyantDb, email: string): Promise<boolean> {
+  const accounts = await db
+    .select({ providerId: authAccount.providerId })
+    .from(authAccount)
+    .innerJoin(authUser, eq(authUser.id, authAccount.userId))
+    .where(and(eq(authUser.email, email.trim().toLowerCase()), eq(authAccount.userId, authUser.id)))
+  return (
+    accounts.length > 0 && accounts.every((account) => isDeactivatedProviderId(account.providerId))
+  )
+}
+
+export interface LocalMemberAccessResolver {
+  isEmailDeactivated(email: string): Promise<boolean>
+  isUserDeactivated(userId: string): Promise<boolean>
+}
+
+const ACCESS_DENIED_MESSAGE = "This account is deactivated."
+
+function requestEmail(context: { path?: string; body?: unknown; query?: unknown }): string | null {
+  const path = context.path ?? ""
+  if (!path.includes("email-otp") && !path.includes("email") && !path.includes("password")) {
+    return null
+  }
+
+  for (const input of [context.body, context.query]) {
+    if (!input || typeof input !== "object") continue
+    const email = (input as Record<string, unknown>).email
+    if (typeof email === "string" && email.trim().length > 0) {
+      return email.trim().toLowerCase()
+    }
+  }
+  return null
+}
+
+function denyAccess(): never {
+  throw new APIError("FORBIDDEN", { message: ACCESS_DENIED_MESSAGE })
+}
+
+export function createLocalMemberAccessPlugin(
+  resolver: LocalMemberAccessResolver,
+): BetterAuthPlugin {
+  return {
+    id: "voyant-local-member-access",
+    init() {
+      return {
+        options: {
+          databaseHooks: {
+            account: {
+              create: {
+                before: async (account) => {
+                  if (await resolver.isUserDeactivated(account.userId)) denyAccess()
+                },
+              },
+            },
+            session: {
+              create: {
+                before: async (session) => {
+                  if (await resolver.isUserDeactivated(session.userId)) denyAccess()
+                },
+              },
+            },
+          },
+        },
+      }
+    },
+    hooks: {
+      before: [
+        {
+          matcher: () => true,
+          handler: createAuthMiddleware(async (context) => {
+            const session = await getSessionFromCtx(context)
+            if (session && (await resolver.isUserDeactivated(session.user.id))) {
+              deleteSessionCookie(context)
+              if (context.path === "/get-session") return context.json(null)
+              denyAccess()
+            }
+
+            const email = requestEmail(context)
+            if (email && (await resolver.isEmailDeactivated(email))) denyAccess()
+          }),
+        },
+      ],
+    },
+  }
+}

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -18,6 +18,7 @@ import {
   createLocalMemberAccessPlugin,
   isLocalMemberDeactivated,
   isLocalMemberEmailDeactivated,
+  isLocalMemberSessionActive,
 } from "./local-member-access.js"
 import { expandTrustedOrigins, getTrustedOrigins } from "./trusted-origins.js"
 import { isFirstAuthUser, provisionCurrentUserProfile } from "./workspace.js"
@@ -230,11 +231,10 @@ export interface CreateBetterAuthOptions<
   sendVerificationOTP?: (data: { email: string; otp: string; type: string }) => Promise<void>
   /**
    * Better Auth session cookie cache: session data rides in a short-lived
-   * signed cookie so `getSession` skips the Postgres lookup on most
-   * requests. Enabled by default with a 5-minute TTL — the trade-off is
-   * that a revoked/expired session can stay usable for up to `maxAge`
-   * seconds. Pass `false` for revocation-sensitive deployments, or tune
-   * `maxAge` (seconds).
+   * signed cookie. Enabled by default with a 5-minute TTL. Voyant still
+   * validates local membership and session existence against Postgres so a
+   * deleted session cannot be revived from the cookie cache. Pass `false` to
+   * disable payload caching, or tune `maxAge` (seconds).
    */
   sessionCookieCache?: false | { maxAge?: number }
   /** Better Auth secondary storage, typically Redis/KV, used for distributed rate limits. */
@@ -311,9 +311,6 @@ export function createBetterAuth<
           session: {
             cookieCache: {
               enabled: true,
-              // Caps how long a revoked session stays usable from the
-              // cookie alone; within the window getSession answers from
-              // the signed cookie with zero DB roundtrips.
               maxAge: options.sessionCookieCache?.maxAge ?? 300,
             },
           },
@@ -377,6 +374,7 @@ export function createBetterAuth<
       }),
       createLocalMemberAccessPlugin({
         isEmailDeactivated: (email) => isLocalMemberEmailDeactivated(db, email),
+        isSessionActive: (sessionId, userId) => isLocalMemberSessionActive(db, sessionId, userId),
         isUserDeactivated: (userId) => isLocalMemberDeactivated(db, userId),
       }),
       ...extraPlugins,

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -14,6 +14,11 @@ import type { BetterAuthPlugin } from "better-auth/types"
 import { sql } from "drizzle-orm"
 import type { AnyPgTable } from "drizzle-orm/pg-core"
 
+import {
+  createLocalMemberAccessPlugin,
+  isLocalMemberDeactivated,
+  isLocalMemberEmailDeactivated,
+} from "./local-member-access.js"
 import { expandTrustedOrigins, getTrustedOrigins } from "./trusted-origins.js"
 import { isFirstAuthUser, provisionCurrentUserProfile } from "./workspace.js"
 
@@ -61,7 +66,11 @@ type ResolvedBetterAuthUserOptions<UserOptions extends BetterAuthOptions["user"]
   changeEmail: ResolvedBetterAuthChangeEmail<UserOptions>
 }
 
-type VoyantBetterAuthPlugins = [ReturnType<typeof apiKey>, ReturnType<typeof emailOTP>]
+type VoyantBetterAuthPlugins = [
+  ReturnType<typeof apiKey>,
+  ReturnType<typeof emailOTP>,
+  ReturnType<typeof createLocalMemberAccessPlugin>,
+]
 
 type ResolvedBetterAuthPlugins<Plugins extends BetterAuthPlugin[] | undefined> =
   Plugins extends BetterAuthPlugin[]
@@ -365,6 +374,10 @@ export function createBetterAuth<
         changeEmail: {
           enabled: true,
         },
+      }),
+      createLocalMemberAccessPlugin({
+        isEmailDeactivated: (email) => isLocalMemberEmailDeactivated(db, email),
+        isUserDeactivated: (userId) => isLocalMemberDeactivated(db, userId),
       }),
       ...extraPlugins,
     ] as ResolvedBetterAuthPlugins<Plugins>,

--- a/packages/auth/src/team-management-local-adapter.ts
+++ b/packages/auth/src/team-management-local-adapter.ts
@@ -8,9 +8,10 @@ import {
   userProfilesTable,
 } from "@voyant-travel/db/schema/iam"
 import { scopesForRole } from "@voyant-travel/types/member-roles"
-import { desc, eq } from "drizzle-orm"
+import { desc, eq, sql } from "drizzle-orm"
 
 import type { IdentityAccessRuntimeProvider } from "./identity-access-runtime-port.js"
+import { isDeactivatedProviderId, localProviderIdForStatus } from "./local-member-access.js"
 import { type TeamManagementAdapter, TeamManagementError } from "./team-management-policy.js"
 import type {
   CreatedTeamInvitationDto,
@@ -30,21 +31,21 @@ const LOCAL_ROLES: TeamRoleDto[] = [
 ]
 
 const ROLE_LEVELS: Record<string, number> = { owner: 40, admin: 30, editor: 20, viewer: 10 }
-const DEACTIVATED_PROVIDER_PREFIX = "voyant-deactivated:"
 
-export function localProviderIdForStatus(
-  providerId: string,
-  status: TeamMemberDto["status"],
-): string {
-  if (status === "deactivated") {
-    return providerId.startsWith(DEACTIVATED_PROVIDER_PREFIX)
-      ? providerId
-      : `${DEACTIVATED_PROVIDER_PREFIX}${providerId}`
-  }
-  return providerId.startsWith(DEACTIVATED_PROVIDER_PREFIX)
-    ? providerId.slice(DEACTIVATED_PROVIDER_PREFIX.length)
-    : providerId
+type TransactionDb<TDb> = TDb extends {
+  transaction<TResult>(
+    callback: (transaction: infer TTransaction) => Promise<TResult>,
+  ): Promise<TResult>
 }
+  ? TTransaction
+  : never
+
+type LocalTeamDb =
+  | TeamManagementRequestContext["db"]
+  | TransactionDb<TeamManagementRequestContext["db"]>
+type LocalTeamRequestContext = Omit<TeamManagementRequestContext, "db"> & { db: LocalTeamDb }
+
+export { localProviderIdForStatus } from "./local-member-access.js"
 
 function roleName(roleId: string): string {
   return LOCAL_ROLES.find((role) => role.id === roleId)?.name ?? roleId
@@ -97,7 +98,7 @@ async function sha256Hex(input: string): Promise<string> {
     .join("")
 }
 
-async function listLocalMembers(context: TeamManagementRequestContext): Promise<TeamMemberDto[]> {
+async function listLocalMembers(context: LocalTeamRequestContext): Promise<TeamMemberDto[]> {
   const [rows, accounts] = await Promise.all([
     context.db
       .select({
@@ -119,7 +120,7 @@ async function listLocalMembers(context: TeamManagementRequestContext): Promise<
   ])
   const activeUserIds = new Set(
     accounts
-      .filter((account) => !account.providerId.startsWith(DEACTIVATED_PROVIDER_PREFIX))
+      .filter((account) => !isDeactivatedProviderId(account.providerId))
       .map((account) => account.userId),
   )
 
@@ -136,6 +137,39 @@ async function listLocalMembers(context: TeamManagementRequestContext): Promise<
       joinedAt: row.createdAt?.toISOString() ?? null,
       lastActivityAt: row.lastActiveAt?.toISOString() ?? null,
     }
+  })
+}
+
+function memberOrThrow(members: TeamMemberDto[], memberId: string): TeamMemberDto {
+  const member = members.find((candidate) => candidate.id === memberId)
+  if (!member) throw new TeamManagementError("member_not_found", "Team member not found.", 404)
+  return member
+}
+
+function assertActiveOwnerRemains(members: TeamMemberDto[], target: TeamMemberDto): void {
+  if (target.status !== "active" || target.roleId !== "owner") return
+  const activeOwnerCount = members.filter(
+    (member) => member.status === "active" && member.roleId === "owner",
+  ).length
+  if (activeOwnerCount <= 1) {
+    throw new TeamManagementError(
+      "last_owner",
+      "The last active owner cannot be demoted or deactivated.",
+      409,
+    )
+  }
+}
+
+async function withLockedLocalTeam<T>(
+  context: TeamManagementRequestContext,
+  operation: (transactionContext: LocalTeamRequestContext) => Promise<T>,
+): Promise<T> {
+  return context.db.transaction(async (transaction) => {
+    // agent-quality: raw-sql reviewed -- owner: auth; table identifiers are static Drizzle schema objects.
+    await transaction.execute(
+      sql`SELECT ${authUser.id} FROM ${authUser} ORDER BY ${authUser.id} FOR UPDATE`,
+    )
+    return operation({ ...context, db: transaction })
   })
 }
 
@@ -243,66 +277,65 @@ export function createLocalTeamManagementAdapter(
       await context.db.delete(userInvitationsTable).where(eq(userInvitationsTable.id, invitationId))
     },
     async updateMemberRole(context, memberId, roleId) {
-      await context.db
-        .update(userProfilesTable)
-        .set({
-          isSuperAdmin: roleId === "owner",
-          permissions: permissionsForRole(roleId),
-          updatedAt: new Date(),
-        })
-        .where(eq(userProfilesTable.id, memberId))
-      const member = (await listLocalMembers(context)).find(
-        (candidate) => candidate.id === memberId,
-      )
-      if (!member) throw new TeamManagementError("member_not_found", "Team member not found.", 404)
-      return member
+      return withLockedLocalTeam(context, async (transactionContext) => {
+        const members = await listLocalMembers(transactionContext)
+        const target = memberOrThrow(members, memberId)
+        if (roleId !== "owner") assertActiveOwnerRemains(members, target)
+
+        await transactionContext.db
+          .update(userProfilesTable)
+          .set({
+            isSuperAdmin: roleId === "owner",
+            permissions: permissionsForRole(roleId),
+            updatedAt: new Date(),
+          })
+          .where(eq(userProfilesTable.id, memberId))
+        return memberOrThrow(await listLocalMembers(transactionContext), memberId)
+      })
     },
     async deactivateMember(context, memberId) {
-      await context.db.delete(authSession).where(eq(authSession.userId, memberId))
-      await context.db.delete(apikeyTable).where(eq(apikeyTable.referenceId, memberId))
-      const accounts = await context.db
-        .select({ id: authAccount.id, providerId: authAccount.providerId })
-        .from(authAccount)
-        .where(eq(authAccount.userId, memberId))
-      await Promise.all(
-        accounts.map((account) =>
-          context.db
+      return withLockedLocalTeam(context, async (transactionContext) => {
+        const members = await listLocalMembers(transactionContext)
+        assertActiveOwnerRemains(members, memberOrThrow(members, memberId))
+
+        await transactionContext.db.delete(authSession).where(eq(authSession.userId, memberId))
+        await transactionContext.db.delete(apikeyTable).where(eq(apikeyTable.referenceId, memberId))
+        const accounts = await transactionContext.db
+          .select({ id: authAccount.id, providerId: authAccount.providerId })
+          .from(authAccount)
+          .where(eq(authAccount.userId, memberId))
+        for (const account of accounts) {
+          await transactionContext.db
             .update(authAccount)
             .set({ providerId: localProviderIdForStatus(account.providerId, "deactivated") })
-            .where(eq(authAccount.id, account.id)),
-        ),
-      )
-      const member = (await listLocalMembers(context)).find(
-        (candidate) => candidate.id === memberId,
-      )
-      if (!member) throw new TeamManagementError("member_not_found", "Team member not found.", 404)
-      return member
+            .where(eq(authAccount.id, account.id))
+        }
+        return memberOrThrow(await listLocalMembers(transactionContext), memberId)
+      })
     },
     async activateMember(context, memberId) {
-      const accounts = await context.db
-        .select({ id: authAccount.id, providerId: authAccount.providerId })
-        .from(authAccount)
-        .where(eq(authAccount.userId, memberId))
-      await Promise.all(
-        accounts.map((account) =>
-          context.db
+      return withLockedLocalTeam(context, async (transactionContext) => {
+        memberOrThrow(await listLocalMembers(transactionContext), memberId)
+        const accounts = await transactionContext.db
+          .select({ id: authAccount.id, providerId: authAccount.providerId })
+          .from(authAccount)
+          .where(eq(authAccount.userId, memberId))
+        for (const account of accounts) {
+          await transactionContext.db
             .update(authAccount)
             .set({ providerId: localProviderIdForStatus(account.providerId, "active") })
-            .where(eq(authAccount.id, account.id)),
-        ),
-      )
-      const member = (await listLocalMembers(context)).find(
-        (candidate) => candidate.id === memberId,
-      )
-      if (!member) throw new TeamManagementError("member_not_found", "Team member not found.", 404)
-      if (member.status !== "active") {
-        throw new TeamManagementError(
-          "activation_unavailable",
-          "This local member has no sign-in account to reactivate.",
-          409,
-        )
-      }
-      return member
+            .where(eq(authAccount.id, account.id))
+        }
+        const member = memberOrThrow(await listLocalMembers(transactionContext), memberId)
+        if (member.status !== "active") {
+          throw new TeamManagementError(
+            "activation_unavailable",
+            "This local member has no sign-in account to reactivate.",
+            409,
+          )
+        }
+        return member
+      })
     },
     roleLevel(roleId) {
       return ROLE_LEVELS[roleId] ?? 0

--- a/packages/auth/src/voyant.ts
+++ b/packages/auth/src/voyant.ts
@@ -60,6 +60,7 @@ export const authTeamVoyantModule = defineModule({
       mount: "team",
       resource: "team",
       openapi: { document: "team" },
+      transactional: true,
       runtime: {
         entry: "@voyant-travel/auth/identity-access-graph-runtime",
         export: "createTeamVoyantRuntime",

--- a/packages/auth/tests/integration/local-team-management.test.ts
+++ b/packages/auth/tests/integration/local-team-management.test.ts
@@ -1,0 +1,189 @@
+import { createDbClient } from "@voyant-travel/db"
+import { authAccount, authUser, userProfilesTable } from "@voyant-travel/db/schema/iam"
+import { eq } from "drizzle-orm"
+import { afterAll, beforeEach, describe, expect, it } from "vitest"
+
+import { createBetterAuth } from "../../src/server.js"
+import { createLocalTeamManagementAdapter } from "../../src/team-management-local-adapter.js"
+import type { TeamManagementRequestContext } from "../../src/team-management-runtime-port.js"
+
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const BASE_URL = "http://localhost:3000"
+const PASSWORD = "p".repeat(16)
+
+function request(path: string, body?: Record<string, unknown>, cookie?: string): Request {
+  return new Request(`${BASE_URL}/api/auth${path}`, {
+    method: body ? "POST" : "GET",
+    headers: {
+      ...(body ? { "content-type": "application/json" } : {}),
+      ...(cookie ? { cookie } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  })
+}
+
+function cookieHeader(response: Response): string {
+  return response.headers
+    .getSetCookie()
+    .map((cookie) => cookie.split(";", 1)[0])
+    .join("; ")
+}
+
+describe.skipIf(!TEST_DATABASE_URL)("local team management integration", () => {
+  const db = createDbClient(TEST_DATABASE_URL!, {
+    adapter: "node",
+    nodeMaxConnections: 4,
+    timeouts: { connectMs: false, queryMs: false, statementMs: false },
+  })
+  const adapter = createLocalTeamManagementAdapter({
+    resolveDeployment() {
+      return {
+        appUrl: "https://operator.example.com",
+        authMode: "local",
+        cloudAdminMembers: null,
+      }
+    },
+    async sendInvitationEmail() {
+      return true
+    },
+  })
+
+  function context(userId: string): TeamManagementRequestContext {
+    return { bindings: {}, db, userId }
+  }
+
+  async function insertOwner(id: string, email: string) {
+    const now = new Date()
+    await db.insert(authUser).values({
+      id,
+      name: email,
+      email,
+      emailVerified: true,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(userProfilesTable).values({ id, isSuperAdmin: true, permissions: ["*"] })
+    await db.insert(authAccount).values({
+      id: `account-${id}`,
+      accountId: id,
+      providerId: "credential",
+      userId: id,
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+
+  beforeEach(async () => {
+    await db.delete(authUser)
+  })
+
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  it("atomically preserves an active owner during concurrent demote and deactivate", async () => {
+    await insertOwner("owner-a", "owner-a@example.com")
+    await insertOwner("owner-b", "owner-b@example.com")
+
+    const results = await Promise.allSettled([
+      adapter.updateMemberRole(context("owner-b"), "owner-a", "admin"),
+      adapter.deactivateMember(context("owner-a"), "owner-b"),
+    ])
+
+    expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1)
+    expect(results.filter((result) => result.status === "rejected")).toHaveLength(1)
+    expect(results.find((result) => result.status === "rejected")).toMatchObject({
+      reason: { code: "last_owner" },
+    })
+
+    const profiles = await db
+      .select({ id: userProfilesTable.id, isSuperAdmin: userProfilesTable.isSuperAdmin })
+      .from(userProfilesTable)
+    const accounts = await db
+      .select({ userId: authAccount.userId, providerId: authAccount.providerId })
+      .from(authAccount)
+    const activeUserIds = new Set(
+      accounts
+        .filter((account) => !account.providerId.startsWith("voyant-deactivated:"))
+        .map((account) => account.userId),
+    )
+    const activeOwners = profiles.filter(
+      (profile) => profile.isSuperAdmin && activeUserIds.has(profile.id),
+    )
+
+    expect(activeOwners).toHaveLength(1)
+    expect(
+      await db
+        .select({ id: authUser.id })
+        .from(authUser)
+        .where(eq(authUser.id, activeOwners[0]!.id)),
+    ).toHaveLength(1)
+  })
+
+  it("drives session, password, and OTP access from durable local deactivation state", async () => {
+    await insertOwner("owner", "owner@example.com")
+    const sentOtps: string[] = []
+    const auth = createBetterAuth({
+      baseURL: BASE_URL,
+      db,
+      disableSignupWhenUsersExist: { enabled: false },
+      secret: "x".repeat(32),
+      sendVerificationOTP: async ({ otp }) => {
+        sentOtps.push(otp)
+      },
+    })
+    const signup = await auth.handler(
+      request("/sign-up/email", {
+        email: "member@example.com",
+        name: "Member",
+        password: PASSWORD,
+      }),
+    )
+    expect(signup.status).toBe(200)
+    const signupBody = (await signup.json()) as { user: { id: string } }
+    const memberId = signupBody.user.id
+    await db.update(authUser).set({ emailVerified: true }).where(eq(authUser.id, memberId))
+    const activePassword = await auth.handler(
+      request("/sign-in/email", { email: "member@example.com", password: PASSWORD }),
+    )
+    expect(activePassword.status).toBe(200)
+    const cookie = cookieHeader(activePassword)
+    sentOtps.length = 0
+
+    await adapter.deactivateMember(context("owner"), memberId)
+
+    const deniedSession = await auth.handler(request("/get-session", undefined, cookie))
+    expect(deniedSession.status).toBe(200)
+    expect(await deniedSession.json()).toBeNull()
+
+    const deniedPassword = await auth.handler(
+      request("/sign-in/email", { email: "member@example.com", password: PASSWORD }),
+    )
+    expect(deniedPassword.status).toBe(403)
+
+    const deniedOtp = await auth.handler(
+      request("/email-otp/send-verification-otp", {
+        email: "member@example.com",
+        type: "sign-in",
+      }),
+    )
+    expect(deniedOtp.status).toBe(403)
+    expect(sentOtps).toHaveLength(0)
+
+    await adapter.activateMember(context("owner"), memberId)
+
+    const restoredPassword = await auth.handler(
+      request("/sign-in/email", { email: "member@example.com", password: PASSWORD }),
+    )
+    expect(restoredPassword.status).toBe(200)
+
+    const restoredOtp = await auth.handler(
+      request("/email-otp/send-verification-otp", {
+        email: "member@example.com",
+        type: "sign-in",
+      }),
+    )
+    expect(restoredOtp.status).toBe(200)
+    expect(sentOtps).toHaveLength(1)
+  })
+})

--- a/packages/auth/tests/integration/local-team-management.test.ts
+++ b/packages/auth/tests/integration/local-team-management.test.ts
@@ -172,6 +172,10 @@ describe.skipIf(!TEST_DATABASE_URL)("local team management integration", () => {
 
     await adapter.activateMember(context("owner"), memberId)
 
+    const deniedReactivatedSession = await auth.handler(request("/get-session", undefined, cookie))
+    expect(deniedReactivatedSession.status).toBe(200)
+    expect(await deniedReactivatedSession.json()).toBeNull()
+
     const restoredPassword = await auth.handler(
       request("/sign-in/email", { email: "member@example.com", password: PASSWORD }),
     )

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -56,8 +56,18 @@ vi.mock("better-auth", () => ({
   betterAuth: betterAuthMock,
 }))
 
+vi.mock("better-auth/api", () => ({
+  APIError: class APIError extends Error {},
+  createAuthMiddleware: vi.fn((handler: unknown) => handler),
+  getSessionFromCtx: vi.fn(async () => null),
+}))
+
 vi.mock("better-auth/adapters/drizzle", () => ({
   drizzleAdapter: drizzleAdapterMock,
+}))
+
+vi.mock("better-auth/cookies", () => ({
+  deleteSessionCookie: vi.fn(),
 }))
 
 vi.mock("better-auth/plugins", () => ({
@@ -312,6 +322,7 @@ describe("createBetterAuth", () => {
         plugins: [
           expect.objectContaining({ id: "apiKey" }),
           expect.objectContaining({ id: "emailOTP" }),
+          expect.objectContaining({ id: "voyant-local-member-access" }),
           jwtPlugin,
           customPlugin,
         ],

--- a/packages/auth/tests/unit/local-member-access.test.ts
+++ b/packages/auth/tests/unit/local-member-access.test.ts
@@ -1,0 +1,178 @@
+import { betterAuth } from "better-auth"
+import { memoryAdapter } from "better-auth/adapters/memory"
+import { emailOTP } from "better-auth/plugins"
+import { describe, expect, it, vi } from "vitest"
+
+import { createLocalMemberAccessPlugin } from "../../src/local-member-access.js"
+
+const BASE_URL = "http://localhost:3000"
+const PASSWORD = "p".repeat(16)
+const SECRET = "x".repeat(32)
+
+function cookieHeader(response: Response): string {
+  return response.headers
+    .getSetCookie()
+    .map((cookie) => cookie.split(";", 1)[0])
+    .join("; ")
+}
+
+function request(path: string, body?: Record<string, unknown>, cookie?: string): Request {
+  return new Request(`${BASE_URL}/api/auth${path}`, {
+    method: body ? "POST" : "GET",
+    headers: {
+      ...(body ? { "content-type": "application/json" } : {}),
+      ...(cookie ? { cookie } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  })
+}
+
+function authFixture() {
+  const deactivatedUserIds = new Set<string>()
+  const deactivatedEmails = new Set<string>()
+  const sentOtps = new Map<string, string>()
+  const sendVerificationOTP = vi.fn(
+    async ({ email, otp }: { email: string; otp: string; type: string }) => {
+      sentOtps.set(email, otp)
+    },
+  )
+  const auth = betterAuth({
+    baseURL: BASE_URL,
+    secret: SECRET,
+    database: memoryAdapter({ account: [], session: [], user: [], verification: [] }),
+    emailAndPassword: { enabled: true },
+    session: { cookieCache: { enabled: true, maxAge: 300 } },
+    plugins: [
+      emailOTP({ sendVerificationOTP }),
+      createLocalMemberAccessPlugin({
+        isEmailDeactivated: async (email) => deactivatedEmails.has(email),
+        isUserDeactivated: async (userId) => deactivatedUserIds.has(userId),
+      }),
+    ],
+  })
+
+  return {
+    auth,
+    deactivate(user: { id: string; email: string }) {
+      deactivatedUserIds.add(user.id)
+      deactivatedEmails.add(user.email)
+    },
+    reactivate(user: { id: string; email: string }) {
+      deactivatedUserIds.delete(user.id)
+      deactivatedEmails.delete(user.email)
+    },
+    sendVerificationOTP,
+    sentOtps,
+  }
+}
+
+async function signUp(
+  auth: ReturnType<typeof authFixture>["auth"],
+  email: string,
+): Promise<{ cookie: string; user: { id: string; email: string } }> {
+  const response = await auth.handler(
+    request("/sign-up/email", {
+      email,
+      name: "Team Member",
+      password: PASSWORD,
+    }),
+  )
+  expect(response.status).toBe(200)
+  const body = (await response.json()) as { user: { id: string; email: string } }
+  return { cookie: cookieHeader(response), user: body.user }
+}
+
+describe("local member access Better Auth pipeline", () => {
+  it("denies cached sessions and password sign-in until the member is reactivated", async () => {
+    const fixture = authFixture()
+    const member = await signUp(fixture.auth, "member@example.com")
+
+    const activeSession = await fixture.auth.handler(
+      request("/get-session", undefined, member.cookie),
+    )
+    expect(await activeSession.json()).toMatchObject({ user: { id: member.user.id } })
+
+    fixture.deactivate(member.user)
+
+    const deniedCachedSession = await fixture.auth.handler(
+      request("/get-session", undefined, member.cookie),
+    )
+    expect(deniedCachedSession.status).toBe(200)
+    expect(await deniedCachedSession.json()).toBeNull()
+
+    const deniedSignIn = await fixture.auth.handler(
+      request("/sign-in/email", {
+        email: member.user.email,
+        password: PASSWORD,
+      }),
+    )
+    expect(deniedSignIn.status).toBe(403)
+
+    fixture.reactivate(member.user)
+
+    const restoredSignIn = await fixture.auth.handler(
+      request("/sign-in/email", {
+        email: member.user.email,
+        password: PASSWORD,
+      }),
+    )
+    expect(restoredSignIn.status).toBe(200)
+    expect(await restoredSignIn.json()).toMatchObject({ user: { id: member.user.id } })
+  })
+
+  it("denies OTP issuance and OTP sign-in until the member is reactivated", async () => {
+    const fixture = authFixture()
+    const member = await signUp(fixture.auth, "otp-member@example.com")
+
+    const issuedBeforeDeactivation = await fixture.auth.handler(
+      request("/email-otp/send-verification-otp", {
+        email: member.user.email,
+        type: "sign-in",
+      }),
+    )
+    expect(issuedBeforeDeactivation.status).toBe(200)
+    const preDeactivationOtp = fixture.sentOtps.get(member.user.email)
+    expect(preDeactivationOtp).toBeDefined()
+
+    fixture.deactivate(member.user)
+
+    const deniedPreIssuedOtp = await fixture.auth.handler(
+      request("/sign-in/email-otp", {
+        email: member.user.email,
+        otp: preDeactivationOtp,
+      }),
+    )
+    expect(deniedPreIssuedOtp.status).toBe(403)
+
+    const deniedOtp = await fixture.auth.handler(
+      request("/email-otp/send-verification-otp", {
+        email: member.user.email,
+        type: "sign-in",
+      }),
+    )
+    expect(deniedOtp.status).toBe(403)
+    expect(fixture.sendVerificationOTP).toHaveBeenCalledTimes(1)
+
+    fixture.reactivate(member.user)
+
+    const issuedOtp = await fixture.auth.handler(
+      request("/email-otp/send-verification-otp", {
+        email: member.user.email,
+        type: "sign-in",
+      }),
+    )
+    expect(issuedOtp.status).toBe(200)
+
+    const otp = fixture.sentOtps.get(member.user.email)
+    expect(otp).toBeDefined()
+
+    const restoredOtpSignIn = await fixture.auth.handler(
+      request("/sign-in/email-otp", {
+        email: member.user.email,
+        otp,
+      }),
+    )
+    expect(restoredOtpSignIn.status).toBe(200)
+    expect(await restoredOtpSignIn.json()).toMatchObject({ user: { id: member.user.id } })
+  })
+})

--- a/packages/auth/tests/unit/local-member-access.test.ts
+++ b/packages/auth/tests/unit/local-member-access.test.ts
@@ -30,6 +30,7 @@ function request(path: string, body?: Record<string, unknown>, cookie?: string):
 function authFixture() {
   const deactivatedUserIds = new Set<string>()
   const deactivatedEmails = new Set<string>()
+  const revokedSessionIds = new Set<string>()
   const sentOtps = new Map<string, string>()
   const sendVerificationOTP = vi.fn(
     async ({ email, otp }: { email: string; otp: string; type: string }) => {
@@ -46,6 +47,7 @@ function authFixture() {
       emailOTP({ sendVerificationOTP }),
       createLocalMemberAccessPlugin({
         isEmailDeactivated: async (email) => deactivatedEmails.has(email),
+        isSessionActive: async (sessionId) => !revokedSessionIds.has(sessionId),
         isUserDeactivated: async (userId) => deactivatedUserIds.has(userId),
       }),
     ],
@@ -60,6 +62,9 @@ function authFixture() {
     reactivate(user: { id: string; email: string }) {
       deactivatedUserIds.delete(user.id)
       deactivatedEmails.delete(user.email)
+    },
+    revokeSession(sessionId: string) {
+      revokedSessionIds.add(sessionId)
     },
     sendVerificationOTP,
     sentOtps,
@@ -90,9 +95,14 @@ describe("local member access Better Auth pipeline", () => {
     const activeSession = await fixture.auth.handler(
       request("/get-session", undefined, member.cookie),
     )
-    expect(await activeSession.json()).toMatchObject({ user: { id: member.user.id } })
+    const activeSessionBody = (await activeSession.json()) as {
+      session: { id: string }
+      user: { id: string }
+    }
+    expect(activeSessionBody).toMatchObject({ user: { id: member.user.id } })
 
     fixture.deactivate(member.user)
+    fixture.revokeSession(activeSessionBody.session.id)
 
     const deniedCachedSession = await fixture.auth.handler(
       request("/get-session", undefined, member.cookie),
@@ -109,6 +119,12 @@ describe("local member access Better Auth pipeline", () => {
     expect(deniedSignIn.status).toBe(403)
 
     fixture.reactivate(member.user)
+
+    const deniedReactivatedCachedSession = await fixture.auth.handler(
+      request("/get-session", undefined, member.cookie),
+    )
+    expect(deniedReactivatedCachedSession.status).toBe(200)
+    expect(await deniedReactivatedCachedSession.json()).toBeNull()
 
     const restoredSignIn = await fixture.auth.handler(
       request("/sign-in/email", {

--- a/packages/auth/tests/unit/voyant-manifest.test.ts
+++ b/packages/auth/tests/unit/voyant-manifest.test.ts
@@ -48,7 +48,14 @@ describe("auth identity/access deployment manifests", () => {
       packageName: "@voyant-travel/auth",
       provides: { ports: [{ id: teamManagementRuntimePort.id }] },
       runtimePorts: [{ id: teamManagementRuntimePort.id }],
-      api: [{ surface: "admin", mount: "team", openapi: { document: "team" } }],
+      api: [
+        {
+          surface: "admin",
+          mount: "team",
+          openapi: { document: "team" },
+          transactional: true,
+        },
+      ],
       admin: {
         runtime: {
           entry: "@voyant-travel/auth-react/admin",


### PR DESCRIPTION
Follow-up correctness hardening for local team management.

- enforce deactivation across cached sessions, new sessions, password/social sign-in, and email OTP
- preserve revoked session and API-key semantics across reactivation
- serialize owner mutations and reject concurrent removal of the final active owner
- cover the Better Auth pipeline and Postgres concurrency behavior

Follow-up to #3357.