### PR TITLE
Release @voyant-travel/hono dynamic CORS (missing changeset)

### DIFF
--- a/.changeset/hono-dynamic-cors.md
+++ b/.changeset/hono-dynamic-cors.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/hono": minor
+---
+
+Release the request-time dynamic CORS support in the shared `cors()` middleware
+(`resolveDynamicOrigin` + `isDynamicPath`, consumed via
+`VoyantAuthIntegration.resolveCorsOrigin`). This code merged with the storefront
+direct-client work but was omitted from that release's changeset, so the hono
+consumer never published — leaving the per-storefront dynamic CORS chain inert
+even though `@voyant-travel/auth` and `@voyant-travel/runtime` shipped their
+halves. Publishing hono completes the browser/mobile direct-client storefront
+API path.


### PR DESCRIPTION
The storefront direct-client work modified `@voyant-travel/hono` (dynamic CORS in `cors()` via `resolveDynamicOrigin`/`isDynamicPath`, consumed through `VoyantAuthIntegration.resolveCorsOrigin`), but that PR's changeset only covered `@voyant-travel/auth`. `hono` is standalone (no fixed group), so it never published — its dynamic-CORS code is on `main` but the latest published `hono@0.131.2` predates it. `auth@0.141.0` (port method + bearer) and `runtime@0.15.8` (sets the origin) shipped their halves, but hono is the *consumer*, so the per-storefront dynamic-CORS chain is inert without it.

This adds the missing `@voyant-travel/hono` minor changeset so the release publishes hono (and cascades a dependent bump to auth/runtime's hono range). No code change — the source is already on `main`.