### PR TITLE
fix(i18n): stop formatDateTime crashing when passed date-part component options

### DIFF
--- a/.changeset/fix-formatdatetime-component-options.md
+++ b/.changeset/fix-formatdatetime-component-options.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/i18n": patch
+---
+
+Fix `formatDateTime` crashing with `Invalid option : option` when called with individual date-part component options.
+
+`createLocaleFormatters().formatDateTime` unconditionally merged its default `dateStyle`/`timeStyle` on top of the caller's options. `Intl.DateTimeFormat` forbids combining `dateStyle`/`timeStyle` with individual component options (`year`, `month`, `day`, `hour`, `minute`, …), so callers passing component options threw a `TypeError`. This took down the Apps admin surfaces (installed apps list and marketplace consent screen) whenever an app was installed. The default styles are now only applied when the caller hasn't specified a shape of their own (`timeZone` alone does not count as a shape).

--- a/packages/i18n/src/package-formatters.ts
+++ b/packages/i18n/src/package-formatters.ts
@@ -109,11 +109,16 @@ export function createLocaleFormatters(
         return String(value)
       }
 
-      return getDateTimeFormatter({
-        dateStyle: "medium",
-        timeStyle: "short",
-        ...options,
-      }).format(normalizedValue)
+      // `Intl.DateTimeFormat` forbids combining `dateStyle`/`timeStyle` with
+      // individual component options, so only apply the default styles when the
+      // caller hasn't specified a shape of their own. `timeZone` is compatible
+      // with the styles, so it doesn't count as an explicit shape.
+      const hasExplicitShape =
+        options !== undefined && Object.keys(options).some((key) => key !== "timeZone")
+
+      return getDateTimeFormatter(
+        hasExplicitShape ? options : { dateStyle: "medium", timeStyle: "short", ...options },
+      ).format(normalizedValue)
     },
     formatNumber(value, options) {
       const normalizedValue = coerceNumber(value)

--- a/packages/i18n/src/runtime.test.ts
+++ b/packages/i18n/src/runtime.test.ts
@@ -115,6 +115,24 @@ describe("message and value formatting", () => {
     expect(() => formatMessage("Hello, {name}!", {})).toThrow(/name/)
   })
 
+  it("formats date-time with individual component options without throwing", () => {
+    const formatter = createLocaleFormatters("en-US", "UTC")
+    const options = {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    } as const
+
+    expect(() => formatter.formatDateTime("2026-03-08T07:30:00Z", options)).not.toThrow()
+
+    const formatted = formatter.formatDateTime("2026-03-08T07:30:00Z", options)
+    expect(formatted).toContain("Mar")
+    expect(formatted).toContain("2026")
+    expect(formatted).toContain("07:30")
+  })
+
   it("applies and validates the configured timezone", () => {
     const formatter = createLocaleFormatters("en-US", "America/New_York")
     expect(formatter.timeZone).toBe("America/New_York")


### PR DESCRIPTION
## Summary

Fixes #3540 — the Apps admin surfaces (`installed-apps-page` and the marketplace `consent-screen`) crashed with **`Invalid option : option`** as soon as any app was installed.

## Root cause

`createLocaleFormatters().formatDateTime` in `packages/i18n/src/package-formatters.ts` unconditionally merged its default `dateStyle: "medium"`/`timeStyle: "short"` on **top** of the caller's options. `apps-react`'s `formatWhen` calls it with individual date-part component options (`year`/`month`/`day`/`hour`/`minute`). `Intl.DateTimeFormat` forbids combining `dateStyle`/`timeStyle` with individual component options, so it threw `TypeError: Invalid option : option`. Since `formatWhen` runs for every installed row's `installedAt`, the first installed app took the whole page down.

## Fix

Only apply the default `dateStyle`/`timeStyle` when the caller hasn't specified a shape of their own. `timeZone` is compatible with the styles, so it doesn't count as an explicit shape.

```ts
const hasExplicitShape =
  options !== undefined && Object.keys(options).some((key) => key !== "timeZone")

return getDateTimeFormatter(
  hasExplicitShape ? options : { dateStyle: "medium", timeStyle: "short", ...options },
).format(normalizedValue)
```

## Tests

- Added a regression test in `packages/i18n/src/runtime.test.ts` for `formatDateTime` with component options (`{ year, month, day, hour, minute }`) — asserts it does not throw and honors the components.
- Existing style-based and timezone tests remain valid (callers passing `dateStyle`/`timeStyle` are unaffected).

## Verification

Verified the `Intl` semantics and the branch logic against Node's `Intl.DateTimeFormat` directly: the old merge throws `Invalid option : option`; the fix formats component options (`Mar 8, 2026, 07:30 AM`), preserves the default-styles path when no options are passed, and keeps the existing explicit-style output (`3/8/26, 3:30 AM`). Full lint/typecheck/test run in CI.

## Impact

Restores the managed Marketplace `/apps` admin (and the consent dialog) once any app is installed.
