### PR TITLE
trips: charge payment links via the connected processor

### DIFF
--- a/.changeset/payment-link-card-adapter.md
+++ b/.changeset/payment-link-card-adapter.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/trips": minor
+---
+
+Charge payment links by card through the deployment's connected processor.
+
+The Storefront payment-link `start-card` path was a stub that always reported
+"not configured" (503), so only the full booking checkout could take card
+payments. The trips runtime contributor now threads the selected payment adapter
+into the payment-link route options, wiring `startCardPayment` to the same
+neutral finance card starter the checkout path uses — so a card payment link
+redirects the customer to the connected processor's hosted checkout.
+
+Also corrects the processor notify (IPN) URL to the operator API mount:
+`${publicCheckoutBaseUrl}/api/v1/public/payment-link/callback` (was missing the
+`/api` prefix), so the processor's server-side confirmation reaches the
+deployment webhook.

--- a/packages/trips/src/runtime-contributor.ts
+++ b/packages/trips/src/runtime-contributor.ts
@@ -73,8 +73,13 @@ export function createTripsRuntimePortContribution(
     withDb: (bindings, operation) =>
       host.primitives.database.transaction(bindings, (database) => operation(database as never)),
   }
+  const paymentLinkOptions = paymentAdapter
+    ? Promise.resolve(paymentAdapter).then((adapter) =>
+        createStandardPaymentLinkRouteOptions(adapter),
+      )
+    : createStandardPaymentLinkRouteOptions()
   const contribution: Record<string, unknown> = {
-    [storefrontPaymentLinkRuntimePort.id]: createStandardPaymentLinkRouteOptions(),
+    [storefrontPaymentLinkRuntimePort.id]: paymentLinkOptions,
     [tripsRoutesRuntimePort.id]: tripsRoutes,
     [tripsDatabaseRuntimePort.id]: tripsDatabase,
   }

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -58,12 +58,20 @@ async function startAdapterCardPayment(
     // Tell the processor to POST its callback/IPN to the deployment's public
     // payment webhook, so payment confirmation is authoritative (server-side)
     // instead of relying on the confirmation-page poll.
-    resolveNotifyUrl: (c) => {
-      const base = resolvePublicCheckoutBaseUrl(c.env as Record<string, unknown>)
-      return base ? `${base}/v1/public/payment-link/callback` : undefined
-    },
+    resolveNotifyUrl: (c) => resolvePaymentCallbackUrl(c.env as Record<string, unknown>),
   })
   return starter(context, args)
+}
+
+/**
+ * The deployment's public payment webhook — where a redirect processor POSTs
+ * its server-side confirmation (IPN). The operator API is served under `/api`,
+ * so the callback registered at `/v1/public/payment-link/callback` is publicly
+ * reachable at `/api/v1/public/payment-link/callback`.
+ */
+function resolvePaymentCallbackUrl(bindings: Record<string, unknown>): string | undefined {
+  const base = resolvePublicCheckoutBaseUrl(bindings)
+  return base ? `${base}/api/v1/public/payment-link/callback` : undefined
 }
 
 interface PaymentConfigBindings {
@@ -121,10 +129,48 @@ async function resolveBankTransferDetails(c: Context) {
   }
 }
 
-/** Start a fresh card payment via this deployment's processor, or report it isn't configured. */
-const startCardPayment: PaymentLinkRoutesOptions["startCardPayment"] = async () => ({
+/** No processor wired (self-host with mocks, or Cloud not connected): the handler 503s. */
+const unconfiguredStartCardPayment: PaymentLinkRoutesOptions["startCardPayment"] = async () => ({
   configured: false,
 })
+
+/**
+ * Start a card payment for a payment-link session via this deployment's selected
+ * processor (the same neutral adapter the checkout path uses), returning the
+ * processor's hosted-checkout redirect URL. Enables paying a payment link by
+ * card, not just the full booking checkout.
+ */
+function createAdapterStartCardPayment(
+  adapter: PaymentAdapter,
+): PaymentLinkRoutesOptions["startCardPayment"] {
+  return async (c, session) => {
+    const { createPaymentAdapterCardPaymentStarter } = (await import(
+      FINANCE_CARD_PAYMENT_MODULE
+    )) as {
+      createPaymentAdapterCardPaymentStarter: PaymentAdapterCardPaymentStarterFactory
+    }
+    const starter = createPaymentAdapterCardPaymentStarter(adapter, {
+      resolveContext: (ctx) => ({ env: ctx.env }),
+      resolveRuntime: (ctx) => ({ eventBus: ctx.var.eventBus }),
+      idempotencyKey: (sessionId) => `payment:${sessionId}`,
+      resolveNotifyUrl: (ctx) => resolvePaymentCallbackUrl(ctx.env as Record<string, unknown>),
+    })
+    const trimmedName = (session.payerName ?? "").trim()
+    const [firstName, ...rest] = trimmedName ? trimmedName.split(/\s+/) : []
+    const result = await starter(c, {
+      db: getDb(c),
+      sessionId: session.id,
+      billing: {
+        email: session.payerEmail ?? "",
+        firstName: firstName || session.payerEmail || "Customer",
+        lastName: rest.join(" "),
+      },
+      description: session.notes || "Payment",
+      returnUrl: session.redirectUrl ?? undefined,
+    })
+    return { configured: true, redirectUrl: result?.redirectUrl ?? null }
+  }
+}
 
 /**
  * Resolve a trip envelope (+ reconcile a paid checkout) and its visible
@@ -226,13 +272,22 @@ const resolveTripData: PaymentLinkRoutesOptions["resolveTripData"] = async (
   }
 }
 
-/** Build the payment-link route-module options for this deployment. */
-export function createStandardPaymentLinkRouteOptions(): PaymentLinkRoutesOptions {
+/**
+ * Build the payment-link route-module options for this deployment. When a
+ * payment adapter is selected, card payment links charge through it; otherwise
+ * the card path reports "not configured" (the handler 503s) and bank transfer
+ * still works.
+ */
+export function createStandardPaymentLinkRouteOptions(
+  adapter?: PaymentAdapter,
+): PaymentLinkRoutesOptions {
   return {
     resolveBankTransferDetails,
     resolvePublicCheckoutBaseUrl: (c) =>
       resolvePublicCheckoutBaseUrl(c.env as Record<string, unknown>),
-    startCardPayment,
+    startCardPayment: adapter
+      ? createAdapterStartCardPayment(adapter)
+      : unconfiguredStartCardPayment,
     resolveTripData,
   }
 }


### PR DESCRIPTION
## What

Makes **card payment links** actually charge through the deployment's connected
processor. Previously the Storefront payment-link `start-card` path was a
hardcoded stub in trips that always returned \`{ configured: false }\`, so
\`POST /v1/public/payment-link/:id/start-card\` always 503'd — only the full
booking checkout could take a card payment.

Discovered while testing the managed sandbox: Netopia connected + adapter wired,
but the payment-link start-card still 503'd "Card processor not configured"
because the adapter was only fed to the *commerce* card-payment port, never the
payment-link route options.

## Changes (trips)

- `runtime-contributor.ts` — thread the resolved payment adapter into
  `createStandardPaymentLinkRouteOptions(adapter)` (it was called with no args).
- `storefront-payment-link-runtime.ts` — `createStandardPaymentLinkRouteOptions`
  accepts an optional adapter; when present, `startCardPayment` runs the same
  neutral `createPaymentAdapterCardPaymentStarter` the checkout path uses and
  returns the processor's hosted-checkout redirect URL. Falls back to the
  "not configured" stub (503) when no adapter is selected (bank transfer still
  works).
- Fix the processor notify (IPN) URL to the operator API mount:
  `${publicCheckoutBaseUrl}/api/v1/public/payment-link/callback` (was missing
  the `/api` prefix), so server-side confirmation reaches the deployment webhook.

## Effect

Connecting a processor now powers **both** checkout surfaces — full booking
checkout and standalone card payment links.