### PR TITLE
media: Media Library admin navigation page

### DIFF
--- a/.changeset/media-library-nav.md
+++ b/.changeset/media-library-nav.md
@@ -1,0 +1,13 @@
+---
+"@voyant-travel/media-react": minor
+"@voyant-travel/media": minor
+"@voyant-travel/i18n": minor
+---
+
+Add the Media library admin navigation surface. The media deployment manifest
+now declares an `admin` block with a runtime factory, route, and navigation
+entry, and `@voyant-travel/media-react/admin` exposes
+`createSelectedMediaAdminExtension`, which contributes a "Media library"
+navigation item plus a route that renders the `<MediaLibrary>` browse surface.
+The operator navigation catalogue gains the `mediaLibrary` label in English and
+Romanian.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1290,6 +1290,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1291,6 +1291,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1257,6 +1257,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1258,6 +1258,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1244,6 +1244,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1238,6 +1238,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1291,6 +1291,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1292,6 +1292,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1311,6 +1311,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1312,6 +1312,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1325,6 +1325,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1320,6 +1320,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1329,6 +1329,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1330,6 +1330,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/i18n/src/admin/operator-nav.ts
+++ b/packages/i18n/src/admin/operator-nav.ts
@@ -19,6 +19,7 @@ export type OperatorAdminNavMessages = {
   products: string
   categories: string
   bookings: string
+  mediaLibrary: string
   trips: string
   allTrips: string
   newTrip: string
@@ -79,6 +80,7 @@ export const operatorAdminNavMessages = {
       products: "Products",
       categories: "Categories",
       bookings: "Bookings",
+      mediaLibrary: "Media library",
       trips: "Trips",
       allTrips: "All trips",
       newTrip: "New trip",
@@ -138,6 +140,7 @@ export const operatorAdminNavMessages = {
       products: "Produse",
       categories: "Categorii",
       bookings: "Rezervari",
+      mediaLibrary: "Bibliotecă media",
       trips: "Calatorii",
       allTrips: "Toate calatoriile",
       newTrip: "Calatorie noua",

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1325,6 +1325,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1320,6 +1320,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1264,6 +1264,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1265,6 +1265,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/media-react/package.json
+++ b/packages/media-react/package.json
@@ -12,6 +12,7 @@
   "sideEffects": false,
   "exports": {
     ".": "./src/index.ts",
+    "./admin": "./src/admin/index.tsx",
     "./provider": "./src/provider.tsx",
     "./hooks": "./src/hooks/index.ts",
     "./client": "./src/client.ts",
@@ -33,12 +34,17 @@
   },
   "peerDependencies": {
     "@tanstack/react-query": "^5.0.0",
+    "@voyant-travel/admin": "workspace:^",
     "@voyant-travel/ui": "workspace:^",
+    "lucide-react": "^0.475.0 || ^1.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "zod": "^4.0.0"
   },
   "peerDependenciesMeta": {
+    "@voyant-travel/admin": {
+      "optional": true
+    },
     "@voyant-travel/ui": {
       "optional": true
     }
@@ -54,6 +60,7 @@
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
+    "@voyant-travel/admin": "workspace:^",
     "@voyant-travel/i18n": "workspace:^",
     "@voyant-travel/media": "workspace:^",
     "@voyant-travel/react": "workspace:^",
@@ -79,6 +86,11 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js",
         "default": "./dist/index.js"
+      },
+      "./admin": {
+        "types": "./dist/admin/index.d.ts",
+        "import": "./dist/admin/index.js",
+        "default": "./dist/admin/index.js"
       },
       "./provider": {
         "types": "./dist/provider.d.ts",

--- a/packages/media-react/src/admin/index.tsx
+++ b/packages/media-react/src/admin/index.tsx
@@ -1,5 +1,14 @@
 "use client"
 
+import {
+  type AdminExtension,
+  adminRoutePageModule,
+  defineAdminExtension,
+  type NavItem,
+  type SelectedAdminExtensionFactoryContext,
+} from "@voyant-travel/admin"
+import { Images } from "lucide-react"
+
 import { MediaLibrary, type MediaLibraryProps } from "../components/media-library.js"
 import { MediaUiMessagesProvider } from "../i18n/provider.js"
 
@@ -13,8 +22,8 @@ export interface MediaLibraryAdminViewProps extends MediaLibraryProps {
 /**
  * A ready-to-mount media-library admin view: the browse surface wrapped in its
  * own messages provider so a host can drop it onto a page without wiring the
- * i18n context itself. This is a standalone convenience mount — the operator
- * nav integration lands in a follow-up slice (voyant#3555).
+ * i18n context itself. The selected-graph nav integration below reuses the same
+ * `MediaUiMessagesProvider` as the route messages provider.
  */
 export function MediaLibraryAdminView({ locale, timeZone, ...props }: MediaLibraryAdminViewProps) {
   return (
@@ -22,4 +31,82 @@ export function MediaLibraryAdminView({ locale, timeZone, ...props }: MediaLibra
       <MediaLibrary {...props} />
     </MediaUiMessagesProvider>
   )
+}
+
+export interface CreateMediaAdminExtensionOptions {
+  /**
+   * Mount path of the media library inside the admin workspace. Default
+   * `/media-library`.
+   */
+  basePath?: string
+  /** Localized nav/page labels. Defaults to the English operator nav label. */
+  labels?: {
+    mediaLibrary?: string
+  }
+  /** Nav icon — icon choice stays with the host (e.g. lucide `Images`). */
+  icon?: NavItem["icon"]
+}
+
+/**
+ * The media-library admin contribution (packaged-admin RFC Phase 3,
+ * `@voyant-travel/<domain>-react/admin` convention; voyant#3555).
+ *
+ * NAVIGATION: package-delivered. The Media library item is NOT part of the BASE
+ * operator navigation, so the extension contributes it — spliced directly after
+ * Bookings via `insertAfter`, alongside the other operationally-managed
+ * catalogue surfaces. The icon stays a host choice.
+ *
+ * ROUTES: a single contribution carries the FULL browse surface at `basePath`,
+ * where operators upload, organise, and inspect catalogued assets. All library
+ * data flows through the shared `@voyant-travel/react` provider mounted by the
+ * workspace shell (client-side hooks), so the route needs no SSR loader; the
+ * localized copy arrives via the `MediaUiMessagesProvider` route messages
+ * provider.
+ *
+ * WIDGETS: none contributed and no slots exposed yet.
+ */
+export function createMediaAdminExtension(
+  options: CreateMediaAdminExtensionOptions = {},
+): AdminExtension {
+  const { basePath = "/media-library", labels = {}, icon } = options
+  const { mediaLibrary = "Media library" } = labels
+
+  return defineAdminExtension({
+    id: "media",
+    navigation: [
+      {
+        insertAfter: "bookings",
+        items: [{ id: "media-library", title: mediaLibrary, url: basePath, icon }],
+      },
+    ],
+    routes: [
+      {
+        id: "media-library-index",
+        path: basePath,
+        title: mediaLibrary,
+        ssr: "data-only",
+        routeMessagesProvider: mediaRouteMessagesProvider,
+        page: () =>
+          import("./media-library-host.js").then((module) =>
+            adminRoutePageModule(module.MediaLibraryHost),
+          ),
+      },
+    ],
+  })
+}
+
+/** Selected-graph adapter owning the standard Operator copy key and icon. */
+export function createSelectedMediaAdminExtension(
+  { navMessages }: SelectedAdminExtensionFactoryContext = { navMessages: {} },
+): AdminExtension {
+  return createMediaAdminExtension({
+    labels: { mediaLibrary: navMessages.mediaLibrary ?? "Media library" },
+    icon: Images,
+  })
+}
+
+function mediaRouteMessagesProvider() {
+  return import("../i18n/provider.js").then((module) => ({
+    default: module.MediaUiMessagesProvider,
+  }))
 }

--- a/packages/media-react/src/admin/media-library-host.tsx
+++ b/packages/media-react/src/admin/media-library-host.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import { MediaLibrary } from "../components/media-library.js"
+
+/**
+ * Packaged admin host for the media library (voyant#3555). The landing surface
+ * for the media domain: browse folders, filter and upload assets, and inspect a
+ * selected asset's usage. All data flows through the shared
+ * `@voyant-travel/react` provider context mounted by the workspace shell, and
+ * the localized copy arrives via the route's messages provider
+ * (`MediaUiMessagesProvider`), so the host mounts the browse surface directly.
+ */
+export function MediaLibraryHost() {
+  return <MediaLibrary />
+}

--- a/packages/media/src/voyant.ts
+++ b/packages/media/src/voyant.ts
@@ -72,6 +72,42 @@ export const mediaVoyantModule = defineModule({
       },
     ],
   },
+  admin: {
+    compositionOrder: 120,
+    runtime: {
+      entry: "@voyant-travel/media-react/admin",
+      export: "createSelectedMediaAdminExtension",
+    },
+    copy: [
+      {
+        id: "@voyant-travel/media#admin.copy.navigation",
+        namespace: "operator.admin.navigation",
+        fallbackLocale: "en",
+        runtime: {
+          entry: "@voyant-travel/i18n",
+          export: "operatorAdminNavMessages",
+        },
+      },
+    ],
+    routes: [
+      {
+        id: "@voyant-travel/media#admin.route.media-library-index",
+        path: "/media-library",
+        requiredScopes: ["media-library:read"],
+        runtime: {
+          entry: "@voyant-travel/media-react/admin",
+          export: "createSelectedMediaAdminExtension",
+        },
+      },
+    ],
+    nav: [
+      {
+        id: "@voyant-travel/media#admin.nav.media-library",
+        routeId: "@voyant-travel/media#admin.route.media-library-index",
+        label: { namespace: "operator.admin.navigation", key: "nav.mediaLibrary" },
+      },
+    ],
+  },
   lifecycle: {
     uninstall: { default: "retain-data", purge: "not-supported" },
   },

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1343,6 +1343,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1338,6 +1338,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/operator-standard/package.json
+++ b/packages/operator-standard/package.json
@@ -111,6 +111,7 @@
     "@voyant-travel/legal-react": "workspace:*",
     "@voyant-travel/mcp": "workspace:*",
     "@voyant-travel/media": "workspace:*",
+    "@voyant-travel/media-react": "workspace:*",
     "@voyant-travel/mice": "workspace:*",
     "@voyant-travel/mice-react": "workspace:*",
     "@voyant-travel/navigation-preferences": "workspace:*",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1336,6 +1336,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/workflows/tsconfig.build.json
+++ b/packages/workflows/tsconfig.build.json
@@ -1337,6 +1337,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/packages/workflows/tsconfig.typecheck.json
+++ b/packages/workflows/tsconfig.typecheck.json
@@ -1338,6 +1338,7 @@
       "@voyant-travel/mcp/voyant": ["../mcp/dist/voyant.d.ts"],
       "@voyant-travel/media": ["../media/dist/index.d.ts"],
       "@voyant-travel/media-react": ["../media-react/dist/index.d.ts"],
+      "@voyant-travel/media-react/admin": ["../media-react/dist/admin/index.d.ts"],
       "@voyant-travel/media-react/client": ["../media-react/dist/client.d.ts"],
       "@voyant-travel/media-react/components/*": ["../media-react/dist/components/*.d.ts"],
       "@voyant-travel/media-react/hooks": ["../media-react/dist/hooks/index.d.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3230,6 +3230,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@voyant-travel/admin':
+        specifier: workspace:^
+        version: link:../admin
       '@voyant-travel/ui':
         specifier: workspace:^
         version: link:../ui
@@ -4008,6 +4011,9 @@ importers:
       '@voyant-travel/media':
         specifier: workspace:*
         version: link:../media
+      '@voyant-travel/media-react':
+        specifier: workspace:*
+        version: link:../media-react
       '@voyant-travel/mice':
         specifier: workspace:*
         version: link:../mice
@@ -5859,6 +5865,9 @@ importers:
       '@voyant-travel/legal-react':
         specifier: workspace:^
         version: link:../../packages/legal-react
+      '@voyant-travel/media-react':
+        specifier: workspace:^
+        version: link:../../packages/media-react
       '@voyant-travel/mice-react':
         specifier: workspace:^
         version: link:../../packages/mice-react

--- a/starters/operator/package.json
+++ b/starters/operator/package.json
@@ -53,6 +53,7 @@
     "@voyant-travel/hono": "workspace:^",
     "@voyant-travel/inventory-react": "workspace:^",
     "@voyant-travel/legal-react": "workspace:^",
+    "@voyant-travel/media-react": "workspace:^",
     "@voyant-travel/mice-react": "workspace:^",
     "@voyant-travel/operations-react": "workspace:^",
     "@voyant-travel/runtime": "workspace:^",

--- a/starters/operator/tests/selected-graph-action-ledger-admin.test.ts
+++ b/starters/operator/tests/selected-graph-action-ledger-admin.test.ts
@@ -42,6 +42,7 @@ describe("selected-graph Action Ledger admin composition", () => {
       "mice",
       "realtime",
       "action-ledger",
+      "media",
       "apps",
       "event-catalog",
     ])


### PR DESCRIPTION
## Summary

Adds the **Media Library** admin navigation surface to the operator. Follow-up to #3578, which mounted the media library *backend* (routes + `"media"` storage provider) into main; this PR adds the admin **nav item + page** that renders `<MediaLibrary>`, wired through the selected-graph admin composition (mirrors `action-ledger`). Part of #3555.

## What's included

- `packages/media/src/voyant.ts` — `admin` block: `compositionOrder`, runtime factory (`@voyant-travel/media-react/admin#createSelectedMediaAdminExtension`), the `copy` block (i18n nav messages), a `/media-library` route (`media-library:read` scope), and the nav item. `meta.agentTools` preserved.
- `packages/media-react/src/admin/` — `createMediaAdminExtension` / `createSelectedMediaAdminExtension` + `media-library-host.tsx` rendering `<MediaLibrary>`. Adds the `./admin` export + `@voyant-travel/admin` (optional peer) / `lucide-react` peers.
- `packages/i18n/src/admin/operator-nav.ts` — `mediaLibrary` nav label (en "Media library" / ro "Bibliotecă media").
- `packages/operator-standard` + `starters/operator` — `@voyant-travel/media-react` dep; regenerated dep-paths / dist-configs / standard-product-distribution against current main.

## Verification

- **`verify:admin-composition-drift`: OK** (23 admin domains, 25 selected-graph admin bundle) — the Media Library nav is bundled into the operator admin graph (not silently dropped), no cascade onto other modules.
- `verify:agent-tool-coverage` OK, `verify:deployment-graph` no drift, `verify:dep-paths` / `dist-configs` / `product-distribution` / `lockstep-membership` OK.
- `i18n:check` pass (en/ro parity + ui-literals). Operator tests 58/58; media + media-react suites pass.
- `release:plan`: only `media` / `media-react` / `i18n` minor from the single changeset (no stale/already-released entries).

## Live smoke — not yet done

The interactive browser walkthrough (sign-in → open Media Library → upload → browse) hasn't been run: the operator wouldn't boot in any local environment I tried (unrelated operator toolchain issues — a CLI/framework version skew for source boot, and the production Docker image not starting due to a missing `tsx` + source-`.ts` resolution). Recommend a live smoke in a normal dev/staging operator once available. The composition/architecture checks confirm the nav is correctly wired.
