### PR TITLE
Advertise TYPESENSE_COLLECTION_PREFIX in typesense deployment requirements

### DIFF
--- a/.changeset/typesense-prefix-requirement.md
+++ b/.changeset/typesense-prefix-requirement.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+The typesense search provider's deployment requirements now advertise the optional `TYPESENSE_COLLECTION_PREFIX` variable, so requirement-driven env provisioning surfaces it alongside `TYPESENSE_HOST` and `TYPESENSE_API_KEY`.

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -124,6 +124,11 @@ function envForProvider(
       ? [
           variable("TYPESENSE_HOST", "Typesense host URL."),
           secret("TYPESENSE_API_KEY", "Typesense API key."),
+          variable(
+            "TYPESENSE_COLLECTION_PREFIX",
+            "Optional collection-name prefix for multi-tenant shared clusters.",
+            false,
+          ),
         ]
       : [
           variable("ALGOLIA_APP_ID", "Algolia application id."),


### PR DESCRIPTION
Follow-up to #3410 (review finding): the catalog module's typesense indexer provider reads the optional `TYPESENSE_COLLECTION_PREFIX` config, but the `search`/`typesense` branch of the standard deployment requirements still advertised only `TYPESENSE_HOST` and `TYPESENSE_API_KEY`. Deployments that derive or provision env from the requirements would never surface the prefix — a shared-cluster setup with a prefix-scoped key would index unprefixed collections and fail its key ACL (or collide across tenants).

Adds the optional `TYPESENSE_COLLECTION_PREFIX` variable requirement alongside the existing Typesense vars. Framework patch changeset included; 294 framework tests green.