### PR TITLE
chore: add framework runtime dependency changeset

### DIFF
--- a/.changeset/lazy-framework-typescript.md
+++ b/.changeset/lazy-framework-typescript.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Remove TypeScript from framework production dependencies so snapshot-driven runtimes do not require the compiler.


### PR DESCRIPTION
## Summary
- add the missing patch changeset for the framework runtime dependency fix

## Why
The merged fix removes TypeScript from the framework production dependency graph. This changeset ensures the release workflow publishes the patched framework package.

Closes #3391