### PR TITLE
Declare custom-fields-react's repository for npm provenance

### DIFF
--- a/.changeset/custom-fields-react-repository.md
+++ b/.changeset/custom-fields-react-repository.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/custom-fields-react": patch
+---
+
+Declare the repository field so npm provenance verification accepts the publish (0.2.1 was rejected with E422: repository.url "" did not match the GitHub Actions provenance).

--- a/packages/custom-fields-react/package.json
+++ b/packages/custom-fields-react/package.json
@@ -104,5 +104,10 @@
         "default": "./src/styles.css"
       }
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/custom-fields-react"
   }
 }


### PR DESCRIPTION
The 0.2.1 publish was rejected with `E422 Unprocessable Entity — Error verifying sigstore provenance bundle: repository.url is \"\", expected to match https://github.com/voyant-travel/voyant`. npm's provenance verification requires `package.json`'s `repository.url` to match the GitHub Actions source repo, and `custom-fields-react` was the only workspace package missing the field (everything else in the batch published).

Adds the standard repository block (matching every sibling react package) plus a patch changeset so the next release publishes 0.2.2 with a valid manifest.