### PR TITLE
chore: patch-bump payments to republish a consumable tarball

### DIFF
--- a/.changeset/payments-republish.md
+++ b/.changeset/payments-republish.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/payments": patch
+---
+
+Republish with resolved dependency ranges. The 0.2.0 tarball on npm carries a
+raw `workspace:^` specifier for `@voyant-travel/core` and cannot be installed
+by consumers.


### PR DESCRIPTION
The manually published `@voyant-travel/payments@0.2.0` tarball carries a raw `workspace:^` specifier for `@voyant-travel/core` (it was published without the workspace-protocol rewrite), so every consumer install of `finance@0.166.0` fails with `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`. This patch changeset makes the release train publish a corrected 0.2.1 — finance pins `^0.2.0`, so resolution heals without touching finance. 0.2.0 should be deprecated on npm afterwards.