### PR TITLE
payments: simplify Netopia connect form (drop Merchant ID, clarify API key)

### DIFF
--- a/.changeset/netopia-connect-form.md
+++ b/.changeset/netopia-connect-form.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/payments": patch
+---
+
+Simplify the Netopia connect form. Drop the confusing "Merchant ID" field —
+Netopia API v2 has no separate merchant number; the POS signature (Semnătura) is
+the point-of-sale identifier, and the adapter already ignores `merchantId` when a
+POS signature is present. Clarify the "API key" help text to point operators at
+the account API key (Security → API key) used as the Authorization header.

--- a/packages/payments/src/default-catalog.ts
+++ b/packages/payments/src/default-catalog.ts
@@ -37,14 +37,18 @@ const netopia: PaymentProviderDescriptor = {
   modes: ["sandbox", "live"],
   regions: ["RO"],
   currencies: ["RON", "EUR", "USD"],
+  // Netopia API v2 identifies the point of sale by its POS signature and
+  // authenticates requests with the account API key (sent as the Authorization
+  // header). There is no separate "merchant number" — the POS signature is the
+  // identifier — so that confusing field is not collected.
   credentialFieldSchema: [
     {
-      key: "merchantId",
-      label: "Merchant ID",
-      kind: "text",
+      key: "posSignature",
+      label: "POS signature",
+      kind: "secret",
       required: true,
       placeholder: "e.g. 2X4B-1AAA-...",
-      helpText: "Your Netopia merchant / seller identifier.",
+      helpText: "The POS signature (Semnătura) identifying your Netopia point of sale.",
       maxLength: 128,
     },
     {
@@ -52,16 +56,9 @@ const netopia: PaymentProviderDescriptor = {
       label: "API key",
       kind: "secret",
       required: true,
-      helpText: "Netopia API key used to initiate payments.",
+      helpText:
+        "Your Netopia account API key (Security → API key), sent as the Authorization header to initiate payments.",
       maxLength: 512,
-    },
-    {
-      key: "posSignature",
-      label: "POS signature",
-      kind: "secret",
-      required: true,
-      helpText: "The POS signature identifying your Netopia point of sale.",
-      maxLength: 128,
     },
     {
       key: "ipnPublicKey",


### PR DESCRIPTION
## What

The Netopia connect form asks for four credentials — **Merchant ID · API key · POS signature · IPN public key**. The **Merchant ID** field is wrong and confusing:

- Netopia API **v2** identifies the point of sale by its **POS signature** (`Semnătura`); there is no separate merchant number.
- The adapter already **ignores** `merchantId` when a POS signature is present.

This removes the `merchantId` field and clarifies the **API key** help text (it's the account API key from Netopia's Security → API key screen, sent as the `Authorization` header — not the POS private key).

Form after this change: **POS signature · API key · IPN public key**.

## Follow-up (not in this PR)

The `ipnPublicKey` field should also go — Netopia signs IPNs with its own **platform** key (verified: the IPN JWT is `iss: "NETOPIA Payments"`, RS512, no `kid`), so verification uses a Netopia certificate bundled in the adapter, not a per-merchant value. That's tracked in #3618 (coupled with the adapter change so verification keeps working).

## Verification

`pnpm typecheck` green (225/225). Catalog data change only.