### PR TITLE
fix(release): verify public dependency tree installs

### DIFF
--- a/.changeset/external-provider-install-tree.md
+++ b/.changeset/external-provider-install-tree.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/flights": patch
+"@voyant-travel/trips": patch
+---
+
+Keep the externally maintained Netopia provider out of the default public dependency tree so
+framework consumers can install the standard package graph with npm.

--- a/.changeset/wide-lucide-peer-compatibility.md
+++ b/.changeset/wide-lucide-peer-compatibility.md
@@ -1,8 +1,15 @@
 ---
 "@voyant-travel/admin": patch
 "@voyant-travel/admin-app": patch
+"@voyant-travel/action-ledger-react": patch
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/commerce-react": patch
+"@voyant-travel/mice-react": patch
+"@voyant-travel/notifications-react": patch
 "@voyant-travel/operations-react": patch
+"@voyant-travel/quotes-react": patch
 "@voyant-travel/storefront-react": patch
+"@voyant-travel/trips-react": patch
 ---
 
 Accept current Lucide releases in public peer ranges so the standard Operator package closure

--- a/.changeset/wide-lucide-peer-compatibility.md
+++ b/.changeset/wide-lucide-peer-compatibility.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/admin": patch
+"@voyant-travel/admin-app": patch
+"@voyant-travel/operations-react": patch
+"@voyant-travel/storefront-react": patch
+---
+
+Accept current Lucide releases in public peer ranges so the standard Operator package closure
+resolves for external npm consumers.

--- a/docs/architecture/package-release-workflow.md
+++ b/docs/architecture/package-release-workflow.md
@@ -14,6 +14,10 @@ the package names represent one installable module surface.
 - Use `workspace:^` for internal `@voyant-travel/*` dependencies. Patch releases
   should not force compatible dependents to publish; minor and major releases
   still propagate when they leave the dependent's range.
+- Treat externally maintained provider packages as optional peers when a module
+  can be installed without selecting that provider. Keep the provider in
+  `devDependencies` for local compilation, and mark the peer optional so a
+  generic package install does not inherit a frozen provider dependency graph.
 - Build and verify only the package set that will be published, plus the build
   dependencies Turbo needs for those packages.
 - Starter GitHub Releases are separate from npm package publication. Refresh
@@ -26,7 +30,8 @@ On pushes to `main`, the release workflow plans work before building:
 
 1. If package versions are ahead of npm, build the pending package set with
    Turbo filters.
-2. Verify exports and publish tarballs for the same pending package set.
+2. Verify exports and publish tarballs for the same pending package set, then
+   resolve those packed packages together in a clean npm project.
 3. Publish those pending packages through Changesets.
 4. If releasable changesets exist, create or update the Changesets release PR
    without building the package graph.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "verify:ui-components-barrel": "node scripts/check-ui-components-barrel.mjs",
     "verify:ui-orientation-selectors": "node scripts/check-ui-orientation-selectors.mjs",
     "verify:date-picker-single-source": "node scripts/check-date-picker-single-source.mjs",
-    "verify:publish-tarballs": "node --test scripts/tests/packed-exports.test.mjs scripts/tests/packed-sourcemaps.test.mjs && node scripts/verify-package-tarballs.mjs",
+    "verify:publish-tarballs": "node --test scripts/tests/packed-exports.test.mjs scripts/tests/packed-install.test.mjs scripts/tests/packed-sourcemaps.test.mjs && node scripts/verify-package-tarballs.mjs",
     "verify:tenant-scoping": "node scripts/check-tenant-scoping.mjs",
     "verify:route-authoring": "node scripts/check-route-authoring.mjs",
     "verify:route-ownership": "node scripts/check-route-ownership.mjs",

--- a/packages/action-ledger-react/package.json
+++ b/packages/action-ledger-react/package.json
@@ -30,7 +30,7 @@
     "@voyant-travel/inventory-react": "workspace:^",
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/admin-app/package.json
+++ b/packages/admin-app/package.json
@@ -34,7 +34,7 @@
     "@voyant-travel/react": "workspace:^",
     "@voyant-travel/types": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^0.475.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -52,7 +52,7 @@
     "@tanstack/react-query": "^5.0.0",
     "@tanstack/react-router": "^1.0.0",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^0.475.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "recharts": "^3.0.0"

--- a/packages/bookings-react/package.json
+++ b/packages/bookings-react/package.json
@@ -66,7 +66,7 @@
     "@voyant-travel/inventory": "workspace:^",
     "@voyant-travel/storefront-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",

--- a/packages/commerce-react/package.json
+++ b/packages/commerce-react/package.json
@@ -75,7 +75,7 @@
     "@voyant-travel/distribution-react": "workspace:^",
     "@voyant-travel/inventory-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",

--- a/packages/flights/package.json
+++ b/packages/flights/package.json
@@ -153,16 +153,24 @@
     "@voyant-travel/catalog-contracts": "workspace:^",
     "@voyant-travel/flights-contracts": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
-    "@voyant-travel/plugin-netopia": "^0.105.21",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@voyant-travel/plugin-netopia": "^0.105.21",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "drizzle-kit": "^0.31.10",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@voyant-travel/plugin-netopia": "^0.105.21"
+  },
+  "peerDependenciesMeta": {
+    "@voyant-travel/plugin-netopia": {
+      "optional": true
+    }
   },
   "repository": {
     "type": "git",

--- a/packages/flights/src/runtime.ts
+++ b/packages/flights/src/runtime.ts
@@ -1,11 +1,26 @@
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { CardPaymentStarter } from "@voyant-travel/finance/card-payment"
-import { lazyProvider } from "@voyant-travel/hono"
 import type { FlightsRuntime } from "./runtime-port.js"
 
-const cardPaymentStarter: CardPaymentStarter = lazyProvider(async () =>
-  import("@voyant-travel/plugin-netopia").then((module) => module.netopiaCardPaymentStarter()),
-)
+let cardPaymentStarterPromise: Promise<CardPaymentStarter | null> | undefined
+
+function resolveCardPaymentStarter(): Promise<CardPaymentStarter | null> {
+  cardPaymentStarterPromise ??= import("@voyant-travel/plugin-netopia")
+    .then((module) => module.netopiaCardPaymentStarter())
+    .catch((error: unknown) => {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_MODULE_NOT_FOUND" &&
+        /Cannot find (?:package|module) ['"]@voyant-travel\/plugin-netopia['"]/.test(error.message)
+      ) {
+        return null
+      }
+      throw error
+    })
+  return cardPaymentStarterPromise
+}
+
 type CardPaymentInput = Parameters<CardPaymentStarter>[1]
 
 /** Build the standard Node Flights runtime from domain-neutral host primitives. */
@@ -17,6 +32,8 @@ export function createFlightsRuntime(primitives: VoyantRuntimeHostPrimitives): F
       )
     },
     async startCardPayment(c, sessionId, billing) {
+      const cardPaymentStarter = await resolveCardPaymentStarter()
+      if (!cardPaymentStarter) return
       await cardPaymentStarter(c, {
         db: primitives.database.fromContext<CardPaymentInput["db"]>(c),
         sessionId,

--- a/packages/mice-react/package.json
+++ b/packages/mice-react/package.json
@@ -36,7 +36,7 @@
     "@voyant-travel/mice": "workspace:^",
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/notifications-react/package.json
+++ b/packages/notifications-react/package.json
@@ -36,7 +36,7 @@
     "@voyant-travel/admin": "workspace:^",
     "@voyant-travel/notifications": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",

--- a/packages/operations-react/package.json
+++ b/packages/operations-react/package.json
@@ -74,7 +74,7 @@
     "@voyant-travel/operations": "workspace:^",
     "@voyant-travel/inventory-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^0.475.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.80.0",

--- a/packages/quotes-react/package.json
+++ b/packages/quotes-react/package.json
@@ -41,7 +41,7 @@
     "@voyant-travel/quotes": "workspace:^",
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/storefront-react/package.json
+++ b/packages/storefront-react/package.json
@@ -43,7 +43,7 @@
     "@voyant-travel/auth-react": "workspace:^",
     "@voyant-travel/storefront": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^0.475.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/trips-react/package.json
+++ b/packages/trips-react/package.json
@@ -38,7 +38,7 @@
     "@voyant-travel/relationships-react": "workspace:^",
     "@voyant-travel/trips": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
-    "lucide-react": "^1.23.0",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"

--- a/packages/trips/package.json
+++ b/packages/trips/package.json
@@ -68,7 +68,6 @@
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/inventory": "workspace:^",
     "@voyant-travel/operator-settings": "workspace:^",
-    "@voyant-travel/plugin-netopia": "^0.105.21",
     "@voyant-travel/storefront": "workspace:^",
     "@voyant-travel/tools": "workspace:^",
     "@voyant-travel/types": "workspace:^",
@@ -77,10 +76,19 @@
     "zod": "catalog:"
   },
   "devDependencies": {
+    "@voyant-travel/plugin-netopia": "^0.105.21",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "drizzle-kit": "^0.31.10",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@voyant-travel/plugin-netopia": "^0.105.21"
+  },
+  "peerDependenciesMeta": {
+    "@voyant-travel/plugin-netopia": {
+      "optional": true
+    }
   },
   "files": [
     "dist",

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -1,12 +1,12 @@
 /** Standard statically composed payment-link runtime selected by Storefront. */
 
 import type { CommerceCardPaymentRuntime } from "@voyant-travel/commerce/runtime-port"
+import type { CardPaymentStarter } from "@voyant-travel/finance/card-payment"
 import { productMedia, products } from "@voyant-travel/inventory/schema"
 import {
   getOperatorPaymentInstructions,
   getOperatorProfile,
 } from "@voyant-travel/operator-settings"
-import { netopiaCardPaymentStarter } from "@voyant-travel/plugin-netopia"
 import type {
   PaymentLinkRoutesOptions,
   PaymentLinkTripData,
@@ -17,15 +17,34 @@ import type { Context } from "hono"
 import { tripComponents, tripEnvelopes } from "./schema.js"
 import { tripsService } from "./service.js"
 
-const cardPaymentStarter = netopiaCardPaymentStarter()
+let cardPaymentStarterPromise: Promise<CardPaymentStarter | null> | undefined
+
+function resolveCardPaymentStarter(): Promise<CardPaymentStarter | null> {
+  cardPaymentStarterPromise ??= import("@voyant-travel/plugin-netopia")
+    .then((module) => module.netopiaCardPaymentStarter())
+    .catch((error: unknown) => {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        error.code === "ERR_MODULE_NOT_FOUND" &&
+        error.message.includes("@voyant-travel/plugin-netopia")
+      ) {
+        return null
+      }
+      throw error
+    })
+  return cardPaymentStarterPromise
+}
 
 /** Standard selected payment provider exposed through Commerce's neutral port. */
 export function createCommerceCardPaymentRuntime(): CommerceCardPaymentRuntime {
   return {
     createStartCardPayment:
       (context) =>
-      async ({ db, sessionId, billing, description, returnUrl }) =>
-        cardPaymentStarter(context, {
+      async ({ db, sessionId, billing, description, returnUrl }) => {
+        const cardPaymentStarter = await resolveCardPaymentStarter()
+        if (!cardPaymentStarter) return null
+        return cardPaymentStarter(context, {
           db,
           sessionId,
           billing: {
@@ -41,7 +60,8 @@ export function createCommerceCardPaymentRuntime(): CommerceCardPaymentRuntime {
           },
           description,
           returnUrl,
-        }),
+        })
+      },
   }
 }
 
@@ -102,6 +122,8 @@ async function resolveBankTransferDetails(c: Context) {
 
 /** Start a fresh card payment via this deployment's processor, or report it isn't configured. */
 const startCardPayment: PaymentLinkRoutesOptions["startCardPayment"] = async (c, session) => {
+  const cardPaymentStarter = await resolveCardPaymentStarter()
+  if (!cardPaymentStarter) return { configured: false }
   const [first, ...rest] = (session.payerName ?? "").trim().split(/\s+/)
   const last = rest.length > 0 ? rest.join(" ") : "Customer"
   const result = await cardPaymentStarter(c, {

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -27,7 +27,7 @@ function resolveCardPaymentStarter(): Promise<CardPaymentStarter | null> {
         error instanceof Error &&
         "code" in error &&
         error.code === "ERR_MODULE_NOT_FOUND" &&
-        error.message.includes("@voyant-travel/plugin-netopia")
+        /Cannot find (?:package|module) ['"]@voyant-travel\/plugin-netopia['"]/.test(error.message)
       ) {
         return null
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2087,9 +2087,6 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
-      '@voyant-travel/plugin-netopia':
-        specifier: ^0.105.21
-        version: 0.105.21(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       drizzle-orm:
         specifier: 'catalog:'
         version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -2100,6 +2097,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@voyant-travel/plugin-netopia':
+        specifier: ^0.105.21
+        version: 0.105.21(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config
@@ -4637,9 +4637,6 @@ importers:
       '@voyant-travel/operator-settings':
         specifier: workspace:^
         version: link:../operator-settings
-      '@voyant-travel/plugin-netopia':
-        specifier: ^0.105.21
-        version: 0.105.21(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/storefront':
         specifier: workspace:^
         version: link:../storefront
@@ -4659,6 +4656,9 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
+      '@voyant-travel/plugin-netopia':
+        specifier: ^0.105.21
+        version: 0.105.21(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config

--- a/scripts/check-dependency-versions.mjs
+++ b/scripts/check-dependency-versions.mjs
@@ -4,6 +4,7 @@ import { readdirSync, readFileSync } from "node:fs"
 import path from "node:path"
 
 const dependencySections = ["dependencies", "devDependencies", "optionalDependencies"]
+const firstPartyPeerDependencyRanges = new Map([["lucide-react", "^0.475.0 || ^1.0.0"]])
 
 const catalogDependencies = readDefaultCatalogDependencies()
 const packageJsonFiles = listPackageJsonFiles(".")
@@ -34,14 +35,24 @@ for (const packageJsonFile of packageJsonFiles) {
       }
     }
   }
+
+  if (packageJson.name?.startsWith("@voyant-travel/")) {
+    for (const [dependencyName, expectedRange] of firstPartyPeerDependencyRanges) {
+      const requestedRange = packageJson.peerDependencies?.[dependencyName]
+      if (requestedRange && requestedRange !== expectedRange) {
+        violations.push(
+          `${packageJsonFile}: peerDependencies.${dependencyName} must use ${expectedRange} (found ${requestedRange})`,
+        )
+      }
+    }
+  }
 }
 
 if (violations.length > 0) {
   console.error(
     [
       "Dependency version policy violations found.",
-      "Use pnpm workspace catalog entries for shared concrete dependencies.",
-      "Peer dependency ranges are intentionally checked separately from this policy.",
+      "Use pnpm workspace catalog entries for shared concrete dependencies and canonical first-party peer ranges.",
       "",
       ...violations,
     ].join("\n"),
@@ -50,7 +61,7 @@ if (violations.length > 0) {
 }
 
 console.log(
-  `Dependency version policy passed for ${catalogDependencies.size} catalog dependencies across ${packageJsonFiles.length} package manifests.`,
+  `Dependency version policy passed for ${catalogDependencies.size} catalog dependencies and ${firstPartyPeerDependencyRanges.size} first-party peer policies across ${packageJsonFiles.length} package manifests.`,
 )
 
 function readDefaultCatalogDependencies() {

--- a/scripts/lib/packed-install.mjs
+++ b/scripts/lib/packed-install.mjs
@@ -1,0 +1,52 @@
+import { execFile } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { promisify } from "node:util"
+
+const execFileAsync = promisify(execFile)
+
+export function createPackedInstallManifest(packedPackages) {
+  const dependencies = Object.fromEntries(
+    [...packedPackages]
+      .sort((left, right) => left.name.localeCompare(right.name))
+      .map(({ name, tarballPath }) => [name, `file:${path.resolve(tarballPath)}`]),
+  )
+
+  return {
+    name: "voyant-packed-install-verification",
+    version: "0.0.0",
+    private: true,
+    dependencies,
+  }
+}
+
+export async function verifyPackedPackageInstall(packedPackages) {
+  if (packedPackages.length === 0) return
+
+  const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "voyant-packed-install-"))
+  try {
+    const manifest = createPackedInstallManifest(packedPackages)
+    fs.writeFileSync(
+      path.join(installDir, "package.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    )
+
+    await execFileAsync(
+      "npm",
+      ["install", "--package-lock-only", "--ignore-scripts", "--no-audit", "--no-fund"],
+      {
+        cwd: installDir,
+        encoding: "utf8",
+        maxBuffer: 64 * 1024 * 1024,
+        env: process.env,
+      },
+    )
+  } catch (error) {
+    const detail =
+      error.stderr?.toString().trim() || error.stdout?.toString().trim() || error.message
+    throw new Error(`npm could not resolve the packed public dependency tree: ${detail}`)
+  } finally {
+    fs.rmSync(installDir, { recursive: true, force: true })
+  }
+}

--- a/scripts/tests/packed-install.test.mjs
+++ b/scripts/tests/packed-install.test.mjs
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict"
+import { execFile } from "node:child_process"
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, test } from "node:test"
+import { promisify } from "node:util"
+
+import { createPackedInstallManifest, verifyPackedPackageInstall } from "../lib/packed-install.mjs"
+
+const execFileAsync = promisify(execFile)
+const temporaryDirectories = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+test("creates a deterministic install manifest from packed packages", () => {
+  const manifest = createPackedInstallManifest([
+    { name: "@voyant-travel/zeta", tarballPath: "/tmp/zeta.tgz" },
+    { name: "@voyant-travel/alpha", tarballPath: "/tmp/alpha.tgz" },
+  ])
+
+  assert.deepEqual(Object.keys(manifest.dependencies), [
+    "@voyant-travel/alpha",
+    "@voyant-travel/zeta",
+  ])
+  assert.equal(manifest.dependencies["@voyant-travel/alpha"], "file:/tmp/alpha.tgz")
+})
+
+test("rejects package-manager protocols in a transitive packed dependency", async () => {
+  const fixtureRoot = createTemporaryDirectory("voyant-packed-install-fixture-")
+  const brokenTarball = await packFixture(fixtureRoot, "broken", {
+    name: "@fixture/broken",
+    version: "1.0.0",
+    dependencies: { zod: "catalog:" },
+  })
+  const consumerTarball = await packFixture(fixtureRoot, "consumer", {
+    name: "@fixture/consumer",
+    version: "1.0.0",
+    dependencies: { "@fixture/broken": `file:${brokenTarball}` },
+  })
+
+  await assert.rejects(
+    verifyPackedPackageInstall([{ name: "@fixture/consumer", tarballPath: consumerTarball }]),
+    /Unsupported URL Type "catalog:"/,
+  )
+})
+
+test("does not install an optional provider peer", async () => {
+  const fixtureRoot = createTemporaryDirectory("voyant-packed-optional-peer-")
+  const consumerTarball = await packFixture(fixtureRoot, "consumer", {
+    name: "@fixture/consumer",
+    version: "1.0.0",
+    peerDependencies: { "@fixture/provider": "1.0.0" },
+    peerDependenciesMeta: { "@fixture/provider": { optional: true } },
+  })
+
+  await verifyPackedPackageInstall([{ name: "@fixture/consumer", tarballPath: consumerTarball }])
+})
+
+function createTemporaryDirectory(prefix) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
+  temporaryDirectories.push(directory)
+  return directory
+}
+
+async function packFixture(root, directoryName, manifest) {
+  const packageDir = path.join(root, directoryName)
+  const packDir = path.join(root, "tarballs")
+  fs.mkdirSync(packageDir, { recursive: true })
+  fs.mkdirSync(packDir, { recursive: true })
+  fs.writeFileSync(path.join(packageDir, "package.json"), `${JSON.stringify(manifest, null, 2)}\n`)
+
+  const { stdout } = await execFileAsync(
+    "npm",
+    ["pack", "--json", "--ignore-scripts", "--pack-destination", packDir],
+    { cwd: packageDir, encoding: "utf8" },
+  )
+  const [packInfo] = JSON.parse(stdout)
+  return path.join(packDir, packInfo.filename)
+}

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -23,6 +23,7 @@ import path from "node:path"
 import { promisify } from "node:util"
 
 import { packedFileExportsName } from "./lib/packed-exports.mjs"
+import { verifyPackedPackageInstall } from "./lib/packed-install.mjs"
 import { collectPackedManifestProtocolDependencies } from "./lib/packed-manifest.mjs"
 import { collectPackedSourceMapProblems } from "./lib/packed-sourcemaps.mjs"
 
@@ -452,10 +453,10 @@ async function packAndInspectPackage(packageDir) {
     missingPackedExports = collectPackedExportProblems(extracted.root, packedManifest.name)
     packedSourceMapProblems = collectPackedSourceMapProblems(extracted.root, packInfo)
   } catch (error) {
+    fs.rmSync(packDestination, { recursive: true, force: true })
     return { error: `could not parse pnpm pack output: ${error.message}` }
   } finally {
     extracted?.cleanup()
-    fs.rmSync(packDestination, { recursive: true, force: true })
   }
 
   return {
@@ -465,6 +466,13 @@ async function packAndInspectPackage(packageDir) {
     legacyVoyantSpecifiers,
     missingPackedExports,
     packedSourceMapProblems,
+    packedTarball: {
+      name: packedManifest.name,
+      tarballPath: path.join(packDestination, path.basename(packInfo.filename)),
+      cleanup() {
+        fs.rmSync(packDestination, { recursive: true, force: true })
+      },
+    },
   }
 }
 
@@ -586,6 +594,7 @@ async function verifyPackage(packageDir) {
   let { missingTargets, problems } = collectTarballProblems(inspection, sourceFiles)
 
   if (REUSE_DIST && missingTargets.length > 0 && pkg.scripts?.build) {
+    inspection.packedTarball.cleanup()
     const buildProblem = await cleanAndBuildPackage(packageDir, pkg)
     if (buildProblem) return { name: pkg.name, packageDir, problems: [buildProblem] }
 
@@ -600,22 +609,21 @@ async function verifyPackage(packageDir) {
     ;({ problems } = collectTarballProblems(inspection, sourceFiles))
   }
 
-  if (problems.length === 0) return null
-
-  return { name: pkg.name, packageDir, problems }
+  return { name: pkg.name, packageDir, problems, packedTarball: inspection.packedTarball }
 }
 
-const failures = []
+const results = []
 const queue = [...packageDirs]
 const workers = Array.from({ length: Math.min(PACK_CONCURRENCY, queue.length) }, async () => {
   while (queue.length > 0) {
     const packageDir = queue.shift()
     if (!packageDir) break
     const result = await verifyPackage(packageDir)
-    if (result) failures.push(result)
+    if (result) results.push(result)
   }
 })
 await Promise.all(workers)
+const failures = results.filter((result) => result.problems.length > 0)
 failures.sort((left, right) => left.name.localeCompare(right.name))
 
 if (failures.length > 0) {
@@ -627,7 +635,17 @@ if (failures.length > 0) {
     }
     console.error("")
   }
+  for (const result of results) result.packedTarball?.cleanup()
   process.exit(1)
 }
 
+try {
+  await verifyPackedPackageInstall(results.map((result) => result.packedTarball))
+} catch (error) {
+  console.error(`Publish tarball verification failed:\n\n${error.message}`)
+  for (const result of results) result.packedTarball?.cleanup()
+  process.exit(1)
+}
+
+for (const result of results) result.packedTarball?.cleanup()
 console.log(`Verified publish tarballs for ${packageDirs.length} package directories.`)


### PR DESCRIPTION
Make the published Operator closure installable as an external npm consumer.

- keep the externally maintained Netopia provider out of the default dependency tree
- lazy-load the optional provider and preserve an unconfigured fallback
- resolve selected publish tarballs together in a clean npm project
- reject transitive package-manager protocols before release
- document the external-provider release policy

Part of #3356.