### PR TITLE
fix(bookings-react): don't flag a pristine booking journey as un-priceable

### DIFF
--- a/packages/bookings-react/src/journey/components/booking-journey.pristine-unpriceable.test.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.pristine-unpriceable.test.tsx
@@ -1,0 +1,108 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+
+// Reproduces the EXACT payload the owned booking-engine returns when the journey
+// first opens for a stay/room product (captured live from the acme managed
+// operator, product `Coastal Day Cruise`): the baseline quote is `available:
+// false` / `invalidReason: "no_sell_amount_configured"` because no room has been
+// picked yet, and the shape carries an `option-units` configure sub-step (so
+// it's a room product). Before the fix, step 1 rendered the red "can't be priced"
+// banner AND a raw `no_sell_amount_configured` code — making a bookable product
+// look broken. This test pins the pristine baseline to a clean, non-alarming state.
+const ACME_PRISTINE_QUOTE = {
+  quoteId: "cquo_pristine",
+  quotedAt: new Date().toISOString(),
+  expiresAt: new Date(Date.now() + 60_000).toISOString(),
+  available: false,
+  invalidReason: "no_sell_amount_configured",
+  pricing: undefined,
+}
+
+const ACME_SHAPE = {
+  showsConfigure: true,
+  showsBilling: true,
+  showsTravelers: true,
+  showsAccommodation: false,
+  showsAddons: false,
+  showsPayment: true,
+  showsReview: true,
+  configureSubSteps: [
+    {
+      kind: "product-option",
+      options: [
+        {
+          id: "popt_standard",
+          code: "standard",
+          name: "Standard",
+          isDefault: true,
+          units: [
+            {
+              id: "ount_double",
+              name: "Double",
+              unitType: "room",
+              minQuantity: 3,
+              maxQuantity: 3,
+            },
+          ],
+        },
+      ],
+    },
+    { kind: "departure", required: true },
+    { kind: "option-units" },
+    {
+      kind: "occupancy",
+      bands: [{ code: "adult", label: "Adult", minAge: 18, minCount: 1, maxCount: 8 }],
+    },
+  ],
+  paxBands: [{ code: "adult", label: "Adult", minAge: 18, minCount: 1, maxCount: 8 }],
+  paxBandsAllowedTotal: { min: 1, max: 8 },
+  paxBandDependencies: [],
+  travelerFields: [
+    { key: "firstName", label: "First name", type: "text", required: true },
+    { key: "lastName", label: "Last name", type: "text", required: true },
+  ],
+  bookingFields: [
+    { key: "buyerType", label: "Buyer type", type: "select", required: true, group: "billing" },
+  ],
+  paymentIntents: ["card", "bank_transfer", "hold", "inquiry", "ticket_on_credit"],
+}
+
+vi.mock("@voyant-travel/catalog-react/booking-engine", () => ({
+  useBookingQuote: () => ({
+    data: ACME_PRISTINE_QUOTE,
+    isQuoting: false,
+    error: null,
+    requote: async () => ({}) as never,
+    refetch: async () => ({}) as never,
+  }),
+  // The journey treats this as a room product via the `option-units` sub-step.
+  useBookingDraftShape: () => ACME_SHAPE,
+  useBookingDraft: () => ({ save: { mutate: () => {} } }),
+  useBookingCommit: () => ({ mutateAsync: async () => {}, isPending: false, error: null }),
+  useBookingHold: () => ({ place: async () => ({}), release: async () => ({}) }),
+}))
+
+const { BookingJourney } = await import("./booking-journey.js")
+
+describe("BookingJourney — pristine baseline is not flagged un-priceable (voyant#3584/#3586)", () => {
+  const html = renderToStaticMarkup(
+    <BookingJourney
+      entityModule="products"
+      entityId="prod_coastal"
+      draftId="draft-1"
+      surface="public"
+    />,
+  )
+
+  it("does not show the 'can't be priced' banner before any room is picked", () => {
+    expect(html).not.toContain("This selection can&#x27;t be priced right now")
+  })
+
+  it("never leaks the raw engine reason code", () => {
+    expect(html).not.toContain("no_sell_amount_configured")
+  })
+
+  it("guides the buyer to pick a room instead", () => {
+    expect(html).toContain("Select rooms to see pricing")
+  })
+})

--- a/packages/bookings-react/src/journey/components/booking-journey.tsx
+++ b/packages/bookings-react/src/journey/components/booking-journey.tsx
@@ -289,6 +289,21 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
     (quote.data.available === false ||
       (quote.data.invalidReason != null && quote.data.invalidReason !== ""))
   const quoteBlocked = hasQuoteError || quoteUnpriceable
+  // The pristine baseline quote is intentionally un-priceable: a product has no
+  // price until its price driver — a room, or a traveler count — is chosen, and
+  // the engine reports that empty draft as `no_sell_amount_configured`. Suppress
+  // the un-priceable banner (and the side-panel error) for exactly that baseline
+  // so step 1 doesn't scream "can't be priced" before the buyer has picked
+  // anything. Any other reason (e.g. `rates_missing` on an already-picked stay,
+  // #2638), or the same code once a driver IS picked (a room that carries no
+  // price), still surfaces. Commit stays gated on `quoteBlocked` regardless, so
+  // an unpriced booking can never be submitted.
+  const priceDriversConfigured =
+    (draft?.configure?.optionSelections?.length ?? 0) > 0 ||
+    Object.values(draft?.configure?.pax ?? {}).reduce<number>((sum, n) => sum + (n ?? 0), 0) > 0
+  const isPristineUnconfigured =
+    quote.data?.invalidReason === "no_sell_amount_configured" && !priceDriversConfigured
+  const showQuoteUnpriceable = quoteBlocked && !isPristineUnconfigured
   const quoteReady = Boolean(quote.data?.quoteId)
   // Step navigation only hard-blocks on a thrown quote error (a transient fetch
   // failure that a retry fixes). An un-priceable quote (e.g. `rates_missing`
@@ -520,7 +535,7 @@ export function BookingJourney(props: BookingJourneyProps): React.ReactElement {
     setConfirmError(null)
     void quote.refetch()
   }
-  const quoteErrorBanner = quoteBlocked ? (
+  const quoteErrorBanner = showQuoteUnpriceable ? (
     <div
       role="alert"
       aria-live="polite"

--- a/packages/bookings-react/src/journey/components/side-panel.tsx
+++ b/packages/bookings-react/src/journey/components/side-panel.tsx
@@ -78,7 +78,15 @@ export function PriceSidePanel({
           <StepRecap steps={steps} currentStep={currentStep} draft={draft} />
         ) : null}
 
-        {invalidReason ? <p className="text-destructive text-sm">{invalidReason}</p> : null}
+        {/* `invalidReason` is a raw engine code (e.g. `no_sell_amount_configured`)
+            and is expected on the pristine draft before any price driver is
+            picked — surface it only once the buyer has configured what drives
+            the price, and as a human-readable message, never the raw code. */}
+        {invalidReason && showPricing ? (
+          <p className="text-destructive text-sm">
+            {messages.bookingJourney.validation.pricingUnavailable}
+          </p>
+        ) : null}
         {!showPricing ? (
           <p className="border-t pt-4 text-muted-foreground text-sm">{pricingHint}</p>
         ) : isQuoting && !pricing ? (


### PR DESCRIPTION
## Problem

Opening the booking journey for a stay/room product (e.g. an owned accommodation-style product) shows an alarming red banner — **"This selection can't be priced right now. Please adjust your choice before confirming your booking."** — plus a raw engine code **`no_sell_amount_configured`** in the side panel, on **step 1**, before the buyer has selected anything.

The baseline quote for an empty draft is *intentionally* un-priceable: the price depends on a later selection (a room to pick, travelers to add). Surfacing that empty state as an error is noise and makes a perfectly bookable product look broken. Found while chasing the "no working entry point to create a booking" reports (voyant#3584 / voyant#3586) into the journey itself.

## Fix

- Suppress the un-priceable **banner** and the side-panel **error** for exactly that pristine baseline — the engine's `no_sell_amount_configured` reason with **no price driver picked** (no room in `configure.optionSelections`, no `configure.pax`).
- Any other reason (notably `rates_missing` on an already-picked stay — #2638), or the *same* code once a room **is** picked but carries no price, still surfaces.
- The side panel now shows a human-readable message (`validation.pricingUnavailable`) instead of the raw engine code, and only once a price driver is configured.
- **Commit is still gated on the full un-priceable check** (`quoteBlocked` is unchanged), so an unpriced booking can never be submitted — this only changes what's *displayed*, not what's *allowed*.

## Tests

All journey tests pass (`src/journey`, 15/15), including the #2638 `rates_missing` test which still asserts the banner. Package typecheck clean.

## Note

This surfaced on the managed operator (acme sandbox). Like the navigation fix, it reaches that deployment only after a `@voyant-travel/bookings-react` release + a managed-runtime lockfile bump.