### PR TITLE
Return 401/403 (not 500) for storefront customer-auth failures

### DIFF
--- a/.changeset/storefront-customer-auth-401.md
+++ b/.changeset/storefront-customer-auth-401.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Return a clean 401/403 instead of a 500 when a storefront customer-auth request
+presents a missing/invalid storefront access key or a missing/disallowed origin.
+`StorefrontCustomerAuthResolutionError` now carries an HTTP status and a stable,
+non-leaky code, and the auth handler's error boundary translates it to 401
+(missing/invalid key or missing origin header) or 403 (a known key presented
+from a disallowed origin). Genuine server faults still surface as 500.

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -68,6 +68,7 @@ import {
   handleApiTokenManagementRequest,
   handleOrganizationMembersRequest,
 } from "./server.js"
+import { StorefrontCustomerAuthResolutionError } from "./storefront-customer-auth-resolver.js"
 import { ensureCurrentUserProfile } from "./workspace.js"
 
 // Type ctx so that `c.get("db")` resolves to the parent app's middleware-
@@ -354,9 +355,21 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
       })
     }
   })
-  auth.onError((err, c) =>
-    handleApiError(err, c, { reporter: runtimeOptions.reporter, appName: runtimeOptions.appName }),
-  )
+  auth.onError((err, c) => {
+    // A storefront customer-auth resolution failure is a client-side auth
+    // failure (missing/invalid storefront key or a disallowed origin), not a
+    // server fault. Translate it into a clean 401/403 with a stable, non-leaky
+    // body instead of letting it fall through to `handleApiError`'s 500. The
+    // catch is narrowed to this error type so genuine server faults still 500.
+    if (err instanceof StorefrontCustomerAuthResolutionError) {
+      c.header("Cache-Control", "no-store")
+      return c.json({ error: err.code }, err.status)
+    }
+    return handleApiError(err, c, {
+      reporter: runtimeOptions.reporter,
+      appName: runtimeOptions.appName,
+    })
+  })
 
   const DEFAULT_APP_URL = "http://localhost:3300"
   const CLOUD_BETTER_AUTH_ALLOWLIST = new Set([

--- a/packages/auth/src/storefront-customer-auth-resolver.ts
+++ b/packages/auth/src/storefront-customer-auth-resolver.ts
@@ -45,10 +45,37 @@ export interface LocalStorefrontCustomerAuthResolverConfig<Env> {
   keyHeader?: string
 }
 
+/**
+ * Reason a storefront customer-auth resolution failed. Every variant is a
+ * client-side auth failure (bad/absent credentials or a disallowed origin), not
+ * a server fault, so the auth handler maps these to 401/403 — never 500.
+ */
+export type StorefrontCustomerAuthFailureReason =
+  | "missing_origin"
+  | "missing_key"
+  | "unknown_key"
+  | "origin_not_allowed"
+
+/**
+ * Thrown by the local storefront customer-auth resolver when the presented
+ * credentials/origin cannot be resolved to a storefront. Carries an HTTP status
+ * and a stable machine code so the auth handler can translate it into a clean
+ * 401 (or 403 for a known key from a disallowed origin) instead of a 500. The
+ * message is intentionally non-leaky — it never echoes the presented key.
+ */
 export class StorefrontCustomerAuthResolutionError extends Error {
-  constructor(message: string) {
+  readonly reason: StorefrontCustomerAuthFailureReason
+  /** HTTP status the auth handler should surface (401 unauthorized / 403 forbidden). */
+  readonly status: 401 | 403
+  /** Stable client-facing error code. */
+  readonly code: "unauthorized" | "forbidden"
+
+  constructor(reason: StorefrontCustomerAuthFailureReason, message: string) {
     super(message)
     this.name = "StorefrontCustomerAuthResolutionError"
+    this.reason = reason
+    this.status = reason === "origin_not_allowed" ? 403 : 401
+    this.code = reason === "origin_not_allowed" ? "forbidden" : "unauthorized"
   }
 }
 
@@ -81,12 +108,14 @@ export function createLocalStorefrontCustomerAuthResolver<Env>(
     const origin = request.headers.get(originHeader)?.trim()
     if (!origin) {
       throw new StorefrontCustomerAuthResolutionError(
+        "missing_origin",
         `Local storefront customer auth requires ${originHeader} from the storefront BFF.`,
       )
     }
     const token = request.headers.get(keyHeader)?.trim()
     if (!token) {
       throw new StorefrontCustomerAuthResolutionError(
+        "missing_key",
         `Local storefront customer auth requires a storefront key (${keyHeader}).`,
       )
     }
@@ -96,12 +125,14 @@ export function createLocalStorefrontCustomerAuthResolver<Env>(
       const resolved = await config.provider.resolveStorefrontByApiKey(context, token)
       if (!resolved) {
         throw new StorefrontCustomerAuthResolutionError(
+          "unknown_key",
           "The presented storefront key is unknown or revoked.",
         )
       }
       const { storefront } = resolved
       if (!isStorefrontOriginAllowed(origin, storefront.allowedOrigins)) {
         throw new StorefrontCustomerAuthResolutionError(
+          "origin_not_allowed",
           "The request origin is not a declared allowed origin for this storefront.",
         )
       }

--- a/packages/auth/tests/unit/node-runtime.test.ts
+++ b/packages/auth/tests/unit/node-runtime.test.ts
@@ -4,6 +4,12 @@ import {
   buildBetterAuthCookieAdvancedOptions,
   createOperatorAuthNodeRuntime,
 } from "../../src/node-runtime.js"
+import {
+  createLocalStorefrontCustomerAuthResolver,
+  STOREFRONT_KEY_HEADER,
+  STOREFRONT_ORIGIN_HEADER,
+} from "../../src/storefront-customer-auth-resolver.js"
+import type { StorefrontDto, StorefrontRuntimeProvider } from "../../src/storefront-runtime-port.js"
 
 describe("buildBetterAuthCookieAdvancedOptions", () => {
   it("leaves Better Auth cookie defaults untouched when the domain is unset", () => {
@@ -487,5 +493,122 @@ describe("createOperatorAuthNodeRuntime", () => {
       }),
     ).rejects.toThrow("Customer auth requires BETTER_AUTH_CUSTOMER_SECRET")
     expect(dispose).toHaveBeenCalledOnce()
+  })
+})
+
+describe("createOperatorAuthNodeRuntime storefront customer-auth failures", () => {
+  const STOREFRONT: StorefrontDto = {
+    id: "sf_1",
+    organizationId: "org_1",
+    name: "Shop",
+    slug: "shop",
+    hostingKind: "external",
+    siteId: null,
+    allowedOrigins: ["https://shop.example.com"],
+    methods: {
+      emailCode: true,
+      emailPassword: false,
+      google: false,
+      facebook: false,
+      apple: false,
+    },
+    accountPolicy: {
+      allowedKinds: ["personal"],
+      personalSignup: "open",
+      businessOnboarding: "disabled",
+    },
+    hostOnlyCookies: true,
+    createdAt: "2026-07-19T00:00:00.000Z",
+    updatedAt: "2026-07-19T00:00:00.000Z",
+  }
+
+  function fakeProvider(
+    resolveStorefrontByApiKey?: () => Promise<unknown>,
+  ): StorefrontRuntimeProvider {
+    return {
+      resolveStorefrontByApiKey:
+        resolveStorefrontByApiKey ?? (async () => ({ storefront: STOREFRONT, key: null })),
+      resolveProviderCredentials: async () => ({}),
+    } as unknown as StorefrontRuntimeProvider
+  }
+
+  function makeRuntime(provider: StorefrontRuntimeProvider) {
+    return createOperatorAuthNodeRuntime({
+      accessCatalog: { resources: [], presets: [] },
+      appName: "auth-test",
+      authMode: "local",
+      reporter: { captureException: vi.fn() },
+      openDatabase: () => ({ db: {} as never, dispose: async () => {} }),
+      resolveCustomerAuthContext: createLocalStorefrontCustomerAuthResolver({
+        provider,
+        openResolveContext: async () => ({
+          context: { bindings: {}, db: {} as never },
+          dispose: async () => {},
+        }),
+      }),
+    })
+  }
+
+  const ENV = {
+    DATABASE_URL: "postgres://unused",
+    BETTER_AUTH_CUSTOMER_SECRET: "customer-secret-with-at-least-32-characters",
+    SESSION_CLAIMS_ADMIN_SECRET: "admin-secret-with-at-least-32-characters",
+  }
+
+  async function configRequest(headers: Record<string, string>) {
+    return makeRuntime(fakeProvider()).handler.fetch(
+      new Request("https://shop.example.com/auth/customer/config", { headers }),
+      ENV,
+      { waitUntil: vi.fn() } as never,
+    )
+  }
+
+  it("returns 401 when the storefront key is missing", async () => {
+    const response = await configRequest({ [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com" })
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "unauthorized" })
+  })
+
+  it("returns 401 when the storefront origin header is missing", async () => {
+    const response = await configRequest({ [STOREFRONT_KEY_HEADER]: "vpk_token" })
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "unauthorized" })
+  })
+
+  it("returns 401 for an unknown or revoked key without leaking it", async () => {
+    const response = await makeRuntime(fakeProvider(async () => null)).handler.fetch(
+      new Request("https://shop.example.com/auth/customer/config", {
+        headers: {
+          [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com",
+          [STOREFRONT_KEY_HEADER]: "vpk_secret_value",
+        },
+      }),
+      ENV,
+      { waitUntil: vi.fn() } as never,
+    )
+    expect(response.status).toBe(401)
+    const body = await response.text()
+    expect(JSON.parse(body)).toEqual({ error: "unauthorized" })
+    expect(body).not.toContain("vpk_secret_value")
+  })
+
+  it("returns 403 for a known key presented from a disallowed origin", async () => {
+    const response = await configRequest({
+      [STOREFRONT_ORIGIN_HEADER]: "https://evil.example.com",
+      [STOREFRONT_KEY_HEADER]: "vpk_token",
+    })
+    expect(response.status).toBe(403)
+    expect(await response.json()).toEqual({ error: "forbidden" })
+  })
+
+  it("still resolves a valid key + allowed origin (200 path unaffected)", async () => {
+    const response = await configRequest({
+      [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com",
+      [STOREFRONT_KEY_HEADER]: "vpk_token",
+    })
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      methods: { emailCode: true, emailPassword: false },
+    })
   })
 })

--- a/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
+++ b/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
@@ -4,6 +4,7 @@ import {
   createLocalStorefrontCustomerAuthResolver,
   STOREFRONT_KEY_HEADER,
   STOREFRONT_ORIGIN_HEADER,
+  StorefrontCustomerAuthResolutionError,
 } from "../../src/storefront-customer-auth-resolver.js"
 import type {
   ResolvedStorefrontApiKey,
@@ -121,25 +122,44 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
     expect(context.baseURL).toBe("https://preview.example.com")
   })
 
+  async function rejection(
+    promise: Promise<unknown>,
+  ): Promise<StorefrontCustomerAuthResolutionError> {
+    try {
+      await promise
+    } catch (error) {
+      return error as StorefrontCustomerAuthResolutionError
+    }
+    throw new Error("expected the resolver to reject")
+  }
+
   it("requires the origin header", async () => {
     const { resolver } = makeResolver(fakeProvider())
-    await expect(resolver({}, request({ [STOREFRONT_KEY_HEADER]: "vpk_token" }))).rejects.toThrow(
-      /origin/i,
-    )
+    const error = await rejection(resolver({}, request({ [STOREFRONT_KEY_HEADER]: "vpk_token" })))
+    expect(error).toBeInstanceOf(StorefrontCustomerAuthResolutionError)
+    expect(error.message).toMatch(/origin/i)
+    expect(error.reason).toBe("missing_origin")
+    expect(error.status).toBe(401)
+    expect(error.code).toBe("unauthorized")
   })
 
   it("requires the key header", async () => {
     const { resolver } = makeResolver(fakeProvider())
-    await expect(
+    const error = await rejection(
       resolver({}, request({ [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com" })),
-    ).rejects.toThrow(/key/i)
+    )
+    expect(error.message).toMatch(/key/i)
+    expect(error.reason).toBe("missing_key")
+    expect(error.status).toBe(401)
+    // The message must not echo any presented key.
+    expect(error.message).not.toMatch(/vpk_/)
   })
 
   it("rejects an unknown or revoked key", async () => {
     const { resolver, disposed } = makeResolver(
       fakeProvider({ resolveStorefrontByApiKey: async () => null }),
     )
-    await expect(
+    const error = await rejection(
       resolver(
         {},
         request({
@@ -147,13 +167,17 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
           [STOREFRONT_KEY_HEADER]: "vpk_bad",
         }),
       ),
-    ).rejects.toThrow(/unknown or revoked/i)
+    )
+    expect(error.message).toMatch(/unknown or revoked/i)
+    expect(error.reason).toBe("unknown_key")
+    expect(error.status).toBe(401)
+    expect(error.message).not.toMatch(/vpk_bad/)
     expect(disposed()).toBe(1)
   })
 
-  it("rejects an origin outside the declared allowlist", async () => {
+  it("rejects an origin outside the declared allowlist as forbidden", async () => {
     const { resolver } = makeResolver(fakeProvider())
-    await expect(
+    const error = await rejection(
       resolver(
         {},
         request({
@@ -161,6 +185,11 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
           [STOREFRONT_KEY_HEADER]: "vpk_token",
         }),
       ),
-    ).rejects.toThrow(/declared allowed origin/i)
+    )
+    expect(error.message).toMatch(/declared allowed origin/i)
+    expect(error.reason).toBe("origin_not_allowed")
+    // A known key from a disallowed origin is a 403 (forbidden), not a 401.
+    expect(error.status).toBe(403)
+    expect(error.code).toBe("forbidden")
   })
 })


### PR DESCRIPTION
Storefront customer-auth requests with a missing/unknown/revoked key or a missing/disallowed origin returned HTTP 500; they now return 401 (missing/unknown key) or 403 (disallowed origin) via a stable non-leaky code, mapped narrowly at the auth onError boundary so real server faults still 500. Adds resolver + real-handler tests and a patch changeset.