### PR TITLE
Derive managed admin session scopes from the access catalog

### DIFF
--- a/.changeset/managed-cloud-team-admin-scopes.md
+++ b/.changeset/managed-cloud-team-admin-scopes.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": patch
+"@voyant-travel/auth": patch
+"@voyant-travel/types": patch
+---
+
+Grant managed-cloud admin sessions explicit access-catalog scopes for admin-only resources such as Team management.

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -24,7 +24,7 @@ import {
 } from "@voyant-travel/hono/middleware/error-boundary"
 import { getRequestId } from "@voyant-travel/hono/observability"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
-import { scopesForRole } from "@voyant-travel/types/member-roles"
+import { accessCatalogScopesForRole, isFullAccessRole } from "@voyant-travel/types/member-roles"
 import { eq, sql } from "drizzle-orm"
 import { type Context, Hono } from "hono"
 import {
@@ -397,7 +397,7 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
   const FULL_ACCESS_SCOPES = ["*"]
 
   function scopesForOperatorRole(role: string | null | undefined): string[] | null {
-    const base = scopesForRole(role)
+    const base = accessCatalogScopesForRole(role, runtimeOptions.accessCatalog)
     if (!base) return null
     const normalizedRole = (role ?? "").trim().toLowerCase()
     const presetId =
@@ -431,7 +431,9 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
         .from(cloudAuthUserLinks)
         .where(eq(cloudAuthUserLinks.userId, userId))
         .limit(1)
-      return link?.scopes ?? scopesForOperatorRole(link?.roleSlug) ?? FULL_ACCESS_SCOPES
+      const fullAccessScopes = scopesForOperatorRole("admin") ?? FULL_ACCESS_SCOPES
+      const roleScopes = scopesForOperatorRole(link?.roleSlug) ?? fullAccessScopes
+      return isFullAccessRole(link?.roleSlug) ? roleScopes : (link?.scopes ?? roleScopes)
     }
 
     const [profile] = await db

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -43,7 +43,8 @@ import {
   resolveDocumentDownloadUrl,
 } from "@voyant-travel/storage/runtime"
 import type { StorageProvider, StorageProviderResolver } from "@voyant-travel/storage/types"
-import { scopesForRole } from "@voyant-travel/types/member-roles"
+import type { AccessCatalog } from "@voyant-travel/types/api-keys"
+import { accessCatalogScopesForRole, isFullAccessRole } from "@voyant-travel/types/member-roles"
 import type { KVStore } from "@voyant-travel/utils/cache"
 import { createRedisKvStore } from "@voyant-travel/utils/redis-kv"
 import { createTieredKvStore } from "@voyant-travel/utils/tiered-kv"
@@ -312,6 +313,7 @@ export async function loadVoyantNodeRuntime(
     env,
     auth: options.app?.auth ?? options.auth,
     activeModules,
+    accessCatalog: options.app?.accessCatalog ?? options.graphRuntime.accessCatalog,
   })
   const resources = { ...(options.providers ?? {}), ...(options.resources ?? {}) }
   const graphComposition = await composeVoyantGraphRuntime({
@@ -435,6 +437,7 @@ export function createVoyantNodeApp(options: {
     env: options.env,
     auth: options.app?.auth ?? options.auth,
     activeModules: options.activeModules,
+    accessCatalog: options.app?.accessCatalog,
   })
   const workflows = createVoyantNodeWorkflowConfig({
     deployment: options.deployment,
@@ -501,14 +504,16 @@ function resolveVoyantNodeAuthIntegration(options: {
   auth?: VoyantAuthIntegration<VoyantNodeRuntimeEnv>
   /** Active module ids surfaced on `/auth/bootstrap-status` for admin gating (voyant#3063). */
   activeModules?: readonly string[]
+  accessCatalog?: AccessCatalog
 }): VoyantAuthIntegration<VoyantNodeRuntimeEnv> | undefined {
   if (options.auth) return options.auth
   if (!isManagedVoyantCloudAuthMode(options.env)) return undefined
-  return createManagedCloudAdminAuthIntegration(options.activeModules ?? [])
+  return createManagedCloudAdminAuthIntegration(options.activeModules ?? [], options.accessCatalog)
 }
 
 function createManagedCloudAdminAuthIntegration(
   activeModules: readonly string[],
+  accessCatalog: AccessCatalog | undefined,
 ): VoyantAuthIntegration<VoyantNodeRuntimeEnv> {
   return {
     handler: () => {
@@ -543,7 +548,7 @@ function createManagedCloudAdminAuthIntegration(
         organizationId: null,
         callerType: "session",
         actor: "staff",
-        scopes: await resolveManagedCloudMemberScopes(db, session.user.id),
+        scopes: await resolveManagedCloudMemberScopes(db, session.user.id, accessCatalog),
         email: session.user.email ?? null,
       }
     },
@@ -849,13 +854,20 @@ function getManagedCloudAuthRevalidateConfig(env: VoyantNodeRuntimeEnv) {
   }
 }
 
-async function resolveManagedCloudMemberScopes(db: VoyantDb, userId: string): Promise<string[]> {
+async function resolveManagedCloudMemberScopes(
+  db: VoyantDb,
+  userId: string,
+  accessCatalog: AccessCatalog | undefined,
+): Promise<string[]> {
   const [link] = await db
     .select({ scopes: cloudAuthUserLinks.scopes, roleSlug: cloudAuthUserLinks.roleSlug })
     .from(cloudAuthUserLinks)
     .where(eq(cloudAuthUserLinks.userId, userId))
     .limit(1)
-  return link?.scopes ?? scopesForRole(link?.roleSlug) ?? MANAGED_FULL_ACCESS_SCOPES
+  const fullAccessScopes =
+    accessCatalogScopesForRole("admin", accessCatalog) ?? MANAGED_FULL_ACCESS_SCOPES
+  const roleScopes = accessCatalogScopesForRole(link?.roleSlug, accessCatalog) ?? fullAccessScopes
+  return isFullAccessRole(link?.roleSlug) ? roleScopes : (link?.scopes ?? roleScopes)
 }
 
 function isManagedCloudAllowedBetterAuthRoute(request: Request): boolean {

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -43,11 +43,16 @@ import {
   resolveDocumentDownloadUrl,
 } from "@voyant-travel/storage/runtime"
 import type { StorageProvider, StorageProviderResolver } from "@voyant-travel/storage/types"
-import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import { accessCatalogScopesForRole, isFullAccessRole } from "@voyant-travel/types/member-roles"
 import type { KVStore } from "@voyant-travel/utils/cache"
 import { createRedisKvStore } from "@voyant-travel/utils/redis-kv"
 import { createTieredKvStore } from "@voyant-travel/utils/tiered-kv"
+
+// Derived from the member-roles helper so this file keeps zero first-party
+// PRODUCT imports (architecture gate): the node runtime only threads the
+// catalog through to scope derivation, never interprets it.
+type AccessCatalog = NonNullable<Parameters<typeof accessCatalogScopesForRole>[1]>
+
 import { createCloudWorkflowDriver } from "@voyant-travel/workflows/client"
 import type { DriverFactory } from "@voyant-travel/workflows/driver"
 import { createInMemoryDriver } from "@voyant-travel/workflows-orchestrator/in-memory"

--- a/packages/hono/tests/unit/require-actor.test.ts
+++ b/packages/hono/tests/unit/require-actor.test.ts
@@ -1,7 +1,41 @@
+import { accessCatalogScopesForRole } from "@voyant-travel/types/member-roles"
 import { Hono } from "hono"
 import { describe, expect, it } from "vitest"
 
 import { requireActor } from "../../src/middleware/require-actor.js"
+
+const teamAccessCatalog = {
+  resources: [
+    {
+      id: "@voyant-travel/auth#access.team",
+      unitId: "@voyant-travel/auth#team",
+      resource: "team",
+      label: "Team",
+      description: "Manage staff team members and their access.",
+      wildcard: "explicit-resource",
+      actions: [
+        {
+          action: "read",
+          label: "View team",
+          description: "View staff team members.",
+        },
+        {
+          action: "write",
+          label: "Manage team",
+          description: "Invite staff and update roles or access.",
+          wildcard: "explicit",
+        },
+        {
+          action: "delete",
+          label: "Remove team access",
+          description: "Revoke invitations or deactivate staff team members.",
+          wildcard: "explicit",
+        },
+      ],
+    },
+  ],
+  presets: [],
+} as const
 
 function makeApp(
   setVars: (c: {
@@ -475,6 +509,24 @@ describe("requireActor — staff session RBAC scopes (voyant#2085)", () => {
     expect(
       (await allowed.request("/v1/admin/team/members/m_1/permissions", { method: "POST" })).status,
     ).toBe(200)
+  })
+
+  it("admits managed-cloud admin role scopes to the packaged Team route with a catalog", async () => {
+    const adminScopes = accessCatalogScopesForRole("admin", teamAccessCatalog) ?? []
+    const admin = staffSession(adminScopes)
+    admin.use("*", requireActor({ accessCatalog: teamAccessCatalog }, "staff"))
+    admin.get("/v1/admin/team/members", (c) => c.json({ ok: true }))
+
+    expect((await admin.request("/v1/admin/team/members")).status).toBe(200)
+
+    const memberScopes = accessCatalogScopesForRole("member", teamAccessCatalog) ?? []
+    const member = staffSession(memberScopes)
+    member.use("*", requireActor({ accessCatalog: teamAccessCatalog }, "staff"))
+    member.post("/v1/admin/team/members/member_1/role", (c) => c.json({ ok: true }))
+
+    expect(
+      (await member.request("/v1/admin/team/members/member_1/role", { method: "POST" })).status,
+    ).toBe(403)
   })
 
   it("still lets a restricted member read _meta", async () => {

--- a/packages/types/src/member-roles.ts
+++ b/packages/types/src/member-roles.ts
@@ -11,6 +11,7 @@
  * docs/architecture/member-rbac-rfc.md (voyant#2085).
  */
 import {
+  type AccessCatalog,
   type ApiKeyPermissionString,
   type ApiKeyPermissions,
   hasApiKeyPermission,
@@ -129,6 +130,39 @@ export function permissionsForRole(role: string | null | undefined): ApiKeyPermi
 export function scopesForRole(role: string | null | undefined): ApiKeyPermissionString[] | null {
   const permissions = permissionsForRole(role)
   return permissions ? permissionsToStrings(permissions) : null
+}
+
+function accessCatalogScope(resource: string, action: string): ApiKeyPermissionString {
+  return `${resource}:${action}` as ApiKeyPermissionString
+}
+
+function explicitAccessCatalogScopes(
+  catalog: AccessCatalog | null | undefined,
+): ApiKeyPermissionString[] {
+  return (
+    catalog?.resources.flatMap((resource) =>
+      resource.wildcard === "explicit-resource"
+        ? resource.actions.map((action) => accessCatalogScope(resource.resource, action.action))
+        : resource.actions
+            .filter((action) => action.wildcard === "explicit")
+            .map((action) => accessCatalogScope(resource.resource, action.action)),
+    ) ?? []
+  )
+}
+
+/**
+ * Resolve a role slug to runtime session scopes. Full-access roles include the
+ * explicit catalog grants that `*` intentionally does not satisfy, such as
+ * team-management resources.
+ */
+export function accessCatalogScopesForRole(
+  role: string | null | undefined,
+  catalog: AccessCatalog | null | undefined,
+): ApiKeyPermissionString[] | null {
+  const roleScopes = scopesForRole(role)
+  if (!roleScopes) return null
+  if (!isFullAccessRole(role)) return roleScopes
+  return Array.from(new Set([...roleScopes, ...explicitAccessCatalogScopes(catalog)])).sort()
 }
 
 /** True when a role slug grants full (manage-everything) access. */

--- a/packages/types/tests/member-roles.test.ts
+++ b/packages/types/tests/member-roles.test.ts
@@ -1,12 +1,46 @@
 import { describe, expect, it } from "vitest"
 
-import { hasApiKeyPermission } from "../src/api-keys.js"
+import { hasApiKeyPermission, permissionStringsToPermissions } from "../src/api-keys.js"
 import {
+  accessCatalogScopesForRole,
   isFullAccessRole,
   MEMBER_ROLE_PRESETS,
   permissionsForRole,
   scopesForRole,
 } from "../src/member-roles.js"
+
+const teamAccessCatalog = {
+  resources: [
+    {
+      id: "@voyant-travel/auth#access.team",
+      unitId: "@voyant-travel/auth#team",
+      resource: "team",
+      label: "Team",
+      description: "Manage staff team members and their access.",
+      wildcard: "explicit-resource",
+      actions: [
+        {
+          action: "read",
+          label: "View team",
+          description: "View staff team members.",
+        },
+        {
+          action: "write",
+          label: "Manage team",
+          description: "Invite staff and update roles or access.",
+          wildcard: "explicit",
+        },
+        {
+          action: "delete",
+          label: "Remove team access",
+          description: "Revoke invitations or deactivate staff team members.",
+          wildcard: "explicit",
+        },
+      ],
+    },
+  ],
+  presets: [],
+} as const
 
 describe("permissionsForRole", () => {
   it("maps owner/admin/super-admin to full access", () => {
@@ -55,6 +89,28 @@ describe("scopesForRole", () => {
 
   it("returns null for slugs without a preset", () => {
     expect(scopesForRole("custom")).toBeNull()
+  })
+})
+
+describe("accessCatalogScopesForRole", () => {
+  it("expands admin roles with explicit catalog grants for managed-cloud sessions", () => {
+    const scopes = accessCatalogScopesForRole("admin", teamAccessCatalog)
+    const permissions = permissionStringsToPermissions(scopes ?? [])
+
+    expect(scopes).toEqual(["*", "team:delete", "team:read", "team:write"])
+    expect(hasApiKeyPermission(permissions, "team", "read", teamAccessCatalog)).toBe(true)
+    expect(hasApiKeyPermission(permissions, "team", "write", teamAccessCatalog)).toBe(true)
+    expect(
+      hasApiKeyPermission(permissionStringsToPermissions(["*"]), "team", "read", teamAccessCatalog),
+    ).toBe(false)
+  })
+
+  it("does not add team-management grants to non-admin managed-cloud roles", () => {
+    const scopes = accessCatalogScopesForRole("member", teamAccessCatalog) ?? []
+    const permissions = permissionStringsToPermissions(scopes)
+
+    expect(hasApiKeyPermission(permissions, "team", "write", teamAccessCatalog)).toBe(false)
+    expect(scopes).not.toContain("team:write")
   })
 })
 


### PR DESCRIPTION
Fixes the managed Team page 403 (platform RFC #1118 P1, issue platform#1120): on managed-cloud deployments, an org admin's session scopes came from the static `scopesForRole` map, which predates the `auth.team` access resource — so `GET /v1/admin/team/members` failed its permission gate with `Forbidden: missing required permission` even for admins, and Settings → Team could never load.

- `@voyant-travel/types`: `accessCatalogScopesForRole` derives a role's scopes from the deployment's access catalog (admins cover every declared resource/action) + `isFullAccessRole`; unit tests.
- `@voyant-travel/framework`: the managed-cloud auth integration threads the graph's access catalog into member-scope resolution; admin sessions get catalog-derived full coverage (stale stored scopes can no longer shadow an admin), non-admin roles keep stored/narrow scopes.
- `@voyant-travel/auth`: same treatment for the local operator auth runtime.
- Tests cover the team-route permission gate for admin (passes) and non-admin (still denied); patch changesets for all three packages.