### PR TITLE
operator-standard: fix admin sign-up 404 (scope auth-react fetcher to admin realm)

### DIFF
--- a/.changeset/admin-auth-realm-signup.md
+++ b/.changeset/admin-auth-realm-signup.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/operator-standard": patch
+---
+
+Route admin auth-react requests to the admin realm. The operator's admin React
+context was handed the shared admin fetcher unchanged, so `useSignUp` (and other
+auth-react hooks) targeted the default `/auth/*` surface, which returns 404 now
+that admin Better Auth is isolated under `/auth/admin/*`. This blocked
+first-admin creation from the setup screen. The fetcher is now scoped to the
+admin realm via `createAuthBasePathFetcher`, mirroring the storefront's
+`/auth/customer` rewrite; non-auth URLs pass through unchanged.

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -28,6 +28,7 @@ import type {
   LocalAuthPresentationRuntime,
   LocalAuthRouteContribution,
 } from "@voyant-travel/auth-react/local-auth-routes"
+import { createAuthBasePathFetcher } from "@voyant-travel/auth-react/client"
 import type { RedeemInvitationStatus } from "@voyant-travel/auth-react/ui"
 import {
   StorefrontBookingPage,
@@ -62,6 +63,7 @@ import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import { TooltipProvider } from "@voyant-travel/ui/components/tooltip"
 import { emailOTPClient, organizationClient } from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
+import { useMemo } from "react"
 import type { ComponentType, ReactNode } from "react"
 import { createApiDocsRouteOptions, type OpenApiSpecLoaders } from "./standard-api-docs.js"
 
@@ -342,10 +344,20 @@ export function createStandardOperatorFrontend(
   const providers = [TooltipProvider, AvailabilityProvider] satisfies readonly AdminChildProvider[]
 
   function Providers({ children, queryClient }: { children: ReactNode; queryClient: QueryClient }) {
+    const baseUrl = getAdminApiUrl()
+    // Admin Better Auth routes live under `/auth/admin/*` (the isolated admin
+    // realm). auth-react hooks (useSignUp/useSignIn/useAuthStatus) target the
+    // default `/auth/*` surface, so scope the shared admin fetcher to the admin
+    // realm — mirroring the storefront's `/auth/customer` rewrite. Non-auth URLs
+    // pass through unchanged, so domain data hooks are unaffected.
+    const adminAuthFetcher = useMemo(
+      () => createAuthBasePathFetcher(adminFetcher, { baseUrl, authBasePath: "/auth/admin" }),
+      [baseUrl],
+    )
     return (
       <OperatorAdminShellProvider
-        baseUrl={getAdminApiUrl()}
-        fetcher={adminFetcher}
+        baseUrl={baseUrl}
+        fetcher={adminAuthFetcher}
         queryClient={queryClient}
         providers={providers}
       >

--- a/packages/operator-standard/src/standard-frontend.tsx
+++ b/packages/operator-standard/src/standard-frontend.tsx
@@ -24,11 +24,11 @@ import {
   type AdminHostWorkspace,
   createAdminHostWorkspace,
 } from "@voyant-travel/admin-host/workspace"
+import { createAuthBasePathFetcher } from "@voyant-travel/auth-react/client"
 import type {
   LocalAuthPresentationRuntime,
   LocalAuthRouteContribution,
 } from "@voyant-travel/auth-react/local-auth-routes"
-import { createAuthBasePathFetcher } from "@voyant-travel/auth-react/client"
 import type { RedeemInvitationStatus } from "@voyant-travel/auth-react/ui"
 import {
   StorefrontBookingPage,
@@ -63,8 +63,8 @@ import type { AccessCatalog } from "@voyant-travel/types/api-keys"
 import { TooltipProvider } from "@voyant-travel/ui/components/tooltip"
 import { emailOTPClient, organizationClient } from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
-import { useMemo } from "react"
 import type { ComponentType, ReactNode } from "react"
+import { useMemo } from "react"
 import { createApiDocsRouteOptions, type OpenApiSpecLoaders } from "./standard-api-docs.js"
 
 export {


### PR DESCRIPTION
## Problem

First-admin creation from the operator setup screen fails with `Voyant API error: 404`. The admin sign-up form POSTs `POST /api/auth/sign-up/email`, which no longer exists: admin Better Auth is now isolated under `/auth/admin/*`.

## Root cause

The admin realm split moved admin Better Auth to basePath `/auth/admin` and updated the better-auth **sign-in** client (`standard-frontend.tsx` `authClient.baseURL`) accordingly. But the **auth-react** context — `OperatorAdminShellProvider` → `VoyantReactProvider` — was handed the raw `adminFetcher` with `baseUrl = /api`. auth-react hooks (`useSignUp`, `useSignIn`, `useAuthStatus`) are realm-agnostic: they target the default `/auth/*` surface and rely on the context fetcher to rewrite to the correct realm. The storefront does this via `createAuthBasePathFetcher({ authBasePath: "/auth/customer" })`; the admin side was never given the equivalent, so `useSignUp` posted the un-rewritten `/api/auth/sign-up/email` → 404.

## Fix

Scope the admin context fetcher to the admin realm, mirroring the storefront:

```ts
const adminAuthFetcher = useMemo(
  () => createAuthBasePathFetcher(adminFetcher, { baseUrl, authBasePath: "/auth/admin" }),
  [baseUrl],
)
```

`createAuthBasePathFetcher` only rewrites URLs under `${baseUrl}/auth/*` → `${baseUrl}/auth/admin/*`; every other request (all domain data hooks, `/v1/admin/*`, etc.) passes through unchanged, so the blast radius is limited to admin auth calls — which is exactly where they should go.

## Verification

- Root-caused against a locally-booted operator (`voyant develop`): `POST /api/auth/sign-up/email → 404`; admin Better Auth confirmed mounted only at `/auth/admin/*`.
- Storefront parity: same mechanism as `createCustomerAccountFetcher`.
