### PR TITLE
chore: release packages

### DIFF
--- a/.changeset/payments-registry-runtime-port.md
+++ b/.changeset/payments-registry-runtime-port.md
@@ -1,6 +1,0 @@
----
-"@voyant-travel/payments": minor
-"@voyant-travel/operator-settings": minor
----
-
-Make the managed payment registry injectable via a runtime port (the framework-idiomatic seam). `@voyant-travel/payments` defines `paymentProviderRegistryRuntimePort`; `@voyant-travel/operator-settings` gains a graph-runtime-factory (`createOperatorSettingsVoyantRuntime`) that resolves the optional port and, when a deployment provides it, registers the resolver into the module container at bootstrap. The Settings → Payments routes resolve the registry from the container per request, else the default self-host registry. This supersedes the earlier request-context injection seam (which could not fire in the opaque managed runtime).

--- a/packages/finance-react/CHANGELOG.md
+++ b/packages/finance-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @voyant-travel/finance-react
 
+## 0.182.2
+
+### Patch Changes
+
+- @voyant-travel/finance@0.182.2
+
 ## 0.182.1
 
 ### Patch Changes

--- a/packages/finance-react/package.json
+++ b/packages/finance-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/finance-react",
-  "version": "0.182.1",
+  "version": "0.182.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/finance/CHANGELOG.md
+++ b/packages/finance/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @voyant-travel/finance
 
+## 0.182.2
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/payments@0.4.0
+
 ## 0.182.1
 
 ### Patch Changes

--- a/packages/finance/package.json
+++ b/packages/finance/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/finance",
-  "version": "0.182.1",
+  "version": "0.182.2",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/inventory/CHANGELOG.md
+++ b/packages/inventory/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @voyant-travel/inventory
 
+## 0.14.17
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/operator-settings@0.14.0
+  - @voyant-travel/finance@0.182.2
+
 ## 0.14.16
 
 ### Patch Changes

--- a/packages/inventory/package.json
+++ b/packages/inventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/inventory",
-  "version": "0.14.16",
+  "version": "0.14.17",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/legal-react/CHANGELOG.md
+++ b/packages/legal-react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @voyant-travel/legal-react
 
+## 0.182.2
+
+### Patch Changes
+
+- @voyant-travel/legal@0.182.2
+
 ## 0.182.1
 
 ### Patch Changes

--- a/packages/legal-react/package.json
+++ b/packages/legal-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/legal-react",
-  "version": "0.182.1",
+  "version": "0.182.2",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/legal/CHANGELOG.md
+++ b/packages/legal/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @voyant-travel/legal
 
+## 0.182.2
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/operator-settings@0.14.0
+  - @voyant-travel/finance@0.182.2
+  - @voyant-travel/inventory@0.14.17
+
 ## 0.182.1
 
 ### Patch Changes

--- a/packages/legal/package.json
+++ b/packages/legal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/legal",
-  "version": "0.182.1",
+  "version": "0.182.2",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/operator-settings/CHANGELOG.md
+++ b/packages/operator-settings/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @voyant-travel/operator-settings
 
+## 0.14.0
+
+### Minor Changes
+
+- 225000a: Make the managed payment registry injectable via a runtime port (the framework-idiomatic seam). `@voyant-travel/payments` defines `paymentProviderRegistryRuntimePort`; `@voyant-travel/operator-settings` gains a graph-runtime-factory (`createOperatorSettingsVoyantRuntime`) that resolves the optional port and, when a deployment provides it, registers the resolver into the module container at bootstrap. The Settings → Payments routes resolve the registry from the container per request, else the default self-host registry. This supersedes the earlier request-context injection seam (which could not fire in the opaque managed runtime).
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/payments@0.4.0
+  - @voyant-travel/finance@0.182.2
+
 ## 0.13.1
 
 ### Patch Changes

--- a/packages/operator-settings/package.json
+++ b/packages/operator-settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/operator-settings",
-  "version": "0.13.1",
+  "version": "0.14.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/operator-standard/CHANGELOG.md
+++ b/packages/operator-standard/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @voyant-travel/operator-standard
 
+## 0.9.14
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/payments@0.4.0
+  - @voyant-travel/operator-settings@0.14.0
+  - @voyant-travel/finance@0.182.2
+  - @voyant-travel/trips@0.173.1
+  - @voyant-travel/inventory@0.14.17
+  - @voyant-travel/legal@0.182.2
+  - @voyant-travel/quotes@0.131.24
+  - @voyant-travel/finance-react@0.182.2
+  - @voyant-travel/legal-react@0.182.2
+  - @voyant-travel/trips-react@0.173.1
+
 ## 0.9.13
 
 ### Patch Changes

--- a/packages/operator-standard/package.json
+++ b/packages/operator-standard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/operator-standard",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "Versioned standard Voyant Operator product distribution and dependency BOM.",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/payments/CHANGELOG.md
+++ b/packages/payments/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @voyant-travel/payments
 
+## 0.4.0
+
+### Minor Changes
+
+- 225000a: Make the managed payment registry injectable via a runtime port (the framework-idiomatic seam). `@voyant-travel/payments` defines `paymentProviderRegistryRuntimePort`; `@voyant-travel/operator-settings` gains a graph-runtime-factory (`createOperatorSettingsVoyantRuntime`) that resolves the optional port and, when a deployment provides it, registers the resolver into the module container at bootstrap. The Settings → Payments routes resolve the registry from the container per request, else the default self-host registry. This supersedes the earlier request-context injection seam (which could not fire in the opaque managed runtime).
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/payments/package.json
+++ b/packages/payments/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/payments",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/quotes/CHANGELOG.md
+++ b/packages/quotes/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @voyant-travel/crm
 
+## 0.131.24
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/operator-settings@0.14.0
+  - @voyant-travel/trips@0.173.1
+
 ## 0.131.23
 
 ### Patch Changes

--- a/packages/quotes/package.json
+++ b/packages/quotes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/quotes",
-  "version": "0.131.23",
+  "version": "0.131.24",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/trips-react/CHANGELOG.md
+++ b/packages/trips-react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @voyant-travel/trips-react
 
+## 0.173.1
+
+### Patch Changes
+
+- @voyant-travel/finance@0.182.2
+- @voyant-travel/trips@0.173.1
+
 ## 0.173.0
 
 ### Patch Changes

--- a/packages/trips-react/package.json
+++ b/packages/trips-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/trips-react",
-  "version": "0.173.0",
+  "version": "0.173.1",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/trips/CHANGELOG.md
+++ b/packages/trips/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @voyant-travel/trips
 
+## 0.173.1
+
+### Patch Changes
+
+- Updated dependencies [225000a]
+  - @voyant-travel/payments@0.4.0
+  - @voyant-travel/operator-settings@0.14.0
+  - @voyant-travel/finance@0.182.2
+  - @voyant-travel/inventory@0.14.17
+
 ## 0.173.0
 
 ### Patch Changes

--- a/packages/trips/package.json
+++ b/packages/trips/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voyant-travel/trips",
-  "version": "0.173.0",
+  "version": "0.173.1",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {


### PR DESCRIPTION
# Releases

- `@voyant-travel/finance-react@0.182.2`
- `@voyant-travel/finance@0.182.2`
- `@voyant-travel/inventory@0.14.17`
- `@voyant-travel/legal-react@0.182.2`
- `@voyant-travel/legal@0.182.2`
- `@voyant-travel/operator-settings@0.14.0`
- `@voyant-travel/operator-standard@0.9.14`
- `@voyant-travel/payments@0.4.0`
- `@voyant-travel/quotes@0.131.24`
- `@voyant-travel/trips-react@0.173.1`
- `@voyant-travel/trips@0.173.1`

Created manually (mirrors the `changesets/action` release step) because GitHub's API Requests component was in a partial outage, failing the automated Release workflow at the PR-creation step. The previously versioned packages already published to npm successfully; this PR only accumulates the next set of version bumps.
