### PR TITLE
storage: generic HTTP gateway StorageProvider

### DIFF
--- a/.changeset/storage-gateway-provider.md
+++ b/.changeset/storage-gateway-provider.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/storage": minor
+---
+
+Add a generic `gateway` storage provider: an HTTP client that implements the
+`StorageProvider` interface by calling a configured storage-gateway endpoint
+with a bearer token.
+
+- `createGatewayStorageProvider({ endpoint, token, fetch?, name? })` speaks a
+  small object API under `/v1/objects` — `PUT` to upload, `GET` to fetch bytes
+  (404 → `null`), `DELETE` to remove (404 treated as a no-op), and
+  `POST .../signed-url` to mint a time-limited download URL.
+- Every request carries `Authorization: Bearer ${token}`. The token is opaque:
+  the provider never parses it and leaves scope resolution to the gateway. A
+  `401` raises a clear auth error; other non-2xx responses surface the status
+  and a body snippet.
+- Path segments are URL-encoded individually so keys containing `/` route
+  correctly, while keys are otherwise passed through untouched.
+- The factory and its `GatewayStorageProviderOptions` type are exported from the
+  package root and via the `./providers/gateway` subpath.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1759,6 +1759,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1760,6 +1760,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1726,6 +1726,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1727,6 +1727,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1713,6 +1713,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1707,6 +1707,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1760,6 +1760,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1761,6 +1761,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1780,6 +1780,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1781,6 +1781,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1794,6 +1794,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1789,6 +1789,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1798,6 +1798,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1799,6 +1799,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1794,6 +1794,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1789,6 +1789,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1733,6 +1733,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1734,6 +1734,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1693,6 +1693,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1688,6 +1688,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -15,6 +15,7 @@
     "./voyant": "./src/voyant.ts",
     "./providers/local": "./src/providers/local.ts",
     "./providers/s3-compatible": "./src/providers/s3-compatible.ts",
+    "./providers/gateway": "./src/providers/gateway.ts",
     "./providers/graph": "./src/providers/graph.ts",
     "./openapi/admin/media": "./openapi/admin/storage-media.json",
     "./openapi/admin/uploads": "./openapi/admin/storage-uploads.json",
@@ -89,6 +90,11 @@
         "types": "./dist/providers/s3-compatible.d.ts",
         "import": "./dist/providers/s3-compatible.js",
         "default": "./dist/providers/s3-compatible.js"
+      },
+      "./providers/gateway": {
+        "types": "./dist/providers/gateway.d.ts",
+        "import": "./dist/providers/gateway.js",
+        "default": "./dist/providers/gateway.js"
       },
       "./providers/graph": {
         "types": "./dist/providers/graph.d.ts",

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -1,5 +1,7 @@
 export type { StorageProviderConformanceOptions } from "./conformance.js"
 export { assertStorageProviderConformance } from "./conformance.js"
+export type { GatewayStorageProviderOptions } from "./providers/gateway.js"
+export { createGatewayStorageProvider } from "./providers/gateway.js"
 export type { LocalStorageOptions } from "./providers/local.js"
 export { createLocalStorageProvider } from "./providers/local.js"
 export type { S3CompatibleProviderOptions } from "./providers/s3-compatible.js"

--- a/packages/storage/src/providers/gateway.test.ts
+++ b/packages/storage/src/providers/gateway.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from "vitest"
+
+import { assertStorageProviderConformance } from "../conformance.js"
+import { createGatewayStorageProvider } from "./gateway.js"
+
+interface StoredObject {
+  bytes: Uint8Array
+  contentType: string
+  metadata?: Record<string, string>
+}
+
+/**
+ * A tiny in-memory fake of the storage-gateway HTTP contract. Returns a `fetch`
+ * implementation plus the calls it observed so tests can assert on headers.
+ */
+function createFakeGateway(options: { token?: string } = {}) {
+  const expectedToken = options.token ?? "t"
+  const store = new Map<string, StoredObject>()
+  const calls: Array<{ method: string; url: string; authorization: string | null }> = []
+
+  // A narrow adapter typed as the platform `fetch`, so no cast is needed to
+  // hand it to the provider.
+  const fetch: typeof globalThis.fetch = async (input, init) => {
+    const rawUrl =
+      typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url
+    const url = new URL(rawUrl)
+    const method = init?.method ?? "GET"
+    const headers = new Headers(init?.headers)
+    const authorization = headers.get("authorization")
+    calls.push({ method, url: url.toString(), authorization })
+
+    if (authorization !== `Bearer ${expectedToken}`) {
+      return new Response("unauthorized", { status: 401 })
+    }
+
+    // /v1/objects/<encoded key...>[/signed-url]
+    const prefix = "/v1/objects/"
+    const rest = decodeURIComponent(url.pathname.slice(prefix.length))
+
+    if (method === "POST" && rest.endsWith("/signed-url")) {
+      const key = rest.slice(0, -"/signed-url".length)
+      if (!store.has(key)) return new Response("not found", { status: 404 })
+      return Response.json({ url: `${url.origin}/download/${encodeURIComponent(key)}?sig=abc` })
+    }
+
+    const key = rest
+
+    if (method === "PUT") {
+      const body = new Uint8Array(await bodyToArrayBuffer(init?.body))
+      const rawMetadata = headers.get("x-voyant-metadata")
+      const record: StoredObject = {
+        bytes: body,
+        contentType: headers.get("content-type") ?? "application/octet-stream",
+      }
+      if (rawMetadata) record.metadata = JSON.parse(rawMetadata)
+      store.set(key, record)
+      return Response.json({ key, url: `${url.origin}/objects/${encodeURIComponent(key)}` })
+    }
+
+    if (method === "GET") {
+      const record = store.get(key)
+      if (!record) return new Response("not found", { status: 404 })
+      return new Response(record.bytes as BodyInit, { status: 200 })
+    }
+
+    if (method === "DELETE") {
+      if (!store.has(key)) return new Response(null, { status: 404 })
+      store.delete(key)
+      return new Response(null, { status: 204 })
+    }
+
+    return new Response("method not allowed", { status: 405 })
+  }
+
+  return { fetch, calls, store }
+}
+
+async function bodyToArrayBuffer(body: BodyInit | null | undefined): Promise<ArrayBuffer> {
+  if (body == null) return new ArrayBuffer(0)
+  return new Response(body as BodyInit).arrayBuffer()
+}
+
+describe("createGatewayStorageProvider", () => {
+  it("uploads bytes and returns the gateway-issued key and url", async () => {
+    const gateway = createFakeGateway()
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      fetch: gateway.fetch,
+    })
+
+    const result = await provider.upload(new Uint8Array([1, 2, 3]), {
+      key: "docs/report.pdf",
+      contentType: "application/pdf",
+      metadata: { owner: "workspace" },
+    })
+
+    expect(result).toEqual({
+      key: "docs/report.pdf",
+      url: "https://gw.test/objects/docs%2Freport.pdf",
+    })
+    const stored = gateway.store.get("docs/report.pdf")
+    expect(stored?.bytes).toEqual(new Uint8Array([1, 2, 3]))
+    expect(stored?.contentType).toBe("application/pdf")
+    expect(stored?.metadata).toEqual({ owner: "workspace" })
+  })
+
+  it("round-trips bytes through get and returns null for a missing key", async () => {
+    const gateway = createFakeGateway()
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      fetch: gateway.fetch,
+    })
+
+    const bytes = new Uint8Array([9, 8, 7, 6])
+    const { key } = await provider.upload(bytes, { key: "a/b/c.bin" })
+
+    const fetched = await provider.get(key)
+    expect(fetched).not.toBeNull()
+    expect(new Uint8Array(fetched as ArrayBuffer)).toEqual(bytes)
+
+    await expect(provider.get("missing/object")).resolves.toBeNull()
+  })
+
+  it("deletes an object and is a no-op for a missing key", async () => {
+    const gateway = createFakeGateway()
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      fetch: gateway.fetch,
+    })
+
+    await provider.upload(new Uint8Array([1]), { key: "temp/file" })
+    await provider.delete("temp/file")
+    await expect(provider.get("temp/file")).resolves.toBeNull()
+
+    // No-op on an absent key: resolves without throwing.
+    await expect(provider.delete("temp/file")).resolves.toBeUndefined()
+  })
+
+  it("returns a signed url for an object", async () => {
+    const gateway = createFakeGateway()
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      fetch: gateway.fetch,
+    })
+
+    await provider.upload(new Uint8Array([1]), { key: "docs/file.txt" })
+    const url = await provider.signedUrl?.("docs/file.txt", 60)
+    expect(url).toBe("https://gw.test/download/docs%2Ffile.txt?sig=abc")
+  })
+
+  it("sends Authorization: Bearer on every request", async () => {
+    const gateway = createFakeGateway({ token: "test-bearer-token" })
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "test-bearer-token",
+      fetch: gateway.fetch,
+    })
+
+    await provider.upload(new Uint8Array([1]), { key: "k" })
+    await provider.get("k")
+    await provider.signedUrl?.("k", 30)
+    await provider.delete("k")
+
+    expect(gateway.calls).toHaveLength(4)
+    for (const call of gateway.calls) {
+      expect(call.authorization).toBe("Bearer test-bearer-token")
+    }
+  })
+
+  it("throws a clear auth error on 401", async () => {
+    const gateway = createFakeGateway({ token: "right" })
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "wrong",
+      fetch: gateway.fetch,
+    })
+
+    await expect(provider.upload(new Uint8Array([1]), { key: "k" })).rejects.toThrow(/401/)
+  })
+
+  it("uses the provided name and defaults to gateway", () => {
+    const gateway = createFakeGateway()
+    expect(
+      createGatewayStorageProvider({
+        endpoint: "https://gw.test",
+        token: "t",
+        fetch: gateway.fetch,
+      }).name,
+    ).toBe("gateway")
+    expect(
+      createGatewayStorageProvider({
+        endpoint: "https://gw.test",
+        token: "t",
+        fetch: gateway.fetch,
+        name: "documents",
+      }).name,
+    ).toBe("documents")
+  })
+
+  it("satisfies the portable storage provider conformance contract", async () => {
+    const gateway = createFakeGateway()
+    await assertStorageProviderConformance({
+      createProvider: () =>
+        createGatewayStorageProvider({
+          endpoint: "https://gw.test",
+          token: "t",
+          fetch: gateway.fetch,
+        }),
+    })
+  })
+})

--- a/packages/storage/src/providers/gateway.ts
+++ b/packages/storage/src/providers/gateway.ts
@@ -1,0 +1,138 @@
+import type { StorageObject, StorageProvider, StorageUploadBody, UploadOptions } from "../types.js"
+
+/**
+ * Options for {@link createGatewayStorageProvider}.
+ */
+export interface GatewayStorageProviderOptions {
+  /** Base URL of the storage gateway (for example `"https://gw.example.com"`). */
+  endpoint: string
+  /**
+   * Opaque bearer credential sent as `Authorization: Bearer ${token}` on every
+   * request. The provider does not parse or interpret the token; the gateway is
+   * responsible for validating it and resolving the caller's storage scope.
+   */
+  token: string
+  /** `fetch` implementation to use. Defaults to the global `fetch`. */
+  fetch?: typeof fetch
+  /** Provider name (defaults to `"gateway"`). */
+  name?: string
+}
+
+/**
+ * Build a storage provider that talks to an HTTP storage gateway.
+ *
+ * The gateway exposes a small object API under `/v1/objects` and authenticates
+ * each request with a bearer token. This keeps raw bucket credentials out of the
+ * caller: the gateway holds the credentials and enforces the token's scope,
+ * while this provider only speaks the HTTP contract. It is deliberately generic
+ * and carries no knowledge of any particular deployment or vendor.
+ */
+export function createGatewayStorageProvider(
+  options: GatewayStorageProviderOptions,
+): StorageProvider {
+  const endpoint = options.endpoint.replace(/\/+$/, "")
+  const doFetch = options.fetch ?? globalThis.fetch
+  const name = options.name ?? "gateway"
+
+  function objectUrl(key: string): string {
+    return `${endpoint}/v1/objects/${encodeKey(key)}`
+  }
+
+  function authHeaders(extra?: Record<string, string>): Record<string, string> {
+    return { authorization: `Bearer ${options.token}`, ...extra }
+  }
+
+  return {
+    name,
+    async upload(
+      body: StorageUploadBody,
+      uploadOptions: UploadOptions = {},
+    ): Promise<StorageObject> {
+      const key = uploadOptions.key ?? generateKey()
+      const headers = authHeaders({
+        "content-type": uploadOptions.contentType ?? "application/octet-stream",
+      })
+      if (uploadOptions.metadata !== undefined) {
+        headers["x-voyant-metadata"] = JSON.stringify(uploadOptions.metadata)
+      }
+      const response = await doFetch(objectUrl(key), {
+        method: "PUT",
+        headers,
+        body: await toBytes(body),
+      })
+      await assertOk(response, "upload")
+      const payload = (await response.json()) as { key: string; url: string }
+      return { key: payload.key, url: payload.url }
+    },
+    async delete(key) {
+      const response = await doFetch(objectUrl(key), {
+        method: "DELETE",
+        headers: authHeaders(),
+      })
+      if (response.status === 404) return
+      await assertOk(response, "delete")
+    },
+    async signedUrl(key, expiresIn) {
+      const response = await doFetch(`${objectUrl(key)}/signed-url`, {
+        method: "POST",
+        headers: authHeaders({ "content-type": "application/json" }),
+        body: JSON.stringify({ expiresIn }),
+      })
+      await assertOk(response, "signedUrl")
+      const payload = (await response.json()) as { url: string }
+      return payload.url
+    },
+    async get(key) {
+      const response = await doFetch(objectUrl(key), {
+        method: "GET",
+        headers: authHeaders(),
+      })
+      if (response.status === 404) return null
+      await assertOk(response, "get")
+      return response.arrayBuffer()
+    },
+  }
+}
+
+async function assertOk(response: Response, operation: string): Promise<void> {
+  if (response.ok) return
+  if (response.status === 401) {
+    throw new Error(`Storage gateway rejected the bearer token (401) during ${operation}`)
+  }
+  const snippet = (await safeBodyText(response)).slice(0, 256)
+  throw new Error(
+    `Storage gateway ${operation} failed with status ${response.status}${
+      snippet ? `: ${snippet}` : ""
+    }`,
+  )
+}
+
+async function safeBodyText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).trim()
+  } catch {
+    return ""
+  }
+}
+
+function generateKey(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+function encodeKey(key: string): string {
+  return key
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")
+}
+
+async function toBytes(body: StorageUploadBody): Promise<Uint8Array<ArrayBuffer>> {
+  if (body instanceof ArrayBuffer) return new Uint8Array(body)
+  if (body instanceof Uint8Array) {
+    // Copy into a fresh ArrayBuffer-backed view so the value is a valid `BodyInit`.
+    const copy = new Uint8Array(body.byteLength)
+    copy.set(body)
+    return copy
+  }
+  return new Uint8Array(await body.arrayBuffer())
+}

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1805,6 +1805,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1806,6 +1806,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1807,6 +1807,7 @@
       "@voyant-travel/setup/voyant": ["../setup/dist/voyant.d.ts"],
       "@voyant-travel/storage": ["../storage/dist/index.d.ts"],
       "@voyant-travel/storage/conformance": ["../storage/dist/conformance.d.ts"],
+      "@voyant-travel/storage/providers/gateway": ["../storage/dist/providers/gateway.d.ts"],
       "@voyant-travel/storage/providers/graph": ["../storage/dist/providers/graph.d.ts"],
       "@voyant-travel/storage/providers/local": ["../storage/dist/providers/local.d.ts"],
       "@voyant-travel/storage/providers/s3-compatible": [


### PR DESCRIPTION
## Summary

Adds a generic `gateway` storage provider to `@voyant-travel/storage` — an HTTP client that implements the existing `StorageProvider` interface by calling a storage-gateway endpoint with an opaque bearer token. The gateway holds the underlying bucket credentials and enforces workspace scoping from the token; the deployment holds only the token.

This is the client seam Voyant-managed deployments will use (talk to a proxy worker instead of holding raw R2/S3 credentials). It's profile-agnostic — self-host keeps its direct `s3-compatible`/`local` providers.

Part of #3555.

## API

`createGatewayStorageProvider({ endpoint, token, fetch?, name? })` → `StorageProvider`. Every request sends `Authorization: Bearer ${token}`; keys are passed through (the gateway prefixes the workspace scope from the token). HTTP contract:

- `PUT /v1/objects/{key}` (body = bytes, `Content-Type`, optional `x-voyant-metadata`) → `{ key, url }`
- `GET /v1/objects/{key}` → bytes, or `null` on 404
- `DELETE /v1/objects/{key}` → 2xx; 404 treated as no-op
- `POST /v1/objects/{key}/signed-url` `{ expiresIn }` → `{ url }`

## Verification

- `pnpm --filter @voyant-travel/storage typecheck` / `test` / `lint` green.
- `verify:architecture` + `verify:package-exports` green.
- Test drives the provider against an in-memory fake gateway (injected `fetch`) covering upload/get/delete/signedUrl round-trips, the Bearer header, and 401 handling; also runs `assertStorageProviderConformance`.

## Follow-up (not this PR)

The platform `asset-gateway` worker that implements this HTTP contract server-side — signed-workspace-token verification (JWKS + KV revocation denylist), `[jurisdiction]/[org]` prefix pinning, R2 I/O, presigned tickets for large/video uploads, and private-document serving.
