### PR TITLE
Fix dist-only project resolution without TypeScript

### DIFF
--- a/.changeset/source-free-project-resolution.md
+++ b/.changeset/source-free-project-resolution.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Skip TypeScript convention analysis for source-free projects while preserving
+their deterministic generated artifact set.

--- a/docs/architecture/unified-deployment-graph.md
+++ b/docs/architecture/unified-deployment-graph.md
@@ -227,6 +227,13 @@ Resolution has one authority chain:
 8. The resident Node host validates the artifacts and deployment requirements
    before serving traffic or running migrations.
 
+Convention discovery is filesystem-only and import-cheap. Static TypeScript
+analysis runs only for project-local source contributions that discovery
+actually found. A source-free or dist-only application composes from published
+package manifests and still receives deterministic empty project-local
+artifacts; it must not require the TypeScript compiler in its production
+dependency graph.
+
 Canonical graph JSON has stable ordering, no timestamps or host-specific
 absolute paths, and a content hash calculated over the canonical data. Generated
 entry modules carry the same hash. The same project and lockfile must therefore

--- a/packages/framework/src/project-admin-conventions.ts
+++ b/packages/framework/src/project-admin-conventions.ts
@@ -67,14 +67,16 @@ export class ProjectAdminConventionError extends Error {
 export async function analyzeProjectAdminConventions(
   input: AnalyzeProjectAdminConventionsInput,
 ): Promise<ProjectAdminConventionAnalysis> {
-  await loadTypeScript()
   const projectRoot = path.resolve(input.projectRoot)
-  const realProjectRoot = await realpath(projectRoot)
   const entries: ProjectAdminConventionEntry[] = []
   const diagnostics: ProjectAdminConventionDiagnostic[] = []
   const adminContributions = input.contributions
     .filter((contribution) => contribution.kind === "admin")
     .sort((left, right) => compareStrings(left.sourcePath, right.sourcePath))
+  if (adminContributions.length === 0) return { entries, diagnostics }
+
+  await loadTypeScript()
+  const realProjectRoot = await realpath(projectRoot)
 
   for (const contribution of adminContributions) {
     const sourcePath = normalizeProjectPath(contribution.sourcePath)

--- a/packages/framework/src/project-api-conventions.ts
+++ b/packages/framework/src/project-api-conventions.ts
@@ -6,6 +6,7 @@ import { statementIdentifierName } from "./project-convention-static-data.js"
 import {
   discoverProjectConventions,
   type ProjectConventionApiRoute,
+  type ProjectConventionDiscovery,
   type ProjectConventionRouteSurface,
 } from "./project-conventions.js"
 
@@ -68,6 +69,8 @@ export interface ProjectApiConventionCompilation {
 
 export interface ProjectApiConventionsOptions {
   projectRoot: string
+  /** Reuse an authoritative discovery snapshot instead of scanning the project again. */
+  discovery?: ProjectConventionDiscovery
 }
 
 export class ProjectApiConventionError extends Error {
@@ -83,13 +86,15 @@ export class ProjectApiConventionError extends Error {
 export async function analyzeProjectApiConventions(
   options: ProjectApiConventionsOptions,
 ): Promise<ProjectApiConventionAnalysis> {
-  await loadTypeScript()
   const projectRoot = path.resolve(options.projectRoot)
-  const realProjectRoot = await realpath(projectRoot)
-  const discovery = await discoverProjectConventions(projectRoot)
+  const discovery = options.discovery ?? (await discoverProjectConventions(projectRoot))
   const discoveredRoutes = discovery.contributions.filter(
     (contribution): contribution is ProjectConventionApiRoute => contribution.kind === "api-route",
   )
+  if (discoveredRoutes.length === 0) return { routes: [], diagnostics: [] }
+
+  await loadTypeScript()
+  const realProjectRoot = await realpath(projectRoot)
   const routes: ProjectApiConventionRoute[] = []
   const diagnostics: ProjectApiConventionDiagnostic[] = []
 

--- a/packages/framework/src/project-resolver.ts
+++ b/packages/framework/src/project-resolver.ts
@@ -171,15 +171,18 @@ export async function resolveProject(input: ResolveProjectInput): Promise<Resolv
   assertPathInside(projectRoot, configPath, "configPath")
   const conventions = await discoverProjectConventions({ projectRoot })
   assertProjectConventionDiagnostics(conventions)
+  // Published/source-free applications have no project-local contributions.
+  // Reusing this snapshot lets every compiler emit its deterministic empty
+  // artifact without loading the TypeScript compiler in production.
   const [projectApi, projectAdmin, projectWorkflowJobs, projectSubscriberLinks] = await Promise.all(
     [
-      compileProjectApiConventions({ projectRoot }),
+      compileProjectApiConventions({ projectRoot, discovery: conventions }),
       compileProjectAdminConventions({
         projectRoot,
         contributions: conventions.contributions,
       }),
-      compileProjectWorkflowJobConventions({ projectRoot }),
-      compileProjectSubscriberLinkConventions({ projectRoot }),
+      compileProjectWorkflowJobConventions({ projectRoot, discovery: conventions }),
+      compileProjectSubscriberLinkConventions({ projectRoot, discovery: conventions }),
     ],
   )
 

--- a/packages/framework/src/project-source-free.test.ts
+++ b/packages/framework/src/project-source-free.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import path from "node:path"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("typescript", () => {
+  throw new Error("TypeScript compiler loaded for a source-free project")
+})
+
+import { defineProject, resolveProject } from "./project.js"
+
+const fixtureRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  )
+})
+
+describe("source-free project resolution", () => {
+  it("composes a dist-only application without loading TypeScript", async () => {
+    const projectRoot = await mkdtemp(path.join(tmpdir(), "voyant-source-free-project-"))
+    fixtureRoots.push(projectRoot)
+    const packageJsonPath = path.join(projectRoot, "package.json")
+    await writeFile(
+      packageJsonPath,
+      `${JSON.stringify(
+        {
+          name: "source-free-application",
+          version: "1.0.0",
+          type: "module",
+        },
+        null,
+        2,
+      )}\n`,
+    )
+
+    const resolved = await resolveProject({
+      project: defineProject({ modules: [] }),
+      projectRoot,
+      configPath: packageJsonPath,
+    })
+
+    expect(resolved.conventions).toEqual({ contributions: [], diagnostics: [] })
+    expect(resolved.graph.modules).toEqual([])
+    expect(resolved.graph.extensions).toEqual([])
+    expect(resolved.graph.plugins).toEqual([])
+    expect(resolved.artifacts.files.map(({ path }) => path)).toEqual(
+      expect.arrayContaining([
+        "runtime/project-api.generated.ts",
+        "runtime/project-jobs.generated.ts",
+        "runtime/project-links.generated.ts",
+        "runtime/project-subscribers.generated.ts",
+        "runtime/project-workflows.generated.ts",
+      ]),
+    )
+  })
+})

--- a/packages/framework/src/project-subscriber-link-conventions.ts
+++ b/packages/framework/src/project-subscriber-link-conventions.ts
@@ -24,6 +24,7 @@ import {
 } from "./project-convention-static-data.js"
 import {
   discoverProjectConventions,
+  type ProjectConventionDiscovery,
   type ProjectConventionFileContribution,
 } from "./project-conventions.js"
 import {
@@ -117,6 +118,8 @@ export interface ProjectSubscriberLinkConventionCompilation {
 
 export interface ProjectSubscriberLinkConventionsOptions {
   projectRoot: string
+  /** Reuse an authoritative discovery snapshot instead of scanning the project again. */
+  discovery?: ProjectConventionDiscovery
 }
 
 export class ProjectSubscriberLinkConventionError extends Error {
@@ -132,10 +135,8 @@ export class ProjectSubscriberLinkConventionError extends Error {
 export async function analyzeProjectSubscriberLinkConventions(
   options: ProjectSubscriberLinkConventionsOptions,
 ): Promise<ProjectSubscriberLinkConventionAnalysis> {
-  await loadTypeScript()
   const projectRoot = path.resolve(options.projectRoot)
-  const realProjectRoot = await realpath(projectRoot)
-  const discovery = await discoverProjectConventions(projectRoot)
+  const discovery = options.discovery ?? (await discoverProjectConventions(projectRoot))
   const subscribers: ProjectSubscriberConvention[] = []
   const links: ProjectLinkConvention[] = []
   const diagnostics: ProjectSubscriberLinkDiagnostic[] = []
@@ -158,6 +159,10 @@ export async function analyzeProjectSubscriberLinkConventions(
         message: diagnostic.message,
       })),
   )
+  if (contributions.length === 0) return { subscribers, links, diagnostics }
+
+  await loadTypeScript()
+  const realProjectRoot = await realpath(projectRoot)
 
   for (const contribution of contributions) {
     const sourceFilePath = resolveInsideProject(projectRoot, contribution.sourcePath)

--- a/packages/framework/src/project-workflow-job-conventions.ts
+++ b/packages/framework/src/project-workflow-job-conventions.ts
@@ -10,6 +10,7 @@ import ts, { loadTypeScript } from "./lazy-typescript.js"
 import { statementIdentifierName } from "./project-convention-static-data.js"
 import {
   discoverProjectConventions,
+  type ProjectConventionDiscovery,
   type ProjectConventionFileContribution,
 } from "./project-conventions.js"
 import {
@@ -97,6 +98,8 @@ export interface ProjectWorkflowJobConventionCompilation {
 
 export interface ProjectWorkflowJobConventionsOptions {
   projectRoot: string
+  /** Reuse an authoritative discovery snapshot instead of scanning the project again. */
+  discovery?: ProjectConventionDiscovery
 }
 
 export class ProjectWorkflowJobConventionError extends Error {
@@ -112,10 +115,8 @@ export class ProjectWorkflowJobConventionError extends Error {
 export async function analyzeProjectWorkflowJobConventions(
   options: ProjectWorkflowJobConventionsOptions,
 ): Promise<ProjectWorkflowJobConventionAnalysis> {
-  await loadTypeScript()
   const projectRoot = path.resolve(options.projectRoot)
-  const realProjectRoot = await realpath(projectRoot)
-  const discovery = await discoverProjectConventions(projectRoot)
+  const discovery = options.discovery ?? (await discoverProjectConventions(projectRoot))
   const discoveredWorkflows = discovery.contributions.filter(
     (contribution): contribution is DiscoveredWorkflowConvention =>
       contribution.kind === "workflow",
@@ -129,6 +130,12 @@ export async function analyzeProjectWorkflowJobConventions(
     ...findIdCollisions(discoveredWorkflows, "workflow"),
     ...findIdCollisions(discoveredJobs, "job"),
   ]
+  if (discoveredWorkflows.length === 0 && discoveredJobs.length === 0) {
+    return { workflows, jobs, diagnostics }
+  }
+
+  await loadTypeScript()
+  const realProjectRoot = await realpath(projectRoot)
 
   for (const workflow of discoveredWorkflows) {
     const sourceFile = await readConventionSource(


### PR DESCRIPTION
## Summary

- Reuse the resolver convention-discovery snapshot across project analyzers.
- Load TypeScript only when project-local source files were actually discovered.
- Preserve deterministic empty generated artifacts for source-free, dist-only applications.
- Document the deployment contract and add a framework patch changeset.

## Root cause

Managed production images contain the application package manifest and compiled output, but no project source tree. Convention discovery correctly found no source contributions, yet each analyzer loaded TypeScript before checking that result. Project resolution therefore failed at boot unless the compiler was shipped as a production dependency.

## Impact

Dist-only applications can now resolve their deployment graph without TypeScript in the runtime image. Source-bearing projects retain the existing static-analysis behavior and still receive a clear error if TypeScript is unavailable when analysis is genuinely required.

## Validation

- Framework lint, typecheck, build, and all 291 framework tests
- `pnpm verify:fast`
- `pnpm verify:package-exports`
- Production-shaped built-package proof with every `typescript` resolution blocked

Refs #3391
