### PR TITLE
finance: scope invoicing mode to bank-transfer payments

### DIFF
--- a/.changeset/scope-invoicing-mode-bank-transfer.md
+++ b/.changeset/scope-invoicing-mode-bank-transfer.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/commerce": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/operator-settings": minor
+---
+
+Scope the operator invoicing mode to the deferred bank-transfer payment path.
+
+Payment method now determines the document flow. Card payments always issue the fiscal invoice at checkout finalize and never consult `invoicing.mode`. Bank transfer (deferred payment) is the configurable path: `proforma-first` (now the default, matching the platform's historical behaviour) issues a proforma at order placement and mints the fiscal invoice on settlement; `direct` issues the fiscal invoice at order placement and collects the transfer against it.
+
+The mode consult that PR #3462 added to the checkout finalize saga is removed — finalize once again always issues the fiscal invoice (or converts an existing proforma). The mode is instead wired at the bank-transfer issuance site, and its default flips from `direct` to `proforma-first` (schema default, normalization, and an additive migration that also backfills existing rows). The finance proforma-conversion subscriber no longer gates on the mode: any fully-paid proforma converts, which is correct in every mode and avoids stranding a proforma left outstanding across a mode switch.

--- a/packages/commerce/src/checkout/finalize.test.ts
+++ b/packages/commerce/src/checkout/finalize.test.ts
@@ -154,10 +154,8 @@ describe("dispatchCheckoutFinalize", () => {
     )
   })
 
-  describe("invoicing mode", () => {
-    async function runFinalize(
-      resolveInvoicingMode?: (db: unknown) => Promise<"direct" | "proforma-first">,
-    ) {
+  describe("invoice issuance", () => {
+    async function runFinalize() {
       const db = createCheckoutFinalizeDb()
       await dispatchCheckoutFinalize({
         db: db as never,
@@ -166,25 +164,15 @@ describe("dispatchCheckoutFinalize", () => {
         trigger: "payment.completed",
         correlationId: "ps_card",
         tags: [],
-        resolveInvoicingMode,
       })
       return db
     }
 
-    it("issues a proforma when the operator runs proforma-first", async () => {
-      await runFinalize(async () => "proforma-first")
-
-      expect(issueProformaFromBooking).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ bookingId: "book_card", invoiceType: "proforma" }),
-        expect.any(Object),
-        expect.any(Object),
-      )
-      expect(issueInvoiceFromBooking).not.toHaveBeenCalled()
-    })
-
-    it("issues a fiscal invoice in direct mode (unchanged)", async () => {
-      await runFinalize(async () => "direct")
+    it("always issues the fiscal invoice at finalize (payment has settled)", async () => {
+      // Finalize runs on payment.completed. The document flow is decided
+      // earlier, at order placement, and only for the deferred bank-transfer
+      // path — never here. A fresh finalize always mints the fiscal invoice.
+      await runFinalize()
 
       expect(issueInvoiceFromBooking).toHaveBeenCalledWith(
         expect.anything(),
@@ -195,23 +183,10 @@ describe("dispatchCheckoutFinalize", () => {
       expect(issueProformaFromBooking).not.toHaveBeenCalled()
     })
 
-    it("falls back to direct when no invoicing-mode resolver is wired", async () => {
-      await runFinalize(undefined)
-
-      expect(issueInvoiceFromBooking).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({ invoiceType: "invoice" }),
-        expect.any(Object),
-        expect.any(Object),
-      )
-      expect(issueProformaFromBooking).not.toHaveBeenCalled()
-    })
-
-    it("converts an existing proforma regardless of the operator mode", async () => {
-      // A bank-transfer checkout already minted a proforma; the finalize
-      // step then converts it to a fiscal invoice. That conversion path
-      // must win over the mode default — proforma-first never re-issues a
-      // second proforma on top of the one being settled.
+    it("converts an existing proforma instead of issuing a fresh invoice", async () => {
+      // A bank-transfer checkout in proforma-first mode already minted a
+      // proforma; the finalize step converts it to the fiscal invoice
+      // rather than issuing a new document.
       mocks.runCheckoutFinalize.mockImplementationOnce(async (input, deps) => {
         await deps.confirmBooking(input.bookingId)
         await deps.issueInvoice({ bookingId: input.bookingId, convertedFromInvoiceId: "pro_1" })
@@ -221,7 +196,7 @@ describe("dispatchCheckoutFinalize", () => {
         invoice: { id: "inv_from_pro" },
       })
 
-      await runFinalize(async () => "proforma-first")
+      await runFinalize()
 
       expect(mocks.convertProformaToInvoice).toHaveBeenCalledWith(
         expect.anything(),

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -11,9 +11,7 @@ import {
 import type { EventBus } from "@voyant-travel/core"
 import {
   convertProformaToInvoice,
-  type InvoicingMode,
   issueInvoiceFromBooking,
-  issueProformaFromBooking,
   settleCoveredBookingPaymentSchedules,
 } from "@voyant-travel/finance"
 import { beginWorkflowRun, type WorkflowRunRecorder } from "@voyant-travel/workflow-runs"
@@ -34,23 +32,11 @@ export type CatalogCheckoutContractPdfGenerator = (input: {
   force?: boolean
 }) => Promise<{ contractId: string; attachmentId: string } | null>
 
-/**
- * Resolves the operator invoicing mode for the finalize saga. Injected
- * from the deployment (via the finance operator-settings port). When
- * absent — no operator-settings runtime wired — the mode is treated as
- * `direct`, keeping the historical behaviour of minting a fiscal invoice
- * straight from checkout.
- */
-export type CatalogCheckoutInvoicingModeResolver = (
-  db: PostgresJsDatabase,
-) => Promise<InvoicingMode>
-
 function buildCheckoutFinalizeDeps(
   db: PostgresJsDatabase,
   eventBus: EventBus,
   recorder: WorkflowRunRecorder,
   generateContractPdf?: CatalogCheckoutContractPdfGenerator,
-  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver,
 ): CheckoutFinalizeDeps {
   return {
     db,
@@ -108,22 +94,20 @@ function buildCheckoutFinalizeDeps(
       const today = new Date().toISOString().slice(0, 10)
       const dueDate = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
 
-      // In `proforma-first` mode a fresh checkout issues a proforma; the
-      // fiscal invoice is minted later, once the proforma is fully
-      // settled (the finance proforma-conversion subscriber does that).
-      // `direct` mode issues the fiscal invoice straight away — unchanged
-      // from before. When no resolver is wired the mode is `direct`.
-      const invoicingMode = resolveInvoicingMode ? await resolveInvoicingMode(db) : "direct"
-      const issueFromBooking =
-        invoicingMode === "proforma-first" ? issueProformaFromBooking : issueInvoiceFromBooking
-
-      const invoice = await issueFromBooking(
+      // Finalize runs on payment.completed, i.e. the money has settled.
+      // The fiscal invoice is always issued here. The document-flow choice
+      // (proforma-first vs direct) is made earlier, at order placement, and
+      // is scoped to the deferred bank-transfer path — never card. When a
+      // proforma was issued at placement it is converted above via
+      // `convertProformaToInvoice`; this branch only runs for the direct
+      // path, where no proforma exists.
+      const invoice = await issueInvoiceFromBooking(
         db,
         {
           bookingId,
           issueDate: today,
           dueDate,
-          invoiceType: invoicingMode === "proforma-first" ? "proforma" : "invoice",
+          invoiceType: "invoice",
           convertedFromInvoiceId,
           notes: convertedFromInvoiceId
             ? `Converted from proforma ${convertedFromInvoiceId}`
@@ -246,7 +230,6 @@ export interface DispatchCheckoutFinalizeParams {
   resumeFromStep?: string
   seedResults?: Record<string, unknown>
   generateContractPdf?: CatalogCheckoutContractPdfGenerator
-  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver
 }
 
 function checkoutFinalizeInputRecord(input: CheckoutFinalizeInput): Record<string, unknown> {
@@ -313,7 +296,6 @@ export async function dispatchCheckoutFinalize(
     params.eventBus,
     recorder,
     params.generateContractPdf,
-    params.resolveInvoicingMode,
   )
   try {
     await runCheckoutFinalize(params.input, deps, {

--- a/packages/commerce/src/checkout/runner-runtime.ts
+++ b/packages/commerce/src/checkout/runner-runtime.ts
@@ -2,7 +2,6 @@ import type { EventBus } from "@voyant-travel/core"
 import type { WorkflowRunner } from "@voyant-travel/workflow-runs"
 import type {
   CatalogCheckoutContractPdfGenerator,
-  CatalogCheckoutInvoicingModeResolver,
   DispatchCheckoutFinalizeParams,
 } from "./finalize.js"
 import { dispatchCheckoutFinalize } from "./finalize.js"
@@ -18,7 +17,6 @@ export interface CheckoutFinalizeRunnerRegistrationOptions<TBindings = unknown>
   eventBus: EventBus
   registry: CheckoutFinalizeRunnerRegistry
   generateContractPdf?: CatalogCheckoutContractPdfGenerator
-  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver
   dispatchFinalize?: typeof dispatchCheckoutFinalize
 }
 
@@ -54,7 +52,6 @@ export function createCheckoutFinalizeWorkflowRunner<TBindings = unknown>(
           parentRunId: context.parentRunId,
           triggeredByUserId: context.triggeredByUserId,
           generateContractPdf: options.generateContractPdf,
-          resolveInvoicingMode: options.resolveInvoicingMode,
         }),
       )
     },
@@ -73,7 +70,6 @@ export function createCheckoutFinalizeWorkflowRunner<TBindings = unknown>(
           resumeFromStep: context.resumeFromStep,
           seedResults: context.seedResults,
           generateContractPdf: options.generateContractPdf,
-          resolveInvoicingMode: options.resolveInvoicingMode,
         }),
       )
     },

--- a/packages/commerce/src/checkout/start-service.test.ts
+++ b/packages/commerce/src/checkout/start-service.test.ts
@@ -13,7 +13,12 @@ function stubOptions(overrides: Partial<CheckoutStartOptions> = {}): CheckoutSta
       resolvePipeline: vi.fn().mockResolvedValue(null),
       createInquiry: vi.fn().mockResolvedValue(null),
     },
-    resolveBookingTaxSettings: vi.fn(),
+    resolveBookingTaxSettings: vi.fn().mockResolvedValue({
+      taxPriceMode: "inclusive",
+      taxPolicyProfileId: null,
+      invoicingMode: "proforma-first",
+      fxReferenceSource: "ecb",
+    }),
     getOwnedProductName: vi.fn().mockResolvedValue(null),
     resolveBankTransferInstructions: vi
       .fn()
@@ -369,6 +374,142 @@ describe("startCatalogCheckout", () => {
       reference: "BOOK-BK-1001",
     })
   }, 10000)
+
+  describe("invoicing mode", () => {
+    function bankTransferDb(booking: Record<string, unknown>) {
+      const selectRows = [[booking], []]
+      const nextRows = () => selectRows.shift() ?? []
+      type AwaitableRows = Promise<unknown[]> & { limit: () => Promise<unknown[]> }
+      type SelectChain = { from: () => SelectChain; where: () => AwaitableRows }
+      const selectChain: SelectChain = {
+        from: () => selectChain,
+        where: () => {
+          const rows = nextRows()
+          const result = Promise.resolve(rows) as AwaitableRows
+          result.limit = async () => rows
+          return result
+        },
+      }
+      return {
+        select: () => selectChain,
+        insert: () => ({
+          values: () => ({
+            onConflictDoNothing: () => ({ returning: async () => [] }),
+            returning: async () => [],
+          }),
+        }),
+        update: () => ({ set: () => ({ where: async () => undefined }) }),
+      } as never
+    }
+
+    const booking = {
+      id: "bk_bank",
+      bookingNumber: "BK-1001",
+      status: "on_hold",
+      holdExpiresAt: null,
+      personId: null,
+      organizationId: null,
+      sellAmountCents: 100000,
+      sellCurrency: "EUR",
+      baseCurrency: null,
+      baseSellAmountCents: null,
+      startDate: "2026-09-01",
+    }
+
+    beforeEach(() => {
+      vi.spyOn(financeModule.financeService, "createPaymentSession").mockResolvedValue({
+        id: "ps_bank_transfer",
+      } as never)
+    })
+
+    it("issues a proforma in proforma-first mode (default)", async () => {
+      const seriesSpy = vi
+        .spyOn(financeModule.financeService, "resolveDefaultInvoiceNumberSeries")
+        .mockResolvedValue({ id: "series_proforma" } as never)
+      const proformaSpy = vi
+        .spyOn(financeModule, "issueProformaFromBooking")
+        .mockResolvedValue({ id: "inv_proforma", invoiceNumber: "PF-1001" } as never)
+      const invoiceSpy = vi.spyOn(financeModule, "issueInvoiceFromBooking")
+
+      await startCatalogCheckout(
+        { db: bankTransferDb(booking), env: {}, options: stubOptions() },
+        { bookingId: "bk_bank", paymentIntent: "bank_transfer" },
+      )
+
+      expect(seriesSpy).toHaveBeenCalledWith(expect.anything(), "proforma")
+      expect(proformaSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ bookingId: "bk_bank", invoiceType: "proforma" }),
+        expect.any(Object),
+        expect.any(Object),
+      )
+      expect(invoiceSpy).not.toHaveBeenCalled()
+    })
+
+    it("issues the fiscal invoice directly in direct mode", async () => {
+      const seriesSpy = vi
+        .spyOn(financeModule.financeService, "resolveDefaultInvoiceNumberSeries")
+        .mockResolvedValue({ id: "series_invoice" } as never)
+      const invoiceSpy = vi
+        .spyOn(financeModule, "issueInvoiceFromBooking")
+        .mockResolvedValue({ id: "inv_fiscal", invoiceNumber: "INV-2001" } as never)
+      const proformaSpy = vi.spyOn(financeModule, "issueProformaFromBooking")
+
+      const options = stubOptions({
+        resolveBookingTaxSettings: vi.fn().mockResolvedValue({
+          taxPriceMode: "inclusive",
+          taxPolicyProfileId: null,
+          invoicingMode: "direct",
+          fxReferenceSource: "ecb",
+        }),
+      })
+
+      const result = await startCatalogCheckout(
+        { db: bankTransferDb(booking), env: {}, options },
+        { bookingId: "bk_bank", paymentIntent: "bank_transfer" },
+      )
+
+      // Direct mode checks the `invoice` series, not the `proforma` one.
+      expect(seriesSpy).toHaveBeenCalledWith(expect.anything(), "invoice")
+      expect(invoiceSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ bookingId: "bk_bank", invoiceType: "invoice" }),
+        expect.any(Object),
+        expect.any(Object),
+      )
+      expect(proformaSpy).not.toHaveBeenCalled()
+      expect(result).toMatchObject({
+        kind: "bank_transfer_instructions",
+        proformaId: "inv_fiscal",
+        proformaNumber: "INV-2001",
+      })
+    })
+
+    it("rejects direct-mode bank transfer when no invoice series is active", async () => {
+      vi.spyOn(financeModule.financeService, "resolveDefaultInvoiceNumberSeries").mockResolvedValue(
+        null as never,
+      )
+      const options = stubOptions({
+        resolveBookingTaxSettings: vi.fn().mockResolvedValue({
+          taxPriceMode: "inclusive",
+          taxPolicyProfileId: null,
+          invoicingMode: "direct",
+          fxReferenceSource: "ecb",
+        }),
+      })
+
+      const err = await startCatalogCheckout(
+        { db: bankTransferDb(booking), env: {}, options },
+        { bookingId: "bk_bank", paymentIntent: "bank_transfer" },
+      ).catch((e: unknown) => e)
+
+      expect(err).toBeInstanceOf(CatalogCheckoutStartError)
+      expect(err).toMatchObject({
+        code: "bank_transfer_invoice_number_series_missing",
+        status: 422,
+      })
+    })
+  })
 })
 
 describe("createCatalogCheckoutRoutes", () => {

--- a/packages/commerce/src/checkout/start-service.ts
+++ b/packages/commerce/src/checkout/start-service.ts
@@ -9,6 +9,7 @@ import {
   computePaymentSchedule,
   financeService,
   InvoiceNumberAllocationError,
+  issueInvoiceFromBooking,
   issueProformaFromBooking,
   type PaymentPolicy,
   type PaymentPolicySource,
@@ -133,7 +134,7 @@ export async function startCatalogCheckout(
       {
         beforeMaterialize:
           body.paymentIntent === "bank_transfer"
-            ? () => ensureBankTransferProformaPrerequisites(db)
+            ? () => ensureBankTransferInvoicingPrerequisites(context)
             : undefined,
       },
     )
@@ -402,7 +403,7 @@ async function startBankTransferCheckout(
   body: CheckoutStartInput,
 ): Promise<CatalogCheckoutStartResult> {
   const db = context.db
-  await ensureBankTransferProformaPrerequisites(db)
+  await ensureBankTransferInvoicingPrerequisites(context)
   const paymentTerms = await snapshotAcceptedPaymentTerms(context, booking)
 
   await recordCheckoutActivity(db, booking.id, "Storefront bank-transfer checkout started", {
@@ -428,18 +429,29 @@ async function startBankTransferCheckout(
     })
   }
 
-  // Issue a proforma synchronously so the customer leaves with a
-  // document reference. SmartBill (subscribing to
-  // invoice.proforma.issued) will sync to its proforma endpoint.
+  // Bank transfer is the deferred-payment path: the customer leaves with a
+  // document reference and pays against it. Which document is issued here,
+  // at order placement, is the operator-configurable invoicing mode:
+  //   - `proforma-first` (default): issue a proforma; the fiscal invoice is
+  //     minted later, on settlement, by the finance proforma-conversion
+  //     subscriber. SmartBill (subscribing to invoice.proforma.issued) syncs
+  //     it to its proforma endpoint.
+  //   - `direct`: issue the fiscal invoice straight away and collect the
+  //     bank transfer against it; no later conversion happens.
+  // The mode is read off the same operator tax-settings the checkout
+  // already resolves — absent/null → proforma-first, the historical
+  // bank-transfer behaviour.
+  const taxSettings = await context.options.resolveBookingTaxSettings(db)
+  const issueDirectInvoice = taxSettings.invoicingMode === "direct"
   const issueDate = new Date().toISOString().slice(0, 10)
   const dueDate = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10)
   const eventBus = context.eventBus
 
-  const proformaInput: CreateInvoiceFromBookingInput = {
+  const documentInput: CreateInvoiceFromBookingInput = {
     bookingId: booking.id,
     issueDate,
     dueDate,
-    invoiceType: "proforma",
+    invoiceType: issueDirectInvoice ? "invoice" : "proforma",
     notes: null,
   }
 
@@ -451,11 +463,12 @@ async function startBankTransferCheckout(
     .from(bookingItems)
     .where(eq(bookingItems.bookingId, booking.id))
 
+  const issueDocument = issueDirectInvoice ? issueInvoiceFromBooking : issueProformaFromBooking
   let proforma: Awaited<ReturnType<typeof issueProformaFromBooking>>
   try {
-    proforma = await issueProformaFromBooking(
+    proforma = await issueDocument(
       db,
-      proformaInput,
+      documentInput,
       {
         booking: {
           id: booking.id,
@@ -479,8 +492,13 @@ async function startBankTransferCheckout(
       { eventBus },
     )
   } catch (err) {
-    if (err instanceof InvoiceNumberAllocationError && err.scope === "proforma") {
-      throw bankTransferProformaSeriesError()
+    if (err instanceof InvoiceNumberAllocationError) {
+      if (!issueDirectInvoice && err.scope === "proforma") {
+        throw bankTransferInvoiceSeriesError("proforma")
+      }
+      if (issueDirectInvoice && err.scope === "invoice") {
+        throw bankTransferInvoiceSeriesError("invoice")
+      }
     }
     throw err
   }
@@ -596,11 +614,23 @@ async function recordCheckoutActivity(
   })
 }
 
-async function ensureBankTransferProformaPrerequisites(db: PostgresJsDatabase): Promise<void> {
-  const series = await financeService.resolveDefaultInvoiceNumberSeries(db, "proforma")
-  if (!series) throw bankTransferProformaSeriesError()
+async function ensureBankTransferInvoicingPrerequisites(
+  context: CatalogCheckoutStartContext,
+): Promise<void> {
+  const db = context.db
+  // Direct mode issues the fiscal invoice at placement, so it needs an
+  // `invoice` series; proforma-first (default) needs the `proforma` series.
+  const settings = await context.options.resolveBookingTaxSettings(db)
+  const scope = settings.invoicingMode === "direct" ? "invoice" : "proforma"
+  const series = await financeService.resolveDefaultInvoiceNumberSeries(db, scope)
+  if (!series) throw bankTransferInvoiceSeriesError(scope)
 }
 
-function bankTransferProformaSeriesError(): CatalogCheckoutStartError {
-  return new CatalogCheckoutStartError("bank_transfer_proforma_number_series_missing", 422)
+function bankTransferInvoiceSeriesError(scope: "invoice" | "proforma"): CatalogCheckoutStartError {
+  return new CatalogCheckoutStartError(
+    scope === "invoice"
+      ? "bank_transfer_invoice_number_series_missing"
+      : "bank_transfer_proforma_number_series_missing",
+    422,
+  )
 }

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -3,17 +3,11 @@ import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { workflowRunnerRegistryRuntimePort } from "@voyant-travel/workflow-runs/runtime-port"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import { commerceOperatorSettingsRuntimePort } from "../runtime-port.js"
-
 import {
   type AcceptanceSignatureLegalPort,
   persistAcceptanceSignature,
 } from "./acceptance-signature.js"
-import {
-  type CatalogCheckoutContractPdfGenerator,
-  type CatalogCheckoutInvoicingModeResolver,
-  dispatchCheckoutFinalize,
-} from "./finalize.js"
+import { type CatalogCheckoutContractPdfGenerator, dispatchCheckoutFinalize } from "./finalize.js"
 import { registerCheckoutFinalizeWorkflowRunner } from "./runner-runtime.js"
 import {
   type CatalogCheckoutDatabaseRuntime,
@@ -55,7 +49,6 @@ export interface AcceptanceSignatureSubscriberRuntimeOptions<TBindings = unknown
 export interface CheckoutFinalizeSubscriberRuntimeOptions<TBindings = unknown>
   extends CatalogCheckoutRuntimeDatabase<TBindings> {
   generateContractPdf?: CatalogCheckoutContractPdfGenerator
-  resolveInvoicingMode?: CatalogCheckoutInvoicingModeResolver
   dispatchFinalize?: typeof dispatchCheckoutFinalize
 }
 
@@ -133,7 +126,6 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
                   ...(data.paymentIntent ? [`paymentIntent:${data.paymentIntent}`] : []),
                 ],
                 generateContractPdf: options.generateContractPdf,
-                resolveInvoicingMode: options.resolveInvoicingMode,
               }),
             )
           } catch {
@@ -157,24 +149,12 @@ export const createAcceptanceSignatureSubscriberGraphRuntime = defineGraphRuntim
 
 /** Selected-graph factory for inline payment finalization and dashboard runner registration. */
 export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFactory(
-  async ({ getPort, hasPort }) => {
-    const [database, contractPdf, registry, operatorSettings] = await Promise.all([
+  async ({ getPort }) => {
+    const [database, contractPdf, registry] = await Promise.all([
       getPort(catalogCheckoutDatabaseRuntimePort),
       getPort(catalogCheckoutContractPdfRuntimePort),
       getPort(workflowRunnerRegistryRuntimePort),
-      hasPort(commerceOperatorSettingsRuntimePort)
-        ? getPort(commerceOperatorSettingsRuntimePort)
-        : undefined,
     ])
-    // The invoicing mode drives whether checkout mints a fiscal invoice
-    // (`direct`) or a proforma (`proforma-first`). Read it off the same
-    // operator-settings port that supplies the booking tax settings, so
-    // no new port is invented. The port is optional: without it the
-    // finalize saga keeps the historical `direct` behaviour.
-    const resolveInvoicingMode: CatalogCheckoutInvoicingModeResolver | undefined = operatorSettings
-      ? async (db) =>
-          (await operatorSettings.resolveBookingTaxSettings(db)).invoicingMode ?? "direct"
-      : undefined
     return {
       id: COMMERCE_CHECKOUT_FINALIZE_SUBSCRIBER_ID,
       eventType: "payment.completed",
@@ -184,7 +164,6 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
         const descriptor = createCheckoutFinalizeSubscriberRuntime({
           ...database,
           generateContractPdf,
-          resolveInvoicingMode,
         })
         await descriptor.register(context)
         registerCheckoutFinalizeWorkflowRunner({
@@ -193,7 +172,6 @@ export const createCheckoutFinalizeSubscriberGraphRuntime = defineGraphRuntimeFa
           eventBus: context.eventBus,
           ...database,
           generateContractPdf,
-          resolveInvoicingMode,
         })
       },
     }

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -478,7 +478,6 @@ export const commerceCatalogCheckoutVoyantPlugin = defineExtension({
     requirePort(catalogCheckoutDatabaseRuntimePort),
     requirePort(catalogCheckoutLegalRuntimePort),
     requirePort(catalogCheckoutContractPdfRuntimePort),
-    requirePort(commerceOperatorSettingsRuntimePort, { optional: true }),
     requirePort(workflowRunnerRegistryRuntimePort),
   ],
   api: [

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -209,7 +209,6 @@ describe("commerce deployment manifest", () => {
         { id: catalogCheckoutDatabaseRuntimePort.id },
         { id: catalogCheckoutLegalRuntimePort.id },
         { id: catalogCheckoutContractPdfRuntimePort.id },
-        { id: commerceOperatorSettingsRuntimePort.id, optional: true },
         { id: workflowRunnerRegistryRuntimePort.id },
       ],
       api: [

--- a/packages/finance-react/src/components/invoicing-page.tsx
+++ b/packages/finance-react/src/components/invoicing-page.tsx
@@ -64,7 +64,7 @@ function InvoicingPageContent({ api }: { api: TaxesPageApi }) {
       void queryClient.invalidateQueries({ queryKey: ["booking-tax-settings"] })
     },
   })
-  const invoicingMode = settingsQuery.data?.data.invoicingMode ?? "direct"
+  const invoicingMode = settingsQuery.data?.data.invoicingMode ?? "proforma-first"
   const fxReferenceSource = settingsQuery.data?.data.fxReferenceSource ?? "ecb"
   // Both selects PATCH the same settings row (merge-on-read server side),
   // so while either write is in flight the other control must not fire a
@@ -104,16 +104,16 @@ function InvoicingPageContent({ api }: { api: TaxesPageApi }) {
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="direct">{invoicingMessages.invoicingModeDirect}</SelectItem>
               <SelectItem value="proforma-first">
                 {invoicingMessages.invoicingModeProformaFirst}
               </SelectItem>
+              <SelectItem value="direct">{invoicingMessages.invoicingModeDirect}</SelectItem>
             </SelectContent>
           </Select>
           <p className="mt-2 text-xs text-muted-foreground">
-            {invoicingMode === "proforma-first"
-              ? invoicingMessages.invoicingModeProformaFirstHint
-              : invoicingMessages.invoicingModeDirectHint}
+            {invoicingMode === "direct"
+              ? invoicingMessages.invoicingModeDirectHint
+              : invoicingMessages.invoicingModeProformaFirstHint}
           </p>
         </div>
       </div>

--- a/packages/finance-react/src/i18n/en/numberingAndPayments.ts
+++ b/packages/finance-react/src/i18n/en/numberingAndPayments.ts
@@ -353,14 +353,15 @@ export const taxesPage = {
 export const invoicingPage = {
   title: "Invoicing",
   description: "Control how invoices are issued and which official rates convert foreign currency.",
-  invoicingModeTitle: "Invoicing mode",
+  invoicingModeTitle: "Bank transfer invoicing",
   invoicingModeDescription:
-    "Choose how invoices are issued for new bookings. Existing invoices are unaffected.",
-  invoicingModeDirect: "Direct invoice",
-  invoicingModeDirectHint: "Issue the fiscal invoice straight from the booking.",
-  invoicingModeProformaFirst: "Proforma first",
+    "Choose which document is issued when a customer pays by bank transfer. Card payments always issue the fiscal invoice directly. Existing invoices are unaffected.",
+  invoicingModeProformaFirst: "Proforma first (recommended)",
   invoicingModeProformaFirstHint:
-    "Issue a proforma, then mint the fiscal invoice automatically once it is paid in full.",
+    "Issue a proforma when the order is placed, then mint the fiscal invoice automatically once the transfer is received in full.",
+  invoicingModeDirect: "Direct invoice",
+  invoicingModeDirectHint:
+    "Issue the fiscal invoice when the order is placed and collect the bank transfer against it. No proforma is issued.",
   fxReferenceSourceTitle: "Reference exchange rates",
   fxReferenceSourceDescription:
     "Official reference rate used when converting foreign-currency amounts on invoices.",

--- a/packages/finance-react/src/i18n/ro/numberingAndPayments.ts
+++ b/packages/finance-react/src/i18n/ro/numberingAndPayments.ts
@@ -357,14 +357,15 @@ export const invoicingPage = {
   title: "Facturare",
   description:
     "Controleaza cum se emit facturile si ce cursuri oficiale convertesc sumele in valuta.",
-  invoicingModeTitle: "Mod de facturare",
+  invoicingModeTitle: "Facturare prin transfer bancar",
   invoicingModeDescription:
-    "Alege cum se emit facturile pentru rezervarile noi. Facturile existente nu sunt afectate.",
-  invoicingModeDirect: "Factura directa",
-  invoicingModeDirectHint: "Emite factura fiscala direct din rezervare.",
-  invoicingModeProformaFirst: "Proforma mai intai",
+    "Alege ce document se emite cand clientul plateste prin transfer bancar. Platile cu cardul emit intotdeauna direct factura fiscala. Facturile existente nu sunt afectate.",
+  invoicingModeProformaFirst: "Proforma mai intai (recomandat)",
   invoicingModeProformaFirstHint:
-    "Emite o proforma, apoi genereaza automat factura fiscala dupa ce este achitata integral.",
+    "Emite o proforma la plasarea comenzii, apoi genereaza automat factura fiscala dupa ce transferul este incasat integral.",
+  invoicingModeDirect: "Factura directa",
+  invoicingModeDirectHint:
+    "Emite factura fiscala la plasarea comenzii si incaseaza transferul bancar pe baza ei. Nu se emite proforma.",
   fxReferenceSourceTitle: "Cursuri valutare de referinta",
   fxReferenceSourceDescription:
     "Cursul de referinta oficial folosit la conversia sumelor in valuta pe facturi.",

--- a/packages/finance-react/src/invoicing-page.test.tsx
+++ b/packages/finance-react/src/invoicing-page.test.tsx
@@ -15,7 +15,7 @@ import { InvoicingPage, type InvoicingPageApi } from "./components/invoicing-pag
 type Settings = { invoicingMode: "direct" | "proforma-first"; fxReferenceSource: "ecb" | "bnr" }
 
 function makeApi(
-  settings: Settings = { invoicingMode: "direct", fxReferenceSource: "ecb" },
+  settings: Settings = { invoicingMode: "proforma-first", fxReferenceSource: "ecb" },
   overrides: Partial<InvoicingPageApi> = {},
 ): InvoicingPageApi {
   return {
@@ -45,7 +45,7 @@ describe("InvoicingPage", () => {
       </QueryClientProvider>,
     )
 
-    expect(html).toContain("Invoicing mode")
+    expect(html).toContain("Bank transfer invoicing")
     // The reference-exchange-rate select lives here, not on the Taxes page.
     expect(html).toContain("Reference exchange rates")
     expect(html).toContain("Recommended for most EU operators")
@@ -88,7 +88,7 @@ describe("InvoicingPage", () => {
       expect(fxTrigger?.textContent).toContain("National Bank of Romania (BNR)")
     })
 
-    it("defaults both selects to direct/ecb when the settings row is empty", async () => {
+    it("renders the direct/ecb selection from the fetched settings row", async () => {
       const queryClient = await seededClient({ invoicingMode: "direct", fxReferenceSource: "ecb" })
 
       await act(async () => {

--- a/packages/finance/src/booking-tax.ts
+++ b/packages/finance/src/booking-tax.ts
@@ -37,9 +37,11 @@ export type BookingTaxSettings = {
   taxPriceMode?: "inclusive" | "exclusive" | null
   taxPolicyProfileId?: string | null
   /**
-   * Operator invoicing mode. `direct` bills the fiscal invoice
-   * straight away; `proforma-first` issues a proforma and converts it
-   * to a fiscal invoice on full settlement. Absent/null → `direct`.
+   * Operator invoicing mode for the deferred bank-transfer path.
+   * `proforma-first` issues a proforma at order placement and converts it
+   * to a fiscal invoice on full settlement; `direct` issues the fiscal
+   * invoice at order placement. Card payments always invoice directly and
+   * never consult this. Absent/null → `proforma-first`.
    */
   invoicingMode?: InvoicingMode | null
   /**
@@ -221,22 +223,9 @@ async function resolveBookingTaxSettingsOrDefault(
   return {
     taxPriceMode: settings?.taxPriceMode === "exclusive" ? "exclusive" : "inclusive",
     taxPolicyProfileId: settings?.taxPolicyProfileId ?? null,
-    invoicingMode: settings?.invoicingMode === "proforma-first" ? "proforma-first" : "direct",
+    invoicingMode: settings?.invoicingMode === "direct" ? "direct" : "proforma-first",
     fxReferenceSource: settings?.fxReferenceSource === "bnr" ? "bnr" : "ecb",
   }
-}
-
-/**
- * Resolve just the operator invoicing mode, defaulting to `direct`
- * when no settings row exists. Shared by the proforma-conversion
- * subscriber so it never converts unless the operator opted in.
- */
-export async function resolveInvoicingModeOrDefault(
-  db: PostgresJsDatabase,
-  options: ResolveBookingSellTaxRateOptions = {},
-): Promise<InvoicingMode> {
-  const settings = await resolveBookingTaxSettingsOrDefault(db, options)
-  return settings.invoicingMode
 }
 
 export function computeBookingItemTaxLine(

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -267,7 +267,6 @@ export {
   createBookingTaxApiExtension,
   createBookingTaxRoutes,
   createBookingTaxVoyantRuntime,
-  type InvoicingMode,
   loadProductTaxFacts,
   matchesTaxPolicyCondition,
   mountBookingTaxRoutes,

--- a/packages/finance/src/payment-schedule/routes.ts
+++ b/packages/finance/src/payment-schedule/routes.ts
@@ -536,11 +536,9 @@ export const createBookingScheduleVoyantRuntime = defineGraphRuntimeFactory(
             resolveRoutesOptions: () => provider.options,
             withDb: provider.withDb,
           })
-          // Same host/settings wiring powers the proforma-conversion
-          // subscriber: it reads the operator invoicing mode and, in
-          // proforma-first mode, mints the fiscal invoice on settlement.
+          // Same host wiring powers the proforma-conversion subscriber:
+          // when a fully-paid proforma settles it mints the fiscal invoice.
           container.register(PROFORMA_CONVERSION_SUBSCRIBER_RUNTIME_KEY, {
-            resolveInvoicingMode: operatorSettings.resolveInvoicingMode,
             withDb: provider.withDb,
             eventBus,
           })

--- a/packages/finance/src/proforma-conversion-runtime.ts
+++ b/packages/finance/src/proforma-conversion-runtime.ts
@@ -1,24 +1,29 @@
 import type { EventBus, ModuleContainer, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
-import type { InvoicingMode } from "./booking-tax.js"
 import { financeService } from "./service.js"
 import { convertProformaToInvoice } from "./service-issue.js"
 
 /**
  * Standard proforma → fiscal invoice conversion.
  *
- * When the operator runs `invoicing.mode: "proforma-first"`, a proforma
- * is issued at checkout and the fiscal invoice is minted once the
- * proforma is fully settled. This subscriber watches settlement signals
- * (`invoice.settled` from the settlement poller and
- * `invoice.payment.recorded` from manual/processed payments) and, in
- * proforma-first mode only, converts a fully-paid proforma to its fiscal
- * invoice via {@link convertProformaToInvoice} (which copies lines,
- * assigns the fiscal number, links both documents, and voids the
- * proforma). `direct` mode is a no-op — zero behaviour change for
- * existing deployments — and the conversion is idempotent (the service
- * guards against double-conversion under an advisory lock).
+ * A proforma is issued for deferred (bank-transfer) checkouts when the
+ * operator runs the `proforma-first` invoicing mode, or by the manual
+ * `POST /invoices/{id}/convert-to-invoice` flow. This subscriber watches
+ * settlement signals (`invoice.settled` from the settlement poller and
+ * `invoice.payment.recorded` from manual/processed payments) and converts
+ * a fully-paid proforma to its fiscal invoice via
+ * {@link convertProformaToInvoice} (which copies lines, assigns the fiscal
+ * number, links both documents, and voids the proforma).
+ *
+ * The conversion is not gated on the invoicing mode: any fully-paid
+ * proforma should mint its fiscal invoice, and the `invoiceType ===
+ * "proforma"` guard already scopes it to proformas. Gating on the current
+ * mode would strand a proforma that is still outstanding when an operator
+ * switches from `proforma-first` to `direct`. When no proforma exists
+ * (card checkouts, or bank transfer in `direct` mode) the subscriber
+ * simply never fires. The conversion is idempotent (the service guards
+ * against double-conversion under an advisory lock).
  */
 
 export const FINANCE_PROFORMA_CONVERSION_SUBSCRIBER_ID =
@@ -27,8 +32,6 @@ export const PROFORMA_CONVERSION_SUBSCRIBER_RUNTIME_KEY =
   "finance.proformaConversionSubscriberRuntime"
 
 export interface ProformaConversionSubscriberRuntime {
-  /** Operator invoicing mode; defaults to `direct` when unconfigured. */
-  resolveInvoicingMode(db: PostgresJsDatabase): Promise<InvoicingMode>
   /** Resolve the deployment database and retain ownership of its lifecycle. */
   withDb<T>(bindings: unknown, operation: (db: PostgresJsDatabase) => Promise<T>): Promise<T>
   /** Event bus used to re-emit conversion events for downstream plugins. */
@@ -62,14 +65,12 @@ export function createProformaConversionSubscriberRuntime(
     eventType: "invoice.settled",
     register: ({ bindings, container, eventBus }) => {
       const handler = async ({ data }: { data: SettlementSignalPayload }) => {
-        // Runtime is only registered when the operator-settings port is
-        // available. Absent → treat as `direct` mode → no-op.
+        // Runtime is registered by the finance booking-schedule host wiring.
+        // Absent → the deployment did not mount finance settlement → no-op.
         if (!container.has(PROFORMA_CONVERSION_SUBSCRIBER_RUNTIME_KEY)) return
         const runtime = resolveProformaConversionSubscriberRuntime(container)
         try {
           await runtime.withDb(bindings, async (db) => {
-            if ((await runtime.resolveInvoicingMode(db)) !== "proforma-first") return
-
             const invoice = await financeService.getInvoiceById(db, data.invoiceId)
             if (!invoice) return
             // Only fully-settled proformas convert. Partial payments leave

--- a/packages/finance/tests/unit/booking-tax.test.ts
+++ b/packages/finance/tests/unit/booking-tax.test.ts
@@ -203,7 +203,7 @@ describe("booking tax helpers", () => {
       data: {
         taxPriceMode: "inclusive",
         taxPolicyProfileId: null,
-        invoicingMode: "direct",
+        invoicingMode: "proforma-first",
         fxReferenceSource: "ecb",
       },
     })
@@ -223,7 +223,7 @@ describe("booking tax helpers", () => {
       data: {
         taxPriceMode: "exclusive",
         taxPolicyProfileId: "profile_1",
-        invoicingMode: "direct",
+        invoicingMode: "proforma-first",
         fxReferenceSource: "bnr",
       },
     })
@@ -252,7 +252,7 @@ describe("booking tax helpers", () => {
       data: {
         taxPriceMode: "inclusive",
         taxPolicyProfileId: "profile_1",
-        invoicingMode: "direct",
+        invoicingMode: "proforma-first",
         fxReferenceSource: "ecb",
       },
     })

--- a/packages/finance/tests/unit/proforma-conversion-subscriber-runtime.test.ts
+++ b/packages/finance/tests/unit/proforma-conversion-subscriber-runtime.test.ts
@@ -19,7 +19,6 @@ const {
 } = await import("../../src/proforma-conversion-runtime.js")
 
 interface HarnessOptions {
-  invoicingMode?: "direct" | "proforma-first"
   invoice?: { id: string; invoiceType: string; balanceDueCents: number } | null
   registerRuntime?: boolean
 }
@@ -27,7 +26,6 @@ interface HarnessOptions {
 function setup(options: HarnessOptions = {}) {
   const db = {} as never
   const bindings = { DATABASE_URL: "postgres://finance" }
-  const resolveInvoicingMode = vi.fn(async () => options.invoicingMode ?? "proforma-first")
   const withDb = vi.fn(async (_bindings: unknown, operation: (db: never) => Promise<unknown>) =>
     operation(db),
   )
@@ -35,7 +33,6 @@ function setup(options: HarnessOptions = {}) {
   const container = createContainer()
   if (options.registerRuntime !== false) {
     container.register(PROFORMA_CONVERSION_SUBSCRIBER_RUNTIME_KEY, {
-      resolveInvoicingMode,
       withDb,
       eventBus,
     })
@@ -47,7 +44,7 @@ function setup(options: HarnessOptions = {}) {
   })
   getInvoiceById.mockResolvedValue(options.invoice ?? null)
   convertProformaToInvoice.mockResolvedValue({ status: "ok", invoice: { id: "inv_final" } })
-  return { bindings, container, eventBus, handlers, resolveInvoicingMode, withDb }
+  return { bindings, container, eventBus, handlers, withDb }
 }
 
 const settledEnvelope = (invoiceId: string): EventEnvelope => ({
@@ -80,9 +77,11 @@ describe("finance proforma-conversion subscriber runtime", () => {
     )
   })
 
-  it("converts a fully-paid proforma when the operator runs proforma-first", async () => {
+  it("converts any fully-paid proforma regardless of the operator mode", async () => {
+    // The conversion is not gated on the invoicing mode: a fully-paid
+    // proforma should always mint its fiscal invoice, so a proforma left
+    // outstanding after a mode switch still converts.
     const harness = setup({
-      invoicingMode: "proforma-first",
       invoice: { id: "inv_proforma", invoiceType: "proforma", balanceDueCents: 0 },
     })
     const descriptor = createProformaConversionSubscriberRuntime()
@@ -90,7 +89,6 @@ describe("finance proforma-conversion subscriber runtime", () => {
 
     await harness.handlers[0]?.(settledEnvelope("inv_proforma"))
 
-    expect(harness.resolveInvoicingMode).toHaveBeenCalled()
     expect(getInvoiceById).toHaveBeenCalledWith(expect.anything(), "inv_proforma")
     expect(convertProformaToInvoice).toHaveBeenCalledWith(
       expect.anything(),
@@ -100,23 +98,8 @@ describe("finance proforma-conversion subscriber runtime", () => {
     )
   })
 
-  it("does not convert when the operator runs direct mode", async () => {
-    const harness = setup({
-      invoicingMode: "direct",
-      invoice: { id: "inv_proforma", invoiceType: "proforma", balanceDueCents: 0 },
-    })
-    const descriptor = createProformaConversionSubscriberRuntime()
-    await descriptor.register(harness)
-
-    await harness.handlers[0]?.(settledEnvelope("inv_proforma"))
-
-    expect(getInvoiceById).not.toHaveBeenCalled()
-    expect(convertProformaToInvoice).not.toHaveBeenCalled()
-  })
-
   it("ignores non-proforma invoices and partially-paid proformas", async () => {
     const finalInvoice = setup({
-      invoicingMode: "proforma-first",
       invoice: { id: "inv_final", invoiceType: "invoice", balanceDueCents: 0 },
     })
     const finalDescriptor = createProformaConversionSubscriberRuntime()
@@ -125,7 +108,6 @@ describe("finance proforma-conversion subscriber runtime", () => {
     expect(convertProformaToInvoice).not.toHaveBeenCalled()
 
     const partial = setup({
-      invoicingMode: "proforma-first",
       invoice: { id: "inv_partial", invoiceType: "proforma", balanceDueCents: 500 },
     })
     const partialDescriptor = createProformaConversionSubscriberRuntime()
@@ -134,7 +116,7 @@ describe("finance proforma-conversion subscriber runtime", () => {
     expect(convertProformaToInvoice).not.toHaveBeenCalled()
   })
 
-  it("no-ops when the runtime is not registered (settings runtime absent → direct)", async () => {
+  it("no-ops when the runtime is not registered (finance settlement absent)", async () => {
     const harness = setup({ registerRuntime: false })
     const descriptor = createProformaConversionSubscriberRuntime()
     await descriptor.register(harness)
@@ -146,7 +128,6 @@ describe("finance proforma-conversion subscriber runtime", () => {
 
   it("logs conversion failures without rejecting event delivery", async () => {
     const harness = setup({
-      invoicingMode: "proforma-first",
       invoice: { id: "inv_proforma", invoiceType: "proforma", balanceDueCents: 0 },
     })
     convertProformaToInvoice.mockRejectedValueOnce(new Error("db down"))

--- a/packages/operator-settings/migrations/0003_invoicing_mode_default_proforma_first.sql
+++ b/packages/operator-settings/migrations/0003_invoicing_mode_default_proforma_first.sql
@@ -1,0 +1,13 @@
+-- Scope `invoicing_mode` to the deferred bank-transfer payment path and make
+-- `proforma-first` the default. `proforma-first` is the platform's historical
+-- bank-transfer behaviour (a proforma is issued at order placement and the
+-- fiscal invoice is minted on settlement), so it is the correct default; the
+-- prior `direct` default came from the setting shipping before it was scoped.
+--
+-- Backfilling the existing `direct` rows is safe: the setting shipped in
+-- 0001 and no deployment has intentionally flipped it away from the default,
+-- so any stored `direct` value is the old default rather than an operator
+-- choice. Card checkouts always invoice directly regardless of this column.
+ALTER TABLE "booking_tax_settings" ALTER COLUMN "invoicing_mode" SET DEFAULT 'proforma-first';
+--> statement-breakpoint
+UPDATE "booking_tax_settings" SET "invoicing_mode" = 'proforma-first' WHERE "invoicing_mode" = 'direct';

--- a/packages/operator-settings/migrations/meta/0003_snapshot.json
+++ b/packages/operator-settings/migrations/meta/0003_snapshot.json
@@ -1,0 +1,428 @@
+{
+  "id": "4333525f-c66d-464e-ab84-e4a05bae9338",
+  "prevId": "d1ca11d6-1d4e-4a1b-83ae-3b57674ffd48",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.booking_tax_settings": {
+      "name": "booking_tax_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tax_price_mode": {
+          "name": "tax_price_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inclusive'"
+        },
+        "tax_policy_profile_id": {
+          "name": "tax_policy_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoicing_mode": {
+          "name": "invoicing_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proforma-first'"
+        },
+        "fx_reference_source": {
+          "name": "fx_reference_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ecb'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_payment_defaults": {
+      "name": "operator_payment_defaults",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "customer_payment_policy": {
+          "name": "customer_payment_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "booking_checkout_url_template": {
+          "name": "booking_checkout_url_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_pay_url_template": {
+          "name": "invoice_pay_url_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_payment_instructions": {
+      "name": "operator_payment_instructions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bank_transfer_beneficiary": {
+          "name": "bank_transfer_beneficiary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank": {
+          "name": "bank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_profile": {
+      "name": "operator_profile",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_id": {
+          "name": "vat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_authority": {
+          "name": "license_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatory_name": {
+          "name": "signatory_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatory_role": {
+          "name": "signatory_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operator_settings": {
+      "name": "operator_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "legal_name": {
+          "name": "legal_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vat_id": {
+          "name": "vat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_number": {
+          "name": "registration_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone": {
+          "name": "phone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "website": {
+          "name": "website",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "iban": {
+          "name": "iban",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bank": {
+          "name": "bank",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license": {
+          "name": "license",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "license_authority": {
+          "name": "license_authority",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatory_name": {
+          "name": "signatory_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signatory_role": {
+          "name": "signatory_role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_payment_policy": {
+          "name": "customer_payment_policy",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_price_mode": {
+          "name": "tax_price_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'inclusive'"
+        },
+        "tax_policy_profile_id": {
+          "name": "tax_policy_profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/operator-settings/migrations/meta/_journal.json
+++ b/packages/operator-settings/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784291076524,
       "tag": "0002_fx_reference_source",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784304653807,
+      "tag": "0003_invoicing_mode_default_proforma_first",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/operator-settings/src/schema.ts
+++ b/packages/operator-settings/src/schema.ts
@@ -146,14 +146,16 @@ export const bookingTaxSettings = pgTable("booking_tax_settings", {
   taxPriceMode: text("tax_price_mode").notNull().default("inclusive"),
   taxPolicyProfileId: text("tax_policy_profile_id"),
   /**
-   * Operator invoicing mode. `direct` (default) issues the fiscal
-   * invoice straight from the booking. `proforma-first` issues a
-   * proforma at checkout and mints the fiscal invoice once the
-   * proforma is fully settled (see the finance proforma-conversion
-   * subscriber). Stored here because `booking_tax_settings` is the
-   * finance operator-settings singleton row.
+   * Operator invoicing mode for the deferred bank-transfer payment path.
+   * `proforma-first` (default) issues a proforma at order placement and
+   * mints the fiscal invoice once the proforma is fully settled (see the
+   * finance proforma-conversion subscriber). `direct` issues the fiscal
+   * invoice at order placement and collects the transfer against it. Card
+   * payments always invoice directly and never consult this setting.
+   * Stored here because `booking_tax_settings` is the finance
+   * operator-settings singleton row.
    */
-  invoicingMode: text("invoicing_mode").notNull().default("direct"),
+  invoicingMode: text("invoicing_mode").notNull().default("proforma-first"),
   /**
    * Official FX reference-rate source used when an amount must be
    * converted at a jurisdiction's mandated reference rate (e.g. `ecb`

--- a/packages/operator-settings/src/service.ts
+++ b/packages/operator-settings/src/service.ts
@@ -204,7 +204,7 @@ export async function resolveBookingTaxSettings(
 }
 
 function normalizeInvoicingMode(value: string | null | undefined): "direct" | "proforma-first" {
-  return value === "proforma-first" ? "proforma-first" : "direct"
+  return value === "direct" ? "direct" : "proforma-first"
 }
 
 function normalizeFxReferenceSource(value: string | null | undefined): "ecb" | "bnr" {
@@ -212,10 +212,9 @@ function normalizeFxReferenceSource(value: string | null | undefined): "ecb" | "
 }
 
 /**
- * Resolve just the operator invoicing mode. Defaults to `direct`
- * (zero behaviour change) when no settings row exists. Provided
- * through the finance operator-settings runtime port so the finance
- * proforma-conversion subscriber can gate auto-conversion on it.
+ * Resolve just the operator invoicing mode. Defaults to `proforma-first`
+ * (the historical bank-transfer behaviour) when no settings row exists.
+ * Provided through the finance operator-settings runtime port.
  */
 export async function resolveInvoicingMode(
   db: PostgresJsDatabase,


### PR DESCRIPTION
Fixes a modeling flaw in the invoicing-mode feature (#3449 / #3462 / #3463): `invoicing.mode` was global and consulted in the checkout finalize saga, which runs on `payment.completed` and therefore mostly affects card payments — the one place where a proforma-first flow is wrong.

## The correct model

Payment method determines the document flow:

- **Card** (money captured at checkout): always issue the fiscal invoice at finalize. The setting is never consulted.
- **Bank transfer** (deferred payment): operator-configurable via `invoicing.mode`.
  - `proforma-first` — issue a proforma at order placement, convert it to the fiscal invoice on settlement. This is the platform's historical bank-transfer behaviour, so it is now the **default**.
  - `direct` — issue the fiscal invoice at order placement and collect the transfer against it; no later conversion.

## Changes

1. **Reverted the finalize-saga mode consult (#3462).** Finalize again always issues the fiscal invoice, or converts an existing proforma when the bank-transfer flow passes `convertedFromInvoiceId`. Removed the now-dead `resolveInvoicingMode` plumbing through `finalize` / `runner-runtime` / `subscriber-runtime`, the optional operator-settings port on the checkout extension manifest, and the `InvoicingMode` re-export that #3462 added to the finance package root.
2. **Wired the mode at the bank-transfer issuance site** (`packages/commerce/src/checkout/start-service.ts`, `startBankTransferCheckout`). `proforma-first` issues a proforma (unchanged); `direct` calls `issueInvoiceFromBooking` with `invoiceType: "invoice"`. The mode is read off the operator tax settings the checkout already resolves — no new port. The bank-transfer prerequisite check is now mode-aware (needs the `invoice` number series in direct mode, `proforma` otherwise).
3. **Flipped the default to `proforma-first`**: schema column default, operator-settings + finance normalization, and an additive migration (`ALTER COLUMN SET DEFAULT` + backfill of existing `direct` rows).
4. **Rescoped the finance-react Invoicing settings copy** to bank-transfer / deferred payments ("Bank transfer invoicing", "Proforma first (recommended)" / "Direct invoice", hints noting card payments always invoice directly). EN + RO. The FX reference-source section is untouched.
5. **Simplified the proforma-conversion subscriber**: dropped the mode gate. Any fully-paid proforma converts (the `invoiceType === "proforma"` guard already scopes it), which is correct in every mode and avoids stranding a proforma left outstanding across a mode switch.

## Migration

`packages/operator-settings/migrations/0003_invoicing_mode_default_proforma_first.sql`:

```sql
ALTER TABLE "booking_tax_settings" ALTER COLUMN "invoicing_mode" SET DEFAULT 'proforma-first';
UPDATE "booking_tax_settings" SET "invoicing_mode" = 'proforma-first' WHERE "invoicing_mode" = 'direct';
```

Backfilling is safe: the setting shipped in migration 0001 and no deployment has intentionally flipped it away from the default, so any stored `direct` value is the old default rather than an operator choice.

## Tests

- Card checkout always issues a fiscal invoice at finalize; conversion of an existing proforma still wins.
- Bank transfer: `proforma-first` issues a proforma, `direct` issues the fiscal invoice (and checks the `invoice` series), missing invoice series rejects.
- Proforma-conversion subscriber converts any fully-paid proforma regardless of mode.
- Updated the #3462 finalize tests and the finance-react invoicing-page copy tests.

## Gates

- `@voyant-travel/commerce` / `finance` / `operator-settings` / `finance-react` — tests, typecheck, lint green.
- `pnpm verify:architecture` — green (includes dep-paths, dist-configs, phase5-event-authority with 0 unowned subscriptions, migration-boundaries/cutline/replay-parity, runtime-ports, commerce authorities, admin-composition-drift).
- `pnpm i18n:check:packages` — green (EN/RO parity).
- Full pre-commit hook (broad typecheck/build across the graph) — green.

No export subpaths were added, so `generate:dep-paths` / `generate:dist-configs` were not required.