### PR TITLE
Register the rewritten 0004_framework_baseline as hash-equivalent

### DIFF
--- a/.changeset/custom-fields-react-repository.md
+++ b/.changeset/custom-fields-react-repository.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/custom-fields-react": patch
+---
+
+Declare the repository field so npm provenance verification accepts the publish (0.2.1 was rejected with E422: repository.url "" did not match the GitHub Actions provenance).

--- a/.changeset/framework-baseline-0004-equivalence.md
+++ b/.changeset/framework-baseline-0004-equivalence.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Register the rewritten `framework/0004_framework_baseline` (guarded `custom_field_values` drop → plain `DROP TABLE IF EXISTS`) as hash-equivalent to the original, so databases that applied the 0.9.x bundle don't fail the immutability gate on upgrade.

--- a/packages/custom-fields-react/CHANGELOG.md
+++ b/packages/custom-fields-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @voyant-travel/custom-fields-react
 
+## 0.2.2
+
+### Patch Changes
+
+- 207a29c: Declare the repository field so npm provenance verification accepts the publish (0.2.1 was rejected with E422: repository.url "" did not match the GitHub Actions provenance).
+
 ## 0.2.1
 
 ### Patch Changes

--- a/packages/custom-fields-react/package.json
+++ b/packages/custom-fields-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/custom-fields-react",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "Apache-2.0",
   "type": "module",
   "sideEffects": [

--- a/packages/custom-fields-react/package.json
+++ b/packages/custom-fields-react/package.json
@@ -104,5 +104,10 @@
         "default": "./src/styles.css"
       }
     }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/voyant-travel/voyant.git",
+    "directory": "packages/custom-fields-react"
   }
 }

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -110,6 +110,15 @@ const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
     "db/0001_db_baseline/073492f087f0b3035aa7215cbb03560e910712dd08f28b41a5ef0daa8f9d0e10",
     new Set(["a152b612c5f41e6dd6ad1271faf9e51d3926526de7995df68e28046dc518ad0f"]),
   ],
+  // `framework/0004_framework_baseline` originally shipped a guarded
+  // `custom_field_values` drop (refuse while rows remain); it was rewritten to a
+  // plain `DROP TABLE IF EXISTS` once custom fields were confirmed to have no
+  // production adoption at the cutline. Identical outcome on any database where
+  // the original already applied — the table is gone either way.
+  [
+    "framework/0004_framework_baseline/c089643f03ce56e76239ecd96582b9886d3bc4ae26adcbea48308bcf92a71ed3",
+    new Set(["5ba3a342b91d2d48f6b27dd15bc0cbf46478003d73b497709c5f56d2628bac8d"]),
+  ],
 ])
 
 function isEquivalentMigrationHash(

--- a/packages/operator-standard/CHANGELOG.md
+++ b/packages/operator-standard/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @voyant-travel/operator-standard
 
+## 0.6.9
+
+### Patch Changes
+
+- Updated dependencies [207a29c]
+  - @voyant-travel/custom-fields-react@0.2.2
+
 ## 0.6.8
 
 ### Patch Changes

--- a/packages/operator-standard/package.json
+++ b/packages/operator-standard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/operator-standard",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "Versioned standard Voyant Operator product distribution and dependency BOM.",
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
The frozen framework bundle's `0004_framework_baseline.sql` was rewritten between framework-migrations 0.9.x and 0.10.0 (guarded `custom_field_values` drop → plain `DROP TABLE IF EXISTS`, after confirming custom fields had no production adoption at the cutline) — but the old content hash was never added to `EQUIVALENT_MIGRATION_HASHES`. Every database that applied the 0.9.x bundle now fails the immutability gate on upgrade:

```
MigrationImmutabilityError: framework/0004_framework_baseline changed after it was applied
(ledger 5ba3a342b91d… != current c089643f03ce…)
```

Observed blocking the managed fleet's 0.48.1 rollout (every managed operator DB migrated under 0.9.x).

Registers the pair following the existing `db/0001_db_baseline` precedent — the outcome is identical on any database where the original applied (the table is gone either way). Patch changeset included; 76 framework-migrations tests green.