### PR TITLE
fix(runtime): stop the prepack workspace-closure rebuild; republish the 6 broken tarballs

### DIFF
--- a/.changeset/republish-workspace-spec-tarballs.md
+++ b/.changeset/republish-workspace-spec-tarballs.md
@@ -1,0 +1,16 @@
+---
+"@voyant-travel/runtime": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/distribution": patch
+"@voyant-travel/inventory": patch
+"@voyant-travel/operations": patch
+---
+
+Republish with dependency ranges resolved. The prior tarballs for these packages
+carry raw `workspace:` specifiers (they were published outside the pnpm-aware
+release flow) and cannot be installed by consumers. Also fixes the `runtime`
+package's `prepack`, which rebuilt the entire workspace dependency closure on
+every publish — the slow build stalled the release train's publish step past its
+timeout and wedged the whole batch. `prepack` now builds only the package itself,
+matching every other package.

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "pnpm run clean && NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.build.json",
     "clean": "rm -rf dist tsconfig*.tsbuildinfo",
-    "prepack": "pnpm --workspace-concurrency=1 --filter @voyant-travel/runtime... run build",
+    "prepack": "pnpm run build",
     "typecheck": "NODE_OPTIONS=--max-old-space-size=14336 tsc -p tsconfig.typecheck.json",
     "lint": "biome check src/",
     "test": "vitest run --passWithNoTests"


### PR DESCRIPTION
## Root cause of tonight's release-train failures

`packages/runtime` had `prepack: pnpm --workspace-concurrency=1 --filter @voyant-travel/runtime... run build` — the `...` rebuilds runtime **and its entire dependency closure (~100 packages), serially**, on every publish. During `changeset publish` that slow build stalled the publish step past its per-attempt timeout and wedged the whole batch, so the heaviest packages (finance, commerce, distribution, inventory, operations, runtime) never published across many runs (observed: minutes of silence mid-publish, then the run gets cut off).

A manual `npm publish` then shipped those six — but `npm publish` does **not** rewrite `workspace:` protocol specifiers (only the pnpm-aware flow does), so their tarballs carry raw `@voyant-travel/x@workspace:^` deps and are **uninstallable by consumers** (e.g. `ERR_PNPM_WORKSPACE_PKG_NOT_FOUND`).

## Fix
- `runtime` prepack now builds only itself (`pnpm run build`), matching every other package. The release train's pre-build step already builds the whole graph before publish, so the closure rebuild was pure waste.
- Patch-bump the six affected packages so the (now-unblocked) release flow republishes them with resolved dependency ranges.

The prior broken versions (finance@0.168.0, commerce@0.39.1, distribution@0.158.0, inventory@0.13.5, operations@0.8.6, runtime@0.11.11) should be deprecated on npm after the clean patches land.