### PR TITLE
Serialize workflow timeout in release manifests

### DIFF
--- a/packages/workflows/src/events/__tests__/manifest-builder.test.ts
+++ b/packages/workflows/src/events/__tests__/manifest-builder.test.ts
@@ -197,6 +197,32 @@ describe("buildManifest", () => {
     expect(a.versionId).not.toBe(b.versionId)
   })
 
+  test("workflow timeout is normalized into manifest metadata and identity", async () => {
+    const withoutTimeout = workflow({ id: "timeout-wf", async run() {} })
+    const a = await buildManifest({
+      environment: "production",
+      workflows: [withoutTimeout],
+      eventFilters: [],
+    })
+
+    expect(a.workflows[0]).not.toHaveProperty("timeoutMs")
+
+    __resetRegistry()
+    const withTimeout = workflow({
+      id: "timeout-wf",
+      timeout: "1h",
+      async run() {},
+    })
+    const b = await buildManifest({
+      environment: "production",
+      workflows: [withTimeout],
+      eventFilters: [],
+    })
+
+    expect(b.workflows[0]?.timeoutMs).toBe(3_600_000)
+    expect(b.versionId).not.toBe(a.versionId)
+  })
+
   test("zod schemas are converted before manifest identity is hashed", async () => {
     const bookingSchemaWorkflow = workflow({
       id: "schema-wf",

--- a/packages/workflows/src/events/manifest-builder.ts
+++ b/packages/workflows/src/events/manifest-builder.ts
@@ -18,6 +18,8 @@ import type {
   WorkflowManifestEntry,
   WorkflowReleaseCapabilities,
 } from "../protocol/index.js"
+import { durationToMs } from "../rate-limit/index.js"
+import type { Duration } from "../types.js"
 import type { ConcurrencyPolicy, ScheduleDeclaration } from "../workflow.js"
 import { canonicalJson, shortHash } from "./payload-hash.js"
 
@@ -36,7 +38,7 @@ export interface BuildManifestArgs {
       defaultRuntime?: "node"
       concurrency?: ConcurrencyPolicy<unknown>
       retry?: unknown
-      timeout?: unknown
+      timeout?: Duration
       schedule?: ScheduleDeclaration | readonly ScheduleDeclaration[]
     }
   }>
@@ -76,6 +78,7 @@ export async function buildManifest(args: BuildManifestArgs): Promise<WorkflowMa
         id: wf.id,
         displayName: displayNameFromId(wf.id),
         description: wf.config?.description,
+        ...(wf.config?.timeout === undefined ? {} : { timeoutMs: durationToMs(wf.config.timeout) }),
         capabilities: workflowCapabilities({
           hasSchedules: schedules.length > 0,
           supportsEvents: eventTargetWorkflowIds.has(wf.id),

--- a/packages/workflows/src/protocol/index.ts
+++ b/packages/workflows/src/protocol/index.ts
@@ -62,6 +62,8 @@ export interface WorkflowManifestEntry {
   id: string
   displayName?: string
   description?: string
+  /** Workflow-level compute-time budget, normalized from `WorkflowConfig.timeout`. */
+  timeoutMs?: number
   capabilities: WorkflowDefinitionCapabilities
   version: string
   inputSchema?: unknown


### PR DESCRIPTION
## Summary

- serialize each workflow's normalized timeout into manifest metadata
- include timeout metadata in manifest identity/version hashing
- expose the timeout in the workflow protocol type
- add focused manifest-builder coverage

## Why

The cloud control plane needs an immutable, validated execution budget to select the synchronous service lane or the long-running Cloud Run Job lane without exposing provider details to workflow authors.

## Impact

Existing workflows without an explicit timeout keep their current behavior. Workflows with a timeout now publish `timeoutMs` in release manifests.

## Validation

- Biome check on the three changed workflow files
- `git diff --check`

Full tests/typechecking were not run locally under the repository resource policy; CI should provide the authoritative validation.