### PR TITLE
Parity-gate only unrecorded cutline entries on adopted databases

### DIFF
--- a/.changeset/parity-gate-resumed-adoption.md
+++ b/.changeset/parity-gate-resumed-adoption.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+The import-baseline parity gate now checks only cutline entries the run is about to record: once an entry is in the ledger, applied post-cutline migrations may legitimately have reshaped or dropped its objects, and re-asserting the cutline-era schema on every run wedged partially-adopted databases forever.

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 import type { MigrationClient, MigrationSource } from "./collector.js"
-import { detectExisting, expectedSchema } from "./deployment-runner.js"
+import { detectExisting, expectedSchema, runDeploymentMigrations } from "./deployment-runner.js"
 
 const src = (name: string, sqls: string[]): MigrationSource => ({
   name,
@@ -59,6 +59,62 @@ describe("expectedSchema", () => {
     expect(e.tables.has("tmp")).toBe(false)
     expect(e.dropped.has("tmp")).toBe(true)
     expect([...e.columns].some((c) => c.startsWith("tmp."))).toBe(false)
+  })
+})
+
+describe("runDeploymentMigrations on a partially adopted database", () => {
+  it("does not re-assert cutline schema for already-recorded entries", async () => {
+    // Ledger state: adoption already recorded action-ledger's covered baseline,
+    // and an applied post-cutline increment legitimately DROPPED its outbox
+    // table. A rerun must not demand the cutline-era outbox schema again.
+    const ledgerRows = [
+      { source: "framework", tag: "0000_framework_baseline", content_hash: "h-framework" },
+      { source: "action-ledger", tag: "0000_action_ledger_baseline", content_hash: "h-covered" },
+      {
+        source: "action-ledger",
+        tag: "0001_remove_outbox",
+        content_hash: "b48b95e2b1ec55da472472782e63f89a5f6f8e0f5f26c8f24825ffe7dad5d33c",
+      },
+    ]
+    const client: MigrationClient = {
+      async query(sql: string, params: unknown[] = []) {
+        if (sql.startsWith("SELECT to_regclass")) return { rows: [{ reg: String(params[0]) }] }
+        if (sql.includes("count(*)")) return { rows: [{ n: "1" }] }
+        if (sql.includes('SELECT "source", "tag" FROM')) {
+          return { rows: ledgerRows.map(({ source, tag }) => ({ source, tag })) }
+        }
+        if (sql.includes('SELECT "content_hash", "source" FROM')) {
+          // applyMigrations per-migration lookup: report both recorded rows.
+          return { rows: [] }
+        }
+        if (sql.includes("information_schema.tables")) {
+          return { rows: [] } // outbox (and everything else) absent
+        }
+        if (sql.includes("information_schema.columns")) return { rows: [] }
+        if (sql.includes("pg_constraint")) return { rows: [] }
+        return { rows: [] }
+      },
+    }
+
+    const sources = [
+      {
+        name: "action-ledger",
+        priority: 1,
+        migrations: [
+          {
+            tag: "0000_action_ledger_baseline",
+            sql: 'CREATE TABLE "action_ledger_outbox" ("id" text PRIMARY KEY);',
+          },
+        ],
+      },
+    ]
+    const cutline = { "action-ledger": ["0000_action_ledger_baseline"] }
+
+    // Without the recorded-entry filter this throws "NOT at the cutline schema"
+    // (the outbox table is gone). With it, the covered entry is already
+    // recorded, nothing is left to parity-gate, and the run proceeds.
+    const result = await runDeploymentMigrations(client, sources, cutline)
+    expect(result.existing).toBe(true)
   })
 })
 

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -254,6 +254,33 @@ function cutlineCovered(sources: MigrationSource[], cutline: Cutline): Migration
 }
 
 /**
+ * Drop migrations already recorded in the ledger (under the source's stable OR
+ * legacy names). The baseline parity gate must only assert the schema of
+ * cutline entries it is ABOUT to import-baseline: once an entry is recorded,
+ * later post-cutline migrations may legitimately have altered or dropped its
+ * objects (e.g. a recorded source's outbox table retired by its own
+ * increment), so re-asserting the cutline-era schema on every run would wedge
+ * a partially-adopted database forever.
+ */
+async function withoutRecordedMigrations(
+  client: MigrationClient,
+  sources: MigrationSource[],
+): Promise<MigrationSource[]> {
+  if (sources.length === 0) return sources
+  const ledger = `"${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}"."${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}"`
+  const recordedRows = await client.query(`SELECT "source", "tag" FROM ${ledger}`)
+  const recorded = new Set(
+    recordedRows.rows.map((row) => `${row.source as string}\0${row.tag as string}`),
+  )
+  const isRecorded = (source: MigrationSource, tag: string) =>
+    [source.name, ...(source.legacyNames ?? [])].some((name) => recorded.has(`${name}\0${tag}`))
+
+  return sources
+    .map((s) => ({ ...s, migrations: s.migrations.filter((m) => !isRecorded(s, m.tag)) }))
+    .filter((s) => s.migrations.length > 0)
+}
+
+/**
  * Run the deployment's migrations against `client`'s ledger. Detects FRESH vs
  * EXISTING, gates the EXISTING baseline with a parity check, and applies.
  */
@@ -265,7 +292,11 @@ export async function runDeploymentMigrations(
 ): Promise<RunResult> {
   const existing = await detectExisting(client)
   if (existing) {
-    await assertSchemaAtBaseline(client, cutlineCovered(sources, cutline))
+    // Parity-gate only the cutline entries this run will import-baseline;
+    // already-recorded entries' objects may have been legitimately reshaped by
+    // applied post-cutline migrations.
+    const pending = await withoutRecordedMigrations(client, cutlineCovered(sources, cutline))
+    if (pending.length > 0) await assertSchemaAtBaseline(client, pending)
   }
   const { executed, baselined } = await applyMigrations(client, sources, {
     cutline,


### PR DESCRIPTION
Third replay defect in the managed fleet's 0.48.1 rollout (after #3420 and #3422): a first, partially-failed adoption run recorded `action-ledger/0000` (import-baselined) and applied its post-cutline increment `remove_action_ledger_relay_outbox` (drops the outbox table). Every subsequent run then failed:

```
Error: cannot baseline onto the collector — this database is NOT at the cutline schema.
  • 36 expected column(s) missing: action_ledger_outbox.…
```

`runDeploymentMigrations` re-asserted the FULL cutline schema on every run — but once an entry is recorded, applied post-cutline migrations may legitimately have reshaped or dropped its objects. A partially-adopted database is wedged forever.

Fix: filter the covered set to entries not yet in the ledger (matching stable or legacy source names) before `assertSchemaAtBaseline`; an empty pending set skips the assert. First adoption still parity-gates everything it is about to record. Regression test covers the resumed path; 77 tests green.