### PR TITLE
feat(payments): forward deployment payment webhook to processor as notifyUrl

### DIFF
--- a/.changeset/payment-notify-url.md
+++ b/.changeset/payment-notify-url.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/trips": minor
+---
+
+Pass the deployment's public payment webhook to the card processor as
+`metadata.notifyUrl` when starting a hosted payment. The generic payment
+adapter forwards it to the connected processor worker so redirect processors
+(e.g. Netopia) POST their server-side confirmation (IPN) back to
+`/v1/public/payment-link/callback`, closing the charge-confirmation loop.
+Finance's card-payment starter gains an optional `resolveNotifyUrl(c)`; the
+Storefront-selected trips runtime derives it from the public checkout base URL.

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -72,6 +72,13 @@ export interface PaymentAdapterCardPaymentStarterOptions {
   resolveContext?(c: Context): PaymentAdapterRuntimeContext
   resolveRuntime?(c: Context): FinanceServiceRuntime
   idempotencyKey?(sessionId: string): string
+  /**
+   * Resolve the public URL a redirect processor should POST its callback/IPN to
+   * (the deployment's payment webhook). Passed to the adapter as
+   * `metadata.notifyUrl` so the processor confirms server-side; absent when the
+   * deployment has no public checkout base (confirmation falls back to polling).
+   */
+  resolveNotifyUrl?(c: Context): string | undefined
 }
 
 export function createPaymentAdapterCardPaymentStarter(
@@ -88,6 +95,7 @@ export function createPaymentAdapterCardPaymentStarter(
 
     const idempotencyKey =
       session.idempotencyKey ?? options.idempotencyKey?.(session.id) ?? `payment:${session.id}`
+    const notifyUrl = options.resolveNotifyUrl?.(c)
     const result = await adapter.initiate(options.resolveContext?.(c) ?? { env: c.env }, {
       paymentSessionId: session.id,
       money: { amountMinor: session.amountCents, currency: session.currency },
@@ -100,6 +108,7 @@ export function createPaymentAdapterCardPaymentStarter(
         firstName: args.billing.firstName,
         lastName: args.billing.lastName ?? null,
       },
+      ...(notifyUrl ? { metadata: { notifyUrl } } : {}),
     })
 
     const providerData = {

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -28,6 +28,7 @@ type PaymentAdapterCardPaymentStarterFactory = (
     resolveContext(c: Context): PaymentAdapterRuntimeContext
     resolveRuntime(c: Context): { eventBus?: unknown }
     idempotencyKey(sessionId: string): string
+    resolveNotifyUrl?(c: Context): string | undefined
   },
 ) => (context: Context, args: CardPaymentStartArgs) => Promise<CardPaymentStartResult>
 
@@ -54,6 +55,13 @@ async function startAdapterCardPayment(
     resolveContext: (c) => ({ env: c.env }),
     resolveRuntime: (c) => ({ eventBus: c.var.eventBus }),
     idempotencyKey: (sessionId) => `payment:${sessionId}`,
+    // Tell the processor to POST its callback/IPN to the deployment's public
+    // payment webhook, so payment confirmation is authoritative (server-side)
+    // instead of relying on the confirmation-page poll.
+    resolveNotifyUrl: (c) => {
+      const base = resolvePublicCheckoutBaseUrl(c.env as Record<string, unknown>)
+      return base ? `${base}/v1/public/payment-link/callback` : undefined
+    },
   })
   return starter(context, args)
 }


### PR DESCRIPTION
## What

Closes the charge-**confirmation** loop for connected payment processors.

When a checkout starts a hosted card payment, the deployment now passes its own
public payment webhook to the connected processor as `metadata.notifyUrl`. The
generic remote payment adapter forwards it (unchanged) to the processor worker,
which maps it to the processor's server-side notification URL (e.g. Netopia
`NETOPIA_NOTIFY_URL`). The processor then POSTs its IPN/confirmation to
`POST /v1/public/payment-link/callback`, where `verifyAndApplyPaymentCallback`
marks the session paid and books the trip.

Previously the worker had no deployment-provided notify URL and fell back to a
placeholder, so server-side confirmation never reached the deployment.

## Changes

- **finance** — `PaymentAdapterCardPaymentStarterOptions` gains an optional
  `resolveNotifyUrl(c)`; when present it is injected into the `adapter.initiate`
  input as `metadata: { notifyUrl }`. Absent → no metadata (confirmation falls
  back to polling), so this is backward-compatible.
- **trips** — the Storefront-selected payment-link runtime wires
  `resolveNotifyUrl` from the public checkout base URL
  (`<base>/v1/public/payment-link/callback`).

## Flow (end to end)

`checkout → commerce.card-payment.runtime → payments.adapter.runtime (generic)
→ control plane initiate → processor worker /rpc → hosted checkout URL`, then
`processor IPN → /v1/public/payment-link/callback → verify + apply → booked`.

The `notifyUrl` rides through the existing `metadata` passthrough on the RPC
`initiate` schema — no adapter/control-plane/worker changes needed (the worker
already reads `req.input.metadata?.notifyUrl`).