### PR TITLE
Version packages before publishing pending releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,9 +45,9 @@ Handles package releases:
 
 Notes:
 
-- the push flow publishes packages whose local version is ahead of npm, then creates Changesets release PRs without building the package graph
+- the push flow creates or updates the Changesets release PR whenever releasable changesets exist
 - the publish path builds and verifies only the pending package set and their build dependencies
-- pending package publication and release PR creation can happen in the same run, so unpublished versions are not blocked by newly landed changesets
+- pending package publication runs only after the release PR is merged and no releasable changesets remain; this prevents placeholder versions for new packages from being published before their changesets are applied
 - starter GitHub Releases are separate from npm package publication; run the manual dispatch with `release_assets=true` and an explicit `release_version` to create or refresh starter archives
 - package publishing may still create package tags, but GitHub Releases are intended for starter assets rather than every npm package release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,19 +124,19 @@ jobs:
       # Version bumps can invalidate most workspace build caches. Serialize the
       # release build to stay within the runner's memory limit.
       - name: Build pending publish workspaces
-        if: steps.release_plan.outputs.pending == 'true'
+        if: steps.release_plan.outputs.publish_pending == 'true'
         run: pnpm turbo build ${{ steps.release_plan.outputs.turbo_filters }} --continue --concurrency=1
 
       - name: Verify package exports
-        if: steps.release_plan.outputs.pending == 'true'
+        if: steps.release_plan.outputs.publish_pending == 'true'
         run: pnpm verify:package-exports ${{ steps.release_plan.outputs.package_filters }}
 
       - name: Verify before publish
-        if: steps.release_plan.outputs.pending == 'true'
+        if: steps.release_plan.outputs.publish_pending == 'true'
         run: pnpm verify:fast
 
       - name: Verify publish tarballs
-        if: steps.release_plan.outputs.pending == 'true'
+        if: steps.release_plan.outputs.publish_pending == 'true'
         # `Build pending publish workspaces` above already produced fresh dist
         # via turbo; skip the per-package clean+rebuild inside the verifier.
         env:
@@ -145,7 +145,7 @@ jobs:
 
       - name: Publish pending packages
         id: publish_pending
-        if: steps.release_plan.outputs.pending == 'true'
+        if: steps.release_plan.outputs.publish_pending == 'true'
         # Hard outer bound so a stalled publish can never burn a full job slot.
         timeout-minutes: 25
         run: |

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "release": "changeset publish",
     "release:plan": "node scripts/release-plan.cjs",
     "publish:voyant-travel": "node scripts/publish-voyant-travel-workspace.mjs",
-    "verify:release-config": "node scripts/verify-release-config.cjs",
+    "verify:release-config": "node --test scripts/tests/release-plan.test.mjs && node scripts/verify-release-config.cjs",
     "package:starters": "node scripts/package-starters.mjs",
     "verify:minimal-starter": "node --test scripts/tests/package-starters.test.mjs scripts/tests/minimal-starter-acceptance.test.mjs",
     "measure:standard-node-starter": "node --test scripts/tests/measure-standard-node-starter.test.mjs && node scripts/measure-standard-node-starter.mjs",

--- a/scripts/release-plan.cjs
+++ b/scripts/release-plan.cjs
@@ -110,6 +110,14 @@ function appendGithubOutput(key, value) {
   writeFileSync(outputPath, `${key}=${value}${EOL}`, { flag: "a" })
 }
 
+function getReleaseMode(hasReleasableChangesets, pendingPublication) {
+  if (hasReleasableChangesets) {
+    return "version"
+  }
+
+  return pendingPublication ? "publish" : "none"
+}
+
 async function getReleaseState() {
   const cwd = process.cwd()
   const packages = await getPackages(cwd)
@@ -144,6 +152,7 @@ async function getReleaseState() {
 async function main() {
   const state = await getReleaseState()
   const pendingPublication = state.pendingPackageNames.length > 0
+  const releaseMode = getReleaseMode(state.hasReleasableChangesets, pendingPublication)
   const turboFilters = formatRepeatedArg("--filter", state.pendingPackageNames)
   const packageFilters = formatRepeatedArg("--package", state.pendingPackageNames)
 
@@ -153,6 +162,7 @@ async function main() {
         hasReleasableChangesets: state.hasReleasableChangesets,
         pendingPackages: state.pendingPackages,
         pendingPublication,
+        releaseMode,
         plannedReleases: state.plannedReleases,
       },
       null,
@@ -162,6 +172,8 @@ async function main() {
 
   appendGithubOutput("has_releasable_changesets", state.hasReleasableChangesets ? "true" : "false")
   appendGithubOutput("pending", pendingPublication ? "true" : "false")
+  appendGithubOutput("publish_pending", releaseMode === "publish" ? "true" : "false")
+  appendGithubOutput("release_mode", releaseMode)
   appendGithubOutput("pending_count", String(state.pendingPackageNames.length))
   appendGithubOutput("pending_package_names", state.pendingPackageNames.join(" "))
   appendGithubOutput("pending_packages_json", JSON.stringify(state.pendingPackages))
@@ -178,6 +190,7 @@ if (require.main === module) {
 
 module.exports = {
   getPendingPackages,
+  getReleaseMode,
   getReleaseState,
   main,
 }

--- a/scripts/tests/release-plan.test.mjs
+++ b/scripts/tests/release-plan.test.mjs
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict"
+import { createRequire } from "node:module"
+import test from "node:test"
+
+const require = createRequire(import.meta.url)
+const { getReleaseMode } = require("../release-plan.cjs")
+
+test("release PR creation takes priority over pending publication", () => {
+  assert.equal(getReleaseMode(true, true), "version")
+})
+
+test("pending packages publish after all changesets are applied", () => {
+  assert.equal(getReleaseMode(false, true), "publish")
+})
+
+test("an up-to-date repository needs no release action", () => {
+  assert.equal(getReleaseMode(false, false), "none")
+})


### PR DESCRIPTION
## Summary
- prioritize Changesets release PR creation when releasable changesets and unpublished local packages coexist
- publish pending package versions only after their changesets have been applied and merged
- cover the release state machine with focused tests and document the sequencing

## Verification
- `pnpm verify:release-config`
- `pnpm exec biome check scripts/release-plan.cjs scripts/tests/release-plan.test.mjs package.json`
- `git diff --check`

This prevents new package placeholder versions from being published before the release PR applies their intended version bump.