### PR TITLE
trips: restore inline payment-link registration (fix red checks on main)

### DIFF
--- a/.changeset/fix-storefront-subscriber-authority.md
+++ b/.changeset/fix-storefront-subscriber-authority.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/trips": patch
+---
+
+Keep the Trips runtime contributor's Storefront payment-link registration inline
+(`[storefrontPaymentLinkRuntimePort.id]: createStandardPaymentLinkRouteOptions(...)`)
+so it satisfies the `storefront-subscriber-authority` architecture check, while
+still threading the selected payment adapter into the payment-link route options.
+`createStandardPaymentLinkRouteOptions` now accepts an already-resolved adapter
+or a promise and resolves it lazily inside the card-payment starter.

--- a/packages/trips/src/runtime-contributor.ts
+++ b/packages/trips/src/runtime-contributor.ts
@@ -73,13 +73,8 @@ export function createTripsRuntimePortContribution(
     withDb: (bindings, operation) =>
       host.primitives.database.transaction(bindings, (database) => operation(database as never)),
   }
-  const paymentLinkOptions = paymentAdapter
-    ? Promise.resolve(paymentAdapter).then((adapter) =>
-        createStandardPaymentLinkRouteOptions(adapter),
-      )
-    : createStandardPaymentLinkRouteOptions()
   const contribution: Record<string, unknown> = {
-    [storefrontPaymentLinkRuntimePort.id]: paymentLinkOptions,
+    [storefrontPaymentLinkRuntimePort.id]: createStandardPaymentLinkRouteOptions(paymentAdapter),
     [tripsRoutesRuntimePort.id]: tripsRoutes,
     [tripsDatabaseRuntimePort.id]: tripsDatabase,
   }

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -141,15 +141,16 @@ const unconfiguredStartCardPayment: PaymentLinkRoutesOptions["startCardPayment"]
  * card, not just the full booking checkout.
  */
 function createAdapterStartCardPayment(
-  adapter: PaymentAdapter,
+  adapter: PaymentAdapter | Promise<PaymentAdapter>,
 ): PaymentLinkRoutesOptions["startCardPayment"] {
   return async (c, session) => {
+    const resolvedAdapter = await adapter
     const { createPaymentAdapterCardPaymentStarter } = (await import(
       FINANCE_CARD_PAYMENT_MODULE
     )) as {
       createPaymentAdapterCardPaymentStarter: PaymentAdapterCardPaymentStarterFactory
     }
-    const starter = createPaymentAdapterCardPaymentStarter(adapter, {
+    const starter = createPaymentAdapterCardPaymentStarter(resolvedAdapter, {
       resolveContext: (ctx) => ({ env: ctx.env }),
       resolveRuntime: (ctx) => ({ eventBus: ctx.var.eventBus }),
       idempotencyKey: (sessionId) => `payment:${sessionId}`,
@@ -279,7 +280,7 @@ const resolveTripData: PaymentLinkRoutesOptions["resolveTripData"] = async (
  * still works.
  */
 export function createStandardPaymentLinkRouteOptions(
-  adapter?: PaymentAdapter,
+  adapter?: PaymentAdapter | Promise<PaymentAdapter>,
 ): PaymentLinkRoutesOptions {
   return {
     resolveBankTransferDetails,


### PR DESCRIPTION
main's CI/checks is red after #3600. The storefront-subscriber-authority architecture check requires the Trips contributor to register the payment-link port INLINE: `[storefrontPaymentLinkRuntimePort.id]: createStandardPaymentLinkRouteOptions(...)`. #3600 extracted it to a variable, breaking that regex (only surfaces in the CI checks lane). Fix: register inline, passing the adapter directly; createStandardPaymentLinkRouteOptions now accepts PaymentAdapter|Promise<PaymentAdapter>|undefined and awaits it lazily in the card starter. Same behavior (payment links charge via the connected processor), checker-compliant. Verified locally: check-storefront-subscriber-authority OK, trips typecheck clean, biome clean.