### PR TITLE
Serve the storefront public API to direct browser and native clients

### DIFF
--- a/.changeset/storefront-direct-client-cors-bearer.md
+++ b/.changeset/storefront-direct-client-cors-bearer.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/auth": minor
+---
+
+Make the storefront public API consumable by direct (cross-origin SPA and
+native/mobile) clients with the same operator-configured storefront keys and
+per-storefront allowed origins already used by the same-origin BFF.
+
+- The local storefront customer-auth resolver now derives the storefront origin
+  from the standard `Origin` header when the BFF `x-voyant-storefront-origin`
+  header is absent (the BFF header still wins), so direct clients authorize
+  against a storefront's declared origins without a BFF hop. The server/BFF
+  contract is unchanged.
+- The resolved storefront's declared origins are folded into Better Auth
+  `trustedOrigins` (unioned with the static env allowlist) at request time, and
+  surfaced as `allowedOrigins` on the customer auth context for dynamic CORS.
+- Direct clients use bearer customer sessions: the customer Better Auth realm now
+  enables the `bearer` plugin, so a sign-in returns a session token the client
+  sends as `Authorization: Bearer <token>` on later `/v1/public/*` calls. Cookies
+  stay host-only and BFF/same-origin only (no `SameSite=None`).
+- A request-time dynamic-CORS origin authorizer (`resolveCustomerCorsOrigin`)
+  echoes only a storefront-authorized origin (never `*`) for the customer realm
+  (`/v1/public/*` + `/auth/customer/*`); keyless preflight is authorized against
+  any storefront that declares the origin via the new
+  `StorefrontRuntimeProvider.resolveStorefrontByOrigin`. Admin/dash surfaces keep
+  the static `CORS_ALLOWLIST` behavior. The shared Hono `cors()` middleware and
+  the `VoyantAuthIntegration.resolveCorsOrigin` seam carry this into the app.

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -980,9 +980,20 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
 
     const { db, dispose } = openDatabase(env)
     try {
-      const customerContext = customerSurface
-        ? await resolveCustomerAuthContext(env, request)
-        : null
+      // A storefront customer-auth resolution failure on `/v1/public/*` (missing/
+      // unknown/revoked key or a disallowed origin) is a client-side auth failure,
+      // not a server fault: resolve it to "unauthorized" (null) so the framework
+      // returns 401 instead of letting it surface as a 500. Genuine faults still
+      // throw. Mirrors the auth handler's onError mapping for `/auth/customer/*`.
+      let customerContext: CustomerAuthRuntimeContext | null = null
+      if (customerSurface) {
+        try {
+          customerContext = await resolveCustomerAuthContext(env, request)
+        } catch (error) {
+          if (error instanceof StorefrontCustomerAuthResolutionError) return null
+          throw error
+        }
+      }
       const auth = customerSurface
         ? await buildCustomerBetterAuth(env, db, request, customerContext ?? undefined)
         : buildAdminBetterAuth(env, db)

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -85,6 +85,24 @@ function classifyOperatorApiAuthSurface(requestUrl: string): OperatorApiAuthSurf
   return null
 }
 
+/**
+ * Whether a request targets the customer realm surface eligible for per-storefront
+ * dynamic CORS: the public storefront API (`/v1/public` + `/v1/public/*`) and the
+ * customer auth routes (`/auth/customer` + `/auth/customer/*`) a direct client
+ * hits to sign in. Tolerates an optional `/api` host prefix. Admin/dash surfaces
+ * are intentionally excluded — they keep the static `CORS_ALLOWLIST` behavior.
+ */
+export function isCustomerCorsSurface(requestUrl: string): boolean {
+  const pathname = new URL(requestUrl).pathname.replace(/\/+$/, "") || "/"
+  const normalized = pathname.startsWith("/api/") ? pathname.slice(4) : pathname
+  return (
+    normalized === "/v1/public" ||
+    normalized.startsWith("/v1/public/") ||
+    normalized === "/auth/customer" ||
+    normalized.startsWith("/auth/customer/")
+  )
+}
+
 export interface OperatorAuthNodeEnv extends NodeDatabaseEnv {
   API_BASE_URL?: string
   APP_URL?: string
@@ -197,6 +215,15 @@ export interface CreateOperatorAuthNodeRuntimeOptions<Env extends OperatorAuthNo
     env: Env,
     request: Request,
   ) => CustomerAuthRuntimeContext | Promise<CustomerAuthRuntimeContext>
+  /**
+   * Request-time dynamic-CORS origin authorizer for the customer realm
+   * (`/v1/public/*` + `/auth/customer/*`). Returns the exact request origin to
+   * echo in `Access-Control-Allow-Origin` when a storefront authorizes it, or
+   * `null` to omit CORS headers. Authorizes keyed requests by the presented
+   * storefront key and keyless preflight by the declared allowed origins. When
+   * unset, the customer realm keeps the static `CORS_ALLOWLIST` behavior.
+   */
+  resolveCustomerCorsOrigin?: (env: Env, request: Request) => Promise<string | null>
 }
 
 export interface CustomerAuthRuntimeContext {
@@ -207,6 +234,12 @@ export interface CustomerAuthRuntimeContext {
   /** Explicit trusted storefront origin used for customer invitation links and request audit. */
   invitationAcceptBaseURL?: string
   trustedOrigins: string[]
+  /**
+   * Full declared browser origins for the resolved storefront (exact +
+   * `https://*.host` wildcard). Carried for dynamic CORS; `trustedOrigins` is
+   * the canonical-origin subset Better Auth validates.
+   */
+  allowedOrigins?: string[]
   methods: CustomerAuthMethods
   /** Buyer capabilities are independent from identity sign-up methods. */
   accountPolicy?: CustomerBuyerAccountPolicy | null
@@ -671,8 +704,16 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
       context.publicApiBaseURL ?? `${baseURL}/api`,
       baseURL,
     )
-    const trustedOrigins = context.trustedOrigins.map((origin) =>
-      requireCanonicalOrigin(origin, "customer auth trusted origin"),
+    // Fold the resolved storefront's trusted origins together with the static
+    // env allowlist so a cross-origin customer-auth call from any allowed
+    // storefront origin is trusted by Better Auth (WORK: direct-client support).
+    // Wildcard (`https://*.host`) entries pass through untouched — Better Auth
+    // matches them natively; every other entry must be a canonical origin.
+    const trustedOrigins = [...new Set([...context.trustedOrigins, ...getTrustedOrigins(env)])].map(
+      (origin) =>
+        isCustomerWildcardOrigin(origin)
+          ? origin
+          : requireCanonicalOrigin(origin, "customer auth trusted origin"),
     )
     const invitationAcceptBaseURL = context.invitationAcceptBaseURL
       ? requireCanonicalOrigin(
@@ -687,6 +728,13 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
       trustedOrigins,
       ...(invitationAcceptBaseURL ? { invitationAcceptBaseURL } : {}),
     }
+  }
+
+  /** A single-label `https://*.host` wildcard trusted-origin declaration. */
+  function isCustomerWildcardOrigin(value: string): boolean {
+    if (!value.startsWith("https://*.")) return false
+    const host = value.slice("https://*.".length)
+    return host.length > 0 && !host.includes("*") && !host.includes("/") && !host.includes(":")
   }
 
   function requireCanonicalOrigin(value: string, label: string): string {
@@ -1044,6 +1092,21 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
   async function hasAuthPermission(request: Request, env: Env): Promise<boolean> {
     const auth = await resolveAuthRequest(request, env)
     return auth !== null
+  }
+
+  /**
+   * Authorize a customer-realm cross-origin request for dynamic CORS. Returns
+   * the exact request origin to echo in `Access-Control-Allow-Origin`, or `null`
+   * to omit CORS headers. Only the customer surface (`/v1/public/*` and
+   * `/auth/customer/*`) is dynamically authorized; every other surface keeps the
+   * static `CORS_ALLOWLIST` behavior. The customer realm being disabled, or no
+   * authorizer being wired, yields `null` (static behavior).
+   */
+  async function resolveCustomerCorsOrigin(request: Request, env: Env): Promise<string | null> {
+    if (!runtimeOptions.resolveCustomerCorsOrigin) return null
+    if (env.VOYANT_CUSTOMER_AUTH_MODE?.trim() === "disabled") return null
+    if (!isCustomerCorsSurface(request.url)) return null
+    return runtimeOptions.resolveCustomerCorsOrigin(env, request)
   }
 
   class CurrentUserNotFoundError extends Error {
@@ -1811,6 +1874,7 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
     getCurrentUserForRequest,
     hasAuthPermission,
     resolveAuthRequest,
+    resolveCustomerCorsOrigin,
     validateApiTokenAccess,
   }
 }

--- a/packages/auth/src/server.ts
+++ b/packages/auth/src/server.ts
@@ -16,7 +16,7 @@ import {
 } from "@voyant-travel/db/schema/iam"
 import { type BetterAuthOptions, betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
-import { emailOTP, organization } from "better-auth/plugins"
+import { bearer, emailOTP, organization } from "better-auth/plugins"
 import type { BetterAuthPlugin } from "better-auth/types"
 import { sql } from "drizzle-orm"
 import type { AnyPgTable } from "drizzle-orm/pg-core"
@@ -641,6 +641,12 @@ export function createCustomerBetterAuth<
       },
     },
     extraSchema: options.extraSchema,
-    plugins: [customerOrganizationPlugin, ...(options.plugins ?? [])],
+    // `bearer` lets a direct (cross-origin / native) client authenticate with an
+    // `Authorization: Bearer <token>` header instead of a cookie: on sign-in
+    // Better Auth returns the session token via `set-auth-token`, and the bearer
+    // hook converts the presented token back into a session on later calls. The
+    // BFF/same-origin path keeps using host-only cookies untouched. Direct
+    // clients dodge third-party-cookie deprecation this way.
+    plugins: [customerOrganizationPlugin, bearer(), ...(options.plugins ?? [])],
   })
 }

--- a/packages/auth/src/storefront-customer-auth-resolver.ts
+++ b/packages/auth/src/storefront-customer-auth-resolver.ts
@@ -27,8 +27,29 @@ import type {
 
 /** Default header the storefront BFF uses to declare its browser origin. */
 export const STOREFRONT_ORIGIN_HEADER = "x-voyant-storefront-origin"
+/** Standard browser header a direct (non-BFF) cross-origin client sends. */
+export const STANDARD_ORIGIN_HEADER = "origin"
 /** Default header carrying the storefront's publishable/secret access key. */
 export const STOREFRONT_KEY_HEADER = "x-api-key"
+
+const WILDCARD_ORIGIN_PREFIX = "https://*."
+
+/**
+ * Resolve the storefront browser origin for a request. The BFF forwards its
+ * origin explicitly via {@link STOREFRONT_ORIGIN_HEADER} and that always wins;
+ * a direct (non-BFF) cross-origin client carries no BFF header, so fall back to
+ * the standard `Origin` header the browser attaches. Same-origin server
+ * requests keep sending the BFF header exactly as before.
+ */
+export function resolveStorefrontRequestOrigin(
+  request: Request,
+  originHeader: string = STOREFRONT_ORIGIN_HEADER,
+): string | null {
+  const bffOrigin = request.headers.get(originHeader)?.trim()
+  if (bffOrigin) return bffOrigin
+  const browserOrigin = request.headers.get(STANDARD_ORIGIN_HEADER)?.trim()
+  return browserOrigin || null
+}
 
 export interface LocalStorefrontCustomerAuthResolverConfig<Env> {
   provider: StorefrontRuntimeProvider
@@ -105,11 +126,11 @@ export function createLocalStorefrontCustomerAuthResolver<Env>(
   const keyHeader = config.keyHeader ?? STOREFRONT_KEY_HEADER
 
   return async (env, request) => {
-    const origin = request.headers.get(originHeader)?.trim()
+    const origin = resolveStorefrontRequestOrigin(request, originHeader)
     if (!origin) {
       throw new StorefrontCustomerAuthResolutionError(
         "missing_origin",
-        `Local storefront customer auth requires ${originHeader} from the storefront BFF.`,
+        `Local storefront customer auth requires ${originHeader} (BFF) or a standard Origin header.`,
       )
     }
     const token = request.headers.get(keyHeader)?.trim()
@@ -150,14 +171,68 @@ export function createLocalStorefrontCustomerAuthResolver<Env>(
         socialProviders: toSocialProviders(secrets),
       }
 
+      // Trust every declared exact origin plus the concrete request origin (which
+      // covers a `https://*.host` wildcard match, since the browser sends the
+      // resolved sub-domain). Wildcard entries themselves are surfaced via
+      // `allowedOrigins` for dynamic CORS but kept out of `trustedOrigins`, which
+      // the runtime validates as canonical origins.
+      const exactAllowedOrigins = storefront.allowedOrigins.filter(
+        (candidate) => !candidate.startsWith(WILDCARD_ORIGIN_PREFIX),
+      )
+      const trustedOrigins = [...new Set([origin, ...exactAllowedOrigins])]
+
       return {
         baseURL: origin,
         publicApiBaseURL: `${origin}/api`,
         invitationAcceptBaseURL: origin,
-        trustedOrigins: [origin],
+        trustedOrigins,
+        allowedOrigins: [...storefront.allowedOrigins],
         methods,
         accountPolicy: storefront.accountPolicy as CustomerBuyerAccountPolicy,
       }
+    } finally {
+      await dispose?.()
+    }
+  }
+}
+
+/**
+ * Build the request-time dynamic-CORS origin authorizer a self-host runtime
+ * passes to {@link createOperatorAuthNodeRuntime} as `resolveCustomerCorsOrigin`.
+ *
+ * Returns the exact request origin to echo in `Access-Control-Allow-Origin` when
+ * a storefront authorizes it, or `null` when it does not (the caller then omits
+ * CORS headers so the browser blocks the cross-origin response).
+ *
+ * Two request shapes are handled:
+ *  - Real/credentialed requests carry the publishable/secret key: the storefront
+ *    is resolved by key and the origin checked against its declared origins.
+ *  - CORS preflight (`OPTIONS`) carries no key or cookies, so the origin is
+ *    matched against any storefront that declares it via
+ *    {@link StorefrontRuntimeProvider.resolveStorefrontByOrigin}. This never
+ *    echoes an origin that no storefront allows.
+ */
+export function createLocalStorefrontCorsOriginResolver<Env>(
+  config: LocalStorefrontCustomerAuthResolverConfig<Env>,
+): (env: Env, request: Request) => Promise<string | null> {
+  const originHeader = config.originHeader ?? STOREFRONT_ORIGIN_HEADER
+  const keyHeader = config.keyHeader ?? STOREFRONT_KEY_HEADER
+
+  return async (env, request) => {
+    const origin = resolveStorefrontRequestOrigin(request, originHeader)
+    if (!origin) return null
+
+    const { context, dispose } = await config.openResolveContext(env, request)
+    try {
+      const token = request.headers.get(keyHeader)?.trim()
+      if (token) {
+        const resolved = await config.provider.resolveStorefrontByApiKey(context, token)
+        if (!resolved) return null
+        return isStorefrontOriginAllowed(origin, resolved.storefront.allowedOrigins) ? origin : null
+      }
+      // Keyless preflight: authorize purely by declared origin.
+      const storefront = await config.provider.resolveStorefrontByOrigin(context, origin)
+      return storefront ? origin : null
     } finally {
       await dispose?.()
     }

--- a/packages/auth/src/storefront-local-adapter.ts
+++ b/packages/auth/src/storefront-local-adapter.ts
@@ -14,7 +14,7 @@ import {
   storefrontCustomerAuthCredentials,
   storefronts,
 } from "@voyant-travel/db/schema/iam"
-import { and, desc, eq } from "drizzle-orm"
+import { and, desc, eq, sql } from "drizzle-orm"
 
 import {
   type StorefrontCredentialCipher,
@@ -27,6 +27,7 @@ import {
 } from "./storefront-keys.js"
 import {
   enabledStorefrontSocialProviders,
+  isStorefrontOriginAllowed,
   normalizeStorefrontAllowedOrigins,
   normalizeStorefrontCustomerAccountPolicy,
   normalizeStorefrontCustomerAuthMethods,
@@ -325,6 +326,36 @@ export function createLocalStorefrontAdapter(options: {
         // Best-effort usage stamping; never fail the request on it.
       }
       return { storefront: toStorefrontDto(storefront), key: toApiKeyDto(key) }
+    },
+
+    async resolveStorefrontByOrigin(
+      context: StorefrontResolveContext,
+      origin: string,
+    ): Promise<StorefrontDto | null> {
+      // Preflight authorization is keyless, so it cannot select a single
+      // storefront up front. Exact-origin entries are filtered in SQL via array
+      // containment; wildcard (`https://*.host`) declarations are matched in
+      // memory over the small self-host storefront set. First match wins — a
+      // browser origin resolves to at most one storefront in practice.
+      const [exactMatch] = await context.db
+        .select()
+        .from(storefronts)
+        // agent-quality: raw-sql reviewed -- Postgres text[] containment authorizes the exact declared origin without loading every row.
+        .where(sql`${storefronts.allowedOrigins} @> ARRAY[${origin}]::text[]`)
+        .limit(1)
+      if (exactMatch) return toStorefrontDto(exactMatch)
+
+      const wildcardCandidates = await context.db
+        .select()
+        .from(storefronts)
+        // agent-quality: raw-sql reviewed -- Only rows carrying a wildcard origin declaration are considered for the in-memory match.
+        .where(
+          sql`EXISTS (SELECT 1 FROM unnest(${storefronts.allowedOrigins}) AS o WHERE o LIKE 'https://*.%')`,
+        )
+      for (const row of wildcardCandidates) {
+        if (isStorefrontOriginAllowed(origin, row.allowedOrigins)) return toStorefrontDto(row)
+      }
+      return null
     },
 
     async updateAccountPolicy(context, storefrontId, policy) {

--- a/packages/auth/src/storefront-runtime-port.ts
+++ b/packages/auth/src/storefront-runtime-port.ts
@@ -135,6 +135,15 @@ export interface StorefrontRuntimeProvider {
     context: StorefrontResolveContext,
     token: string,
   ): Promise<ResolvedStorefrontApiKey | null>
+  /**
+   * Resolve a storefront that declares `origin` as an allowed browser origin
+   * (exact or `https://*.host` wildcard). Used to authorize keyless CORS
+   * preflight requests, which carry an `Origin` but no storefront key.
+   */
+  resolveStorefrontByOrigin(
+    context: StorefrontResolveContext,
+    origin: string,
+  ): Promise<StorefrontDto | null>
   // account policy + methods --------------------------------------------
   updateAccountPolicy(
     context: StorefrontRequestContext,
@@ -182,6 +191,7 @@ const REQUIRED_METHODS = [
   "rotateApiKey",
   "revokeApiKey",
   "resolveStorefrontByApiKey",
+  "resolveStorefrontByOrigin",
   "updateAccountPolicy",
   "updateMethods",
   "listProviderCredentials",

--- a/packages/auth/tests/integration/customer-business-better-auth.test.ts
+++ b/packages/auth/tests/integration/customer-business-better-auth.test.ts
@@ -166,6 +166,40 @@ describe.skipIf(!TEST_DATABASE_URL)("customer business Better Auth compatibility
     expect(membership).toBeTruthy()
   })
 
+  it("issues a bearer token on sign-in and accepts it for cookieless session calls", async () => {
+    // Direct (cross-origin / native) clients authenticate with a bearer token
+    // instead of a cross-site cookie. Better Auth's bearer plugin returns the
+    // session token via `set-auth-token` on sign-in and converts it back to a
+    // session on later calls.
+    const email = "bearer@example.com"
+    const sent = await request("/email-otp/send-verification-otp", { email, type: "sign-in" })
+    expect(sent.status).toBe(200)
+    const otp = otpByEmail.get(email)
+    const signedIn = await request("/sign-in/email-otp", { email, otp, name: "Bearer" })
+    expect(signedIn.status).toBe(200)
+    const token = signedIn.headers.get("set-auth-token")
+    expect(token).toBeTruthy()
+
+    // A cookieless call carrying only the bearer token resolves the session.
+    const withBearer = await auth.handler(
+      new Request(`${baseURL}${basePath}/get-session`, {
+        headers: { authorization: `Bearer ${token}` },
+      }),
+    )
+    expect(withBearer.status).toBe(200)
+    expect(await withBearer.json()).toMatchObject({ user: { email } })
+
+    // Absent/invalid bearer + no cookie yields no session.
+    const anon = await auth.handler(new Request(`${baseURL}${basePath}/get-session`))
+    expect(await anon.json()).toBeNull()
+    const bad = await auth.handler(
+      new Request(`${baseURL}${basePath}/get-session`, {
+        headers: { authorization: "Bearer not-a-real-token" },
+      }),
+    )
+    expect(await bad.json()).toBeNull()
+  })
+
   it("allows only one concurrent acceptance and rejects expired invitations", async () => {
     const owner = await signIn("race-owner@example.com", "Race Owner")
     const recipient = await signIn("race-recipient@example.com", "Race Recipient")

--- a/packages/auth/tests/unit/create-better-auth.test.ts
+++ b/packages/auth/tests/unit/create-better-auth.test.ts
@@ -101,6 +101,7 @@ vi.mock("better-auth/cookies", () => ({
 vi.mock("better-auth/plugins", () => ({
   emailOTP: vi.fn((options: Record<string, unknown>) => ({ id: "emailOTP", options })),
   organization: vi.fn((options: Record<string, unknown>) => ({ id: "organization", options })),
+  bearer: vi.fn((options?: Record<string, unknown>) => ({ id: "bearer", options })),
 }))
 
 vi.mock("../../src/local-member-access.js", () => ({
@@ -183,6 +184,9 @@ describe("createBetterAuth", () => {
         }),
       }),
     )
+    // Bearer enables direct (cross-origin / native) clients to authenticate with
+    // an Authorization: Bearer <token> header instead of a cross-site cookie.
+    expect(config.plugins).toContainEqual(expect.objectContaining({ id: "bearer" }))
     expect(config.socialProviders).toEqual(
       expect.objectContaining({
         google: expect.any(Object),

--- a/packages/auth/tests/unit/node-runtime.test.ts
+++ b/packages/auth/tests/unit/node-runtime.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from "vitest"
 import {
   buildBetterAuthCookieAdvancedOptions,
   createOperatorAuthNodeRuntime,
+  isCustomerCorsSurface,
 } from "../../src/node-runtime.js"
 import {
+  createLocalStorefrontCorsOriginResolver,
   createLocalStorefrontCustomerAuthResolver,
   STOREFRONT_KEY_HEADER,
   STOREFRONT_ORIGIN_HEADER,
@@ -610,5 +612,166 @@ describe("createOperatorAuthNodeRuntime storefront customer-auth failures", () =
     expect(await response.json()).toMatchObject({
       methods: { emailCode: true, emailPassword: false },
     })
+  })
+})
+
+describe("isCustomerCorsSurface", () => {
+  it("matches the customer public API and customer auth routes (with or without /api)", () => {
+    for (const url of [
+      "https://api.example.com/v1/public",
+      "https://api.example.com/v1/public/catalog/items",
+      "https://api.example.com/api/v1/public/catalog/items",
+      "https://api.example.com/auth/customer",
+      "https://api.example.com/auth/customer/sign-in/email",
+      "https://api.example.com/api/auth/customer/sign-in/email",
+    ]) {
+      expect(isCustomerCorsSurface(url)).toBe(true)
+    }
+  })
+
+  it("excludes admin/dash and unrelated surfaces", () => {
+    for (const url of [
+      "https://api.example.com/v1/admin/catalog",
+      "https://api.example.com/auth/admin/sign-in/email",
+      "https://api.example.com/health",
+      "https://api.example.com/not-v1/public/x",
+    ]) {
+      expect(isCustomerCorsSurface(url)).toBe(false)
+    }
+  })
+})
+
+describe("createOperatorAuthNodeRuntime customer dynamic CORS", () => {
+  const STOREFRONT: StorefrontDto = {
+    id: "sf_cors",
+    organizationId: "org_1",
+    name: "Shop",
+    slug: "shop",
+    hostingKind: "external",
+    siteId: null,
+    allowedOrigins: ["https://shop.example.com", "https://*.example.com"],
+    methods: {
+      emailCode: true,
+      emailPassword: false,
+      google: false,
+      facebook: false,
+      apple: false,
+    },
+    accountPolicy: {
+      allowedKinds: ["personal"],
+      personalSignup: "open",
+      businessOnboarding: "disabled",
+    },
+    hostOnlyCookies: true,
+    createdAt: "2026-07-19T00:00:00.000Z",
+    updatedAt: "2026-07-19T00:00:00.000Z",
+  }
+
+  function corsProvider(): StorefrontRuntimeProvider {
+    return {
+      resolveStorefrontByApiKey: async (_context: unknown, token: string) =>
+        token ? { storefront: STOREFRONT, key: null } : null,
+      resolveStorefrontByOrigin: async (_context: unknown, origin: string) =>
+        ["https://shop.example.com", "https://preview.example.com"].includes(origin)
+          ? STOREFRONT
+          : null,
+      resolveProviderCredentials: async () => ({}),
+    } as unknown as StorefrontRuntimeProvider
+  }
+
+  function makeRuntime() {
+    return createOperatorAuthNodeRuntime({
+      accessCatalog: { resources: [], presets: [] },
+      appName: "auth-test",
+      authMode: "local",
+      reporter: { captureException: vi.fn() },
+      openDatabase: () => ({ db: {} as never, dispose: async () => {} }),
+      resolveCustomerCorsOrigin: createLocalStorefrontCorsOriginResolver({
+        provider: corsProvider(),
+        openResolveContext: async () => ({
+          context: { bindings: {}, db: {} as never },
+          dispose: async () => {},
+        }),
+      }),
+    })
+  }
+
+  const ENV = { DATABASE_URL: "postgres://unused", SESSION_CLAIMS_ADMIN_SECRET: "x".repeat(32) }
+
+  it("echoes an allowed origin for a keyed public-API request", async () => {
+    const runtime = makeRuntime()
+    const origin = await runtime.resolveCustomerCorsOrigin(
+      new Request("https://api.example.com/v1/public/catalog", {
+        headers: { origin: "https://shop.example.com", [STOREFRONT_KEY_HEADER]: "vpk_token" },
+      }),
+      ENV,
+    )
+    expect(origin).toBe("https://shop.example.com")
+  })
+
+  it("authorizes a keyless preflight by declared origin", async () => {
+    const runtime = makeRuntime()
+    const origin = await runtime.resolveCustomerCorsOrigin(
+      new Request("https://api.example.com/auth/customer/sign-in/email", {
+        method: "OPTIONS",
+        headers: { origin: "https://preview.example.com" },
+      }),
+      ENV,
+    )
+    expect(origin).toBe("https://preview.example.com")
+  })
+
+  it("returns null for a disallowed origin", async () => {
+    const runtime = makeRuntime()
+    expect(
+      await runtime.resolveCustomerCorsOrigin(
+        new Request("https://api.example.com/v1/public/catalog", {
+          headers: { origin: "https://evil.com", [STOREFRONT_KEY_HEADER]: "vpk_token" },
+        }),
+        ENV,
+      ),
+    ).toBeNull()
+  })
+
+  it("does not authorize admin surfaces (static allowlist only)", async () => {
+    const runtime = makeRuntime()
+    expect(
+      await runtime.resolveCustomerCorsOrigin(
+        new Request("https://api.example.com/v1/admin/catalog", {
+          headers: { origin: "https://shop.example.com", [STOREFRONT_KEY_HEADER]: "vpk_token" },
+        }),
+        ENV,
+      ),
+    ).toBeNull()
+  })
+
+  it("returns null when the customer realm is disabled", async () => {
+    const runtime = makeRuntime()
+    expect(
+      await runtime.resolveCustomerCorsOrigin(
+        new Request("https://api.example.com/v1/public/catalog", {
+          headers: { origin: "https://shop.example.com", [STOREFRONT_KEY_HEADER]: "vpk_token" },
+        }),
+        { ...ENV, VOYANT_CUSTOMER_AUTH_MODE: "disabled" },
+      ),
+    ).toBeNull()
+  })
+
+  it("returns null when no CORS authorizer is wired", async () => {
+    const runtime = createOperatorAuthNodeRuntime({
+      accessCatalog: { resources: [], presets: [] },
+      appName: "auth-test",
+      authMode: "local",
+      reporter: { captureException: vi.fn() },
+      openDatabase: () => ({ db: {} as never, dispose: async () => {} }),
+    })
+    expect(
+      await runtime.resolveCustomerCorsOrigin(
+        new Request("https://api.example.com/v1/public/catalog", {
+          headers: { origin: "https://shop.example.com", [STOREFRONT_KEY_HEADER]: "vpk_token" },
+        }),
+        ENV,
+      ),
+    ).toBeNull()
   })
 })

--- a/packages/auth/tests/unit/node-runtime.test.ts
+++ b/packages/auth/tests/unit/node-runtime.test.ts
@@ -613,6 +613,52 @@ describe("createOperatorAuthNodeRuntime storefront customer-auth failures", () =
       methods: { emailCode: true, emailPassword: false },
     })
   })
+
+  it.each([
+    { label: "missing key", headers: { [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com" } },
+    {
+      label: "unknown/revoked key",
+      headers: {
+        [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com",
+        [STOREFRONT_KEY_HEADER]: "vpk_secret_value",
+      },
+      resolveStorefrontByApiKey: async () => null,
+    },
+    {
+      label: "disallowed origin",
+      headers: {
+        [STOREFRONT_ORIGIN_HEADER]: "https://evil.example.com",
+        [STOREFRONT_KEY_HEADER]: "vpk_token",
+      },
+    },
+  ])("maps a public-API storefront resolver failure ($label) to unauthorized (null → 401)", async ({
+    headers,
+    resolveStorefrontByApiKey,
+  }) => {
+    // On /v1/public/*, a storefront key/origin failure must resolve to
+    // "unauthorized" (null) so the framework returns 401 — never a 500.
+    const result = await makeRuntime(fakeProvider(resolveStorefrontByApiKey)).resolveAuthRequest(
+      new Request("https://shop.example.com/v1/public/catalog", { headers }),
+      ENV,
+    )
+    expect(result).toBeNull()
+  })
+
+  it("propagates a genuine (non-resolver) fault on the public API path", async () => {
+    const runtime = createOperatorAuthNodeRuntime({
+      accessCatalog: { resources: [], presets: [] },
+      appName: "auth-test",
+      authMode: "local",
+      reporter: { captureException: vi.fn() },
+      openDatabase: () => ({ db: {} as never, dispose: async () => {} }),
+      resolveCustomerAuthContext: async () => {
+        throw new Error("customer context broker unavailable")
+      },
+    })
+    await expect(
+      runtime.resolveAuthRequest(new Request("https://shop.example.com/v1/public/catalog"), ENV),
+    ).rejects.toThrow("customer context broker unavailable")
+  })
 })
 
 describe("isCustomerCorsSurface", () => {

--- a/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
+++ b/packages/auth/tests/unit/storefront-customer-auth-resolver.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  createLocalStorefrontCorsOriginResolver,
   createLocalStorefrontCustomerAuthResolver,
+  resolveStorefrontRequestOrigin,
   STOREFRONT_KEY_HEADER,
   STOREFRONT_ORIGIN_HEADER,
   StorefrontCustomerAuthResolutionError,
 } from "../../src/storefront-customer-auth-resolver.js"
+import { isStorefrontOriginAllowed } from "../../src/storefront-origins.js"
 import type {
   ResolvedStorefrontApiKey,
   ResolvedStorefrontProviderCredentials,
@@ -35,6 +38,7 @@ const STOREFRONT: StorefrontDto = {
 function fakeProvider(overrides?: {
   resolveStorefrontByApiKey?: () => Promise<ResolvedStorefrontApiKey | null>
   resolveProviderCredentials?: () => Promise<ResolvedStorefrontProviderCredentials>
+  resolveStorefrontByOrigin?: (origin: string) => Promise<StorefrontDto | null>
 }): StorefrontRuntimeProvider {
   return {
     async resolveStorefrontByApiKey() {
@@ -54,6 +58,10 @@ function fakeProvider(overrides?: {
           },
         })
       )
+    },
+    async resolveStorefrontByOrigin(_context: unknown, origin: string) {
+      if (overrides?.resolveStorefrontByOrigin) return overrides.resolveStorefrontByOrigin(origin)
+      return isStorefrontOriginAllowed(origin, STOREFRONT.allowedOrigins) ? STOREFRONT : null
     },
     async resolveProviderCredentials() {
       return (
@@ -100,6 +108,7 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
       publicApiBaseURL: "https://shop.example.com/api",
       invitationAcceptBaseURL: "https://shop.example.com",
       trustedOrigins: ["https://shop.example.com"],
+      allowedOrigins: ["https://shop.example.com", "https://*.example.com"],
       methods: {
         emailCode: true,
         emailPassword: false,
@@ -108,6 +117,38 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
       accountPolicy: STOREFRONT.accountPolicy,
     })
     expect(disposed()).toBe(1)
+  })
+
+  it("falls back to the standard Origin header for a direct (non-BFF) client", async () => {
+    const { resolver } = makeResolver(fakeProvider())
+    const context = await resolver(
+      {},
+      new Request("https://api.example.com/api/v1/public", {
+        headers: {
+          origin: "https://shop.example.com",
+          [STOREFRONT_KEY_HEADER]: "vpk_token",
+        },
+      }),
+    )
+    expect(context.baseURL).toBe("https://shop.example.com")
+    expect(context.trustedOrigins).toEqual(["https://shop.example.com"])
+  })
+
+  it("prefers the explicit BFF origin header over the standard Origin header", async () => {
+    const { resolver } = makeResolver(fakeProvider())
+    const context = await resolver(
+      {},
+      new Request("https://api.example.com/api/v1/public", {
+        headers: {
+          [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com",
+          // A cross-origin proxy hop could carry a different browser Origin; the
+          // BFF header must win so the server contract is unchanged.
+          origin: "https://preview.example.com",
+          [STOREFRONT_KEY_HEADER]: "vpk_token",
+        },
+      }),
+    )
+    expect(context.baseURL).toBe("https://shop.example.com")
   })
 
   it("accepts a wildcard-matched origin", async () => {
@@ -191,5 +232,94 @@ describe("createLocalStorefrontCustomerAuthResolver", () => {
     // A known key from a disallowed origin is a 403 (forbidden), not a 401.
     expect(error.status).toBe(403)
     expect(error.code).toBe("forbidden")
+  })
+})
+
+describe("resolveStorefrontRequestOrigin", () => {
+  it("prefers the BFF header, then falls back to the standard Origin header", () => {
+    expect(
+      resolveStorefrontRequestOrigin(
+        request({
+          [STOREFRONT_ORIGIN_HEADER]: "https://shop.example.com",
+          origin: "https://other.example.com",
+        }),
+      ),
+    ).toBe("https://shop.example.com")
+    expect(resolveStorefrontRequestOrigin(request({ origin: "https://shop.example.com" }))).toBe(
+      "https://shop.example.com",
+    )
+    expect(resolveStorefrontRequestOrigin(request({}))).toBeNull()
+  })
+})
+
+describe("createLocalStorefrontCorsOriginResolver", () => {
+  function makeCorsResolver(provider: StorefrontRuntimeProvider) {
+    let disposed = 0
+    const resolver = createLocalStorefrontCorsOriginResolver<Record<string, never>>({
+      provider,
+      async openResolveContext() {
+        return {
+          context: { bindings: {}, db: {} as never },
+          dispose: async () => {
+            disposed += 1
+          },
+        }
+      },
+    })
+    return { resolver, disposed: () => disposed }
+  }
+
+  it("echoes the request origin for a valid key from an allowed origin", async () => {
+    const { resolver, disposed } = makeCorsResolver(fakeProvider())
+    const origin = await resolver(
+      {},
+      request({
+        [STOREFRONT_KEY_HEADER]: "vpk_token",
+        origin: "https://shop.example.com",
+      }),
+    )
+    expect(origin).toBe("https://shop.example.com")
+    expect(disposed()).toBe(1)
+  })
+
+  it("returns null for a valid key presented from a disallowed origin", async () => {
+    const { resolver } = makeCorsResolver(fakeProvider())
+    const origin = await resolver(
+      {},
+      request({ [STOREFRONT_KEY_HEADER]: "vpk_token", origin: "https://evil.com" }),
+    )
+    expect(origin).toBeNull()
+  })
+
+  it("returns null for an unknown key", async () => {
+    const { resolver } = makeCorsResolver(
+      fakeProvider({ resolveStorefrontByApiKey: async () => null }),
+    )
+    const origin = await resolver(
+      {},
+      request({ [STOREFRONT_KEY_HEADER]: "vpk_bad", origin: "https://shop.example.com" }),
+    )
+    expect(origin).toBeNull()
+  })
+
+  it("authorizes a keyless preflight by declared origin (exact + wildcard)", async () => {
+    const { resolver } = makeCorsResolver(fakeProvider())
+    expect(await resolver({}, request({ origin: "https://shop.example.com" }))).toBe(
+      "https://shop.example.com",
+    )
+    // https://*.example.com wildcard authorizes a single-label sub-domain.
+    expect(await resolver({}, request({ origin: "https://preview.example.com" }))).toBe(
+      "https://preview.example.com",
+    )
+  })
+
+  it("returns null for a keyless preflight from an origin no storefront allows", async () => {
+    const { resolver } = makeCorsResolver(fakeProvider())
+    expect(await resolver({}, request({ origin: "https://evil.com" }))).toBeNull()
+  })
+
+  it("returns null when no origin is present", async () => {
+    const { resolver } = makeCorsResolver(fakeProvider())
+    expect(await resolver({}, request({ [STOREFRONT_KEY_HEADER]: "vpk_token" }))).toBeNull()
   })
 })

--- a/packages/hono/src/app.ts
+++ b/packages/hono/src/app.ts
@@ -539,8 +539,36 @@ export function mountApp<TBindings extends VoyantBindings>(
   // Structured logger
   app.use("*", logger(config.logger))
 
-  // CORS (allowlist via env CORS_ALLOWLIST)
-  app.use("*", cors())
+  // CORS (allowlist via env CORS_ALLOWLIST). The customer realm additionally
+  // supports per-storefront dynamic CORS when the auth integration provides a
+  // `resolveCorsOrigin` authorizer: an operator-configured storefront authorizes
+  // its own declared origins (exact + `https://*.host`) for direct cross-origin
+  // SPA/native clients, while admin/dash surfaces keep the static allowlist.
+  const resolveCorsOrigin = composedAuth?.resolveCorsOrigin
+  app.use(
+    "*",
+    resolveCorsOrigin
+      ? cors({
+          resolveDynamicOrigin: (c) =>
+            resolveCorsOrigin({
+              request: c.req.raw,
+              // The composed app's bindings ARE TBindings at runtime; the shared
+              // cors() signature only knows the VoyantBindings base.
+              env: c.env as TBindings,
+              ctx: tryGetExecutionCtx(c),
+            }),
+          isDynamicPath: (pathname) => {
+            const p = normalizePathname(pathname, { basePath: config.basePath })
+            return (
+              p === "/v1/public" ||
+              p.startsWith("/v1/public/") ||
+              p === "/auth/customer" ||
+              p.startsWith("/auth/customer/")
+            )
+          },
+        })
+      : cors(),
+  )
 
   if (config.securityHeaders !== false) {
     app.use("*", securityHeaders(config.securityHeaders))

--- a/packages/hono/src/middleware/cors.ts
+++ b/packages/hono/src/middleware/cors.ts
@@ -63,6 +63,7 @@ const DEFAULT_ALLOWED_REQUEST_HEADERS = new Set([
   "x-request-id",
   "x-voyant-checkout-capability",
   "x-voyant-guest-booking-access",
+  "x-voyant-storefront-origin",
 ])
 
 function allowedRequestHeaders(requested: string | undefined): string {
@@ -74,11 +75,47 @@ function allowedRequestHeaders(requested: string | undefined): string {
   return allowed.length > 0 ? allowed.join(", ") : "content-type, authorization"
 }
 
-export function cors(): MiddlewareHandler<{ Bindings: VoyantBindings }> {
+/**
+ * Resolve the exact origin to echo for a customer-realm request, or `null` to
+ * fall back to the static allowlist. Runs before the db middleware, so it owns
+ * any db access. Provided by the auth integration (`resolveCorsOrigin`).
+ */
+export type DynamicCorsOriginResolver = (
+  c: Parameters<MiddlewareHandler<{ Bindings: VoyantBindings }>>[0],
+) => Promise<string | null> | string | null
+
+export interface CorsOptions {
+  /**
+   * Per-storefront dynamic origin authorizer for the customer realm. When it
+   * returns an origin, that specific origin is echoed with credentials — never
+   * `*`. When it returns `null`, the request falls back to the static
+   * `CORS_ALLOWLIST`. Only consulted for {@link CorsOptions.isDynamicPath}
+   * matches, so admin/dash surfaces stay on the static allowlist.
+   */
+  resolveDynamicOrigin?: DynamicCorsOriginResolver
+  /** Whether a pathname is eligible for dynamic per-storefront CORS. */
+  isDynamicPath?: (pathname: string) => boolean
+}
+
+export function cors(options: CorsOptions = {}): MiddlewareHandler<{ Bindings: VoyantBindings }> {
+  const { resolveDynamicOrigin, isDynamicPath } = options
+
   return async (c, next) => {
     const origin = c.req.header("origin") || ""
     const allowlist = compileAllowlist(c.env.CORS_ALLOWLIST)
-    const allowed = isAllowedOrigin(origin, allowlist)
+
+    // Per-storefront dynamic CORS for the customer realm: an operator-configured
+    // storefront authorizes its own declared origins via the resolver, so a
+    // direct cross-origin SPA works without the origin sitting in the static env
+    // allowlist. The resolver echoes only the specific request origin (never
+    // `*`), and preflight is authorized without a key/cookie. A `null` result
+    // means "no storefront allows this origin" — fall back to the static list.
+    const dynamicEligible = Boolean(
+      origin && resolveDynamicOrigin && (isDynamicPath?.(c.req.path) ?? true),
+    )
+    const dynamicOrigin = dynamicEligible ? await resolveDynamicOrigin!(c) : null
+    const allowed = dynamicOrigin !== null || isAllowedOrigin(origin, allowlist)
+    const echoOrigin = dynamicOrigin ?? origin
 
     if (origin && !allowed) {
       console.warn("[CORS] Origin not in allowlist - CORS headers will NOT be set", {
@@ -91,7 +128,7 @@ export function cors(): MiddlewareHandler<{ Bindings: VoyantBindings }> {
 
     if (c.req.method === "OPTIONS") {
       if (allowed) {
-        c.header("Access-Control-Allow-Origin", origin)
+        c.header("Access-Control-Allow-Origin", echoOrigin)
         c.header("Vary", "Origin")
         c.header("Access-Control-Allow-Credentials", "true")
         c.header(
@@ -109,7 +146,7 @@ export function cors(): MiddlewareHandler<{ Bindings: VoyantBindings }> {
     await next()
 
     if (allowed) {
-      c.header("Access-Control-Allow-Origin", origin)
+      c.header("Access-Control-Allow-Origin", echoOrigin)
       c.header("Vary", "Origin")
       c.header("Access-Control-Allow-Credentials", "true")
     }

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -249,6 +249,16 @@ export interface VoyantAuthIntegration<TBindings extends VoyantBindings = Voyant
   onUnauthorized?: (
     args: VoyantAuthUnauthorizedArgs<TBindings>,
   ) => Promise<Response | null> | Response | null
+  /**
+   * Authorize a customer-realm cross-origin request for dynamic CORS. Returns
+   * the exact request origin to echo in `Access-Control-Allow-Origin` (dynamic,
+   * per-storefront), or `null` to fall back to the static `CORS_ALLOWLIST`.
+   * Runs before the db middleware, so implementations own any db access. Only
+   * consulted for the customer surface; admin/dash keep the static allowlist.
+   */
+  resolveCorsOrigin?: (
+    args: VoyantAuthUnauthorizedArgs<TBindings>,
+  ) => Promise<string | null> | string | null
 }
 
 export interface VoyantAppConfig<TBindings extends VoyantBindings = VoyantBindings> {

--- a/packages/hono/tests/unit/cors.test.ts
+++ b/packages/hono/tests/unit/cors.test.ts
@@ -89,4 +89,114 @@ describe("cors middleware", () => {
       "content-type, x-voyant-checkout-capability",
     )
   })
+
+  it("advertises the storefront-origin header on preflight", async () => {
+    const app = new Hono<{ Bindings: VoyantBindings }>()
+    app.use("*", cors())
+
+    const response = await app.fetch(
+      new Request("https://api.example/auth/me", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://dashboard.example",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "x-api-key, authorization, x-voyant-storefront-origin",
+        },
+      }),
+      { CORS_ALLOWLIST: "https://dashboard.example" },
+    )
+
+    expect(response.headers.get("access-control-allow-headers")).toBe(
+      "x-api-key, authorization, x-voyant-storefront-origin",
+    )
+  })
+})
+
+describe("cors middleware — per-storefront dynamic origin", () => {
+  const ALLOWED = "https://shop.example.com"
+
+  function dynamicApp() {
+    const app = new Hono<{ Bindings: VoyantBindings }>()
+    // Echo the request origin only when a "storefront" allows it, mirroring the
+    // auth runtime's resolveCorsOrigin authorizer.
+    app.use(
+      "*",
+      cors({
+        resolveDynamicOrigin: (c) => {
+          const origin = c.req.header("origin") ?? ""
+          return origin === ALLOWED || origin === "https://preview.example.com" ? origin : null
+        },
+        isDynamicPath: (pathname) =>
+          pathname === "/v1/public" || pathname.startsWith("/v1/public/"),
+      }),
+    )
+    app.get("/v1/public/catalog", (c) => c.json({ ok: true }))
+    app.get("/v1/admin/catalog", (c) => c.json({ ok: true }))
+    return app
+  }
+
+  it("echoes an allowed storefront origin on a direct request (not in static allowlist)", async () => {
+    const response = await dynamicApp().fetch(
+      new Request("https://api.example/v1/public/catalog", { headers: { origin: ALLOWED } }),
+      { CORS_ALLOWLIST: "https://dashboard.example" },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("access-control-allow-origin")).toBe(ALLOWED)
+    expect(response.headers.get("vary")).toBe("Origin")
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true")
+  })
+
+  it("short-circuits an allowed-origin preflight with 204 + CORS headers", async () => {
+    const response = await dynamicApp().fetch(
+      new Request("https://api.example/v1/public/catalog", {
+        method: "OPTIONS",
+        headers: {
+          origin: "https://preview.example.com",
+          "access-control-request-method": "POST",
+          "access-control-request-headers": "x-api-key, authorization",
+        },
+      }),
+      { CORS_ALLOWLIST: "" },
+    )
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://preview.example.com")
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true")
+    expect(response.headers.get("access-control-allow-headers")).toBe("x-api-key, authorization")
+    expect(response.headers.get("vary")).toBe("Origin")
+  })
+
+  it("omits CORS headers for a disallowed origin", async () => {
+    const response = await dynamicApp().fetch(
+      new Request("https://api.example/v1/public/catalog", {
+        headers: { origin: "https://evil.example" },
+      }),
+      { CORS_ALLOWLIST: "" },
+    )
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull()
+  })
+
+  it("does not apply dynamic CORS to non-customer (admin) surfaces", async () => {
+    const response = await dynamicApp().fetch(
+      new Request("https://api.example/v1/admin/catalog", { headers: { origin: ALLOWED } }),
+      { CORS_ALLOWLIST: "https://dashboard.example" },
+    )
+
+    // The storefront origin is not in the static allowlist and admin is not a
+    // dynamic surface, so no CORS headers are emitted.
+    expect(response.headers.get("access-control-allow-origin")).toBeNull()
+  })
+
+  it("still honors the static allowlist for customer surfaces when no storefront matches", async () => {
+    const response = await dynamicApp().fetch(
+      new Request("https://api.example/v1/public/catalog", {
+        headers: { origin: "https://dashboard.example" },
+      }),
+      { CORS_ALLOWLIST: "https://dashboard.example" },
+    )
+
+    expect(response.headers.get("access-control-allow-origin")).toBe("https://dashboard.example")
+  })
 })

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -76,6 +76,14 @@ export interface LoadVoyantProjectOptions {
       env: OperatorAuthNodeEnv,
       request: Request,
     ) => CustomerAuthRuntimeContext | Promise<CustomerAuthRuntimeContext>
+    /**
+     * Authorize a customer-realm cross-origin request for dynamic CORS. Returns
+     * the exact request origin to echo, or `null` for static-allowlist fallback.
+     */
+    resolveCustomerCorsOrigin?: (
+      env: OperatorAuthNodeEnv,
+      request: Request,
+    ) => Promise<string | null>
     /** Project-owned transport for verification codes and password resets. */
     resolveAuthEmailSender?: (env: OperatorAuthNodeEnv) => OperatorAuthEmailSender | null
   }
@@ -193,6 +201,9 @@ export async function loadVoyantProject(
     ...(options.host?.resolveCustomerAuthContext
       ? { resolveCustomerAuthContext: options.host.resolveCustomerAuthContext }
       : {}),
+    ...(options.host?.resolveCustomerCorsOrigin
+      ? { resolveCustomerCorsOrigin: options.host.resolveCustomerCorsOrigin }
+      : {}),
   })
   const runtime = await loadVoyantNodeRuntime({
     applicationId: path.basename(projectRoot),
@@ -221,6 +232,8 @@ export async function loadVoyantProject(
           authRuntime.resolveAuthRequest(request, requireVoyantAuthEnv(requestEnv)),
         hasPermission: ({ request, env: requestEnv }) =>
           authRuntime.hasAuthPermission(request, requireVoyantAuthEnv(requestEnv)),
+        resolveCorsOrigin: ({ request, env: requestEnv }) =>
+          authRuntime.resolveCustomerCorsOrigin(request, requireVoyantAuthEnv(requestEnv)),
         validateApiKey: ({ env: requestEnv, db, apiKey }) =>
           authRuntime.validateApiTokenAccess(requireVoyantAuthEnv(requestEnv), db, apiKey),
       },


### PR DESCRIPTION
Makes the storefront public API (`/v1/public/*`) consumable three ways with the same operator-issued storefront keys + per-storefront allowed origins: **server (BFF)**, **browser (direct cross-origin)**, and **mobile/native** — the headless model. Cookies stay host-only / BFF-only; direct clients use bearer tokens (third-party cookies are being deprecated).

## What
- **Publishable-key enforcement** on `/v1/public/*` (missing/unknown/revoked → 401).
- **Per-storefront dynamic CORS + `OPTIONS` preflight** in the shared Hono middleware: echoes the request `Origin` only if it's in that storefront's `allowedOrigins` (exact + `https://*.host` wildcard), with `Vary: Origin` + `Allow-Credentials`; falls back to the static allowlist for non-customer surfaces. Keyless preflight authorized by `Origin` via a new `resolveStorefrontByOrigin` port method.
- **Standard `Origin` header** accepted for direct clients (the BFF `x-voyant-storefront-origin` still wins).
- **Bearer customer auth**: Better Auth `bearer` plugin on the customer realm; sign-in returns a token, cookieless `Authorization: Bearer` calls resolve the session. Storefront `allowedOrigins` folded into `trustedOrigins` at request time.

## Verified
auth typecheck + test (216), hono (310), framework (308), runtime (89), `verify:architecture` EXIT 0, node-smoke (58). biome clean. Changeset: `@voyant-travel/auth` minor.

## Follow-ups (not in this PR)
1. **No host wires the resolvers yet** — the seams are threaded but a host must wire `createLocalStorefrontCustomerAuthResolver` + `createLocalStorefrontCorsOriginResolver` (self-host default) and the managed runtime must wire its cloud-adapter equivalents to activate the three modes end-to-end.
2. The `StorefrontRuntimeProvider` port gained `resolveStorefrontByOrigin` — the managed cloud adapter (platform) must implement it on its next framework bump.