### PR TITLE
Render installed apps' admin pages as dynamic nav entries (with icons)

### DIFF
--- a/.changeset/dynamic-app-navigation.md
+++ b/.changeset/dynamic-app-navigation.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/apps": minor
+"@voyant-travel/admin": minor
+---
+
+Render installed apps' full-page admin surfaces (`admin.pages[]`) as first-class operator sidebar entries with an icon and label, routing to `AppExtensionPage`.
+
+- Apps: add an optional app-declared nav `icon` (HTTPS-only) to each admin page plus an app-level default `icon` on the manifest, resolved into each page at normalize time; the resolver threads the icon through `ResolvedAppPage`.
+- Admin: add an optional runtime navigation hook (`AdminExtension.useRuntimeNavItems`) merged after static navigation; the shell calls it for every extension in stable order. The UI-extensions factory now contributes app-page nav entries and a single param route (`apps/$installationId/$pageKey`) that renders the matching installed page. Add `createRemoteNavIcon`, which renders the remote icon URL as a hardened `<img>` (no-referrer, lazy, decorative) with a generic lucide fallback on missing/invalid/broken images.
+
+Pausing or uninstalling an app drops its pages from the resolver, so both the nav entry and the route target disappear on the next query.

--- a/.changeset/dynamic-app-navigation.md
+++ b/.changeset/dynamic-app-navigation.md
@@ -1,11 +1,13 @@
 ---
 "@voyant-travel/apps": minor
 "@voyant-travel/admin": minor
+"@voyant-travel/i18n": minor
 ---
 
 Render installed apps' full-page admin surfaces (`admin.pages[]`) as first-class operator sidebar entries with an icon and label, routing to `AppExtensionPage`.
 
 - Apps: add an optional app-declared nav `icon` (HTTPS-only) to each admin page plus an app-level default `icon` on the manifest, resolved into each page at normalize time; the resolver threads the icon through `ResolvedAppPage`.
-- Admin: add an optional runtime navigation hook (`AdminExtension.useRuntimeNavItems`) merged after static navigation; the shell calls it for every extension in stable order. The UI-extensions factory now contributes app-page nav entries and a single param route (`apps/$installationId/$pageKey`) that renders the matching installed page. Add `createRemoteNavIcon`, which renders the remote icon URL as a hardened `<img>` (no-referrer, lazy, decorative) with a generic lucide fallback on missing/invalid/broken images.
+- Admin: add an optional runtime navigation hook (`AdminExtension.useRuntimeNavItems`) merged after static navigation; the shell calls it for every extension in stable order. The UI-extensions factory now contributes app-page nav entries and a single param route (`apps/$installationId/$pageKey`) that renders the matching installed page. Add `createRemoteNavIcon`, which renders the remote icon URL as a hardened `<img>` (no-referrer, lazy, decorative) with a generic lucide fallback on missing/invalid/broken images. The app-page route's "unavailable" copy is localized via the operator admin messages catalog, and its static route title accepts an optional localized `labels` override.
+- i18n: add `appPageTitle` and `appPageUnavailable` operator admin chrome messages (en + ro).
 
 Pausing or uninstalling an app drops its pages from the resolver, so both the nav entry and the route target disappear on the next query.

--- a/packages/admin/src/components/operator-admin-sidebar.tsx
+++ b/packages/admin/src/components/operator-admin-sidebar.tsx
@@ -39,6 +39,27 @@ import { VoyantMark } from "./brand/voyant-mark.js"
 import { VoyantWordmark } from "./brand/voyant-wordmark.js"
 import { OperatorAdminUserMenu } from "./operator-admin-user-menu.js"
 
+/**
+ * Merge each extension's OPTIONAL runtime navigation hook into a flat list, in
+ * stable extension order. Runtime nav (e.g. installed apps' admin pages fetched
+ * at render time) is appended after static navigation as its own sections.
+ *
+ * Rules-of-hooks: the extension registry is a stable, append-only list, so
+ * calling each extension's `useRuntimeNavItems` once per render in a fixed order
+ * keeps hook call order stable across renders.
+ */
+function useRuntimeExtensionNavItems(
+  extensions: ReadonlyArray<AdminExtension> | undefined,
+): NavItem[] {
+  const runtimeItems: NavItem[] = []
+  for (const extension of extensions ?? []) {
+    // biome-ignore lint/correctness/useHookAtTopLevel: owner: admin; intentional -- the extension registry is a stable, append-only list, so calling each extension's runtime nav hook once per render in a fixed order keeps hook call order stable across renders.
+    const items = extension.useRuntimeNavItems?.() ?? []
+    runtimeItems.push(...items)
+  }
+  return runtimeItems
+}
+
 export interface OperatorAdminSidebarProps
   extends Omit<React.ComponentProps<typeof Sidebar>, "children"> {
   accountHref?: string
@@ -102,11 +123,13 @@ export function OperatorAdminSidebar({
 }: OperatorAdminSidebarProps) {
   const messages = useOperatorAdminMessages()
   const baseItems = navItems ?? createOperatorAdminNavigation({ icons, messages: messages.nav })
-  const resolvedItems = resolveOperatorAdminNavigation({
+  const staticItems = resolveOperatorAdminNavigation({
     baseItems,
     extensions,
     preferences: navigationPreferences,
   })
+  const runtimeItems = useRuntimeExtensionNavItems(extensions)
+  const resolvedItems = runtimeItems.length ? [...staticItems, ...runtimeItems] : staticItems
   const resolvedBrand = brand ?? <DefaultOperatorAdminBrand linkComponent={linkComponent} />
   const LinkComponent = linkComponent ?? DefaultAdminNavLink
   const SettingsIcon = icons?.settings ?? DefaultSettingsIcon
@@ -253,11 +276,17 @@ export function OperatorAdminWorkspaceLayout({
   } = sidebarProps ?? {}
   const baseItems =
     sidebarNavItems ?? navItems ?? createOperatorAdminNavigation({ icons, messages: messages.nav })
-  const resolvedItems = resolveOperatorAdminNavigation({
+  const activeExtensions = sidebarExtensions ?? extensions
+  const staticItems = resolveOperatorAdminNavigation({
     baseItems,
-    extensions: sidebarExtensions ?? extensions,
+    extensions: activeExtensions,
     preferences: navigationPreferences,
   })
+  // Merge runtime nav here (not just in the sidebar) so app-page entries are
+  // resolved for both the sidebar tree and the page-title/breadcrumb lookup;
+  // the nested sidebar is handed the merged list with `extensions={undefined}`.
+  const runtimeItems = useRuntimeExtensionNavItems(activeExtensions)
+  const resolvedItems = runtimeItems.length ? [...staticItems, ...runtimeItems] : staticItems
   const resolvedSide = sidebarSide ?? side
   let pageTitle: string | null = null
   if (pageHead !== false) {

--- a/packages/admin/src/extensions.ts
+++ b/packages/admin/src/extensions.ts
@@ -354,6 +354,16 @@ export const adminWorkspaceHeaderActionsSlot = "workspace.header.actions" satisf
 export interface AdminExtension {
   id: string
   navigation?: ReadonlyArray<AdminNavigationContribution>
+  /**
+   * Runtime navigation hook, merged AFTER static {@link navigation} as its own
+   * appended sections. Unlike static `navigation` (declared at creation), this
+   * lets an extension contribute nav items discovered at runtime — e.g. an
+   * installed app's admin pages fetched via React Query. It IS a React hook
+   * (may call `useQuery`), so the shell calls it unconditionally for every
+   * extension in a stable order to honor the rules of hooks. Keep it fail-soft:
+   * on a fetch error return `[]` rather than throwing.
+   */
+  useRuntimeNavItems?: () => ReadonlyArray<NavItem>
   /** Final navigation-visibility source, evaluated after selected contributions merge. */
   navigationPreferences?: AdminNavigationPreferencesContribution
   routes?: ReadonlyArray<AdminUiRouteContribution>

--- a/packages/admin/src/index.ts
+++ b/packages/admin/src/index.ts
@@ -206,6 +206,7 @@ export {
   type ResolveAdminNavigationPreferencesOptions,
   resolveAdminNavigationPreferences,
 } from "./navigation/preferences.js"
+export { createRemoteNavIcon } from "./navigation/remote-nav-icon.js"
 export {
   AdminExtensionsProvider,
   type AdminExtensionsProviderProps,
@@ -267,6 +268,7 @@ export {
   ADMIN_UI_EXTENSION_API_VERSION,
   ADMIN_UI_EXTENSION_SLOTS,
   type AdminUiExtensionSlot,
+  APP_PAGES_QUERY_KEY,
   type CreateUiExtensionsAdminExtensionOptions,
   createStaticUiExtensionsClient,
   createUiExtensionsAdminExtension,

--- a/packages/admin/src/navigation/remote-nav-icon.tsx
+++ b/packages/admin/src/navigation/remote-nav-icon.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+// Remote nav-icon adapter: app-declared nav icons are HTTPS asset URLs, but the
+// shell's `NavItem.icon` contract is a `React.ComponentType<{ className }>` (a
+// lucide component). This wraps a URL in a hardened `<img>` component that plugs
+// into that contract unchanged, so installed-app nav entries render an icon
+// without special-casing the sidebar.
+import { cn } from "@voyant-travel/ui/components"
+import { AppWindow } from "lucide-react"
+import { useState } from "react"
+import type { NavItem } from "../types.js"
+
+type NavIcon = NonNullable<NavItem["icon"]>
+
+function isHttpsUrl(value: string): boolean {
+  try {
+    return new URL(value).protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Build a {@link NavItem.icon} component for an app-declared icon URL.
+ *
+ * Absent or non-HTTPS URLs return the generic app-icon fallback directly. A
+ * valid URL renders inside a hardened `<img>`: `referrerPolicy="no-referrer"`,
+ * `loading="lazy"`, empty `alt` (decorative), non-draggable, sized by the
+ * caller-passed `className` (the shell passes `h-4 w-4`) plus `object-contain`.
+ * A broken image URL swaps to the same generic fallback via `onError`.
+ *
+ * NOTE: the host's Content-Security-Policy `img-src` must permit remote HTTPS
+ * images for these to load. CSP wiring is downstream host configuration and is
+ * intentionally NOT changed here.
+ */
+export function createRemoteNavIcon(url: string | undefined): NavIcon {
+  if (!url || !isHttpsUrl(url)) {
+    return AppWindow
+  }
+  return function RemoteNavIcon({ className }: { className?: string }) {
+    const [failed, setFailed] = useState(false)
+    if (failed) {
+      return <AppWindow className={className} />
+    }
+    return (
+      <img
+        src={url}
+        alt=""
+        aria-hidden="true"
+        draggable={false}
+        loading="lazy"
+        referrerPolicy="no-referrer"
+        className={cn("object-contain", className)}
+        onError={() => setFailed(true)}
+      />
+    )
+  }
+}

--- a/packages/admin/src/ui-extensions/app-pages.tsx
+++ b/packages/admin/src/ui-extensions/app-pages.tsx
@@ -53,10 +53,33 @@ export function useInstalledAppPages(client: UiExtensionsClient): AppPageDescrip
 
 /** A navigation entry contributed by an installed app page. */
 export interface AppPageNavEntry {
+  /** Stable per-installation key (`<installationId>:<manifest key>`). */
   key: string
-  /** Route path relative to the app-owned admin route segment. */
+  /** Owning installation id — pairs with {@link pageKey} to build the route url. */
+  installationId: string
+  /** Manifest page key (unique within an installation, may repeat across them). */
+  pageKey: string
+  /** App-owned admin sub-path declared by the manifest (e.g. `/settings`). */
   path: string
   label: string
+  /** App-declared nav icon URL (HTTPS). Absent → host renders a generic icon. */
+  icon?: string
+}
+
+/**
+ * Split a resolved descriptor key (`<installationId>:<manifest key>`) back into
+ * its parts. Installation ids never contain a colon, so the first colon is the
+ * boundary; a manifest key may itself contain colons and is kept intact.
+ */
+function splitPageKey(page: AppPageDescriptor): { installationId: string; pageKey: string } {
+  const installationId = page.installationId ?? ""
+  const prefix = `${installationId}:`
+  if (installationId && page.key.startsWith(prefix)) {
+    return { installationId, pageKey: page.key.slice(prefix.length) }
+  }
+  const separator = page.key.indexOf(":")
+  if (separator === -1) return { installationId, pageKey: page.key }
+  return { installationId: page.key.slice(0, separator), pageKey: page.key.slice(separator + 1) }
 }
 
 /**
@@ -64,11 +87,17 @@ export interface AppPageNavEntry {
  * these as nav entries pointing at the app-owned admin route.
  */
 export function useAppPageNavEntries(client: UiExtensionsClient): AppPageNavEntry[] {
-  return useInstalledAppPages(client).map((page) => ({
-    key: page.key,
-    path: page.path,
-    label: page.navLabel,
-  }))
+  return useInstalledAppPages(client).map((page) => {
+    const { installationId, pageKey } = splitPageKey(page)
+    return {
+      key: page.key,
+      installationId,
+      pageKey,
+      path: page.path,
+      label: page.navLabel,
+      ...(page.icon ? { icon: page.icon } : {}),
+    }
+  })
 }
 
 /** Adapt a page descriptor into the SDK descriptor shape the host renders. */

--- a/packages/admin/src/ui-extensions/index.ts
+++ b/packages/admin/src/ui-extensions/index.ts
@@ -41,6 +41,8 @@ export {
   type UiExtensionSessionTokenGrant,
 } from "./ui-extension-host.js"
 export {
+  APP_PAGE_ROUTE_ID,
+  APP_PAGE_ROUTE_PATH,
   type AppPageDescriptor,
   type CreateUiExtensionsAdminExtensionOptions,
   createInstallationUiExtensionsClient,

--- a/packages/admin/src/ui-extensions/ui-extensions-extension.tsx
+++ b/packages/admin/src/ui-extensions/ui-extensions-extension.tsx
@@ -12,9 +12,16 @@ import type {
 } from "@voyant-travel/admin-extension-sdk"
 import { createContext, useContext } from "react"
 
-import { type AdminExtension, defineAdminExtension } from "../extensions.js"
+import {
+  type AdminExtension,
+  type AdminRoutePageProps,
+  defineAdminExtension,
+} from "../extensions.js"
+import { createRemoteNavIcon } from "../navigation/remote-nav-icon.js"
 import { useLocale } from "../providers/locale.js"
 import { useTheme } from "../providers/theme.js"
+import type { NavItem } from "../types.js"
+import { AppExtensionPage, useAppPageNavEntries, useInstalledAppPages } from "./app-pages.js"
 import { ADMIN_UI_EXTENSION_SLOTS } from "./registry.js"
 import { UiExtensionHost, type UiExtensionSessionTokenGrant } from "./ui-extension-host.js"
 
@@ -52,6 +59,8 @@ export interface AppPageDescriptor {
   title: string
   /** Host-rendered navigation label. */
   navLabel: string
+  /** App-declared nav icon URL (HTTPS). Absent → host renders a generic icon. */
+  icon?: string
   appLocale?: string
   direction?: UiExtensionTextDirection
 }
@@ -208,14 +217,69 @@ export interface CreateUiExtensionsAdminExtensionOptions {
 }
 
 /**
+ * Route id + path pattern for the single param route that renders ANY installed
+ * app page. Installations can repeat a manifest page key, so the route is keyed
+ * on both `installationId` and `pageKey`; the component resolves the matching
+ * descriptor at render time. Nav urls built by {@link useAppPageRuntimeNavItems}
+ * match this pattern.
+ */
+export const APP_PAGE_ROUTE_ID = "voyant-ui-extensions:app-page"
+export const APP_PAGE_ROUTE_PATH = "apps/$installationId/$pageKey"
+
+/** Admin nav url for an installed app page, matching {@link APP_PAGE_ROUTE_PATH}. */
+function appPageNavUrl(installationId: string, pageKey: string): string {
+  return `/apps/${encodeURIComponent(installationId)}/${encodeURIComponent(pageKey)}`
+}
+
+/** Fallback shown when the routed installation+page is unknown or inactive. */
+function AppPageNotFound() {
+  return (
+    <div className="p-6 text-sm text-muted-foreground">This app page is no longer available.</div>
+  )
+}
+
+/** Build the param-route page that renders the matching installed app page. */
+function createAppPageRouteComponent(client: UiExtensionsClient) {
+  return function AppPageRoute({ params }: AdminRoutePageProps) {
+    const pages = useInstalledAppPages(client)
+    const descriptorKey = `${params.installationId}:${params.pageKey}`
+    const page = pages.find((candidate) => candidate.key === descriptorKey)
+    if (!page) return <AppPageNotFound />
+    return <AppExtensionPage page={page} className="flex-1" />
+  }
+}
+
+/**
+ * Runtime nav items for installed app pages: one entry per active page, titled
+ * with the resolved nav label, routed to {@link APP_PAGE_ROUTE_PATH}, and iconed
+ * from the app-declared remote URL (generic fallback when absent/invalid). List
+ * failures resolve to `[]` (fail-soft) through {@link useInstalledAppPages}.
+ */
+function useAppPageRuntimeNavItems(client: UiExtensionsClient): NavItem[] {
+  return useAppPageNavEntries(client).map((entry) => ({
+    id: `${APP_PAGE_ROUTE_ID}:${entry.key}`,
+    title: entry.label,
+    url: appPageNavUrl(entry.installationId, entry.pageKey),
+    icon: createRemoteNavIcon(entry.icon),
+  }))
+}
+
+/**
  * Build a standard admin extension that mounts installed UI extensions into
  * every public slot. It contributes one widget per registry slot; each widget
  * reads the shared install list and renders a {@link UiExtensionHost} per
  * descriptor that targets the slot. List failures render nothing (fail-soft).
+ *
+ * It also surfaces installed full-page app extensions as first-class navigation:
+ * {@link AdminExtension.useRuntimeNavItems} contributes one sidebar entry per
+ * active page (icon + label), and a single param route renders the page through
+ * {@link AppExtensionPage}. Pausing/uninstalling an app drops the page from the
+ * resolver, so both the nav entry and the route target vanish on the next query.
  */
 export function createUiExtensionsAdminExtension({
   client,
 }: CreateUiExtensionsAdminExtensionOptions): AdminExtension {
+  const AppPageRoute = createAppPageRouteComponent(client)
   return defineAdminExtension({
     id: "voyant-ui-extensions",
     widgets: ADMIN_UI_EXTENSION_SLOTS.map((slot) => ({
@@ -225,5 +289,16 @@ export function createUiExtensionsAdminExtension({
         return <SlotUiExtensions client={client} slot={slot} />
       },
     })),
+    routes: [
+      {
+        id: APP_PAGE_ROUTE_ID,
+        path: APP_PAGE_ROUTE_PATH,
+        title: "App",
+        page: async () => ({ default: AppPageRoute }),
+      },
+    ],
+    useRuntimeNavItems: function useRuntimeNavItems() {
+      return useAppPageRuntimeNavItems(client)
+    },
   })
 }

--- a/packages/admin/src/ui-extensions/ui-extensions-extension.tsx
+++ b/packages/admin/src/ui-extensions/ui-extensions-extension.tsx
@@ -19,6 +19,7 @@ import {
 } from "../extensions.js"
 import { createRemoteNavIcon } from "../navigation/remote-nav-icon.js"
 import { useLocale } from "../providers/locale.js"
+import { useOperatorAdminMessages } from "../providers/operator-admin-messages.js"
 import { useTheme } from "../providers/theme.js"
 import type { NavItem } from "../types.js"
 import { AppExtensionPage, useAppPageNavEntries, useInstalledAppPages } from "./app-pages.js"
@@ -214,6 +215,16 @@ function SlotUiExtensions({ client, slot }: { client: UiExtensionsClient; slot: 
 
 export interface CreateUiExtensionsAdminExtensionOptions {
   client: UiExtensionsClient
+  /**
+   * Optional localized chrome copy for the app-page route. The visible sidebar
+   * entry is already localized (its label comes from the resolved page's
+   * `navLabel`); these cover the static route metadata a host can't resolve
+   * through a hook. Omitted → the host default copy (English fallback).
+   */
+  labels?: {
+    /** Document/breadcrumb title for the generic app-page route. */
+    appPageTitle?: string
+  }
 }
 
 /**
@@ -226,6 +237,15 @@ export interface CreateUiExtensionsAdminExtensionOptions {
 export const APP_PAGE_ROUTE_ID = "voyant-ui-extensions:app-page"
 export const APP_PAGE_ROUTE_PATH = "apps/$installationId/$pageKey"
 
+/**
+ * English fallback for the app-page route's static metadata title, used when a
+ * host does not pass a localized {@link CreateUiExtensionsAdminExtensionOptions.labels}
+ * value. Mirrors the package-route localization pattern (host-supplied labels
+ * with an English default). The user-visible sidebar label is localized
+ * independently via the resolved page's `navLabel`.
+ */
+const APP_PAGE_ROUTE_TITLE_FALLBACK = "App"
+
 /** Admin nav url for an installed app page, matching {@link APP_PAGE_ROUTE_PATH}. */
 function appPageNavUrl(installationId: string, pageKey: string): string {
   return `/apps/${encodeURIComponent(installationId)}/${encodeURIComponent(pageKey)}`
@@ -233,9 +253,8 @@ function appPageNavUrl(installationId: string, pageKey: string): string {
 
 /** Fallback shown when the routed installation+page is unknown or inactive. */
 function AppPageNotFound() {
-  return (
-    <div className="p-6 text-sm text-muted-foreground">This app page is no longer available.</div>
-  )
+  const messages = useOperatorAdminMessages()
+  return <div className="p-6 text-sm text-muted-foreground">{messages.appPageUnavailable}</div>
 }
 
 /** Build the param-route page that renders the matching installed app page. */
@@ -278,8 +297,10 @@ function useAppPageRuntimeNavItems(client: UiExtensionsClient): NavItem[] {
  */
 export function createUiExtensionsAdminExtension({
   client,
+  labels,
 }: CreateUiExtensionsAdminExtensionOptions): AdminExtension {
   const AppPageRoute = createAppPageRouteComponent(client)
+  const appPageRouteTitle = labels?.appPageTitle ?? APP_PAGE_ROUTE_TITLE_FALLBACK
   return defineAdminExtension({
     id: "voyant-ui-extensions",
     widgets: ADMIN_UI_EXTENSION_SLOTS.map((slot) => ({
@@ -293,7 +314,7 @@ export function createUiExtensionsAdminExtension({
       {
         id: APP_PAGE_ROUTE_ID,
         path: APP_PAGE_ROUTE_PATH,
-        title: "App",
+        title: appPageRouteTitle,
         page: async () => ({ default: AppPageRoute }),
       },
     ],

--- a/packages/admin/tests/unit/app-page-nav-entries.test.tsx
+++ b/packages/admin/tests/unit/app-page-nav-entries.test.tsx
@@ -1,0 +1,56 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderHook, waitFor } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { describe, expect, it } from "vitest"
+
+import { useAppPageNavEntries } from "../../src/ui-extensions/app-pages.js"
+import type {
+  AppPageDescriptor,
+  UiExtensionsClient,
+} from "../../src/ui-extensions/ui-extensions-extension.js"
+
+function page(overrides: Partial<AppPageDescriptor> = {}): AppPageDescriptor {
+  return {
+    key: "apin_1:settings",
+    installationId: "apin_1",
+    path: "/settings",
+    entryUrl: "https://app.example.com/settings",
+    title: "App Settings",
+    navLabel: "Settings",
+    ...overrides,
+  }
+}
+
+function clientWith(pages: AppPageDescriptor[]): UiExtensionsClient {
+  return { list: async () => [], listPages: async () => pages }
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}
+
+describe("useAppPageNavEntries", () => {
+  it("maps the app-declared icon and splits the descriptor key into route parts", async () => {
+    const { result } = renderHook(
+      () => useAppPageNavEntries(clientWith([page({ icon: "https://app.example.com/i.svg" })])),
+      { wrapper },
+    )
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+    const entry = result.current[0]
+    expect(entry?.installationId).toBe("apin_1")
+    expect(entry?.pageKey).toBe("settings")
+    expect(entry?.label).toBe("Settings")
+    expect(entry?.icon).toBe("https://app.example.com/i.svg")
+  })
+
+  it("omits the icon when the page declares none", async () => {
+    const { result } = renderHook(() => useAppPageNavEntries(clientWith([page()])), { wrapper })
+
+    await waitFor(() => expect(result.current).toHaveLength(1))
+    expect(result.current[0]?.icon).toBeUndefined()
+  })
+})

--- a/packages/admin/tests/unit/remote-nav-icon.test.tsx
+++ b/packages/admin/tests/unit/remote-nav-icon.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { createElement } from "react"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createRemoteNavIcon } from "../../src/navigation/remote-nav-icon.js"
+
+afterEach(() => {
+  cleanup()
+})
+
+describe("createRemoteNavIcon", () => {
+  it("renders a hardened <img> for a valid HTTPS url", () => {
+    const Icon = createRemoteNavIcon("https://app.example.com/icon.svg")
+    const { container } = render(createElement(Icon, { className: "h-4 w-4" }))
+
+    const img = container.querySelector("img")
+    expect(img).not.toBeNull()
+    expect(img?.getAttribute("src")).toBe("https://app.example.com/icon.svg")
+    expect(img?.getAttribute("referrerpolicy")).toBe("no-referrer")
+    expect(img?.getAttribute("loading")).toBe("lazy")
+    expect(img?.getAttribute("alt")).toBe("")
+    expect(img?.getAttribute("draggable")).toBe("false")
+    expect(img?.className).toContain("object-contain")
+    expect(img?.className).toContain("h-4")
+  })
+
+  it("swaps to the generic fallback icon when the image fails to load", () => {
+    const Icon = createRemoteNavIcon("https://app.example.com/broken.svg")
+    const { container } = render(createElement(Icon, { className: "h-4 w-4" }))
+
+    const img = container.querySelector("img")
+    expect(img).not.toBeNull()
+    fireEvent.error(img as HTMLImageElement)
+
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("svg")).not.toBeNull()
+  })
+
+  it("returns the generic fallback directly for an absent url", () => {
+    const Icon = createRemoteNavIcon(undefined)
+    const { container } = render(createElement(Icon, { className: "h-4 w-4" }))
+
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("svg")).not.toBeNull()
+  })
+
+  it("returns the generic fallback for a non-HTTPS url", () => {
+    const Icon = createRemoteNavIcon("http://app.example.com/icon.svg")
+    const { container } = render(createElement(Icon, { className: "h-4 w-4" }))
+
+    expect(container.querySelector("img")).toBeNull()
+    expect(container.querySelector("svg")).not.toBeNull()
+  })
+})

--- a/packages/admin/tests/unit/ui-extensions-extension.test.tsx
+++ b/packages/admin/tests/unit/ui-extensions-extension.test.tsx
@@ -93,6 +93,16 @@ describe("createUiExtensionsAdminExtension", () => {
     expect(document.querySelectorAll("iframe")).toHaveLength(1)
   })
 
+  it("contributes a single param route for installed app pages", () => {
+    const extension = createUiExtensionsAdminExtension({
+      client: createStaticUiExtensionsClient([]),
+    })
+    expect(extension.routes).toHaveLength(1)
+    expect(extension.routes?.[0]?.path).toBe("apps/$installationId/$pageKey")
+    expect(extension.routes?.[0]?.page).toBeTypeOf("function")
+    expect(extension.useRuntimeNavItems).toBeTypeOf("function")
+  })
+
   it("renders nothing when the environment is absent", async () => {
     const extension = createUiExtensionsAdminExtension({
       client: createStaticUiExtensionsClient([descriptor()]),

--- a/packages/admin/tests/unit/ui-extensions-extension.test.tsx
+++ b/packages/admin/tests/unit/ui-extensions-extension.test.tsx
@@ -103,6 +103,19 @@ describe("createUiExtensionsAdminExtension", () => {
     expect(extension.useRuntimeNavItems).toBeTypeOf("function")
   })
 
+  it("titles the app-page route with the host default and honors a labels override", () => {
+    const base = createUiExtensionsAdminExtension({
+      client: createStaticUiExtensionsClient([]),
+    })
+    expect(base.routes?.[0]?.title).toBe("App")
+
+    const localized = createUiExtensionsAdminExtension({
+      client: createStaticUiExtensionsClient([]),
+      labels: { appPageTitle: "Aplicație" },
+    })
+    expect(localized.routes?.[0]?.title).toBe("Aplicație")
+  })
+
   it("renders nothing when the environment is absent", async () => {
     const extension = createUiExtensionsAdminExtension({
       client: createStaticUiExtensionsClient([descriptor()]),

--- a/packages/apps/src/compiler.test.ts
+++ b/packages/apps/src/compiler.test.ts
@@ -124,6 +124,60 @@ describe("app manifest compiler", () => {
     ).toThrow(/not an external event contract/)
   })
 
+  it("accepts an HTTPS per-page nav icon and rejects a non-HTTPS one", () => {
+    const parsed = appManifestSchema.parse({
+      ...validManifest,
+      admin: {
+        ...validManifest.admin,
+        pages: [{ ...validManifest.admin.pages[0], icon: "https://app.example.com/icon.svg" }],
+      },
+    })
+    expect(parsed.admin.pages[0]?.icon).toBe("https://app.example.com/icon.svg")
+
+    expect(() =>
+      appManifestSchema.parse({
+        ...validManifest,
+        admin: {
+          ...validManifest.admin,
+          pages: [{ ...validManifest.admin.pages[0], icon: "http://app.example.com/icon.svg" }],
+        },
+      }),
+    ).toThrow(/https/i)
+  })
+
+  it("resolves the app-level default icon into pages that omit their own", () => {
+    const normalized = compileAppManifest({
+      ...validManifest,
+      icon: "https://app.example.com/app-icon.svg",
+      admin: {
+        ...validManifest.admin,
+        pages: [
+          {
+            key: "inherits",
+            titleKey: "t",
+            path: "/inherits",
+            entryUrl: "https://app.example.com/a",
+          },
+          {
+            key: "owns",
+            titleKey: "t",
+            path: "/owns",
+            entryUrl: "https://app.example.com/b",
+            icon: "https://app.example.com/own-icon.svg",
+          },
+        ],
+      },
+    }).normalizedRelease
+    const byKey = new Map(normalized.adminPages.map((page) => [page.key, page.icon]))
+    expect(byKey.get("inherits")).toBe("https://app.example.com/app-icon.svg")
+    expect(byKey.get("owns")).toBe("https://app.example.com/own-icon.svg")
+  })
+
+  it("leaves pages without an icon when neither the page nor the app declares one", () => {
+    const normalized = compileAppManifest(validManifest).normalizedRelease
+    expect(normalized.adminPages[0]?.icon).toBeUndefined()
+  })
+
   it("rejects webhook endpoints that target local infrastructure", () => {
     expect(() =>
       compileAppManifest({

--- a/packages/apps/src/compiler.ts
+++ b/packages/apps/src/compiler.ts
@@ -101,7 +101,14 @@ function normalizeManifest(manifest: AppManifest): AppManifest {
       optional: sortedUnique(manifest.scopes.optional),
     },
     admin: {
-      pages: [...manifest.admin.pages].sort(byKey),
+      // Resolve the app-level default icon into each page that omits its own,
+      // so every normalized/persisted page carries a concrete icon or none.
+      pages: [...manifest.admin.pages]
+        .map((page) => {
+          const icon = page.icon ?? manifest.icon
+          return icon ? { ...page, icon } : page
+        })
+        .sort(byKey),
       slotExtensions: [...manifest.admin.slotExtensions]
         .map((extension) => ({ ...extension, slots: sortedUnique(extension.slots) }))
         .sort(byKey),

--- a/packages/apps/src/contracts.ts
+++ b/packages/apps/src/contracts.ts
@@ -100,6 +100,12 @@ const adminPageSchema = z
       .trim()
       .regex(/^\/[a-z0-9-_/]*$/),
     entryUrl: httpsUrlSchema,
+    /**
+     * App-declared nav icon rendered as a remote `<img>` in admin chrome.
+     * HTTPS-only; the app-level {@link appManifestSchema} `icon` is the
+     * fallback when a page omits its own. Absent/invalid → generic app icon.
+     */
+    icon: httpsUrlSchema.optional(),
   })
   .strict()
 
@@ -140,6 +146,11 @@ export const appManifestSchema = manifestDisallowedKeySchema.pipe(
       schemaVersion: z.literal(APP_MANIFEST_SCHEMA_VERSION),
       releaseVersion: semverLikeSchema,
       apiCompatibility: z.object({ min: semverLikeSchema, max: semverLikeSchema }).strict(),
+      /**
+       * App-level default nav icon (HTTPS remote asset). Applied at normalize
+       * time to any admin page that omits its own `icon`.
+       */
+      icon: httpsUrlSchema.optional(),
       scopes: z
         .object({
           requested: z.array(scopeSchema).default([]),

--- a/packages/apps/src/extension-resolution.test.ts
+++ b/packages/apps/src/extension-resolution.test.ts
@@ -74,6 +74,25 @@ describe("assembleInstalledExtensions", () => {
     expect(page?.navLabel).toBe("Settings")
   })
 
+  it("threads a page's icon from the descriptor when present", () => {
+    const withIcon = pageRow({
+      descriptor: {
+        key: "settings",
+        titleKey: "settings.title",
+        path: "/settings",
+        entryUrl: "https://app.example.com/settings",
+        icon: "https://app.example.com/settings-icon.svg",
+      },
+    })
+    const result = assembleInstalledExtensions([withIcon], localizations, { activeLocale: "en" })
+    expect(result.pages[0]?.icon).toBe("https://app.example.com/settings-icon.svg")
+  })
+
+  it("leaves icon undefined when the descriptor omits it", () => {
+    const result = assembleInstalledExtensions([pageRow()], localizations, { activeLocale: "en" })
+    expect(result.pages[0]?.icon).toBeUndefined()
+  })
+
   it("filters out extensionApi-incompatible slot extensions", () => {
     const incompatible = slotRow({
       descriptor: {

--- a/packages/apps/src/extension-resolution.ts
+++ b/packages/apps/src/extension-resolution.ts
@@ -54,6 +54,12 @@ export interface ResolvedAppPage {
   title: string
   /** Host-rendered navigation label for the page's nav entry. */
   navLabel: string
+  /**
+   * App-declared nav icon (HTTPS remote asset). Already resolved through the
+   * app-level default at manifest-normalize time; absent when neither the page
+   * nor the app declared one (the host falls back to a generic app icon).
+   */
+  icon?: string
   appLocale: string
   direction: AppTextDirection
 }
@@ -163,6 +169,7 @@ export function assembleInstalledExtensions(
         entryUrl: page.entryUrl,
         title,
         navLabel,
+        ...(page.icon ? { icon: page.icon } : {}),
         appLocale: locale.appLocale,
         direction: locale.direction,
       })
@@ -232,6 +239,7 @@ interface ParsedPageDescriptor {
   titleKey: string
   path: string
   entryUrl: string
+  icon?: string
 }
 
 function parsePageDescriptor(value: Record<string, unknown>): ParsedPageDescriptor | null {
@@ -240,7 +248,8 @@ function parsePageDescriptor(value: Record<string, unknown>): ParsedPageDescript
   const path = stringField(value.path)
   const entryUrl = stringField(value.entryUrl)
   if (!key || !titleKey || !path || !entryUrl) return null
-  return { key, titleKey, path, entryUrl }
+  const icon = stringField(value.icon)
+  return icon ? { key, titleKey, path, entryUrl, icon } : { key, titleKey, path, entryUrl }
 }
 
 interface ParsedSlotDescriptor {

--- a/packages/i18n/src/admin/chrome.ts
+++ b/packages/i18n/src/admin/chrome.ts
@@ -27,6 +27,8 @@ export type AdminChromeMessages = {
   extensionLoading: string
   extensionLoadFailed: string
   extensionIncompatible: string
+  appPageTitle: string
+  appPageUnavailable: string
 }
 
 export const adminChromeMessages = {
@@ -58,6 +60,8 @@ export const adminChromeMessages = {
     extensionLoadFailed: "This extension could not be loaded and was skipped.",
     extensionIncompatible:
       "This extension is incompatible with this admin version (requires {required}, admin provides {provided}).",
+    appPageTitle: "App",
+    appPageUnavailable: "This app page is no longer available.",
   },
   ro: {
     loading: "Se încarcă...",
@@ -87,5 +91,7 @@ export const adminChromeMessages = {
     extensionLoadFailed: "Extensia nu a putut fi încărcată și a fost omisă.",
     extensionIncompatible:
       "Extensia nu este compatibilă cu această versiune de administrare (necesită {required}, versiunea curentă oferă {provided}).",
+    appPageTitle: "Aplicație",
+    appPageUnavailable: "Această pagină de aplicație nu mai este disponibilă.",
   },
 } satisfies LocaleMessageDefinitions<AdminChromeMessages>


### PR DESCRIPTION
Closes #3548.

Renders installed marketplace apps' full-page admin surfaces (`admin.pages[]`) as first-class operator sidebar entries — icon + label — routing to `AppExtensionPage`, and unmounting when the app is paused/uninstalled. This closes the last gap in the embedded-app admin runtime; every other layer (session-token mint/exchange, the `request-token` iframe host, install reconciliation, `resolveInstalledExtensions`, the page primitives) already shipped.

## Icon model

App-declared `icon` is an **HTTPS asset URL** (reuses the existing `httpsUrlSchema`), rendered as a hardened `<img>` in admin chrome (`referrerPolicy="no-referrer"`, `loading="lazy"`, decorative `alt`, non-draggable, `object-contain`) with a generic lucide fallback for absent / non-HTTPS / broken images. The host CSP `img-src` must permit remote HTTPS images for these to load (downstream host config; not changed here).

## Changes

**`@voyant-travel/apps`**
- `contracts.ts`: optional per-page `icon` on `adminPageSchema` and an app-level default `icon` on the manifest (both HTTPS-only).
- `compiler.ts`: resolve the app-level default into each page at normalize time, so every persisted page descriptor carries a concrete icon or none.
- `extension-resolution.ts`: `ResolvedAppPage.icon`; `parsePageDescriptor` extracts it; assembly threads it through.

**`@voyant-travel/admin`**
- `extensions.ts`: new optional `AdminExtension.useRuntimeNavItems` hook — runtime nav items (e.g. installed app pages fetched via React Query) merged **after** static `navigation`. The shell calls it unconditionally for every extension in stable order (rules-of-hooks).
- `operator-admin-sidebar.tsx`: consumes the hook in both the sidebar and the workspace layout (so page-title/breadcrumb lookup sees app pages too).
- `remote-nav-icon.tsx` (new): `createRemoteNavIcon(url)` → the hardened `<img>` component with lucide fallback.
- `ui-extensions-extension.tsx`: the UI-extensions factory now contributes one runtime nav entry per active page **and** a single param route `apps/$installationId/$pageKey` that resolves the matching descriptor and renders `AppExtensionPage`.
- `app-pages.tsx`: `AppPageNavEntry` carries `icon` + split route parts.

Pausing/uninstalling drops the page from the resolver, so both the nav entry and the route target disappear on the next query. No downstream (voyant-cloud) change is required beyond a future pin bump — the runtime-nav capability is driven entirely by the already-wired client.

## Verification

- `@voyant-travel/apps` — typecheck ✓, test 111 passed / 11 skipped, lint ✓
- `@voyant-travel/admin` — typecheck ✓, test 155 passed, lint ✓
- `release:plan` valid — apps `0.10.4→0.11.0`, admin `0.127.0→0.128.0` (both minor); changeset lists only the two public packages
- pre-push full-repo turbo lint+typecheck — 116 tasks, all pass

New/extended unit tests cover: contract HTTPS-icon accept/reject + app-level fallback, resolver icon threading + unique descriptor key, `useAppPageNavEntries` icon mapping + key split, and the remote-icon `onError`/absent/non-HTTPS fallback.

Note: `verify:package-exports` (needs a full build) was not run; the added exports are plain re-exports covered by typecheck.
