### PR TITLE
Disable lifecycle scripts during package publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,18 @@ jobs:
         if: steps.release_plan.outputs.publish_pending == 'true'
         # Hard outer bound so a stalled publish can never burn a full job slot.
         timeout-minutes: 50
+        env:
+          # changesets 2.31 publishes up to 10 packages concurrently. Several
+          # packages `clean` their dist in prepack (`pnpm run clean && tsc`),
+          # so a concurrent republish of a dependency (e.g. `@voyant-travel/admin`)
+          # can delete its `dist` while a dependent's prepack `tsc` is resolving
+          # it, failing with "Cannot find module '@voyant-travel/admin'". The
+          # "Build pending publish workspaces" (Turbo) and "Verify publish
+          # tarballs" steps already produced and validated fresh `dist`, so
+          # publish must consume those artifacts immutably rather than rebuild
+          # them under fan-out. Disabling lifecycle scripts skips the racy
+          # prepack rebuild entirely.
+          npm_config_ignore_scripts: "true"
         run: |
           # `pnpm release` is `changeset publish`, which is idempotent: it
           # checks npm per package and skips versions already published, so it

--- a/scripts/verify-release-config.cjs
+++ b/scripts/verify-release-config.cjs
@@ -3,8 +3,71 @@ const path = require("node:path")
 
 const { read } = require("@changesets/config")
 const { getPackages } = require("@manypkg/get-packages")
+const { parse: parseYaml } = require("yaml")
 
 const { getPublishablePackages } = require("./release-utils.cjs")
+
+const RELEASE_WORKFLOW_PATH = ".github/workflows/release.yml"
+const BUILD_STEP = "Build pending publish workspaces"
+const TARBALL_STEP = "Verify publish tarballs"
+const PUBLISH_STEP = "Publish pending packages"
+
+// Publish must consume the Turbo-built, tarball-verified `dist` immutably.
+// Several packages `clean` their dist in prepack, so a concurrent publish
+// (changesets fans out to ~10) can delete a dependency's dist mid-build. The
+// publish step therefore (a) must run after the build + tarball-verify steps
+// and (b) must disable lifecycle scripts so prepack never rebuilds under
+// fan-out. This guards that invariant from silently regressing.
+function collectReleaseWorkflowProblems(cwd) {
+  const problems = []
+  const workflowPath = path.join(cwd, RELEASE_WORKFLOW_PATH)
+
+  let workflow
+  try {
+    workflow = parseYaml(readFileSync(workflowPath, "utf8"))
+  } catch (error) {
+    return [`${RELEASE_WORKFLOW_PATH}: could not read or parse workflow (${error.message})`]
+  }
+
+  const releaseJob = workflow?.jobs?.release
+  const steps = Array.isArray(releaseJob?.steps) ? releaseJob.steps : null
+  if (!steps) {
+    return [`${RELEASE_WORKFLOW_PATH}: missing jobs.release.steps`]
+  }
+
+  const indexOfStep = (name) => steps.findIndex((step) => step?.name === name)
+  const buildIdx = indexOfStep(BUILD_STEP)
+  const tarballIdx = indexOfStep(TARBALL_STEP)
+  const publishIdx = indexOfStep(PUBLISH_STEP)
+
+  for (const [label, idx] of [
+    [BUILD_STEP, buildIdx],
+    [TARBALL_STEP, tarballIdx],
+    [PUBLISH_STEP, publishIdx],
+  ]) {
+    if (idx === -1) problems.push(`${RELEASE_WORKFLOW_PATH}: missing "${label}" step`)
+  }
+
+  if (publishIdx !== -1) {
+    if (buildIdx !== -1 && buildIdx > publishIdx) {
+      problems.push(`${RELEASE_WORKFLOW_PATH}: "${BUILD_STEP}" must precede "${PUBLISH_STEP}"`)
+    }
+    if (tarballIdx !== -1 && tarballIdx > publishIdx) {
+      problems.push(`${RELEASE_WORKFLOW_PATH}: "${TARBALL_STEP}" must precede "${PUBLISH_STEP}"`)
+    }
+
+    const publishEnv = steps[publishIdx].env ?? {}
+    const ignoreScripts = publishEnv.npm_config_ignore_scripts
+    if (String(ignoreScripts) !== "true") {
+      problems.push(
+        `${RELEASE_WORKFLOW_PATH}: "${PUBLISH_STEP}" must set env.npm_config_ignore_scripts: "true" ` +
+          "so publish consumes verified dist immutably instead of racing prepack rebuilds",
+      )
+    }
+  }
+
+  return problems
+}
 
 const DEPENDENCY_FIELDS = [
   "dependencies",
@@ -93,6 +156,7 @@ async function main() {
   }
 
   problems.push(...collectWorkspaceRangeProblems(packages))
+  problems.push(...collectReleaseWorkflowProblems(cwd))
 
   if (problems.length > 0) {
     console.error("Release configuration verification failed:\n")


### PR DESCRIPTION
## Summary

A broad release (triggered by bumping `@voyant-travel/admin` + `@voyant-travel/admin-extension-sdk`, which cascaded a dependent-republish to ~40 `*-react` packages) failed during `changeset publish` with:

```
@voyant-travel/action-ledger-react prepack > tsc
  error TS2307: Cannot find module '@voyant-travel/admin' or its corresponding type declarations.
```

**Root cause:** changesets 2.31 publishes up to 10 packages concurrently. Several packages `clean` their dist in `prepack` (`pnpm run clean && tsc`), so a concurrent republish of a dependency (e.g. `@voyant-travel/admin`) can `rm -rf` its `dist` while a dependent's `prepack` `tsc` is resolving `../admin/dist/index.d.ts`. The `admin-host` `TUser`/`unknown` type error in the same log is downstream of `@voyant-travel/admin/app` being unresolvable. At least eight packages have this destructive clean-before-build behavior, so the failure class is latent across the release, not specific to `admin`.

**Fix:** the `Build pending publish workspaces` (Turbo) and `Verify publish tarballs` steps already produce and validate fresh `dist`, so publish must consume those artifacts immutably rather than rebuild them under fan-out. Set `npm_config_ignore_scripts: "true"` on the `Publish pending packages` step so `prepack` never runs during publish. This fixes the whole class without weakening any package's standalone `pnpm pack` behavior.

Also adds a `verify:release-config` guard asserting the publish step (a) sets `npm_config_ignore_scripts: "true"` and (b) runs after the build + tarball-verify steps, so this invariant can't silently regress.

## Notes
- **Incident already recovered:** the previously-failing versions are live on npm (`action-ledger-react@0.57.0`, `admin-host@0.19.0`, `trips-react@0.160.0`, `admin@0.127.0`) — later idempotent release runs self-healed. This PR prevents recurrence on the next broad release.
- `yaml@2.8.3` (used by the new check) is already a root devDependency.

## Verification
- `pnpm verify:release-config` passes; a negative test (env removed) fails with the exact guard message.
