### PR TITLE
Republish the admin extension SDK with dist exports

### DIFF
--- a/.changeset/extension-sdk-republish.md
+++ b/.changeset/extension-sdk-republish.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/admin-extension-sdk": patch
+---
+
+Republish with packaged `dist` exports. The 0.1.0 tarball was published outside
+the release train, so its `exports` map pointed at unpackaged `src/*.ts` files
+and the package could not be imported.


### PR DESCRIPTION
The 0.1.0 tarball of @voyant-travel/admin-extension-sdk was published outside the release train (manual first publish after the npm token fix), so npm ignored publishConfig and the exports map shipped pointing at unpackaged src/*.ts files — the package cannot be imported. A patch changeset makes the train republish 0.1.1 with the correct dist exports; consumers can then drop local patches.