### PR TITLE
Unblock team-management release plan

### DIFF
--- a/.changeset/team-management-runtime.md
+++ b/.changeset/team-management-runtime.md
@@ -3,7 +3,6 @@
 "@voyant-travel/admin-app": minor
 "@voyant-travel/auth": minor
 "@voyant-travel/auth-react": minor
-"@voyant-travel/voyant-typescript-config": patch
 ---
 
 Add a package-owned `/settings/team` surface backed by a graph-selected,


### PR DESCRIPTION
Removes the ignored TypeScript config package from the mixed team-management changeset. Changesets rejects files that combine ignored and publishable packages.

Verification: `pnpm release:plan` succeeds and includes Framework 0.46.0 plus the pending product releases.