### PR TITLE
finance: wire booking-tax settings options through the runtime container

### DIFF
--- a/.changeset/booking-tax-settings-container-options.md
+++ b/.changeset/booking-tax-settings-container-options.md
@@ -1,0 +1,21 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Wire the booking-tax settings and preview route options through the runtime
+container so the managed runtime's operator-settings resolvers always reach the
+routes.
+
+On the managed runtime every runtime export of a graph unit is invoked: the
+`defineGraphRuntimeFactory` export receives the factory context and wires the
+operator-settings port into options, while the plain api-facet export is called
+with no args and therefore saw empty options. Because the api-facet previously
+returned an eager `adminRoutes` set built from those empty options, `PATCH
+/v1/admin/finance/tax-settings` failed with `Booking tax settings updates are
+not configured`.
+
+The booking-tax settings/preview extensions now mirror the booking-schedule
+pattern: the graph factory registers the wired options into the shared app
+container under a runtime key during `bootstrap`, and the (now lazy) routes
+resolve those options from the container at request time, falling back to the
+closure options for standard callers that pass real options directly.

--- a/packages/finance/src/booking-tax-runtime.ts
+++ b/packages/finance/src/booking-tax-runtime.ts
@@ -1,0 +1,94 @@
+import type { ModuleContainer } from "@voyant-travel/core"
+import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { ApiExtension } from "@voyant-travel/hono/module"
+import type { Context } from "hono"
+import {
+  type BookingTaxRouteOptions,
+  createBookingTaxPreviewApiExtension,
+  createBookingTaxSettingsApiExtension,
+} from "./booking-tax.js"
+import { createFinanceBookingTaxRuntime } from "./runtime.js"
+import { financeOperatorSettingsRuntimePort } from "./runtime-port.js"
+
+// ─────────────────────────────────────────────────────────────────
+// Runtime-container wiring (mirrors booking-schedule)
+// ─────────────────────────────────────────────────────────────────
+//
+// On the managed runtime each graph unit's runtime exports are ALL invoked:
+// a `defineGraphRuntimeFactory` export receives the factory context (`getPort`)
+// and wires the operator-settings port into options; a PLAIN api-facet export
+// is invoked with NO ARGS, so it sees empty options. The graph factory
+// therefore registers the WIRED options into the shared app container under a
+// runtime key, and the routes resolve those options from the container at
+// request time — falling back to the closure options for standard callers that
+// pass real options directly. This keeps the wired options winning without an
+// empty-options route mount racing the factory's.
+
+export const BOOKING_TAX_SETTINGS_RUNTIME_KEY = "finance.bookingTaxSettingsRuntime"
+export const BOOKING_TAX_PREVIEW_RUNTIME_KEY = "finance.bookingTaxPreviewRuntime"
+
+export interface BookingTaxRuntime {
+  resolveRoutesOptions(): BookingTaxRouteOptions
+}
+
+/**
+ * Resolve the container-registered booking-tax route options at request time,
+ * preferring the wired runtime (registered by the graph factory's bootstrap)
+ * over the closure options a plain api-facet call captured. Fail-open: any
+ * missing/empty container falls back to the passed options.
+ */
+export function resolveBookingTaxRouteOptions(
+  c: Context,
+  runtimeKey: string,
+  fallback: BookingTaxRouteOptions,
+): BookingTaxRouteOptions {
+  const container = c.get("container") as ModuleContainer | undefined
+  if (!container?.has(runtimeKey)) return fallback
+  try {
+    return container.resolve<BookingTaxRuntime>(runtimeKey).resolveRoutesOptions()
+  } catch {
+    return fallback
+  }
+}
+
+export const createBookingTaxSettingsVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) => {
+    const options = createFinanceBookingTaxRuntime(
+      await getPort(financeOperatorSettingsRuntimePort),
+    )
+    const configured = createBookingTaxSettingsApiExtension(options)
+    const selected: ApiExtension = {
+      ...configured,
+      extension: {
+        ...configured.extension,
+        bootstrap: async ({ container }) => {
+          container.register(BOOKING_TAX_SETTINGS_RUNTIME_KEY, {
+            resolveRoutesOptions: () => options,
+          } satisfies BookingTaxRuntime)
+        },
+      },
+    }
+    return selected
+  },
+)
+
+export const createBookingTaxPreviewVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort }) => {
+    const options = createFinanceBookingTaxRuntime(
+      await getPort(financeOperatorSettingsRuntimePort),
+    )
+    const configured = createBookingTaxPreviewApiExtension(options)
+    const selected: ApiExtension = {
+      ...configured,
+      extension: {
+        ...configured.extension,
+        bootstrap: async ({ container }) => {
+          container.register(BOOKING_TAX_PREVIEW_RUNTIME_KEY, {
+            resolveRoutesOptions: () => options,
+          } satisfies BookingTaxRuntime)
+        },
+      },
+    }
+    return selected
+  },
+)

--- a/packages/finance/src/booking-tax.ts
+++ b/packages/finance/src/booking-tax.ts
@@ -1,14 +1,16 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
-import type { Extension } from "@voyant-travel/core"
-import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
+import type { Extension, ModuleContainer } from "@voyant-travel/core"
 import { ApiHttpError, openApiValidationHook, stampOpenApiRegistryApiId } from "@voyant-travel/hono"
 import type { ApiExtension } from "@voyant-travel/hono/module"
 import { and, asc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Hono } from "hono"
 
-import { createFinanceBookingTaxRuntime } from "./runtime.js"
-import { financeOperatorSettingsRuntimePort } from "./runtime-port.js"
+import {
+  BOOKING_TAX_PREVIEW_RUNTIME_KEY,
+  BOOKING_TAX_SETTINGS_RUNTIME_KEY,
+  resolveBookingTaxRouteOptions,
+} from "./booking-tax-runtime.js"
 import { taxClasses, taxPolicyProfiles, taxPolicyRules, taxRegimes } from "./schema.js"
 import { executeBoundaryRows } from "./service-boundary-sql.js"
 
@@ -399,27 +401,30 @@ export function createBookingTaxSettingsRoutes(options: BookingTaxRouteOptions =
   const routes = new OpenAPIHono<{
     Variables: {
       db: PostgresJsDatabase
+      container?: ModuleContainer
     }
   }>({ defaultHook: openApiValidationHook })
     .openapi(getBookingTaxSettingsRoute, async (c) => {
+      const opts = resolveBookingTaxRouteOptions(c, BOOKING_TAX_SETTINGS_RUNTIME_KEY, options)
       return c.json(
         {
-          data: await resolveBookingTaxSettingsOrDefault(c.get("db"), options),
+          data: await resolveBookingTaxSettingsOrDefault(c.get("db"), opts),
         },
         200,
       )
     })
     .openapi(updateBookingTaxSettingsRoute, async (c) => {
-      if (!options.updateBookingTaxSettings) {
+      const opts = resolveBookingTaxRouteOptions(c, BOOKING_TAX_SETTINGS_RUNTIME_KEY, options)
+      if (!opts.updateBookingTaxSettings) {
         throw new ApiHttpError("Booking tax settings updates are not configured", {
           status: 409,
           code: "booking_tax_settings_update_not_configured",
         })
       }
 
-      const current = await resolveBookingTaxSettingsOrDefault(c.get("db"), options)
+      const current = await resolveBookingTaxSettingsOrDefault(c.get("db"), opts)
       const patch = c.req.valid("json")
-      const next = await options.updateBookingTaxSettings(c.get("db"), {
+      const next = await opts.updateBookingTaxSettings(c.get("db"), {
         taxPriceMode: patch.taxPriceMode ?? current.taxPriceMode,
         taxPolicyProfileId:
           patch.taxPolicyProfileId === undefined
@@ -453,13 +458,15 @@ export function createBookingTaxPreviewRoutes(options: BookingTaxRouteOptions = 
   const routes = new OpenAPIHono<{
     Variables: {
       db: PostgresJsDatabase
+      container?: ModuleContainer
     }
   }>({ defaultHook: openApiValidationHook }).openapi(previewBookingTaxRoute, async (c) => {
     const body = c.req.valid("json")
+    const opts = resolveBookingTaxRouteOptions(c, BOOKING_TAX_PREVIEW_RUNTIME_KEY, options)
     const taxRate = await resolveBookingSellTaxRate(
       c.get("db"),
       { productId: body.productId },
-      options,
+      opts,
     )
     const taxLine = computeBookingItemTaxLine(taxRate, body.subtotalCents, body.currency)
 
@@ -535,7 +542,7 @@ export function createBookingTaxSettingsApiExtension(
 
   return {
     extension,
-    adminRoutes: createBookingTaxSettingsRoutes(options),
+    lazyAdminRoutes: async () => createBookingTaxSettingsRoutes(options),
   }
 }
 
@@ -549,22 +556,6 @@ export function createBookingTaxPreviewApiExtension(
 
   return {
     extension,
-    adminRoutes: createBookingTaxPreviewRoutes(options),
+    lazyAdminRoutes: async () => createBookingTaxPreviewRoutes(options),
   }
 }
-
-export const createBookingTaxSettingsVoyantRuntime = defineGraphRuntimeFactory(
-  async ({ getPort }) => {
-    return createBookingTaxSettingsApiExtension(
-      createFinanceBookingTaxRuntime(await getPort(financeOperatorSettingsRuntimePort)),
-    )
-  },
-)
-
-export const createBookingTaxPreviewVoyantRuntime = defineGraphRuntimeFactory(
-  async ({ getPort }) => {
-    return createBookingTaxPreviewApiExtension(
-      createFinanceBookingTaxRuntime(await getPort(financeOperatorSettingsRuntimePort)),
-    )
-  },
-)

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -266,10 +266,8 @@ export {
   computeBookingItemTaxLine,
   createBookingTaxPreviewApiExtension,
   createBookingTaxPreviewRoutes,
-  createBookingTaxPreviewVoyantRuntime,
   createBookingTaxSettingsApiExtension,
   createBookingTaxSettingsRoutes,
-  createBookingTaxSettingsVoyantRuntime,
   loadProductTaxFacts,
   matchesTaxPolicyCondition,
   mountBookingTaxPreviewRoutes,
@@ -282,6 +280,13 @@ export {
   type TaxPolicyCondition,
   type UpdateBookingTaxSettings,
 } from "./booking-tax.js"
+export {
+  BOOKING_TAX_PREVIEW_RUNTIME_KEY,
+  BOOKING_TAX_SETTINGS_RUNTIME_KEY,
+  type BookingTaxRuntime,
+  createBookingTaxPreviewVoyantRuntime,
+  createBookingTaxSettingsVoyantRuntime,
+} from "./booking-tax-runtime.js"
 export type {
   CardPaymentBilling,
   CardPaymentStartArgs,

--- a/packages/finance/tests/unit/booking-tax.test.ts
+++ b/packages/finance/tests/unit/booking-tax.test.ts
@@ -1,14 +1,36 @@
+import type { ModuleContainer } from "@voyant-travel/core"
+import { handleApiError } from "@voyant-travel/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
-
 import {
+  type BookingTaxRouteOptions,
   computeBookingItemTaxLine,
   createBookingTaxPreviewRoutes,
+  createBookingTaxSettingsApiExtension,
   createBookingTaxSettingsRoutes,
   matchesTaxPolicyCondition,
 } from "../../src/booking-tax.js"
+import {
+  BOOKING_TAX_SETTINGS_RUNTIME_KEY,
+  type BookingTaxRuntime,
+} from "../../src/booking-tax-runtime.js"
 import { createFinanceApiModule } from "../../src/index.js"
+
+/** Minimal in-memory container mirroring the app runtime's registry. */
+function makeContainer(): ModuleContainer {
+  const services = new Map<string, unknown>()
+  return {
+    register: (name, service) => {
+      services.set(name, service)
+    },
+    resolve: <T>(name: string): T => {
+      if (!services.has(name)) throw new Error(`unregistered: ${name}`)
+      return services.get(name) as T
+    },
+    has: (name) => services.has(name),
+  }
+}
 
 describe("booking tax helpers", () => {
   it("computes exclusive tax lines", () => {
@@ -252,5 +274,127 @@ describe("booking tax helpers", () => {
         invoicingMode: "proforma-first",
       },
     })
+  })
+})
+
+describe("booking tax settings runtime-container wiring (managed runtime)", () => {
+  /**
+   * Build the exact managed-runtime scenario: the api-facet plain export is
+   * invoked with EMPTY options (no `updateBookingTaxSettings`), but the graph
+   * factory's bootstrap registered the WIRED options into the container under
+   * BOOKING_TAX_SETTINGS_RUNTIME_KEY. The routes must read the wired options
+   * from the container at request time.
+   */
+  function buildManagedApp(runtime: BookingTaxRuntime, db: PostgresJsDatabase) {
+    const container = makeContainer()
+    container.register(BOOKING_TAX_SETTINGS_RUNTIME_KEY, runtime)
+    // Empty-options plain api-facet export (the managed-runtime NO-ARGS call).
+    const extension = createBookingTaxSettingsApiExtension()
+    return {
+      container,
+      request: async (path: string, init?: RequestInit) => {
+        const routes = await extension.lazyAdminRoutes!()
+        const app = new Hono()
+          .use("*", async (c, next) => {
+            c.set("db", db)
+            c.set("container", container)
+            await next()
+          })
+          .route("/", routes)
+        app.onError(handleApiError)
+        return app.request(path, init)
+      },
+    }
+  }
+
+  it("exposes lazy admin routes and no eager adminRoutes on the api-facet export", () => {
+    const extension = createBookingTaxSettingsApiExtension()
+    expect(extension.extension).toMatchObject({ name: "booking-tax-settings", module: "finance" })
+    expect(extension.lazyAdminRoutes).toBeTypeOf("function")
+    expect(extension.adminRoutes).toBeUndefined()
+  })
+
+  it("serves the wired resolve on GET even when the api-facet export got empty options", async () => {
+    const wired: BookingTaxRouteOptions = {
+      resolveBookingTaxSettings: () => ({ taxPriceMode: "exclusive", invoicingMode: "direct" }),
+    }
+    const managed = buildManagedApp({ resolveRoutesOptions: () => wired }, {} as PostgresJsDatabase)
+
+    const response = await managed.request("/tax-settings")
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        taxPriceMode: "exclusive",
+        taxPolicyProfileId: null,
+        invoicingMode: "direct",
+      },
+    })
+  })
+
+  it("makes PATCH tax-settings succeed via the container-wired updateBookingTaxSettings", async () => {
+    let settings = {
+      taxPriceMode: "inclusive" as "inclusive" | "exclusive",
+      taxPolicyProfileId: null as string | null,
+      invoicingMode: "proforma-first" as "direct" | "proforma-first",
+    }
+    const updateBookingTaxSettings = vi.fn(async (_db: PostgresJsDatabase, next) => {
+      settings = {
+        taxPriceMode: next.taxPriceMode === "exclusive" ? "exclusive" : "inclusive",
+        taxPolicyProfileId: next.taxPolicyProfileId ?? null,
+        invoicingMode: next.invoicingMode === "direct" ? "direct" : "proforma-first",
+      }
+      return settings
+    })
+    const wired: BookingTaxRouteOptions = {
+      resolveBookingTaxSettings: () => settings,
+      updateBookingTaxSettings,
+    }
+    const managed = buildManagedApp({ resolveRoutesOptions: () => wired }, {} as PostgresJsDatabase)
+
+    const response = await managed.request("/tax-settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoicingMode: "direct" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(updateBookingTaxSettings).toHaveBeenCalledOnce()
+    await expect(response.json()).resolves.toMatchObject({
+      data: { invoicingMode: "direct" },
+    })
+  })
+
+  it("still 409s when the container-wired runtime lacks updateBookingTaxSettings", async () => {
+    const wired: BookingTaxRouteOptions = {
+      resolveBookingTaxSettings: () => ({ taxPriceMode: "inclusive" }),
+    }
+    const managed = buildManagedApp({ resolveRoutesOptions: () => wired }, {} as PostgresJsDatabase)
+
+    const response = await managed.request("/tax-settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ invoicingMode: "direct" }),
+    })
+
+    expect(response.status).toBe(409)
+  })
+
+  it("falls back to closure options when no container runtime is registered", async () => {
+    // Standard (non-managed) caller path: options passed directly, no container.
+    const app = new Hono()
+      .use("*", async (c, next) => {
+        c.set("db", {} as PostgresJsDatabase)
+        await next()
+      })
+      .route(
+        "/",
+        createBookingTaxSettingsRoutes({
+          resolveBookingTaxSettings: () => ({ invoicingMode: "direct" }),
+        }),
+      )
+
+    const response = await app.request("/tax-settings")
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({ data: { invoicingMode: "direct" } })
   })
 })

--- a/starters/operator/tests/api/selected-graph-runtime.test.ts
+++ b/starters/operator/tests/api/selected-graph-runtime.test.ts
@@ -670,9 +670,14 @@ describe("selected Operator graph runtime composition", () => {
     expect(byName("channel-push")?.extension.module).toBe("distribution")
     expect(byName("channel-push")?.adminRoutes).toBeDefined()
     expect(byName("booking-tax-settings")?.extension.module).toBe("finance")
-    expect(byName("booking-tax-settings")?.adminRoutes).toBeDefined()
+    // Tax settings now mount via lazy routes that resolve the container-wired
+    // options at request time (mirrors booking-schedule), so the graph factory
+    // no longer eagerly builds a full adminRoutes app.
+    expect(byName("booking-tax-settings")?.lazyAdminRoutes).toBeTypeOf("function")
+    expect(byName("booking-tax-settings")?.adminRoutes).toBeUndefined()
     expect(byName("booking-tax-preview")?.extension.module).toBe("bookings")
-    expect(byName("booking-tax-preview")?.adminRoutes).toBeDefined()
+    expect(byName("booking-tax-preview")?.lazyAdminRoutes).toBeTypeOf("function")
+    expect(byName("booking-tax-preview")?.adminRoutes).toBeUndefined()
     expect(byName("mice-booking")?.extension.module).toBe("bookings")
     expect(byName("booking-schedule")?.publicPath).toBe("payment-policy")
     expect(byName("proposal")?.publicPath).toBe("proposals")


### PR DESCRIPTION
## Problem

On the managed runtime, saving the invoicing mode via `PATCH /v1/admin/finance/tax-settings` returned `500 Booking tax settings updates are not configured`, while `GET` served a default.

The finance booking-tax-settings extension declares both an extension-level `defineGraphRuntimeFactory` export (which wires the operator-settings port into the route options) and a plain api-facet export. On the managed runtime every runtime export of a graph unit is invoked: the graph factory receives the factory context (`getPort`), but the plain api-facet export is called with **no args**, so it saw empty options. Because that api-facet returned an **eager** `adminRoutes` set built from the empty options, its routes collided with (and won over) the wired factory routes, so `PATCH` never had `updateBookingTaxSettings` and threw 409/500. The same shape affected the tax-preview extension.

## Fix

Mirror the booking-schedule pattern (`payment-schedule/routes.ts`), which already works on managed by decoupling options from the eager closure through the runtime container:

- A new `booking-tax-runtime.ts` module introduces two container runtime keys (`BOOKING_TAX_SETTINGS_RUNTIME_KEY`, `BOOKING_TAX_PREVIEW_RUNTIME_KEY`) carrying `{ resolveRoutesOptions: () => options }`.
- The graph factories (`createBookingTaxSettingsVoyantRuntime` / `createBookingTaxPreviewVoyantRuntime`) build the wired options from `financeOperatorSettingsRuntimePort`, then register them into the shared app container under the key during `bootstrap` — they no longer eagerly emit a second full route set.
- The api-facet exports now return **lazy** `lazyAdminRoutes`, and the route handlers resolve the container-registered options at request time (`c.var.container`), falling back to the closure options for standard callers (`mountBookingTaxSettingsRoutes` / `mountBookingTaxPreviewRoutes` / `createFinanceApiModule`) that pass real options directly.

Route paths and the two-extension split are unchanged — only how options reach the routes so the wired options always win and there is no empty-options mount.

## Tests + gates

- New finance route tests cover the exact managed-runtime scenario: the plain api-facet export built with empty options still serves the container-wired options for `GET` and `PATCH tax-settings` (invoicing mode saves), still 409s when the wired runtime lacks `updateBookingTaxSettings`, and falls back to closure options with no container. Existing route tests stay green (`407` finance tests pass).
- Operator `selected-graph-runtime` composition test updated to assert the booking-tax extensions expose `lazyAdminRoutes` (no eager `adminRoutes`), matching the wired shape (`58` tests pass).
- Gates run green: finance test + typecheck + lint, operator selected-graph-runtime test, `verify:architecture`, `verify:operator-openapi-authority`, and `verify:deployment-graph-openapi-coverage`. OpenAPI still generates from the plain api-facet export (the generator awaits lazy loaders).