### PR TITLE
storage: selectable gateway object-storage provider (managed media, OSS half)

### DIFF
--- a/.changeset/storage-gateway-provider.md
+++ b/.changeset/storage-gateway-provider.md
@@ -1,0 +1,18 @@
+---
+"@voyant-travel/storage": minor
+"@voyant-travel/framework": minor
+---
+
+Add a selectable `gateway` object-storage provider. Managed deployments can now
+resolve their `media`/`documents` stores through the platform asset-storage
+gateway (via the existing `createGatewayStorageProvider`) instead of holding raw
+bucket credentials: both stores talk to `STORAGE_GATEWAY_ENDPOINT` with a
+workspace-scoped `STORAGE_GATEWAY_TOKEN` bearer token, and the gateway brokers
+R2 access scoped to the caller's `<jurisdiction>/<org>` prefix.
+
+The storage manifest exposes the provider under `selection { role: "storage",
+value: "gateway" }`, and the Node runtime provider plan accepts `storage:
+"gateway"` (requiring `STORAGE_GATEWAY_ENDPOINT` + `STORAGE_GATEWAY_TOKEN`) and
+maps it to the `object-storage` deployment resource. Self-hosters are
+unaffected — they continue to use `s3-compatible` or the local memory provider,
+with no token.

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -84,6 +84,21 @@ function envForProvider(
       secret("S3_SESSION_TOKEN", "Optional temporary S3 session token.", false),
     ]
   }
+  if (role === "storage" && provider === "gateway") {
+    return [
+      variable(
+        "STORAGE_GATEWAY_ENDPOINT",
+        "Base URL of the managed asset-storage gateway.",
+        true,
+        "http-url",
+      ),
+      secret(
+        "STORAGE_GATEWAY_TOKEN",
+        "Workspace-scoped bearer token for the managed asset-storage gateway.",
+        true,
+      ),
+    ]
+  }
   if (
     (role === "cache" || role === "sharedState" || role === "rateLimit") &&
     provider === "redis"
@@ -328,7 +343,9 @@ function resourceKeyFor(role: VoyantDeploymentProviderRole, provider: string): s
   ) {
     return "postgres-shared-state"
   }
-  if (role === "storage" && provider === "s3-compatible") return "object-storage"
+  if (role === "storage" && (provider === "s3-compatible" || provider === "gateway")) {
+    return "object-storage"
+  }
   return `${role}:${provider}`
 }
 

--- a/packages/framework/src/deployment-types.ts
+++ b/packages/framework/src/deployment-types.ts
@@ -19,7 +19,7 @@ export type VoyantDeploymentProviderRole =
 
 export interface VoyantDeploymentProviders {
   database: "postgres"
-  storage: "s3-compatible" | "memory" | "custom"
+  storage: "s3-compatible" | "gateway" | "memory" | "custom"
   cache: "redis" | "postgres" | "platform" | "memory"
   sharedState: "redis" | "postgres" | "platform" | "memory"
   rateLimit: "redis" | "postgres" | "platform" | "memory"
@@ -75,7 +75,7 @@ export const DEFAULT_MANAGED_CLOUD_PROVIDERS = {
 
 export const DEPLOYMENT_PROVIDER_CONTRACTS = {
   database: ["postgres"],
-  storage: ["s3-compatible", "memory", "custom"],
+  storage: ["s3-compatible", "gateway", "memory", "custom"],
   cache: ["redis", "postgres", "platform", "memory"],
   sharedState: ["redis", "postgres", "platform", "memory"],
   rateLimit: ["redis", "postgres", "platform", "memory"],

--- a/packages/framework/src/node-provider-plan.test.ts
+++ b/packages/framework/src/node-provider-plan.test.ts
@@ -66,6 +66,27 @@ describe("resolveVoyantNodeProviderPlan", () => {
     ])
   })
 
+  it("maps the managed storage gateway provider and requires its endpoint + token", () => {
+    const plan = resolveVoyantNodeProviderPlan({
+      storage: "gateway",
+      cache: "memory",
+      sharedState: "memory",
+      rateLimit: "memory",
+    })
+
+    expect(plan.storage).toBe("gateway")
+    expect(validateVoyantNodeProviderPlanEnv(plan, {})).toEqual([
+      "env STORAGE_GATEWAY_ENDPOINT is required by the Node provider plan",
+      "env STORAGE_GATEWAY_TOKEN is required by the Node provider plan",
+    ])
+    expect(
+      validateVoyantNodeProviderPlanEnv(plan, {
+        STORAGE_GATEWAY_ENDPOINT: "https://gw.example.test",
+        STORAGE_GATEWAY_TOKEN: "tok",
+      }),
+    ).toEqual([])
+  })
+
   it("accepts DATABASE_URL_DIRECT for Postgres provider roles", () => {
     const plan = resolveVoyantNodeProviderPlan({
       storage: "memory",

--- a/packages/framework/src/node-provider-plan.ts
+++ b/packages/framework/src/node-provider-plan.ts
@@ -1,4 +1,4 @@
-export type VoyantNodeObjectStorageProvider = "memory" | "s3-compatible" | "custom"
+export type VoyantNodeObjectStorageProvider = "memory" | "s3-compatible" | "gateway" | "custom"
 export type VoyantNodeKvProvider = "memory" | "postgres" | "redis"
 
 export interface VoyantNodeProviderPlan {
@@ -32,6 +32,10 @@ export function validateVoyantNodeProviderPlanEnv(
     required.add("STORAGE_MEDIA_BUCKET")
     required.add("STORAGE_DOCUMENTS_BUCKET")
   }
+  if (plan.storage === "gateway") {
+    required.add("STORAGE_GATEWAY_ENDPOINT")
+    required.add("STORAGE_GATEWAY_TOKEN")
+  }
 
   for (const role of KV_PROVIDER_ROLES) {
     if (plan[role] === "redis") required.add("REDIS_URL")
@@ -53,7 +57,9 @@ function objectStorageProvider(
 ): VoyantNodeObjectStorageProvider {
   const provider = requireProvider(providers, role)
   if (provider === "none" || provider === "memory") return "memory"
-  if (provider === "s3-compatible" || provider === "custom") return provider
+  if (provider === "s3-compatible" || provider === "gateway" || provider === "custom") {
+    return provider
+  }
   throw new Error(
     `deployment graph providers.${role}=${provider} is not supported by the Node runtime`,
   )

--- a/packages/storage/src/providers/graph.ts
+++ b/packages/storage/src/providers/graph.ts
@@ -1,4 +1,5 @@
 import type { StorageProvider, StorageProviderResolver, VoyantStorageName } from "../types.js"
+import { createGatewayStorageProvider } from "./gateway.js"
 import { createLocalStorageProvider } from "./local.js"
 import { createS3CompatibleStorageProvider } from "./s3-compatible.js"
 
@@ -16,12 +17,14 @@ const CONFIG = {
   documentsBucket: "@voyant-travel/storage#config.documents-bucket",
   mediaBucket: "@voyant-travel/storage#config.media-bucket",
   mediaPublicBaseUrl: "@voyant-travel/storage#config.media-public-base-url",
+  gatewayEndpoint: "@voyant-travel/storage#config.gateway-endpoint",
 } as const
 
 const SECRET = {
   accessKeyId: "@voyant-travel/storage#secret.s3-access-key-id",
   secretAccessKey: "@voyant-travel/storage#secret.s3-secret-access-key",
   sessionToken: "@voyant-travel/storage#secret.s3-session-token",
+  gatewayToken: "@voyant-travel/storage#secret.gateway-token",
 } as const
 
 /** In-memory resolver selected by deployment.providers.storage. */
@@ -80,6 +83,27 @@ export function createS3CompatibleGraphStorageProvider(
       bucket: requiredString(context.getConfig(CONFIG.mediaBucket), "STORAGE_MEDIA_BUCKET"),
       publicBaseUrl: mediaPublicBaseUrl,
     }),
+  })
+}
+
+/**
+ * HTTP storage-gateway resolver selected by managed deployments. Instead of raw
+ * bucket credentials, both stores talk to the platform asset-gateway worker with
+ * a workspace-scoped bearer token; the gateway brokers R2 access scoped to the
+ * caller's `<jurisdiction>/<org>` prefix. Documents and media share one gateway
+ * endpoint + token and differ only by object key.
+ */
+export function createGatewayGraphStorageProvider(
+  context: StorageGraphProviderContext,
+): StorageProviderResolver {
+  const endpoint = requiredString(
+    context.getConfig(CONFIG.gatewayEndpoint),
+    "STORAGE_GATEWAY_ENDPOINT",
+  )
+  const token = requiredString(context.getSecret(SECRET.gatewayToken), "STORAGE_GATEWAY_TOKEN")
+  return fixedStores({
+    documents: createGatewayStorageProvider({ endpoint, token, name: "gateway:documents" }),
+    media: createGatewayStorageProvider({ endpoint, token, name: "gateway:media" }),
   })
 }
 

--- a/packages/storage/src/voyant.test.ts
+++ b/packages/storage/src/voyant.test.ts
@@ -27,6 +27,10 @@ describe("storage deployment manifest", () => {
           port: "storage.object",
           selection: { role: "storage", value: "s3-compatible" },
         }),
+        expect.objectContaining({
+          port: "storage.object",
+          selection: { role: "storage", value: "gateway" },
+        }),
       ],
       runtimePorts: [{ id: "storage.media-runtime" }],
       resources: [

--- a/packages/storage/src/voyant.ts
+++ b/packages/storage/src/voyant.ts
@@ -77,6 +77,11 @@ export const storageVoyantModule = defineModule({
       key: "MEDIA_PUBLIC_BASE_URL",
       required: false,
     },
+    {
+      id: "@voyant-travel/storage#config.gateway-endpoint",
+      key: "STORAGE_GATEWAY_ENDPOINT",
+      required: true,
+    },
   ],
   secrets: [
     {
@@ -95,6 +100,12 @@ export const storageVoyantModule = defineModule({
       id: "@voyant-travel/storage#secret.s3-session-token",
       key: "S3_SESSION_TOKEN",
       required: false,
+      rotation: "supported",
+    },
+    {
+      id: "@voyant-travel/storage#secret.gateway-token",
+      key: "STORAGE_GATEWAY_TOKEN",
+      required: true,
       rotation: "supported",
     },
   ],
@@ -138,6 +149,19 @@ export const storageVoyantModule = defineModule({
       runtime: {
         entry: "@voyant-travel/storage/providers/graph",
         export: "createS3CompatibleGraphStorageProvider",
+      },
+    },
+    {
+      id: "@voyant-travel/storage#provider.gateway",
+      port: storageObjectRuntimePort.id,
+      selection: { role: "storage", value: "gateway" },
+      uses: {
+        config: ["@voyant-travel/storage#config.gateway-endpoint"],
+        secrets: ["@voyant-travel/storage#secret.gateway-token"],
+      },
+      runtime: {
+        entry: "@voyant-travel/storage/providers/graph",
+        export: "createGatewayGraphStorageProvider",
       },
     },
   ],


### PR DESCRIPTION
First OSS increment of the **managed media** story (the follow-on to the media library).

## What
Makes the existing `createGatewayStorageProvider` factory a **selectable** deployment storage provider, so a managed deployment can resolve its `media`/`documents` stores through the platform asset-storage gateway instead of holding raw R2 credentials.

- **`@voyant-travel/storage`**: new `createGatewayGraphStorageProvider` graph runtime + manifest registration under `selection { role: "storage", value: "gateway" }`. Both stores talk to `STORAGE_GATEWAY_ENDPOINT` with a workspace-scoped `STORAGE_GATEWAY_TOKEN` bearer token (config + secret declarations added).
- **`@voyant-travel/framework`**: `storage: "gateway"` is now a valid provider value (`VoyantDeploymentProviders`, `DEPLOYMENT_PROVIDER_CONTRACTS`, `VoyantNodeObjectStorageProvider`), the Node provider plan requires `STORAGE_GATEWAY_ENDPOINT` + `STORAGE_GATEWAY_TOKEN` when selected, and it maps to the `object-storage` deployment resource.

## Why it's token-based (managed only)
The OSS media module never needs a token — it just uses whatever `StorageProvider` the deployment resolves. On **self-host** that's `s3-compatible`/`local` (no token, unchanged). On **managed** we don't hand deployments raw bucket creds, so the storage seam brokers through the platform `asset-gateway` worker with a workspace token. Per the product decision, that token is **long-lived / non-expiring** (revoked via key rotation, not `exp`).

## Scope / next
This is the OSS half. Still to come (platform repo): minting the RS256 workspace token (mirroring `marketplace-setup-signing`), injecting `STORAGE_GATEWAY_ENDPOINT` + token into managed deploy env, flipping the managed storage default to `gateway`, provisioning jurisdiction×tier R2 buckets, and merging the `asset-gateway` worker. The managed default (`DEFAULT_MANAGED_CLOUD_PROVIDERS.storage`) intentionally stays `s3-compatible` until that lands.

Tests: gateway provider added to the storage manifest test; Node provider-plan test covers the gateway mapping + required-env validation.
