### PR TITLE
Acknowledge managed Marketplace setup

### DIFF
--- a/.changeset/tidy-clouds-acknowledge.md
+++ b/.changeset/tidy-clouds-acknowledge.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/apps": patch
+---
+
+Add a managed-only App API setup-completion operation whose app, release, and
+runtime-installation identity comes exclusively from the verified OAuth access
+token context.

--- a/packages/apps/src/api-runtime.test.ts
+++ b/packages/apps/src/api-runtime.test.ts
@@ -30,7 +30,7 @@ function context(
       resolveAcquisitionIntent: () => Promise<null>
       createSetupHandoff: () => Promise<{ redirectUrl: string }>
       notifyInstallationLifecycle: () => Promise<void>
-      completeInstallationSetup: () => Promise<void>
+      completeInstallationSetup?: () => Promise<void>
     }
   },
 ): VoyantGraphRuntimeFactoryContext {
@@ -138,6 +138,29 @@ describe("createAppsApiModule", () => {
       error: "installation transaction reached",
     })
     expect(transaction).toHaveBeenCalledOnce()
+  })
+
+  it("keeps prior managed Marketplace ports valid without exposing setup completion", async () => {
+    const module = await createAppsApiModule(
+      context(undefined, {
+        deploymentId: "deployment-marketplace-1",
+        acquisitionResolver: {
+          resolveAcquisitionIntent: async () => null,
+          createSetupHandoff: async () => ({
+            redirectUrl: "https://app.example.com/setup?code=opaque",
+          }),
+          notifyInstallationLifecycle: async () => undefined,
+        },
+      }),
+    )
+
+    const routes = await module.lazyRoutes.load()
+    expect(routes.routes).not.toContainEqual(
+      expect.objectContaining({
+        method: "POST",
+        path: "/v1/app/marketplace/setup-completion",
+      }),
+    )
   })
 
   it("rejects conflicting managed deployment identities", async () => {

--- a/packages/apps/src/api-runtime.test.ts
+++ b/packages/apps/src/api-runtime.test.ts
@@ -30,6 +30,7 @@ function context(
       resolveAcquisitionIntent: () => Promise<null>
       createSetupHandoff: () => Promise<{ redirectUrl: string }>
       notifyInstallationLifecycle: () => Promise<void>
+      completeInstallationSetup: () => Promise<void>
     }
   },
 ): VoyantGraphRuntimeFactoryContext {
@@ -103,6 +104,7 @@ describe("createAppsApiModule", () => {
             redirectUrl: "https://app.example.com/setup?code=opaque",
           }),
           notifyInstallationLifecycle: async () => undefined,
+          completeInstallationSetup: async () => undefined,
         },
       }),
     )
@@ -158,6 +160,7 @@ describe("createAppsApiModule", () => {
                 redirectUrl: "https://app.example.com/setup?code=opaque",
               }),
               notifyInstallationLifecycle: async () => undefined,
+              completeInstallationSetup: async () => undefined,
             },
           },
         ),

--- a/packages/apps/src/api-runtime.ts
+++ b/packages/apps/src/api-runtime.ts
@@ -106,6 +106,16 @@ export const createAppsApiModule = defineGraphRuntimeFactory(
             customFieldValueOperations,
             finance,
             ...(webhookDelivery ? { webhookDelivery } : {}),
+            ...(managedMarketplace
+              ? {
+                  completeMarketplaceSetup: (context) =>
+                    managedMarketplace.acquisitionResolver.completeInstallationSetup({
+                      installationId: context.installationId,
+                      appId: context.appId,
+                      releaseId: context.releaseId,
+                    }),
+                }
+              : {}),
           }),
       },
     } satisfies ApiModule

--- a/packages/apps/src/api-runtime.ts
+++ b/packages/apps/src/api-runtime.ts
@@ -41,6 +41,8 @@ export const createAppsApiModule = defineGraphRuntimeFactory(
     const webhookDelivery = hasPort(appsWebhookDeliveryRuntimePort)
       ? await getPort<AppsWebhookDeliveryRuntime>(appsWebhookDeliveryRuntimePort)
       : undefined
+    const completeInstallationSetup =
+      managedMarketplace?.acquisitionResolver.completeInstallationSetup
     if (
       managedAuth &&
       managedMarketplace &&
@@ -106,10 +108,10 @@ export const createAppsApiModule = defineGraphRuntimeFactory(
             customFieldValueOperations,
             finance,
             ...(webhookDelivery ? { webhookDelivery } : {}),
-            ...(managedMarketplace
+            ...(completeInstallationSetup
               ? {
                   completeMarketplaceSetup: (context) =>
-                    managedMarketplace.acquisitionResolver.completeInstallationSetup({
+                    completeInstallationSetup({
                       installationId: context.installationId,
                       appId: context.appId,
                       releaseId: context.releaseId,

--- a/packages/apps/src/app-api-marketplace-setup.test.ts
+++ b/packages/apps/src/app-api-marketplace-setup.test.ts
@@ -1,0 +1,97 @@
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { Hono } from "hono"
+import { describe, expect, it, vi } from "vitest"
+
+import { createAppsAppApiRoutes } from "./app-api-routes.js"
+
+type TestEnv = {
+  Bindings: Record<string, never>
+  Variables: {
+    db: PostgresJsDatabase
+    callerType: string
+    appId: string
+    appInstallationId: string
+    appReleaseId: string
+    appTokenMode: "offline" | "online"
+    scopes: string[]
+  }
+}
+
+describe("managed Marketplace setup App API", () => {
+  it("derives every completion coordinate from the verified app token context", async () => {
+    const completeMarketplaceSetup = vi.fn(async () => undefined)
+    const app = authenticatedApp({ completeMarketplaceSetup })
+
+    const response = await app.request("/v1/app/marketplace/setup-completion", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      // Caller-selected identity fields are deliberately not parsed.
+      body: JSON.stringify({
+        appId: "app_attacker",
+        installationId: "apin_attacker",
+        releaseId: "rel_attacker",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: { acknowledged: true },
+    })
+    expect(completeMarketplaceSetup).toHaveBeenCalledWith({
+      appId: "app_1",
+      installationId: "apin_1",
+      releaseId: "rel_1",
+      tokenMode: "offline",
+      viewerId: undefined,
+      contextConstraint: undefined,
+      scopes: [],
+      apiVersion: undefined,
+    })
+  })
+
+  it("does not expose the completion operation in a self-hosted runtime", async () => {
+    const app = authenticatedApp()
+
+    const response = await app.request("/v1/app/marketplace/setup-completion", { method: "POST" })
+
+    expect(response.status).toBe(404)
+  })
+
+  it("rejects requests without an App API access-token context", async () => {
+    const completeMarketplaceSetup = vi.fn(async () => undefined)
+    const app = new Hono<TestEnv>()
+    app.use("*", async (c, next) => {
+      c.set("db", {} as PostgresJsDatabase)
+      c.set("callerType", "staff")
+      await next()
+    })
+    app.route("/", createAppsAppApiRoutes({ completeMarketplaceSetup }))
+
+    const response = await app.request("/v1/app/marketplace/setup-completion", { method: "POST" })
+
+    expect(response.status).toBe(401)
+    expect(completeMarketplaceSetup).not.toHaveBeenCalled()
+  })
+})
+
+function authenticatedApp(
+  options: {
+    completeMarketplaceSetup?: Parameters<
+      typeof createAppsAppApiRoutes
+    >[0]["completeMarketplaceSetup"]
+  } = {},
+) {
+  const app = new Hono<TestEnv>()
+  app.use("*", async (c, next) => {
+    c.set("db", {} as PostgresJsDatabase)
+    c.set("callerType", "app")
+    c.set("appId", "app_1")
+    c.set("appInstallationId", "apin_1")
+    c.set("appReleaseId", "rel_1")
+    c.set("appTokenMode", "offline")
+    c.set("scopes", [])
+    await next()
+  })
+  app.route("/", createAppsAppApiRoutes(options))
+  return app
+}

--- a/packages/apps/src/app-api-marketplace-setup.test.ts
+++ b/packages/apps/src/app-api-marketplace-setup.test.ts
@@ -24,13 +24,6 @@ describe("managed Marketplace setup App API", () => {
 
     const response = await app.request("/v1/app/marketplace/setup-completion", {
       method: "POST",
-      headers: { "content-type": "application/json" },
-      // Caller-selected identity fields are deliberately not parsed.
-      body: JSON.stringify({
-        appId: "app_attacker",
-        installationId: "apin_attacker",
-        releaseId: "rel_attacker",
-      }),
     })
 
     expect(response.status).toBe(200)
@@ -47,6 +40,24 @@ describe("managed Marketplace setup App API", () => {
       scopes: [],
       apiVersion: undefined,
     })
+  })
+
+  it("rejects caller-selected identity fields instead of parsing them", async () => {
+    const completeMarketplaceSetup = vi.fn(async () => undefined)
+    const app = authenticatedApp({ completeMarketplaceSetup })
+
+    const response = await app.request("/v1/app/marketplace/setup-completion", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        appId: "app_attacker",
+        installationId: "apin_attacker",
+        releaseId: "rel_attacker",
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(completeMarketplaceSetup).not.toHaveBeenCalled()
   })
 
   it("does not expose the completion operation in a self-hosted runtime", async () => {

--- a/packages/apps/src/app-api-marketplace-setup.test.ts
+++ b/packages/apps/src/app-api-marketplace-setup.test.ts
@@ -45,6 +45,21 @@ describe("managed Marketplace setup App API", () => {
     })
   })
 
+  it("accepts a zero-byte POST represented by an empty request stream", async () => {
+    const completeMarketplaceSetup = vi.fn(async () => undefined)
+    const app = authenticatedApp({ completeMarketplaceSetup })
+    const request = new Request("http://test/v1/app/marketplace/setup-completion", {
+      method: "POST",
+      body: "",
+    })
+
+    expect(request.body).not.toBeNull()
+    const response = await app.request(request)
+
+    expect(response.status).toBe(200)
+    expect(completeMarketplaceSetup).toHaveBeenCalledOnce()
+  })
+
   it("rejects caller-selected identity fields instead of parsing them", async () => {
     const completeMarketplaceSetup = vi.fn(async () => undefined)
     const app = authenticatedApp({ completeMarketplaceSetup })

--- a/packages/apps/src/app-api-marketplace-setup.test.ts
+++ b/packages/apps/src/app-api-marketplace-setup.test.ts
@@ -1,8 +1,11 @@
+import { handleApiError } from "@voyant-travel/hono"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { Hono } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
 import { createAppsAppApiRoutes } from "./app-api-routes.js"
+
+type RouteOptions = NonNullable<Parameters<typeof createAppsAppApiRoutes>[0]>
 
 type TestEnv = {
   Bindings: Record<string, never>
@@ -71,6 +74,7 @@ describe("managed Marketplace setup App API", () => {
   it("rejects requests without an App API access-token context", async () => {
     const completeMarketplaceSetup = vi.fn(async () => undefined)
     const app = new Hono<TestEnv>()
+    app.onError((error, c) => handleApiError(error, c))
     app.use("*", async (c, next) => {
       c.set("db", {} as PostgresJsDatabase)
       c.set("callerType", "staff")
@@ -86,13 +90,10 @@ describe("managed Marketplace setup App API", () => {
 })
 
 function authenticatedApp(
-  options: {
-    completeMarketplaceSetup?: Parameters<
-      typeof createAppsAppApiRoutes
-    >[0]["completeMarketplaceSetup"]
-  } = {},
+  options: { completeMarketplaceSetup?: RouteOptions["completeMarketplaceSetup"] } = {},
 ) {
   const app = new Hono<TestEnv>()
+  app.onError((error, c) => handleApiError(error, c))
   app.use("*", async (c, next) => {
     c.set("db", {} as PostgresJsDatabase)
     c.set("callerType", "app")

--- a/packages/apps/src/app-api-routes.ts
+++ b/packages/apps/src/app-api-routes.ts
@@ -126,6 +126,12 @@ export function createAppsAppApiRoutes(options: AppsAppApiRouteOptions = {}) {
       // The verified OAuth App API context is the sole identity input. This
       // operation intentionally has no request schema/body and no tenant-
       // supplied Cloud credential.
+      if (c.req.raw.body !== null) {
+        throw new ApiHttpError("Marketplace setup completion does not accept a request body.", {
+          status: 400,
+          code: "app_api_setup_completion_body_not_allowed",
+        })
+      }
       const context = appContext(c)
       await withAppApiDeadline(completeMarketplaceSetup(context), options.deadlineMs)
       c.header("cache-control", "no-store")

--- a/packages/apps/src/app-api-routes.ts
+++ b/packages/apps/src/app-api-routes.ts
@@ -74,11 +74,14 @@ export interface AppsAppApiRouteOptions extends AppApiServiceOptions {
   deadlineMs?: number
   maxPayloadBytes?: number
   maxFinanceArtifactBytes?: number
+  /** Managed-host acknowledgement; absent for self-hosted runtimes. */
+  completeMarketplaceSetup?: (context: AppApiAccessContext) => Promise<void>
 }
 
 export function createAppsAppApiRoutes(options: AppsAppApiRouteOptions = {}) {
   const routes = new Hono<Env>()
   const service = createAppApiService(options)
+  const completeMarketplaceSetup = options.completeMarketplaceSetup
   const maxPayloadBytes = options.maxPayloadBytes ?? 256 * 1024
   const maxFinanceArtifactBytes = options.maxFinanceArtifactBytes ?? 10 * 1024 * 1024
 
@@ -117,6 +120,18 @@ export function createAppsAppApiRoutes(options: AppsAppApiRouteOptions = {}) {
   routes.get("/self", (c) =>
     run(c, service.introspect(c.get("db"), appContext(c)), options.deadlineMs),
   )
+
+  if (completeMarketplaceSetup) {
+    routes.post("/marketplace/setup-completion", async (c) => {
+      // The verified OAuth App API context is the sole identity input. This
+      // operation intentionally has no request schema/body and no tenant-
+      // supplied Cloud credential.
+      const context = appContext(c)
+      await withAppApiDeadline(completeMarketplaceSetup(context), options.deadlineMs)
+      c.header("cache-control", "no-store")
+      return c.json({ data: { acknowledged: true as const } }, 200)
+    })
+  }
 
   routes.get("/entities/:entity", (c) => {
     const { entity } = parseEntityParams(c.req.param())

--- a/packages/apps/src/app-api-routes.ts
+++ b/packages/apps/src/app-api-routes.ts
@@ -126,7 +126,7 @@ export function createAppsAppApiRoutes(options: AppsAppApiRouteOptions = {}) {
       // The verified OAuth App API context is the sole identity input. This
       // operation intentionally has no request schema/body and no tenant-
       // supplied Cloud credential.
-      if (c.req.raw.body !== null) {
+      if (await hasRequestBodyBytes(c)) {
         throw new ApiHttpError("Marketplace setup completion does not accept a request body.", {
           status: 400,
           code: "app_api_setup_completion_body_not_allowed",
@@ -422,6 +422,29 @@ function isFinancePdfArtifactRequest(c: Context<Env>) {
     c.req.method === "PUT" &&
     /^\/v1\/app\/finance\/documents\/[^/]+\/artifacts\/provider-pdf$/.test(c.req.path)
   )
+}
+
+async function hasRequestBodyBytes(c: Context<Env>) {
+  const declaredLength = c.req.header("content-length")
+  if (declaredLength === "0") return false
+  if (declaredLength !== undefined) return true
+
+  const body = c.req.raw.body
+  if (!body) return false
+
+  const reader = body.getReader()
+  try {
+    while (true) {
+      const next = await reader.read()
+      if (next.done) return false
+      if (next.value.byteLength > 0) {
+        await reader.cancel("Marketplace setup completion does not accept a request body.")
+        return true
+      }
+    }
+  } finally {
+    reader.releaseLock()
+  }
 }
 
 function hasPdfSignature(bytes: Uint8Array) {

--- a/packages/apps/src/installation-routes.test.ts
+++ b/packages/apps/src/installation-routes.test.ts
@@ -349,6 +349,7 @@ describe.skipIf(!DB_AVAILABLE)("apps installation admin routes", () => {
             redirectUrl: "https://app.example.com/setup?code=opaque",
           }),
           notifyInstallationLifecycle,
+          completeInstallationSetup: async () => undefined,
         },
       }),
     )

--- a/packages/apps/src/runtime-contributor.test.ts
+++ b/packages/apps/src/runtime-contributor.test.ts
@@ -98,6 +98,7 @@ describe("createAppsRuntimePortContribution", () => {
             redirectUrl: "https://app.example.com/setup?code=opaque",
           }),
           notifyInstallationLifecycle: async () => undefined,
+          completeInstallationSetup: async () => undefined,
         },
       }),
     ).not.toThrow()
@@ -120,6 +121,18 @@ describe("createAppsRuntimePortContribution", () => {
     ).toThrow(/notifyInstallationLifecycle/)
     expect(() =>
       appsManagedMarketplaceRuntimePort.test({
+        deploymentId: "deployment-1",
+        acquisitionResolver: {
+          resolveAcquisitionIntent: async () => null,
+          createSetupHandoff: async () => ({
+            redirectUrl: "https://app.example.com/setup?code=opaque",
+          }),
+          notifyInstallationLifecycle: async () => undefined,
+        },
+      } as never),
+    ).toThrow(/completeInstallationSetup/)
+    expect(() =>
+      appsManagedMarketplaceRuntimePort.test({
         deploymentId: "",
         acquisitionResolver: {
           resolveAcquisitionIntent: async () => null,
@@ -127,6 +140,7 @@ describe("createAppsRuntimePortContribution", () => {
             redirectUrl: "https://app.example.com/setup?code=opaque",
           }),
           notifyInstallationLifecycle: async () => undefined,
+          completeInstallationSetup: async () => undefined,
         },
       }),
     ).toThrow(/deploymentId/)

--- a/packages/apps/src/runtime-contributor.test.ts
+++ b/packages/apps/src/runtime-contributor.test.ts
@@ -130,7 +130,7 @@ describe("createAppsRuntimePortContribution", () => {
           notifyInstallationLifecycle: async () => undefined,
         },
       } as never),
-    ).toThrow(/completeInstallationSetup/)
+    ).not.toThrow()
     expect(() =>
       appsManagedMarketplaceRuntimePort.test({
         deploymentId: "",

--- a/packages/apps/src/runtime-contributor.test.ts
+++ b/packages/apps/src/runtime-contributor.test.ts
@@ -133,6 +133,19 @@ describe("createAppsRuntimePortContribution", () => {
     ).not.toThrow()
     expect(() =>
       appsManagedMarketplaceRuntimePort.test({
+        deploymentId: "deployment-1",
+        acquisitionResolver: {
+          resolveAcquisitionIntent: async () => null,
+          createSetupHandoff: async () => ({
+            redirectUrl: "https://app.example.com/setup?code=opaque",
+          }),
+          notifyInstallationLifecycle: async () => undefined,
+          completeInstallationSetup: "not-a-function",
+        },
+      } as never),
+    ).toThrow(/completeInstallationSetup/)
+    expect(() =>
+      appsManagedMarketplaceRuntimePort.test({
         deploymentId: "",
         acquisitionResolver: {
           resolveAcquisitionIntent: async () => null,

--- a/packages/apps/src/runtime-port.ts
+++ b/packages/apps/src/runtime-port.ts
@@ -146,6 +146,17 @@ export interface ManagedMarketplaceAcquisitionResolver {
     appId: string
     releaseId: string
   }): Promise<void>
+
+  /**
+   * Acknowledge that the publisher durably stored both its Voyant OAuth token
+   * and provider credentials. Identity is supplied by the verified App API
+   * token context; publisher request bodies cannot choose these coordinates.
+   */
+  completeInstallationSetup(input: {
+    installationId: string
+    appId: string
+    releaseId: string
+  }): Promise<void>
 }
 
 export interface AppsManagedMarketplaceRuntime {
@@ -176,6 +187,11 @@ export const appsManagedMarketplaceRuntimePort = definePort<AppsManagedMarketpla
     if (typeof runtime.acquisitionResolver.notifyInstallationLifecycle !== "function") {
       throw new TypeError(
         "apps.managed-marketplace acquisitionResolver.notifyInstallationLifecycle must be a function.",
+      )
+    }
+    if (typeof runtime.acquisitionResolver.completeInstallationSetup !== "function") {
+      throw new TypeError(
+        "apps.managed-marketplace acquisitionResolver.completeInstallationSetup must be a function.",
       )
     }
   },

--- a/packages/apps/src/runtime-port.ts
+++ b/packages/apps/src/runtime-port.ts
@@ -189,5 +189,13 @@ export const appsManagedMarketplaceRuntimePort = definePort<AppsManagedMarketpla
         "apps.managed-marketplace acquisitionResolver.notifyInstallationLifecycle must be a function.",
       )
     }
+    if (
+      runtime.acquisitionResolver.completeInstallationSetup !== undefined &&
+      typeof runtime.acquisitionResolver.completeInstallationSetup !== "function"
+    ) {
+      throw new TypeError(
+        "apps.managed-marketplace acquisitionResolver.completeInstallationSetup must be a function when provided.",
+      )
+    }
   },
 })

--- a/packages/apps/src/runtime-port.ts
+++ b/packages/apps/src/runtime-port.ts
@@ -152,7 +152,7 @@ export interface ManagedMarketplaceAcquisitionResolver {
    * and provider credentials. Identity is supplied by the verified App API
    * token context; publisher request bodies cannot choose these coordinates.
    */
-  completeInstallationSetup(input: {
+  completeInstallationSetup?(input: {
     installationId: string
     appId: string
     releaseId: string
@@ -187,11 +187,6 @@ export const appsManagedMarketplaceRuntimePort = definePort<AppsManagedMarketpla
     if (typeof runtime.acquisitionResolver.notifyInstallationLifecycle !== "function") {
       throw new TypeError(
         "apps.managed-marketplace acquisitionResolver.notifyInstallationLifecycle must be a function.",
-      )
-    }
-    if (typeof runtime.acquisitionResolver.completeInstallationSetup !== "function") {
-      throw new TypeError(
-        "apps.managed-marketplace acquisitionResolver.completeInstallationSetup must be a function.",
       )
     }
   },


### PR DESCRIPTION
## What changed

- adds a managed-only App API operation for Marketplace setup completion
- derives runtime installation identity from the authenticated app token context
- validates request bodies and relays exact completion identity through the runtime port
- adds focused route, runtime-contributor, error, and rejection tests plus a changeset

## Why

Apps such as SmartBill must acknowledge setup only after credentials are durable, without accepting caller-supplied installation identity as authority. The managed runtime needs a token-context-derived completion operation to relay that acknowledgement to Voyant Cloud.

## Impact

The operation is unavailable outside managed runtime context and does not alter existing install/setup behavior until a publisher invokes it. Invalid, stale, or mismatched completion requests fail closed.

## Validation

- focused `@voyant-travel/apps` suites: 12 tests passed; 8 intentionally skipped in the existing fixture
- package typecheck passed
- package lint passed across 52 files
- git diff --check passed

## Rollout

Release `@voyant-travel/apps` first. Voyant Cloud must then bump its managed runtime dependency before deploying the completion relay and before SmartBill 0.2.0 is admitted.
