### PR TITLE
Build custom-fields-react on prepack so the tarball ships dist

### DIFF
--- a/.changeset/custom-fields-react-prepack.md
+++ b/.changeset/custom-fields-react-prepack.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/custom-fields-react": patch
+---
+
+Republish with compiled output: 0.2.0 was packed without `prepack`, so the tarball shipped no `dist/` and its entry points were unresolvable for consumers.

--- a/packages/custom-fields-react/package.json
+++ b/packages/custom-fields-react/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
+    "prepack": "pnpm run build",
     "typecheck": "tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests"


### PR DESCRIPTION
`@voyant-travel/custom-fields-react@0.2.0` published without `dist/`: it is the only react package missing the standard `prepack: pnpm run build` script, so the pack step shipped a tarball whose entry points (mapped to `./dist/*` by `publishConfig.exports`) resolve to nothing — consumers cannot import `@voyant-travel/custom-fields-react/admin` at all.

Adds the standard prepack script (matching every sibling `*-react` package) and a patch changeset so 0.2.1 republishes with compiled output.