### PR TITLE
Separate processor callbacks from checkout URLs

### DIFF
--- a/.changeset/calm-coins-callback.md
+++ b/.changeset/calm-coins-callback.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/trips": patch
+---
+
+Separate the operator payment callback origin from the customer-facing checkout URL.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -6,6 +6,7 @@ The full history (including patch-level changes and dependency updates) lives in
 
 ## Available
 
+- [Separate the payment callback origin](./payment-callback-origin.md) — configure processor callbacks independently from customer-facing payment links.
 - [Migrating Framework to 0.42](./migrating-to-0.42.md) - require explicit graph runtime metadata and select workflow execution and outbound webhook enqueueing through deployment providers.
 - [Migrating Auth to 0.128](./migrating-to-0.128.md) - move the removed top-level `useSecureCookies` option under Better Auth's `advanced` configuration.
 - [Workflow Runs 0.119](./migrating-to-0.119.md) — custom `workflows.runner-registry` providers must implement both `register()` and `get()`; direct registry and route composition APIs remain available.

--- a/docs/migrations/payment-callback-origin.md
+++ b/docs/migrations/payment-callback-origin.md
@@ -1,0 +1,47 @@
+# Separate the payment callback origin
+
+Payment processors send server-to-server notifications to the Operator, while
+customers open payment links on a storefront or website. Those URLs now have
+separate configuration:
+
+- `PAYMENT_CALLBACK_BASE_URL` is the public **Operator origin** that receives
+  processor callbacks.
+- `PUBLIC_CHECKOUT_BASE_URL` remains the customer-facing payment-link base URL.
+
+Set `PAYMENT_CALLBACK_BASE_URL` to an HTTP(S) origin only:
+
+```dotenv
+PAYMENT_CALLBACK_BASE_URL="https://operator.example.com"
+PUBLIC_CHECKOUT_BASE_URL="https://www.example.com/pay"
+```
+
+The runtime derives the callback URL as:
+
+```text
+https://operator.example.com/api/v1/public/payment-link/callback
+```
+
+Paths (including `/api`), credentials, query strings, and fragments are
+rejected. Local development may use an `http://localhost:<port>` origin.
+
+## Compatibility and rollout
+
+For deployments upgrading before their platform injects the new setting, the
+runtime temporarily falls back to `DASH_BASE_URL`, then to the origin obtained
+from `APP_URL` after removing its conventional trailing `/api`. Both describe
+the Operator itself. `PUBLIC_CHECKOUT_BASE_URL` is intentionally not a fallback
+because it may describe a different host or include a customer route such as
+`/pay`.
+
+1. Add `PAYMENT_CALLBACK_BASE_URL` before or with the package upgrade.
+2. Start a sandbox payment and verify the processor receives the derived
+   `/api/v1/public/payment-link/callback` URL.
+3. Verify a signed callback advances the payment session exactly once.
+4. Keep the previous callback endpoint reachable until payment sessions created
+   before the rollout have settled or expired.
+5. Remove any deployment-specific workaround that derived callbacks from
+   `PUBLIC_CHECKOUT_BASE_URL`.
+
+Voyant Cloud must inject the managed Operator's public origin into
+`PAYMENT_CALLBACK_BASE_URL`. Self-hosted deployments set it explicitly in their
+runtime environment.

--- a/packages/trips/src/storefront-payment-link-runtime.ts
+++ b/packages/trips/src/storefront-payment-link-runtime.ts
@@ -69,9 +69,9 @@ async function startAdapterCardPayment(
  * so the callback registered at `/v1/public/payment-link/callback` is publicly
  * reachable at `/api/v1/public/payment-link/callback`.
  */
-function resolvePaymentCallbackUrl(bindings: Record<string, unknown>): string | undefined {
-  const base = resolvePublicCheckoutBaseUrl(bindings)
-  return base ? `${base}/api/v1/public/payment-link/callback` : undefined
+export function resolvePaymentCallbackUrl(bindings: Record<string, unknown>): string | undefined {
+  const origin = resolvePaymentCallbackOrigin(bindings)
+  return origin ? `${origin}/api/v1/public/payment-link/callback` : undefined
 }
 
 interface PaymentConfigBindings {
@@ -80,7 +80,46 @@ interface PaymentConfigBindings {
   BANK_TRANSFER_BENEFICIARY?: string
   BANK_TRANSFER_IBAN?: string
   DASH_BASE_URL?: string
+  PAYMENT_CALLBACK_BASE_URL?: string
   PUBLIC_CHECKOUT_BASE_URL?: string
+}
+
+function resolvePaymentCallbackOrigin(bindings: Record<string, unknown>): string | undefined {
+  const env = bindings as PaymentConfigBindings
+  const configured = env.PAYMENT_CALLBACK_BASE_URL?.trim()
+  if (configured) return requireHttpOrigin(configured, "PAYMENT_CALLBACK_BASE_URL")
+
+  // Compatibility for deployments created before PAYMENT_CALLBACK_BASE_URL:
+  // DASH_BASE_URL and APP_URL describe this operator deployment, so they are
+  // safe callback origins. PUBLIC_CHECKOUT_BASE_URL deliberately is not a
+  // fallback: it may point at a customer website or a path such as `/pay`.
+  const dashboard = env.DASH_BASE_URL?.trim()
+  if (dashboard) return requireHttpOrigin(dashboard, "DASH_BASE_URL")
+
+  const app = env.APP_URL?.trim().replace(/\/api\/?$/, "")
+  return app ? requireHttpOrigin(app, "APP_URL") : undefined
+}
+
+function requireHttpOrigin(value: string, key: string): string {
+  let url: URL
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error(`${key} must be an absolute HTTP(S) origin`)
+  }
+
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error(`${key} must be an absolute HTTP(S) origin without a path, query, or hash`)
+  }
+
+  return url.origin
 }
 
 function resolvePublicCheckoutBaseUrl(bindings: Record<string, unknown>): string | null {

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -71,6 +71,15 @@ export const tripsVoyantModule = defineModule({
       source: "./migrations",
     },
   ],
+  config: [
+    {
+      id: "@voyant-travel/trips#config.payment-callback-base-url",
+      key: "PAYMENT_CALLBACK_BASE_URL",
+      required: false,
+      description:
+        "Public operator origin that receives payment processor callbacks; paths are rejected.",
+    },
+  ],
   access: {
     resources: [
       {

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -76,8 +76,6 @@ export const tripsVoyantModule = defineModule({
       id: "@voyant-travel/trips#config.payment-callback-base-url",
       key: "PAYMENT_CALLBACK_BASE_URL",
       required: false,
-      description:
-        "Public operator origin that receives payment processor callbacks; paths are rejected.",
     },
   ],
   access: {

--- a/packages/trips/tests/payment-callback-url.test.ts
+++ b/packages/trips/tests/payment-callback-url.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { resolvePaymentCallbackUrl } from "../src/storefront-payment-link-runtime.js"
+
+describe("payment callback URL", () => {
+  it("uses the dedicated callback origin", () => {
+    expect(
+      resolvePaymentCallbackUrl({
+        PAYMENT_CALLBACK_BASE_URL: " https://operator.example.com/ ",
+        PUBLIC_CHECKOUT_BASE_URL: "https://www.example.com/pay",
+      }),
+    ).toBe("https://operator.example.com/api/v1/public/payment-link/callback")
+  })
+
+  it("temporarily falls back to the operator dashboard or API origin", () => {
+    expect(resolvePaymentCallbackUrl({ DASH_BASE_URL: "http://localhost:3300" })).toBe(
+      "http://localhost:3300/api/v1/public/payment-link/callback",
+    )
+    expect(resolvePaymentCallbackUrl({ APP_URL: "https://operator.example.com/api" })).toBe(
+      "https://operator.example.com/api/v1/public/payment-link/callback",
+    )
+  })
+
+  it("never treats the customer-facing checkout URL as a callback origin", () => {
+    expect(
+      resolvePaymentCallbackUrl({ PUBLIC_CHECKOUT_BASE_URL: "https://www.example.com/pay" }),
+    ).toBeUndefined()
+  })
+
+  it.each([
+    "operator.example.com",
+    "ftp://operator.example.com",
+    "https://user:password@operator.example.com",
+    "https://operator.example.com/pay",
+    "https://operator.example.com?tenant=one",
+    "https://operator.example.com#callback",
+  ])("rejects a callback base that is not an HTTP(S) origin: %s", (value) => {
+    expect(() => resolvePaymentCallbackUrl({ PAYMENT_CALLBACK_BASE_URL: value })).toThrow(
+      /PAYMENT_CALLBACK_BASE_URL must be an absolute HTTP\(S\) origin/,
+    )
+  })
+})

--- a/packages/trips/tests/voyant-manifest.test.ts
+++ b/packages/trips/tests/voyant-manifest.test.ts
@@ -60,6 +60,13 @@ describe("trips deployment manifest", () => {
       ],
       schema: [{ id: "@voyant-travel/trips#schema" }],
       migrations: [{ id: "@voyant-travel/trips#migrations" }],
+      config: [
+        {
+          id: "@voyant-travel/trips#config.payment-callback-base-url",
+          key: "PAYMENT_CALLBACK_BASE_URL",
+          required: false,
+        },
+      ],
       subscribers: [
         {
           id: "@voyant-travel/trips#subscriber.payment-completed",

--- a/starters/operator/.env.example
+++ b/starters/operator/.env.example
@@ -8,6 +8,10 @@
 # origin. Match the integration application's local development port (3300).
 APP_URL="http://localhost:3300/api"
 DASH_BASE_URL="http://localhost:3300"
+# Public origin where payment processors can reach this operator's callback.
+# Set an origin only (no `/api`, `/pay`, query, or fragment). Customer-facing
+# payment links continue to use PUBLIC_CHECKOUT_BASE_URL when configured.
+PAYMENT_CALLBACK_BASE_URL="http://localhost:3300"
 EMAIL_FROM="Voyant <voyant@notifications.example.com>"
 
 # Database (Postgres). On Node the pooled node-postgres lane is the production


### PR DESCRIPTION
## What changed

- adds origin-validated `PAYMENT_CALLBACK_BASE_URL` for processor callbacks
- removes `PUBLIC_CHECKOUT_BASE_URL` as a callback fallback
- retains a temporary operator-owned fallback through `DASH_BASE_URL`, then `APP_URL`
- documents the rollout contract and adds manifest/runtime tests plus a changeset

## Why

The ProTravel website may expose payment links on a customer-facing path, while Netopia must callback directly to the managed Operator API. Deriving both from one setting can send provider callbacks to the wrong host or path.

## Impact

Checkout links remain controlled by `PUBLIC_CHECKOUT_BASE_URL`. Processor callbacks use `PAYMENT_CALLBACK_BASE_URL` and append `/api/v1/public/payment-link/callback`. Existing operator-owned URL settings remain a temporary compatibility fallback.

## Validation

- focused Trips tests passed: 21 files / 144 tests
- Trips lint passed: 58 files
- repository 8 GB typecheck and pre-push test gate passed remotely
- git diff --check passed

## Rollout note

Release this runtime package before enabling the Cloud control-plane injection in platform PR #1275. Set the callback value to the exact public managed Operator origin, never the path-prefixed storefront payment URL.
