### PR TITLE
Fix MCP auth fallback and refund replay

### DIFF
--- a/.changeset/calm-otters-refund.md
+++ b/.changeset/calm-otters-refund.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Return previously issued invoice credit notes when an approved refund command is retried exactly.

--- a/.changeset/mcp-auth-audience-fallback.md
+++ b/.changeset/mcp-auth-audience-fallback.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Default an omitted authenticated grant audience to its actor so internal API keys and custom auth resolvers reach audience-gated selected routes with a complete authorization context.

--- a/.changeset/quiet-ligers-approve.md
+++ b/.changeset/quiet-ligers-approve.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/action-ledger": patch
+---
+
+Validate approved-action fingerprints and principals before reporting a prior execution as a replay.

--- a/packages/action-ledger/src/service.ts
+++ b/packages/action-ledger/src/service.ts
@@ -336,26 +336,6 @@ export const actionLedgerService = {
       }
     }
 
-    const existingExecution = await actionLedgerService.listEntries(db, {
-      actionName: input.actionName,
-      actionKind: input.executionActionKind,
-      targetType: input.targetType,
-      targetId: input.targetId,
-      causationActionId: requestedAction.id,
-      approvalId: result.approval.id,
-      status: input.executionStatus ?? "succeeded",
-      limit: 1,
-    })
-    if (existingExecution.entries.length > 0) {
-      return {
-        ok: false,
-        reason: "already_executed",
-        approval: result.approval,
-        requestedAction,
-        existingActionId: existingExecution.entries[0]?.id,
-      }
-    }
-
     if (!requestedAction.idempotencyFingerprint) {
       return {
         ok: false,
@@ -385,6 +365,26 @@ export const actionLedgerService = {
         reason: "principal_mismatch",
         approval: result.approval,
         requestedAction,
+      }
+    }
+
+    const existingExecution = await actionLedgerService.listEntries(db, {
+      actionName: input.actionName,
+      actionKind: input.executionActionKind,
+      targetType: input.targetType,
+      targetId: input.targetId,
+      causationActionId: requestedAction.id,
+      approvalId: result.approval.id,
+      status: input.executionStatus ?? "succeeded",
+      limit: 1,
+    })
+    if (existingExecution.entries.length > 0) {
+      return {
+        ok: false,
+        reason: "already_executed",
+        approval: result.approval,
+        requestedAction,
+        existingActionId: existingExecution.entries[0]?.id,
       }
     }
 

--- a/packages/action-ledger/tests/unit/service-reversal-validation.test.ts
+++ b/packages/action-ledger/tests/unit/service-reversal-validation.test.ts
@@ -303,6 +303,18 @@ describe("actionLedgerService.validateApprovedAction", () => {
     const { db } = makeValidateApprovedActionDb({
       approval,
       entry: requestedAction,
+      existingExecutions: [
+        makeEntry({
+          id: "alge_execution",
+          actionName: requestedAction.actionName,
+          actionKind: "update",
+          status: "succeeded",
+          targetType: requestedAction.targetType,
+          targetId: requestedAction.targetId,
+          causationActionId: requestedAction.id,
+          approvalId: approval.id,
+        }),
+      ],
     })
 
     await expect(
@@ -344,6 +356,18 @@ describe("actionLedgerService.validateApprovedAction", () => {
     const { db } = makeValidateApprovedActionDb({
       approval,
       entry: requestedAction,
+      existingExecutions: [
+        makeEntry({
+          id: "alge_execution",
+          actionName: requestedAction.actionName,
+          actionKind: "update",
+          status: "succeeded",
+          targetType: requestedAction.targetType,
+          targetId: requestedAction.targetId,
+          causationActionId: requestedAction.id,
+          approvalId: approval.id,
+        }),
+      ],
     })
 
     await expect(
@@ -386,6 +410,18 @@ describe("actionLedgerService.validateApprovedAction", () => {
     const { db } = makeValidateApprovedActionDb({
       approval,
       entry: requestedAction,
+      existingExecutions: [
+        makeEntry({
+          id: "alge_execution",
+          actionName: requestedAction.actionName,
+          actionKind: "update",
+          status: "succeeded",
+          targetType: requestedAction.targetType,
+          targetId: requestedAction.targetId,
+          causationActionId: requestedAction.id,
+          approvalId: approval.id,
+        }),
+      ],
     })
 
     await expect(

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -171,6 +171,29 @@ export const voyantToolContextContribution = defineToolContextContribution({
               replayed: authorization.replayed,
             }
           }
+          if (authorization.status === "already_executed") {
+            const creditNote = await financeService.getCreditNoteById(
+              db,
+              authorization.creditNoteId,
+            )
+            if (!creditNote) {
+              throw new ToolError("The previously issued credit note was not found.", "NOT_FOUND", {
+                creditNoteId: authorization.creditNoteId,
+              })
+            }
+            if (creditNote.invoiceId !== input.invoiceId || creditNote.status !== "issued") {
+              throw new ToolError(
+                "The previous refund result does not match this issued invoice credit note.",
+                "INVALID_INPUT",
+                { creditNoteId: authorization.creditNoteId, invoiceId: input.invoiceId },
+              )
+            }
+            return {
+              status: "issued" as const,
+              creditNote: toJsonValue(creditNote),
+              replayed: true,
+            }
+          }
           if (authorization.status !== "authorized") {
             throw financeRefundAuthorizationError(authorization)
           }
@@ -201,6 +224,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
           return {
             status: "issued" as const,
             creditNote: toJsonValue(creditNote),
+            replayed: false,
           }
         },
       },
@@ -229,7 +253,7 @@ function financeToolActionLedgerContext(c: Context<Env>): ActionLedgerRequestCon
 function financeRefundAuthorizationError(
   result: Exclude<
     Awaited<ReturnType<typeof authorizeFinanceRefund>>,
-    { status: "authorized" | "approval_required" }
+    { status: "authorized" | "approval_required" | "already_executed" }
   >,
 ) {
   switch (result.status) {

--- a/packages/finance/src/refund-authorization.ts
+++ b/packages/finance/src/refund-authorization.ts
@@ -61,6 +61,7 @@ export type FinanceRefundAuthorizationResult =
       approval: Awaited<ReturnType<typeof requestActionLedgerApproval>>["approval"]
       replayed: boolean
     }
+  | { status: "already_executed"; access: ActionLedgerCapabilityAccessResult; creditNoteId: string }
   | { status: "denied"; access: ActionLedgerCapabilityAccessResult }
   | { status: "missing_idempotency_key"; access: ActionLedgerCapabilityAccessResult }
   | {
@@ -146,7 +147,25 @@ export async function authorizeFinanceRefund(
       executionActionKind: "create",
       executionStatus: "succeeded",
     })
-    if (!validation.ok) return { status: "invalid_approval", access, validation }
+    if (!validation.ok) {
+      const requestedAction = validation.requestedAction
+      const isExactReplay =
+        validation.reason === "already_executed" &&
+        requestedAction !== undefined &&
+        requestedAction.idempotencyFingerprint === fingerprint &&
+        (!principal.principalType ||
+          !principal.principalId ||
+          (requestedAction.principalType === principal.principalType &&
+            requestedAction.principalId === principal.principalId))
+      if (isExactReplay && validation.existingActionId) {
+        const creditNoteId = await resolveExecutedRefundCreditNoteId(
+          input.db,
+          validation.existingActionId,
+        )
+        if (creditNoteId) return { status: "already_executed", access, creditNoteId }
+      }
+      return { status: "invalid_approval", access, validation }
+    }
     return {
       status: "authorized",
       access,
@@ -205,6 +224,21 @@ export async function authorizeFinanceRefund(
     }
     throw error
   }
+}
+
+export function parseCreditNoteCommandResultRef(resultRef: string | null): string | null {
+  const prefix = "credit_note:"
+  if (!resultRef?.startsWith(prefix)) return null
+  const creditNoteId = resultRef.slice(prefix.length).trim()
+  return creditNoteId || null
+}
+
+export async function resolveExecutedRefundCreditNoteId(
+  db: PostgresJsDatabase,
+  existingActionId: string,
+): Promise<string | null> {
+  const existing = await actionLedgerService.getEntry(db, existingActionId)
+  return parseCreditNoteCommandResultRef(existing?.mutationDetail?.commandResultRef ?? null)
 }
 
 async function loadInvoiceRefundTargetState(db: PostgresJsDatabase, invoiceId: string) {

--- a/packages/finance/src/service-invoice-credit-notes.ts
+++ b/packages/finance/src/service-invoice-credit-notes.ts
@@ -107,6 +107,15 @@ export const financeInvoiceCreditNoteService = {
       .orderBy(desc(creditNotes.createdAt))
   },
 
+  async getCreditNoteById(db: PostgresJsDatabase, creditNoteId: string) {
+    const [row] = await db
+      .select()
+      .from(creditNotes)
+      .where(eq(creditNotes.id, creditNoteId))
+      .limit(1)
+    return row ?? null
+  },
+
   async createCreditNote(
     db: PostgresJsDatabase,
     invoiceId: string,

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -179,7 +179,7 @@ const pendingFinanceApprovalSchema = z.object({
 
 export const issueInvoiceRefundOutputSchema = z.union([
   pendingFinanceApprovalSchema,
-  z.object({ status: z.literal("issued"), creditNote: creditNoteSchema }),
+  z.object({ status: z.literal("issued"), creditNote: creditNoteSchema, replayed: z.boolean() }),
 ])
 
 export const issueInvoiceRefundTool = defineTool<

--- a/packages/finance/tests/unit/mcp-runtime-refund-replay.test.ts
+++ b/packages/finance/tests/unit/mcp-runtime-refund-replay.test.ts
@@ -1,0 +1,131 @@
+import type { ToolContext } from "@voyant-travel/tools"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const authorizeFinanceRefund = vi.hoisted(() => vi.fn())
+
+vi.mock("../../src/refund-authorization.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/refund-authorization.js")>()),
+  authorizeFinanceRefund,
+}))
+
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
+import { financeService } from "../../src/service.js"
+import type { FinanceToolServices } from "../../src/tools.js"
+
+const db = {} as never
+const toolContext: ToolContext = {
+  db,
+  actor: "staff",
+  audience: "staff",
+  tenantId: "operator_1",
+  resolverScope: { locale: "en", audience: "staff", market: "default", actor: "staff" },
+}
+const request = {
+  get(key: string) {
+    return {
+      actor: "staff",
+      callerType: "agent",
+      scopes: ["finance:refund"],
+      agentId: "agent_1",
+      isInternalRequest: false,
+    }[key]
+  },
+  req: { header: () => null },
+}
+const input = {
+  invoiceId: "invoice_1",
+  creditNoteNumber: "CN-1",
+  amountCents: 1000,
+  currency: "EUR",
+  reason: "Approved refund",
+  idempotencyKey: "refund-1",
+  approvalId: "approval_1",
+}
+const creditNote = {
+  id: "credit_1",
+  creditNoteNumber: "CN-1",
+  invoiceId: "invoice_1",
+  status: "issued",
+  amountCents: 1000,
+  currency: "EUR",
+  baseCurrency: null,
+  baseAmountCents: null,
+  fxRateSetId: null,
+  reason: "Approved refund",
+  notes: null,
+  createdAt: new Date("2026-07-15T10:00:00.000Z"),
+  updatedAt: new Date("2026-07-15T10:00:00.000Z"),
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  authorizeFinanceRefund.mockReset()
+})
+
+async function financeTools() {
+  const contribution = await voyantToolContextContribution.contribute({
+    context: toolContext,
+    request,
+    resources: {},
+  })
+  return contribution.finance as FinanceToolServices
+}
+
+describe("issue_invoice_refund replay", () => {
+  it("marks the first approved credit-note execution as non-replayed", async () => {
+    authorizeFinanceRefund.mockResolvedValue({
+      status: "authorized",
+      access: { authorizationSource: "finance.refund.tool" },
+      approvedAction: {
+        requestedActionId: "action_requested_1",
+        approvalId: "approval_1",
+        idempotencyFingerprint: "sha256:approved",
+      },
+    })
+    vi.spyOn(financeService, "createCreditNote").mockResolvedValue(creditNote as never)
+
+    await expect((await financeTools()).issueInvoiceRefund(input)).resolves.toEqual({
+      status: "issued",
+      creditNote: {
+        ...creditNote,
+        createdAt: "2026-07-15T10:00:00.000Z",
+        updatedAt: "2026-07-15T10:00:00.000Z",
+      },
+      replayed: false,
+    })
+  })
+
+  it("returns the prior issued credit note and does not create another", async () => {
+    authorizeFinanceRefund.mockResolvedValue({
+      status: "already_executed",
+      creditNoteId: "credit_1",
+    })
+    vi.spyOn(financeService, "getCreditNoteById").mockResolvedValue(creditNote as never)
+    const create = vi.spyOn(financeService, "createCreditNote")
+
+    await expect((await financeTools()).issueInvoiceRefund(input)).resolves.toEqual({
+      status: "issued",
+      creditNote: {
+        ...creditNote,
+        createdAt: "2026-07-15T10:00:00.000Z",
+        updatedAt: "2026-07-15T10:00:00.000Z",
+      },
+      replayed: true,
+    })
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it("fails closed when the prior credit note cannot be loaded", async () => {
+    authorizeFinanceRefund.mockResolvedValue({
+      status: "already_executed",
+      creditNoteId: "credit_missing",
+    })
+    vi.spyOn(financeService, "getCreditNoteById").mockResolvedValue(null)
+    const create = vi.spyOn(financeService, "createCreditNote")
+
+    await expect((await financeTools()).issueInvoiceRefund(input)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    })
+    expect(create).not.toHaveBeenCalled()
+  })
+})

--- a/packages/finance/tests/unit/refund-authorization.test.ts
+++ b/packages/finance/tests/unit/refund-authorization.test.ts
@@ -1,0 +1,122 @@
+import { actionLedgerService } from "@voyant-travel/action-ledger"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  authorizeFinanceRefund,
+  resolveExecutedRefundCreditNoteId,
+} from "../../src/refund-authorization.js"
+import { financeService } from "../../src/service.js"
+
+const db = {} as never
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("refund approval replay", () => {
+  it("recovers the credit note result from an exactly validated prior execution", async () => {
+    vi.spyOn(financeService, "getInvoiceById").mockResolvedValue({
+      status: "issued",
+      invoiceType: "invoice",
+      invoiceNumber: "INV-1",
+      currency: "EUR",
+      totalCents: 1000,
+      paidCents: 1000,
+      balanceDueCents: 0,
+      updatedAt: new Date("2026-07-15T10:00:00.000Z"),
+    } as never)
+    vi.spyOn(actionLedgerService, "validateApprovedAction").mockImplementation(
+      async (_db, validationInput) =>
+        ({
+          ok: false,
+          reason: "already_executed",
+          existingActionId: "action_execution_1",
+          requestedAction: {
+            idempotencyFingerprint: validationInput.idempotencyFingerprint,
+            principalType: "agent",
+            principalId: "agent_1",
+          },
+        }) as never,
+    )
+    vi.spyOn(actionLedgerService, "getEntry").mockResolvedValue({
+      mutationDetail: { commandResultRef: "credit_note:credit_1" },
+    } as never)
+
+    await expect(
+      authorizeFinanceRefund({
+        db,
+        invoiceId: "invoice_1",
+        commandInput: {
+          creditNoteNumber: "CN-1",
+          status: "issued",
+          amountCents: 1000,
+          currency: "EUR",
+          reason: "Approved refund",
+        },
+        actor: "staff",
+        callerType: "agent",
+        scopes: ["finance:refund"],
+        requestContext: { agentId: "agent_1", callerType: "agent", actor: "staff" },
+        approvalId: "approval_1",
+        idempotencyKey: "refund-1",
+      }),
+    ).resolves.toMatchObject({ status: "already_executed", creditNoteId: "credit_1" })
+  })
+
+  it("fails closed instead of recovering a previous result for a different fingerprint", async () => {
+    vi.spyOn(financeService, "getInvoiceById").mockResolvedValue({
+      status: "issued",
+      invoiceType: "invoice",
+      invoiceNumber: "INV-1",
+      currency: "EUR",
+      totalCents: 1000,
+      paidCents: 1000,
+      balanceDueCents: 0,
+      updatedAt: new Date("2026-07-15T10:00:00.000Z"),
+    } as never)
+    vi.spyOn(actionLedgerService, "validateApprovedAction").mockResolvedValue({
+      ok: false,
+      reason: "already_executed",
+      existingActionId: "action_execution_1",
+      requestedAction: {
+        idempotencyFingerprint: "sha256:different",
+        principalType: "agent",
+        principalId: "agent_1",
+      },
+    } as never)
+    const getEntry = vi.spyOn(actionLedgerService, "getEntry")
+
+    await expect(
+      authorizeFinanceRefund({
+        db,
+        invoiceId: "invoice_1",
+        commandInput: {
+          creditNoteNumber: "CN-1",
+          status: "issued",
+          amountCents: 1000,
+          currency: "EUR",
+          reason: "Changed refund",
+        },
+        actor: "staff",
+        callerType: "agent",
+        scopes: ["finance:refund"],
+        requestContext: { agentId: "agent_1", callerType: "agent", actor: "staff" },
+        approvalId: "approval_1",
+        idempotencyKey: "refund-1",
+      }),
+    ).resolves.toMatchObject({ status: "invalid_approval" })
+    expect(getEntry).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    null,
+    "invoice:invoice_1",
+    "credit_note:   ",
+  ])("fails closed when the previous execution result reference is %s", async (commandResultRef) => {
+    vi.spyOn(actionLedgerService, "getEntry").mockResolvedValue(
+      commandResultRef === null ? null : ({ mutationDetail: { commandResultRef } } as never),
+    )
+
+    await expect(resolveExecutedRefundCreditNoteId(db, "action_execution_1")).resolves.toBeNull()
+  })
+})

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -136,7 +136,14 @@ function applyAuthContext(
   if (auth.organizationId !== undefined) c.set("organizationId", auth.organizationId ?? undefined)
   if (auth.callerType) c.set("callerType", auth.callerType)
   if (auth.actor) c.set("actor", auth.actor)
-  if (auth.audience) c.set("audience", auth.audience)
+  if (auth.audience !== undefined) {
+    c.set("audience", auth.audience)
+  } else if (auth.actor) {
+    // VoyantAuthContext defines an omitted grant audience as the authenticated
+    // actor. Normalize once here so every downstream surface, including MCP,
+    // receives the same complete authorization context.
+    c.set("audience", auth.actor)
+  }
   if (auth.scopes !== undefined) c.set("scopes", auth.scopes)
   if (auth.isInternalRequest !== undefined) c.set("isInternalRequest", auth.isInternalRequest)
   if (auth.apiTokenId) c.set("apiTokenId", auth.apiTokenId)

--- a/packages/hono/tests/unit/auth-middleware.test.ts
+++ b/packages/hono/tests/unit/auth-middleware.test.ts
@@ -41,6 +41,7 @@ describe("requireAuth API keys", () => {
       c.json({
         callerType: c.get("callerType"),
         actor: c.get("actor"),
+        audience: c.get("audience"),
         scopes: c.get("scopes"),
         isInternalRequest: c.get("isInternalRequest"),
       }),
@@ -62,8 +63,41 @@ describe("requireAuth API keys", () => {
     expect(await response.json()).toEqual({
       callerType: "internal",
       actor: "staff",
+      audience: "staff",
       scopes: ["products:read", "bookings:write"],
       isInternalRequest: true,
+    })
+  })
+
+  it("defaults a custom resolver audience to its authenticated actor", async () => {
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => ({}) as never, {
+        auth: {
+          resolve: () => ({ userId: "user_123", actor: "partner" }),
+        },
+      }),
+    )
+    app.get("/secure", (c) =>
+      c.json({
+        userId: c.get("userId"),
+        actor: c.get("actor"),
+        audience: c.get("audience"),
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure"),
+      TEST_ENV,
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      userId: "user_123",
+      actor: "partner",
+      audience: "partner",
     })
   })
 

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { requireAuth } from "@voyant-travel/hono/middleware/auth"
 import {
   createToolRegistry,
   defineTool,
@@ -82,6 +83,13 @@ function rpc(method: string, params: unknown, id: number | string = 1) {
     method: "POST",
     headers: MCP_HEADERS,
     body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  }
+}
+
+function testExecutionContext(): ExecutionContext {
+  return {
+    waitUntil() {},
+    passThroughOnException() {},
   }
 }
 
@@ -661,6 +669,33 @@ describe("createMcpHonoApp", () => {
     app.route("/", routes)
 
     expect((await app.request("/manifest")).status).toBe(500)
+  })
+
+  it("lets an internal API key reach selected MCP routes with actor-derived audience", async () => {
+    const routes = await selectedRuntimeRoutes()
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => ({}) as never),
+    )
+    app.route("/", routes)
+
+    const response = await app.fetch(
+      new Request("http://example.test/manifest", {
+        headers: { Authorization: "Bearer internal-test-key" },
+      }),
+      {
+        DATABASE_URL: "postgres://test",
+        INTERNAL_API_KEY: "internal-test-key",
+        INTERNAL_API_KEY_SCOPES: "catalog:read",
+      },
+      testExecutionContext(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      tools: [expect.objectContaining({ name: "echo" })],
+    })
   })
 
   it("exposes selected action invocation metadata and gates before domain dispatch", async () => {


### PR DESCRIPTION
## Summary

- normalize omitted authenticated grant audiences to the actor at the shared Hono auth boundary
- keep selected MCP runtimes strict for missing or invalid raw claims
- validate approved-action fingerprints and principals before reporting an execution replay
- recover and return the previously issued credit note for exact refund retries without creating a duplicate
- expose `replayed` on issued refund results and add patch changesets

## Root cause

The internal-key and actor-only custom auth paths authenticated requests without populating `audience`, even though the core auth contract defines actor fallback. The selected MCP runtime then rejected those otherwise valid requests.

Refund execution validation also reported `already_executed` before checking the current fingerprint and principal. Refund authorization treated every non-success validation as invalid and did not recover the credit note reference already stored on the successful ledger entry.

## Impact

Existing internal and staff MCP clients can discover and call audience-gated tools again. Exact approved refund retries now return the original issued credit note with `replayed: true`; changed commands, changed principals, malformed result references, and missing prior credit notes continue to fail closed.

Follow-up to #3378.

## Verification

Depot CI run `4g9nqsxkz0`:

- build graph: 105/105 tasks passed
- selective typecheck/build graph: 131/131 tasks passed
- tests: 108/108 package tasks passed
- full lint, architecture, and i18n checks passed

Focused regression coverage also exercises internal-key MCP discovery, raw-claim fail-closed behavior, approved-action validation ordering, exact refund replay, missing prior results, and first-execution replay flags.