### PR TITLE
commerce: issue proformas from checkout in proforma-first mode

### DIFF
--- a/.changeset/checkout-proforma-mode.md
+++ b/.changeset/checkout-proforma-mode.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/commerce": minor
+"@voyant-travel/finance": minor
+---
+
+Wire checkout finalization to the operator invoicing mode. When an operator runs `proforma-first`, a fresh checkout now issues a proforma instead of a fiscal invoice; the fiscal invoice is minted later once the proforma settles. `direct` mode is unchanged, an explicitly requested proforma conversion always wins over the mode default, and deployments without an operator-settings runtime fall back to `direct`.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -129,6 +129,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -130,6 +130,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -176,6 +176,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -183,6 +183,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/commerce/src/checkout/finalize.test.ts
+++ b/packages/commerce/src/checkout/finalize.test.ts
@@ -3,6 +3,7 @@ import { runCheckoutFinalize } from "@voyant-travel/catalog/booking-engine"
 import {
   financeService,
   issueInvoiceFromBooking,
+  issueProformaFromBooking,
   settleCoveredBookingPaymentSchedules,
 } from "@voyant-travel/finance"
 import { beginWorkflowRun } from "@voyant-travel/workflow-runs"
@@ -14,6 +15,7 @@ const mocks = vi.hoisted(() => ({
   confirmBooking: vi.fn(),
   recoverExpiredPaidBooking: vi.fn(),
   issueInvoiceFromBooking: vi.fn(),
+  issueProformaFromBooking: vi.fn(),
   convertProformaToInvoice: vi.fn(),
   createPayment: vi.fn(),
   settleCoveredBookingPaymentSchedules: vi.fn(),
@@ -35,6 +37,7 @@ vi.mock("@voyant-travel/catalog/booking-engine", () => ({
 vi.mock("@voyant-travel/finance", () => ({
   convertProformaToInvoice: mocks.convertProformaToInvoice,
   issueInvoiceFromBooking: mocks.issueInvoiceFromBooking,
+  issueProformaFromBooking: mocks.issueProformaFromBooking,
   settleCoveredBookingPaymentSchedules: mocks.settleCoveredBookingPaymentSchedules,
   financeService: {
     createPayment: mocks.createPayment,
@@ -50,6 +53,7 @@ describe("dispatchCheckoutFinalize", () => {
     vi.clearAllMocks()
     mocks.confirmBooking.mockResolvedValue({ status: "ok" })
     mocks.issueInvoiceFromBooking.mockResolvedValue({ id: "inv_final" })
+    mocks.issueProformaFromBooking.mockResolvedValue({ id: "pro_final" })
     mocks.createPayment.mockResolvedValue({ id: "pay_card" })
     mocks.settleCoveredBookingPaymentSchedules.mockResolvedValue([])
     mocks.beginWorkflowRun.mockResolvedValue(createRecorder())
@@ -148,6 +152,86 @@ describe("dispatchCheckoutFinalize", () => {
         correlationId: "ps_card",
       }),
     )
+  })
+
+  describe("invoicing mode", () => {
+    async function runFinalize(
+      resolveInvoicingMode?: (db: unknown) => Promise<"direct" | "proforma-first">,
+    ) {
+      const db = createCheckoutFinalizeDb()
+      await dispatchCheckoutFinalize({
+        db: db as never,
+        eventBus: { emit: vi.fn() } as never,
+        input: { bookingId: "book_card", paymentSessionId: "ps_card", paymentIntent: "card" },
+        trigger: "payment.completed",
+        correlationId: "ps_card",
+        tags: [],
+        resolveInvoicingMode,
+      })
+      return db
+    }
+
+    it("issues a proforma when the operator runs proforma-first", async () => {
+      await runFinalize(async () => "proforma-first")
+
+      expect(issueProformaFromBooking).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ bookingId: "book_card", invoiceType: "proforma" }),
+        expect.any(Object),
+        expect.any(Object),
+      )
+      expect(issueInvoiceFromBooking).not.toHaveBeenCalled()
+    })
+
+    it("issues a fiscal invoice in direct mode (unchanged)", async () => {
+      await runFinalize(async () => "direct")
+
+      expect(issueInvoiceFromBooking).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ bookingId: "book_card", invoiceType: "invoice" }),
+        expect.any(Object),
+        expect.any(Object),
+      )
+      expect(issueProformaFromBooking).not.toHaveBeenCalled()
+    })
+
+    it("falls back to direct when no invoicing-mode resolver is wired", async () => {
+      await runFinalize(undefined)
+
+      expect(issueInvoiceFromBooking).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ invoiceType: "invoice" }),
+        expect.any(Object),
+        expect.any(Object),
+      )
+      expect(issueProformaFromBooking).not.toHaveBeenCalled()
+    })
+
+    it("converts an existing proforma regardless of the operator mode", async () => {
+      // A bank-transfer checkout already minted a proforma; the finalize
+      // step then converts it to a fiscal invoice. That conversion path
+      // must win over the mode default — proforma-first never re-issues a
+      // second proforma on top of the one being settled.
+      mocks.runCheckoutFinalize.mockImplementationOnce(async (input, deps) => {
+        await deps.confirmBooking(input.bookingId)
+        await deps.issueInvoice({ bookingId: input.bookingId, convertedFromInvoiceId: "pro_1" })
+      })
+      mocks.convertProformaToInvoice.mockResolvedValue({
+        status: "ok",
+        invoice: { id: "inv_from_pro" },
+      })
+
+      await runFinalize(async () => "proforma-first")
+
+      expect(mocks.convertProformaToInvoice).toHaveBeenCalledWith(
+        expect.anything(),
+        "pro_1",
+        {},
+        expect.any(Object),
+      )
+      expect(issueProformaFromBooking).not.toHaveBeenCalled()
+      expect(issueInvoiceFromBooking).not.toHaveBeenCalled()
+    })
   })
 })
 

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -11,7 +11,9 @@ import {
 import type { EventBus } from "@voyant-travel/core"
 import {
   convertProformaToInvoice,
+  type InvoicingMode,
   issueInvoiceFromBooking,
+  issueProformaFromBooking,
   settleCoveredBookingPaymentSchedules,
 } from "@voyant-travel/finance"
 import { beginWorkflowRun, type WorkflowRunRecorder } from "@voyant-travel/workflow-runs"
@@ -32,11 +34,23 @@ export type CatalogCheckoutContractPdfGenerator = (input: {
   force?: boolean
 }) => Promise<{ contractId: string; attachmentId: string } | null>
 
+/**
+ * Resolves the operator invoicing mode for the finalize saga. Injected
+ * from the deployment (via the finance operator-settings port). When
+ * absent — no operator-settings runtime wired — the mode is treated as
+ * `direct`, keeping the historical behaviour of minting a fiscal invoice
+ * straight from checkout.
+ */
+export type CatalogCheckoutInvoicingModeResolver = (
+  db: PostgresJsDatabase,
+) => Promise<InvoicingMode>
+
 function buildCheckoutFinalizeDeps(
   db: PostgresJsDatabase,
   eventBus: EventBus,
   recorder: WorkflowRunRecorder,
   generateContractPdf?: CatalogCheckoutContractPdfGenerator,
+  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver,
 ): CheckoutFinalizeDeps {
   return {
     db,
@@ -94,13 +108,22 @@ function buildCheckoutFinalizeDeps(
       const today = new Date().toISOString().slice(0, 10)
       const dueDate = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
 
-      const invoice = await issueInvoiceFromBooking(
+      // In `proforma-first` mode a fresh checkout issues a proforma; the
+      // fiscal invoice is minted later, once the proforma is fully
+      // settled (the finance proforma-conversion subscriber does that).
+      // `direct` mode issues the fiscal invoice straight away — unchanged
+      // from before. When no resolver is wired the mode is `direct`.
+      const invoicingMode = resolveInvoicingMode ? await resolveInvoicingMode(db) : "direct"
+      const issueFromBooking =
+        invoicingMode === "proforma-first" ? issueProformaFromBooking : issueInvoiceFromBooking
+
+      const invoice = await issueFromBooking(
         db,
         {
           bookingId,
           issueDate: today,
           dueDate,
-          invoiceType: "invoice",
+          invoiceType: invoicingMode === "proforma-first" ? "proforma" : "invoice",
           convertedFromInvoiceId,
           notes: convertedFromInvoiceId
             ? `Converted from proforma ${convertedFromInvoiceId}`
@@ -223,6 +246,7 @@ export interface DispatchCheckoutFinalizeParams {
   resumeFromStep?: string
   seedResults?: Record<string, unknown>
   generateContractPdf?: CatalogCheckoutContractPdfGenerator
+  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver
 }
 
 function checkoutFinalizeInputRecord(input: CheckoutFinalizeInput): Record<string, unknown> {
@@ -289,6 +313,7 @@ export async function dispatchCheckoutFinalize(
     params.eventBus,
     recorder,
     params.generateContractPdf,
+    params.resolveInvoicingMode,
   )
   try {
     await runCheckoutFinalize(params.input, deps, {

--- a/packages/commerce/src/checkout/runner-runtime.ts
+++ b/packages/commerce/src/checkout/runner-runtime.ts
@@ -2,6 +2,7 @@ import type { EventBus } from "@voyant-travel/core"
 import type { WorkflowRunner } from "@voyant-travel/workflow-runs"
 import type {
   CatalogCheckoutContractPdfGenerator,
+  CatalogCheckoutInvoicingModeResolver,
   DispatchCheckoutFinalizeParams,
 } from "./finalize.js"
 import { dispatchCheckoutFinalize } from "./finalize.js"
@@ -17,6 +18,7 @@ export interface CheckoutFinalizeRunnerRegistrationOptions<TBindings = unknown>
   eventBus: EventBus
   registry: CheckoutFinalizeRunnerRegistry
   generateContractPdf?: CatalogCheckoutContractPdfGenerator
+  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver
   dispatchFinalize?: typeof dispatchCheckoutFinalize
 }
 
@@ -52,6 +54,7 @@ export function createCheckoutFinalizeWorkflowRunner<TBindings = unknown>(
           parentRunId: context.parentRunId,
           triggeredByUserId: context.triggeredByUserId,
           generateContractPdf: options.generateContractPdf,
+          resolveInvoicingMode: options.resolveInvoicingMode,
         }),
       )
     },
@@ -70,6 +73,7 @@ export function createCheckoutFinalizeWorkflowRunner<TBindings = unknown>(
           resumeFromStep: context.resumeFromStep,
           seedResults: context.seedResults,
           generateContractPdf: options.generateContractPdf,
+          resolveInvoicingMode: options.resolveInvoicingMode,
         }),
       )
     },

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -157,19 +157,24 @@ export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntim
 
 /** Selected-graph factory for inline payment finalization and dashboard runner registration. */
 export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFactory(
-  async ({ getPort }) => {
+  async ({ getPort, hasPort }) => {
     const [database, contractPdf, registry, operatorSettings] = await Promise.all([
       getPort(catalogCheckoutDatabaseRuntimePort),
       getPort(catalogCheckoutContractPdfRuntimePort),
       getPort(workflowRunnerRegistryRuntimePort),
-      getPort(commerceOperatorSettingsRuntimePort),
+      hasPort(commerceOperatorSettingsRuntimePort)
+        ? getPort(commerceOperatorSettingsRuntimePort)
+        : undefined,
     ])
     // The invoicing mode drives whether checkout mints a fiscal invoice
     // (`direct`) or a proforma (`proforma-first`). Read it off the same
     // operator-settings port that supplies the booking tax settings, so
-    // no new port is invented.
-    const resolveInvoicingMode: CatalogCheckoutInvoicingModeResolver = async (db) =>
-      (await operatorSettings.resolveBookingTaxSettings(db)).invoicingMode ?? "direct"
+    // no new port is invented. The port is optional: without it the
+    // finalize saga keeps the historical `direct` behaviour.
+    const resolveInvoicingMode: CatalogCheckoutInvoicingModeResolver | undefined = operatorSettings
+      ? async (db) =>
+          (await operatorSettings.resolveBookingTaxSettings(db)).invoicingMode ?? "direct"
+      : undefined
     return {
       id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
       eventType: "payment.completed",

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -3,11 +3,17 @@ import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { workflowRunnerRegistryRuntimePort } from "@voyant-travel/workflow-runs/runtime-port"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { commerceOperatorSettingsRuntimePort } from "../runtime-port.js"
+
 import {
   type AcceptanceSignatureLegalPort,
   persistAcceptanceSignature,
 } from "./acceptance-signature.js"
-import { type CatalogCheckoutContractPdfGenerator, dispatchCheckoutFinalize } from "./finalize.js"
+import {
+  type CatalogCheckoutContractPdfGenerator,
+  type CatalogCheckoutInvoicingModeResolver,
+  dispatchCheckoutFinalize,
+} from "./finalize.js"
 import { registerCheckoutFinalizeWorkflowRunner } from "./runner-runtime.js"
 import {
   type CatalogCheckoutDatabaseRuntime,
@@ -49,6 +55,7 @@ export interface AcceptanceSignatureSubscriberRuntimeOptions<TBindings = unknown
 export interface CheckoutFinalizeSubscriberRuntimeOptions<TBindings = unknown>
   extends CatalogCheckoutRuntimeDatabase<TBindings> {
   generateContractPdf?: CatalogCheckoutContractPdfGenerator
+  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver
   dispatchFinalize?: typeof dispatchCheckoutFinalize
 }
 
@@ -126,6 +133,7 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
                   ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
                 ],
                 generateContractPdf: options.generateContractPdf,
+                resolveInvoicingMode: options.resolveInvoicingMode,
               }),
             )
           } catch {
@@ -150,11 +158,18 @@ export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntim
 /** Selected-graph factory for inline payment finalization and dashboard runner registration. */
 export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFactory(
   async ({ getPort }) => {
-    const [database, contractPdf, registry] = await Promise.all([
+    const [database, contractPdf, registry, operatorSettings] = await Promise.all([
       getPort(catalogCheckoutDatabaseRuntimePort),
       getPort(catalogCheckoutContractPdfRuntimePort),
       getPort(workflowRunnerRegistryRuntimePort),
+      getPort(commerceOperatorSettingsRuntimePort),
     ])
+    // The invoicing mode drives whether checkout mints a fiscal invoice
+    // (`direct`) or a proforma (`proforma-first`). Read it off the same
+    // operator-settings port that supplies the booking tax settings, so
+    // no new port is invented.
+    const resolveInvoicingMode: CatalogCheckoutInvoicingModeResolver = async (db) =>
+      (await operatorSettings.resolveBookingTaxSettings(db)).invoicingMode ?? "direct"
     return {
       id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
       eventType: "payment.completed",
@@ -164,6 +179,7 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
         const descriptor = createCheckoutFinalizeSubscriberRuntime({
           ...database,
           generateContractPdf,
+          resolveInvoicingMode,
         })
         await descriptor.register(context)
         registerCheckoutFinalizeWorkflowRunner({
@@ -172,6 +188,7 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
           eventBus: context.eventBus,
           ...database,
           generateContractPdf,
+          resolveInvoicingMode,
         })
       },
     }

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -478,6 +478,7 @@ export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
     requirePort(catalogCheckoutDatabaseRuntimePort),
     requirePort(catalogCheckoutLegalRuntimePort),
     requirePort(catalogCheckoutContractPdfRuntimePort),
+    requirePort(commerceOperatorSettingsRuntimePort),
     requirePort(workflowRunnerRegistryRuntimePort),
   ],
   api: [

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -478,7 +478,7 @@ export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
     requirePort(catalogCheckoutDatabaseRuntimePort),
     requirePort(catalogCheckoutLegalRuntimePort),
     requirePort(catalogCheckoutContractPdfRuntimePort),
-    requirePort(commerceOperatorSettingsRuntimePort),
+    requirePort(commerceOperatorSettingsRuntimePort, { optional: true }),
     requirePort(workflowRunnerRegistryRuntimePort),
   ],
   api: [

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -209,6 +209,7 @@ describe("commerce deployment manifest", () => {
         { id: catalogCheckoutDatabaseRuntimePort.id },
         { id: catalogCheckoutLegalRuntimePort.id },
         { id: catalogCheckoutContractPdfRuntimePort.id },
+        { id: commerceOperatorSettingsRuntimePort.id },
         { id: workflowRunnerRegistryRuntimePort.id },
       ],
       api: [

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -209,7 +209,7 @@ describe("commerce deployment manifest", () => {
         { id: catalogCheckoutDatabaseRuntimePort.id },
         { id: catalogCheckoutLegalRuntimePort.id },
         { id: catalogCheckoutContractPdfRuntimePort.id },
-        { id: commerceOperatorSettingsRuntimePort.id },
+        { id: commerceOperatorSettingsRuntimePort.id, optional: true },
         { id: workflowRunnerRegistryRuntimePort.id },
       ],
       api: [

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -176,6 +176,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -176,6 +176,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -182,6 +182,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -243,6 +243,7 @@ export {
   createBookingTaxApiExtension,
   createBookingTaxRoutes,
   createBookingTaxVoyantRuntime,
+  type InvoicingMode,
   loadProductTaxFacts,
   matchesTaxPolicyCondition,
   mountBookingTaxRoutes,

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -176,6 +176,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -182,6 +182,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -176,6 +176,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -182,6 +182,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -175,6 +175,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -176,6 +176,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -177,6 +177,7 @@
       "@voyant-travel/apps/compiler": ["../apps/dist/compiler.d.ts"],
       "@voyant-travel/apps/contracts": ["../apps/dist/contracts.d.ts"],
       "@voyant-travel/apps/ingestion": ["../apps/dist/ingestion.d.ts"],
+      "@voyant-travel/apps/installation-service": ["../apps/dist/installation-service.d.ts"],
       "@voyant-travel/apps/routes": ["../apps/dist/routes.d.ts"],
       "@voyant-travel/apps/schema": ["../apps/dist/schema.d.ts"],
       "@voyant-travel/apps/service": ["../apps/dist/service.d.ts"],


### PR DESCRIPTION
Completes the checkout half of #3434.

The checkout finalize saga now consults the operator invoicing mode (via the existing commerce operator-settings port — no new port): `proforma-first` issues a proforma at checkout, and the fiscal invoice is minted later by the finance proforma-conversion subscriber once the proforma settles. `direct` mode is unchanged. When the finalize step is converting an existing proforma (bank-transfer flow), that conversion always wins over the mode default — no second proforma is issued on top of the one being settled. Deployments without an operator-settings runtime fall back to `direct`.

The `InvoicingMode` type is re-exported from the finance package root (existing module, no new subpath).

Tests cover: proforma-first issues a proforma, direct unchanged, absent resolver falls back to direct, conversion path precedence.