### PR TITLE
inventory-react: media library picker for product + itinerary media

### DIFF
--- a/.changeset/product-media-library-picker.md
+++ b/.changeset/product-media-library-picker.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/inventory-react": minor
+---
+
+Wire the media library into product and itinerary-day media management. The
+"Upload" action on the product detail gallery and the itinerary-day media tray
+now opens the media library picker — a dialog where you can select existing
+assets or upload new ones — instead of a bare file input. Selected assets are
+linked to the product/day (`assetId`) and served through the shared media
+byte route so uploads surface in the library and vice versa.

--- a/packages/inventory-react/src/components/product-day-media-tray.tsx
+++ b/packages/inventory-react/src/components/product-day-media-tray.tsx
@@ -1,10 +1,11 @@
 "use client"
 
+import type { MediaAsset } from "@voyant-travel/media-react"
+import { MediaPicker } from "@voyant-travel/media-react/ui"
 import { Badge } from "@voyant-travel/ui/components/badge"
 import { Button } from "@voyant-travel/ui/components/button"
 import { ImageIcon, Loader2, Pencil, Plus, Star, Trash2, Upload } from "lucide-react"
 import * as React from "react"
-import { useProductMediaUpload } from "../hooks/use-product-media-upload.js"
 import { useProductsUiMessagesOrDefault } from "../i18n/provider.js"
 import { type ProductMediaRecord, useProductMedia, useProductMediaMutation } from "../index.js"
 import { ProductMediaDialog } from "./product-media-dialog.js"
@@ -18,22 +19,14 @@ export interface ProductDayMediaTrayProps {
   emptyState?: React.ReactNode
 }
 
-export function ProductDayMediaTray({
-  productId,
-  dayId,
-  uploadMedia,
-  uploadAccept = "image/*,video/*,application/pdf",
-  emptyState,
-}: ProductDayMediaTrayProps) {
+export function ProductDayMediaTray({ productId, dayId, emptyState }: ProductDayMediaTrayProps) {
   const messages = useProductsUiMessagesOrDefault()
   const [dialogOpen, setDialogOpen] = React.useState(false)
+  const [pickerOpen, setPickerOpen] = React.useState(false)
   const [editingMedia, setEditingMedia] = React.useState<ProductMediaRecord | undefined>()
-  const [isUploading, setIsUploading] = React.useState(false)
   const [uploadError, setUploadError] = React.useState<string | null>(null)
-  const fileInputRef = React.useRef<HTMLInputElement>(null)
   const { data, isPending, isError } = useProductMedia(productId, { dayId, limit: 50 })
-  const { remove, setCover } = useProductMediaMutation()
-  const { upload } = useProductMediaUpload()
+  const { create, remove, setCover } = useProductMediaMutation()
 
   const media = React.useMemo(
     () =>
@@ -46,27 +39,33 @@ export function ProductDayMediaTray({
     [data?.data],
   )
 
-  const handleUpload = async (file: File) => {
+  const handleSelectFromLibrary = async (assets: MediaAsset[]) => {
+    if (assets.length === 0) return
     setUploadError(null)
-    setIsUploading(true)
-
     try {
-      await upload(
-        file,
-        {
+      let coverAssigned = media.some((item) => item.isCover)
+      for (const [offset, asset] of assets.entries()) {
+        const assignCover = asset.type === "image" && !coverAssigned
+        if (assignCover) coverAssigned = true
+        await create.mutateAsync({
           productId,
           dayId,
-          sortOrder: media.length,
-          isCover: !media.some((item) => item.isCover),
-        },
-        uploadMedia,
-      )
+          mediaType: asset.type,
+          name: asset.name,
+          url: `/api/v1/admin/media/${asset.storageKey}`,
+          storageKey: asset.storageKey,
+          mimeType: asset.mimeType,
+          fileSize: asset.fileSize,
+          altText: asset.alt,
+          assetId: asset.id,
+          sortOrder: media.length + offset,
+          isCover: assignCover,
+        })
+      }
     } catch (error) {
       setUploadError(
-        error instanceof Error ? error.message : messages.productMediaSection.uploadFailed,
+        error instanceof Error ? error.message : messages.productMediaSection.libraryAddFailed,
       )
-    } finally {
-      setIsUploading(false)
     }
   }
 
@@ -75,33 +74,10 @@ export function ProductDayMediaTray({
       <div className="flex items-center justify-between gap-2">
         <div className="text-sm font-medium">{messages.productMediaSection.titles.dayMedia}</div>
         <div className="flex items-center gap-1">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            disabled={isUploading}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            {isUploading ? (
-              <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />
-            ) : (
-              <Upload className="mr-2 size-4" aria-hidden="true" />
-            )}
+          <Button type="button" variant="outline" size="sm" onClick={() => setPickerOpen(true)}>
+            <Upload className="mr-2 size-4" aria-hidden="true" />
             {messages.productMediaSection.actions.upload}
           </Button>
-          <input
-            ref={fileInputRef}
-            type="file"
-            accept={uploadAccept}
-            className="hidden"
-            onChange={(event) => {
-              const file = event.target.files?.[0]
-              if (file) {
-                void handleUpload(file)
-                event.target.value = ""
-              }
-            }}
-          />
           <Button
             type="button"
             variant="outline"
@@ -200,6 +176,17 @@ export function ProductDayMediaTray({
         dayId={dayId}
         media={editingMedia}
         onSuccess={() => setEditingMedia(undefined)}
+      />
+
+      <MediaPicker
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        multiple
+        resolveAssetUrl={(asset) => `/api/v1/admin/media/${asset.storageKey}`}
+        onSelect={(assets) => {
+          setPickerOpen(false)
+          void handleSelectFromLibrary(assets)
+        }}
       />
     </div>
   )

--- a/packages/inventory-react/src/components/product-detail/product-detail-media-sections.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-media-sections.tsx
@@ -1,4 +1,5 @@
 import { formatMessage } from "@voyant-travel/i18n"
+import type { MediaAsset } from "@voyant-travel/media-react"
 import { Button } from "@voyant-travel/ui/components"
 import { Download, FileText, RefreshCw } from "lucide-react"
 import { useProductDetailMessages } from "./host.js"
@@ -75,6 +76,7 @@ export function ProductMediaSection({
   media,
   isUploading,
   onUpload,
+  onSelectFromLibrary,
   onSetCover,
   onDelete,
 }: {
@@ -82,6 +84,7 @@ export function ProductMediaSection({
   media: ProductMediaItem[]
   isUploading: boolean
   onUpload: (file: File) => void
+  onSelectFromLibrary?: (assets: MediaAsset[]) => void
   onSetCover: (mediaId: string) => void
   onDelete: (mediaId: string) => void
 }) {
@@ -94,6 +97,7 @@ export function ProductMediaSection({
           media={media}
           isUploading={isUploading}
           onUpload={onUpload}
+          onSelectFromLibrary={onSelectFromLibrary}
           onSetCover={onSetCover}
           onDelete={onDelete}
         />

--- a/packages/inventory-react/src/components/product-detail/product-detail-page.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-detail-page.tsx
@@ -121,6 +121,7 @@ export function ProductDetailPage({ id }: { id: string }) {
             media={galleryMedia}
             isUploading={mutations.uploadMedia.isPending}
             onUpload={(file) => mutations.uploadMedia.mutate({ file })}
+            onSelectFromLibrary={(assets) => mutations.addMediaFromLibrary.mutate({ assets })}
             onSetCover={(mediaId) => mutations.setCover.mutate(mediaId)}
             onDelete={(mediaId) => {
               if (confirm(productMessages.deleteMediaConfirm)) {

--- a/packages/inventory-react/src/components/product-detail/product-media-gallery.tsx
+++ b/packages/inventory-react/src/components/product-detail/product-media-gallery.tsx
@@ -2,6 +2,8 @@
 
 import { useMutation } from "@tanstack/react-query"
 import { formatMessage } from "@voyant-travel/i18n"
+import type { MediaAsset } from "@voyant-travel/media-react"
+import { MediaPicker } from "@voyant-travel/media-react/ui"
 import { Button } from "@voyant-travel/ui/components"
 import {
   Carousel,
@@ -33,6 +35,11 @@ interface ProductMediaGalleryProps {
   media: ProductMediaItem[]
   isUploading: boolean
   onUpload: (file: File) => void
+  /**
+   * When provided, the "Upload" action opens the media library picker (select
+   * existing assets or upload new ones) instead of a bare file input.
+   */
+  onSelectFromLibrary?: (assets: MediaAsset[]) => void
   onSetCover: (mediaId: string) => void
   onDelete: (mediaId: string) => void
   onReorderLocal?: (items: ProductMediaItem[]) => void
@@ -49,6 +56,7 @@ export function ProductMediaGallery({
   media,
   isUploading,
   onUpload,
+  onSelectFromLibrary,
   onSetCover,
   onDelete,
   onReorderLocal,
@@ -57,6 +65,7 @@ export function ProductMediaGallery({
   const api = useProductDetailApi()
   const mediaMessages = messages.products.operations.media
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const [pickerOpen, setPickerOpen] = useState(false)
   const [carouselApi, setCarouselApi] = useState<CarouselApi>()
   const [active, setActive] = useState(0)
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null)
@@ -155,7 +164,9 @@ export function ProductMediaGallery({
             size="sm"
             className="h-8 text-xs"
             disabled={isUploading || reorderMode}
-            onClick={() => fileInputRef.current?.click()}
+            onClick={() =>
+              onSelectFromLibrary ? setPickerOpen(true) : fileInputRef.current?.click()
+            }
           >
             {isUploading ? (
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -251,6 +262,19 @@ export function ProductMediaGallery({
         onClose={() => setLightboxIndex(null)}
         mediaMessages={mediaMessages}
       />
+
+      {onSelectFromLibrary ? (
+        <MediaPicker
+          open={pickerOpen}
+          onOpenChange={setPickerOpen}
+          multiple
+          resolveAssetUrl={(asset) => `/api/v1/admin/media/${asset.storageKey}`}
+          onSelect={(assets) => {
+            setPickerOpen(false)
+            if (assets.length > 0) onSelectFromLibrary(assets)
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/packages/inventory-react/src/components/product-detail/use-product-detail-data.ts
+++ b/packages/inventory-react/src/components/product-detail/use-product-detail-data.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query"
+import type { MediaAsset } from "@voyant-travel/media-react"
 import { useMemo } from "react"
 import { productsQueryKeys, useProduct, useProductItineraries } from "../../index.js"
 
@@ -40,6 +41,9 @@ export interface UseProductDetailDataResult {
     deleteSlot: ReturnType<typeof useMutation<unknown, Error, string>>
     deleteRule: ReturnType<typeof useMutation<unknown, Error, string>>
     uploadMedia: ReturnType<typeof useMutation<unknown, Error, { file: File; dayId?: string }>>
+    addMediaFromLibrary: ReturnType<
+      typeof useMutation<unknown, Error, { assets: MediaAsset[]; dayId?: string }>
+    >
     deleteMedia: ReturnType<typeof useMutation<unknown, Error, string>>
     setCover: ReturnType<typeof useMutation<unknown, Error, string>>
     generateBrochure: ReturnType<typeof useMutation<unknown, Error, void>>
@@ -140,6 +144,30 @@ export function useProductDetailData(productId: string): UseProductDetailDataRes
     },
   })
 
+  const addMediaFromLibrary = useMutation({
+    mutationFn: async ({ assets, dayId }: { assets: MediaAsset[]; dayId?: string }) => {
+      const endpoint = dayId
+        ? `/v1/admin/products/${productId}/days/${dayId}/media`
+        : `/v1/admin/products/${productId}/media`
+      for (const asset of assets) {
+        await api.post(endpoint, {
+          mediaType: asset.type,
+          name: asset.name,
+          url: `/api/v1/admin/media/${asset.storageKey}`,
+          storageKey: asset.storageKey,
+          mimeType: asset.mimeType,
+          fileSize: asset.fileSize,
+          altText: asset.alt,
+          assetId: asset.id,
+        })
+      }
+    },
+    onSuccess: () => {
+      void mediaQuery.refetch()
+      void queryClient.invalidateQueries({ queryKey: productActionLedgerQueryKey })
+    },
+  })
+
   const deleteMedia = useMutation({
     mutationFn: (mediaId: string) => api.delete(`/v1/admin/products/media/${mediaId}`),
     onSuccess: () => {
@@ -203,6 +231,7 @@ export function useProductDetailData(productId: string): UseProductDetailDataRes
       deleteSlot,
       deleteRule,
       uploadMedia,
+      addMediaFromLibrary,
       deleteMedia,
       setCover,
       generateBrochure,


### PR DESCRIPTION
## What
The "Upload" action on the **product detail** media gallery and the **itinerary-day** media tray now opens the media library picker — a dialog to select existing assets **or** upload new ones — instead of a bare file input. This unifies product/itinerary media with the media library (uploads surface in the library; library assets are reusable across products).

- `product-media-gallery.tsx` gains an optional `onSelectFromLibrary`; when provided, "Upload" opens `<MediaPicker>`.
- `use-product-detail-data.ts` adds an `addMediaFromLibrary` mutation that links selected assets (`assetId`, `/api/v1/admin/media/{storageKey}`) to the product/day and refetches.
- `product-day-media-tray.tsx` routes "Upload" through the picker using its own `useProductMediaMutation().create`.

## Verification (live, chrome-devtools)
On a product detail page: clicked **Upload → the media gallery dialog opens** (search, type filter, "Browse files" upload, existing assets). Selected an asset → **`POST /products/{id}/media` → 201** → the media list refetched and the asset renders on the product. The itinerary-day tray uses the identical picker + create-mutation pattern.
