### PR TITLE
Read an optional collection prefix in the Typesense indexer provider

### DIFF
--- a/.changeset/typesense-collection-prefix.md
+++ b/.changeset/typesense-collection-prefix.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/catalog": minor
+---
+
+The Typesense catalog indexer provider reads an optional `TYPESENSE_COLLECTION_PREFIX` deployment config and namespaces every collection with it, so multi-tenant deployments can share one Typesense cluster with per-tenant key scoping (`<prefix>__.*`).

--- a/packages/catalog/src/indexer/typesense-provider.test.ts
+++ b/packages/catalog/src/indexer/typesense-provider.test.ts
@@ -1,11 +1,24 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
+import { createTypesenseIndexer } from "./typesense.js"
 import { createTypesenseGraphIndexerProvider } from "./typesense-provider.js"
+
+vi.mock("./typesense.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./typesense.js")>()
+  return { ...actual, createTypesenseIndexer: vi.fn(actual.createTypesenseIndexer) }
+})
+
+const HOST_CONFIG_ID = "@voyant-travel/catalog#config.typesense-host"
+const PREFIX_CONFIG_ID = "@voyant-travel/catalog#config.typesense-collection-prefix"
+
+function configOf(values: Record<string, string | undefined>) {
+  return (<T>(declarationId: string) => values[declarationId] as T | undefined) as never
+}
 
 describe("Typesense graph indexer provider", () => {
   it("constructs an adapter from provider-owned credentials", () => {
     const provider = createTypesenseGraphIndexerProvider({
-      getConfig: () => "https://search.example.test",
+      getConfig: configOf({ [HOST_CONFIG_ID]: "https://search.example.test" }),
       getSecret: () => "secret-key",
     } as never)
 
@@ -19,10 +32,40 @@ describe("Typesense graph indexer provider", () => {
     expect(adapter.admin).toBeDefined()
   })
 
+  it("passes the optional collection prefix through to the indexer", () => {
+    const provider = createTypesenseGraphIndexerProvider({
+      getConfig: configOf({
+        [HOST_CONFIG_ID]: "https://search.example.test",
+        [PREFIX_CONFIG_ID]: "acme-prod",
+      }),
+      getSecret: () => "secret-key",
+    } as never)
+
+    provider.create({ registries: new Map(), vectorDimensions: 768 })
+
+    const lastCall = vi.mocked(createTypesenseIndexer).mock.calls.at(-1)
+    expect(lastCall?.[0]).toMatchObject({ collectionPrefix: "acme-prod" })
+  })
+
+  it("omits the collection prefix when the config is absent or blank", () => {
+    const provider = createTypesenseGraphIndexerProvider({
+      getConfig: configOf({
+        [HOST_CONFIG_ID]: "https://search.example.test",
+        [PREFIX_CONFIG_ID]: "  ",
+      }),
+      getSecret: () => "secret-key",
+    } as never)
+
+    provider.create({ registries: new Map(), vectorDimensions: 768 })
+
+    const lastCall = vi.mocked(createTypesenseIndexer).mock.calls.at(-1)
+    expect(lastCall?.[0]).not.toHaveProperty("collectionPrefix")
+  })
+
   it("fails during provider setup when selected credentials are invalid", () => {
     expect(() =>
       createTypesenseGraphIndexerProvider({
-        getConfig: () => "not-a-url",
+        getConfig: configOf({ [HOST_CONFIG_ID]: "not-a-url" }),
         getSecret: () => "secret-key",
       } as never),
     ).toThrow("Invalid URL")

--- a/packages/catalog/src/indexer/typesense-provider.ts
+++ b/packages/catalog/src/indexer/typesense-provider.ts
@@ -4,6 +4,8 @@ import { createTypesenseFetchClient } from "./typesense-fetch-client.js"
 
 const TYPESENSE_HOST_CONFIG_ID = "@voyant-travel/catalog#config.typesense-host"
 const TYPESENSE_API_KEY_SECRET_ID = "@voyant-travel/catalog#secret.typesense-api-key"
+const TYPESENSE_COLLECTION_PREFIX_CONFIG_ID =
+  "@voyant-travel/catalog#config.typesense-collection-prefix"
 
 interface TypesenseGraphProviderContext {
   getConfig: <T = unknown>(declarationId: string) => T | undefined
@@ -16,6 +18,10 @@ export function createTypesenseGraphIndexerProvider(
 ): IndexerProvider {
   const host = requiredString(context.getConfig(TYPESENSE_HOST_CONFIG_ID), "TYPESENSE_HOST")
   const apiKey = requiredString(context.getSecret(TYPESENSE_API_KEY_SECRET_ID), "TYPESENSE_API_KEY")
+  // Optional: multi-tenant single-cluster deployments (e.g. a managed fleet
+  // sharing one Typesense cluster) namespace every collection and scope each
+  // tenant's API key to `<prefix>__.*`.
+  const collectionPrefix = optionalString(context.getConfig(TYPESENSE_COLLECTION_PREFIX_CONFIG_ID))
   const url = new URL(host)
 
   return {
@@ -24,8 +30,13 @@ export function createTypesenseGraphIndexerProvider(
         client: createTypesenseFetchClient(url.toString(), apiKey),
         registries,
         vectorDimensions,
+        ...(collectionPrefix ? { collectionPrefix } : {}),
       }),
   }
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
 }
 
 function requiredString(value: unknown, name: string): string {

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -130,6 +130,11 @@ export const catalogVoyantModule = defineModule({
       key: "TYPESENSE_HOST",
       required: false,
     },
+    {
+      id: "@voyant-travel/catalog#config.typesense-collection-prefix",
+      key: "TYPESENSE_COLLECTION_PREFIX",
+      required: false,
+    },
   ],
   secrets: [
     {
@@ -146,7 +151,10 @@ export const catalogVoyantModule = defineModule({
       port: "catalog.indexer",
       selection: { role: "search", value: "typesense" },
       uses: {
-        config: ["@voyant-travel/catalog#config.typesense-host"],
+        config: [
+          "@voyant-travel/catalog#config.typesense-host",
+          "@voyant-travel/catalog#config.typesense-collection-prefix",
+        ],
         secrets: ["@voyant-travel/catalog#secret.typesense-api-key"],
       },
       runtime: {


### PR DESCRIPTION
`createTypesenseIndexer` already supports an optional `collectionPrefix` ("useful for multi-tenant single-cluster setups"), but the graph provider selected by `deployment.providers.search: "typesense"` had no way to receive one — every deployment sharing a cluster would collide on collection names.

- Declare `TYPESENSE_COLLECTION_PREFIX` as an optional config on the catalog module and add it to the typesense provider's `uses.config`.
- `createTypesenseGraphIndexerProvider` reads it (trimmed, blank = absent) and passes `collectionPrefix` through.
- Tests cover pass-through and the absent/blank cases; the provider tests' `getConfig` fakes are now declaration-id-aware.

Motivation: Voyant Cloud's managed operator fleet shares the platform's managed Typesense clusters; each deployment gets an API key scoped to `<prefix>__.*` and this config is how the indexer stays inside that namespace.