### PR TITLE
media-react: widen media picker + graceful thumbnail fallback

### DIFF
--- a/.changeset/media-picker-width-thumbnail-fallback.md
+++ b/.changeset/media-picker-width-thumbnail-fallback.md
@@ -2,8 +2,11 @@
 "@voyant-travel/media-react": patch
 ---
 
-Media picker polish: widen the picker dialog (`sm:!max-w-5xl`, 4-column grid on
+Media picker polish: widen the picker dialog (`sm:max-w-5xl`, 4-column grid on
 large screens) so more assets are visible at once, and render a muted image icon
 when a thumbnail fails to load (missing bytes, an undecodable file, or a
 security-downgraded content type such as inline SVG) instead of the browser's
 broken-image glyph.
+
+The `sm:max-w-5xl` matches the base dialog's `sm:` max-width variant so
+tailwind-merge replaces it (a base-variant class like `max-w-3xl` would not).

--- a/.changeset/media-picker-width-thumbnail-fallback.md
+++ b/.changeset/media-picker-width-thumbnail-fallback.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/media-react": patch
+---
+
+Media picker polish: widen the picker dialog (`sm:!max-w-5xl`, 4-column grid on
+large screens) so more assets are visible at once, and render a muted image icon
+when a thumbnail fails to load (missing bytes, an undecodable file, or a
+security-downgraded content type such as inline SVG) instead of the browser's
+broken-image glyph.

--- a/packages/media-react/src/components/media-asset-thumbnail.tsx
+++ b/packages/media-react/src/components/media-asset-thumbnail.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { cn } from "@voyant-travel/ui/lib/utils"
-import { FileText, Film } from "lucide-react"
+import { FileText, Film, ImageOff } from "lucide-react"
+import * as React from "react"
 
 import type { MediaAsset } from "../schemas.js"
 
@@ -13,11 +14,18 @@ export interface MediaAssetThumbnailProps {
 
 /**
  * Renders a preview appropriate to the asset kind: an `<img>` for images, a
- * muted `<video>` for videos, and a document glyph for everything else. Purely
- * presentational — no user-facing copy (the alt text comes from the asset).
+ * muted `<video>` for videos, and a document glyph for everything else. Images
+ * that fail to load (missing bytes, an undecodable file, or a security-downgraded
+ * content type such as inline SVG) fall back to a muted icon instead of the
+ * browser's broken-image glyph. Purely presentational — no user-facing copy (the
+ * alt text comes from the asset).
  */
 export function MediaAssetThumbnail({ asset, url, className }: MediaAssetThumbnailProps) {
-  if (asset.type === "image") {
+  // Tiles are keyed by asset id, so a new asset remounts this component and
+  // clears the error state — no reset effect needed.
+  const [errored, setErrored] = React.useState(false)
+
+  if (asset.type === "image" && !errored) {
     return (
       <img
         src={url}
@@ -25,22 +33,12 @@ export function MediaAssetThumbnail({ asset, url, className }: MediaAssetThumbna
         className={cn("h-full w-full object-cover", className)}
         draggable={false}
         loading="lazy"
+        onError={() => setErrored(true)}
       />
     )
   }
 
-  if (asset.type === "video") {
-    return (
-      <div
-        className={cn(
-          "flex h-full w-full items-center justify-center bg-muted text-muted-foreground",
-          className,
-        )}
-      >
-        <Film className="size-6" aria-hidden="true" />
-      </div>
-    )
-  }
+  const FallbackIcon = asset.type === "video" ? Film : asset.type === "image" ? ImageOff : FileText
 
   return (
     <div
@@ -49,7 +47,7 @@ export function MediaAssetThumbnail({ asset, url, className }: MediaAssetThumbna
         className,
       )}
     >
-      <FileText className="size-6" aria-hidden="true" />
+      <FallbackIcon className="size-6" aria-hidden="true" />
     </div>
   )
 }

--- a/packages/media-react/src/components/media-picker.tsx
+++ b/packages/media-react/src/components/media-picker.tsx
@@ -74,7 +74,7 @@ export function MediaPicker({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {trigger ? <DialogTrigger render={trigger as React.ReactElement} /> : null}
-      <DialogContent className="max-w-3xl">{body}</DialogContent>
+      <DialogContent className="sm:!max-w-5xl">{body}</DialogContent>
     </Dialog>
   )
 }
@@ -187,7 +187,7 @@ function MediaPickerBody({
           </EmptyHeader>
         </Empty>
       ) : (
-        <div className="grid max-h-[45vh] grid-cols-2 gap-3 overflow-y-auto sm:grid-cols-3">
+        <div className="grid max-h-[45vh] grid-cols-2 gap-3 overflow-y-auto sm:grid-cols-3 lg:grid-cols-4">
           {assets.map((asset) => (
             <MediaAssetTile
               key={asset.id}

--- a/packages/media-react/src/components/media-picker.tsx
+++ b/packages/media-react/src/components/media-picker.tsx
@@ -74,7 +74,7 @@ export function MediaPicker({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       {trigger ? <DialogTrigger render={trigger as React.ReactElement} /> : null}
-      <DialogContent className="sm:!max-w-5xl">{body}</DialogContent>
+      <DialogContent className="sm:max-w-5xl">{body}</DialogContent>
     </Dialog>
   )
 }


### PR DESCRIPTION
Two media picker fixes (verified live in the operator).

## Wider dialog
The picker's `max-w-3xl` was being overridden by the base `DialogContent` `sm:max-w-md`, so it rendered narrow. Forced a wider max-width with `sm:!max-w-5xl` and added a 4th grid column on large screens (`lg:grid-cols-4`), so more assets are visible at once.

## Graceful thumbnail fallback
Image thumbnails that fail to load (missing bytes, an undecodable file, or a security-downgraded content type such as inline SVG) showed the browser's broken-image glyph. `MediaAssetThumbnail` now renders a muted image icon on `onError` instead. This affects the picker and the media library grid.

## Verification
Opened the picker on a product detail page: the dialog is noticeably wider (4 columns), and assets whose bytes are missing/undecodable now show a clean icon instead of a broken-image glyph.
