### PR TITLE
fix: remove TypeScript from framework runtime dependencies

### DIFF
--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -70,8 +70,7 @@
     "@voyant-travel/workflows-orchestrator": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "pg": "^8.22.0",
-    "typescript": "catalog:"
+    "pg": "^8.22.0"
   },
   "peerDependencies": {
     "@hono/zod-openapi": "^1.4.0",
@@ -85,6 +84,7 @@
     "@types/node": "catalog:",
     "@types/pg": "^8.15.6",
     "hono": "catalog:",
+    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "publishConfig": {

--- a/packages/framework/src/project-import-cheap.test.ts
+++ b/packages/framework/src/project-import-cheap.test.ts
@@ -29,4 +29,13 @@ describe("framework project import boundary", () => {
       expect(source).not.toContain("starters\\")
     }
   })
+
+  it("keeps TypeScript out of the production framework dependency graph", () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    ) as { dependencies?: Record<string, string>; devDependencies?: Record<string, string> }
+
+    expect(packageJson.dependencies?.typescript).toBeUndefined()
+    expect(packageJson.devDependencies?.typescript).toBeDefined()
+  })
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2300,9 +2300,6 @@ importers:
       pg:
         specifier: ^8.22.0
         version: 8.22.0
-      typescript:
-        specifier: 'catalog:'
-        version: 6.0.3
     devDependencies:
       '@hono/zod-openapi':
         specifier: 'catalog:'
@@ -2316,6 +2313,9 @@ importers:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(jsdom@29.1.1(@noble/hashes@2.2.0))(msw@2.12.14(@types/node@25.5.2)(typescript@6.0.3))(vite@8.1.3(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.16.9)(tsx@4.22.4)(yaml@2.8.3))

--- a/scripts/generate-standard-product-distribution.mjs
+++ b/scripts/generate-standard-product-distribution.mjs
@@ -107,7 +107,6 @@ const frameworkDependencies = {
   "drizzle-orm": "catalog:",
   hono: "catalog:",
   pg: "^8.22.0",
-  typescript: "catalog:",
 }
 
 // BOM dependencies include every standard product selection owner, not only


### PR DESCRIPTION
## Summary
- move TypeScript from the framework production dependencies to build-only dependencies
- keep the lockfile importer metadata aligned
- add a regression test for the production dependency boundary

## Why
Snapshot-driven managed runtimes do not parse TypeScript project configuration at request time. Shipping TypeScript as a framework runtime dependency caused pruned Cloud Run images to retain an unnecessary compiler import and fail when it was absent.

## Validation
- `pnpm --filter @voyant-travel/framework lint`
- `pnpm --filter @voyant-travel/framework test -- project-import-cheap.test.ts`
- `pnpm --filter @voyant-travel/framework typecheck`

Closes #3391