### PR TITLE
Fix migration imports when managed profiles expand

### DIFF
--- a/.changeset/framework-migrations-profile-expansion.md
+++ b/.changeset/framework-migrations-profile-expansion.md
@@ -1,0 +1,8 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Execute a newly added migration source from the beginning when an existing
+deployment has no ledger lineage or schema footprint for that source. Partial
+or previously recorded sources remain protected by the import-baseline parity
+gate.

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -211,6 +211,23 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     expect(inserted.map(({ source, tag }) => `${source}/${tag}`)).toEqual(result.executed)
   })
 
+  it("import-baselines a fully materialized unledgered source", async () => {
+    const source = profileExpansionSource("accommodations", 8)
+    const tables = Array.from({ length: 8 }, (_, index) => `accommodations_${index}`)
+    const { client, executedCreates } = expansionClient({
+      tables,
+      columns: tables.map((table) => [table, "id"]),
+    })
+
+    const result = await runDeploymentMigrations(client, [source], {
+      accommodations: ["0000_accommodations_baseline"],
+    })
+
+    expect(result.executed).toEqual([])
+    expect(result.baselined).toEqual(["accommodations/0000_accommodations_baseline"])
+    expect(executedCreates).toEqual([])
+  })
+
   it("refuses a partially-present unledgered source instead of executing or baselining it", async () => {
     const source = profileExpansionSource("accommodations", 8)
     const firstTable = "accommodations_0"

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -117,11 +117,13 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     expect(result.existing).toBe(true)
   })
 
-  function expansionClient(options: {
-    tables?: string[]
-    columns?: Array<[string, string]>
-    recordedSources?: string[]
-  } = {}) {
+  function expansionClient(
+    options: {
+      tables?: string[]
+      columns?: Array<[string, string]>
+      recordedSources?: string[]
+    } = {},
+  ) {
     const executedCreates: string[] = []
     const inserted: Array<{ source: string; tag: string; contentHash: string }> = []
     const recordedSources = options.recordedSources ?? []
@@ -228,21 +230,24 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     expect(executedCreates).toEqual([])
   })
 
-  it("refuses a partially-present unledgered source instead of executing or baselining it", async () => {
-    const source = profileExpansionSource("accommodations", 8)
-    const firstTable = "accommodations_0"
-    const { client, executedCreates } = expansionClient({
-      tables: [firstTable],
-      columns: [[firstTable, "id"]],
-    })
+  it(
+    "refuses a partially-present unledgered source instead of executing or baselining it",
+    async () => {
+      const source = profileExpansionSource("accommodations", 8)
+      const firstTable = "accommodations_0"
+      const { client, executedCreates } = expansionClient({
+        tables: [firstTable],
+        columns: [[firstTable, "id"]],
+      })
 
-    await expect(
-      runDeploymentMigrations(client, [source], {
-        accommodations: ["0000_accommodations_baseline"],
-      }),
-    ).rejects.toThrow("7 expected table(s) missing")
-    expect(executedCreates).toEqual([])
-  })
+      await expect(
+        runDeploymentMigrations(client, [source], {
+          accommodations: ["0000_accommodations_baseline"],
+        }),
+      ).rejects.toThrow("7 expected table(s) missing")
+      expect(executedCreates).toEqual([])
+    },
+  )
 
   it("refuses an absent source with existing ledger lineage", async () => {
     const source = profileExpansionSource("accommodations", 8)

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -230,24 +230,21 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     expect(executedCreates).toEqual([])
   })
 
-  it(
-    "refuses a partially-present unledgered source instead of executing or baselining it",
-    async () => {
-      const source = profileExpansionSource("accommodations", 8)
-      const firstTable = "accommodations_0"
-      const { client, executedCreates } = expansionClient({
-        tables: [firstTable],
-        columns: [[firstTable, "id"]],
-      })
+  it("refuses a partially-present unledgered source instead of executing or baselining it", async () => {
+    const source = profileExpansionSource("accommodations", 8)
+    const firstTable = "accommodations_0"
+    const { client, executedCreates } = expansionClient({
+      tables: [firstTable],
+      columns: [[firstTable, "id"]],
+    })
 
-      await expect(
-        runDeploymentMigrations(client, [source], {
-          accommodations: ["0000_accommodations_baseline"],
-        }),
-      ).rejects.toThrow("7 expected table(s) missing")
-      expect(executedCreates).toEqual([])
-    },
-  )
+    await expect(
+      runDeploymentMigrations(client, [source], {
+        accommodations: ["0000_accommodations_baseline"],
+      }),
+    ).rejects.toThrow("7 expected table(s) missing")
+    expect(executedCreates).toEqual([])
+  })
 
   it("refuses an absent source with existing ledger lineage", async () => {
     const source = profileExpansionSource("accommodations", 8)

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -119,22 +119,26 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
 
   function expansionClient(
     options: {
+      existing?: boolean
       tables?: string[]
       columns?: Array<[string, string]>
       recordedSources?: string[]
     } = {},
   ) {
+    const queries: string[] = []
     const executedCreates: string[] = []
     const inserted: Array<{ source: string; tag: string; contentHash: string }> = []
+    const existing = options.existing ?? true
     const recordedSources = options.recordedSources ?? []
     const client: MigrationClient = {
       async query(sql: string, params: unknown[] = []) {
+        queries.push(sql)
         if (sql.startsWith("SELECT to_regclass")) {
           return { rows: [{ reg: String(params[0]) }] }
         }
         if (sql.includes("count(*)")) {
           if (sql.includes('"drizzle"."__drizzle_migrations"')) {
-            return { rows: [{ n: "45" }] }
+            return { rows: [{ n: existing ? "45" : "0" }] }
           }
           return { rows: [{ n: "0" }] }
         }
@@ -166,7 +170,7 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
         return { rows: [] }
       },
     }
-    return { client, executedCreates, inserted }
+    return { client, executedCreates, inserted, queries }
   }
 
   function profileExpansionSource(name: string, tableCount: number): MigrationSource {
@@ -213,27 +217,31 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     expect(inserted.map(({ source, tag }) => `${source}/${tag}`)).toEqual(result.executed)
   })
 
-  it("import-baselines a fully materialized unledgered source", async () => {
-    const source = profileExpansionSource("accommodations", 8)
-    const tables = Array.from({ length: 8 }, (_, index) => `accommodations_${index}`)
-    const { client, executedCreates } = expansionClient({
-      tables,
-      columns: tables.map((table) => [table, "id"]),
+  it("import-baselines a fully-present unledgered source when an existing profile expands", async () => {
+    const source = profileExpansionSource("accommodations", 2)
+    const { client, executedCreates, inserted } = expansionClient({
+      tables: ["accommodations_0", "accommodations_1"],
+      columns: [
+        ["accommodations_0", "id"],
+        ["accommodations_1", "id"],
+      ],
     })
 
     const result = await runDeploymentMigrations(client, [source], {
       accommodations: ["0000_accommodations_baseline"],
     })
 
+    expect(result.existing).toBe(true)
     expect(result.executed).toEqual([])
     expect(result.baselined).toEqual(["accommodations/0000_accommodations_baseline"])
     expect(executedCreates).toEqual([])
+    expect(inserted.map(({ source, tag }) => `${source}/${tag}`)).toEqual(result.baselined)
   })
 
   it("refuses a partially-present unledgered source instead of executing or baselining it", async () => {
     const source = profileExpansionSource("accommodations", 8)
     const firstTable = "accommodations_0"
-    const { client, executedCreates } = expansionClient({
+    const { client, executedCreates, queries } = expansionClient({
       tables: [firstTable],
       columns: [[firstTable, "id"]],
     })
@@ -244,12 +252,27 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
       }),
     ).rejects.toThrow("7 expected table(s) missing")
     expect(executedCreates).toEqual([])
+    expect(queries[0]).toContain("pg_advisory_lock")
+    expect(queries.some((sql) => sql.startsWith("CREATE SCHEMA"))).toBe(false)
+    expect(queries.some((sql) => sql.startsWith("INSERT INTO"))).toBe(false)
+    expect(queries.some((sql) => sql === "BEGIN")).toBe(false)
+    expect(queries.at(-1)).toContain("pg_advisory_unlock")
   })
 
-  it("refuses an absent source with existing ledger lineage", async () => {
-    const source = profileExpansionSource("accommodations", 8)
+  it.each([
+    ["stable", undefined, "accommodations"],
+    [
+      "legacy",
+      ["schema:@voyant-travel/accommodations#migrations"],
+      "schema:@voyant-travel/accommodations#migrations",
+    ],
+  ] as const)("refuses an absent source with existing %s ledger lineage", async (_kind, legacyNames, recordedSource) => {
+    const source = {
+      ...profileExpansionSource("accommodations", 8),
+      ...(legacyNames ? { legacyNames } : {}),
+    }
     const { client, executedCreates } = expansionClient({
-      recordedSources: ["accommodations"],
+      recordedSources: [recordedSource],
     })
 
     await expect(
@@ -258,6 +281,50 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
       }),
     ).rejects.toThrow("8 expected table(s) missing")
     expect(executedCreates).toEqual([])
+  })
+
+  it("keeps fresh databases on the normal execute-from-scratch path", async () => {
+    const source = profileExpansionSource("accommodations", 2)
+    const { client, executedCreates } = expansionClient({ existing: false })
+
+    const result = await runDeploymentMigrations(client, [source], {
+      accommodations: ["0000_accommodations_baseline"],
+    })
+
+    expect(result.existing).toBe(false)
+    expect(result.baselined).toEqual([])
+    expect(result.executed).toEqual(["accommodations/0000_accommodations_baseline"])
+    expect(executedCreates).toHaveLength(2)
+  })
+
+  it("still import-baselines cutline rows and executes post-cutline increments", async () => {
+    const source: MigrationSource = {
+      ...profileExpansionSource("accommodations", 1),
+      migrations: [
+        {
+          tag: "0000_accommodations_baseline",
+          sql: 'CREATE TABLE "accommodations_0" (\n\t"id" text PRIMARY KEY NOT NULL\n);',
+        },
+        {
+          tag: "0001_accommodations_increment",
+          sql: 'CREATE TABLE "accommodations_increment" (\n\t"id" text PRIMARY KEY NOT NULL\n);',
+        },
+      ],
+    }
+    const { client, executedCreates } = expansionClient({
+      tables: ["accommodations_0"],
+      columns: [["accommodations_0", "id"]],
+    })
+
+    const result = await runDeploymentMigrations(client, [source], {
+      accommodations: ["0000_accommodations_baseline"],
+    })
+
+    expect(result.baselined).toEqual(["accommodations/0000_accommodations_baseline"])
+    expect(result.executed).toEqual(["accommodations/0001_accommodations_increment"])
+    expect(executedCreates).toEqual([
+      'CREATE TABLE "accommodations_increment" (\n\t"id" text PRIMARY KEY NOT NULL\n);',
+    ])
   })
 })
 

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -116,6 +116,130 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
     const result = await runDeploymentMigrations(client, sources, cutline)
     expect(result.existing).toBe(true)
   })
+
+  function expansionClient(options: {
+    tables?: string[]
+    columns?: Array<[string, string]>
+    recordedSources?: string[]
+  } = {}) {
+    const executedCreates: string[] = []
+    const inserted: Array<{ source: string; tag: string; contentHash: string }> = []
+    const recordedSources = options.recordedSources ?? []
+    const client: MigrationClient = {
+      async query(sql: string, params: unknown[] = []) {
+        if (sql.startsWith("SELECT to_regclass")) {
+          return { rows: [{ reg: String(params[0]) }] }
+        }
+        if (sql.includes("count(*)")) {
+          if (sql.includes('"drizzle"."__drizzle_migrations"')) {
+            return { rows: [{ n: "45" }] }
+          }
+          return { rows: [{ n: "0" }] }
+        }
+        if (sql.includes('SELECT DISTINCT "source"')) {
+          return { rows: recordedSources.map((source) => ({ source })) }
+        }
+        if (sql.includes('SELECT "source", "tag" FROM')) return { rows: [] }
+        if (sql.includes('SELECT "content_hash", "source" FROM')) return { rows: [] }
+        if (sql.includes("information_schema.tables")) {
+          return { rows: (options.tables ?? []).map((table_name) => ({ table_name })) }
+        }
+        if (sql.includes("information_schema.columns")) {
+          return {
+            rows: (options.columns ?? []).map(([table_name, column_name]) => ({
+              table_name,
+              column_name,
+            })),
+          }
+        }
+        if (sql.includes("pg_constraint")) return { rows: [] }
+        if (sql.startsWith('CREATE TABLE "')) executedCreates.push(sql)
+        if (sql.startsWith("INSERT INTO") && params.length === 3) {
+          inserted.push({
+            source: String(params[0]),
+            tag: String(params[1]),
+            contentHash: String(params[2]),
+          })
+        }
+        return { rows: [] }
+      },
+    }
+    return { client, executedCreates, inserted }
+  }
+
+  function profileExpansionSource(name: string, tableCount: number): MigrationSource {
+    return {
+      name,
+      priority: 1,
+      migrations: [
+        {
+          tag: `0000_${name}_baseline`,
+          sql: Array.from(
+            { length: tableCount },
+            (_, index) =>
+              `CREATE TABLE "${name.replaceAll("-", "_")}_${index}" (\n\t"id" text PRIMARY KEY NOT NULL\n);`,
+          ).join("\n--> statement-breakpoint\n"),
+        },
+      ],
+    }
+  }
+
+  it("executes wholly-absent unledgered sources when an existing profile expands", async () => {
+    // Mirrors ProTravel's managed-profile delta exactly: accommodations adds
+    // eight cutline tables, charters seven, and cruises nineteen. None of the
+    // three sources or tables existed in the tenant before the profile grew.
+    const sources = [
+      profileExpansionSource("accommodations", 8),
+      profileExpansionSource("charters", 7),
+      profileExpansionSource("cruises", 19),
+    ]
+    const cutline = Object.fromEntries(
+      sources.map((source) => [source.name, [source.migrations[0]?.tag as string]]),
+    )
+    const { client, executedCreates, inserted } = expansionClient()
+
+    const result = await runDeploymentMigrations(client, sources, cutline)
+
+    expect(result.existing).toBe(true)
+    expect(result.baselined).toEqual([])
+    expect(result.executed).toEqual([
+      "accommodations/0000_accommodations_baseline",
+      "charters/0000_charters_baseline",
+      "cruises/0000_cruises_baseline",
+    ])
+    expect(executedCreates).toHaveLength(8 + 7 + 19)
+    expect(inserted.map(({ source, tag }) => `${source}/${tag}`)).toEqual(result.executed)
+  })
+
+  it("refuses a partially-present unledgered source instead of executing or baselining it", async () => {
+    const source = profileExpansionSource("accommodations", 8)
+    const firstTable = "accommodations_0"
+    const { client, executedCreates } = expansionClient({
+      tables: [firstTable],
+      columns: [[firstTable, "id"]],
+    })
+
+    await expect(
+      runDeploymentMigrations(client, [source], {
+        accommodations: ["0000_accommodations_baseline"],
+      }),
+    ).rejects.toThrow("7 expected table(s) missing")
+    expect(executedCreates).toEqual([])
+  })
+
+  it("refuses an absent source with existing ledger lineage", async () => {
+    const source = profileExpansionSource("accommodations", 8)
+    const { client, executedCreates } = expansionClient({
+      recordedSources: ["accommodations"],
+    })
+
+    await expect(
+      runDeploymentMigrations(client, [source], {
+        accommodations: ["0000_accommodations_baseline"],
+      }),
+    ).rejects.toThrow("8 expected table(s) missing")
+    expect(executedCreates).toEqual([])
+  })
 })
 
 describe("detectExisting", () => {

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -57,6 +57,33 @@ async function recordedCollectorSources(client: MigrationClient): Promise<Set<st
   return new Set(rows.rows.map((row) => String(row.source)))
 }
 
+const deploymentMigrationLockKey = "voyant.framework-migrations.runDeploymentMigrations"
+
+async function withDeploymentMigrationLock<T>(
+  client: MigrationClient,
+  run: () => Promise<T>,
+): Promise<T> {
+  await client.query(`SELECT pg_advisory_lock(hashtextextended($1::text, 0))`, [
+    deploymentMigrationLockKey,
+  ])
+  const unlock = () =>
+    client.query(`SELECT pg_advisory_unlock(hashtextextended($1::text, 0))`, [
+      deploymentMigrationLockKey,
+    ])
+  try {
+    const result = await run()
+    await unlock()
+    return result
+  } catch (error) {
+    try {
+      await unlock()
+    } catch {
+      // Preserve the migration failure; the session will close and release locks.
+    }
+    throw error
+  }
+}
+
 /**
  * EXISTING when the retired monolithic bundle or the legacy runner already materialised
  * this schema: a `framework/*` collector-ledger row, or the pre-collector
@@ -336,46 +363,48 @@ export async function runDeploymentMigrations(
   cutline: Cutline,
   hooks?: { onApplied?: (id: string) => void; onBaselined?: (id: string) => void },
 ): Promise<RunResult> {
-  const existing = await detectExisting(client)
-  let effectiveCutline = cutline
-  if (existing) {
-    // Parity-gate only the cutline entries this run will import-baseline;
-    // already-recorded entries' objects may have been legitimately reshaped by
-    // applied post-cutline migrations.
-    const pending = await withoutRecordedMigrations(client, cutlineCovered(sources, cutline))
-    if (pending.length > 0) {
-      const [recordedSources, live] = await Promise.all([
-        recordedCollectorSources(client),
-        readLiveSchema(client),
-      ])
-      const pendingNames = new Set(pending.map((source) => source.name))
-      const expandingSources = new Set(
-        sources
-          .filter((source) => pendingNames.has(source.name))
-          .filter((source) =>
-            [source.name, ...(source.legacyNames ?? [])].every(
-              (name) => !recordedSources.has(name),
-            ),
-          )
-          .filter((source) => isWhollyAbsentSource(source, live))
-          .map((source) => source.name),
-      )
-      const baselinePending = pending.filter((source) => !expandingSources.has(source.name))
-      if (baselinePending.length > 0) {
-        await assertSchemaAtBaseline(client, baselinePending)
-      }
-      if (expandingSources.size > 0) {
-        effectiveCutline = Object.fromEntries(
-          Object.entries(cutline).filter(([source]) => !expandingSources.has(source)),
+  return withDeploymentMigrationLock(client, async () => {
+    const existing = await detectExisting(client)
+    let effectiveCutline = cutline
+    if (existing) {
+      // Parity-gate only the cutline entries this run will import-baseline;
+      // already-recorded entries' objects may have been legitimately reshaped by
+      // applied post-cutline migrations.
+      const pending = await withoutRecordedMigrations(client, cutlineCovered(sources, cutline))
+      if (pending.length > 0) {
+        const [recordedSources, live] = await Promise.all([
+          recordedCollectorSources(client),
+          readLiveSchema(client),
+        ])
+        const pendingNames = new Set(pending.map((source) => source.name))
+        const expandingSources = new Set(
+          sources
+            .filter((source) => pendingNames.has(source.name))
+            .filter((source) =>
+              [source.name, ...(source.legacyNames ?? [])].every(
+                (name) => !recordedSources.has(name),
+              ),
+            )
+            .filter((source) => isWhollyAbsentSource(source, live))
+            .map((source) => source.name),
         )
+        const baselinePending = pending.filter((source) => !expandingSources.has(source.name))
+        if (baselinePending.length > 0) {
+          await assertSchemaAtBaseline(client, baselinePending)
+        }
+        if (expandingSources.size > 0) {
+          effectiveCutline = Object.fromEntries(
+            Object.entries(cutline).filter(([source]) => !expandingSources.has(source)),
+          )
+        }
       }
     }
-  }
-  const { executed, baselined } = await applyMigrations(client, sources, {
-    cutline: effectiveCutline,
-    existing,
-    onApplied: hooks?.onApplied,
-    onBaselined: hooks?.onBaselined,
+    const { executed, baselined } = await applyMigrations(client, sources, {
+      cutline: effectiveCutline,
+      existing,
+      onApplied: hooks?.onApplied,
+      onBaselined: hooks?.onBaselined,
+    })
+    return { existing, executed, baselined }
   })
-  return { existing, executed, baselined }
 }

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -6,10 +6,12 @@
  *   1. detects whether the database is FRESH or an EXISTING pre-collector deployment
  *      (a `framework/*` ledger row from the retired monolithic bundle, or the legacy
  *      `drizzle.__drizzle_migrations`);
- *   2. on EXISTING, gates the import-baseline with a schema-parity check over
- *      exactly the cutline-covered migrations (so we never record a baseline the
- *      DB doesn't actually have);
- *   3. runs {@link applyMigrations}.
+ *   2. on EXISTING, executes a newly-added source from the beginning only when
+ *      it has no ledger lineage and its whole schema footprint is absent;
+ *   3. gates every other import-baseline with a schema-parity check over exactly
+ *      the cutline-covered migrations (so we never record a baseline the DB
+ *      doesn't actually have);
+ *   4. runs {@link applyMigrations}.
  *
  * Free of dotenv/config/process concerns so it can be driven against an
  * arbitrary database in tests. See docs/architecture/migration-collector-d2.md.

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -42,18 +42,34 @@ async function ledgerRowCount(
   return Number((count.rows[0]?.n as string | undefined) ?? 0)
 }
 
+const collectorLedger =
+  `"${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}".` +
+  `"${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}"`
+
+async function recordedCollectorSources(client: MigrationClient): Promise<Set<string>> {
+  const exists = await client.query(`SELECT to_regclass($1) AS reg`, [
+    `${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}.${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}`,
+  ])
+  if (!exists.rows[0]?.reg) return new Set()
+  const rows = await client.query(`SELECT DISTINCT "source" FROM ${collectorLedger}`)
+  return new Set(rows.rows.map((row) => String(row.source)))
+}
+
 /**
  * EXISTING when the retired monolithic bundle or the legacy runner already materialised
  * this schema: a `framework/*` collector-ledger row, or the pre-collector
  * `drizzle.__drizzle_migrations` table. Else FRESH.
  */
 export async function detectExisting(client: MigrationClient): Promise<boolean> {
-  const ledger = `"${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}"."${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}"`
-  const frameworkRows = await ledgerRowCount(client, ledger, `"source" = 'framework'`)
+  const frameworkRows = await ledgerRowCount(
+    client,
+    collectorLedger,
+    `"source" = 'framework'`,
+  )
   if (frameworkRows > 0) return true
   const graphSchemaRows = await ledgerRowCount(
     client,
-    ledger,
+    collectorLedger,
     `"source" LIKE 'schema:%#migrations'`,
   )
   if (graphSchemaRows > 0) return true
@@ -66,6 +82,52 @@ interface ExpectedSchema {
   dropped: Set<string>
   columns: Set<string>
   droppedConstraints: Set<string>
+}
+
+interface LiveSchema {
+  tables: Set<string>
+  columns: Set<string>
+  constraints: Set<string>
+}
+
+async function readLiveSchema(client: MigrationClient): Promise<LiveSchema> {
+  const liveTablesRows = await client.query(
+    `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`,
+  )
+  const liveColsRows = await client.query(
+    `SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public'`,
+  )
+  const liveConstraintRows = await client.query(
+    `SELECT c.conname FROM pg_constraint c
+       JOIN pg_namespace n ON n.oid = c.connamespace
+      WHERE n.nspname = 'public'`,
+  )
+  return {
+    tables: new Set(liveTablesRows.rows.map((row) => String(row.table_name))),
+    columns: new Set(
+      liveColsRows.rows.map((row) => `${String(row.table_name)}.${String(row.column_name)}`),
+    ),
+    constraints: new Set(liveConstraintRows.rows.map((row) => String(row.conname))),
+  }
+}
+
+/**
+ * A source may join an existing deployment when a managed profile expands.
+ * It is safe to execute that source from the beginning only when it has no
+ * ledger lineage and its entire schema footprint is absent. Anything partial
+ * stays on the ordinary parity-gated baseline path and is rejected there.
+ */
+function isWhollyAbsentSource(source: MigrationSource, live: LiveSchema): boolean {
+  const expected = expectedSchema([source])
+  if (expected.tables.size === 0) return false
+  return (
+    [...expected.tables].every((table) => !live.tables.has(table)) &&
+    [...expected.columns].every((column) => !live.columns.has(column)) &&
+    [...expected.dropped].every((table) => !live.tables.has(table)) &&
+    [...expected.droppedConstraints].every(
+      (constraint) => !live.constraints.has(constraint),
+    )
+  )
 }
 
 /**
@@ -189,28 +251,13 @@ export async function assertSchemaAtBaseline(
 ): Promise<void> {
   const expected = expectedSchema(sources)
 
-  const liveTablesRows = await client.query(
-    `SELECT table_name FROM information_schema.tables WHERE table_schema = 'public'`,
-  )
-  const liveTables = new Set(liveTablesRows.rows.map((r) => r.table_name as string))
-  const liveColsRows = await client.query(
-    `SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public'`,
-  )
-  const liveColumns = new Set(
-    liveColsRows.rows.map((r) => `${r.table_name as string}.${r.column_name as string}`),
-  )
-  const liveConstraintRows = await client.query(
-    `SELECT c.conname FROM pg_constraint c
-       JOIN pg_namespace n ON n.oid = c.connamespace
-      WHERE n.nspname = 'public'`,
-  )
-  const liveConstraints = new Set(liveConstraintRows.rows.map((r) => r.conname as string))
+  const live = await readLiveSchema(client)
 
-  const missingTables = [...expected.tables].filter((t) => !liveTables.has(t)).sort()
-  const missingColumns = [...expected.columns].filter((c) => !liveColumns.has(c)).sort()
-  const lingeringDropped = [...expected.dropped].filter((t) => liveTables.has(t)).sort()
+  const missingTables = [...expected.tables].filter((t) => !live.tables.has(t)).sort()
+  const missingColumns = [...expected.columns].filter((c) => !live.columns.has(c)).sort()
+  const lingeringDropped = [...expected.dropped].filter((t) => live.tables.has(t)).sort()
   const lingeringConstraints = [...expected.droppedConstraints]
-    .filter((c) => liveConstraints.has(c))
+    .filter((c) => live.constraints.has(c))
     .sort()
 
   const problems: string[] = []
@@ -267,8 +314,11 @@ async function withoutRecordedMigrations(
   sources: MigrationSource[],
 ): Promise<MigrationSource[]> {
   if (sources.length === 0) return sources
-  const ledger = `"${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}"."${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}"`
-  const recordedRows = await client.query(`SELECT "source", "tag" FROM ${ledger}`)
+  const ledgerExists = await client.query(`SELECT to_regclass($1) AS reg`, [
+    `${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}.${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}`,
+  ])
+  if (!ledgerExists.rows[0]?.reg) return sources
+  const recordedRows = await client.query(`SELECT "source", "tag" FROM ${collectorLedger}`)
   const recorded = new Set(
     recordedRows.rows.map((row) => `${row.source as string}\0${row.tag as string}`),
   )
@@ -291,15 +341,44 @@ export async function runDeploymentMigrations(
   hooks?: { onApplied?: (id: string) => void; onBaselined?: (id: string) => void },
 ): Promise<RunResult> {
   const existing = await detectExisting(client)
+  let effectiveCutline = cutline
   if (existing) {
     // Parity-gate only the cutline entries this run will import-baseline;
     // already-recorded entries' objects may have been legitimately reshaped by
     // applied post-cutline migrations.
     const pending = await withoutRecordedMigrations(client, cutlineCovered(sources, cutline))
-    if (pending.length > 0) await assertSchemaAtBaseline(client, pending)
+    if (pending.length > 0) {
+      const [recordedSources, live] = await Promise.all([
+        recordedCollectorSources(client),
+        readLiveSchema(client),
+      ])
+      const pendingNames = new Set(pending.map((source) => source.name))
+      const expandingSources = new Set(
+        sources
+          .filter((source) => pendingNames.has(source.name))
+          .filter((source) =>
+            [source.name, ...(source.legacyNames ?? [])].every(
+              (name) => !recordedSources.has(name),
+            ),
+          )
+          .filter((source) => isWhollyAbsentSource(source, live))
+          .map((source) => source.name),
+      )
+      const baselinePending = pending.filter(
+        (source) => !expandingSources.has(source.name),
+      )
+      if (baselinePending.length > 0) {
+        await assertSchemaAtBaseline(client, baselinePending)
+      }
+      if (expandingSources.size > 0) {
+        effectiveCutline = Object.fromEntries(
+          Object.entries(cutline).filter(([source]) => !expandingSources.has(source)),
+        )
+      }
+    }
   }
   const { executed, baselined } = await applyMigrations(client, sources, {
-    cutline,
+    cutline: effectiveCutline,
     existing,
     onApplied: hooks?.onApplied,
     onBaselined: hooks?.onBaselined,

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -63,11 +63,7 @@ async function recordedCollectorSources(client: MigrationClient): Promise<Set<st
  * `drizzle.__drizzle_migrations` table. Else FRESH.
  */
 export async function detectExisting(client: MigrationClient): Promise<boolean> {
-  const frameworkRows = await ledgerRowCount(
-    client,
-    collectorLedger,
-    `"source" = 'framework'`,
-  )
+  const frameworkRows = await ledgerRowCount(client, collectorLedger, `"source" = 'framework'`)
   if (frameworkRows > 0) return true
   const graphSchemaRows = await ledgerRowCount(
     client,
@@ -126,9 +122,7 @@ function isWhollyAbsentSource(source: MigrationSource, live: LiveSchema): boolea
     [...expected.tables].every((table) => !live.tables.has(table)) &&
     [...expected.columns].every((column) => !live.columns.has(column)) &&
     [...expected.dropped].every((table) => !live.tables.has(table)) &&
-    [...expected.droppedConstraints].every(
-      (constraint) => !live.constraints.has(constraint),
-    )
+    [...expected.droppedConstraints].every((constraint) => !live.constraints.has(constraint))
   )
 }
 
@@ -366,9 +360,7 @@ export async function runDeploymentMigrations(
           .filter((source) => isWhollyAbsentSource(source, live))
           .map((source) => source.name),
       )
-      const baselinePending = pending.filter(
-        (source) => !expandingSources.has(source.name),
-      )
+      const baselinePending = pending.filter((source) => !expandingSources.has(source.name))
       if (baselinePending.length > 0) {
         await assertSchemaAtBaseline(client, baselinePending)
       }


### PR DESCRIPTION
## What changed

- detect cutline sources that are completely new to an existing deployment
- execute a source from the beginning only when neither its stable nor legacy ledger lineage exists and its complete schema footprint is absent
- preserve import-baseline behavior for fully materialized sources
- keep partial schemas and ledger/schema mismatches behind the existing parity failure
- serialize detection, classification, and application with a session advisory lock
- handle legacy databases whose collector ledger table has not been created yet
- add a patch changeset

## Why

The ProTravel managed-runtime rehearsal reached the collector with a valid 70-row package/deployment ledger, but the managed standard profile adds three schema-owning packages that the source deployment never selected. Their cutline footprints are wholly absent:

- accommodations: 8 tables / 123 columns
- charters: 7 tables / 144 columns
- cruises: 19 tables / 348 columns

That is exactly the migration failure: 34 tables / 615 columns. The existing global `existing=true` mode incorrectly tried to import-baseline these brand-new sources and rejected the database for not already containing them.

## Safety

The source-from-scratch path is intentionally narrow. Any partial table/column footprint or any existing stable/legacy source lineage stays on the parity-gated baseline path and fails before migration SQL runs. A database-scoped session advisory lock prevents overlapping runners from racing the absence check. Fresh and incremental databases retain their current paths.

## Checks

- high-effort remote review
- focused Biome lint: passed
- focused TypeScript typecheck: passed
- framework-migrations tests: 46 passed, 11 skipped
- full remote pre-push test graph: 118/118 tasks passed
- Depot CI checks, DB integration, DB replay, DB union, package artifacts, packaged acceptance, build, build graph, and node smoke: passed
- gitleaks and Socket Security: passed

The disposable rehearsal database has not been modified; it will only be retried using a released runtime artifact containing this change.