### PR TITLE
Inject managed payment registry via a request-context resolver

### DIFF
--- a/.changeset/payments-managed-registry-injection.md
+++ b/.changeset/payments-managed-registry-injection.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operator-settings": minor
+---
+
+Add a managed payment registry injection seam. The Settings → Payments routes now resolve their `PaymentProviderRegistry` from a deployment-provided resolver on the request context (`PAYMENT_PROVIDER_REGISTRY_RESOLVER_VAR`), falling back to the default self-host registry. A managed deployment injects a registry that brokers to the payments control plane; the routes keep a single API surface and never learn where the managed registry lives.

--- a/packages/operator-settings/src/index.ts
+++ b/packages/operator-settings/src/index.ts
@@ -8,6 +8,7 @@
  * that consume operator settings.
  */
 
+export * from "./payment-provider-injection.js"
 export * from "./payment-provider-registry.js"
 export * from "./payment-provider-service.js"
 export * from "./schema.js"

--- a/packages/operator-settings/src/payment-provider-injection.ts
+++ b/packages/operator-settings/src/payment-provider-injection.ts
@@ -1,0 +1,37 @@
+/**
+ * Managed payment registry injection seam.
+ *
+ * The Settings → Payments routes own the API surface and default to the
+ * self-host registry (env-var configured, read-only). A managed deployment
+ * (voyant-cloud) injects a different `PaymentProviderRegistry` — one that
+ * brokers to the payments control plane — by setting a resolver on the request
+ * context. The routes never learn where the managed registry lives; they only
+ * resolve whichever registry the deployment provided, else the default.
+ *
+ * This keeps a single route surface owned by this package while the deployment
+ * supplies the implementation (the Option A seam from voyant
+ * `docs/adr/0015-payment-adapter-transports-and-managed-connect.md`).
+ */
+
+import type { PaymentProviderRegistry } from "@voyant-travel/payments"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+/** Per-request context a resolver may use to build a registry. */
+export interface PaymentProviderRegistryContext {
+  db: PostgresJsDatabase
+  env: Readonly<Record<string, unknown>>
+  /** The raw request — a managed resolver uses it to resolve the acting user. */
+  request: Request
+}
+
+/** Deployment-provided factory producing a request-scoped registry. */
+export type PaymentProviderRegistryResolver = (
+  context: PaymentProviderRegistryContext,
+) => PaymentProviderRegistry | Promise<PaymentProviderRegistry>
+
+/**
+ * Hono context variable key a deployment sets to inject the managed registry.
+ * Set it in middleware ahead of the operator-settings routes; absent it, the
+ * routes use the default self-host registry.
+ */
+export const PAYMENT_PROVIDER_REGISTRY_RESOLVER_VAR = "paymentProviderRegistryResolver" as const

--- a/packages/operator-settings/src/payment-provider-routes.ts
+++ b/packages/operator-settings/src/payment-provider-routes.ts
@@ -12,12 +12,36 @@
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { openApiValidationHook } from "@voyant-travel/hono"
+import type { PaymentProviderRegistry } from "@voyant-travel/payments"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
-import type { Hono } from "hono"
+import type { Context, Hono } from "hono"
 
+import {
+  PAYMENT_PROVIDER_REGISTRY_RESOLVER_VAR,
+  type PaymentProviderRegistryResolver,
+} from "./payment-provider-injection.js"
 import { createDefaultPaymentProviderRegistry } from "./payment-provider-registry.js"
 
-type Env = { Variables: { db: PostgresJsDatabase } }
+type Env = {
+  Variables: {
+    db: PostgresJsDatabase
+    paymentProviderRegistryResolver?: PaymentProviderRegistryResolver
+  }
+}
+
+/**
+ * Resolve the registry for this request: the deployment-injected one when
+ * present (managed → control plane), else the default self-host registry.
+ */
+async function resolveRegistry(c: Context<Env>): Promise<PaymentProviderRegistry> {
+  const db = c.get("db")
+  const env = c.env as Record<string, unknown>
+  const resolver = c.get(PAYMENT_PROVIDER_REGISTRY_RESOLVER_VAR)
+  if (resolver) {
+    return resolver({ db, env, request: c.req.raw })
+  }
+  return createDefaultPaymentProviderRegistry({ db, env })
+}
 
 export interface OpenApiMountTarget {
   // biome-ignore lint/suspicious/noExplicitAny: accept any Env-typed sub-app; the mount only composes routes.
@@ -144,10 +168,7 @@ export function mountPaymentProviderRoutes(hono: OpenApiMountTarget): void {
     .openapi(listProvidersRoute, (c) =>
       asRouteResponse(
         (async () => {
-          const registry = createDefaultPaymentProviderRegistry({
-            db: c.get("db"),
-            env: c.env as Record<string, unknown>,
-          })
+          const registry = await resolveRegistry(c)
           return c.json({ data: await registry.listProviders() }, 200)
         })(),
       ),
@@ -155,10 +176,7 @@ export function mountPaymentProviderRoutes(hono: OpenApiMountTarget): void {
     .openapi(getConnectionRoute, (c) =>
       asRouteResponse(
         (async () => {
-          const registry = createDefaultPaymentProviderRegistry({
-            db: c.get("db"),
-            env: c.env as Record<string, unknown>,
-          })
+          const registry = await resolveRegistry(c)
           return c.json({ data: await registry.getConnection() }, 200)
         })(),
       ),
@@ -166,10 +184,7 @@ export function mountPaymentProviderRoutes(hono: OpenApiMountTarget): void {
     .openapi(connectRoute, (c) =>
       asRouteResponse(
         (async () => {
-          const registry = createDefaultPaymentProviderRegistry({
-            db: c.get("db"),
-            env: c.env as Record<string, unknown>,
-          })
+          const registry = await resolveRegistry(c)
           return c.json({ data: await registry.connect(c.req.valid("json")) }, 200)
         })(),
       ),
@@ -177,10 +192,7 @@ export function mountPaymentProviderRoutes(hono: OpenApiMountTarget): void {
     .openapi(disconnectRoute, (c) =>
       asRouteResponse(
         (async () => {
-          const registry = createDefaultPaymentProviderRegistry({
-            db: c.get("db"),
-            env: c.env as Record<string, unknown>,
-          })
+          const registry = await resolveRegistry(c)
           await registry.disconnect()
           return c.json({ data: await registry.getConnection() }, 200)
         })(),


### PR DESCRIPTION
## Summary

Adds the injection seam that lets a **managed** deployment broker Settings → Payments to the payments control plane, while self-host keeps the default env-configured registry — without the operator runtime ever learning the payment route shapes (the Option A seam from ADR 0015).

The Settings → Payments routes now resolve their `PaymentProviderRegistry` per request:
- if the deployment set a resolver on the request context (`PAYMENT_PROVIDER_REGISTRY_RESOLVER_VAR`), use it (managed → a control-plane-brokering registry);
- otherwise fall back to `createDefaultPaymentProviderRegistry` (self-host, env-configured, read-only).

The package keeps a single API surface (`/v1/admin/settings/payments/*`); the deployment supplies the implementation. A managed resolver receives the raw request so it can resolve the acting user.

## Changes

- `payment-provider-injection.ts` — `PaymentProviderRegistryResolver`, `PaymentProviderRegistryContext`, and the context-var key, all exported for the managed deployment (voyant-cloud) to provide.
- `payment-provider-routes.ts` — resolve the registry from the injected resolver, else the default.

No behavior change for self-host. Managed brokering is enabled by voyant-cloud providing the resolver (separate change).

## Verification

`@voyant-travel/operator-settings` typecheck, 27 tests, and lint — all green (Depot).
