### PR TITLE
Share Marketplace permission labels

### DIFF
--- a/.changeset/bright-marketplace-permissions.md
+++ b/.changeset/bright-marketplace-permissions.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/apps-react": patch
+"@voyant-travel/types": patch
+---
+
+Share host-owned human-readable permission labels between Marketplace discovery and managed consent.

--- a/packages/apps-react/src/components/consent-screen.tsx
+++ b/packages/apps-react/src/components/consent-screen.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { formatMessage } from "@voyant-travel/i18n"
+import { formatApiKeyPermissionLabel } from "@voyant-travel/types/api-keys"
 import {
   Alert,
   AlertDescription,
@@ -364,19 +365,7 @@ export function ConsentScreen({
   )
 }
 
-export function formatScopeLabel(scope: string) {
-  const [resource, action] = scope.split(":")
-  const readableResource = (resource || scope).replaceAll("-", " ")
-  const readableAction =
-    {
-      read: "Read",
-      write: "Write",
-      manage: "Manage",
-      delete: "Delete",
-      execute: "Execute",
-    }[action ?? ""] ?? titleCase(action || "Access")
-  return `${readableAction} ${readableResource}`
-}
+export const formatScopeLabel = formatApiKeyPermissionLabel
 
 export function ScopeLabel({ scope }: { scope: string }) {
   return (
@@ -419,8 +408,4 @@ function ManagedInstallIdentity({
       </p>
     </div>
   )
-}
-
-function titleCase(value: string) {
-  return value ? `${value[0]?.toUpperCase()}${value.slice(1).replaceAll("-", " ")}` : value
 }

--- a/packages/types/src/api-keys.ts
+++ b/packages/types/src/api-keys.ts
@@ -314,6 +314,37 @@ export function describePermissions(
   } action${actions.size === 1 ? "" : "s"}`
 }
 
+/**
+ * Format a permission scope as host-owned consent copy. Callers should retain
+ * the raw scope as secondary technical detail; publishers must never supply the
+ * primary label shown to a customer approving access.
+ */
+export function formatApiKeyPermissionLabel(scope: string): string {
+  const normalized = scope.trim().toLowerCase()
+  if (normalized === "*" || normalized === "*:*") return "Wildcard access"
+
+  const parts = normalized.split(":")
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    return humanizePermissionToken(normalized)
+      ? `Access ${humanizePermissionToken(normalized)}`
+      : "Access"
+  }
+
+  const [resource, action] = parts
+  if (resource === "*") return `Wildcard ${humanizePermissionToken(action)} access`
+  if (action === "*") return `Wildcard access to ${humanizePermissionToken(resource)}`
+  return `${humanizePermissionAction(action)} ${humanizePermissionToken(resource)}`
+}
+
+function humanizePermissionAction(action: string): string {
+  const readable = humanizePermissionToken(action)
+  return readable ? `${readable[0]?.toUpperCase()}${readable.slice(1)}` : "Access"
+}
+
+function humanizePermissionToken(token: string): string {
+  return token.replaceAll("-", " ")
+}
+
 export const EXPIRATION_PRESETS = {
   never: {
     label: "Never",

--- a/packages/types/tests/api-keys.test.ts
+++ b/packages/types/tests/api-keys.test.ts
@@ -4,6 +4,7 @@ import {
   type AccessCatalog,
   areKnownPermissions,
   assertKnownPermissions,
+  formatApiKeyPermissionLabel,
   hasApiKeyPermission,
   UnknownApiKeyPermissionError,
 } from "../src/api-keys.js"
@@ -121,5 +122,26 @@ describe("assertKnownPermissions", () => {
     expect(() => assertKnownPermissions({ bookings: ["send"] }, selectedCatalog)).toThrow(
       UnknownApiKeyPermissionError,
     )
+  })
+})
+
+describe("formatApiKeyPermissionLabel", () => {
+  it.each([
+    ["finance-documents:read", "Read finance documents"],
+    ["finance-document-artifacts:write", "Write finance document artifacts"],
+    ["provider-connections:manage", "Manage provider connections"],
+    ["invoice-issuance:execute", "Execute invoice issuance"],
+    ["finance-documents:sync-now", "Sync now finance documents"],
+    ["*:read", "Wildcard read access"],
+    ["finance-documents:*", "Wildcard access to finance documents"],
+    ["*", "Wildcard access"],
+    ["*:*", "Wildcard access"],
+    ["finance-documents", "Access finance documents"],
+  ])("formats %s as host-owned consent copy", (scope, label) => {
+    expect(formatApiKeyPermissionLabel(scope)).toBe(label)
+  })
+
+  it("normalizes surrounding whitespace and casing", () => {
+    expect(formatApiKeyPermissionLabel("  Finance-Documents:READ  ")).toBe("Read finance documents")
   })
 })


### PR DESCRIPTION
## Summary
- move host-owned permission copy into the browser-safe types package
- use the shared formatter in managed app consent while preserving the existing export
- keep raw scopes visible and describe wildcards without overstating catalog authority

## Verification
- Biome check (focused)
- Depot checks and build graph in progress: `7n3sv4kvw4`