### PR TITLE
storage: pin a tier prefix in the gateway provider

### DIFF
--- a/.changeset/gateway-tier-prefix.md
+++ b/.changeset/gateway-tier-prefix.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storage": patch
+---
+
+Gateway storage provider: pin a tier prefix per store. `createGatewayStorageProvider` now accepts a `tier` option that is prepended to every object key on the wire (`media/…`, `documents/…`), which the asset-gateway uses to select the target bucket. The prefix is transparent to callers — keys passed in and returned stay un-prefixed, so `upload → get/delete` round-trips no longer double-prefix. `createGatewayGraphStorageProvider` pins `media`/`documents` accordingly. Fixes managed uploads failing with `400 invalid_key` because the media module's `uploads/media/…` keys reached the gateway without a tier segment.

--- a/packages/storage/src/providers/gateway.test.ts
+++ b/packages/storage/src/providers/gateway.test.ts
@@ -201,6 +201,33 @@ describe("createGatewayStorageProvider", () => {
     ).toBe("documents")
   })
 
+  it("prefixes the tier on the wire but keeps caller keys un-prefixed", async () => {
+    const gateway = createFakeGateway()
+    const provider = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      fetch: gateway.fetch,
+      tier: "media",
+    })
+
+    const result = await provider.upload(new Uint8Array([1, 2, 3]), {
+      key: "uploads/media/x.png",
+      contentType: "image/png",
+    })
+
+    // The caller sees its own key; the object is stored under the tier-prefixed
+    // wire key (so the gateway can route to the media bucket).
+    expect(result.key).toBe("uploads/media/x.png")
+    expect(gateway.store.has("media/uploads/media/x.png")).toBe(true)
+    expect(gateway.store.has("uploads/media/x.png")).toBe(false)
+
+    // get/delete round-trip with the caller key — no double-prefix.
+    const fetched = await provider.get(result.key)
+    expect(new Uint8Array(fetched as ArrayBuffer)).toEqual(new Uint8Array([1, 2, 3]))
+    await provider.delete(result.key)
+    expect(gateway.store.has("media/uploads/media/x.png")).toBe(false)
+  })
+
   it("satisfies the portable storage provider conformance contract", async () => {
     const gateway = createFakeGateway()
     await assertStorageProviderConformance({

--- a/packages/storage/src/providers/gateway.ts
+++ b/packages/storage/src/providers/gateway.ts
@@ -16,6 +16,14 @@ export interface GatewayStorageProviderOptions {
   fetch?: typeof fetch
   /** Provider name (defaults to `"gateway"`). */
   name?: string
+  /**
+   * Tier segment prepended to every object key on the wire (for example
+   * `"media"` or `"documents"`). The gateway derives the target bucket from the
+   * first key segment, so a per-store provider must pin its tier here. The
+   * prefix is transparent to callers: keys passed in and returned by this
+   * provider are always the un-prefixed, caller-facing keys.
+   */
+  tier?: string
 }
 
 /**
@@ -33,9 +41,15 @@ export function createGatewayStorageProvider(
   const endpoint = options.endpoint.replace(/\/+$/, "")
   const doFetch = options.fetch ?? globalThis.fetch
   const name = options.name ?? "gateway"
+  const tier = options.tier?.replace(/^\/+|\/+$/g, "") || ""
+
+  /** Prepend the pinned tier so the gateway routes to the right bucket. */
+  function wireKey(key: string): string {
+    return tier ? `${tier}/${key}` : key
+  }
 
   function objectUrl(key: string): string {
-    return `${endpoint}/v1/objects/${encodeKey(key)}`
+    return `${endpoint}/v1/objects/${encodeKey(wireKey(key))}`
   }
 
   function authHeaders(extra?: Record<string, string>): Record<string, string> {
@@ -62,7 +76,9 @@ export function createGatewayStorageProvider(
       })
       await assertOk(response, "upload")
       const payload = (await response.json()) as { key: string; url: string }
-      return { key: payload.key, url: payload.url }
+      // Return the caller-facing (un-prefixed) key, not the gateway's
+      // tier-prefixed echo — otherwise a later get/delete would double-prefix.
+      return { key, url: payload.url }
     },
     async delete(key) {
       const response = await doFetch(objectUrl(key), {

--- a/packages/storage/src/providers/graph.ts
+++ b/packages/storage/src/providers/graph.ts
@@ -102,8 +102,13 @@ export function createGatewayGraphStorageProvider(
   )
   const token = requiredString(context.getSecret(SECRET.gatewayToken), "STORAGE_GATEWAY_TOKEN")
   return fixedStores({
-    documents: createGatewayStorageProvider({ endpoint, token, name: "gateway:documents" }),
-    media: createGatewayStorageProvider({ endpoint, token, name: "gateway:media" }),
+    documents: createGatewayStorageProvider({
+      endpoint,
+      token,
+      name: "gateway:documents",
+      tier: "documents",
+    }),
+    media: createGatewayStorageProvider({ endpoint, token, name: "gateway:media", tier: "media" }),
   })
 }
 


### PR DESCRIPTION
The asset-gateway derives the target bucket from the **first object-key segment** (the tier: `media`/`documents`). But `createGatewayStorageProvider` sent keys as-is, so the media module's `uploads/media/<checksum>` keys reached the gateway without a tier segment → **400 `invalid_key`** (managed uploads failed).

Fix: `createGatewayStorageProvider` takes a `tier` option that is prepended to the key on the wire (`media/…`, `documents/…`) and **stripped from the returned key**, so it's transparent to callers and `upload → get/delete` round-trips don't double-prefix. `createGatewayGraphStorageProvider` pins `media`/`documents` per store.

Storage gateway tests pass (9, incl. a new tier-prefix round-trip case). Verified end-to-end against the live gateway: a tier-prefixed key stores in `voyant-media` and serves via `cdn.onvoyant.com`; the un-prefixed key was the only failure.