### PR TITLE
media: /media route, folder-create dialog, upload content-type fix

### DIFF
--- a/.changeset/media-route-folder-contenttype.md
+++ b/.changeset/media-route-folder-contenttype.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/media": patch
+"@voyant-travel/media-react": patch
+---
+
+Media library polish:
+
+- Rename the admin route from `/media-library` to `/media` (nav + default host base path).
+- Move folder creation from an inline sidebar form into a dialog.
+- Give uploaded objects a file extension in their storage key so the byte-serving route (which sends `X-Content-Type-Options: nosniff`) infers the correct `Content-Type` — raster images and PDFs now render instead of downloading as `application/octet-stream`.

--- a/packages/media-react/src/admin/index.tsx
+++ b/packages/media-react/src/admin/index.tsx
@@ -68,7 +68,7 @@ export interface CreateMediaAdminExtensionOptions {
 export function createMediaAdminExtension(
   options: CreateMediaAdminExtensionOptions = {},
 ): AdminExtension {
-  const { basePath = "/media-library", labels = {}, icon } = options
+  const { basePath = "/media", labels = {}, icon } = options
   const { mediaLibrary = "Media library" } = labels
 
   return defineAdminExtension({

--- a/packages/media-react/src/components/media-folder-sidebar.tsx
+++ b/packages/media-react/src/components/media-folder-sidebar.tsx
@@ -1,6 +1,14 @@
 "use client"
 
 import { Button } from "@voyant-travel/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@voyant-travel/ui/components/dialog"
 import { Input } from "@voyant-travel/ui/components/input"
 import { cn } from "@voyant-travel/ui/lib/utils"
 import { Folder, FolderPlus, Library, Loader2, Trash2 } from "lucide-react"
@@ -38,53 +46,61 @@ export function MediaFolderSidebar({ selectedFolderId, onSelectFolder }: MediaFo
         <span className="text-xs font-medium text-muted-foreground uppercase">
           {folderMessages.title}
         </span>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          aria-label={folderMessages.newFolder}
-          onClick={() => setCreating((open) => !open)}
+        <Dialog
+          open={creating}
+          onOpenChange={(open) => {
+            setCreating(open)
+            if (!open) setName("")
+          }}
         >
-          <FolderPlus className="size-4" aria-hidden="true" />
-        </Button>
-      </div>
-
-      {creating ? (
-        <div className="flex flex-col gap-2 px-2 pb-2">
-          <Input
-            value={name}
-            autoFocus
-            placeholder={folderMessages.newFolderPlaceholder}
-            aria-label={folderMessages.newFolderPlaceholder}
-            onChange={(event) => setName(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === "Enter") void submit()
-            }}
+          <DialogTrigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={folderMessages.newFolder}
+              >
+                <FolderPlus className="size-4" aria-hidden="true" />
+              </Button>
+            }
           />
-          <div className="flex gap-2">
-            <Button
-              type="button"
-              size="sm"
-              className="flex-1"
-              disabled={create.isPending || !name.trim()}
-              onClick={() => void submit()}
-            >
-              {folderMessages.create}
-            </Button>
-            <Button
-              type="button"
-              size="sm"
-              variant="ghost"
-              onClick={() => {
-                setCreating(false)
-                setName("")
+          <DialogContent className="max-w-sm">
+            <DialogHeader>
+              <DialogTitle>{folderMessages.newFolder}</DialogTitle>
+            </DialogHeader>
+            <Input
+              value={name}
+              autoFocus
+              placeholder={folderMessages.newFolderPlaceholder}
+              aria-label={folderMessages.newFolderPlaceholder}
+              onChange={(event) => setName(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") void submit()
               }}
-            >
-              {messages.common.cancel}
-            </Button>
-          </div>
-        </div>
-      ) : null}
+            />
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="ghost"
+                onClick={() => {
+                  setCreating(false)
+                  setName("")
+                }}
+              >
+                {messages.common.cancel}
+              </Button>
+              <Button
+                type="button"
+                disabled={create.isPending || !name.trim()}
+                onClick={() => void submit()}
+              >
+                {folderMessages.create}
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <button
         type="button"

--- a/packages/media/src/service.ts
+++ b/packages/media/src/service.ts
@@ -56,6 +56,31 @@ export interface CreateMediaAssetResult {
 /** All object keys minted by the library live under this servable prefix. */
 const MEDIA_STORAGE_KEY_PREFIX = "uploads/media/"
 
+/**
+ * Storage keys are content-addressed by checksum. Append the file extension so
+ * the byte-serving route (`@voyant-travel/storage`, which sends
+ * `X-Content-Type-Options: nosniff`) can infer the correct `Content-Type` from
+ * the key and browsers render the asset instead of downloading octet-stream.
+ */
+const MEDIA_EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+  "image/svg+xml": "svg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+  "application/pdf": "pdf",
+}
+
+function storageKeyExtension(mimeType: string | undefined): string {
+  const normalized = (mimeType ?? "").toLowerCase().split(";")[0]?.trim() ?? ""
+  const ext = MEDIA_EXTENSION_BY_MIME[normalized]
+  return ext ? `.${ext}` : ""
+}
+
 async function toBytes(body: StorageUploadBody): Promise<Uint8Array> {
   if (body instanceof Uint8Array) return body
   if (body instanceof ArrayBuffer) return new Uint8Array(body)
@@ -101,7 +126,7 @@ export async function createMediaAsset(
     return { asset: existing, deduped: true }
   }
 
-  const storageKey = `${MEDIA_STORAGE_KEY_PREFIX}${checksum}`
+  const storageKey = `${MEDIA_STORAGE_KEY_PREFIX}${checksum}${storageKeyExtension(input.mimeType)}`
   await storage.upload(bytes, {
     key: storageKey,
     ...(input.mimeType ? { contentType: input.mimeType } : {}),

--- a/packages/media/src/service.ts
+++ b/packages/media/src/service.ts
@@ -75,7 +75,7 @@ const MEDIA_EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
   "application/pdf": "pdf",
 }
 
-function storageKeyExtension(mimeType: string | undefined): string {
+function storageKeyExtension(mimeType: string | null | undefined): string {
   const normalized = (mimeType ?? "").toLowerCase().split(";")[0]?.trim() ?? ""
   const ext = MEDIA_EXTENSION_BY_MIME[normalized]
   return ext ? `.${ext}` : ""

--- a/packages/media/src/voyant.ts
+++ b/packages/media/src/voyant.ts
@@ -92,7 +92,7 @@ export const mediaVoyantModule = defineModule({
     routes: [
       {
         id: "@voyant-travel/media#admin.route.media-library-index",
-        path: "/media-library",
+        path: "/media",
         requiredScopes: ["media-library:read"],
         runtime: {
           entry: "@voyant-travel/media-react/admin",


### PR DESCRIPTION
Media library polish, verified live against a locally-booted operator (chrome-devtools).

## 1. Route `/media-library` → `/media`
The admin page is now at `/media` (nav + `createMediaAdminExtension` default base path). Verified: nav links to `/media`, page renders there.

## 2. Folder create → dialog
Creating a folder was an inline form pushed into the sidebar. It's now a dialog (title, focused name input, Cancel/Create). Verified: clicking "New folder" opens the dialog; created a "Brochures" folder through it.

## 3. Upload content-type fix
Uploaded media rendered as broken thumbnails on localhost. Root cause: content-addressed storage keys (`uploads/media/<checksum>`) have no file extension, so the byte-serving route in `@voyant-travel/storage` — which sends `X-Content-Type-Options: nosniff` — served everything as `application/octet-stream`, and browsers refused to render it. The media-library upload now appends the file extension to the key (matching the storage package's own `/v1/admin/uploads` route). Verified: a fresh PNG upload now serves `200 image/png` and renders in the grid.

Note: SVGs remain served as octet-stream by design — `@voyant-travel/storage` downgrades scriptable types (SVG/HTML) to prevent stored-XSS.
