### PR TITLE
Managed card checkout: remote payment transport + IPN webhook (Phase 2B)

### DIFF
--- a/.changeset/payments-checkout-remote-transport.md
+++ b/.changeset/payments-checkout-remote-transport.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/payments": minor
+"@voyant-travel/storefront": minor
+---
+
+Managed card checkout (Phase 2B): the concrete control-plane remote payment transport that the generic `createRemotePaymentAdapter` delegates to (brokers initiate/status/verifyCallback to the platform payments control plane), plus the inbound processor IPN webhook (`POST /v1/public/payment-link/callback`) that verifies the callback through the payment adapter and applies the event. Together these let a connected processor actually charge cards without the deployment bundling any per-processor SDK.

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -243,6 +243,10 @@ export type {
   RemotePaymentTransport,
 } from "./remote-adapter.js"
 export { createRemotePaymentAdapter, PAYMENT_REMOTE_NOT_IMPLEMENTED } from "./remote-adapter.js"
+export {
+  type ControlPlaneRemotePaymentTransportConfig,
+  createControlPlaneRemotePaymentTransport,
+} from "./remote-transport.js"
 
 export {
   PAYMENT_PROVIDER_REGISTRY_RUNTIME_PORT_ID,

--- a/packages/payments/src/remote-transport.ts
+++ b/packages/payments/src/remote-transport.ts
@@ -13,10 +13,7 @@
  * adapter are the only payment code in the bundle, for any of N processors.
  */
 
-import type {
-  PaymentCallbackRequest,
-  PaymentCallbackVerificationResult,
-} from "./index.js"
+import type { PaymentCallbackRequest, PaymentCallbackVerificationResult } from "./index.js"
 import type { RemotePaymentCall, RemotePaymentTransport } from "./remote-adapter.js"
 
 export interface ControlPlaneRemotePaymentTransportConfig {
@@ -64,17 +61,14 @@ export function createControlPlaneRemotePaymentTransport(
       body: JSON.stringify(body),
     })
     if (!response.ok) {
-      throw new Error(
-        `Payments control plane ${path} failed (${response.status}).`,
-      )
+      throw new Error(`Payments control plane ${path} failed (${response.status}).`)
     }
     return response.json()
   }
 
   /** Unwrap a `{ data: { ok, result } | { ok, error } }` control-plane body. */
   function unwrapOutcome<T>(body: unknown): T {
-    const data = (body as { data?: { ok: boolean; result?: T; error?: string } })
-      .data
+    const data = (body as { data?: { ok: boolean; result?: T; error?: string } }).data
     if (!data) throw new Error("Malformed control-plane response.")
     if (!data.ok) throw new Error(data.error ?? "Control-plane operation failed.")
     if (data.result === undefined) {

--- a/packages/payments/src/remote-transport.ts
+++ b/packages/payments/src/remote-transport.ts
@@ -1,0 +1,131 @@
+/**
+ * Control-plane remote payment transport (managed mode, Phase 2B).
+ *
+ * The concrete `RemotePaymentTransport` the generic `createRemotePaymentAdapter`
+ * delegates to. It brokers each checkout op to the platform payments control
+ * plane (`/admin-runtime/payments/{initiate,status,callback/verify}`)
+ * authenticated as the DEPLOYMENT (client token + deployment id — no acting
+ * user, since these run at customer-checkout / inbound-IPN time). The control
+ * plane resolves the deployment's connected processor, decrypts its
+ * credentials, and forwards to that processor's worker.
+ *
+ * The deployment ships NO processor SDK — this transport plus the generic
+ * adapter are the only payment code in the bundle, for any of N processors.
+ */
+
+import type {
+  PaymentCallbackRequest,
+  PaymentCallbackVerificationResult,
+} from "./index.js"
+import type { RemotePaymentCall, RemotePaymentTransport } from "./remote-adapter.js"
+
+export interface ControlPlaneRemotePaymentTransportConfig {
+  /**
+   * Control-plane checkout base, e.g.
+   * `https://api.example/cloud/v1/admin-runtime/payments`.
+   */
+  endpoint: string
+  /** Deployment client token (bearer) + id — the deployment's own credential. */
+  deploymentToken: string
+  deploymentId: string
+  fetchImpl?: typeof fetch
+  now?: () => Date
+}
+
+function flattenHeaders(
+  headers: Readonly<Record<string, string | string[] | undefined>>,
+): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries(headers)) {
+    if (Array.isArray(value)) {
+      if (value[0] !== undefined) out[key] = value[0]
+    } else if (typeof value === "string") {
+      out[key] = value
+    }
+  }
+  return out
+}
+
+export function createControlPlaneRemotePaymentTransport(
+  config: ControlPlaneRemotePaymentTransportConfig,
+): RemotePaymentTransport {
+  const doFetch = config.fetchImpl ?? fetch
+  const base = config.endpoint.replace(/\/+$/, "")
+  const now = config.now ?? (() => new Date())
+
+  async function post(path: string, body: unknown): Promise<unknown> {
+    const response = await doFetch(`${base}${path}`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${config.deploymentToken}`,
+        "x-voyant-deployment-id": config.deploymentId,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify(body),
+    })
+    if (!response.ok) {
+      throw new Error(
+        `Payments control plane ${path} failed (${response.status}).`,
+      )
+    }
+    return response.json()
+  }
+
+  /** Unwrap a `{ data: { ok, result } | { ok, error } }` control-plane body. */
+  function unwrapOutcome<T>(body: unknown): T {
+    const data = (body as { data?: { ok: boolean; result?: T; error?: string } })
+      .data
+    if (!data) throw new Error("Malformed control-plane response.")
+    if (!data.ok) throw new Error(data.error ?? "Control-plane operation failed.")
+    if (data.result === undefined) {
+      throw new Error("Control-plane response missing result.")
+    }
+    return data.result
+  }
+
+  return {
+    async call<TResult>(rpcCall: RemotePaymentCall): Promise<TResult> {
+      switch (rpcCall.method) {
+        case "initiate":
+          return unwrapOutcome<TResult>(await post("/initiate", rpcCall.payload))
+
+        case "status":
+          return unwrapOutcome<TResult>(await post("/status", rpcCall.payload))
+
+        case "verifyCallback": {
+          // Fail CLOSED: any transport/parse failure rejects the callback.
+          const request = rpcCall.payload as PaymentCallbackRequest
+          const rejected: PaymentCallbackVerificationResult = {
+            verified: false,
+            reason: "malformed",
+          }
+          try {
+            const rawBody =
+              typeof request.rawBody === "string"
+                ? request.rawBody
+                : new TextDecoder().decode(request.rawBody)
+            const body = (await post("/callback/verify", {
+              headers: flattenHeaders(request.headers),
+              rawBody,
+              receivedAt: request.receivedAt,
+            })) as { data?: PaymentCallbackVerificationResult }
+            return (body.data ?? rejected) as TResult
+          } catch {
+            return rejected as TResult
+          }
+        }
+
+        case "health":
+          return {
+            status: "ok",
+            checkedAt: now().toISOString(),
+          } as TResult
+
+        default:
+          throw new Error(
+            `Remote payment method "${rpcCall.method}" is not supported by the managed transport.`,
+          )
+      }
+    },
+  }
+}

--- a/packages/storefront/package.json
+++ b/packages/storefront/package.json
@@ -85,6 +85,7 @@
   "peerDependencies": {
     "@voyant-travel/identity": "workspace:^",
     "@voyant-travel/legal": "workspace:^",
+    "@voyant-travel/payments": "workspace:^",
     "@voyant-travel/relationships": "workspace:^"
   },
   "peerDependenciesMeta": {

--- a/packages/storefront/src/payment-link/routes.ts
+++ b/packages/storefront/src/payment-link/routes.ts
@@ -34,10 +34,7 @@ import { applyPaymentAdapterCallbackEvent, financeService } from "@voyant-travel
 import { invoices, paymentSessions } from "@voyant-travel/finance/schema"
 import { openApiValidationHook, stampOpenApiRegistryApiId } from "@voyant-travel/hono"
 import type { ApiModule } from "@voyant-travel/hono/module"
-import {
-  type PaymentCallbackRequest,
-  paymentAdapterRuntimePort,
-} from "@voyant-travel/payments"
+import { type PaymentCallbackRequest, paymentAdapterRuntimePort } from "@voyant-travel/payments"
 import { and, asc, desc, eq, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"

--- a/packages/storefront/src/payment-link/routes.ts
+++ b/packages/storefront/src/payment-link/routes.ts
@@ -30,10 +30,14 @@
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { bookingItems, bookings } from "@voyant-travel/bookings/schema"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
-import { financeService } from "@voyant-travel/finance"
+import { applyPaymentAdapterCallbackEvent, financeService } from "@voyant-travel/finance"
 import { invoices, paymentSessions } from "@voyant-travel/finance/schema"
 import { openApiValidationHook, stampOpenApiRegistryApiId } from "@voyant-travel/hono"
 import type { ApiModule } from "@voyant-travel/hono/module"
+import {
+  type PaymentCallbackRequest,
+  paymentAdapterRuntimePort,
+} from "@voyant-travel/payments"
 import { and, asc, desc, eq, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -50,6 +54,7 @@ export const PAYMENT_LINK_ROUTE_PATHS = [
   "/v1/public/payment-link/:sessionId/trip-summary",
   "/v1/public/payment-link/:sessionId/booking-summary",
   "/v1/public/bookings/:bookingId/checkout-status",
+  "/v1/public/payment-link/callback",
 ] as const
 
 // ─────────────────────────────────────────────────────────────────
@@ -129,6 +134,15 @@ export interface PaymentLinkRoutesOptions {
       redirectUrl: string | null
     },
   ): Promise<{ configured: true; redirectUrl: string | null } | { configured: false }>
+  /**
+   * Verify an inbound processor IPN/webhook and apply its event (mark the
+   * payment session paid → complete the booking). Absent when no payment
+   * adapter is wired. Fails closed: an unverified callback is rejected.
+   */
+  verifyAndApplyPaymentCallback?(
+    c: Context,
+    request: PaymentCallbackRequest,
+  ): Promise<{ ok: true } | { ok: false; reason: string }>
   /**
    * Resolve a trip envelope (+ reconcile a paid checkout) and its visible
    * components with product-media enrichment, or `null` when the envelope is
@@ -859,9 +873,32 @@ export function createPaymentLinkRoutes(options: PaymentLinkRoutesOptions): Open
       )
     })
 
-  return new OpenAPIHono({ defaultHook: openApiValidationHook })
+  const app = new OpenAPIHono({ defaultHook: openApiValidationHook })
     .route("/", sessionActionRoutes)
     .route("/", summaryRoutes)
+
+  // Public processor IPN/webhook. The processor POSTs the raw signed callback;
+  // we verify it through the payment adapter (which brokers to the connected
+  // processor's verifyCallback) and apply the event. Fails closed.
+  app.post("/v1/public/payment-link/callback", async (c) => {
+    if (!options.verifyAndApplyPaymentCallback) {
+      return c.json({ ok: false, error: "not_configured" }, 503)
+    }
+    const rawBody = await c.req.text()
+    const headers: Record<string, string> = {}
+    c.req.raw.headers.forEach((value, key) => {
+      headers[key] = value
+    })
+    const result = await options.verifyAndApplyPaymentCallback(c, {
+      headers,
+      rawBody,
+      receivedAt: new Date().toISOString(),
+    })
+    // 200 when applied; 400 when rejected (a processor may retry on non-2xx).
+    return c.json(result, result.ok ? 200 : 400)
+  })
+
+  return app
 }
 
 /** Package-owned module descriptor; deployments inject provider and projection adapters. */
@@ -881,9 +918,33 @@ export function createPaymentLinkApiModule(options: PaymentLinkRoutesOptions): A
   }
 }
 
-export const createPaymentLinkVoyantRuntime = defineGraphRuntimeFactory(async ({ getPort }) => {
-  return createPaymentLinkApiModule(await getPort(storefrontPaymentLinkRuntimePort))
-})
+export const createPaymentLinkVoyantRuntime = defineGraphRuntimeFactory(
+  async ({ getPort, hasPort }) => {
+    const options = await getPort(storefrontPaymentLinkRuntimePort)
+    // The payment adapter is optional: absent on deployments without a card
+    // processor, present (self-host in-process OR the managed remote adapter)
+    // when one is wired. When present, the IPN webhook verifies + applies.
+    const adapter = hasPort(paymentAdapterRuntimePort)
+      ? await getPort(paymentAdapterRuntimePort)
+      : undefined
+    return createPaymentLinkApiModule({
+      ...options,
+      verifyAndApplyPaymentCallback: adapter
+        ? async (c, request) => {
+            const verification = await adapter.verifyCallback(
+              { env: c.env as Readonly<Record<string, unknown>> },
+              request,
+            )
+            if (!verification.verified) {
+              return { ok: false, reason: verification.reason }
+            }
+            await applyPaymentAdapterCallbackEvent(getDb(c), verification.event)
+            return { ok: true }
+          }
+        : undefined,
+    })
+  },
+)
 
 // ─────────────────────────────────────────────────────────────────
 // Pure schedule resolution helpers

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -1,5 +1,6 @@
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/ports"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
+import { paymentAdapterRuntimePort } from "@voyant-travel/payments"
 import { bookingBootstrapRequestedEventPayloadSchema } from "./event-payload-schemas.js"
 import {
   storefrontBookingIntentsRuntimePort,
@@ -469,7 +470,12 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
     entry: "@voyant-travel/storefront/payment-link",
     export: "createPaymentLinkVoyantRuntime",
   },
-  runtimePorts: [requirePort(storefrontPaymentLinkRuntimePort)],
+  runtimePorts: [
+    requirePort(storefrontPaymentLinkRuntimePort),
+    // Optional: when a payment adapter is wired (self-host in-process OR the
+    // managed remote adapter), the IPN webhook verifies + applies callbacks.
+    requirePort(paymentAdapterRuntimePort, { optional: true }),
+  ],
   api: [
     {
       id: "@voyant-travel/storefront#payment-link.api",

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -1,7 +1,13 @@
 import { customerBusinessAccountOnboardingRuntimePort } from "@voyant-travel/auth/ports"
 import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
-import { paymentAdapterRuntimePort } from "@voyant-travel/payments"
 import { bookingBootstrapRequestedEventPayloadSchema } from "./event-payload-schemas.js"
+
+// Lightweight reference (id only) so the deployment-graph manifest stays
+// import-cheap — importing the real port from @voyant-travel/payments would
+// pull the whole package into the manifest graph. Mirrors trips/voyant.ts.
+const paymentAdapterRuntimePortReference = {
+  id: "payments.adapter.runtime",
+} as const
 import {
   storefrontBookingIntentsRuntimePort,
   storefrontCustomerPortalRuntimePort,
@@ -474,7 +480,7 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
     requirePort(storefrontPaymentLinkRuntimePort),
     // Optional: when a payment adapter is wired (self-host in-process OR the
     // managed remote adapter), the IPN webhook verifies + applies callbacks.
-    requirePort(paymentAdapterRuntimePort, { optional: true }),
+    { ...paymentAdapterRuntimePortReference, optional: true },
   ],
   api: [
     {

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -8,6 +8,7 @@ import { bookingBootstrapRequestedEventPayloadSchema } from "./event-payload-sch
 const paymentAdapterRuntimePortReference = {
   id: "payments.adapter.runtime",
 } as const
+
 import {
   storefrontBookingIntentsRuntimePort,
   storefrontCustomerPortalRuntimePort,

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -215,7 +215,10 @@ describe("storefront deployment manifest", () => {
         entry: "@voyant-travel/storefront/payment-link",
         export: "createPaymentLinkVoyantRuntime",
       },
-      runtimePorts: [{ id: "storefront.payment-link.runtime" }],
+      runtimePorts: [
+        { id: "storefront.payment-link.runtime" },
+        { id: "payments.adapter.runtime", optional: true },
+      ],
       api: [
         {
           id: "@voyant-travel/storefront#payment-link.api",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5039,6 +5039,9 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
+      '@voyant-travel/payments':
+        specifier: workspace:^
+        version: link:../payments
       '@voyant-travel/relationships-contracts':
         specifier: workspace:^
         version: link:../relationships-contracts


### PR DESCRIPTION
Part of the managed payments Phase 2B (charging via a connected processor). Companion PRs: voyant-cloud (control-plane ops + routes + managed wiring) and netopia-adapter (worker initiate/status/verifyCallback).

- **packages/payments**: `createControlPlaneRemotePaymentTransport` — the concrete `RemotePaymentTransport` the generic `createRemotePaymentAdapter` delegates to; brokers initiate/status/verifyCallback to `/admin-runtime/payments/*` authenticated as the deployment (no acting user). One adapter+transport is the only payment code a managed deployment bundles, for any connected processor.
- **packages/storefront**: inbound IPN webhook `POST /v1/public/payment-link/callback` — resolves the (optional) payment adapter port, verifies the raw callback through it, and applies the event via `applyPaymentAdapterCallbackEvent` (mark paid → booked). Fails closed.

Not yet verified (Depot CI down); typecheck/build/test to follow.