### PR TITLE
Republish custom-fields with substituted dependency specifiers

### DIFF
--- a/.changeset/custom-fields-republish.md
+++ b/.changeset/custom-fields-republish.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/custom-fields": patch
+---
+
+Republish through the workspace release flow: 0.2.0 was published with raw `catalog:` and `workspace:^` specifiers in its manifest, which npm cannot resolve — any consumer install (including the release tarball verification) fails with EUNSUPPORTEDPROTOCOL.


### PR DESCRIPTION
`@voyant-travel/custom-fields@0.2.0` reached npm with raw `catalog:` and `workspace:^` specifiers in its published manifest — it was published outside the workspace release flow, so pnpm's protocol substitution never ran:

```json
{ "@hono/zod-openapi": "catalog:", "@voyant-travel/core": "workspace:^", "drizzle-orm": "catalog:", "hono": "catalog:", "zod": "catalog:" }
```

npm cannot resolve those protocols, so every consumer install fails with `EUNSUPPORTEDPROTOCOL` — including the Release workflow's tarball verification, which installs the packed set plus published transitive deps (`relationships` and `operator-standard` both depend on `custom-fields`). That's what blocked the current release run.

This changeset publishes 0.2.1 through changesets so the manifest carries real ranges; with 0.2.1 in the release set, verification resolves the workspace tarball instead of the poisoned npm manifest.