### PR TITLE
media-react: pad media library page + move asset detail into a sheet

### DIFF
--- a/.changeset/media-library-padding-sheet.md
+++ b/.changeset/media-library-padding-sheet.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/media-react": patch
+---
+
+Polish the media library layout. Add standard page padding (`p-6`) to the
+browse surface so it no longer sits flush against the shell edges, and move the
+asset detail/edit form out of a permanent inline right column into a right-side
+sheet that opens when an asset is selected and closes back to the grid. This
+reclaims the horizontal space the empty "Select an asset" column wasted and
+gives the edit form more room.

--- a/packages/media-react/src/components/media-asset-detail-panel.tsx
+++ b/packages/media-react/src/components/media-asset-detail-panel.tsx
@@ -105,14 +105,7 @@ export function MediaAssetDetailPanel({
   const usageRecords = usage.data?.data ?? []
 
   return (
-    <div
-      className="flex w-80 shrink-0 flex-col gap-4 overflow-y-auto"
-      data-slot="media-asset-detail"
-    >
-      <div>
-        <h3 className="text-sm font-semibold">{detail.title}</h3>
-      </div>
-
+    <div className="flex w-full flex-col gap-4" data-slot="media-asset-detail">
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="media-asset-name">{detail.nameLabel}</Label>
         <Input

--- a/packages/media-react/src/components/media-library.tsx
+++ b/packages/media-react/src/components/media-library.tsx
@@ -8,6 +8,13 @@ import {
   EmptyHeader,
   EmptyTitle,
 } from "@voyant-travel/ui/components/empty"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@voyant-travel/ui/components/sheet"
 import { Skeleton } from "@voyant-travel/ui/components/skeleton"
 import { cn } from "@voyant-travel/ui/lib/utils"
 import { LayoutGrid, List } from "lucide-react"
@@ -89,7 +96,7 @@ export function MediaLibrary({
   }
 
   return (
-    <div className={cn("flex flex-col gap-4", className)} data-slot="media-library">
+    <div className={cn("flex flex-col gap-6 p-6", className)} data-slot="media-library">
       <div className="flex flex-col gap-1">
         <h2 className="text-lg font-semibold">{library.title}</h2>
         <p className="text-sm text-muted-foreground">{library.description}</p>
@@ -207,18 +214,32 @@ export function MediaLibrary({
           )}
         </div>
 
-        {selected ? (
-          <MediaAssetDetailPanel
-            asset={selected}
-            currentFolderId={folderId}
-            onDeleted={() => setSelectedId(undefined)}
-          />
-        ) : (
-          <div className="hidden w-80 shrink-0 items-start justify-center pt-8 text-sm text-muted-foreground lg:flex">
-            {library.detail.selectPrompt}
-          </div>
-        )}
       </div>
+
+      <Sheet
+        open={Boolean(selected)}
+        onOpenChange={(open) => {
+          if (!open) setSelectedId(undefined)
+        }}
+      >
+        <SheetContent side="right" className="w-full gap-0 p-0 sm:max-w-md">
+          {selected ? (
+            <>
+              <SheetHeader className="border-b">
+                <SheetTitle className="truncate">{selected.name}</SheetTitle>
+                <SheetDescription>{library.detail.title}</SheetDescription>
+              </SheetHeader>
+              <div className="min-h-0 flex-1 overflow-y-auto p-4">
+                <MediaAssetDetailPanel
+                  asset={selected}
+                  currentFolderId={folderId}
+                  onDeleted={() => setSelectedId(undefined)}
+                />
+              </div>
+            </>
+          ) : null}
+        </SheetContent>
+      </Sheet>
     </div>
   )
 }

--- a/packages/media-react/src/components/media-library.tsx
+++ b/packages/media-react/src/components/media-library.tsx
@@ -213,7 +213,6 @@ export function MediaLibrary({
             </div>
           )}
         </div>
-
       </div>
 
       <Sheet


### PR DESCRIPTION
Two layout fixes to the media library browse surface, verified live against a locally-booted operator (screenshots below).

## Padding
The page rendered flush against the shell edges. Added the standard `flex flex-col gap-6 p-6` page padding used by the other admin domain hosts (notifications, apps, inventory).

## Asset detail → sheet
The detail/edit form was a permanent inline right column that showed only "Select an asset to see its details." until you clicked something — wasting a full column of horizontal space. It now opens in a **right-side sheet** when an asset is selected:

- Click an asset → sheet slides in with its name as the title, plus the full edit form (name, alt, tags, folders, metadata, where-used, delete).
- Close (X / backdrop / Esc) → clears the selection and returns to the grid.
- The grid now spans the reclaimed width.

`MediaAssetDetailPanel` drops its fixed `w-80` and its own heading (the sheet header provides the title), so it fills the sheet.

## Verification
Booted the operator, uploaded an asset, and exercised the flow via chrome-devtools: page padding correct, clicking the asset opens the sheet with the populated form, closing returns to the grid.
