### PR TITLE
Harden app manifest ingestion DNS pinning and release version conflicts

### DIFF
--- a/packages/apps/src/ingestion.test.ts
+++ b/packages/apps/src/ingestion.test.ts
@@ -52,4 +52,18 @@ describe("protected manifest ingestion", () => {
       }),
     ).rejects.toThrow(/maximum allowed size/)
   })
+
+  it("rejects DNS rebinding between the public pre-check and the pinned connect", async () => {
+    let resolutions = 0
+    await expect(
+      fetchProtectedManifest("https://app.example.invalid/manifest.json", {
+        timeoutMs: 2000,
+        resolveHost: async () => {
+          resolutions += 1
+          return resolutions === 1 ? ["203.0.113.10"] : ["10.0.0.7"]
+        },
+      }),
+    ).rejects.toThrow(/private or reserved/)
+    expect(resolutions).toBeGreaterThanOrEqual(2)
+  })
 })

--- a/packages/apps/src/ingestion.ts
+++ b/packages/apps/src/ingestion.ts
@@ -1,5 +1,6 @@
 import { lookup } from "node:dns/promises"
-import { isIP } from "node:net"
+import { request as httpsRequest } from "node:https"
+import { isIP, type LookupFunction } from "node:net"
 
 export interface ManifestFetchOptions {
   fetch?: typeof fetch
@@ -20,13 +21,15 @@ export interface FetchedManifest {
 const DEFAULT_MAX_BYTES = 256 * 1024
 const DEFAULT_MAX_REDIRECTS = 3
 const DEFAULT_TIMEOUT_MS = 5000
+/** Hard transport-level body cap; the caller enforces the tighter manifest cap. */
+const TRANSPORT_MAX_BODY_BYTES = 1024 * 1024
 const DEFAULT_CONTENT_TYPES = ["application/json", "application/manifest+json"] as const
 
 export async function fetchProtectedManifest(
   inputUrl: string,
   options: ManifestFetchOptions = {},
 ): Promise<FetchedManifest> {
-  const fetcher = options.fetch ?? fetch
+  const fetcher = options.fetch ?? createPinnedFetch(options.resolveHost)
   const maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES
   const maxRedirects = options.maxRedirects ?? DEFAULT_MAX_REDIRECTS
   const allowedContentTypes = options.allowedContentTypes ?? DEFAULT_CONTENT_TYPES
@@ -136,6 +139,95 @@ async function assertPublicHostname(
 async function defaultResolveHost(hostname: string): Promise<string[]> {
   const result = await lookup(hostname, { all: true, verbatim: true })
   return result.map((entry: { address: string }) => entry.address)
+}
+
+/**
+ * A fetch-compatible transport whose socket connects only to addresses that
+ * were validated inside the same DNS resolution. `assertPublicHostname` alone
+ * is a time-of-check/time-of-use guard: a publisher-controlled name can
+ * rebind between the check and the connect. Pinning validation into the
+ * connection `lookup` closes that window.
+ */
+function createPinnedFetch(resolveHost: ManifestFetchOptions["resolveHost"]): typeof fetch {
+  const pinnedLookup: LookupFunction = (hostname, lookupOptions, callback) => {
+    const resolve = async () => {
+      const addresses = resolveHost
+        ? (await resolveHost(hostname)).map((address) => ({
+            address,
+            family: isIP(address) === 6 ? 6 : 4,
+          }))
+        : await lookup(hostname, { all: true, verbatim: true })
+      if (addresses.length === 0) {
+        throw new Error("Manifest URL host did not resolve.")
+      }
+      for (const entry of addresses) {
+        if (isPrivateAddress(entry.address)) {
+          throw new Error("Manifest URL resolved to a private or reserved address.")
+        }
+      }
+      return addresses
+    }
+    resolve().then(
+      (addresses) => {
+        if (lookupOptions.all) {
+          callback(null, addresses)
+          return
+        }
+        const first = addresses[0] as { address: string; family: number }
+        callback(null, first.address, first.family)
+      },
+      (error) => callback(error as NodeJS.ErrnoException, "", 4),
+    )
+  }
+
+  return (input, init) =>
+    new Promise<Response>((resolvePromise, rejectPromise) => {
+      const url = new URL(
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+      )
+      const headers: Record<string, string> = {}
+      if (init?.headers && !Array.isArray(init.headers) && !(init.headers instanceof Headers)) {
+        Object.assign(headers, init.headers)
+      }
+      const request = httpsRequest(
+        {
+          host: url.hostname,
+          port: url.port === "" ? 443 : Number(url.port),
+          path: `${url.pathname}${url.search}`,
+          method: init?.method ?? "GET",
+          headers,
+          signal: init?.signal ?? undefined,
+          lookup: pinnedLookup,
+        },
+        (incoming) => {
+          const status = incoming.statusCode ?? 0
+          const responseHeaders = new Headers()
+          for (const [name, value] of Object.entries(incoming.headers)) {
+            if (typeof value === "string") responseHeaders.set(name, value)
+            else if (Array.isArray(value)) responseHeaders.set(name, value.join(", "))
+          }
+          const chunks: Buffer[] = []
+          let received = 0
+          incoming.on("data", (chunk: Buffer) => {
+            received += chunk.byteLength
+            if (received > TRANSPORT_MAX_BODY_BYTES) {
+              incoming.destroy()
+              rejectPromise(new Error("Manifest response exceeded the maximum allowed size."))
+              return
+            }
+            chunks.push(chunk)
+          })
+          incoming.on("end", () => {
+            const body =
+              status === 204 || status === 304 ? null : new Uint8Array(Buffer.concat(chunks))
+            resolvePromise(new Response(body, { status, headers: responseHeaders }))
+          })
+          incoming.on("error", rejectPromise)
+        },
+      )
+      request.on("error", rejectPromise)
+      request.end()
+    })
 }
 
 function isRedirect(status: number): boolean {

--- a/packages/apps/src/service.test.ts
+++ b/packages/apps/src/service.test.ts
@@ -143,6 +143,36 @@ describe("apps service", () => {
     expect(Object.keys(service)).not.toContain("updateRelease")
   })
 
+  it("rejects reusing a release version with different content", async () => {
+    const { db, rows } = createRegistryDb()
+    const service = createAppsService()
+    const app = await service.createCustomApp(db, {
+      ownerId: "owner_1",
+      displayName: "Acme Sync",
+      slug: "acme-sync",
+      redirectUris: [],
+      createdBy: "user_1",
+    })
+
+    await service.releaseFromUpload(db, app.id, {
+      manifest: validManifest,
+      createdBy: "user_1",
+      provenance: { source: "test" },
+    })
+
+    await expect(
+      service.releaseFromUpload(db, app.id, {
+        manifest: {
+          ...validManifest,
+          scopes: { requested: ["bookings:read", "invoices:read"], optional: [] },
+        },
+        createdBy: "user_1",
+        provenance: { source: "test" },
+      }),
+    ).rejects.toMatchObject({ status: 409 })
+    expect(rows.releases).toHaveLength(1)
+  })
+
   it("fetch ingestion stores only the validated snapshot", async () => {
     const { db, rows } = createRegistryDb()
     const fetcher = vi.fn(

--- a/packages/apps/src/service.ts
+++ b/packages/apps/src/service.ts
@@ -142,6 +142,18 @@ async function createRelease(
     if (!existingApp) {
       throw new ApiHttpError("App registration not found", { status: 404, code: "app_not_found" })
     }
+    const releaseVersion = input.compiled.manifest.releaseVersion
+    const versionRow = await selectReleaseByVersion(tx, appId, releaseVersion)
+    if (
+      versionRow &&
+      versionRow.releaseVersion === releaseVersion &&
+      versionRow.manifestDigest !== input.compiled.digest
+    ) {
+      throw new ApiHttpError(
+        `Release version ${releaseVersion} already exists with different content; releases are immutable, publish a new version instead`,
+        { status: 409, code: "app_release_version_conflict" },
+      )
+    }
     const manifestSnapshot = JSON.parse(input.compiled.canonicalJson) as Record<string, unknown>
     const normalizedRecord: Record<string, unknown> = JSON.parse(
       JSON.stringify(input.compiled.normalizedRelease),
@@ -199,6 +211,15 @@ async function createRelease(
 
 async function selectAppForUpdate(db: PostgresJsDatabase, appId: string) {
   const [row] = await db.select().from(apps).where(eq(apps.id, appId)).for("update").limit(1)
+  return row ?? null
+}
+
+async function selectReleaseByVersion(db: PostgresJsDatabase, appId: string, version: string) {
+  const [row] = await db
+    .select()
+    .from(appReleases)
+    .where(and(eq(appReleases.appId, appId), eq(appReleases.releaseVersion, version)))
+    .limit(1)
   return row ?? null
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3452 carrying the two review fixes that were intended for that PR but did not land before merge (the original fix commit was rejected by the pre-commit quality gate for a double type assertion, and the failure went unnoticed before the merge).

- **DNS rebinding (P1):** the default protected-manifest transport now validates resolved addresses inside the connection `lookup`, so the socket can only connect to addresses vetted in the same resolution; `assertPublicHostname` remains as a pre-check. The transport buffers responses with a hard 1 MB cap (the caller enforces the tighter manifest cap). Regression test simulates a rebind (public on pre-check, private at connect) and asserts rejection.
- **Release version conflicts (P2):** `createRelease` pre-checks `(appId, releaseVersion)` inside the same transaction (serialized by the app-row `FOR UPDATE` lock) and returns an explicit 409 `app_release_version_conflict` when the digest differs; the same-digest path stays idempotent. Test added.

## Verification

- `@voyant-travel/apps` tests 10/10; `turbo run typecheck` green; agent-quality checker clean on changed files.
- No changeset added: `@voyant-travel/apps` is unreleased and its pending changeset from #3452 covers this follow-up.
