### PR TITLE
Expose remote finance issuance app contract

### DIFF
--- a/.changeset/remote-finance-issuance.md
+++ b/.changeset/remote-finance-issuance.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/apps": minor
+"@voyant-travel/finance": minor
+"@voyant-travel/finance-contracts": minor
+---
+
+Expose provider-neutral finance issuance hydration, external-reference writeback,
+and invoice/proforma issuance webhooks through the remote App API boundary.

--- a/docs/architecture/remote-app-platform-rfc.md
+++ b/docs/architecture/remote-app-platform-rfc.md
@@ -1,358 +1,139 @@
-# RFC/PRD: Remote App Platform And App-Owned Custom Fields
+# Remote App Runtime And App-Owned Custom Fields
 
-- **Status:** Proposed
-- **Tracking:** `voyant#3395`
-- **Audience:** framework, Operator, Cloud, security, finance, and integration maintainers
-- **Decision type:** product architecture and platform contract
-- **Target:** one remote app runtime model with a managed-only monetized
-  marketplace and deployment-local custom apps, separate from deployment-time
-  modules and adapters
+- **Status:** Accepted
+- **Audience:** framework, Operator, security, and integration maintainers
+- **Decision type:** public runtime and package contract
 
-## Executive Decision
+## Decision
 
-Voyant will treat an **app** as a separately deployed service activated for a
+Voyant treats an **app** as a separately deployed service activated for a
 deployment through OAuth. App backend code never executes inside the Operator
-process and an app never contributes database migrations to a Voyant
-deployment.
+process, and an app never contributes database migrations, graph units,
+providers, routes, or other executable server code to a Voyant deployment.
 
-There will be two creation and discovery paths:
+This repository provides a deployment-local remote app runtime:
 
-1. **Marketplace discovery (managed runtime only):** an operator on the Voyant
-   managed runtime selects a reviewed listing and grants its requested
-   permissions. The marketplace is a monetized distribution channel: a
-   marketplace app prices through Voyant billing, its subscription and usage
-   charges appear as line items on the operator's Voyant invoice, and Voyant
-   retains a platform revenue share and pays out the app developer.
-2. **Custom app creation:** a developer or authorized operator creates a private
-   app registration directly in Voyant, supplies its manifest and endpoints,
-   and grants permissions through the same flow. Custom apps are the only app
-   path available to self-hosted deployments.
+- custom app registration;
+- immutable declarative releases;
+- release acquisition by upload or protected HTTPS manifest fetch;
+- consent, installation, grants, pause, revoke, uninstall, and purge;
+- OAuth credentials and versioned App APIs;
+- durable webhook subscriptions;
+- sandboxed admin extensions;
+- app-owned, namespaced custom fields;
+- local audit and health state.
 
-Both paths create the same durable app installation, grants, extension
-descriptors, webhook subscriptions, and app-owned custom-field definitions.
-A custom app does not require a marketplace listing, marketplace review,
-publication, or any Voyant-operated infrastructure. Marketplace submission is
-an optional later distribution choice available to managed distribution, not a
-prerequisite for app creation or installation.
+Custom apps do not require a listing, publication workflow, or Voyant-operated
+service. A deployment owner supplies and supports the app and explicitly chooses
+when to ingest and activate a new release.
 
-Each app release is an immutable, signed release artifact. The managed catalog
-is the canonical registry for marketplace releases; the deployment-local app
-registry (or a restricted managed registry) is canonical for a private custom
-app. Release acquisition has two channels:
+Operated catalogs, listing services, publisher programs, commerce, and hosted
+distribution policy are outside this repository. A host may offer an admitted
+release to the same installation runtime through an explicit integration, but
+the public runtime does not discover, authorize, bill, or operate such a service.
 
-1. **Managed runtime:** the platform acquires the catalog release and applies
-   compatible updates according to installation policy.
-2. **Custom apps:** the owning developer uploads the signed release artifact or
-   registers an HTTPS manifest source; the deployment stores the validated
-   snapshot locally.
+Each app release is an immutable, signed, content-addressed artifact. It contains
+closed declarative metadata and optional sandboxed static UI assets, never the
+app backend or executable Operator code. Acquisition and activation are
+separate: acquiring a release stores a verified snapshot; OAuth consent and
+activation create or advance the durable installation.
 
-App release artifacts are never distributed through npm or any package
-manager. Npm remains exclusively a deployment mechanism for trusted executable
-code selected by the developer: Voyant modules, project modules, infrastructure
-providers, and deeply integrated adapters. Executable deployment components and
-declarative app release artifacts use different manifests, validation, and
-runtime authority.
-
-Acquisition and activation are separate. Acquiring a release makes it available
-to a deployment. OAuth consent and activation create or upgrade the same
-durable app installation aggregate regardless of delivery channel. There is no
-hybrid app split between local and remote behavior.
-
-Payment processing stays on the deployment side of this boundary. Netopia,
-Voyant Payments, and future processors implement one payment adapter contract,
-following the same provider-selection shape as search engines. Accounting
-integrations, including SmartBill, move to the remote app model because they can
-integrate through scoped finance APIs, events, webhooks, app-owned custom fields,
-and remote admin UI.
+Npm remains exclusively a deployment mechanism for trusted executable code
+selected by a developer: Voyant modules, project modules, infrastructure
+providers, and deeply integrated adapters. An app release artifact is not an npm
+package, plugin, or deployment graph unit.
 
 Deployment-local TypeScript custom-field declarations are unsupported. The
-database is the only runtime authority for custom-field definitions:
-operator-owned definitions are created in Settings, while app-owned definitions
-are reconciled from the installed app manifest or app API and displayed in the
-same Settings surface.
+database is the only runtime authority for custom-field definitions.
+Operator-owned definitions are created in Settings; app-owned definitions are
+reconciled from the installed app release or app API.
 
 Every app receives a platform-assigned reserved namespace. Apps address their
-own namespace through an alias; they cannot submit, claim, or write another
-app's physical namespace. Custom-field identity is `(target, namespace, key)`,
-so two apps can safely use the same key on the same entity type.
+own namespace through the `$app` alias and cannot submit, claim, read, or write
+another app's physical namespace. Custom-field identity is `(target, namespace,
+key)`.
 
-Each app owns its sandboxed UI and localization resources. An app release may
-carry immutable static UI and locale assets that Voyant stores and serves from
-an isolated app origin without compiling or executing them in the admin origin.
-Voyant passes the active locale to app extensions, while app releases provide
-validated localized metadata for the small amount of app text rendered by the
-Voyant host, such as navigation labels and extension titles.
+## Scope
 
-## Problem Statement
+### Goals
 
-Voyant currently uses “plugin” for several different concepts:
-
-- a reusable npm distribution bundle;
-- a deployment-selected provider or adapter;
-- code and migrations loaded into the Operator process;
-- an admin UI contribution;
-- and, prospectively, something an operator installs from a marketplace.
-
-Those concepts have incompatible trust, versioning, lifecycle, and data
-ownership models. Executable npm code is selected and pinned by a developer,
-while an operator must be able to activate, pause, and remove an app without
-executing ecosystem code or migrations. Self-hosted deployments additionally
-need app creation and installation that works without any Voyant-operated
-infrastructure, while managed deployments need safe, policy-driven updates and
-a billing-integrated marketplace from the same release lineage.
-
-The previous custom-fields system compounded the problem. Definitions could
-come from deployment-local TypeScript or the database, code won collisions, the
-runtime table and UI were owned by Relationships, and the database target enum
-supported only a small fixed entity set. The current generic module uses
-database-only definitions, selected-graph targets, durable ownership, and
-collision-proof namespaces.
-
-Without a clearer boundary, remote apps would either need unsafe access to the
-Voyant runtime and schema or would invent disconnected storage that the admin,
-search, export, invoice, and workflow surfaces cannot understand.
-
-## Goals
-
-1. Let an operator activate, pause, or uninstall an acquired app without
-   executing ecosystem code, migrations, or graph changes.
-2. Use the same runtime contract for marketplace and custom apps.
-3. Keep all app execution outside the Operator process.
-4. Give apps least-privilege access through versioned APIs and OAuth grants.
-5. Support secure remote admin pages and targeted UI extensions.
-6. Deliver versioned events reliably to remote app webhooks.
-7. Let apps attach typed values to Voyant entities without schema migrations.
-8. Prevent custom-field collisions and cross-app reads or writes by
-   construction.
-9. Keep complex app-owned records in the app's own database.
-10. Preserve deployment-time packages for capabilities that require deep,
-    synchronous, or infrastructure-level integration.
-11. Establish payment processing as a conformance-tested deployment adapter
-    role, with Voyant Payments as a first-party implementation and Netopia as an
-    alternative implementation.
-12. Move accounting integrations toward remote apps rather than package-owned
-    Operator schema and runtime code.
-13. Make installation, grants, calls, deliveries, and custom-field mutations
-    auditable.
-14. Let developers and authorized operators create and install custom apps
-    without marketplace publication.
-15. Let every app own its UI, translations, supported locales, and fallback
+1. Let an operator activate, pause, or uninstall an app without executing
+   ecosystem code, migrations, or graph changes.
+2. Keep all app execution outside the Operator process.
+3. Give apps least-privilege access through versioned APIs and OAuth grants.
+4. Support secure remote admin pages and targeted UI extensions.
+5. Deliver versioned events reliably to remote app webhooks.
+6. Let apps attach typed values to Voyant entities without schema migrations.
+7. Prevent custom-field collisions and cross-app access by construction.
+8. Keep complex app-owned records in the app's own database.
+9. Make installation, grants, calls, deliveries, and custom-field mutations
+   auditable.
+10. Let a deployment create, release, and install custom apps without an
+    operated catalog or publication service.
+11. Let every app own its UI, translations, supported locales, and fallback
     locale without adding app strings to Voyant translation catalogs.
-16. Publish one immutable app release artifact across managed-catalog and
-    private custom-app delivery.
-17. Let self-hosted deployments create, release, and install custom apps with
-    no dependency on Voyant-operated infrastructure.
-18. Let managed deployments automatically apply compatible app updates without
-    silently granting scopes or crossing compatibility boundaries.
-19. Make the installed app release visible to the remote backend on every
-    authenticated request.
-20. Make the marketplace a monetized managed distribution channel: Voyant-billed
-    app subscriptions on the operator invoice, platform revenue share, and
-    developer payouts.
+12. Bind every authenticated app interaction to the installed release and
+    negotiated contract versions.
 
-## Non-Goals
+### Non-goals
 
-- Runtime package-manager execution, dynamic imports, or mutable
-  `install(app)` hooks inside the Operator.
+- Runtime package-manager execution, dynamic imports, or mutable `install(app)`
+  hooks inside the Operator.
 - Allowing remote apps to contribute Drizzle schemas or migrations.
 - Running remote app callbacks inside a Voyant database transaction.
 - Providing a general-purpose hosted relational database for apps.
-- Replacing Voyant modules with apps.
-- Making storage, cache, search, payment, or other deployment infrastructure
-  operator-installable marketplace apps.
-- Supporting arbitrary remote JavaScript or React in the admin origin.
-- Requiring a custom app to be listed, reviewed, or published in a marketplace.
-- Marketplace access, listings, or marketplace app installation for self-hosted
-  deployments.
-- Distributing app release artifacts through npm or any package manager.
-- Technically preventing a developer from privately distributing a custom app
-  to self-hosted deployments; multi-deployment distribution terms are
-  contractual, not mechanical.
-- Compiling, modifying, or executing app UI in the admin origin. Voyant may
-  store and serve immutable app-provided assets from an isolated app origin.
+- Replacing Voyant modules, adapters, or providers with runtime apps.
+- Supporting arbitrary app JavaScript or React in the admin origin.
+- Operating a public catalog, listing review, publisher program, subscription,
+  billing, or payout system.
+- Automatically updating a custom app from a mutable remote source.
+- Distributing app releases through npm or any package manager.
+- Preventing a developer from privately distributing an app artifact to another
+  deployment; distribution terms are outside the runtime contract.
 - Guaranteeing ordered or exactly-once webhook delivery.
-- Allowing custom validation functions in custom-field definitions.
-- Migrating every existing integration in the first implementation phase.
+- Allowing arbitrary validation functions in custom-field definitions.
 
 ## Terminology
 
 | Term | Meaning |
 | --- | --- |
 | **App** | A separately deployed service activated for a Voyant deployment through OAuth. |
-| **App registration** | The stable global identity, credentials, redirect URIs, ownership, and distribution policy of an app. |
-| **App release** | An immutable, validated snapshot of an app manifest and its declared capabilities. |
-| **App release artifact** | The signed, content-addressed package for one app release, containing declarative integration metadata and optional sandboxed static UI assets, but no app backend or Operator runtime code. |
-| **Release acquisition** | Making an app release artifact available to one deployment through the managed catalog or a private custom-app upload or manifest fetch. |
-| **App installation** | The deployment-local relationship between one app registration and one Voyant deployment. |
-| **Marketplace app** | An app distributed through a reviewed marketplace listing, installable only on the managed runtime and billed through Voyant. |
-| **App subscription** | The Voyant-billed commercial relationship between an operator and a marketplace app installation, carried on the operator's Voyant invoice with a platform revenue share. |
-| **Custom app** | A private app created directly by an authorized developer or operator and installed without marketplace publication. |
+| **App registration** | Stable identity, credentials, redirect URIs, ownership, and release-signing identity for an app. |
+| **App release** | An immutable validated snapshot of an app manifest and its declared capabilities. |
+| **App release artifact** | The signed, content-addressed declarative package for one release, with optional sandboxed static assets and no backend or Operator runtime code. |
+| **Release acquisition** | Storing a verified release artifact in a deployment-local registry or accepting one from an explicit host integration. |
+| **App installation** | The deployment-local relationship between an app registration, one active release, grants, and lifecycle state. |
+| **Custom app** | An app registered directly by an authorized deployment actor and installed without an operated listing service. |
 | **Admin extension** | A remote page or slot contribution rendered through the sandboxed admin extension host. |
-| **App locale catalog** | App-owned translations for the app's remote UI and validated localized metadata for host-rendered app labels. |
-| **Deployment component** | Trusted executable npm-selected module, adapter, or provider included in the resolved deployment graph. |
-| **Payment adapter** | A deployment component implementing the canonical payment processor contract. |
+| **App locale catalog** | App-owned translations for its remote UI and validated localized metadata for host-rendered labels. |
+| **Deployment component** | Trusted npm-selected module, adapter, or provider included in the resolved deployment graph. |
 | **Custom-field target** | A Voyant entity type whose owning module supports namespaced custom fields. |
-| **Operator-owned field** | A definition created and structurally controlled by an operator in Settings. |
-| **App-owned field** | A definition structurally controlled by one registered app. |
-| **Reserved app namespace** | An immutable physical namespace assigned by Voyant to one app registration. |
+| **Reserved app namespace** | An immutable physical namespace assigned by the deployment to one app registration. |
 
-The word **plugin** should not be used for a runtime-installed product. Existing
-executable npm plugin bundles should be reclassified by their actual deployment
-role: module, extension, adapter, or provider. A declarative app release package
-is an app distribution artifact, not a plugin or graph unit.
+The word **plugin** does not describe a runtime-installed app. Executable npm
+bundles are classified by their deployment role: module, extension, adapter, or
+provider. A declarative app artifact is not a plugin or graph unit.
 
 ## Product Classification
 
-| Capability | Delivery | Reason |
-| --- | --- | --- |
-| Core and vertical domain behavior | Voyant or project module | Owns native behavior and often native schema. |
-| Search engine implementation | Deployment provider/adapter | Infrastructure selection used throughout request and indexing paths. |
-| Payment processor implementation | Deployment payment adapter | Participates in security-sensitive checkout, callbacks, finance state, and capability routing. |
-| Object storage, cache, workflow runtime | Deployment provider | Process and infrastructure authority. |
-| Accounting synchronization | Remote app | Can operate through finance APIs, events, webhooks, and remote UI. |
-| CRM/accounting/document export integration | Remote app | External service owns its runtime and integration state. |
-| Dashboard card or entity-side panel | Remote admin extension | UI contribution does not require host code execution. |
-| Small app-specific attribute on a Voyant entity | App-owned custom field | Typed, namespaced attachment to native data. |
-| Complex app-specific records | App database | Independent lifecycle and query model remain outside Voyant. |
+| Capability | Delivery |
+| --- | --- |
+| Core and vertical domain behavior | Voyant or project module |
+| Search, payment, storage, cache, or workflow implementation | Deployment adapter or provider |
+| CRM, accounting, document export, or remote synchronization | Remote app when stable APIs and events are sufficient |
+| Dashboard card or entity-side panel | Remote admin extension |
+| Small app-specific attribute on a Voyant entity | App-owned custom field |
+| Complex app-specific records | App-owned database |
 
-## User Stories
+Capabilities requiring native transactions, synchronous checkout participation,
+schema ownership, or infrastructure authority remain deployment components.
 
-1. As an operator, I want to activate an app release already available to my
-   deployment, so that consent and lifecycle do not execute ecosystem code.
-2. As an operator, I want to review requested permissions before installation,
-   so that I understand which data and actions the app can access.
-3. As an operator, I want to deny optional permissions, so that an app receives
-   only the access needed for enabled features.
-4. As an operator, I want to see every installed app and its health, grants,
-   extensions, and recent activity, so that I can govern integrations.
-5. As an operator, I want to uninstall or pause an app immediately, so that I
-   can stop access without waiting for a deployment.
-6. As an operator, I want app-owned data retained by default on uninstall, so
-   that accidental removal does not destroy operational history.
-7. As an operator, I want an explicit purge flow, so that retained app-owned
-   fields can be removed when policy requires it.
-8. As an operator, I want marketplace and custom apps to use the same consent
-   and lifecycle model, so that security does not depend on discovery source.
-9. As a self-hosted developer, I want to register a privately deployed app, so
-   that I can build operator-specific integrations without publishing them.
-10. As an app developer, I want a stable app identity across all installations,
-    so that namespaces and lifecycle events remain predictable.
-11. As an app developer, I want versioned OAuth scopes and APIs, so that I can
-    evolve my service without depending on Operator internals.
-12. As an app developer, I want an offline installation credential for webhooks
-    and background synchronization, so that work does not require an active
-    staff session.
-13. As an app developer, I want a short-lived online credential bounded by the
-    current viewer's permissions, so that interactive actions preserve staff
-    authorization.
-14. As an app developer, I want signed, short-lived admin session tokens, so
-    that my embedded UI can authenticate without third-party cookies.
-15. As an app developer, I want to contribute full pages and selected UI slots,
-    so that my app feels integrated without executing code in the admin origin.
-16. As an app developer, I want entity context in an admin extension, so that I
-    can render the relevant remote information for a booking, person, or
-    invoice.
-17. As an app developer, I want versioned webhook events with delivery IDs, so
-    that my handlers can be idempotent.
-18. As an app developer, I want replay and reconciliation support, so that a
-    temporary outage does not permanently desynchronize data.
-19. As an app developer, I want to declare typed custom fields in my app
-    manifest, so that required attachments appear consistently after install.
-20. As an app developer, I want a reserved namespace assigned by Voyant, so
-    that another app cannot collide with or impersonate my data.
-21. As an app developer, I want to use a stable `$app` alias rather than know a
-    physical namespace, so that every request is constrained to my app.
-22. As an app developer, I want optional logical sub-namespaces, so that I can
-    group fields without acquiring additional global namespaces.
-23. As an app developer, I want declarative validation and visibility controls,
-    so that Voyant can safely render, search, export, and expose field values.
-24. As an operator, I want app-owned fields visible in Settings with clear
-    ownership, so that I can understand why they exist.
-25. As an operator, I want app-controlled schema to be read-only in Settings,
-    so that an edit cannot silently break the app.
-26. As an operator, I want field-value edit permissions declared separately
-    from definition ownership, so that staff can edit values when appropriate.
-27. As an operator, I want two apps to use the same field key safely, so that
-    installation order cannot create collisions.
-28. As a Voyant module owner, I want to register supported custom-field targets,
-    so that apps cannot attach data to unsupported or unknown tables.
-29. As a finance maintainer, I want accounting apps to consume stable finance
-    events and APIs, so that accounting behavior does not run in-process.
-30. As an accounting app developer, I want to store sync cursors, mappings, and
-    reconciliation state in my own service, so that I control their lifecycle.
-31. As an accounting app developer, I want to attach an external reference or
-    summarized status to a Voyant invoice, so that staff can see integration
-    context without joining my database.
-32. As a deployment owner, I want to select one payment adapter explicitly, so
-    that environment variables cannot silently select a processor.
-33. As a deployment owner, I want Netopia, Voyant Payments, and future
-    processors to pass the same conformance suite, so that checkout does not
-    depend on provider-specific assumptions.
-34. As a finance maintainer, I want payment callbacks verified and normalized by
-    the selected adapter, so that native payment state remains trustworthy.
-35. As an operator, I want app API calls, field writes, permission changes, and
-    lifecycle actions in the audit trail, so that app activity is accountable.
-36. As a security administrator, I want immediate token revocation and key
-    rotation, so that compromised credentials can be contained.
-37. As a platform operator, I want manifest and API compatibility checks before
-    activation, so that incompatible apps fail before their UI is mounted.
-38. As a platform operator, I want per-app rate limits and delivery telemetry,
-    so that one unhealthy app cannot degrade the Operator.
-39. As an app reviewer, I want declared endpoints, scopes, data classes, and
-    retention behavior, so that marketplace review is evidence-based.
-40. As a user, I want a failed app extension to fail softly, so that the native
-    admin remains usable.
-41. As an authorized operator or developer, I want to create a custom app
-    directly in Voyant, so that private and operator-specific integrations do
-    not require marketplace publication.
-42. As a custom app developer, I want the same manifest, OAuth, UI, webhook, and
-    custom-field capabilities as a marketplace app, so that private
-    distribution is not a reduced app model.
-43. As an app developer, I want to own my app's UI and translation bundles, so
-    that I can release localized experiences on my own cadence.
-44. As a staff user, I want an app extension and its host-rendered labels to use
-    my active locale with deterministic fallbacks, so that the embedded
-    experience is linguistically consistent with the admin.
-45. As a self-hosted developer, I want to create, release, and install custom
-    apps entirely within my deployment, so that my integrations never depend on
-    Voyant-operated infrastructure.
-46. As a managed-runtime operator, I want compatible app updates applied
-    automatically according to policy, so that I receive fixes without
-    redeploying Voyant.
-47. As an operator, I want new scopes, incompatible protocol changes, and major
-    releases to require approval, so that automatic updates cannot expand
-    access or break an installation.
-48. As an app developer, I want one validated release artifact to serve
-    self-hosted and managed deployments, so that I do not maintain two app
-    architectures.
-49. As a custom app developer, I want to upload the same release artifact
-    privately or register a signed manifest source, so that private delivery
-    never requires marketplace publication.
-50. As an app backend developer, I want each request to identify the installed
-    app release and protocol versions, so that I can honor compatibility for
-    deployments that upgrade on different schedules.
-51. As a managed-runtime operator, I want app subscription charges on my
-    regular Voyant invoice, so that installed apps do not create separate
-    billing relationships.
-52. As a marketplace app developer, I want Voyant to bill operators and pay out
-    my revenue share, so that I can sell to every managed operator without
-    building my own billing.
+## Trust Boundary
 
-## Architecture
-
-### 1. Trust Boundary
-
-The Operator graph remains immutable at runtime. Activating or upgrading an app
-installation changes database state and sandboxed asset registrations only; it
-does not add graph units, routes, migrations, imports, providers, or executable
-server code.
-
-On self-hosted deployments, acquiring a release means registering a custom app
-and storing its validated, signed release snapshot in the deployment-local app
-registry through upload or a protected HTTPS manifest fetch. Nothing about
-acquisition touches the project package manifest, the lockfile, or the build.
-On managed deployments, the control plane performs catalog acquisition without
-mutating the Operator graph.
+The Operator graph is immutable at runtime. Activating or upgrading an app
+changes database state and sandboxed asset registrations only. It does not
+change the project manifest, lockfile, build, migration plan, imports, graph
+units, or provider selection.
 
 Remote apps interact with Voyant through five public contract families:
 
@@ -362,1171 +143,467 @@ Remote apps interact with Voyant through five public contract families:
 4. Sandboxed admin extensions.
 5. Namespaced custom-field definition and value APIs.
 
-All app traffic is treated as external network traffic even when the app is
-deployed by the same organization or on the same infrastructure.
+All app traffic is external network traffic even when the app is operated by the
+same organization or deployed on nearby infrastructure.
 
-### 2. App Registration And Distribution
+## Registration And Distribution
 
-An app registration has one immutable platform ID. Human-readable names and
-slugs may change and are never authorization or namespace identity.
+An app registration has one immutable app ID and physical namespace.
+Human-readable names and slugs may change and are never authorization or
+namespace identity.
 
-The registration records:
+A registration records:
 
-- immutable app ID;
-- developer or owning organization;
-- display metadata and listing state;
-- marketplace or custom distribution policy;
+- immutable app ID and reserved namespace;
+- owning actor or organization;
+- display metadata and lifecycle state;
 - exact redirect URI allowlist;
-- launch and lifecycle URLs;
-- client authentication material;
-- signing keys and rotation state;
+- launch, lifecycle, privacy, health, and support URLs;
+- client authentication material and signing keys;
 - requested and optional scopes;
 - supported Voyant API range;
-- current released manifest version;
-- release signing identity and allowed distribution channels;
-- review and suspension state.
+- released manifest history.
 
-A marketplace listing references an approved app registration but is not the
-source of app identity. Marketplace registrations live in the managed control
-plane, and marketplace listings are installable only on managed deployments.
-A custom app is created from an Apps developer or Settings surface by an
-authorized actor; on a self-hosted deployment that registration is stored
-locally and is the only supported app path. Creation assigns the immutable app
-ID, reserved namespace, distribution policy, and initial credential generation
-before installation.
+Custom app creation must:
 
-Custom app creation must support at least:
+1. Require a dedicated app-development or app-administration permission.
+2. Assign the app ID and reserved namespace before installation.
+3. Record exact redirect URIs and lifecycle endpoints.
+4. Accept a signed manifest snapshot or protected HTTPS source.
+5. Validate requested scopes and compatibility.
+6. Create an immutable release.
+7. Issue or register client authentication material.
+8. Start consent directly or produce a restricted installation link.
 
-1. Create a private app registration for one operator organization or
-   deployment.
-2. Record developer ownership, redirect URIs, lifecycle URLs, and a signed
-   manifest source or uploaded manifest snapshot.
-3. Validate requested scopes and manifest compatibility.
-4. Create an immutable app release.
-5. Issue or register client authentication material.
-6. Start installation directly or generate a restricted installation link.
+An arbitrary URL can never choose an app ID or reserved namespace.
 
-None of these steps creates a marketplace listing or requires marketplace
-review. A custom app may remain private indefinitely. If its owner later submits
-it for marketplace distribution, the listing references the existing app
-identity; publication must not replace its app ID, namespace, releases, or
-existing installations.
-
-Marketplace distribution is also a commercial contract. A listed app must
-price through Voyant billing: its subscription and usage charges are collected
-by Voyant, appear as line items on the operator's Voyant invoice, and carry a
-platform revenue share paid out to the developer. Listing terms restrict
-distributing the same app to multiple unrelated operators through the custom
-path; that restriction is contractual, because Voyant has no technical
-enforcement point inside a self-hosted deployment. Marketplace commerce state
-— listings, pricing plans, subscriptions, invoicing linkage, and payouts —
-lives in the managed control plane, keyed by app, installation, and deployment
-identity, and consumes installation lifecycle events. No commerce logic enters
-the Operator or this repository's packages.
-
-Accepting an arbitrary URL must never let the URL choose its app ID or reserved
-namespace. The actor creating a custom app must hold a dedicated app-development
-or app-administration permission. Managed deployments may store the registration
-in a managed control plane and self-hosted deployments may store it locally, but
-both must expose the same app and installation semantics.
-
-### 3. App Manifest, Artifact, And Releases
+## Manifest And Release Artifact
 
 The manifest is closed, versioned, declarative data. It may declare:
 
-- manifest schema version and release version;
+- manifest schema version and app release version;
 - Voyant API compatibility range;
 - requested and optional scopes;
-- admin pages and slot extensions;
-- default locale, supported locales, and localized host-rendered metadata;
+- admin pages and supported slot extensions;
+- default locale, supported locales, and localized host metadata;
 - webhook event subscriptions and event versions;
 - app-owned custom-field definitions;
 - setup and configuration descriptors;
 - health, launch, privacy, and support URLs;
 - data classification and retention declarations.
 
-It may not declare schemas, migrations, host routes, runtime factories,
-subscribers, infrastructure providers, or arbitrary executable hooks.
+It may not declare:
 
-Releasing a manifest creates an immutable app release artifact. The artifact is
-content-addressed, signed, and includes:
+- database schemas or migrations;
+- host routes or runtime factories;
+- subscribers or infrastructure providers;
+- dependency installation or lifecycle scripts;
+- arbitrary executable host hooks.
+
+Releasing a manifest creates an immutable artifact containing:
 
 - the canonical manifest snapshot;
-- host-rendered localized metadata;
-- optional static iframe UI and in-frame locale assets;
-- integrity hashes and provenance;
-- declared API, event, extension-protocol, and Voyant compatibility ranges;
-- generated metadata needed for deterministic reconciliation.
+- validated host-rendered localized metadata;
+- optional static iframe UI and locale assets;
+- integrity hashes and signature provenance;
+- declared API, event, extension, and Voyant compatibility ranges;
+- deterministic reconciliation metadata.
 
-The artifact may reference app backend endpoints, but it may not contain or
-install the backend implementation. Any included JavaScript, CSS, fonts, images,
-or locale catalogs are treated as untrusted static iframe assets. They are
-served only from a sandbox-compatible isolated origin and never imported by the
-Operator or admin bundle.
+Any included JavaScript, CSS, fonts, images, or locale catalogs are untrusted
+static iframe assets. They are served only from an isolated origin and never
+imported by the Operator, admin bundle, build, or migration process.
 
-An app release artifact has no executable surface. Publication and ingestion
-reject an artifact that contains:
+Publication or ingestion rejects:
 
-- lifecycle scripts or any package-manager metadata implying execution;
-- dependency declarations of any kind;
-- binary entries, native addons, or executable exports;
-- files outside the declared release envelope and asset inventory.
+- lifecycle scripts or package-manager metadata implying execution;
+- dependency declarations;
+- binary entries and native addons;
+- executable host exports;
+- undeclared files outside the release envelope and asset inventory.
 
-Static JavaScript included in the asset inventory is iframe content only. It is
-never resolved, imported, or executed by the Operator, the admin bundle, or a
-build step.
+A release cannot be replaced in place. Marking a release unavailable prevents
+new acquisition where policy permits but does not silently rewrite an already
+verified installation.
 
-The managed app catalog is the canonical release registry for marketplace
-apps. The deployment-local app registry (or a restricted managed registry)
-performs the same role for a custom app. Publication validates and signs the
-release once, then exposes the identical artifact through:
+Direct HTTPS manifest submission is an ingress path, not a mutable runtime
+source of truth. Fetching must enforce HTTPS, response-size, redirect,
+DNS-rebinding, timeout, content-type, and signature protections. The deployment
+stores the validated snapshot and digest used for the release.
 
-- the managed-runtime installer for marketplace apps;
-- restricted artifact upload or a protected HTTPS manifest source for custom
-  apps.
+## Installation Lifecycle
 
-App release artifacts are never distributed through npm or any package
-manager, and registry state outside Voyant is never app identity or release
-authority. A catalog release cannot be replaced in place. Yanking a release
-prevents new acquisition where policy permits, but does not invalidate an
-already verified installation artifact.
-
-Managed deployments acquire releases from the catalog and may advance active
-installations automatically only when release and tenant update policy allow
-it. New required scopes always require renewed operator consent. Incompatible
-protocol changes, unsupported Voyant ranges, and releases outside the accepted
-update policy remain pending rather than activating.
-
-Existing installations move to a new release only after compatibility,
-integrity, consent, and custom-field reconciliation checks. The app's remote
-backend deployment remains the app developer's responsibility, but the backend
-must honor the installed release contract for its declared support period.
-
-Marketplace manifests are read from the reviewed registry. Custom manifests
-must be fetched over HTTPS with response-size, redirect, DNS-rebinding, timeout,
-content-type, and signature protections. Voyant stores the validated snapshot
-used for each installation; it never executes content from a manifest response.
-
-Direct HTTPS manifest submission is a development and private-publication
-ingress, not a mutable runtime source of truth. Once released, both managed and
-self-hosted installations consume the immutable artifact and digest.
-
-### 4. App Installation Lifecycle
-
-An app installation is a deployment-local aggregate with these states:
+An installation has these states:
 
 `pending`, `authorizing`, `active`, `paused`, `degraded`, `revoked`, and
 `uninstalled`.
 
-Release acquisition precedes installation:
+Acquisition precedes activation:
 
-- self-hosted deployments acquire a custom-app release by upload or protected
-  HTTPS manifest fetch into the deployment-local app registry;
-- managed deployments acquire marketplace releases from the catalog
-  automatically or on operator request, and custom-app releases through the
-  same upload or fetch ingress.
-
-Acquisition makes a release available but grants no data access. Installation
-or upgrade is idempotent and follows this order:
-
-1. Resolve an approved app release.
-2. Verify release signature, digest, provenance, and deployment availability.
+1. Acquire an immutable release artifact.
+2. Verify digest, signature, provenance, and app identity.
 3. Validate Voyant, API, event, extension, and custom-field compatibility.
 4. Present required and optional grants.
 5. Complete OAuth authorization.
-6. Create or upgrade the installation and credentials atomically.
-7. Reconcile safe manifest declarations and immutable assets.
-8. Activate webhook subscriptions and admin extensions.
-9. Emit an auditable installation or upgrade event.
+6. Create or advance the installation atomically.
+7. Reconcile safe manifest declarations.
+8. Activate webhooks and sandboxed extensions.
+9. Emit an auditable lifecycle event.
+
+Installation is idempotent. Reinstalling the same app reuses the reserved
+namespace. Credential generations cannot overlap silently.
 
 Pausing disables API credentials, webhook delivery, and extension mounting but
-retains installation state. Uninstall additionally removes active webhook and
-UI registrations and marks app-owned definitions inactive. Values remain by
-default. Purge is a distinct privileged operation with a preview and retention
-checks.
-
-Reinstalling the same app registration reuses its reserved namespace. Whether
-it reactivates the prior installation row or creates a new generation is an
-implementation detail, but old and new credentials must never overlap silently.
-
-### 5. OAuth, Grants, And Tokens
-
-Voyant acts as the authorization server for app access. Authorization uses the
-authorization-code flow with PKCE, exact redirect matching, state validation,
-short-lived codes, and confidential-client authentication where applicable.
-
-Two access modes are required:
-
-- **Offline installation access:** for webhooks, scheduled work, and background
-  synchronization. It is bounded to the app installation and granted scopes.
-- **Online actor access:** short-lived access for an interactive admin session.
-  Effective permissions are the intersection of app grants, viewer grants, and
-  contextual restrictions.
-
-Refresh and rotation behavior must support immediate revocation. Access tokens
-must include or resolve to the app ID, installation ID, deployment audience,
-installed app release ID, negotiated API and extension-protocol versions,
-grants, issue time, expiry, and credential generation.
-
-The app cannot request a scope merely because it appears in its manifest. The
-scope must exist in the selected Voyant access catalog, be valid for remote
-apps, and be granted by an authorized operator.
-
-### 6. Remote Admin Extensions
-
-App UI uses the existing sandboxed iframe and versioned message protocol. The
-runtime installation store replaces the static self-hosted descriptor list as
-the source for activated extensions.
-
-The app owns all UI rendered inside its iframe: framework, components, styling,
-content, accessibility, and localization. Voyant does not compile or modify app
-UI and does not require app strings to be added to a Voyant package. A release
-may include immutable static UI assets that Voyant stores and serves byte-for-
-byte from an isolated app asset origin. Alternatively, a release may declare an
-immutable, integrity-bound app-owned asset origin when deployment policy allows
-it. This is equally true for marketplace and custom apps.
-
-The installed release, not the app's mutable default URL, determines which UI
-artifact is mounted. Rollback selects a previous compatible app release; it
-never mutates an existing release in place.
-
-Extensions may contribute:
-
-- full app pages under an app-owned admin route;
-- navigation entries pointing to those pages;
-- explicitly supported dashboard and entity-detail slots;
-- configuration and setup pages.
-
-The host never enables `allow-same-origin`, never injects an installation access
-token, and never trusts frame-provided entity or viewer context.
-
-The reserved token request becomes a short-lived admin session token. Its
-claims include issuer, app audience, installation, deployment, viewer, current
-entity and slot, issued/expiry times, and a unique token ID. The iframe sends
-that token to its own backend. The backend may exchange it for online actor
-access; the session token itself is not a general Voyant API credential.
-
-Session tokens must be short enough to make replay low value and must be
-reissued for current context. Third-party cookies are not part of the design.
-
-#### 6.1 App UI Internationalization
-
-The host sends the active canonical locale in the initial extension context and
-on every locale change. Locale identifiers use canonical BCP 47 language tags.
-The context also includes resolved text direction, `ltr` or `rtl`, so the app
-can render correctly without inferring direction from an incomplete language
-list.
-
-The app manifest declares:
-
-- one required default locale;
-- supported locale tags;
-- localized app name, navigation labels, extension titles, setup labels, and
-  other text rendered by the Voyant host;
-- optional localized custom-field labels and descriptions;
-- the location or release digest of app-owned in-frame locale catalogs.
-
-The iframe fetches and renders its own release-pinned locale catalog from the
-isolated release assets or an integrity-bound app origin. Voyant may store and
-serve the bytes, but it does not merge, compile, or become the authoring source
-of truth for in-frame translations. The manifest's localized host metadata is
-different: Voyant validates and pins it with the app release because the host
-renders those strings outside the iframe.
-
-Locale resolution is deterministic:
-
-1. exact active locale match;
-2. progressively less specific language match where declared, such as
-   `pt-BR` to `pt`;
-3. the app's declared default locale.
-
-The app receives both the requested active locale and the resolved app locale.
-It may choose a more sophisticated in-frame fallback, but host-rendered labels
-always use the platform algorithm above. Missing translations do not prevent an
-app from loading when the default locale is complete; they produce release
-validation warnings. A missing or incomplete default locale is a release error.
-
-Localized host metadata is plain text with field-specific length limits. It
-cannot contain HTML, scripts, message-format code, or executable expressions.
-Variable interpolation for host-rendered strings is limited to platform-defined
-placeholders with validated types. App-owned iframe catalogs may use the app's
-chosen localization library because they execute only inside the sandboxed app
-origin.
+retains installation state. Uninstall additionally deactivates subscriptions
+and app-owned definitions while retaining values by default. Purge is a
+separate privileged operation with preview and retention checks.
+
+Custom app releases never advance automatically from a mutable remote source.
+The owner first ingests an immutable release; an authorized actor then activates
+it after compatibility and consent checks.
+
+## OAuth, Grants, And Credentials
+
+Voyant acts as the authorization server for deployment-local app access.
+Authorization uses the authorization-code flow with PKCE, exact redirect
+matching, state validation, short-lived one-time codes, and confidential-client
+authentication where applicable.
+
+Two access modes are supported:
+
+- **Offline installation access:** bounded to an installation and its grants for
+  webhooks, scheduled work, and background synchronization.
+- **Online actor access:** short-lived access for an interactive admin session;
+  effective permission is the intersection of installation grants, viewer
+  grants, and contextual restrictions.
+
+Refresh, rotation, pause, and revoke must invalidate credential generations
+immediately. Tokens include or resolve to the app, installation, deployment
+audience, installed release, negotiated API version, grants, issue time, expiry,
+and credential generation.
+
+A scope is usable only when it exists in the selected Voyant access catalog, is
+allowed for remote apps, appears in the installed release, and is granted by an
+authorized actor. OAuth scope never bypasses action-ledger or approval policy.
+
+## Remote Admin Extensions
+
+Remote UI uses a sandboxed iframe and versioned message protocol. Active
+installation state is the source of mounted pages, navigation entries, and
+supported dashboard or entity-detail slots.
+
+App assets never execute in the admin origin. The host passes only declared,
+validated context. Full entity payloads and installation credentials are not
+sent through iframe initialization messages.
+
+The host issues short-lived, audience-bound session tokens for an extension.
+The iframe sends the token to its own backend, which exchanges it for online
+actor access. Effective access remains bounded by the app, installation,
+release, viewer, entity context, and current grants.
+
+Extensions fail soft. A slow, invalid, or unavailable app origin cannot block a
+native admin page.
+
+### Localization
+
+The app owns its in-frame translation catalogs. The release declares a complete
+default locale, supported locales, and validated localized strings for the small
+amount of app text rendered by Voyant, such as navigation labels.
+
+Locale resolution uses exact match, declared language fallback, then the
+complete default locale. The host passes active locale, resolved app locale,
+text direction, and locale changes through the extension protocol.
+
+## App APIs
+
+App APIs are a narrow, versioned surface distinct from broad admin routes. Every
+request resolves:
+
+- app and installation identity;
+- active installed release and digest;
+- deployment audience;
+- negotiated API version;
+- effective scopes and actor mode;
+- app namespace and relevant entity context.
+
+There is no universal database API. Resource-owning modules expose explicit
+remote-safe reads and actions through the selected access catalog. App APIs do
+not expose internal table shapes or bypass module services.
+
+Finance integrations use provider-neutral document contracts:
+
+- `GET /v1/app/finance/documents/:id` hydrates an invoice or proforma by its
+  stable Voyant ID, including billing identity, lines, tax fields, currencies,
+  persisted FX context, dates, language, totals, number-series metadata,
+  special tax-regime and margin-scheme Article 311 flags, and
+  external-allocation state. It requires `finance-documents:read`.
+- `GET /v1/app/finance/documents/:id/external-reference` reads the
+  provider reference under `finance-external-references:read`.
+- `PUT /v1/app/finance/documents/:id/external-reference` idempotently replaces
+  the complete, size-bounded reference document under
+  `finance-external-references:write`. An optional `allocation.invoiceNumber`
+  requires the additional `finance-external-allocation:write` scope.
+
+The allocation and reference write share one database transaction and one app
+audit record. Replaying the same allocation succeeds as `already_applied`;
+attempting to replace it or reuse an occupied number returns a stable conflict.
+Reference ownership is derived from the authenticated immutable app ID. A
+caller cannot select, discover, read, or overwrite another app's provider key.
+The provider-neutral DTOs and runtime port are owned by `finance-contracts`;
+Finance implements that port and the Apps gateway consumes it without either
+package importing the other's implementation.
+
+## Events And Webhooks
+
+Only events explicitly declared as externally deliverable can be subscribed to
+by an app. Subscriptions pin an event schema version and are reconciled from the
+active release and grants.
 
-Locale changes remount or notify the extension through the versioned protocol
-without requiring a new OAuth grant or installation. An app release may add
-translations without changing scopes; removing the default locale or a locale
-required by an installation's policy is a compatibility change.
-
-### 7. App APIs
-
-Remote app APIs are versioned public contracts, distinct from internal package
-routes. They use the existing access catalog but expose only scopes explicitly
-marked safe for remote apps.
-
-The first contract families should cover:
-
-- installation introspection and optional grant status;
-- supported core entity reads;
-- narrowly authorized mutations;
-- finance documents and accounting export actions;
-- custom-field definitions and values;
-- webhook subscription health and replay requests;
-- app-owned audit history;
-- admin session token exchange.
-
-Resource APIs must enforce installation status and ownership at the service
-boundary, not only in HTTP middleware. Local API defaults that bypass access
-control must not be reachable through app routes.
-
-### 8. Events And Webhook Delivery
-
-Apps consume externally visible, schema-versioned Voyant events. Package-owned
-event declarations remain the authority for event shape and redaction.
-
-Each delivery includes:
-
-- globally unique delivery ID;
-- installation and app identity;
-- event type and schema version;
-- event occurrence time and delivery attempt time;
-- subject identity and permitted payload;
-- signature and key identifier;
-- retry attempt metadata.
-
-Delivery is at least once and ordering is not guaranteed. Apps must deduplicate
-by delivery ID and process idempotently. Voyant signs the exact bytes sent,
-applies bounded exponential retry, records every attempt, exposes health, and
-supports replay from retained event history where policy permits.
-
-Repeated failures degrade and eventually pause the subscription, not the
-Operator. A periodic reconciliation API is required for integrations where a
-missed event would cause durable drift.
-
-### 9. Custom-Field Ownership And Namespaces
-
-Custom fields are typed values attached to native Voyant entities. They are not
-a general remote database and do not introduce app-defined tables.
-
-There are three namespace classes:
-
-| Owner | Namespace | Definition control | Default value control |
-| --- | --- | --- | --- |
-| Voyant | platform-reserved | Owning Voyant module | Owning module/policy |
-| Operator | `custom` | Operator in Settings | Operator and explicitly granted apps |
-| App | platform-assigned `app--<opaque-id>` | Owning app only | Definition policy |
-
-Apps never submit the physical `app--<opaque-id>` namespace. App-facing APIs
-accept `$app` or `$app:<subnamespace>` and resolve it from the authenticated app
-registration. The resulting physical namespace is immutable and cannot be
-claimed by another registration, including a custom app with the same display
-name or URL.
-
-The unique definition identity is:
-
-`(target_type, physical_namespace, key)`.
-
-This permits two apps to define `status`, `external_id`, or any other common key
-on the same target without collision. Duplicate identity within one app is a
-manifest or API error.
-
-#### 9.1 Target Registry
+`invoice.issued` and `invoice.proforma.issued` are externally deliverable. Their
+external projection contains only the stable `invoiceId`, provider-neutral
+`invoiceType`, and `skipExternalSync` control. Apps hydrate the current finance
+document through the scoped API instead of receiving customer, line, tax,
+series, or provider configuration in the webhook payload.
+`skipExternalSync` is an issuance-scoped decision that is not persisted on the
+document; the webhook projection is authoritative and a Worker must stop before
+hydration when it is true.
 
-Custom-field targets are declared by the Voyant module that owns the entity.
-The selected deployment graph lowers these declarations into a read-only target
-registry containing:
+Delivery is durable, signed, at-least-once, idempotency-friendly, retried with
+bounded backoff, observable, and replayable where retention policy permits.
+Queues isolate destinations and installations so one unhealthy app cannot starve
+another app or the Operator.
 
-- stable target type;
-- owning graph unit;
-- supported storage and API capabilities;
-- allowed custom-field types;
-- read, write, search, export, and presentation support;
-- limits and PII posture.
-
-Apps select from this registry. They cannot create new target types or point at
-arbitrary tables. The target registry replaces the Relationships-owned Postgres
-enum and hard-coded UI entity list.
-
-#### 9.2 Definitions
-
-A definition contains:
-
-- target, namespace, and key;
-- owner kind and owner ID;
-- label and description;
-- canonical type and declarative validations;
-- required/default behavior where the target supports it;
-- staff, app, public, export, invoice, and search visibility;
-- value write policy;
-- PII/data classification;
-- lifecycle status and manifest release provenance;
-- created and updated audit metadata.
-
-Operator-owned definitions are created and structurally edited in Settings.
-App-owned definitions are reconciled from an active app release or created
-through an owner-constrained app API. They appear in Settings, but structural
-properties are read-only to staff. Staff may manage explicitly supported
-presentation overrides without changing the app-owned schema.
-
-Only declarative validations are supported: length, numeric bounds, choices,
-patterns from an approved safe subset, reference target, and list cardinality.
-Arbitrary TypeScript validators are not supported.
-
-#### 9.3 Values
-
-Values remain with the owning entity in its `custom_fields` JSONB column. The
-logical shape is namespaced rather than flat:
-
-`custom_fields[namespace][key] = value`.
-
-Readers and writers use the custom-fields service; callers do not build JSONB
-paths directly. Validation resolves the definition by full identity and rejects
-unknown namespaces, unknown keys, invalid types, and unauthorized writes.
-
-Legacy flat values migrate into the operator-owned `custom` namespace unless a
-specific migration proves another owner. The migration must detect ambiguous
-keys and preserve the original value before changing shape.
-
-#### 9.4 Access Policies
-
-Definition ownership and value access are separate. App-owned definitions may
-select one supported value policy:
-
-- app read/write, staff read-only;
-- app read/write, staff read/write;
-- app write, staff hidden except privileged diagnostics;
-- app read, staff write;
-- read-only projection after creation.
-
-Policy is bounded by target capability and OAuth grants. An app's generic
-entity write scope does not grant writes to another app namespace. Operator
-fields require an explicit operator-field scope and never become app-owned.
-
-Search, export, invoice, storefront, and customer-account visibility are
-independent, conservative, and opt-in where data may leave the admin. PII fields
-must not become externally visible merely because an app asks for it.
-
-#### 9.5 Reconciliation And Compatibility
-
-Manifest reconciliation is deterministic and owner-scoped:
-
-- additive definitions are allowed;
-- labels and descriptions may change;
-- validation may be widened automatically;
-- validation tightening requires existing-value validation and an explicit
-  migration posture;
-- target, namespace, key, and type are immutable after values exist;
-- removal deprecates and hides a definition before any purge;
-- newly requested visibility or write access may require operator consent.
-
-No app release may shadow, replace, or modify an operator, platform, or other
-app definition.
-
-#### 9.6 Limits
-
-Voyant must enforce configurable per-installation and per-target limits for
-definition count, value size, JSON depth, list cardinality, indexed fields, and
-publicly exposed fields. Limits protect entity-row size, search fan-out, admin
-usability, and export cost.
-
-### 10. App Data Ownership
-
-Remote apps own their complex records in their own database. Voyant stores only
-the platform-side integration state needed to govern access and make native
-entities useful:
-
-- app registration and installation;
-- grants and credential metadata;
-- validated manifest snapshot;
-- extension and webhook registrations;
-- delivery and audit history;
-- app-owned custom-field definitions and values;
-- explicit source connections or projections where a Voyant capability owns
-  that contract.
-
-Sync cursors, app job state, accounting-specific mappings, and app business
-records stay remote unless Voyant defines a narrow interoperable projection.
-Secrets never belong in custom fields or manifest configuration JSON.
-
-### 11. Payment Adapter Boundary
-
-Payments are not marketplace apps. A processor participates in checkout,
-payment-session state, callback verification, idempotency, capture/refund
-semantics, and finance reconciliation. Its adapter is trusted deployment code
-selected in the resolved graph.
-
-Voyant will expose a canonical payment adapter port with:
-
-- declared processor capabilities;
-- create/initiate payment;
-- hosted checkout or redirect details;
-- authorize, capture, void, refund, and status operations as capabilities;
-- callback signature verification and canonical event mapping;
-- idempotency and retry contract;
-- health and diagnostics;
-- sandbox/test-mode declaration;
-- conformance tests for money, state transitions, replay, and failure behavior.
-
-The deployment selects the adapter explicitly through a payment provider role.
-Environment variables configure the selected adapter and never select one by
-their presence. The initial first-party choices are Voyant Payments and Netopia;
-future processors implement the same port. A custom selection is available for
-operator-owned adapters that pass the public conformance suite.
-
-V1 should select one active payment adapter per deployment. Multi-processor
-routing is deferred until concrete regional or method-routing requirements
-justify a router contract.
-
-### 12. Accounting App Boundary
-
-Accounting integrations are remote apps. They receive finance events, read
-authorized invoices and payments, perform remote synchronization, and write
-back only through scoped APIs and owned custom fields.
-
-For SmartBill, the target model is:
-
-- OAuth app installation and finance scopes;
-- invoice and credit-note event webhooks;
-- remote synchronization and reconciliation state;
-- remote configuration/admin pages mounted through the iframe host;
-- app-owned invoice fields for small external references or summarized status;
-- app API actions for explicit issue, retry, or reconcile operations where
-  finance policy permits them;
-- audit records for every remote mutation.
-
-Voyant remains authoritative for native finance records. The accounting app is
-authoritative for its remote job state and the external accounting system
-remains authoritative for its own issued identifiers and status. Any mirrored
-field must state its authority and freshness semantics.
-
-## Data Model
-
-The following aggregates are required. Exact SQL belongs to implementation
-design, but ownership and uniqueness are decisions of this RFC.
-
-### App registry
-
-- `apps`: immutable app identity and developer ownership.
-- `app_redirect_uris`: exact authorized redirects.
-- `app_credentials`: client and signing-key generations, never raw public API
-  tokens.
-- `app_releases`: immutable validated manifest snapshots, default locale, and
-  supported locales, compatibility ranges, support window, and lifecycle state.
-- `app_release_artifacts`: immutable digest, signature, provenance, registry
-  coordinates, asset inventory, and availability state.
-- `app_release_localizations`: validated host-rendered strings keyed by release,
-  locale, surface, and message key.
-- `app_release_channels`: managed-catalog and private distribution coordinates
-  for the same artifact digest.
-- `app_listings`: marketplace metadata, pricing-plan references, and review
-  state (managed control plane only).
-
-Marketplace commerce aggregates — pricing plans, app subscriptions, operator
-invoice line items, revenue-share ledgers, and developer payouts — belong to
-the managed control plane and are keyed by app, installation, and deployment
-identity. They are intentionally absent from this repository's data model.
-
-### Installation
-
-- `app_installations`: app, deployment, release, status, namespace assignment,
-  installed actor, update policy, last compatible release check, and lifecycle
-  timestamps.
-- `app_release_acquisitions`: deployment, app release, delivery channel,
-  verified digest, catalog or private upload/manifest-source provenance,
-  acquisition time, and availability state.
-- `app_grants`: requested, granted, optional, and revoked scopes.
-- `app_access_credentials`: hashed or encrypted credential metadata and
-  generations.
-- `app_extension_installations`: resolved page and slot descriptors.
-- `app_webhook_subscriptions`: resolved event/version/endpoints and status.
-- `app_installation_settings`: non-secret validated configuration.
-- `app_secret_references`: references to a secret store, not secret values.
-
-### Delivery and governance
-
-- `app_webhook_deliveries`: payload reference/hash, attempts, response posture,
-  next retry, and terminal state.
-- `app_audit_events`: installation, grants, tokens, API actions, definition
-  reconciliation, value writes, and lifecycle events.
-- `app_health`: derived or sampled health posture without making health checks a
-  source of truth for installation state.
-
-### Custom fields
-
-- `custom_field_targets`: generated or projected read-only selected-graph
-  targets.
-- `custom_field_definitions`: namespaced definition and owner.
-- `custom_field_definition_overrides`: operator-owned presentation overrides for
-  app definitions.
-- entity-local namespaced `custom_fields` JSONB values.
-
-The definition uniqueness constraint is exactly `(target_type, namespace,
-key)`. Ownership checks additionally require `owner_app_id` to match the app
-registration resolved from the authenticated installation.
-
-## API And Scope Decisions
-
-Scope names must describe resources and actions rather than app categories. The
-initial set should distinguish:
-
-- app installation self-read;
-- entity read scopes;
-- finance document read and authorized action scopes;
-- event subscription scopes;
-- own custom-field definition read/write;
-- own custom-field value read/write per target;
-- operator-owned custom-field access when separately granted;
-- online token exchange;
-- audit self-read.
-
-There is no broad `custom-fields:write` grant that permits cross-namespace
-writes. “Own namespace” is derived from the authenticated app and cannot be
-supplied as request data.
-
-High-impact finance actions use the existing action/approval policy. OAuth
-scope alone does not bypass approval or action-ledger requirements.
+Webhook payloads identify the event, delivery, installation, release, schema
+version, occurrence time, and deployment. Secrets and undeclared fields are
+excluded through the event catalog rather than app preference alone.
+
+## App-Owned Custom Fields
+
+### Target registry
+
+Each entity-owning module registers supported custom-field targets, including
+identity, storage and API capabilities, allowed types, and read/write/search/
+export/presentation behavior. Apps cannot attach fields to an unknown or
+unsupported table.
+
+### Ownership and identity
+
+Definitions distinguish operator and app ownership:
+
+| Owner | Namespace | Structural control |
+| --- | --- | --- |
+| Operator | operator-assigned | Authorized staff |
+| App | platform-assigned `app--<opaque-id>` | Owning app release or app API |
+
+Definition uniqueness is `(target, namespace, key)`. The `$app` alias is
+resolved from authenticated installation identity. A submitted physical app
+namespace is rejected.
+
+App-owned structural properties are read-only to staff. Explicitly supported
+presentation overrides may remain operator-owned. Definition policy and value
+policy are separate.
+
+Only declarative validation is allowed: length, numeric bounds, choices,
+patterns from an accepted subset, date constraints, nullability, and defaults
+where the target supports them.
+
+### Values and lifecycle
+
+Entity values are stored as namespaced JSONB:
+
+```json
+{
+  "operator": { "internal_note": "..." },
+  "app--01ABC": { "external_ref": "INV-42" }
+}
+```
+
+An app can read or write only its own namespace unless a distinct operator-owned
+field grant permits otherwise. Removing a definition does not silently delete
+values. Uninstall retains values by default; purge is explicit and audited.
+
+## App Data Ownership
+
+Voyant stores only data needed for native integration:
+
+- app identity, releases, installations, grants, and credentials;
+- resolved extensions and webhook subscriptions;
+- app-owned field definitions and values;
+- installation configuration, audit, and health state.
+
+The app stores complex records, cursors, mappings, queues, and provider-specific
+state in its own service. Voyant remains authoritative for native domain records;
+the app is authoritative for its private operational records.
 
 ## Versioning And Compatibility
 
-The platform versions these surfaces independently:
+The runtime versions independently:
 
-- app release artifact format and signature profile;
-- app manifest schema;
+- artifact format and signature profile;
+- manifest schema;
 - Voyant App API;
-- event payload schema per event type;
+- event payload schemas;
 - admin extension protocol;
-- app manifest localization and host-label schema;
-- payment adapter contract and conformance version.
+- manifest localization and host-label schema.
 
-An app release declares compatible ranges. Install and upgrade fail closed when
-there is no overlap. Breaking API versions have an announced support window and
-an installation-visible deadline. Event subscriptions pin a supported event
-version rather than silently receiving a new shape.
+An app release declares compatible ranges. Acquisition and activation fail
+closed when there is no overlap. Event subscriptions pin supported versions.
+Breaking contract versions require an announced support window and an
+installation-visible deadline.
 
-Remote app backend deployments do not automatically change the stored manifest.
-Capabilities visible to Voyant change only through an app release, preserving
-reviewability and rollback.
+Every authenticated request, token exchange, webhook, and lifecycle callback is
+bound to the installed release and relevant negotiated versions. A remote app
+backend must honor the release contract it declares. An unsupported or invalid
+backend response degrades only that installation; it cannot block Operator boot
+or native operation.
 
-#### Release Delivery And Update Policy
+## Security Requirements
 
-One app release has one identity and digest across every delivery channel.
-Catalog and private delivery must never produce semantically different
-artifacts for the same release ID.
-
-A custom-app installation advances only when its owner ingests a new release
-and an authorized actor activates it; there is no automatic remote update
-path for custom apps on self-hosted deployments. Voyant must expose installed,
-available, and incompatible release state for every installation.
-
-Managed marketplace installations have an explicit update policy:
-
-- `manual`: never advance without operator approval;
-- `compatible`: automatically advance releases within the current major version
-  that require no new consent and remain within all declared compatibility
-  ranges;
-- `patch`: a stricter compatible policy limited to patch releases;
-- `pinned`: remain on one release until explicitly unpinned.
-
-The managed default should be `compatible`, subject to platform rollback and
-release suspension controls. An organization may choose a stricter policy.
-Semantic version alone is insufficient evidence of compatibility; manifest
-diffing and platform contract checks are authoritative.
-
-An update cannot activate automatically when it:
-
-- requests a new required scope or expands sensitive data access;
-- crosses the installed app release's major-version boundary;
-- changes an immutable custom-field identity or tightens validation without an
-  accepted migration posture;
-- requires unsupported Voyant, API, event, artifact, or extension versions;
-- changes a reviewed high-risk endpoint or data-retention declaration;
-- has been suspended, revoked, or fails integrity verification.
-
-Such a release remains available but pending, with a human-readable explanation
-and required action. Compatible release rollback follows the same artifact and
-consent checks; rollback never rewrites release history.
-
-#### Remote Backend Compatibility
-
-The immutable artifact controls Voyant-visible capabilities and UI, but the app
-developer still deploys the remote backend. Every authenticated API request,
-session-token exchange, webhook, and lifecycle callback therefore includes or
-cryptographically binds:
-
-- app ID;
-- installation ID;
-- installed app release ID and digest;
-- negotiated Voyant App API version;
-- event schema version where applicable;
-- admin extension protocol version where applicable.
-
-The app provider must honor each release for its declared support period.
-Marketplace publication requires a minimum support policy and a declared
-end-of-support date or rolling support rule. Backend changes must remain
-compatible with every supported installed release.
-
-Voyant cannot technically prevent a remote provider from breaking its backend.
-It can detect incompatible responses or explicit unsupported-release signals,
-mark the installation degraded, stop mounting unsafe extensions, pause failing
-subscriptions, and preserve native admin operation. Managed catalog governance
-may suspend new installs or updates when a provider violates its support
-contract.
-
-## Security And Privacy Requirements
-
-1. Exact OAuth redirect matching; no wildcard production redirects.
-2. Authorization code PKCE, state validation, one-time codes, and short expiry.
+1. Exact OAuth redirect matching with no wildcard production redirects.
+2. PKCE, state validation, one-time authorization codes, and short expiry.
 3. Immediate pause, uninstall, grant revocation, and credential-generation
    revocation.
-4. App credentials stored or represented through the secret system; never in
-   custom fields, manifests, logs, or iframe context.
+4. Credentials stored through the secret system and never placed in manifests,
+   custom fields, logs, or iframe context.
 5. Short-lived, audience-bound admin session tokens with replay-resistant IDs.
 6. No installation access token delivered to an iframe.
-7. Service-boundary scope, installation, target, and namespace checks.
+7. Service-boundary scope, installation, target, and namespace enforcement.
 8. Webhook signatures over exact bytes, timestamp tolerance, rotation, and
    unique delivery IDs.
 9. Outbound endpoint SSRF protections and HTTPS requirements.
 10. Per-app and per-installation rate, concurrency, payload, and retry limits.
-11. Data classification and PII redaction derived from platform event and field
-    declarations, not app preference alone.
+11. Data classification derived from platform declarations.
 12. Audit coverage for grants, credentials, remote mutations, exports, and
     app-owned field access.
-13. Marketplace review for high-risk scopes and sensitive extension points.
-14. App suspension that disables every installation without deleting data.
-15. Explicit uninstall and privacy callbacks with bounded completion and
-    evidence.
-16. Tenant identity derived from the deployment and installation, never from an
+13. Tenant identity derived from deployment and installation, never from an
     app-supplied tenant parameter.
-17. Localized host metadata treated as untrusted plain text with strict schema
-    and length validation.
-18. Release artifacts require signature, digest, provenance, and package-to-app
-    identity verification before acquisition or activation.
-19. Static app assets are served from an isolated origin with restrictive
-    content security policy and cannot become admin-origin code.
-20. Package lifecycle events such as yanking or deprecation never silently
-    replace or invalidate an already verified artifact.
-21. App release publication and ingestion reject scripts, dependency
-    declarations, binaries, native addons, executable exports, and undeclared
-    files.
-22. Custom-app release ingestion enforces size, redirect, DNS-rebinding,
-    timeout, content-type, and signature protections before storing a
-    snapshot.
+14. Localized host metadata treated as untrusted plain text.
+15. Artifact signature, digest, provenance, and package-to-app identity
+    verification before acquisition or activation.
+16. Static assets isolated by origin and restrictive content security policy.
+17. Ingestion rejection for scripts, dependencies, binaries, native addons,
+    executable exports, and undeclared files.
+18. Protected HTTPS manifest fetch with size, redirect, DNS-rebinding, timeout,
+    content-type, and signature checks.
 
-## Reliability And Operational Requirements
+## Module Ownership
 
-- App API calls have explicit deadlines and cancellation.
-- Native Operator requests do not synchronously depend on a remote app unless a
-  dedicated contract defines timeout and failure posture.
-- UI extensions fail soft and cannot block native pages.
-- Webhook queues isolate destinations and installations.
-- Retries are bounded and observable; poison deliveries reach a terminal state.
-- Delivery replay is privileged, audited, and idempotency-preserving.
-- App status pages show grant drift, release compatibility, webhook health,
-  recent errors, and paused subscriptions.
-- App status pages show delivery channel, pinned or active release, available
-  updates, update policy, backend support deadline, and why an update is
-  blocked.
-- Managed compatible updates are reversible to the previous verified release.
-- Self-hosted deployments remain fully operational with no reachable
-  Voyant-operated service; acquired custom-app releases are stored in the
-  deployment itself.
-- Remote app outages do not prevent Operator boot, migration, or native finance
-  operations.
-- Payment adapter failures use the finance/payment state machine and are not
-  handled through generic app webhook infrastructure.
+Implementation is divided into independently testable modules:
 
-## Deep Modules And Ownership
-
-Implementation should prefer these independently testable modules:
-
-1. **App Registry:** registration, releases, review, support policy, and
-   immutable app identity.
-2. **Release Distribution:** signing, content addressing, managed catalog
-   acquisition, private artifact upload and manifest ingestion, provenance,
-   and rollback.
-3. **Installation Service:** consent, state machine, grants, update policy,
-   upgrade, pause, uninstall, reinstall, and purge planning.
+1. **App Registry:** custom registration, releases, and immutable app identity.
+2. **Release Ingestion:** protected fetch/upload, content addressing, signature
+   verification, provenance, and local release state.
+3. **Installation Service:** consent, grants, lifecycle, activation, pause,
+   uninstall, reinstall, and purge planning.
 4. **Manifest Compiler:** closed-schema validation and deterministic
-   reconciliation into installation capabilities and localized host metadata.
-5. **App Authorization Server:** OAuth codes, offline credentials, online token
-   exchange, rotation, revocation, and scope intersection.
-6. **Remote App Gateway:** release-aware version negotiation, rate limits,
-   authenticated service context, and app-safe resource APIs.
-7. **Admin Extension Broker:** installed release assets and descriptors, iframe
-   session tokens, token exchange, locale context, host-label resolution, and
-   fail-soft hosting.
-8. **Webhook Delivery Service:** subscription resolution, signing, durable
-   attempts, retry, replay, and health.
-9. **Custom Fields Module:** targets, namespaces, definitions, values,
-   validation, visibility, reconciliation, and migration.
-10. **Payment Adapter Contract:** provider selection, capability contract,
-   conformance suite, and canonical callback mapping.
-11. **App Governance UI:** listings, acquisitions, installs, update policy,
-    grants, health, audit, Settings integration, and data-retention actions.
-12. **Marketplace Commerce (managed control plane):** listings review,
-    pricing plans, app subscriptions, operator invoice line items, revenue
-    share, and developer payouts. This module lives outside this repository
-    and consumes installation lifecycle events.
+   reconciliation.
+5. **Authorization Server:** OAuth codes, credentials, online token exchange,
+   rotation, revocation, and scope intersection.
+6. **Remote App Gateway:** release-aware negotiation, rate limits, service
+   context, and remote-safe APIs.
+7. **Admin Extension Broker:** descriptors, isolated assets, iframe tokens,
+   locale context, and fail-soft hosting.
+8. **Webhook Integration:** subscription resolution, signed durable delivery,
+   retry, replay, and health.
+9. **Custom Fields:** targets, namespaces, definitions, values, validation,
+   reconciliation, and lifecycle.
+10. **App Governance UI:** custom app development, installations, grants, health,
+    audit, and data-retention actions.
 
-No generic module should import a specific accounting app, payment processor,
-or marketplace listing.
+No generic module imports a specific app, listing service, or provider.
 
-## Migration Plan
+## Public Data Model
 
-### Phase 0: Accept vocabulary and authority
+The deployment-local model contains:
 
-- Accept this RFC and update the module/provider/adapter/app taxonomy.
-- Reserve **app** for remote OAuth installations.
-- Stop presenting npm packages as operator-installable plugins.
-- Record the payment-versus-accounting boundary as normative architecture.
+- app registrations, redirect URIs, credentials, and immutable releases;
+- release artifacts, localizations, and acquisition provenance;
+- installations, grants, credentials, settings, and secret references;
+- resolved extension registrations and webhook subscriptions;
+- delivery and app audit records;
+- custom-field targets, definitions, overrides, and namespaced values.
 
-### Phase 1: Namespace-ready custom fields
+An externally operated listing or commerce model is not part of this schema.
+The deployment stores only the provenance needed to verify and explain an
+offered release.
 
-- Extract definition ownership, API, and Settings UI from Relationships into a
-  generic custom-fields module.
-- Replace the fixed Relationships entity enum with selected-graph targets.
-- Add owner kind, owner ID, namespace, access, visibility, and lifecycle fields.
-- Change uniqueness to `(target, namespace, key)`.
-- Introduce the server-resolved `$app` alias.
-- Migrate flat entity values into namespaced JSONB.
-- Remove project TypeScript discovery and code/database merge precedence.
-- Preserve compatibility reads during a time-bounded migration window.
+## Verification
 
-### Phase 2: App registry and OAuth installation
+Tests assert public behavior and durable invariants:
 
-- Add app registration, release, installation, grants, and lifecycle services.
-- Define and sign the immutable app release artifact.
-- Publish identical release digests through managed-catalog and private
-  distribution channels.
-- Reject scripts, dependencies, binaries, native addons, executable exports,
-  and undeclared files during app release publication and ingestion.
-- Add custom-app release upload and protected HTTPS manifest ingestion into
-  the deployment-local app registry.
-- Add managed acquisition, update-policy evaluation, rollback, and blocked-
-  update explanations.
-- Build custom app creation in Apps developer or Settings UI without a
-  marketplace dependency.
-- Implement marketplace discovery in the managed control plane over the same
-  release model; marketplace commerce (billing, revenue share, payouts) is a
-  managed workstream outside this repository.
-- Implement offline credentials, rotation, pause, revoke, and uninstall.
-- Build Installed Apps and consent UI.
-- Add audit and health surfaces.
-
-### Phase 3: Remote UI and token broker
-
-- Source admin extension descriptors from active installations.
-- Add app pages, navigation contributions, and selected slots.
-- Add manifest localization validation, release-pinned host labels, locale
-  negotiation, and locale/direction extension context.
-- Implement short-lived iframe session tokens and online token exchange.
-- Keep the existing sandbox posture and compatibility checks.
-
-### Phase 4: App API and webhooks
-
-- Publish the initial App API and remote-safe access scopes.
-- Lower externally visible event declarations into app subscriptions.
-- Add signing, durable delivery, retry, replay, and reconciliation contracts.
-- Add app developer SDK helpers without making them runtime authority.
-
-### Phase 5: Accounting app migration
-
-- Define the finance event and API coverage required by accounting apps.
-- Build SmartBill as the first remote accounting app reference.
-- Migrate configuration, external references, and operational state with an
-  explicit authority map.
-- Run package and remote implementations in comparison mode if necessary, but
-  permit only one write authority.
-- Remove the embedded SmartBill runtime after parity and migration evidence.
-
-### Phase 6: Payment adapters
-
-- Extract and publish the canonical payment adapter port.
-- Add the payment provider selection role and conformance kit.
-- Adapt Netopia to the contract and harden callback verification.
-- Implement Voyant Payments as the first-party default where available.
-- Update checkout and finance runtime composition to depend on the selected
-  payment adapter rather than plugin identity.
-- Defer multiple simultaneous processors until a routing requirement is
-  accepted.
-
-### Phase 7: Retire legacy plugin and custom-field seams
-
-- Remove deployment-local TypeScript custom-field support and documentation.
-  ✅ Custom-field portion complete.
-- Reclassify remaining npm plugin bundles by module/adapter/provider role.
-- Remove static installed-app lists once the installation service owns them.
-- Add mechanical checks that prevent app release packages from appearing as
-  executable deployment graph units and prevent executable deployment packages
-  from registering as apps.
-
-## Testing Decisions
-
-Tests should assert public behavior and durable invariants rather than internal
-function shape.
-
-### Contract and unit tests
-
-- Manifest schema acceptance, rejection, canonicalization, and deterministic
-  reconciliation.
-- Installation state-machine transitions and idempotency.
-- Scope intersection for offline and online access.
-- Credential rotation, pause, revoke, and expiry.
-- Namespace allocation, `$app` substitution, and rejection of physical or
-  foreign namespaces.
-- Cross-app collision tests using identical target and key.
-- Definition ownership and value-policy matrices.
-- Declarative custom-field validation and visibility.
-- App-release compatibility and renewed-consent rules.
-- Artifact signature, digest, provenance, channel-equivalence, and yanking
-  behavior.
-- Release-artifact rejection for scripts, dependency declarations, binaries,
-  native addons, executable exports, and undeclared files.
-- Managed `manual`, `compatible`, `patch`, and `pinned` update policies.
-- Custom-app release ingestion, explicit activation, and rejection of any
-  automatic remote update path.
-- Release-aware token and request context.
-- Webhook signing, duplicate delivery IDs, retry scheduling, and terminal
-  failure.
-- Admin session token audience, context, expiry, and replay posture.
-- Locale canonicalization, exact and language fallback, default-locale
-  completeness, and host-label validation.
-- Payment adapter conformance for every implementation.
-
-### Integration tests
-
-- Directly created custom apps and marketplace-discovered apps produce
-  equivalent installation aggregates.
-- The same release delivered through catalog acquisition and private upload
-  produces the same release ID, digest, manifest, assets, and reconciliation
-  result.
-- Publishing a new custom-app release does not change an installation until an
-  authorized actor activates it.
-- A managed compatible update activates automatically, while new scopes or
-  incompatible contracts leave the update pending.
-- A marketplace listing cannot be installed on a deployment without managed
-  catalog access.
-- Creating and installing a custom app never creates or requires a marketplace
-  listing.
-- OAuth install, API call, token refresh/rotation, pause, and uninstall.
-- Iframe handshake, session token, backend exchange, contextual API call, and
-  revocation.
-- Iframe UI receives requested locale, resolved app locale, direction, and live
-  locale changes; host labels use the same pinned app release.
-- Event emission through durable signed webhook delivery and replay.
-- App-owned definition install, value write, search/export visibility, uninstall,
-  and reinstall.
-- Two installed apps define and write the same key without collision.
-- An app cannot read or write another app's private definition or value.
-- Legacy flat custom-field data migrates without loss.
-- Accounting invoice event, remote synchronization, reference writeback, and
-  audit history.
-- Payment initiation, callback verification, duplicate callback, capture,
-  refund, and reconciliation against both Netopia and Voyant Payments adapters.
-
-### End-to-end and security tests
-
-- Consent accurately displays effective required and optional grants.
-- Native admin remains usable when the app origin is slow, invalid, or down.
-- Tampered, unsigned, mismatched, or replaced release artifacts fail before
-  activation.
-- An artifact containing any script, dependency declaration, binary, native
-  addon, executable export, or undeclared file is rejected without executing
-  it.
-- App static assets cannot execute in the admin origin or escape iframe sandbox
-  policy.
-- An app backend receives and honors the installed release context; an explicit
-  unsupported-release response degrades only that installation.
-- Missing non-default app translations fall back deterministically, while an
-  incomplete default locale fails release validation.
-- Third-party cookie blocking does not break embedded app authentication.
-- OAuth redirect, state, code replay, token audience, and confused-deputy tests.
-- Manifest-fetch SSRF, redirect, oversized body, invalid signature, and timeout
-  tests.
-- Webhook HMAC/JWS, timestamp, body mutation, endpoint isolation, and replay
-  tests.
-- Rate-limit and queue-isolation tests demonstrating one app cannot starve
-  another or the Operator.
-- Purge preview and execution tests proving retained data is not silently
-  destroyed.
-
-The repository's existing deployment graph, access catalog, admin extension,
-event catalog, action ledger, custom-field, and provider conformance tests are
-the prior art. New tests should use the same package-owned contract style.
+- manifest and artifact acceptance, rejection, canonicalization, and signatures;
+- rejection of executable or undeclared artifact content;
+- protected manifest-fetch behavior;
+- installation state transitions and idempotency;
+- explicit custom-release activation with no automatic mutable-source update;
+- scope intersection, token audience, rotation, pause, and revoke;
+- release and negotiated-version context on all app interactions;
+- iframe sandbox, session exchange, locale context, and fail-soft behavior;
+- webhook signing, isolation, retries, replay, and duplicates;
+- namespace allocation, `$app` resolution, and cross-app isolation;
+- custom-field ownership, lifecycle, validation, presentation, search, and export;
+- remote app outages degrading only the installation;
+- architecture checks preventing apps from entering the executable deployment
+  graph and preventing deployment packages from registering as apps.
 
 ## Acceptance Criteria
 
-1. Activating or upgrading an app never adds executable code, graph units,
-   routes, providers, schemas, migrations, or app backend code to the Operator.
-2. A self-hosted deployment can create, release, and install a custom app with
-   no dependency on Voyant-operated infrastructure, and acquisition never
-   touches the project package manifest, lockfile, or build.
-3. An authorized actor can create, release, and install a custom app without a
-   marketplace listing, publication, or review.
-4. Marketplace-discovered and directly created custom apps use one installation
-   aggregate and OAuth flow.
-5. No remote app manifest can declare schema, migrations, providers, or runtime
-   code.
-6. One immutable release ID and digest is used across managed-catalog and
-   private delivery channels.
-7. App release artifacts contain no lifecycle scripts, dependency declarations,
-   binaries, native addons, executable exports, or undeclared files.
-8. Marketplace listings are installable only on managed deployments, and every
-   marketplace installation has a Voyant-billed subscription context.
-9. A custom-app installation advances only when an authorized actor activates
-   an ingested release; publishing a newer release does not silently update it.
-10. Managed releases update only according to explicit policy, compatibility,
-   integrity, and consent checks.
-11. New required scopes always require operator consent, including on managed
-   deployments with automatic compatible updates.
-12. Installed app UI is always app-owned, release-pinned, and sandboxed.
-13. Every app can declare its default locale, supported locales, and localized
-   host-rendered metadata without adding strings to Voyant packages.
-14. The iframe receives the active locale, resolved app locale, and text
-   direction, and the app remains authoritative for its in-frame translations.
-15. Host-rendered app labels use deterministic locale fallback and a
-   release-pinned, complete default locale.
-16. The iframe receives no installation credential and can authenticate through
-   a short-lived session-token flow.
-17. Every app API request resolves an active installation, installed release,
-   negotiated contract versions, and effective scopes.
-18. Every app has an immutable platform-assigned namespace.
-19. An app cannot name, claim, read, define, or write another app namespace.
-20. Two apps can define the same key on the same target without collision.
-21. Operator-owned fields and app-owned fields have distinct definition and
-    value controls.
-22. Custom-field definitions have one database authority; project TypeScript
-    declarations are unsupported.
-23. Custom-field targets come from selected entity-owning modules rather than a
-    Relationships-owned enum.
-24. Uninstall revokes access and extensions immediately while retaining values
-    by default.
-25. Webhook delivery is signed, durable, at-least-once, idempotency-friendly,
-    observable, and replayable.
-26. Remote app outages or unsupported backend releases cannot block Operator
-    boot or native admin pages.
-27. Accounting integrations can operate through the App API and event surface
-    without in-process code.
-28. Netopia and Voyant Payments implement the same selected payment adapter
-    contract and pass its conformance suite.
-29. Environment variables never implicitly select a payment adapter.
-30. High-impact app actions remain subject to Voyant approval and action-ledger
-    policy.
-31. Architecture checks prevent vocabulary and authority from drifting back to
-    runtime-installed npm plugins.
+1. Activating or upgrading an app adds no executable code, graph units, routes,
+   providers, schemas, migrations, or backend code to the Operator.
+2. A deployment can create, release, and install a custom app with no dependency
+   on a Voyant-operated service.
+3. A custom release advances only through explicit ingestion and activation.
+4. No app manifest can declare schema, migrations, providers, or runtime code.
+5. Each release is immutable, signed, content-addressed, and verified before
+   activation.
+6. App UI is app-owned, release-pinned, isolated, and sandboxed.
+7. Every app request resolves an active installation, installed release,
+   negotiated versions, and effective scopes.
+8. Every app has an immutable reserved namespace, and cross-app namespace access
+   is rejected by construction.
+9. Custom-field definitions have one database authority and explicit ownership.
+10. Pause, revoke, and uninstall immediately remove access and extension
+    activation while retaining values by default.
+11. Webhook delivery is signed, durable, observable, bounded, and replayable.
+12. App outages and unsupported releases cannot block Operator boot or native
+    pages.
+13. Public packages contain no operated catalog, listing, commerce, or publisher
+    workflow authority.
 
 ## Consequences
 
 ### Benefits
 
-- Clear trust and ownership boundary.
-- Runtime OAuth activation, pause, and uninstall without executable deployment
-  mutation.
-- One installation model for managed and self-hosted operators.
-- Self-hosted custom apps with zero dependency on Voyant-operated
-  infrastructure.
-- Safe policy-driven updates and rollback for managed deployments.
-- One signed app artifact and compatibility contract across both channels.
-- A monetized marketplace that differentiates the managed runtime and funds
-  the app ecosystem through Voyant-billed subscriptions and revenue share.
+- A stable public app contract usable without an operated service.
+- Runtime activation without executable deployment mutation.
 - App failures isolated from the Operator process.
-- App developers own their runtime, database, and release cadence.
-- Collision-proof extensible entity data.
-- Smaller and more stable public extension surface.
-- Payment processing receives the stronger integration contract it requires.
-- Accounting integrations become independently deployable and upgradeable.
+- Least-privilege APIs and collision-proof extensible data.
+- App-owned UI, localization, backend, and release cadence.
+- A narrow, testable boundary for hosts that choose to offer acquired releases.
 
 ### Costs
 
-- Voyant must operate an authorization server, app registry, installation
-  service, signed release registry, token broker, webhook delivery plane, and
-  review process.
-- The managed control plane must additionally operate marketplace commerce:
-  pricing plans, subscription billing on operator invoices, revenue share, and
-  developer payouts.
-- Managed update policy, rollback, artifact retention, signing, and provenance
-  add operational complexity.
-- Marketplace reach excludes self-hosted deployments; app developers address
-  self-hosted operators only through custom apps under contractual terms.
-- Remote app providers must support multiple installed releases concurrently
-  for their declared support window.
-- Remote calls add latency and failure modes.
+- Deployments operate authorization, installation, token, webhook, and sandbox
+  infrastructure for custom apps.
+- Remote calls introduce latency and failure modes.
 - Apps cannot participate in native transactions.
-- App APIs and event schemas require long-term compatibility discipline.
-- Custom-field storage and APIs require a namespace migration.
-- SmartBill and other existing embedded integrations require deliberate remote
-  migration rather than mechanical package renaming.
-
-These costs are preferred to executing ecosystem code and migrations inside the
-Operator. Managed-catalog and private custom-app acquisition are two delivery
-channels for one app release and runtime architecture, not two app models.
+- App APIs and event schemas require compatibility discipline.
+- Deployment owners are responsible for acquiring, updating, and supporting
+  their custom apps.
 
 ## Resolved Decisions
 
 - App backends are remote-only; release artifacts are declarative.
-- Custom apps can be created and installed without marketplace listing,
-  publication, or review.
-- Marketplace and custom discovery converge on one OAuth installation model.
-- Every app release is an immutable signed artifact with one identity and digest
-  across delivery channels.
-- The marketplace is available only to managed deployments. It is a monetized
-  distribution channel: marketplace apps price through Voyant billing, their
-  subscription and usage charges appear on the operator's Voyant invoice, and
-  Voyant retains a platform revenue share and pays out developers.
-- Self-hosted deployments support custom apps only; their registrations and
-  acquired releases are stored in the deployment itself.
-- App release artifacts are never distributed through npm or any package
-  manager; npm is exclusively for executable deployment components.
-- Distributing one app to multiple unrelated operators outside the marketplace
-  is restricted contractually; Voyant does not technically enforce it inside
-  self-hosted deployments.
-- Marketplace commerce state lives in the managed control plane and never in
-  Operator packages.
-- Managed deployments acquire releases from the catalog and may apply
-  compatible updates according to explicit installation policy; custom-app
-  releases advance only by explicit owner activation.
-- The managed catalog is canonical for marketplace releases; a restricted
-  managed or deployment-local app registry is canonical for private custom
-  releases. Private uploads are delivery channels, not release identity.
-- An app release artifact is declarative and may contain sandboxed static UI
-  assets, but never backend implementation or executable Operator code.
-- App release artifacts have no scripts, dependency declarations, binaries,
-  native addons, executable exports, or undeclared files.
-- Acquisition and OAuth activation are separate operations.
-- There is no hybrid app mode.
+- Custom apps can be created and installed without a listing or operated
+  publication service.
+- App artifacts are never distributed through npm.
+- Acquisition and OAuth activation are separate.
+- App releases advance only through immutable snapshots and explicit activation.
 - New required scopes always require renewed consent.
-- Every app request and callback is bound to the installed release and
-  negotiated contract versions.
-- App providers must honor installed releases for their declared support
-  periods; unsupported backends degrade the app rather than the Operator.
+- Every app interaction is bound to the installed release and negotiated
+  contract versions.
 - Remote apps own complex records in their own database.
-- Custom fields are the native attachment seam, not a replacement for an app
-  database.
-- Physical app namespaces are assigned by Voyant and immutable.
-- App APIs resolve `$app` server-side and never trust a submitted physical
-  namespace.
-- Definition identity includes target, namespace, and key.
+- App-owned custom fields use immutable namespaces and server-resolved `$app`.
 - Database definitions are the sole runtime custom-field authority.
-- Payment processors are deployment adapters.
-- Netopia and Voyant Payments implement the same payment adapter contract.
-- Accounting integrations are remote apps.
-- V1 selects one active payment adapter per deployment.
-- Uninstall retains app-owned values by default; purge is explicit.
-- Each app owns its iframe UI and in-frame localization catalogs.
-- Voyant stores only validated, release-pinned localization used for
-  host-rendered app labels.
-- Locale resolution uses exact match, declared language fallback, then the
-  app's complete default locale.
-
-## Deferred Decisions
-
-- Exact revenue-share percentages, pricing-plan mechanics, trial and proration
-  rules, and payout schedules for marketplace subscriptions.
-- Exact App API transport shape beyond HTTP/JSON and webhook contracts.
-- Public-key versus confidential-secret client authentication defaults.
-- Fine-grained limits per custom-field target and deployment plan.
-- A future platform-native custom-object facility for interoperable standalone
-  records. Remote app databases remain the v1 answer.
-- Multi-processor payment routing.
-- Cross-deployment app installations for managed multi-deployment operator
-  organizations.
+- App UI and localization remain app-owned and isolated from the admin origin.
+- Operated catalogs, listings, commerce, publisher review, and hosted
+  distribution policy are outside the public repository.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -884,6 +884,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -885,6 +885,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/apps/package.json
+++ b/packages/apps/package.json
@@ -42,6 +42,7 @@
     "@voyant-travel/admin-extension-sdk": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/custom-fields": "workspace:^",
+    "@voyant-travel/finance-contracts": "workspace:^",
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/types": "workspace:^",

--- a/packages/apps/src/api-runtime.ts
+++ b/packages/apps/src/api-runtime.ts
@@ -6,29 +6,36 @@ import {
   customFieldValueOperationsRuntimePort,
 } from "@voyant-travel/core/runtime-port"
 import { createCustomFieldTargetRegistry } from "@voyant-travel/custom-fields"
+import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/app-api"
 import type { ApiModule } from "@voyant-travel/hono/module"
 import { createAppsAppApiRoutes } from "./app-api-routes.js"
 import { createAppsAdminRoutes } from "./routes.js"
 
-export const createAppsApiModule = defineGraphRuntimeFactory(async ({ getPorts, graph }) => {
-  const customFieldTargets = createCustomFieldTargetRegistry(graph.customFieldTargets ?? [])
-  const customFieldValueLifecycles = await getPorts<CustomFieldValueLifecycleRuntime>(
-    customFieldValueLifecycleRuntimePort,
-  )
-  const customFieldValueOperations = await getPorts<CustomFieldValueOperationsRuntime>(
-    customFieldValueOperationsRuntimePort,
-  )
-  return {
-    module: { name: "apps" },
-    adminRoutes: createAppsAdminRoutes({ eventCatalog: graph.eventCatalog }),
-    lazyRoutes: {
-      paths: ["/v1/app", "/v1/app/*"],
-      load: async () =>
-        createAppsAppApiRoutes({
-          customFieldTargets,
-          customFieldValueLifecycles,
-          customFieldValueOperations,
-        }),
-    },
-  } satisfies ApiModule
-})
+export const createAppsApiModule = defineGraphRuntimeFactory(
+  async ({ getPort, getPorts, graph, hasPort }) => {
+    const customFieldTargets = createCustomFieldTargetRegistry(graph.customFieldTargets ?? [])
+    const customFieldValueLifecycles = await getPorts<CustomFieldValueLifecycleRuntime>(
+      customFieldValueLifecycleRuntimePort,
+    )
+    const customFieldValueOperations = await getPorts<CustomFieldValueOperationsRuntime>(
+      customFieldValueOperationsRuntimePort,
+    )
+    const finance = hasPort(financeAppApiRuntimePort)
+      ? await getPort(financeAppApiRuntimePort)
+      : undefined
+    return {
+      module: { name: "apps" },
+      adminRoutes: createAppsAdminRoutes({ eventCatalog: graph.eventCatalog }),
+      lazyRoutes: {
+        paths: ["/v1/app", "/v1/app/*"],
+        load: async () =>
+          createAppsAppApiRoutes({
+            customFieldTargets,
+            customFieldValueLifecycles,
+            customFieldValueOperations,
+            finance,
+          }),
+      },
+    } satisfies ApiModule
+  },
+)

--- a/packages/apps/src/app-api-contracts.ts
+++ b/packages/apps/src/app-api-contracts.ts
@@ -5,6 +5,10 @@ import {
   updateCustomFieldDefinitionSchema,
   upsertCustomFieldValueSchema,
 } from "@voyant-travel/custom-fields"
+import type {
+  FinanceAppApiExternalReference,
+  FinanceAppApiIssuanceDocument,
+} from "@voyant-travel/finance-contracts/app-api"
 import { z } from "zod"
 
 export const APP_API_VERSION = "2026-07-01"
@@ -31,6 +35,36 @@ export const appApiFinanceActionSchema = z
     approvalId: z.string().min(1).optional(),
     idempotencyKey: z.string().min(1),
     payload: z.record(z.string(), z.unknown()).default({}),
+  })
+  .strict()
+
+export const appApiFinanceExternalReferenceSchema = z
+  .object({
+    externalId: z.string().min(1).max(500).nullable(),
+    externalNumber: z.string().min(1).max(500).nullable(),
+    externalUrl: z
+      .string()
+      .url()
+      .max(2_048)
+      .refine((value) => new URL(value).protocol === "https:", "External URL must use HTTPS.")
+      .nullable(),
+    status: z.string().min(1).max(100).nullable(),
+    metadata: z
+      .record(z.string().min(1).max(100), z.unknown())
+      .refine((value) => JSON.stringify(value).length <= 16_384, "Metadata is too large.")
+      .nullable(),
+    syncedAt: z.string().datetime().nullable(),
+    syncError: z.string().max(4_000).nullable(),
+  })
+  .strict()
+
+export const appApiFinanceExternalReferenceUpsertSchema = z
+  .object({
+    reference: appApiFinanceExternalReferenceSchema,
+    allocation: z
+      .object({ invoiceNumber: z.string().trim().min(1).max(500) })
+      .strict()
+      .optional(),
   })
   .strict()
 
@@ -74,5 +108,11 @@ export {
 export type AppApiEntityReadQuery = z.infer<typeof appApiEntityReadQuerySchema>
 export type AppApiFinanceDocumentQuery = z.infer<typeof appApiFinanceDocumentQuerySchema>
 export type AppApiFinanceActionInput = z.infer<typeof appApiFinanceActionSchema>
+export type AppApiFinanceExternalReferenceUpsertInput = z.infer<
+  typeof appApiFinanceExternalReferenceUpsertSchema
+>
 export type AppApiWebhookReplayInput = z.infer<typeof appApiWebhookReplaySchema>
 export type AppApiAuditQuery = z.infer<typeof appApiAuditQuerySchema>
+
+export type AppApiFinanceIssuanceDocument = FinanceAppApiIssuanceDocument
+export type AppApiFinanceExternalReference = FinanceAppApiExternalReference

--- a/packages/apps/src/app-api-finance-routes.test.ts
+++ b/packages/apps/src/app-api-finance-routes.test.ts
@@ -1,0 +1,184 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+import { createAppsAppApiRoutes } from "./app-api-routes.js"
+import { appGrants, appInstallations, appReleases } from "./schema.js"
+
+type TestEnv = {
+  Variables: {
+    db: PostgresJsDatabase
+    callerType: string
+    appId: string
+    appInstallationId: string
+    appReleaseId: string
+    appTokenMode: "offline" | "online"
+    scopes: string[]
+  }
+}
+
+function accessDb(scopes: readonly string[] = ["finance-documents:read"]): PostgresJsDatabase {
+  const db = Object.create(null) as PostgresJsDatabase
+  Object.assign(db, {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => {
+          const rows = () => {
+            if (table === appInstallations) {
+              return [
+                {
+                  id: "inst_1",
+                  appId: "app_1",
+                  deploymentId: "dep_1",
+                  releaseId: "rel_1",
+                  status: "active",
+                  namespace: "app--one",
+                },
+              ]
+            }
+            if (table === appReleases) {
+              return [
+                {
+                  id: "rel_1",
+                  appId: "app_1",
+                  releaseVersion: "1.0.0",
+                  apiCompatibility: { min: "2026-07-01", max: "2026-12-31" },
+                },
+              ]
+            }
+            if (table === appGrants) return scopes.map((scope) => ({ scope }))
+            return []
+          }
+          return {
+            // biome-ignore lint/suspicious/noThenProperty: models Drizzle's awaitable query builder.
+            then: (resolve: (value: unknown[]) => unknown) => Promise.resolve(rows()).then(resolve),
+            limit: async () => rows(),
+          }
+        },
+      }),
+    }),
+  })
+  return db
+}
+
+describe("finance App API routes", () => {
+  it("hydrates a finance issuance document by stable id", async () => {
+    const getIssuanceDocument = vi.fn().mockResolvedValue({ id: "inv_1" })
+    const app = new Hono<TestEnv>()
+    app.use("*", async (c, next) => {
+      c.set("db", accessDb())
+      c.set("callerType", "app")
+      c.set("appId", "app_1")
+      c.set("appInstallationId", "inst_1")
+      c.set("appReleaseId", "rel_1")
+      c.set("appTokenMode", "offline")
+      c.set("scopes", ["finance-documents:read"])
+      await next()
+    })
+    app.route("/", createAppsAppApiRoutes({ finance: { getIssuanceDocument } }))
+
+    const response = await app.request("/v1/app/finance/documents/inv_1")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ data: { id: "inv_1" } })
+  })
+
+  it("does not expose a caller-selected provider reference route", async () => {
+    const getExternalReference = vi.fn().mockResolvedValue({ id: "ref_1" })
+    const upsertExternalReference = vi.fn()
+    const app = new Hono<TestEnv>()
+    app.use("*", async (c, next) => {
+      c.set("db", accessDb(["finance-external-references:read"]))
+      c.set("callerType", "app")
+      c.set("appId", "app_1")
+      c.set("appInstallationId", "inst_1")
+      c.set("appReleaseId", "rel_1")
+      c.set("appTokenMode", "offline")
+      c.set("scopes", ["finance-external-references:read"])
+      await next()
+    })
+    app.route(
+      "/",
+      createAppsAppApiRoutes({ finance: { getExternalReference, upsertExternalReference } }),
+    )
+
+    const ownedResponse = await app.request("/v1/app/finance/documents/inv_1/external-reference")
+    expect(ownedResponse.status).toBe(200)
+    expect(getExternalReference).toHaveBeenCalledWith(expect.anything(), "inv_1", "app_1")
+
+    const response = await app.request(
+      "/v1/app/finance/documents/inv_1/external-references/another-provider",
+      {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          reference: {
+            externalId: null,
+            externalNumber: null,
+            externalUrl: null,
+            status: null,
+            metadata: null,
+            syncedAt: null,
+            syncError: null,
+          },
+        }),
+      },
+    )
+
+    expect(response.status).toBe(404)
+    expect(upsertExternalReference).not.toHaveBeenCalled()
+  })
+
+  it("atomically writes the owned reference, allocation, and audit through HTTP", async () => {
+    const scopes = ["finance-external-references:write", "finance-external-allocation:write"]
+    const db = accessDb(scopes)
+    const auditValues = vi.fn().mockResolvedValue(undefined)
+    Object.assign(db, {
+      transaction: (callback: (tx: PostgresJsDatabase) => unknown) => callback(db),
+      insert: () => ({ values: auditValues }),
+    })
+    const upsertExternalReference = vi.fn().mockResolvedValue({
+      status: "ok",
+      reference: { id: "ref_1" },
+      referenceOutcome: "created",
+      allocationOutcome: "applied",
+    })
+    const app = new Hono<TestEnv>()
+    app.use("*", async (c, next) => {
+      c.set("db", db)
+      c.set("callerType", "app")
+      c.set("appId", "app_1")
+      c.set("appInstallationId", "inst_1")
+      c.set("appReleaseId", "rel_1")
+      c.set("appTokenMode", "offline")
+      c.set("scopes", scopes)
+      await next()
+    })
+    app.route("/", createAppsAppApiRoutes({ finance: { upsertExternalReference } }))
+
+    const response = await app.request("/v1/app/finance/documents/inv_1/external-reference", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        reference: {
+          externalId: "remote_1",
+          externalNumber: "SB-42",
+          externalUrl: null,
+          status: "issued",
+          metadata: null,
+          syncedAt: null,
+          syncError: null,
+        },
+        allocation: { invoiceNumber: "SB-42" },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(upsertExternalReference).toHaveBeenCalledWith(db, "inv_1", "app_1", expect.anything())
+    expect(auditValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "app_1",
+        action: "finance.external-reference.upserted",
+      }),
+    )
+  })
+})

--- a/packages/apps/src/app-api-routes.ts
+++ b/packages/apps/src/app-api-routes.ts
@@ -19,6 +19,7 @@ import {
   appApiEntityReadQuerySchema,
   appApiFinanceActionSchema,
   appApiFinanceDocumentQuerySchema,
+  appApiFinanceExternalReferenceUpsertSchema,
   appApiTokenExchangeSchema,
   appApiVersionHeader,
   appApiWebhookReplaySchema,
@@ -121,6 +122,34 @@ export function createAppsAppApiRoutes(options: AppsAppApiRouteOptions = {}) {
       options.deadlineMs,
     ),
   )
+
+  routes.get("/finance/documents/:id", (c) => {
+    const { id } = parseIdParams(c.req.param())
+    return run(
+      c,
+      service.getFinanceIssuanceDocument(c.get("db"), appContext(c), id),
+      options.deadlineMs,
+    )
+  })
+
+  routes.get("/finance/documents/:id/external-reference", (c) => {
+    const { id } = parseIdParams(c.req.param())
+    return run(
+      c,
+      service.getFinanceExternalReference(c.get("db"), appContext(c), id),
+      options.deadlineMs,
+    )
+  })
+
+  routes.put("/finance/documents/:id/external-reference", async (c) => {
+    const { id } = parseIdParams(c.req.param())
+    const body = await parseJsonBody(c, appApiFinanceExternalReferenceUpsertSchema)
+    return run(
+      c,
+      service.upsertFinanceExternalReference(c.get("db"), appContext(c), id, body),
+      options.deadlineMs,
+    )
+  })
 
   routes.post("/finance/actions", async (c) => {
     const body = await parseJsonBody(c, appApiFinanceActionSchema)

--- a/packages/apps/src/app-api-service.test.ts
+++ b/packages/apps/src/app-api-service.test.ts
@@ -1,6 +1,8 @@
+import { FinanceAppApiNumberConflictError } from "@voyant-travel/finance-contracts/app-api"
 import { ApiHttpError } from "@voyant-travel/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { describe, expect, it, vi } from "vitest"
+import { appApiFinanceExternalReferenceUpsertSchema } from "./app-api-contracts.js"
 import {
   type AppApiAccessContext,
   assertAppNamespaceAlias,
@@ -137,6 +139,64 @@ describe("App API service boundary", () => {
     expect(executeAction).not.toHaveBeenCalled()
   })
 
+  it("hydrates one finance document through the stable App API identifier", async () => {
+    const getIssuanceDocument = vi.fn().mockResolvedValue({ id: "inv_1" })
+    const service = createAppApiService({
+      finance: { listDocuments: vi.fn(), executeAction: vi.fn(), getIssuanceDocument },
+    })
+
+    await expect(
+      service.getFinanceIssuanceDocument(
+        createAccessDb({ scopes: ["finance-documents:read"] }),
+        { ...context, scopes: ["finance-documents:read"] },
+        "inv_1",
+      ),
+    ).resolves.toEqual({ data: { id: "inv_1" } })
+    expect(getIssuanceDocument).toHaveBeenCalledWith(expect.anything(), "inv_1")
+  })
+
+  it("maps a provider-owned invoice number conflict to a stable App API conflict", async () => {
+    const upsertExternalReference = vi
+      .fn()
+      .mockRejectedValue(new FinanceAppApiNumberConflictError("SB-42"))
+    const service = createAppApiService({ finance: { upsertExternalReference } })
+    const db = createAccessDb({
+      scopes: ["finance-external-references:write", "finance-external-allocation:write"],
+    })
+    Object.assign(db, {
+      transaction: (callback: (tx: PostgresJsDatabase) => unknown) => callback(db),
+    })
+
+    await expect(
+      service.upsertFinanceExternalReference(
+        db,
+        {
+          ...context,
+          scopes: ["finance-external-references:write", "finance-external-allocation:write"],
+        },
+        "inv_1",
+        {
+          reference: {
+            externalId: null,
+            externalNumber: null,
+            externalUrl: null,
+            status: null,
+            metadata: null,
+            syncedAt: null,
+            syncError: null,
+          },
+          allocation: { invoiceNumber: "SB-42" },
+        },
+      ),
+    ).rejects.toMatchObject({ status: 409, code: "app_api_finance_number_conflict" })
+    expect(upsertExternalReference).toHaveBeenCalledWith(
+      expect.anything(),
+      "inv_1",
+      "app_1",
+      expect.anything(),
+    )
+  })
+
   it("isolates rate limits per installation", async () => {
     const service = createAppApiService({
       rateLimit: { installationLimit: 1, appLimit: 10, windowMs: 60_000 },
@@ -165,5 +225,24 @@ describe("App API service boundary", () => {
     expect(() =>
       assertCompatibleVersion("2027-01-01", { min: "2026-07-01", max: "2026-12-31" }),
     ).toThrow(ApiHttpError)
+  })
+
+  it("requires a complete bounded external-reference replacement", () => {
+    expect(appApiFinanceExternalReferenceUpsertSchema.safeParse({ reference: {} }).success).toBe(
+      false,
+    )
+    expect(
+      appApiFinanceExternalReferenceUpsertSchema.safeParse({
+        reference: {
+          externalId: null,
+          externalNumber: null,
+          externalUrl: null,
+          status: null,
+          metadata: { payload: "x".repeat(17_000) },
+          syncedAt: null,
+          syncError: null,
+        },
+      }).success,
+    ).toBe(false)
   })
 })

--- a/packages/apps/src/app-api-service.ts
+++ b/packages/apps/src/app-api-service.ts
@@ -7,6 +7,10 @@ import {
   createAppCustomFieldDefinitionOwner,
   createCustomFieldsService,
 } from "@voyant-travel/custom-fields"
+import {
+  FinanceAppApiNumberConflictError,
+  type FinanceAppApiRuntime,
+} from "@voyant-travel/finance-contracts/app-api"
 import { ApiHttpError } from "@voyant-travel/hono"
 import { and, asc, eq, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -16,8 +20,10 @@ import type {
   AppApiEntityReadQuery,
   AppApiFinanceActionInput,
   AppApiFinanceDocumentQuery,
+  AppApiFinanceExternalReferenceUpsertInput,
 } from "./app-api-contracts.js"
 import { APP_API_VERSION } from "./app-api-contracts.js"
+import { audit } from "./installation-reconciliation.js"
 import { appAuditEvents, appGrants, appReleases, appWebhookSubscriptions } from "./schema.js"
 
 export interface AppApiAccessContext {
@@ -34,9 +40,9 @@ export interface AppApiEntityReader {
   list(db: PostgresJsDatabase, query: AppApiEntityReadQuery): Promise<unknown>
 }
 
-export interface AppApiFinanceRuntime {
-  listDocuments(db: PostgresJsDatabase, query: AppApiFinanceDocumentQuery): Promise<unknown>
-  executeAction(db: PostgresJsDatabase, input: AppApiFinanceActionInput): Promise<unknown>
+export interface AppApiFinanceRuntime extends Partial<FinanceAppApiRuntime> {
+  listDocuments?(db: PostgresJsDatabase, query: AppApiFinanceDocumentQuery): Promise<unknown>
+  executeAction?(db: PostgresJsDatabase, input: AppApiFinanceActionInput): Promise<unknown>
 }
 
 export interface AppApiRateLimitPolicy {
@@ -125,7 +131,22 @@ export function createAppApiService(options: AppApiServiceOptions = {}) {
   ) {
     await requireAccess(db, context, ["finance-documents:read"])
     if (!options.finance) throw notSupported("Finance App API runtime is not configured.")
+    if (!options.finance.listDocuments)
+      throw notSupported("Finance document listing is unavailable.")
     return { data: await options.finance.listDocuments(db, query) }
+  }
+
+  async function getFinanceIssuanceDocument(
+    db: PostgresJsDatabase,
+    context: AppApiAccessContext,
+    documentId: string,
+  ) {
+    await requireAccess(db, context, ["finance-documents:read"])
+    const getDocument = options.finance?.getIssuanceDocument
+    if (!getDocument) throw notSupported("Finance document hydration is unavailable.")
+    const data = await getDocument(db, documentId)
+    if (!data) throw notFound("Finance document not found.")
+    return { data }
   }
 
   async function executeFinanceAction(
@@ -135,6 +156,7 @@ export function createAppApiService(options: AppApiServiceOptions = {}) {
   ) {
     await requireAccess(db, context, [`finance-actions:${input.action}`])
     if (!options.finance) throw notSupported("Finance App API runtime is not configured.")
+    if (!options.finance.executeAction) throw notSupported("Finance actions are unavailable.")
     if (!input.approvalId) {
       throw new ApiHttpError("Finance action requires action-ledger approval.", {
         status: 403,
@@ -142,6 +164,76 @@ export function createAppApiService(options: AppApiServiceOptions = {}) {
       })
     }
     return { data: await options.finance.executeAction(db, input) }
+  }
+
+  async function getFinanceExternalReference(
+    db: PostgresJsDatabase,
+    context: AppApiAccessContext,
+    documentId: string,
+  ) {
+    await requireAccess(db, context, ["finance-external-references:read"])
+    const getReference = options.finance?.getExternalReference
+    if (!getReference) throw notSupported("Finance external references are unavailable.")
+    const data = await getReference(db, documentId, context.appId)
+    if (!data) throw notFound("Finance external reference not found.")
+    return { data }
+  }
+
+  async function upsertFinanceExternalReference(
+    db: PostgresJsDatabase,
+    context: AppApiAccessContext,
+    documentId: string,
+    input: AppApiFinanceExternalReferenceUpsertInput,
+  ) {
+    const scopes = ["finance-external-references:write"]
+    if (input.allocation) scopes.push("finance-external-allocation:write")
+    const access = await requireAccess(db, context, scopes)
+    const upsertReference = options.finance?.upsertExternalReference
+    if (!upsertReference) throw notSupported("Finance external reference writes are unavailable.")
+
+    let result: Awaited<ReturnType<typeof upsertReference>>
+    try {
+      result = await db.transaction(async (tx) => {
+        const mutation = await upsertReference(tx, documentId, context.appId, input)
+        if (mutation.status === "ok") {
+          await audit(
+            tx,
+            access.installation,
+            `app:${context.appId}`,
+            "reconciliation",
+            "finance.external-reference.upserted",
+            {
+              documentId,
+              provider: context.appId,
+              referenceOutcome: mutation.referenceOutcome,
+              allocationOutcome: mutation.allocationOutcome,
+              releaseId: context.releaseId,
+              tokenMode: context.tokenMode,
+            },
+          )
+        }
+        return mutation
+      })
+    } catch (error) {
+      if (error instanceof FinanceAppApiNumberConflictError) {
+        throw new ApiHttpError("Finance document number is already in use.", {
+          status: 409,
+          code: "app_api_finance_number_conflict",
+          details: { invoiceNumber: error.invoiceNumber },
+        })
+      }
+      throw error
+    }
+
+    if (result.status === "not_found") throw notFound("Finance document not found.")
+    if (result.status === "allocation_conflict") {
+      throw new ApiHttpError("Finance document has already received a different allocation.", {
+        status: 409,
+        code: "app_api_finance_allocation_conflict",
+        details: result,
+      })
+    }
+    return { data: result }
   }
 
   async function listCustomFieldDefinitions(
@@ -240,7 +332,10 @@ export function createAppApiService(options: AppApiServiceOptions = {}) {
     introspect,
     listEntities,
     listFinanceDocuments,
+    getFinanceIssuanceDocument,
     executeFinanceAction,
+    getFinanceExternalReference,
+    upsertFinanceExternalReference,
     listCustomFieldDefinitions,
     createCustomFieldDefinition,
     updateCustomFieldDefinition,

--- a/packages/apps/src/voyant.ts
+++ b/packages/apps/src/voyant.ts
@@ -3,6 +3,7 @@ import {
   customFieldValueLifecycleRuntimePort,
   customFieldValueOperationsRuntimePort,
 } from "@voyant-travel/core/runtime-port"
+import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/runtime-port"
 
 const appsAdminRuntime = {
   entry: "@voyant-travel/apps-react/admin",
@@ -33,6 +34,7 @@ export const appsVoyantModule = defineModule({
       optional: true,
       cardinality: "many",
     }),
+    requirePort(financeAppApiRuntimePort, { optional: true }),
   ],
   api: [
     {
@@ -259,6 +261,45 @@ export const appsVoyantModule = defineModule({
             action: "reconcile",
             label: "Reconcile finance documents",
             description: "Request approved finance document reconciliation.",
+            sensitive: true,
+            wildcard: "explicit",
+          },
+        ],
+        wildcard: "explicit-resource",
+      },
+      {
+        id: "@voyant-travel/apps#access.finance-external-references",
+        resource: "finance-external-references",
+        label: "Finance external references",
+        description: "Read and record provider-owned finance document references.",
+        remoteSafe: true,
+        actions: [
+          {
+            action: "read",
+            label: "Read external references",
+            description: "Read the app provider's reference for a finance document.",
+          },
+          {
+            action: "write",
+            label: "Write external references",
+            description: "Idempotently record the app provider's finance document reference.",
+            sensitive: true,
+            wildcard: "explicit",
+          },
+        ],
+        wildcard: "explicit-resource",
+      },
+      {
+        id: "@voyant-travel/apps#access.finance-external-allocation",
+        resource: "finance-external-allocation",
+        label: "External finance number allocation",
+        description: "Write a provider-owned number to a pending finance document.",
+        remoteSafe: true,
+        actions: [
+          {
+            action: "write",
+            label: "Allocate external finance number",
+            description: "Atomically finalize a pending provider-owned document number.",
             sensitive: true,
             wildcard: "explicit",
           },

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -851,6 +851,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -852,6 +852,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -838,6 +838,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -832,6 +832,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -885,6 +885,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -886,6 +886,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -905,6 +905,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -906,6 +906,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/finance-contracts/package.json
+++ b/packages/finance-contracts/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./app-api": "./src/app-api.ts",
+    "./runtime-port": "./src/runtime-port.ts",
     "./validation": "./src/validation.ts",
     "./travel-credits": "./src/validation-travel-credits.ts"
   },
@@ -27,6 +29,16 @@
         "import": "./dist/index.js",
         "default": "./dist/index.js"
       },
+      "./app-api": {
+        "types": "./dist/app-api.d.ts",
+        "import": "./dist/app-api.js",
+        "default": "./dist/app-api.js"
+      },
+      "./runtime-port": {
+        "types": "./dist/runtime-port.d.ts",
+        "import": "./dist/runtime-port.js",
+        "default": "./dist/runtime-port.js"
+      },
       "./validation": {
         "types": "./dist/validation.d.ts",
         "import": "./dist/validation.js",
@@ -43,6 +55,7 @@
   },
   "dependencies": {
     "@voyant-travel/schema-kit": "workspace:^",
+    "drizzle-orm": "catalog:",
     "zod": "catalog:"
   },
   "devDependencies": {

--- a/packages/finance-contracts/src/app-api.ts
+++ b/packages/finance-contracts/src/app-api.ts
@@ -1,0 +1,124 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { financeAppApiRuntimePort as importCheapFinanceAppApiRuntimePort } from "./runtime-port.js"
+
+export interface FinanceAppApiIssuanceDocument {
+  id: string
+  documentType: "invoice" | "proforma"
+  number: string
+  status: string
+  booking: { id: string; number: string | null }
+  billing: {
+    name: string
+    email: string | null
+    phone: string | null
+    address: string | null
+    city: string | null
+    region: string | null
+    country: string | null
+    vatCode: string | null
+    registrationNumber: string | null
+  }
+  currency: { document: string; base: string | null }
+  fx: {
+    rateSetId: string | null
+    rate: number | null
+    effectiveRate: number | null
+    source: string | null
+    quotedAt: string | null
+    validUntil: string | null
+    commissionBasisPoints: number | null
+    invoiceMention: string | null
+  } | null
+  totals: { subtotalCents: number; taxCents: number; totalCents: number }
+  dates: { issuedOn: string | null; dueOn: string | null }
+  language: string | null
+  taxRegime: {
+    id: string
+    code: string
+    name: string
+    legalReference: string | null
+    specialRegime: boolean
+    marginSchemeArticle311: boolean
+  } | null
+  series: { id: string; code: string; name: string; scope: string } | null
+  allocation: { required: boolean; pending: boolean; placeholderNumber: string | null }
+  lines: readonly {
+    id: string
+    description: string
+    quantity: number
+    unitPriceCents: number
+    totalCents: number
+    tax: { ratePercent: number | null; name: string | null; regimeCode: string | null }
+  }[]
+}
+
+export interface FinanceAppApiExternalReferenceInput {
+  externalId: string | null
+  externalNumber: string | null
+  externalUrl: string | null
+  status: string | null
+  metadata: Record<string, unknown> | null
+  syncedAt: string | null
+  syncError: string | null
+}
+
+export interface FinanceAppApiExternalReferenceUpsertInput {
+  reference: FinanceAppApiExternalReferenceInput
+  allocation?: { invoiceNumber: string }
+}
+
+export interface FinanceAppApiExternalReference {
+  id: string
+  documentId: string
+  provider: string
+  externalId: string | null
+  externalNumber: string | null
+  externalUrl: string | null
+  status: string | null
+  metadata: Record<string, unknown> | null
+  syncedAt: string | null
+  syncError: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+export type FinanceAppApiReferenceMutationResult =
+  | {
+      status: "ok"
+      reference: FinanceAppApiExternalReference
+      referenceOutcome: "created" | "updated" | "unchanged"
+      allocationOutcome: "not_requested" | "applied" | "already_applied"
+    }
+  | { status: "not_found" }
+  | { status: "allocation_conflict"; currentNumber: string; currentStatus: string }
+
+export class FinanceAppApiNumberConflictError extends Error {
+  constructor(readonly invoiceNumber: string) {
+    super(`Finance document number "${invoiceNumber}" is already in use.`)
+    this.name = "FinanceAppApiNumberConflictError"
+  }
+}
+
+export interface FinanceAppApiRuntime {
+  getIssuanceDocument(
+    db: PostgresJsDatabase,
+    documentId: string,
+  ): Promise<FinanceAppApiIssuanceDocument | null>
+  getExternalReference(
+    db: PostgresJsDatabase,
+    documentId: string,
+    provider: string,
+  ): Promise<FinanceAppApiExternalReference | null>
+  upsertExternalReference(
+    db: PostgresJsDatabase,
+    documentId: string,
+    provider: string,
+    input: FinanceAppApiExternalReferenceUpsertInput,
+  ): Promise<FinanceAppApiReferenceMutationResult>
+}
+
+/** Typed runtime view of the exact object used by import-cheap manifests. */
+export const financeAppApiRuntimePort: {
+  readonly id: typeof importCheapFinanceAppApiRuntimePort.id
+  readonly test: (provider: FinanceAppApiRuntime) => void
+} = importCheapFinanceAppApiRuntimePort

--- a/packages/finance-contracts/src/contracts.test.ts
+++ b/packages/finance-contracts/src/contracts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
-
 import {
+  financeAppApiRuntimePort,
   insertBookingItemCommissionSchema,
   insertBookingItemTaxLineSchema,
   insertPaymentAuthorizationSchema,
@@ -16,8 +16,17 @@ import {
   updatePaymentSchema,
   updateTaxRegimeSchema,
 } from "./index.js"
+import { financeAppApiRuntimePort as importCheapFinanceAppApiRuntimePort } from "./runtime-port.js"
 
 describe("finance-contracts", () => {
+  it("keeps the finance App API runtime seam provider-neutral and closed", () => {
+    expect(financeAppApiRuntimePort.id).toBe("finance.app-api.runtime")
+    expect(financeAppApiRuntimePort).toBe(importCheapFinanceAppApiRuntimePort)
+    expect(() =>
+      financeAppApiRuntimePort.test({ getIssuanceDocument: async () => null } as never),
+    ).toThrow(/getExternalReference/)
+  })
+
   it("accepts valid enum values", () => {
     expect(invoiceStatusSchema.parse("issued")).toBe("issued")
     expect(paymentMethodSchema.parse("bank_transfer")).toBe("bank_transfer")

--- a/packages/finance-contracts/src/index.ts
+++ b/packages/finance-contracts/src/index.ts
@@ -1,1 +1,2 @@
+export * from "./app-api.js"
 export * from "./validation.js"

--- a/packages/finance-contracts/src/runtime-port.ts
+++ b/packages/finance-contracts/src/runtime-port.ts
@@ -1,0 +1,21 @@
+/**
+ * Import-cheap deployment declaration for the Finance App API runtime.
+ * Runtime DTOs deliberately stay behind `./app-api`.
+ */
+export const financeAppApiRuntimePort = Object.freeze({
+  id: "finance.app-api.runtime",
+  test(provider: unknown) {
+    if (!provider || typeof provider !== "object") {
+      throw new Error("finance.app-api.runtime provider must be an object.")
+    }
+    for (const method of [
+      "getIssuanceDocument",
+      "getExternalReference",
+      "upsertExternalReference",
+    ]) {
+      if (typeof Reflect.get(provider, method) !== "function") {
+        throw new Error(`finance.app-api.runtime provider must implement ${method}().`)
+      }
+    }
+  },
+})

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -937,6 +937,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -932,6 +932,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -68,6 +68,7 @@
     "@voyant-travel/tools": "workspace:^"
   },
   "devDependencies": {
+    "@voyant-travel/webhook-delivery": "workspace:^",
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "drizzle-kit": "^0.31.10",
     "typescript": "catalog:"

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -1,0 +1,276 @@
+import { bookings } from "@voyant-travel/bookings/schema"
+import type {
+  FinanceAppApiExternalReference,
+  FinanceAppApiExternalReferenceUpsertInput,
+  FinanceAppApiIssuanceDocument,
+  FinanceAppApiReferenceMutationResult,
+  FinanceAppApiRuntime,
+} from "@voyant-travel/finance-contracts/app-api"
+import { FinanceAppApiNumberConflictError } from "@voyant-travel/finance-contracts/app-api"
+import { and, asc, eq, sql } from "drizzle-orm"
+import {
+  invoiceExternalRefs,
+  invoiceLineItems,
+  invoiceNumberSeries,
+  invoices,
+  taxRegimes,
+} from "./schema.js"
+import { financeService } from "./service.js"
+import { buildInvoiceIssuedEvent } from "./service-issue.js"
+import { InvoiceNumberConflictError, toRows } from "./service-shared.js"
+
+export function createFinanceAppApiRuntime(): FinanceAppApiRuntime {
+  return {
+    async getIssuanceDocument(db, documentId) {
+      const [invoice] = await db.select().from(invoices).where(eq(invoices.id, documentId)).limit(1)
+      if (!invoice || invoice.invoiceType === "credit_note") return null
+
+      const [[booking], [series], [taxRegime], lines, issuedEvent] = await Promise.all([
+        db.select().from(bookings).where(eq(bookings.id, invoice.bookingId)).limit(1),
+        invoice.seriesId
+          ? db
+              .select()
+              .from(invoiceNumberSeries)
+              .where(eq(invoiceNumberSeries.id, invoice.seriesId))
+              .limit(1)
+          : Promise.resolve([]),
+        invoice.taxRegimeId
+          ? db.select().from(taxRegimes).where(eq(taxRegimes.id, invoice.taxRegimeId)).limit(1)
+          : Promise.resolve([]),
+        db
+          .select()
+          .from(invoiceLineItems)
+          .where(eq(invoiceLineItems.invoiceId, documentId))
+          .orderBy(asc(invoiceLineItems.sortOrder)),
+        buildInvoiceIssuedEvent(db, invoice),
+      ])
+
+      return {
+        id: invoice.id,
+        documentType: invoice.invoiceType,
+        number: invoice.invoiceNumber,
+        status: invoice.status,
+        booking: { id: invoice.bookingId, number: booking?.bookingNumber ?? null },
+        billing: {
+          name:
+            [booking?.contactFirstName, booking?.contactLastName].filter(Boolean).join(" ") ||
+            "Customer",
+          email: booking?.contactEmail ?? null,
+          phone: booking?.contactPhone ?? null,
+          address:
+            [booking?.contactAddressLine1, booking?.contactAddressLine2]
+              .filter(Boolean)
+              .join("\n") || null,
+          city: booking?.contactCity ?? null,
+          region: booking?.contactRegion ?? null,
+          country: booking?.contactCountry ?? null,
+          vatCode: booking?.contactTaxId ?? null,
+          registrationNumber: null,
+        },
+        currency: { document: invoice.currency, base: invoice.baseCurrency },
+        fx: buildHydratedFx(invoice, issuedEvent),
+        totals: {
+          subtotalCents: invoice.subtotalCents,
+          taxCents: invoice.taxCents,
+          totalCents: invoice.totalCents,
+        },
+        dates: { issuedOn: invoice.issueDate, dueOn: invoice.dueDate },
+        language: invoice.language,
+        taxRegime: taxRegime
+          ? {
+              id: taxRegime.id,
+              code: taxRegime.code,
+              name: taxRegime.name,
+              legalReference: taxRegime.legalReference,
+              specialRegime: !["standard", "reduced"].includes(taxRegime.code),
+              marginSchemeArticle311: taxRegime.code === "margin_scheme_art311",
+            }
+          : null,
+        series: series
+          ? {
+              id: series.id,
+              code: series.code,
+              name: series.name,
+              scope: series.scope,
+            }
+          : null,
+        allocation: {
+          required: Boolean(series?.externalProvider),
+          pending: invoice.status === "pending_external_allocation",
+          placeholderNumber:
+            invoice.status === "pending_external_allocation" ? invoice.invoiceNumber : null,
+        },
+        lines: lines.map((line, index) => {
+          const projectedLine = issuedEvent.lineItems?.[index]
+          return {
+            id: line.id,
+            description: line.description,
+            quantity: line.quantity,
+            unitPriceCents: line.unitPriceCents,
+            totalCents: line.totalCents,
+            tax: {
+              ratePercent: projectedLine?.taxPercentage ?? line.taxRate,
+              name: projectedLine?.taxName ?? null,
+              regimeCode: projectedLine?.taxRegimeCode ?? null,
+            },
+          }
+        }),
+      } satisfies FinanceAppApiIssuanceDocument
+    },
+
+    async getExternalReference(db, documentId, provider) {
+      const [row] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(
+          and(
+            eq(invoiceExternalRefs.invoiceId, documentId),
+            eq(invoiceExternalRefs.provider, provider),
+          ),
+        )
+        .limit(1)
+      return row ? mapExternalReference(row) : null
+    },
+
+    async upsertExternalReference(db, documentId, provider, input) {
+      const locked = toRows<{ invoice_number: string; status: string }>(
+        await db.execute(
+          // agent-quality: raw-sql reviewed -- identifiers are static and values are bound.
+          sql`SELECT invoice_number, status FROM invoices WHERE id = ${documentId} FOR UPDATE`,
+        ),
+      )[0]
+      if (!locked) return { status: "not_found" }
+
+      let allocationOutcome: "not_requested" | "applied" | "already_applied" = "not_requested"
+      if (input.allocation) {
+        if (locked.status !== "pending_external_allocation") {
+          if (locked.invoice_number !== input.allocation.invoiceNumber) {
+            return {
+              status: "allocation_conflict",
+              currentNumber: locked.invoice_number,
+              currentStatus: locked.status,
+            }
+          }
+          allocationOutcome = "already_applied"
+        } else {
+          try {
+            const allocation = await financeService.applyExternalInvoiceAllocation(db, documentId, {
+              invoiceNumber: input.allocation.invoiceNumber,
+            })
+            if (allocation.status === "not_found") return { status: "not_found" }
+            if (allocation.status === "not_pending_external_allocation") {
+              return {
+                status: "allocation_conflict",
+                currentNumber: allocation.invoice.invoiceNumber,
+                currentStatus: allocation.invoice.status,
+              }
+            }
+            allocationOutcome = "applied"
+          } catch (error) {
+            if (error instanceof InvoiceNumberConflictError) {
+              throw new FinanceAppApiNumberConflictError(input.allocation.invoiceNumber)
+            }
+            throw error
+          }
+        }
+      }
+
+      const [existing] = await db
+        .select()
+        .from(invoiceExternalRefs)
+        .where(
+          and(
+            eq(invoiceExternalRefs.invoiceId, documentId),
+            eq(invoiceExternalRefs.provider, provider),
+          ),
+        )
+        .limit(1)
+      const referenceOutcome = existing
+        ? referenceMatches(existing, input.reference)
+          ? "unchanged"
+          : "updated"
+        : "created"
+      const row =
+        referenceOutcome === "unchanged"
+          ? existing
+          : await financeService.registerInvoiceExternalRef(db, documentId, {
+              provider,
+              ...input.reference,
+            })
+      if (!row) return { status: "not_found" }
+      return {
+        status: "ok",
+        reference: mapExternalReference(row),
+        referenceOutcome,
+        allocationOutcome,
+      } satisfies FinanceAppApiReferenceMutationResult
+    },
+  }
+}
+
+function buildHydratedFx(
+  invoice: typeof invoices.$inferSelect,
+  issuedEvent: Awaited<ReturnType<typeof buildInvoiceIssuedEvent>>,
+): FinanceAppApiIssuanceDocument["fx"] {
+  if (!invoice.baseCurrency || invoice.baseCurrency === invoice.currency) return null
+  const persistedRate = derivePersistedFxRate(invoice)
+  return {
+    rateSetId: issuedEvent.fxRateSetId ?? invoice.fxRateSetId,
+    rate: issuedEvent.fxRate ?? persistedRate,
+    effectiveRate: issuedEvent.effectiveRate ?? persistedRate,
+    source: issuedEvent.fxRateSource ?? null,
+    quotedAt: issuedEvent.fxRateQuotedAt ?? null,
+    validUntil: issuedEvent.fxRateValidUntil ?? null,
+    commissionBasisPoints: issuedEvent.fxCommissionBps ?? null,
+    invoiceMention: issuedEvent.fxCommissionInvoiceMention ?? null,
+  }
+}
+
+function derivePersistedFxRate(invoice: typeof invoices.$inferSelect): number | null {
+  const pairs = [
+    [invoice.baseTotalCents, invoice.totalCents],
+    [invoice.baseSubtotalCents, invoice.subtotalCents],
+  ] as const
+  for (const [baseAmount, documentAmount] of pairs) {
+    if (baseAmount != null && documentAmount > 0) return baseAmount / documentAmount
+  }
+  return null
+}
+
+function mapExternalReference(
+  row: typeof invoiceExternalRefs.$inferSelect,
+): FinanceAppApiExternalReference {
+  return {
+    id: row.id,
+    documentId: row.invoiceId,
+    provider: row.provider,
+    externalId: row.externalId,
+    externalNumber: row.externalNumber,
+    externalUrl: row.externalUrl,
+    status: row.status,
+    metadata: isRecord(row.metadata) ? row.metadata : null,
+    syncedAt: row.syncedAt?.toISOString() ?? null,
+    syncError: row.syncError,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  }
+}
+
+function referenceMatches(
+  existing: typeof invoiceExternalRefs.$inferSelect,
+  input: FinanceAppApiExternalReferenceUpsertInput["reference"],
+) {
+  return (
+    existing.externalId === (input.externalId ?? null) &&
+    existing.externalNumber === (input.externalNumber ?? null) &&
+    existing.externalUrl === (input.externalUrl ?? null) &&
+    existing.status === (input.status ?? null) &&
+    JSON.stringify(existing.metadata) === JSON.stringify(input.metadata ?? null) &&
+    (existing.syncedAt?.toISOString() ?? null) === (input.syncedAt ?? null) &&
+    existing.syncError === (input.syncError ?? null)
+  )
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+}

--- a/packages/finance/src/app-api-runtime.ts
+++ b/packages/finance/src/app-api-runtime.ts
@@ -133,10 +133,14 @@ export function createFinanceAppApiRuntime(): FinanceAppApiRuntime {
     },
 
     async upsertExternalReference(db, documentId, provider, input) {
-      const locked = toRows<{ invoice_number: string; status: string }>(
+      const locked = toRows<{
+        invoice_number: string
+        series_id: string | null
+        status: string
+      }>(
         await db.execute(
           // agent-quality: raw-sql reviewed -- identifiers are static and values are bound.
-          sql`SELECT invoice_number, status FROM invoices WHERE id = ${documentId} FOR UPDATE`,
+          sql`SELECT invoice_number, series_id, status FROM invoices WHERE id = ${documentId} FOR UPDATE`,
         ),
       )[0]
       if (!locked) return { status: "not_found" }
@@ -153,6 +157,20 @@ export function createFinanceAppApiRuntime(): FinanceAppApiRuntime {
           }
           allocationOutcome = "already_applied"
         } else {
+          const series = toRows<{ external_provider: string | null }>(
+            await db.execute(
+              // agent-quality: raw-sql reviewed -- identifiers are static and values are bound.
+              sql`SELECT external_provider FROM invoice_number_series WHERE id = ${locked.series_id} FOR UPDATE`,
+            ),
+          )[0]
+          if (!series || series.external_provider !== provider) {
+            return {
+              status: "allocation_conflict",
+              currentNumber: locked.invoice_number,
+              currentStatus: locked.status,
+            }
+          }
+
           try {
             const allocation = await financeService.applyExternalInvoiceAllocation(db, documentId, {
               invoiceNumber: input.allocation.invoiceNumber,

--- a/packages/finance/src/runtime-contributor.ts
+++ b/packages/finance/src/runtime-contributor.ts
@@ -7,7 +7,9 @@ import {
   bookingsFinanceRuntimePort,
 } from "@voyant-travel/bookings/runtime-port"
 import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/app-api"
 import { checkFinanceActionLedgerDrift } from "./action-ledger-drift.js"
+import { createFinanceAppApiRuntime } from "./app-api-runtime.js"
 import { financeHostRuntimePort } from "./runtime-port.js"
 import { createFinanceStaleBookingHoldsRuntime } from "./stale-booking-holds-runtime.js"
 
@@ -20,6 +22,7 @@ export function createFinanceRuntimePortContribution(
   host: FinanceRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
   return {
+    [financeAppApiRuntimePort.id]: createFinanceAppApiRuntime(),
     [actionLedgerFinanceDriftRuntimePort.id]: {
       checkFinanceDrift: checkFinanceActionLedgerDrift,
     } satisfies ActionLedgerFinanceDriftRuntime,

--- a/packages/finance/src/voyant-event-schemas.ts
+++ b/packages/finance/src/voyant-event-schemas.ts
@@ -14,6 +14,23 @@ export const invoiceStatusSchema = {
 export const renditionFormatSchema = { enum: ["html", "pdf", "xml", "json"] } as const
 export const nullableStringSchema = { type: ["string", "null"] } as const
 
+/**
+ * Deliberately small projection used when an issued document leaves the
+ * deployment through the remote-app webhook boundary. Apps hydrate the
+ * current provider-neutral document by `invoiceId`; customer, line, routing,
+ * and numbering details remain inside Finance until that authorized read.
+ */
+export const invoiceIssuanceExternalPayloadSchema = {
+  type: "object",
+  required: ["invoiceId", "invoiceType"],
+  properties: {
+    invoiceId: { type: "string" },
+    invoiceType: { enum: ["invoice", "proforma"] },
+    skipExternalSync: { type: "boolean" },
+  },
+  additionalProperties: false,
+} as const
+
 export const invoiceIssuedPayloadSchema = {
   type: "object",
   required: ["invoiceId", "invoiceNumber", "invoiceType", "bookingId", "totalCents", "currency"],

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -7,6 +7,7 @@ import {
   requirePort,
 } from "@voyant-travel/core/project"
 import { customFieldsRuntimePort } from "@voyant-travel/core/runtime-port"
+import { financeAppApiRuntimePort } from "@voyant-travel/finance-contracts/runtime-port"
 import {
   financeAccommodationsPaymentPolicyRuntimePort,
   financeCheckoutPaymentStartersRuntimePort,
@@ -26,7 +27,7 @@ import {
   bookingDualCreatedPayloadSchema,
   bookingPaymentSchedulePaidPayloadSchema,
   invoiceDocumentGeneratedPayloadSchema,
-  invoiceIssuedPayloadSchema,
+  invoiceIssuanceExternalPayloadSchema,
   invoicePaymentRecordedPayloadSchema,
   invoiceProformaConvertedPayloadSchema,
   invoiceRenderedPayloadSchema,
@@ -57,6 +58,7 @@ export const financeVoyantModule = defineModule({
       providePort(actionLedgerFinanceDriftRuntimePort),
       providePort(bookingsFinanceRuntimePort),
       providePort(financeHostRuntimePort),
+      providePort(financeAppApiRuntimePort),
     ],
   },
   api: [
@@ -129,16 +131,16 @@ export const financeVoyantModule = defineModule({
       id: "@voyant-travel/finance#event.invoice.issued",
       eventType: "invoice.issued",
       version: "1.0.0",
-      payloadSchema: invoiceIssuedPayloadSchema,
-      visibility: "internal",
+      payloadSchema: invoiceIssuanceExternalPayloadSchema,
+      visibility: "external",
       audit: { sourceModule: "finance", category: "domain" },
     },
     {
       id: "@voyant-travel/finance#event.invoice.proforma.issued",
       eventType: "invoice.proforma.issued",
       version: "1.0.0",
-      payloadSchema: invoiceIssuedPayloadSchema,
-      visibility: "internal",
+      payloadSchema: invoiceIssuanceExternalPayloadSchema,
+      visibility: "external",
       audit: { sourceModule: "finance", category: "domain" },
     },
     {
@@ -236,6 +238,18 @@ export const financeVoyantModule = defineModule({
       payloadSchema: bookingPaymentSchedulePaidPayloadSchema,
       visibility: "internal",
       audit: { sourceModule: "finance", category: "domain" },
+    },
+  ],
+  webhooks: [
+    {
+      id: "@voyant-travel/finance#webhook.invoice-issued",
+      direction: "outbound",
+      eventId: "@voyant-travel/finance#event.invoice.issued",
+    },
+    {
+      id: "@voyant-travel/finance#webhook.invoice-proforma-issued",
+      direction: "outbound",
+      eventId: "@voyant-travel/finance#event.invoice.proforma.issued",
     },
   ],
   setupMigrations: [

--- a/packages/finance/tests/unit/app-api-runtime.test.ts
+++ b/packages/finance/tests/unit/app-api-runtime.test.ts
@@ -1,0 +1,211 @@
+import { bookings } from "@voyant-travel/bookings/schema"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+import { createFinanceAppApiRuntime } from "../../src/app-api-runtime.js"
+import { invoiceLineItems, invoiceNumberSeries, invoices, taxRegimes } from "../../src/schema.js"
+
+function postgresStub(implementation: object): PostgresJsDatabase {
+  const db = Object.create(null) as PostgresJsDatabase
+  Object.assign(db, implementation)
+  return db
+}
+
+describe("finance App API runtime", () => {
+  it("hydrates provider-neutral accounting fields required for remote issuance", async () => {
+    const rows = new Map<unknown, unknown[]>([
+      [
+        invoices,
+        [
+          {
+            id: "inv_1",
+            invoiceNumber: "PENDING-1",
+            invoiceType: "invoice",
+            bookingId: "book_1",
+            status: "pending_external_allocation",
+            seriesId: "series_1",
+            taxRegimeId: "tax_1",
+            language: "ro",
+            currency: "EUR",
+            baseCurrency: "RON",
+            fxRateSetId: "fxset_1",
+            subtotalCents: 8_000,
+            baseSubtotalCents: 40_000,
+            taxCents: 1_900,
+            baseTaxCents: 9_500,
+            totalCents: 9_900,
+            baseTotalCents: 49_500,
+            issueDate: "2026-07-18",
+            dueDate: "2026-07-25",
+            convertedFromInvoiceId: null,
+          },
+        ],
+      ],
+      [
+        bookings,
+        [
+          {
+            id: "book_1",
+            bookingNumber: "B-1",
+            contactFirstName: "Ana",
+            contactLastName: "Popescu",
+            contactEmail: "ana@example.test",
+            contactPhone: "+40123456789",
+            contactAddressLine1: "Strada Test 1",
+            contactAddressLine2: null,
+            contactCity: "Bucuresti",
+            contactRegion: "B",
+            contactCountry: "RO",
+            contactTaxId: "RO123",
+          },
+        ],
+      ],
+      [
+        invoiceNumberSeries,
+        [
+          {
+            id: "series_1",
+            code: "F",
+            name: "Fiscal",
+            scope: "invoice",
+            externalProvider: "internal-provider-routing",
+          },
+        ],
+      ],
+      [
+        taxRegimes,
+        [
+          {
+            id: "tax_1",
+            code: "margin_scheme_art311",
+            name: "Regim marja",
+            legalReference: "Art. 311 Cod Fiscal",
+          },
+        ],
+      ],
+      [
+        invoiceLineItems,
+        [
+          {
+            id: "line_1",
+            invoiceId: "inv_1",
+            bookingItemId: null,
+            bookingPaymentScheduleId: null,
+            description: "Servicii turistice",
+            quantity: 1,
+            unitPriceCents: 9_900,
+            totalCents: 9_900,
+            taxRate: 19,
+            sortOrder: 0,
+          },
+        ],
+      ],
+    ])
+    const db = postgresStub({
+      select: () => ({
+        from: (table: unknown) => {
+          const tableRows = rows.get(table) ?? []
+          const query = {
+            where: () => query,
+            limit: async () => tableRows,
+            orderBy: async () => tableRows,
+          }
+          return query
+        },
+      }),
+    })
+
+    const document = await createFinanceAppApiRuntime().getIssuanceDocument(db, "inv_1")
+
+    expect(document).toMatchObject({
+      language: "ro",
+      billing: {
+        name: "Ana Popescu",
+        address: "Strada Test 1",
+        vatCode: "RO123",
+      },
+      currency: { document: "EUR", base: "RON" },
+      fx: { rateSetId: "fxset_1", rate: 5, effectiveRate: 5 },
+      taxRegime: {
+        code: "margin_scheme_art311",
+        legalReference: "Art. 311 Cod Fiscal",
+        specialRegime: true,
+        marginSchemeArticle311: true,
+      },
+      series: { id: "series_1", code: "F" },
+      allocation: { required: true, pending: true, placeholderNumber: "PENDING-1" },
+      lines: [{ description: "Servicii turistice", tax: { ratePercent: 19 } }],
+    })
+    expect(document?.series).not.toHaveProperty("externalProvider")
+    expect(document).not.toHaveProperty("skipExternalSync")
+  })
+
+  it("rejects replacing an already allocated provider-owned number", async () => {
+    const runtime = createFinanceAppApiRuntime()
+    const db = postgresStub({
+      execute: async () => [{ invoice_number: "SB-41", status: "issued" }],
+    })
+
+    await expect(
+      runtime.upsertExternalReference?.(db, "inv_1", "accounting-provider", {
+        reference: {
+          externalId: null,
+          externalNumber: null,
+          externalUrl: null,
+          status: null,
+          metadata: null,
+          syncedAt: null,
+          syncError: null,
+        },
+        allocation: { invoiceNumber: "SB-42" },
+      }),
+    ).resolves.toEqual({
+      status: "allocation_conflict",
+      currentNumber: "SB-41",
+      currentStatus: "issued",
+    })
+  })
+
+  it("treats the same allocation and provider reference as an idempotent replay", async () => {
+    const now = new Date("2026-07-18T09:00:00.000Z")
+    const existing = {
+      id: "ref_1",
+      invoiceId: "inv_1",
+      provider: "accounting-provider",
+      externalId: "remote_1",
+      externalNumber: "SB-42",
+      externalUrl: null,
+      status: "issued",
+      metadata: null,
+      syncedAt: now,
+      syncError: null,
+      createdAt: now,
+      updatedAt: now,
+    }
+    const runtime = createFinanceAppApiRuntime()
+    const db = postgresStub({
+      execute: async () => [{ invoice_number: "SB-42", status: "issued" }],
+      select: () => ({
+        from: () => ({ where: () => ({ limit: async () => [existing] }) }),
+      }),
+    })
+
+    const result = await runtime.upsertExternalReference?.(db, "inv_1", "accounting-provider", {
+      reference: {
+        externalId: "remote_1",
+        externalNumber: "SB-42",
+        externalUrl: null,
+        status: "issued",
+        metadata: null,
+        syncedAt: now.toISOString(),
+        syncError: null,
+      },
+      allocation: { invoiceNumber: "SB-42" },
+    })
+
+    expect(result).toMatchObject({
+      status: "ok",
+      referenceOutcome: "unchanged",
+      allocationOutcome: "already_applied",
+    })
+  })
+})

--- a/packages/finance/tests/unit/app-api-runtime.test.ts
+++ b/packages/finance/tests/unit/app-api-runtime.test.ts
@@ -1,6 +1,6 @@
 import { bookings } from "@voyant-travel/bookings/schema"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { createFinanceAppApiRuntime } from "../../src/app-api-runtime.js"
 import { invoiceLineItems, invoiceNumberSeries, invoices, taxRegimes } from "../../src/schema.js"
 
@@ -163,6 +163,41 @@ describe("finance App API runtime", () => {
       currentNumber: "SB-41",
       currentStatus: "issued",
     })
+  })
+
+  it("rejects allocation when the caller does not own the external series", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          invoice_number: "PENDING-INVOICE-1",
+          series_id: "series_1",
+          status: "pending_external_allocation",
+        },
+      ])
+      .mockResolvedValueOnce([{ external_provider: "another-provider" }])
+    const runtime = createFinanceAppApiRuntime()
+    const db = postgresStub({ execute })
+
+    await expect(
+      runtime.upsertExternalReference?.(db, "inv_1", "accounting-provider", {
+        reference: {
+          externalId: "remote_1",
+          externalNumber: "SB-42",
+          externalUrl: null,
+          status: "issued",
+          metadata: null,
+          syncedAt: null,
+          syncError: null,
+        },
+        allocation: { invoiceNumber: "SB-42" },
+      }),
+    ).resolves.toEqual({
+      status: "allocation_conflict",
+      currentNumber: "PENDING-INVOICE-1",
+      currentStatus: "pending_external_allocation",
+    })
+    expect(execute).toHaveBeenCalledTimes(2)
   })
 
   it("treats the same allocation and provider reference as an idempotent replay", async () => {

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -1,3 +1,4 @@
+import { prepareExternalWebhookEvent } from "@voyant-travel/webhook-delivery"
 import { describe, expect, it } from "vitest"
 import { createFinanceVoyantRuntime } from "../../src/index.js"
 import {
@@ -20,6 +21,7 @@ describe("finance deployment manifest", () => {
           { id: "action-ledger.finance-drift-runtime" },
           { id: "bookings.finance.runtime" },
           { id: "finance.host.runtime" },
+          { id: "finance.app-api.runtime" },
         ],
       },
       runtime: { entry: "@voyant-travel/finance", export: "createFinanceVoyantRuntime" },
@@ -124,6 +126,62 @@ describe("finance deployment manifest", () => {
         from: { tools: ["@voyant-travel/finance#tool.void-invoice"] },
       }),
     )
+  })
+
+  it("projects issued invoice events to stable external document references", () => {
+    const issued = financeVoyantModule.events.find((event) => event.eventType === "invoice.issued")
+    const proformaIssued = financeVoyantModule.events.find(
+      (event) => event.eventType === "invoice.proforma.issued",
+    )
+    expect(issued).toMatchObject({ visibility: "external", version: "1.0.0" })
+    expect(proformaIssued).toMatchObject({
+      visibility: "external",
+      version: "1.0.0",
+      payloadSchema: issued?.payloadSchema,
+    })
+    expect(financeVoyantModule.webhooks).toEqual([
+      {
+        id: "@voyant-travel/finance#webhook.invoice-issued",
+        direction: "outbound",
+        eventId: "@voyant-travel/finance#event.invoice.issued",
+      },
+      {
+        id: "@voyant-travel/finance#webhook.invoice-proforma-issued",
+        direction: "outbound",
+        eventId: "@voyant-travel/finance#event.invoice.proforma.issued",
+      },
+    ])
+
+    const projected = prepareExternalWebhookEvent(
+      {
+        name: "invoice.issued",
+        data: {
+          invoiceId: "inv_1",
+          invoiceType: "invoice",
+          skipExternalSync: false,
+          clientEmail: "private@example.test",
+          lineItems: [{ description: "Internal line detail" }],
+          externalProvider: "internal-routing-hint",
+        },
+        emittedAt: new Date("2026-07-18T10:00:00.000Z"),
+        metadata: {
+          graphEventId: "@voyant-travel/finance#event.invoice.issued",
+          graphEventVersion: "1.0.0",
+        },
+      },
+      {
+        eventId: issued!.id,
+        eventType: issued!.eventType!,
+        eventVersion: issued!.version!,
+        payloadSchema: issued!.payloadSchema!,
+      },
+    )
+
+    expect(projected.data).toEqual({
+      invoiceId: "inv_1",
+      invoiceType: "invoice",
+      skipExternalSync: false,
+    })
   })
 
   it("mounts only selected Finance API surfaces", async () => {

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -931,6 +931,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -932,6 +932,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -937,6 +937,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -932,6 +932,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -931,6 +931,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -932,6 +932,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -937,6 +937,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -932,6 +932,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/operator-standard/package.json
+++ b/packages/operator-standard/package.json
@@ -99,6 +99,7 @@
     "@voyant-travel/event-catalog": "workspace:*",
     "@voyant-travel/event-catalog-react": "workspace:*",
     "@voyant-travel/finance": "workspace:*",
+    "@voyant-travel/finance-contracts": "workspace:*",
     "@voyant-travel/finance-react": "workspace:*",
     "@voyant-travel/flights": "workspace:*",
     "@voyant-travel/flights-react": "workspace:*",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -930,6 +930,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -931,6 +931,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -932,6 +932,10 @@
       ],
       "@voyant-travel/finance": ["../finance/dist/index.d.ts"],
       "@voyant-travel/finance-contracts": ["../finance-contracts/dist/index.d.ts"],
+      "@voyant-travel/finance-contracts/app-api": ["../finance-contracts/dist/app-api.d.ts"],
+      "@voyant-travel/finance-contracts/runtime-port": [
+        "../finance-contracts/dist/runtime-port.d.ts"
+      ],
       "@voyant-travel/finance-contracts/travel-credits": [
         "../finance-contracts/dist/validation-travel-credits.d.ts"
       ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -812,6 +812,9 @@ importers:
       '@voyant-travel/db':
         specifier: workspace:^
         version: link:../db
+      '@voyant-travel/finance-contracts':
+        specifier: workspace:^
+        version: link:../finance-contracts
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
@@ -2200,6 +2203,9 @@ importers:
       '@voyant-travel/voyant-typescript-config':
         specifier: workspace:^
         version: link:../typescript-config
+      '@voyant-travel/webhook-delivery':
+        specifier: workspace:^
+        version: link:../webhook-delivery
       drizzle-kit:
         specifier: ^0.31.10
         version: 0.31.10
@@ -2212,6 +2218,9 @@ importers:
       '@voyant-travel/schema-kit':
         specifier: workspace:^
         version: link:../schema-kit
+      drizzle-orm:
+        specifier: 'catalog:'
+        version: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       zod:
         specifier: 'catalog:'
         version: 4.4.3
@@ -3853,6 +3862,9 @@ importers:
       '@voyant-travel/finance':
         specifier: workspace:*
         version: link:../finance
+      '@voyant-travel/finance-contracts':
+        specifier: workspace:*
+        version: link:../finance-contracts
       '@voyant-travel/finance-react':
         specifier: workspace:*
         version: link:../finance-react


### PR DESCRIPTION
Closes #3495

## Summary

- add provider-neutral App API hydration for invoice and proforma issuance
- add app-owned external-reference reads and atomic reference/allocation writes
- publish minimal versioned invoice issuance webhook payloads
- keep caller identity in trusted app context rather than request paths or bodies
- expose an import-cheap finance runtime port for deployment graph composition
- document the open-core remote app runtime boundary

## Safety and compatibility

The replacement schema is strict and bounded. External references are always scoped to the authenticated app, spoofed provider identifiers are rejected, allocation conflicts return `409`, and reference plus number allocation commit atomically. The public RFC covers runtime contracts only; operated catalog, admission, commerce, and hosting policy remain outside this repository.

## Verification

Depot run `2w50s3n1cf` passed the full `checks` job. This includes the complete test matrix, affected typechecks/builds, deployment graph and package boundary gates, product distribution, dependency-path generation, and dist-config validation.