### PR TITLE
fix: deduplicate Marketplace intent resolution

### DIFF
--- a/.changeset/bright-foxes-worry.md
+++ b/.changeset/bright-foxes-worry.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/apps-react": patch
+---
+
+Deduplicate concurrent Marketplace install-intent resolution so the managed consent screen remains usable when it remounts during the handoff.

--- a/packages/apps-react/src/hooks/use-marketplace-install-intent.ts
+++ b/packages/apps-react/src/hooks/use-marketplace-install-intent.ts
@@ -1,24 +1,34 @@
 "use client"
 
-import { useMutation } from "@tanstack/react-query"
+import { useMutation, useQueryClient } from "@tanstack/react-query"
 import { fetchWithValidation } from "../client.js"
 import { useVoyantContext } from "../provider.js"
 import { marketplaceInstallIntentResponse, marketplaceSetupHandoffResponse } from "../schemas.js"
 
 export function useMarketplaceInstallIntent() {
   const { baseUrl, fetcher } = useVoyantContext()
+  const queryClient = useQueryClient()
   const client = { baseUrl, fetcher }
 
   const resolveIntent = useMutation({
-    mutationFn: async (intent: string) => {
-      const response = await fetchWithValidation(
-        "/v1/admin/apps/marketplace/install-intents/resolve",
-        marketplaceInstallIntentResponse,
-        client,
-        { method: "POST", body: JSON.stringify({ intent }) },
-      )
-      return response.data
-    },
+    mutationFn: (intent: string) =>
+      queryClient.fetchQuery({
+        // The consent screen can remount while its opaque handoff is in
+        // flight. Query caching deduplicates that replay and retains the
+        // verified result for the rest of this admin session.
+        queryKey: ["apps", "marketplace-install-intent", intent],
+        queryFn: async () => {
+          const response = await fetchWithValidation(
+            "/v1/admin/apps/marketplace/install-intents/resolve",
+            marketplaceInstallIntentResponse,
+            client,
+            { method: "POST", body: JSON.stringify({ intent }) },
+          )
+          return response.data
+        },
+        staleTime: Infinity,
+        retry: false,
+      }),
   })
 
   const createSetupHandoff = useMutation({


### PR DESCRIPTION
## Summary
- route Marketplace intent resolution through the React Query cache
- deduplicate concurrent consent handoffs caused by a managed admin remount
- retain the verified result for the active admin session

## Verification
- Depot full verification run 2bxh7vl9pl (in progress)