### PR TITLE
test(framework): bump standard-distribution extension counts for the booking-tax split

### DIFF
--- a/packages/framework/src/operator-distribution.test.ts
+++ b/packages/framework/src/operator-distribution.test.ts
@@ -39,7 +39,7 @@ describe("standard Operator distribution", () => {
       "@voyant-travel/catalog-authoring",
       "@voyant-travel/workflow-runs",
     ])
-    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toHaveLength(24)
+    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toHaveLength(25)
     expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toContain(
       "@voyant-travel/distribution/extension",
     )
@@ -50,7 +50,7 @@ describe("standard Operator distribution", () => {
     expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.modules).size).toBe(
       STANDARD_OPERATOR_DISTRIBUTION.modules.length,
     )
-    expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.extensions).size).toBe(24)
+    expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.extensions).size).toBe(25)
   })
 
   it("defaults authored differences without treating extensions as plugins", () => {

--- a/packages/framework/src/project-config.test.ts
+++ b/packages/framework/src/project-config.test.ts
@@ -7,7 +7,7 @@ describe("framework project config", () => {
 
     expect(project.modules).toHaveLength(STANDARD_OPERATOR_DISTRIBUTION.modules.length)
     expect(project.modules.map((unit) => unit.id)).toContain("@voyant-travel/bookings#extras")
-    expect(project.extensions).toHaveLength(24)
+    expect(project.extensions).toHaveLength(25)
     expect(project.plugins).toEqual([])
     expect(project.productBom).toEqual({
       schemaVersion: "voyant.product-bom-reference.v1",
@@ -21,7 +21,7 @@ describe("framework project config", () => {
       "@voyant-travel/relationships",
     ])
     expect(project.extensions.map((unit) => unit.schemaVersion)).toEqual(
-      Array.from({ length: 24 }, () => "voyant.extension.v1"),
+      Array.from({ length: 25 }, () => "voyant.extension.v1"),
     )
   })
 
@@ -38,7 +38,7 @@ describe("framework project config", () => {
     })
 
     expect(project.modules).toHaveLength(STANDARD_OPERATOR_DISTRIBUTION.modules.length + 1)
-    expect(project.extensions).toHaveLength(25)
+    expect(project.extensions).toHaveLength(26)
     expect(project.plugins).toHaveLength(1)
     expect(project.modules.at(-1)).toMatchObject({
       id: "local/src.modules.team",

--- a/packages/framework/src/project-import-cheap.test.ts
+++ b/packages/framework/src/project-import-cheap.test.ts
@@ -21,7 +21,7 @@ describe("framework project import boundary", () => {
     })
     const config = authoring.defineConfig()
     expect(config.modules.map((unit) => unit.id)).toContain("@voyant-travel/bookings#extras")
-    expect(config.extensions).toHaveLength(24)
+    expect(config.extensions).toHaveLength(25)
     expect(config.plugins).toEqual([])
     expect(authoring.resolveProject).toBeTypeOf("function")
   })


### PR DESCRIPTION
Main went red after #3478: PR #3477 split the booking-tax extension into `booking-tax-settings` (finance surface) and `booking-tax-preview` (bookings surface), adding one entry to the standard operator distribution. The completing work updated the operator starter's config test but missed the **framework** package's hardcoded distribution-count assertions. Bumps the six literals (24→25, one 25→26) in operator-distribution.test.ts, project-config.test.ts, and project-import-cheap.test.ts. Framework package tests: 295/295 green.