### PR TITLE
Release workflow timeout manifests

### DIFF
--- a/.changeset/workflow-timeout-manifest.md
+++ b/.changeset/workflow-timeout-manifest.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/workflows": patch
+---
+
+Serialize each workflow's configured execution timeout in generated manifests
+so hosted runtimes can enforce the authored timeout.


### PR DESCRIPTION
## What changed

- add the missing patch Changeset for `@voyant-travel/workflows`
- describe the workflow timeout manifest serialization shipped by #3627

## Why

PR #3627 merged without a Changeset. The release workflow therefore completed
without bumping or publishing the workflows fixed package group; the registry
still exposes `0.122.16`, which predates the timeout-manifest change.

Merging this PR lets the normal release flow publish the SDK change required by
platform PR voyant-travel/platform#1276.

## Validation

- `git diff --check`
- verified `packages/workflows/package.json` and the registry both remain at
  `0.122.16` after #3627
