### PR TITLE
Add Redis namespace and TCP runtime support

### DIFF
--- a/.changeset/regional-redis-namespace.md
+++ b/.changeset/regional-redis-namespace.md
@@ -5,10 +5,13 @@
 ---
 
 Add framework-owned Redis namespacing for managed regional cache and rate-limit
-state. Redis KV and rate-limit adapters now accept an optional `keyPrefix`,
-deployment/runtime Redis URL validation matches the Upstash-compatible REST URL
-contract, and the Node runtime wires `REDIS_NAMESPACE` to
-`voyant:v1:<namespace>:cache:` and `voyant:v1:<namespace>:rate:` prefixes while
-keeping managed shared state on Postgres by default. Self-hosted deployments
-that explicitly select Redis for shared state and provide `REDIS_NAMESPACE` now
-use the distinct `voyant:v1:<namespace>:state:` prefix.
+state, plus a Node-only persistent TCP Redis adapter in the Framework boundary.
+Redis KV and rate-limit adapters still preserve the Upstash-compatible HTTP(S)
+REST path for edge and self-hosted consumers. Resident Node now accepts
+`redis://` and `rediss://` TCP Redis URLs in addition to HTTP(S) REST, reuses
+one lazy Redis client across cache, shared-state, and rate-limit roles, and
+wires `REDIS_NAMESPACE` to `voyant:v1:<namespace>:cache:`,
+`voyant:v1:<namespace>:state:`, and `voyant:v1:<namespace>:rate:` prefixes.
+Managed Cloud requires `REDIS_NAMESPACE` for every Redis role, requires
+`rediss://` for TCP while retaining HTTPS REST compatibility, rejects plaintext
+`redis://`, and keeps managed shared state on Postgres by default.

--- a/.changeset/regional-redis-namespace.md
+++ b/.changeset/regional-redis-namespace.md
@@ -1,0 +1,14 @@
+---
+"@voyant-travel/framework": minor
+"@voyant-travel/hono": minor
+"@voyant-travel/utils": minor
+---
+
+Add framework-owned Redis namespacing for managed regional cache and rate-limit
+state. Redis KV and rate-limit adapters now accept an optional `keyPrefix`,
+deployment/runtime Redis URL validation matches the Upstash-compatible REST URL
+contract, and the Node runtime wires `REDIS_NAMESPACE` to
+`voyant:v1:<namespace>:cache:` and `voyant:v1:<namespace>:rate:` prefixes while
+keeping managed shared state on Postgres by default. Self-hosted deployments
+that explicitly select Redis for shared state and provide `REDIS_NAMESPACE` now
+use the distinct `voyant:v1:<namespace>:state:` prefix.

--- a/docs/adr/0001-tenant-scoping.md
+++ b/docs/adr/0001-tenant-scoping.md
@@ -51,11 +51,13 @@ inherit the same model.
 ## Redis cache and rate-limit namespace exception
 
 Managed Cloud may consolidate Redis-backed **cache** and **rate-limit** state
-onto a regional Upstash-compatible REST Redis service. Those records are
-non-authoritative: cache entries can be recomputed, and rate-limit counters are
-traffic brakes rather than customer data. The framework-owned Node runtime
-therefore accepts a deployment-static `REDIS_NAMESPACE` and prefixes managed
-Redis keys as:
+onto a regional Redis service. The framework-owned Node runtime accepts
+`rediss://` TCP Redis and HTTPS Redis REST for managed deployments; it rejects
+plaintext `redis://`. Those records are non-authoritative: cache entries can be
+recomputed, and rate-limit counters are traffic brakes rather than customer
+data. The framework-owned Node runtime therefore requires a deployment-static
+`REDIS_NAMESPACE` for every managed Redis role and prefixes managed Redis keys
+as:
 
 - `voyant:v1:<namespace>:cache:`
 - `voyant:v1:<namespace>:rate:`

--- a/docs/adr/0001-tenant-scoping.md
+++ b/docs/adr/0001-tenant-scoping.md
@@ -38,11 +38,38 @@ Concretely, this means:
   for the purpose of filtering.
 - Domain modules MAY include an `organizationId` column for reporting
   or grouping, but the framework does not enforce it at the query layer.
+- Non-authoritative Redis cache and rate-limit state MAY share a managed
+  regional Redis substrate when keys are prefixed by an immutable deployment
+  identity. This namespace is deployment-static infrastructure configuration,
+  not per-request organization scoping.
 
 When asked "how is one customer's data isolated from another customer's?"
 the answer is: **separate Postgres database, separate compute runtime.**
 Voyant Cloud's provisioning is the enforcement; customers self-hosting
 inherit the same model.
+
+## Redis cache and rate-limit namespace exception
+
+Managed Cloud may consolidate Redis-backed **cache** and **rate-limit** state
+onto a regional Upstash-compatible REST Redis service. Those records are
+non-authoritative: cache entries can be recomputed, and rate-limit counters are
+traffic brakes rather than customer data. The framework-owned Node runtime
+therefore accepts a deployment-static `REDIS_NAMESPACE` and prefixes managed
+Redis keys as:
+
+- `voyant:v1:<namespace>:cache:`
+- `voyant:v1:<namespace>:rate:`
+
+`<namespace>` is an immutable deployment identity assigned by provisioning. It
+is not read from requests, sessions, headers, database rows, or organization
+ids, and package code must not derive tenant filters from it. Authoritative
+state remains governed by the deployment-boundary model above; managed Cloud
+uses Postgres for shared state by default. Self-hosted deployments may still
+choose Redis for shared state explicitly; when they also provide
+`REDIS_NAMESPACE`, the Node runtime uses the distinct
+`voyant:v1:<namespace>:state:` prefix for that shared-state store. That is the
+self-hoster's infrastructure contract rather than a framework-provided
+shared-tenant isolation mechanism.
 
 ## Consequences
 

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -48,10 +48,14 @@ workload class well. On Node none of it is necessary.
   the graph-selected provider; their mere presence must not change provider
   choice. There is no `caches.default` shim (the public-cache middleware reads
   `env.CACHE` directly).
-  Redis-backed Node providers use the single `REDIS_URL` contract, which is an
-  Upstash-compatible HTTP(S) Redis REST URL with a token. HTTP is accepted for
-  local and self-hosted deployments; managed Cloud requires HTTPS. Managed
-  Cloud also supplies a deployment-static `REDIS_NAMESPACE`; the runtime
+  Redis-backed Node providers use the single `REDIS_URL` contract. Resident
+  Node accepts `redis://` and `rediss://` TCP URLs plus the existing
+  Upstash-compatible HTTP(S) REST URL with a token; Worker and shared utility
+  consumers keep using the REST adapter only. Managed Cloud rejects plaintext
+  `redis://` and requires `rediss://` for TCP, while HTTPS REST remains
+  accepted for compatibility. Local and self-hosted deployments may use
+  `redis://`, `rediss://`, HTTP, or HTTPS. Managed Cloud also requires a
+  deployment-static `REDIS_NAMESPACE` for every Redis role; the runtime
   prefixes cache keys with `voyant:v1:<namespace>:cache:` and rate-limit
   counters with `voyant:v1:<namespace>:rate:`. Managed Cloud keeps
   authoritative shared state on Postgres by default. If a self-hosted

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -48,6 +48,17 @@ workload class well. On Node none of it is necessary.
   the graph-selected provider; their mere presence must not change provider
   choice. There is no `caches.default` shim (the public-cache middleware reads
   `env.CACHE` directly).
+  Redis-backed Node providers use the single `REDIS_URL` contract, which is an
+  Upstash-compatible HTTP(S) Redis REST URL with a token. HTTP is accepted for
+  local and self-hosted deployments; managed Cloud requires HTTPS. Managed
+  Cloud also supplies a deployment-static `REDIS_NAMESPACE`; the runtime
+  prefixes cache keys with `voyant:v1:<namespace>:cache:` and rate-limit
+  counters with `voyant:v1:<namespace>:rate:`. Managed Cloud keeps
+  authoritative shared state on Postgres by default. If a self-hosted
+  deployment intentionally selects Redis for shared state and provides
+  `REDIS_NAMESPACE`, the runtime uses `voyant:v1:<namespace>:state:` for that
+  store. The namespace is immutable deployment identity, not per-request
+  organization scoping.
 - **Build:** `pnpm --filter operator build` (Vite, no `@cloudflare/vite-plugin`)
   emits `dist/client` + `dist/server/server.js`. **Run:** `pnpm --filter operator
   start` (`node dist/server/server.js`).

--- a/docs/architecture/managed-profile-contract.md
+++ b/docs/architecture/managed-profile-contract.md
@@ -110,10 +110,12 @@ roles, provider ids, resource keys, required variables/secrets/bindings, the
 Managed operator profiles emit one `redis` resource requirement with
 `REDIS_URL` for cache and rate limiting plus a deployment-static
 `REDIS_NAMESPACE` used to prefix those Redis keys. Managed Cloud requires
-HTTPS Redis REST URLs and keeps authoritative `sharedState` on Postgres by
-default. Self-hosted deployments that explicitly select Redis for
-`sharedState` may reuse `REDIS_NAMESPACE`; the runtime writes that store under
-`voyant:v1:<namespace>:state:`.
+`rediss://` for Redis TCP and still accepts HTTPS Redis REST URLs for
+compatibility; plaintext `redis://` is rejected. Managed profiles keep
+authoritative `sharedState` on Postgres by default. Self-hosted deployments
+that explicitly select Redis for `sharedState` may use `redis://`,
+`rediss://`, HTTP, or HTTPS and may reuse `REDIS_NAMESPACE`; the runtime writes
+that store under `voyant:v1:<namespace>:state:`.
 
 ## Runtime Bridge
 

--- a/docs/architecture/managed-profile-contract.md
+++ b/docs/architecture/managed-profile-contract.md
@@ -87,9 +87,10 @@ Validation checks:
 For `mode: "managed-cloud"`, database/cache/storage/auth/email/search are
 framework-owned substrate, not user-selected project config. The standard
 operator profile emits Postgres, S3/R2-compatible storage, Voyant Cloud auth and
-delivery, and Redis for `cache`, `sharedState`, and `rateLimit`. Local or
-self-hosted profiles can include explicit provider selections, including
-`postgres`, `kv`, or `memory` where the provider contract allows them.
+delivery, Redis for `cache` and `rateLimit`, and Postgres for authoritative
+`sharedState`. Local or self-hosted profiles can include explicit provider
+selections, including `postgres`, `kv`, or `memory` where the provider contract
+allows them.
 Payment, accounting, fiscalization, and channel systems are plugins, not
 provider roles; Managed Cloud must not imply a specific payment processor.
 
@@ -107,7 +108,12 @@ The returned requirements include selected modules, plugins, settings, provider
 roles, provider ids, resource keys, required variables/secrets/bindings, the
 `createVoyantApp` module exclusion list, and framework migration metadata.
 Managed operator profiles emit one `redis` resource requirement with
-`REDIS_URL`; its roles include cache, shared state, and rate limiting.
+`REDIS_URL` for cache and rate limiting plus a deployment-static
+`REDIS_NAMESPACE` used to prefix those Redis keys. Managed Cloud requires
+HTTPS Redis REST URLs and keeps authoritative `sharedState` on Postgres by
+default. Self-hosted deployments that explicitly select Redis for
+`sharedState` may reuse `REDIS_NAMESPACE`; the runtime writes that store under
+`voyant:v1:<namespace>:state:`.
 
 ## Runtime Bridge
 

--- a/docs/architecture/managed-profile-runtime.md
+++ b/docs/architecture/managed-profile-runtime.md
@@ -32,12 +32,12 @@ manifest. The JSON snapshot remains a compatibility input for older callers
 and cannot override graph-selected self-hosted providers.
 
 The source-free managed runtime is not yet a complete managed Cloud image by
-itself. Redis-backed cache and rate-limit providers, Voyant Cloud admin auth
-broker integration, snapshot plugin resolution, and route families still backed
-by starter-local loaders must be promoted to package/framework-owned exports
-before the corresponding managed Cloud surfaces can be enabled. Until then, the
-managed Cloud profile bridge excludes those starter-local surfaces and rejects
-explicit attempts to include them.
+itself. Redis-backed cache, shared-state, and rate-limit providers, Voyant Cloud
+admin auth broker integration, snapshot plugin resolution, and route families
+still backed by starter-local loaders must be promoted to package/framework-owned
+exports before the corresponding managed Cloud surfaces can be enabled. Until
+then, the managed Cloud profile bridge excludes those starter-local surfaces and
+rejects explicit attempts to include them.
 
 Storefront, site, blog, and shop apps remain separate Cloud applications that
 consume the managed API for the profile; they are not bundled by this runtime

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -69,7 +69,8 @@
     "@voyant-travel/workflows-orchestrator": "workspace:^",
     "drizzle-orm": "catalog:",
     "hono": "catalog:",
-    "pg": "^8.22.0"
+    "pg": "^8.22.0",
+    "redis": "^6.1.0"
   },
   "peerDependencies": {
     "@hono/zod-openapi": "^1.4.0",

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -106,7 +106,7 @@ function envForProvider(
     return [
       secret(
         "REDIS_URL",
-        "Upstash-compatible Redis REST URL used for cache, shared state, and rate limiting.",
+        "Redis URL used for cache, shared state, and rate limiting. Node runtimes accept redis://, rediss://, or an Upstash-compatible HTTP(S) REST URL with a token.",
         true,
         [],
         "redis-url",

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -106,10 +106,15 @@ function envForProvider(
     return [
       secret(
         "REDIS_URL",
-        "Redis URL used for cache, shared state, and rate limiting.",
+        "Upstash-compatible Redis REST URL used for cache, shared state, and rate limiting.",
         true,
         [],
         "redis-url",
+      ),
+      variable(
+        "REDIS_NAMESPACE",
+        "Immutable deployment namespace for framework-owned Redis cache, shared-state, and rate-limit keys.",
+        false,
       ),
     ]
   }

--- a/packages/framework/src/deployment-types.test.ts
+++ b/packages/framework/src/deployment-types.test.ts
@@ -33,4 +33,12 @@ describe("deployment provider contracts", () => {
       "none",
     ])
   })
+
+  it("keeps managed-cloud authoritative shared state on Postgres", () => {
+    expect(DEFAULT_MANAGED_CLOUD_PROVIDERS).toMatchObject({
+      cache: "redis",
+      sharedState: "postgres",
+      rateLimit: "redis",
+    })
+  })
 })

--- a/packages/framework/src/deployment-types.ts
+++ b/packages/framework/src/deployment-types.ts
@@ -59,7 +59,7 @@ export const DEFAULT_MANAGED_CLOUD_PROVIDERS = {
   database: "postgres",
   storage: "s3-compatible",
   cache: "redis",
-  sharedState: "redis",
+  sharedState: "postgres",
   rateLimit: "redis",
   search: "typesense",
   email: "voyant-cloud",

--- a/packages/framework/src/node-deployment-artifacts.ts
+++ b/packages/framework/src/node-deployment-artifacts.ts
@@ -451,7 +451,7 @@ function hasFormat(
     const parsed = new URL(value)
     if (format === "postgres-url")
       return parsed.protocol === "postgres:" || parsed.protocol === "postgresql:"
-    if (format === "redis-url") return parsed.protocol === "redis:" || parsed.protocol === "rediss:"
+    if (format === "redis-url") return isRedisRestUrl(parsed)
     return parsed.protocol === "http:" || parsed.protocol === "https:"
   } catch {
     return false
@@ -462,8 +462,15 @@ function formatDescription(
   format: NonNullable<VoyantNodeDeploymentGraphEnvRequirement["format"]>,
 ): string {
   if (format === "postgres-url") return "a Postgres URL"
-  if (format === "redis-url") return "a Redis URL"
+  if (format === "redis-url") return "an HTTP(S) Redis REST URL with a token"
   return "an HTTP(S) URL"
+}
+
+function isRedisRestUrl(parsed: URL): boolean {
+  return (
+    (parsed.protocol === "https:" || parsed.protocol === "http:") &&
+    (parsed.password.length > 0 || (parsed.searchParams.get("token")?.length ?? 0) > 0)
+  )
 }
 
 function requireEnvFormat(

--- a/packages/framework/src/node-deployment-artifacts.ts
+++ b/packages/framework/src/node-deployment-artifacts.ts
@@ -451,7 +451,7 @@ function hasFormat(
     const parsed = new URL(value)
     if (format === "postgres-url")
       return parsed.protocol === "postgres:" || parsed.protocol === "postgresql:"
-    if (format === "redis-url") return isRedisRestUrl(parsed)
+    if (format === "redis-url") return isRedisUrl(parsed)
     return parsed.protocol === "http:" || parsed.protocol === "https:"
   } catch {
     return false
@@ -462,8 +462,13 @@ function formatDescription(
   format: NonNullable<VoyantNodeDeploymentGraphEnvRequirement["format"]>,
 ): string {
   if (format === "postgres-url") return "a Postgres URL"
-  if (format === "redis-url") return "an HTTP(S) Redis REST URL with a token"
+  if (format === "redis-url") return "a Redis REST HTTP(S) URL with a token or Redis TCP URL"
   return "an HTTP(S) URL"
+}
+
+function isRedisUrl(parsed: URL): boolean {
+  if (parsed.protocol === "redis:" || parsed.protocol === "rediss:") return true
+  return isRedisRestUrl(parsed)
 }
 
 function isRedisRestUrl(parsed: URL): boolean {

--- a/packages/framework/src/node-redis-client.test.ts
+++ b/packages/framework/src/node-redis-client.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const redisClients = vi.hoisted(
+  () =>
+    [] as Array<{
+      url: string
+      events: string[]
+      connect: ReturnType<typeof vi.fn>
+      close: ReturnType<typeof vi.fn>
+      destroy: ReturnType<typeof vi.fn>
+      get: ReturnType<typeof vi.fn>
+      set: ReturnType<typeof vi.fn>
+      del: ReturnType<typeof vi.fn>
+      scan: ReturnType<typeof vi.fn>
+      incr: ReturnType<typeof vi.fn>
+      expire: ReturnType<typeof vi.fn>
+    }>,
+)
+const nextConnectError = vi.hoisted(() => ({ error: undefined as Error | undefined }))
+
+vi.mock("redis", () => ({
+  createClient: ({ url }: { url: string }) => {
+    const client = {
+      url,
+      events: [] as string[],
+      connect: vi.fn(async () => {
+        if (nextConnectError.error) throw nextConnectError.error
+      }),
+      close: vi.fn(async () => undefined),
+      destroy: vi.fn(),
+      get: vi.fn(async () => "stored-value"),
+      set: vi.fn(async () => "OK"),
+      del: vi.fn(async () => 1),
+      scan: vi.fn(async () => ({ cursor: "0", keys: ["key:1"] })),
+      incr: vi.fn(async () => 2),
+      expire: vi.fn(async () => true),
+      on: vi.fn((event: string) => {
+        client.events.push(event)
+      }),
+    }
+    redisClients.push(client)
+    return client
+  },
+}))
+
+beforeEach(() => {
+  redisClients.length = 0
+  nextConnectError.error = undefined
+  vi.resetModules()
+})
+
+function credentialedRedisUrl(protocol: "redis:" | "rediss:" | "https:"): string {
+  const path = protocol === "https:" ? "/redis" : "/0"
+  const port = protocol === "redis:" ? ":6379" : protocol === "rediss:" ? ":6380" : ""
+  const url = new URL(`${protocol}//example.redis.test${port}${path}`)
+  url.username = "default"
+  url.password = "secret"
+  return url.toString()
+}
+
+async function createTcpClient(redisUrl = credentialedRedisUrl("rediss:")) {
+  const { createLazyNodeRedisTcpClient } = await import("./node-redis-client.js")
+  return createLazyNodeRedisTcpClient(redisUrl)
+}
+
+describe("createLazyNodeRedisTcpClient", () => {
+  it("connects lazily once and maps Redis commands", async () => {
+    const lazyClient = await createTcpClient()
+    const client = await lazyClient.get()
+
+    await expect(lazyClient.get()).resolves.toBe(client)
+    await expect(client.get("key")).resolves.toBe("stored-value")
+    await client.set("ttl-key", "value", { ex: 12 })
+    await client.set("plain-key", "value")
+    await client.del("old-key")
+    await expect(client.scan!(0, { match: "prefix:*", count: 100 })).resolves.toEqual([
+      "0",
+      ["key:1"],
+    ])
+    await expect(client.incr("counter")).resolves.toBe(2)
+    await client.expire("counter", 60)
+
+    expect(redisClients).toHaveLength(1)
+    expect(redisClients[0]!.events).toEqual(["error"])
+    expect(redisClients[0]!.connect).toHaveBeenCalledOnce()
+    expect(redisClients[0]!.set).toHaveBeenNthCalledWith(1, "ttl-key", "value", {
+      expiration: { type: "EX", value: 12 },
+    })
+    expect(redisClients[0]!.set).toHaveBeenNthCalledWith(2, "plain-key", "value")
+    expect(redisClients[0]!.del).toHaveBeenCalledWith("old-key")
+    expect(redisClients[0]!.scan).toHaveBeenCalledWith("0", {
+      COUNT: 100,
+      MATCH: "prefix:*",
+    })
+    expect(redisClients[0]!.expire).toHaveBeenCalledWith("counter", 60)
+  })
+
+  it("normalizes tuple SCAN replies from compatible clients", async () => {
+    const lazyClient = await createTcpClient()
+    const client = await lazyClient.get()
+    redisClients[0]!.scan.mockResolvedValueOnce(["7", ["a", "b"]])
+
+    await expect(client.scan!(0)).resolves.toEqual(["7", ["a", "b"]])
+  })
+
+  it("rejects non-TCP URLs before constructing a TCP client", async () => {
+    const lazyClient = await createTcpClient(credentialedRedisUrl("https:"))
+
+    await expect(lazyClient.get()).rejects.toThrow(/redis:\/\/ or rediss:\/\//)
+    expect(redisClients).toHaveLength(0)
+  })
+
+  it("sanitizes connection failures", async () => {
+    nextConnectError.error = Object.assign(
+      new Error(`connect ${credentialedRedisUrl("rediss:")} failed`),
+      { code: "ECONNREFUSED" },
+    )
+    const lazyClient = await createTcpClient()
+
+    await expect(lazyClient.get()).rejects.toThrow(
+      "Redis TCP client failed to connect (ECONNREFUSED)",
+    )
+    await expect(lazyClient.get()).rejects.not.toThrow(/secret|example\.redis\.test/u)
+    expect(redisClients[0]!.close).toHaveBeenCalled()
+  })
+})

--- a/packages/framework/src/node-redis-client.test.ts
+++ b/packages/framework/src/node-redis-client.test.ts
@@ -123,4 +123,28 @@ describe("createLazyNodeRedisTcpClient", () => {
     await expect(lazyClient.get()).rejects.not.toThrow(/secret|example\.redis\.test/u)
     expect(redisClients[0]!.close).toHaveBeenCalled()
   })
+
+  it("retries with a fresh client after an initial sanitized connection failure", async () => {
+    nextConnectError.error = Object.assign(
+      new Error(`connect ${credentialedRedisUrl("rediss:")} failed`),
+      { code: "WRONGPASS" },
+    )
+    const lazyClient = await createTcpClient()
+
+    const firstAttempt = lazyClient.get()
+    const concurrentFirstAttempt = lazyClient.get()
+    expect(concurrentFirstAttempt).toBe(firstAttempt)
+    await expect(firstAttempt).rejects.toThrow("Redis TCP client failed to connect (WRONGPASS)")
+    await expect(concurrentFirstAttempt).rejects.not.toThrow(/default|secret|example\.redis\.test/u)
+    expect(redisClients).toHaveLength(1)
+    expect(redisClients[0]!.connect).toHaveBeenCalledOnce()
+    expect(redisClients[0]!.close).toHaveBeenCalledOnce()
+
+    nextConnectError.error = undefined
+    const client = await lazyClient.get()
+
+    await expect(lazyClient.get()).resolves.toBe(client)
+    expect(redisClients).toHaveLength(2)
+    expect(redisClients[1]!.connect).toHaveBeenCalledOnce()
+  })
 })

--- a/packages/framework/src/node-redis-client.ts
+++ b/packages/framework/src/node-redis-client.ts
@@ -1,0 +1,109 @@
+import type { LazyRedisClient, RedisClient } from "@voyant-travel/utils/redis-client"
+import { createClient, type RedisClientType } from "redis"
+
+type NodeRedisClient = RedisClientType
+
+export function createLazyNodeRedisTcpClient(redisUrl: string): LazyRedisClient {
+  let clientPromise: Promise<RedisClient> | undefined
+
+  return {
+    get() {
+      clientPromise ??= connectNodeRedisClient(redisUrl)
+      return clientPromise
+    },
+  }
+}
+
+async function connectNodeRedisClient(redisUrl: string): Promise<RedisClient> {
+  assertRedisTcpUrl(redisUrl)
+  const client = createClient({ url: redisUrl })
+  client.on("error", () => {
+    // node-redis requires an error listener. Keep details out of framework logs because
+    // connection errors can include credential-bearing URLs from lower layers.
+  })
+  try {
+    await client.connect()
+  } catch (error) {
+    await closeNodeRedisClient(client)
+    throw sanitizedRedisTcpError(error)
+  }
+  return adaptNodeRedisClient(client)
+}
+
+function adaptNodeRedisClient(client: NodeRedisClient): RedisClient {
+  return {
+    async get<T = unknown>(key: string): Promise<T | null> {
+      return (await client.get(key)) as T | null
+    },
+    async set(key: string, value: string, options?: { ex?: number }): Promise<unknown> {
+      if (options?.ex !== undefined) {
+        return client.set(key, value, { expiration: { type: "EX", value: options.ex } })
+      }
+      return client.set(key, value)
+    },
+    async del(key: string): Promise<unknown> {
+      return client.del(key)
+    },
+    async scan(
+      cursor: number,
+      options?: { match?: string; count?: number },
+    ): Promise<[number | string, string[]]> {
+      const result = await client.scan(String(cursor), {
+        ...(options?.match ? { MATCH: options.match } : {}),
+        ...(options?.count !== undefined ? { COUNT: options.count } : {}),
+      })
+      return normalizeScanResult(result)
+    },
+    async incr(key: string): Promise<number> {
+      return client.incr(key)
+    },
+    async expire(key: string, seconds: number): Promise<unknown> {
+      return client.expire(key, seconds)
+    },
+  }
+}
+
+function normalizeScanResult(result: unknown): [number | string, string[]] {
+  if (Array.isArray(result)) {
+    return [String(result[0] ?? "0"), normalizeScanKeys(result[1])]
+  }
+  if (result && typeof result === "object") {
+    const record = result as { cursor?: unknown; keys?: unknown }
+    return [String(record.cursor ?? "0"), normalizeScanKeys(record.keys)]
+  }
+  return ["0", []]
+}
+
+function normalizeScanKeys(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((key): key is string => typeof key === "string") : []
+}
+
+function assertRedisTcpUrl(redisUrl: string): void {
+  try {
+    const parsed = new URL(redisUrl)
+    if (parsed.protocol === "redis:" || parsed.protocol === "rediss:") return
+  } catch {
+    // Fall through to sanitized error below.
+  }
+  throw new Error("REDIS_URL must be a redis:// or rediss:// Redis TCP URL.")
+}
+
+async function closeNodeRedisClient(client: NodeRedisClient): Promise<void> {
+  try {
+    await client.close()
+  } catch {
+    try {
+      client.destroy()
+    } catch {
+      // Ignore cleanup failures after a failed connection attempt.
+    }
+  }
+}
+
+function sanitizedRedisTcpError(error: unknown): Error {
+  const code =
+    error && typeof error === "object" && "code" in error && typeof error.code === "string"
+      ? ` (${error.code})`
+      : ""
+  return new Error(`Redis TCP client failed to connect${code}`)
+}

--- a/packages/framework/src/node-redis-client.ts
+++ b/packages/framework/src/node-redis-client.ts
@@ -8,7 +8,13 @@ export function createLazyNodeRedisTcpClient(redisUrl: string): LazyRedisClient 
 
   return {
     get() {
-      clientPromise ??= connectNodeRedisClient(redisUrl)
+      if (!clientPromise) {
+        const connectPromise = connectNodeRedisClient(redisUrl).catch((error: unknown) => {
+          if (clientPromise === connectPromise) clientPromise = undefined
+          throw error
+        })
+        clientPromise = connectPromise
+      }
       return clientPromise
     },
   }

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { VoyantDeploymentProviders } from "./deployment-types.js"
+import { createVoyantNodeEnv, loadVoyantNodeRuntime } from "./node-runtime.js"
+import { createVoyantGraphRuntime } from "./runtime-lowering.js"
+
+const redisOperations = vi.hoisted(
+  () => [] as Array<{ op: string; key: string; redisUrl?: string }>,
+)
+
+vi.mock("@voyant-travel/utils/redis-kv", () => ({
+  createRedisKvStore: (redisUrl: string, options?: { keyPrefix?: string }) => {
+    const values = new Map<string, string>()
+    const keyPrefix = options?.keyPrefix ?? ""
+
+    return {
+      async get<T = string>(key: string): Promise<T | null> {
+        const physicalKey = `${keyPrefix}${key}`
+        redisOperations.push({ op: "get", key: physicalKey, redisUrl })
+        return (values.get(physicalKey) ?? null) as T | null
+      },
+      async put(key: string, value: string): Promise<void> {
+        const physicalKey = `${keyPrefix}${key}`
+        redisOperations.push({ op: "set", key: physicalKey, redisUrl })
+        values.set(physicalKey, value)
+      },
+      async delete(key: string): Promise<void> {
+        const physicalKey = `${keyPrefix}${key}`
+        redisOperations.push({ op: "del", key: physicalKey, redisUrl })
+        values.delete(physicalKey)
+      },
+      async list(): Promise<{ keys: Array<{ name: string }> }> {
+        return { keys: [] }
+      },
+    }
+  },
+}))
+
+vi.mock("@voyant-travel/hono", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@voyant-travel/hono")>()
+
+  return {
+    ...original,
+    createRedisRateLimitStore: (redisUrl: string, options?: { keyPrefix?: string }) => ({
+      async limit(key: string, { windowSeconds }: { max: number; windowSeconds: number }) {
+        const windowKey = Math.floor(Math.floor(Date.now() / 1000) / windowSeconds)
+        const physicalKey = `${options?.keyPrefix ?? ""}${key}:${windowKey}`
+        redisOperations.push({ op: "incr", key: physicalKey, redisUrl })
+        redisOperations.push({ op: "expire", key: physicalKey, redisUrl })
+        return { allowed: true, remaining: 1, retryAfterSeconds: windowSeconds }
+      },
+    }),
+  }
+})
+
+const BASE_PROVIDERS = {
+  database: "postgres",
+  storage: "memory",
+  cache: "memory",
+  sharedState: "memory",
+  rateLimit: "memory",
+  search: "none",
+  email: "none",
+  sms: "none",
+  adminAuth: "voyant-cloud",
+  customerAuth: "disabled",
+  realtime: "none",
+  scheduledJobs: "none",
+  workflows: "none",
+  outboundWebhooks: "none",
+  payments: "none",
+} satisfies VoyantDeploymentProviders
+
+afterEach(() => {
+  redisOperations.length = 0
+})
+
+function emptyGraphRuntime(providers: VoyantDeploymentProviders) {
+  return createVoyantGraphRuntime({
+    graphHash: "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+    entries: {},
+    modules: [],
+    plugins: [],
+    providerSelections: { ...providers },
+  })
+}
+
+function authIntegration() {
+  return {
+    handler: () => ({
+      fetch: async () => new Response(null, { status: 404 }),
+    }),
+  }
+}
+
+describe("createVoyantNodeEnv Redis namespace", () => {
+  it("uses role-specific Redis key prefixes when REDIS_NAMESPACE is supplied", async () => {
+    const env = createVoyantNodeEnv(
+      {
+        REDIS_URL: "https://example.upstash.io?token=test-token",
+        REDIS_NAMESPACE: "region_eu-1",
+      },
+      {
+        storage: "memory",
+        cache: "redis",
+        sharedState: "redis",
+        rateLimit: "redis",
+      },
+    )
+
+    await env.CACHE!.put("cache-key", "cache-value")
+    await env.SHARED_STATE!.put("state-key", "state-value")
+    await env.RATE_LIMIT_STORE!.limit("lim:auth:client", { max: 10, windowSeconds: 60 })
+
+    expect(redisOperations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ op: "set", key: "voyant:v1:region_eu-1:cache:cache-key" }),
+        expect.objectContaining({ op: "set", key: "voyant:v1:region_eu-1:state:state-key" }),
+        expect.objectContaining({
+          op: "incr",
+          key: expect.stringMatching(/^voyant:v1:region_eu-1:rate:lim:auth:client:\d+$/u),
+        }),
+        expect.objectContaining({
+          op: "expire",
+          key: expect.stringMatching(/^voyant:v1:region_eu-1:rate:lim:auth:client:\d+$/u),
+        }),
+      ]),
+    )
+  })
+
+  it("leaves self-hosted Redis shared state compatible when namespace is omitted", async () => {
+    const env = createVoyantNodeEnv(
+      {
+        REDIS_URL: "http://redis-rest.local?token=test-token",
+      },
+      {
+        storage: "memory",
+        cache: "memory",
+        sharedState: "redis",
+        rateLimit: "memory",
+      },
+    )
+
+    await env.SHARED_STATE!.put("state-key", "state-value")
+
+    expect(redisOperations).toContainEqual(expect.objectContaining({ op: "set", key: "state-key" }))
+  })
+})
+
+describe("loadVoyantNodeRuntime Redis URL validation", () => {
+  it("requires REDIS_NAMESPACE when managed shared state uses Redis", async () => {
+    const providers = {
+      ...BASE_PROVIDERS,
+      sharedState: "redis",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "managed-cloud", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: "https://example.upstash.io?token=test-token",
+        },
+        auth: authIntegration(),
+      }),
+    ).rejects.toThrow(
+      /managed-cloud Redis cache, shared-state, and rate-limit providers require REDIS_NAMESPACE/,
+    )
+  })
+
+  it("rejects HTTP Redis REST URLs in managed cloud", async () => {
+    const providers = {
+      ...BASE_PROVIDERS,
+      cache: "redis",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "managed-cloud", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: "http://example.upstash.io?token=test-token",
+          REDIS_NAMESPACE: "region-eu-1",
+        },
+        auth: authIntegration(),
+      }),
+    ).rejects.toThrow(/managed-cloud Redis providers require an HTTPS Redis REST URL with a token/)
+  })
+
+  it("allows managed Redis providers when HTTPS URL and namespace are configured", async () => {
+    const providers = {
+      ...BASE_PROVIDERS,
+      cache: "redis",
+      rateLimit: "redis",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "managed-cloud", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: "https://example.upstash.io?token=test-token",
+          REDIS_NAMESPACE: "region-eu-1",
+        },
+        auth: authIntegration(),
+      }),
+    ).resolves.toMatchObject({
+      deployment: { mode: "managed-cloud" },
+      env: { REDIS_NAMESPACE: "region-eu-1" },
+    })
+  })
+})

--- a/packages/framework/src/node-runtime.test.ts
+++ b/packages/framework/src/node-runtime.test.ts
@@ -1,31 +1,118 @@
+import type { LazyRedisClient } from "@voyant-travel/utils/redis-client"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import type { VoyantDeploymentProviders } from "./deployment-types.js"
 import { createVoyantNodeEnv, loadVoyantNodeRuntime } from "./node-runtime.js"
 import { createVoyantGraphRuntime } from "./runtime-lowering.js"
 
 const redisOperations = vi.hoisted(
-  () => [] as Array<{ op: string; key: string; redisUrl?: string }>,
+  () => [] as Array<{ op: string; key: string; redisUrl?: string; client?: string }>,
+)
+const tcpRedisConnections = vi.hoisted(
+  () => [] as Array<{ protocol: string; username: string; password: string }>,
+)
+const restRedisConstructed = vi.hoisted(
+  () => [] as Array<{ options: { url: string; token: string } }>,
+)
+const resolvedRedisClientIds = vi.hoisted(() => new WeakMap<object, string>())
+const redisStoreCreations = vi.hoisted(
+  () => [] as Array<{ kind: "kv" | "rate"; redisUrl: string; client?: LazyRedisClient }>,
 )
 
+vi.mock("redis", () => ({
+  createClient: ({ url }: { url: string }) => {
+    const parsed = new URL(url)
+    const id = `${parsed.protocol}//${parsed.host}${parsed.pathname}`
+    return {
+      on: vi.fn(),
+      connect: vi.fn(async () => {
+        tcpRedisConnections.push({
+          protocol: parsed.protocol,
+          username: parsed.username,
+          password: parsed.password,
+        })
+      }),
+      close: vi.fn(async () => undefined),
+      destroy: vi.fn(),
+      get: vi.fn(async () => null),
+      set: vi.fn(async () => "OK"),
+      del: vi.fn(async () => 1),
+      scan: vi.fn(async () => ({ cursor: "0", keys: [] })),
+      incr: vi.fn(async () => 1),
+      expire: vi.fn(async () => true),
+      __id: id,
+    }
+  },
+}))
+
+vi.mock("@upstash/redis", () => {
+  class Redis {
+    readonly __id: string
+
+    constructor(readonly options: { url: string; token: string }) {
+      this.__id = `rest:${options.url}`
+      restRedisConstructed.push({ options })
+    }
+  }
+
+  return { Redis }
+})
+
+async function redisClientId(client?: LazyRedisClient): Promise<string | undefined> {
+  if (!client) return undefined
+  const resolved = (await client.get()) as object
+  let id = resolvedRedisClientIds.get(resolved)
+  if (!id) {
+    id = `client:${resolvedRedisClientIdsSize()}`
+    resolvedRedisClientIds.set(resolved, id)
+  }
+  return id
+}
+
+function resolvedRedisClientIdsSize(): number {
+  return redisOperations.reduce((size, operation) => {
+    if (!operation.client) return size
+    return Math.max(size, Number.parseInt(operation.client.replace("client:", ""), 10) + 1)
+  }, 0)
+}
+
 vi.mock("@voyant-travel/utils/redis-kv", () => ({
-  createRedisKvStore: (redisUrl: string, options?: { keyPrefix?: string }) => {
+  createRedisKvStore: (
+    redisUrl: string,
+    options?: { client?: LazyRedisClient; keyPrefix?: string },
+  ) => {
+    redisStoreCreations.push({ kind: "kv", redisUrl, client: options?.client })
     const values = new Map<string, string>()
     const keyPrefix = options?.keyPrefix ?? ""
 
     return {
       async get<T = string>(key: string): Promise<T | null> {
         const physicalKey = `${keyPrefix}${key}`
-        redisOperations.push({ op: "get", key: physicalKey, redisUrl })
+        redisOperations.push({
+          op: "get",
+          key: physicalKey,
+          redisUrl,
+          client: await redisClientId(options?.client),
+        })
         return (values.get(physicalKey) ?? null) as T | null
       },
       async put(key: string, value: string): Promise<void> {
         const physicalKey = `${keyPrefix}${key}`
-        redisOperations.push({ op: "set", key: physicalKey, redisUrl })
+        redisOperations.push({
+          op: "set",
+          key: physicalKey,
+          redisUrl,
+          client: await redisClientId(options?.client),
+        })
         values.set(physicalKey, value)
       },
       async delete(key: string): Promise<void> {
         const physicalKey = `${keyPrefix}${key}`
-        redisOperations.push({ op: "del", key: physicalKey, redisUrl })
+        redisOperations.push({
+          op: "del",
+          key: physicalKey,
+          redisUrl,
+          client: await redisClientId(options?.client),
+        })
         values.delete(physicalKey)
       },
       async list(): Promise<{ keys: Array<{ name: string }> }> {
@@ -40,12 +127,17 @@ vi.mock("@voyant-travel/hono", async (importOriginal) => {
 
   return {
     ...original,
-    createRedisRateLimitStore: (redisUrl: string, options?: { keyPrefix?: string }) => ({
+    createRedisRateLimitStore: (
+      redisUrl: string,
+      options?: { client?: LazyRedisClient; keyPrefix?: string },
+    ) => ({
       async limit(key: string, { windowSeconds }: { max: number; windowSeconds: number }) {
+        redisStoreCreations.push({ kind: "rate", redisUrl, client: options?.client })
         const windowKey = Math.floor(Math.floor(Date.now() / 1000) / windowSeconds)
         const physicalKey = `${options?.keyPrefix ?? ""}${key}:${windowKey}`
-        redisOperations.push({ op: "incr", key: physicalKey, redisUrl })
-        redisOperations.push({ op: "expire", key: physicalKey, redisUrl })
+        const client = await redisClientId(options?.client)
+        redisOperations.push({ op: "incr", key: physicalKey, redisUrl, client })
+        redisOperations.push({ op: "expire", key: physicalKey, redisUrl, client })
         return { allowed: true, remaining: 1, retryAfterSeconds: windowSeconds }
       },
     }),
@@ -72,6 +164,10 @@ const BASE_PROVIDERS = {
 
 afterEach(() => {
   redisOperations.length = 0
+  tcpRedisConnections.length = 0
+  restRedisConstructed.length = 0
+  redisStoreCreations.length = 0
+  vi.clearAllMocks()
 })
 
 function emptyGraphRuntime(providers: VoyantDeploymentProviders) {
@@ -90,6 +186,21 @@ function authIntegration() {
       fetch: async () => new Response(null, { status: 404 }),
     }),
   }
+}
+
+function redisUrlWithCredentials(options: {
+  protocol: "redis:" | "rediss:" | "https:"
+  host: string
+  port?: string
+  path?: string
+  credential: string
+}): string {
+  const url = new URL(
+    `${options.protocol}//${options.host}${options.port ?? ""}${options.path ?? "/0"}`,
+  )
+  url.username = "default"
+  url.password = options.credential
+  return url.toString()
 }
 
 describe("createVoyantNodeEnv Redis namespace", () => {
@@ -144,6 +255,79 @@ describe("createVoyantNodeEnv Redis namespace", () => {
 
     expect(redisOperations).toContainEqual(expect.objectContaining({ op: "set", key: "state-key" }))
   })
+
+  it("reuses one lazy TCP Redis client across cache, shared-state, and rate-limit roles", async () => {
+    const redisUrl = redisUrlWithCredentials({
+      protocol: "rediss:",
+      host: "redis.example.test",
+      port: ":6380",
+      credential: "secret",
+    })
+    const env = createVoyantNodeEnv(
+      {
+        REDIS_URL: redisUrl,
+        REDIS_NAMESPACE: "region-eu-1",
+      },
+      {
+        storage: "memory",
+        cache: "redis",
+        sharedState: "redis",
+        rateLimit: "redis",
+      },
+    )
+
+    await env.CACHE!.put("cache-key", "cache-value")
+    await env.SHARED_STATE!.put("state-key", "state-value")
+    await env.RATE_LIMIT_STORE!.limit("lim:auth:client", { max: 10, windowSeconds: 60 })
+
+    expect(tcpRedisConnections).toEqual([
+      { protocol: "rediss:", username: "default", password: "secret" },
+    ])
+    expect(new Set(redisOperations.map((operation) => operation.client))).toEqual(
+      new Set(["client:0"]),
+    )
+  })
+
+  it("keeps HTTPS Redis REST compatibility through the shared Upstash adapter", async () => {
+    const redisUrl = redisUrlWithCredentials({
+      protocol: "https:",
+      host: "example.upstash.io",
+      path: "/redis",
+      credential: "test-token",
+    })
+    const env = createVoyantNodeEnv(
+      {
+        REDIS_URL: redisUrl,
+        REDIS_NAMESPACE: "region-eu-1",
+      },
+      {
+        storage: "memory",
+        cache: "redis",
+        sharedState: "memory",
+        rateLimit: "redis",
+      },
+    )
+
+    await env.CACHE!.put("cache-key", "cache-value")
+    await env.RATE_LIMIT_STORE!.limit("lim:auth:client", { max: 10, windowSeconds: 60 })
+
+    expect(tcpRedisConnections).toEqual([])
+    expect(redisStoreCreations).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: "kv",
+          redisUrl,
+        }),
+        expect.objectContaining({
+          kind: "rate",
+          redisUrl,
+        }),
+      ]),
+    )
+    expect(new Set(redisOperations.map((operation) => operation.client))).toEqual(
+      new Set(["client:0"]),
+    )
+  })
 })
 
 describe("loadVoyantNodeRuntime Redis URL validation", () => {
@@ -185,7 +369,50 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
         },
         auth: authIntegration(),
       }),
-    ).rejects.toThrow(/managed-cloud Redis providers require an HTTPS Redis REST URL with a token/)
+    ).rejects.toThrow(
+      /managed-cloud Redis providers require rediss:\/\/ for Redis TCP or an HTTPS Redis REST URL with a token/,
+    )
+  })
+
+  it("rejects plaintext Redis TCP URLs in managed cloud without leaking credentials", async () => {
+    const redisUrl = redisUrlWithCredentials({
+      protocol: "redis:",
+      host: "example.redis.test",
+      port: ":6379",
+      credential: ["credential", "sentinel"].join("-"),
+    })
+    const providers = {
+      ...BASE_PROVIDERS,
+      cache: "redis",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "managed-cloud", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: redisUrl,
+          REDIS_NAMESPACE: "region-eu-1",
+        },
+        auth: authIntegration(),
+      }),
+    ).rejects.toThrow(
+      /managed-cloud Redis providers require rediss:\/\/ for Redis TCP or an HTTPS Redis REST URL with a token/,
+    )
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "managed-cloud", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: redisUrl,
+          REDIS_NAMESPACE: "region-eu-1",
+        },
+        auth: authIntegration(),
+      }),
+    ).rejects.not.toThrow(/credential-sentinel|example\.redis\.test/u)
   })
 
   it("allows managed Redis providers when HTTPS URL and namespace are configured", async () => {
@@ -209,6 +436,63 @@ describe("loadVoyantNodeRuntime Redis URL validation", () => {
     ).resolves.toMatchObject({
       deployment: { mode: "managed-cloud" },
       env: { REDIS_NAMESPACE: "region-eu-1" },
+    })
+  })
+
+  it("allows managed Redis providers when rediss URL and namespace are configured", async () => {
+    const redisUrl = redisUrlWithCredentials({
+      protocol: "rediss:",
+      host: "example.redis.test",
+      port: ":6380",
+      credential: "test-token",
+    })
+    const providers = {
+      ...BASE_PROVIDERS,
+      cache: "redis",
+      rateLimit: "redis",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "managed-cloud", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: redisUrl,
+          REDIS_NAMESPACE: "region-eu-1",
+        },
+        auth: authIntegration(),
+      }),
+    ).resolves.toMatchObject({
+      deployment: { mode: "managed-cloud" },
+      env: { REDIS_NAMESPACE: "region-eu-1" },
+    })
+  })
+
+  it("allows self-hosted Redis providers to use plaintext TCP without a namespace", async () => {
+    const redisUrl = redisUrlWithCredentials({
+      protocol: "redis:",
+      host: "example.redis.test",
+      port: ":6379",
+      credential: "test-token",
+    })
+    const providers = {
+      ...BASE_PROVIDERS,
+      adminAuth: "better-auth",
+      cache: "redis",
+    } satisfies VoyantDeploymentProviders
+
+    await expect(
+      loadVoyantNodeRuntime({
+        graphRuntime: emptyGraphRuntime(providers),
+        deployment: { mode: "self-hosted", providers },
+        deploymentRequirements: { resources: [] },
+        env: {
+          REDIS_URL: redisUrl,
+        },
+      }),
+    ).resolves.toMatchObject({
+      deployment: { mode: "self-hosted" },
     })
   })
 })

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -33,6 +33,7 @@ import {
 } from "@voyant-travel/storage/runtime"
 import type { StorageProvider, StorageProviderResolver } from "@voyant-travel/storage/types"
 import type { KVStore } from "@voyant-travel/utils/cache"
+import { createLazyRedisClient, type LazyRedisClient } from "@voyant-travel/utils/redis-client"
 import { createRedisKvStore } from "@voyant-travel/utils/redis-kv"
 import { createTieredKvStore } from "@voyant-travel/utils/tiered-kv"
 
@@ -59,6 +60,7 @@ import {
   type VoyantNodeProviderPlan,
   validateVoyantNodeProviderPlanEnv,
 } from "./node-provider-plan.js"
+import { createLazyNodeRedisTcpClient } from "./node-redis-client.js"
 import { composeVoyantGraphRuntime } from "./runtime-composition.js"
 import type { VoyantGraphRuntime } from "./runtime-lowering.js"
 import {
@@ -490,6 +492,7 @@ function createNodeSharedStores(
   const redisUrl = selectedProviders.includes("redis")
     ? requireNodeEnv(env, "REDIS_URL")
     : undefined
+  const redisClient = redisUrl ? createLazyNodeRedisClient(redisUrl) : undefined
   const redisNamespace = redisUrl ? optionalRedisNamespace(env.REDIS_NAMESPACE) : undefined
   const postgresDatabase = selectedProviders.includes("postgres")
     ? resolveProviderDatabase(env)
@@ -498,12 +501,15 @@ function createNodeSharedStores(
     ...(redisUrl
       ? {
           redisCacheKv: createRedisKvStore(redisUrl, {
+            client: redisClient,
             keyPrefix: redisNamespace ? redisRoleKeyPrefix(redisNamespace, "cache") : undefined,
           }),
           redisSharedStateKv: createRedisKvStore(redisUrl, {
+            client: redisClient,
             keyPrefix: redisNamespace ? redisRoleKeyPrefix(redisNamespace, "state") : undefined,
           }),
           redisRateLimit: createRedisRateLimitStore(redisUrl, {
+            client: redisClient,
             keyPrefix: redisNamespace ? redisRoleKeyPrefix(redisNamespace, "rate") : undefined,
           }),
         }
@@ -520,6 +526,15 @@ function createNodeSharedStores(
     SHARED_STATE: selectedAuthoritativeKvStore(plan.sharedState, l1SharedState, resources),
     RATE_LIMIT_STORE: selectedRateLimitStore(plan.rateLimit, resources),
   }
+}
+
+function createLazyNodeRedisClient(redisUrl: string): LazyRedisClient {
+  const protocol = redisUrlProtocol(redisUrl)
+  if (protocol === "http:" || protocol === "https:") return createLazyRedisClient(redisUrl)
+  if (protocol === "redis:" || protocol === "rediss:") return createLazyNodeRedisTcpClient(redisUrl)
+  throw new Error(
+    "REDIS_URL must be an HTTP(S) Redis REST URL with a token or a redis:// or rediss:// Redis TCP URL.",
+  )
 }
 
 function selectedCacheStore(
@@ -630,9 +645,11 @@ function assertVoyantNodeRuntimeSupport(options: {
     (options.providerPlan.cache === "redis" ||
       options.providerPlan.sharedState === "redis" ||
       options.providerPlan.rateLimit === "redis") &&
-    !isRedisRestUrl(options.env.REDIS_URL, { requireHttps: true })
+    !isManagedRedisUrl(options.env.REDIS_URL)
   ) {
-    issues.push("managed-cloud Redis providers require an HTTPS Redis REST URL with a token")
+    issues.push(
+      "managed-cloud Redis providers require rediss:// for Redis TCP or an HTTPS Redis REST URL with a token",
+    )
   }
   if (issues.length > 0) {
     throw new Error(`Voyant Node runtime is not ready to start:\n${formatIssues(issues)}`)
@@ -687,7 +704,7 @@ function hasFormat(
     const parsed = new URL(value)
     if (format === "postgres-url")
       return parsed.protocol === "postgres:" || parsed.protocol === "postgresql:"
-    if (format === "redis-url") return isRedisRestUrl(value, { requireHttps: false })
+    if (format === "redis-url") return isRedisUrl(value)
     return parsed.protocol === "http:" || parsed.protocol === "https:"
   } catch {
     return false
@@ -696,21 +713,44 @@ function hasFormat(
 
 function formatDescription(format: NonNullable<VoyantDeploymentEnvRequirement["format"]>): string {
   if (format === "postgres-url") return "a Postgres URL"
-  if (format === "redis-url") return "an HTTP(S) Redis REST URL with a token"
+  if (format === "redis-url") return "a Redis REST HTTP(S) URL with a token or Redis TCP URL"
   return "an HTTP(S) URL"
+}
+
+function isRedisUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) return false
+  try {
+    const protocol = redisUrlProtocol(value)
+    if (protocol === "redis:" || protocol === "rediss:") return true
+    return isRedisRestUrl(value, { requireHttps: false })
+  } catch {
+    return false
+  }
+}
+
+function isManagedRedisUrl(value: unknown): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) return false
+  try {
+    const protocol = redisUrlProtocol(value)
+    if (protocol === "rediss:") return true
+    if (protocol === "redis:") return false
+    return isRedisRestUrl(value, { requireHttps: true })
+  } catch {
+    return false
+  }
 }
 
 function isRedisRestUrl(value: unknown, options: { requireHttps: boolean }): value is string {
   if (typeof value !== "string" || value.trim().length === 0) return false
-  try {
-    const parsed = new URL(value)
-    return (
-      (parsed.protocol === "https:" || (!options.requireHttps && parsed.protocol === "http:")) &&
-      (parsed.password.length > 0 || (parsed.searchParams.get("token")?.length ?? 0) > 0)
-    )
-  } catch {
-    return false
-  }
+  const parsed = new URL(value)
+  return (
+    (parsed.protocol === "https:" || (!options.requireHttps && parsed.protocol === "http:")) &&
+    (parsed.password.length > 0 || (parsed.searchParams.get("token")?.length ?? 0) > 0)
+  )
+}
+
+function redisUrlProtocol(value: string): string {
+  return new URL(value).protocol
 }
 
 function resolveDb(env: unknown): VoyantDb {

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -80,6 +80,7 @@ export interface VoyantNodeRuntimeEnv extends VoyantBindings {
   MEDIA_PUBLIC_BASE_URL?: string
   API_BASE_URL?: string
   REDIS_URL?: string
+  REDIS_NAMESPACE?: string
   RATE_LIMIT_STORE?: RateLimitStore
   VOYANT_ADMIN_AUTH_MODE?: string
   VOYANT_CUSTOMER_AUTH_MODE?: string
@@ -245,7 +246,8 @@ interface NodeSharedStores {
 }
 
 interface NodeSharedProviderResources {
-  redisKv?: KVStore
+  redisCacheKv?: KVStore
+  redisSharedStateKv?: KVStore
   redisRateLimit?: RateLimitStore
   postgresKv?: KVStore
   postgresRateLimit?: RateLimitStore
@@ -310,6 +312,7 @@ export async function loadVoyantNodeRuntime(
   )
   assertVoyantNodeRuntimeSupport({
     mode: options.deployment.mode,
+    providerPlan,
     requirements,
     env,
     hasAuthIntegration: Boolean(auth),
@@ -487,14 +490,22 @@ function createNodeSharedStores(
   const redisUrl = selectedProviders.includes("redis")
     ? requireNodeEnv(env, "REDIS_URL")
     : undefined
+  const redisNamespace = redisUrl ? optionalRedisNamespace(env.REDIS_NAMESPACE) : undefined
   const postgresDatabase = selectedProviders.includes("postgres")
     ? resolveProviderDatabase(env)
     : undefined
   const resources: NodeSharedProviderResources = {
     ...(redisUrl
       ? {
-          redisKv: createRedisKvStore(redisUrl),
-          redisRateLimit: createRedisRateLimitStore(redisUrl),
+          redisCacheKv: createRedisKvStore(redisUrl, {
+            keyPrefix: redisNamespace ? redisRoleKeyPrefix(redisNamespace, "cache") : undefined,
+          }),
+          redisSharedStateKv: createRedisKvStore(redisUrl, {
+            keyPrefix: redisNamespace ? redisRoleKeyPrefix(redisNamespace, "state") : undefined,
+          }),
+          redisRateLimit: createRedisRateLimitStore(redisUrl, {
+            keyPrefix: redisNamespace ? redisRoleKeyPrefix(redisNamespace, "rate") : undefined,
+          }),
         }
       : {}),
     ...(postgresDatabase
@@ -518,7 +529,7 @@ function selectedCacheStore(
 ): KVStore {
   if (provider === "memory") return memory
   if (provider === "redis") {
-    return createTieredKvStore(memory, requireProviderResource(resources.redisKv))
+    return createTieredKvStore(memory, requireProviderResource(resources.redisCacheKv))
   }
   return createTieredKvStore(memory, requireProviderResource(resources.postgresKv))
 }
@@ -529,7 +540,7 @@ function selectedAuthoritativeKvStore(
   resources: NodeSharedProviderResources,
 ): KVStore {
   if (provider === "memory") return memory
-  if (provider === "redis") return requireProviderResource(resources.redisKv)
+  if (provider === "redis") return requireProviderResource(resources.redisSharedStateKv)
   return requireProviderResource(resources.postgresKv)
 }
 
@@ -563,6 +574,26 @@ function requireNodeEnv(env: Record<string, string>, name: string): string {
   throw new Error(`${name} is required by the selected Node provider`)
 }
 
+function optionalRedisNamespace(value: string | undefined): string | undefined {
+  const namespace = value?.trim()
+  if (!namespace) return undefined
+  assertValidRedisNamespace(namespace)
+  return namespace
+}
+
+function redisRoleKeyPrefix(namespace: string, role: "cache" | "state" | "rate"): string {
+  assertValidRedisNamespace(namespace)
+  return `voyant:v1:${namespace}:${role}:`
+}
+
+function assertValidRedisNamespace(namespace: string): void {
+  if (!/^[A-Za-z0-9][A-Za-z0-9_-]{0,62}$/u.test(namespace)) {
+    throw new Error(
+      "REDIS_NAMESPACE must be 1-63 characters of ASCII letters, numbers, underscores, or hyphens, and start with a letter or number.",
+    )
+  }
+}
+
 function isPostgresConnectionUrl(value: string): boolean {
   try {
     const parsed = new URL(value)
@@ -574,6 +605,7 @@ function isPostgresConnectionUrl(value: string): boolean {
 
 function assertVoyantNodeRuntimeSupport(options: {
   mode: VoyantDeploymentMode
+  providerPlan: VoyantNodeProviderPlan
   requirements: VoyantGraphDeploymentRequirements
   env: VoyantNodeRuntimeEnv
   hasAuthIntegration: boolean
@@ -581,6 +613,26 @@ function assertVoyantNodeRuntimeSupport(options: {
   const issues = nodeRuntimeEnvIssues(options.requirements, options.env)
   if (options.mode === "managed-cloud" && !options.hasAuthIntegration) {
     issues.push("managed-cloud applications require an injected auth integration")
+  }
+  if (
+    options.mode === "managed-cloud" &&
+    (options.providerPlan.cache === "redis" ||
+      options.providerPlan.sharedState === "redis" ||
+      options.providerPlan.rateLimit === "redis") &&
+    !options.env.REDIS_NAMESPACE?.trim()
+  ) {
+    issues.push(
+      "managed-cloud Redis cache, shared-state, and rate-limit providers require REDIS_NAMESPACE",
+    )
+  }
+  if (
+    options.mode === "managed-cloud" &&
+    (options.providerPlan.cache === "redis" ||
+      options.providerPlan.sharedState === "redis" ||
+      options.providerPlan.rateLimit === "redis") &&
+    !isRedisRestUrl(options.env.REDIS_URL, { requireHttps: true })
+  ) {
+    issues.push("managed-cloud Redis providers require an HTTPS Redis REST URL with a token")
   }
   if (issues.length > 0) {
     throw new Error(`Voyant Node runtime is not ready to start:\n${formatIssues(issues)}`)
@@ -635,7 +687,7 @@ function hasFormat(
     const parsed = new URL(value)
     if (format === "postgres-url")
       return parsed.protocol === "postgres:" || parsed.protocol === "postgresql:"
-    if (format === "redis-url") return parsed.protocol === "redis:" || parsed.protocol === "rediss:"
+    if (format === "redis-url") return isRedisRestUrl(value, { requireHttps: false })
     return parsed.protocol === "http:" || parsed.protocol === "https:"
   } catch {
     return false
@@ -644,8 +696,21 @@ function hasFormat(
 
 function formatDescription(format: NonNullable<VoyantDeploymentEnvRequirement["format"]>): string {
   if (format === "postgres-url") return "a Postgres URL"
-  if (format === "redis-url") return "a Redis URL"
+  if (format === "redis-url") return "an HTTP(S) Redis REST URL with a token"
   return "an HTTP(S) URL"
+}
+
+function isRedisRestUrl(value: unknown, options: { requireHttps: boolean }): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) return false
+  try {
+    const parsed = new URL(value)
+    return (
+      (parsed.protocol === "https:" || (!options.requireHttps && parsed.protocol === "http:")) &&
+      (parsed.password.length > 0 || (parsed.searchParams.get("token")?.length ?? 0) > 0)
+    )
+  } catch {
+    return false
+  }
 }
 
 function resolveDb(env: unknown): VoyantDb {

--- a/packages/hono/src/middleware/rate-limit.ts
+++ b/packages/hono/src/middleware/rate-limit.ts
@@ -173,6 +173,23 @@ export function createMemoryRateLimitStore(options?: { maxEntries?: number }): R
 
 export interface RedisRateLimitStoreOptions {
   client?: LazyRedisClient
+  keyPrefix?: string
+}
+
+function normalizeRedisRateLimitKeyPrefix(keyPrefix: string | undefined): string {
+  if (keyPrefix === undefined || keyPrefix.length === 0) return ""
+  if (hasControlCharacter(keyPrefix)) {
+    throw new Error("Redis rate-limit keyPrefix must not contain control characters.")
+  }
+  return keyPrefix
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code <= 0x1f || code === 0x7f) return true
+  }
+  return false
 }
 
 export function createRedisRateLimitStore(
@@ -180,13 +197,14 @@ export function createRedisRateLimitStore(
   options: RedisRateLimitStoreOptions = {},
 ): RateLimitStore {
   const lazyClient = options.client ?? createLazyRedisClient(redisUrl)
+  const keyPrefix = normalizeRedisRateLimitKeyPrefix(options.keyPrefix)
 
   return {
     async limit(key, { max, windowSeconds }) {
       const client = await lazyClient.get()
       const nowSeconds = Math.floor(Date.now() / 1000)
       const windowKey = Math.floor(nowSeconds / windowSeconds)
-      const storageKey = `${key}:${windowKey}`
+      const storageKey = `${keyPrefix}${key}:${windowKey}`
       const count = await client.incr(storageKey)
       if (count === 1) {
         await client.expire(storageKey, Math.max(1, windowSeconds * 2))

--- a/packages/hono/tests/unit/rate-limit-store.test.ts
+++ b/packages/hono/tests/unit/rate-limit-store.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it, vi } from "vitest"
+import type { LazyRedisClient, RedisClient } from "@voyant-travel/utils/redis-client"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   clientIpKey,
@@ -6,6 +7,43 @@ import {
   type RateLimitStore,
   resolveRateLimitStore,
 } from "../../src/middleware/rate-limit.js"
+
+class FakeRedisClient implements RedisClient {
+  readonly values = new Map<string, string>()
+  readonly expiries = new Map<string, number>()
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    return (this.values.get(key) ?? null) as T | null
+  }
+
+  async set(key: string, value: string, options?: { ex?: number }): Promise<unknown> {
+    this.values.set(key, value)
+    if (options?.ex !== undefined) this.expiries.set(key, options.ex)
+  }
+
+  async del(key: string): Promise<unknown> {
+    this.values.delete(key)
+    this.expiries.delete(key)
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = Number(this.values.get(key) ?? "0") + 1
+    this.values.set(key, String(next))
+    return next
+  }
+
+  async expire(key: string, seconds: number): Promise<unknown> {
+    this.expiries.set(key, seconds)
+  }
+}
+
+function fakeClient(client: RedisClient): LazyRedisClient {
+  return { get: async () => client }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 describe("clientIpKey", () => {
   it("supports standard Node reverse-proxy client IP headers", () => {
@@ -47,5 +85,58 @@ describe("createRedisRateLimitStore", () => {
     )
     expect(incr).toHaveBeenCalledWith(expect.stringMatching(/^lim:test:client:/))
     expect(expire).toHaveBeenCalledWith(expect.stringMatching(/^lim:test:client:/), 120)
+  })
+
+  it("isolates counters by keyPrefix", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-21T00:00:00.000Z"))
+    const client = new FakeRedisClient()
+    const eu = createRedisRateLimitStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:eu:rate:",
+    })
+    const us = createRedisRateLimitStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:us:rate:",
+    })
+
+    await expect(eu.limit("lim:auth:client", { max: 1, windowSeconds: 60 })).resolves.toEqual(
+      expect.objectContaining({ allowed: true, remaining: 0 }),
+    )
+    await expect(eu.limit("lim:auth:client", { max: 1, windowSeconds: 60 })).resolves.toEqual(
+      expect.objectContaining({ allowed: false, remaining: 0 }),
+    )
+    await expect(us.limit("lim:auth:client", { max: 1, windowSeconds: 60 })).resolves.toEqual(
+      expect.objectContaining({ allowed: true, remaining: 0 }),
+    )
+
+    expect([...client.values.keys()].sort()).toEqual([
+      "voyant:v1:eu:rate:lim:auth:client:29743200",
+      "voyant:v1:us:rate:lim:auth:client:29743200",
+    ])
+  })
+
+  it("sets expiry on the prefixed fixed-window key only once", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-07-21T00:00:00.000Z"))
+    const client = new FakeRedisClient()
+    const store = createRedisRateLimitStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:eu:rate:",
+    })
+
+    await store.limit("lim:auth:client", { max: 2, windowSeconds: 30 })
+    await store.limit("lim:auth:client", { max: 2, windowSeconds: 30 })
+
+    expect(client.expiries).toEqual(new Map([["voyant:v1:eu:rate:lim:auth:client:59486400", 60]]))
+  })
+
+  it("rejects control characters in keyPrefix", () => {
+    expect(() =>
+      createRedisRateLimitStore("https://example.test?token=test-token", {
+        client: fakeClient(new FakeRedisClient()),
+        keyPrefix: "voyant:v1:bad\nnamespace:rate:",
+      }),
+    ).toThrow(/keyPrefix/)
   })
 })

--- a/packages/utils/src/redis-client.ts
+++ b/packages/utils/src/redis-client.ts
@@ -28,7 +28,9 @@ function parseRedisRestUrl(rawUrl: string): { url: string; token: string } {
     throw new Error("REDIS_URL must be an HTTP(S) Redis REST URL.")
   }
 
-  const token = parsed.password || parsed.searchParams.get("token") || ""
+  const passwordToken = parsed.password
+  const queryToken = parsed.searchParams.get("token")
+  const token = passwordToken ? decodeURIComponent(passwordToken) : (queryToken ?? "")
   if (!token) {
     throw new Error("REDIS_URL must include a Redis REST token as the URL password or token query.")
   }
@@ -38,7 +40,7 @@ function parseRedisRestUrl(rawUrl: string): { url: string; token: string } {
   parsed.searchParams.delete("token")
   return {
     url: parsed.toString().replace(/\/$/, ""),
-    token: decodeURIComponent(token),
+    token,
   }
 }
 

--- a/packages/utils/src/redis-kv.ts
+++ b/packages/utils/src/redis-kv.ts
@@ -3,18 +3,50 @@ import { createLazyRedisClient, type LazyRedisClient } from "./redis-client.js"
 
 export interface RedisKvStoreOptions {
   client?: LazyRedisClient
+  keyPrefix?: string
 }
 
 function getType(options?: "json" | { type?: "json" | "text" }): "json" | "text" {
   return typeof options === "string" ? options : (options?.type ?? "text")
 }
 
+function normalizeKeyPrefix(keyPrefix: string | undefined): string {
+  if (keyPrefix === undefined || keyPrefix.length === 0) return ""
+  if (hasControlCharacter(keyPrefix)) {
+    throw new Error("Redis keyPrefix must not contain control characters.")
+  }
+  return keyPrefix
+}
+
+function hasControlCharacter(value: string): boolean {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code <= 0x1f || code === 0x7f) return true
+  }
+  return false
+}
+
+function physicalKey(keyPrefix: string, key: string): string {
+  return `${keyPrefix}${key}`
+}
+
+function logicalKey(keyPrefix: string, key: string): string | undefined {
+  if (!keyPrefix) return key
+  return key.startsWith(keyPrefix) ? key.slice(keyPrefix.length) : undefined
+}
+
 function scanPattern(prefix: string): string {
-  return `${prefix.replaceAll("[", "\\[").replaceAll("*", "\\*")}*`
+  return `${prefix
+    .replaceAll("\\", "\\\\")
+    .replaceAll("[", "\\[")
+    .replaceAll("]", "\\]")
+    .replaceAll("*", "\\*")
+    .replaceAll("?", "\\?")}*`
 }
 
 export function createRedisKvStore(redisUrl: string, options: RedisKvStoreOptions = {}): KVStore {
   const lazyClient = options.client ?? createLazyRedisClient(redisUrl)
+  const keyPrefix = normalizeKeyPrefix(options.keyPrefix)
 
   return {
     async get<T = string>(
@@ -22,7 +54,7 @@ export function createRedisKvStore(redisUrl: string, options: RedisKvStoreOption
       options?: "json" | { type?: "json" | "text" },
     ): Promise<T | null> {
       const client = await lazyClient.get()
-      const value = await client.get<string>(key)
+      const value = await client.get<string>(physicalKey(keyPrefix, key))
       if (value === null || value === undefined) return null
       return (
         getType(options) === "json" && typeof value === "string" ? JSON.parse(value) : value
@@ -30,25 +62,35 @@ export function createRedisKvStore(redisUrl: string, options: RedisKvStoreOption
     },
     async put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void> {
       const client = await lazyClient.get()
+      const storedKey = physicalKey(keyPrefix, key)
       if (options?.expirationTtl !== undefined) {
-        await client.set(key, value, { ex: Math.max(1, Math.ceil(options.expirationTtl)) })
+        await client.set(storedKey, value, { ex: Math.max(1, Math.ceil(options.expirationTtl)) })
         return
       }
-      await client.set(key, value)
+      await client.set(storedKey, value)
     },
     async delete(key: string): Promise<void> {
       const client = await lazyClient.get()
-      await client.del(key)
+      await client.del(physicalKey(keyPrefix, key))
     },
     async list(options?: { prefix?: string }): Promise<{ keys: Array<{ name: string }> }> {
       const client = await lazyClient.get()
       if (!client.scan) return { keys: [] }
       const keys: Array<{ name: string }> = []
       let cursor: number | string = 0
-      const match = scanPattern(options?.prefix ?? "")
+      const requestedPrefix = options?.prefix
+      const match = scanPattern(physicalKey(keyPrefix, requestedPrefix ?? ""))
       do {
         const [nextCursor, batch] = await client.scan(Number(cursor), { match, count: 100 })
-        for (const name of batch) keys.push({ name })
+        for (const name of batch) {
+          const logicalName = logicalKey(keyPrefix, name)
+          if (
+            logicalName !== undefined &&
+            (requestedPrefix === undefined || logicalName.startsWith(requestedPrefix))
+          ) {
+            keys.push({ name: logicalName })
+          }
+        }
         cursor = nextCursor
       } while (String(cursor) !== "0")
       return { keys }

--- a/packages/utils/tests/redis-client.test.ts
+++ b/packages/utils/tests/redis-client.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const redisConstructed = vi.hoisted(() => [] as Array<{ options: { url: string; token: string } }>)
+
+vi.mock("@upstash/redis", () => {
+  class Redis {
+    constructor(readonly options: { url: string; token: string }) {
+      redisConstructed.push({ options })
+    }
+  }
+
+  return { Redis }
+})
+
+async function createClient(redisUrl: string) {
+  const { createLazyRedisClient } = await import("../src/redis-client.js")
+  return createLazyRedisClient(redisUrl).get()
+}
+
+beforeEach(() => {
+  redisConstructed.length = 0
+  vi.resetModules()
+})
+
+describe("createLazyRedisClient Redis REST URL parsing", () => {
+  it("percent-decodes URL password tokens exactly once", async () => {
+    await createClient("https://default:a%40b%3Ac%2Fd%3Fe%23f%25g@example.test/redis")
+
+    expect(redisConstructed[0]?.options.url).toBe("https://example.test/redis")
+    expect(redisConstructed[0]?.options.token).toBe(["a@b", "c/d?e#f%g"].join(":"))
+  })
+
+  it("does not decode query tokens a second time", async () => {
+    await createClient("https://example.test/redis?token=a%40b%3Ac%2Fd%3Fe%23f%25g")
+
+    expect(redisConstructed[0]?.options.url).toBe("https://example.test/redis")
+    expect(redisConstructed[0]?.options.token).toBe(["a@b", "c/d?e#f%g"].join(":"))
+  })
+
+  it("preserves query token percent sequences that would be malformed if decoded again", async () => {
+    await createClient("https://example.test/redis?token=%25E0%25A4%25A")
+
+    expect(redisConstructed[0]?.options.url).toBe("https://example.test/redis")
+    expect(redisConstructed[0]?.options.token).toBe(["%E0", "%A4", "%A"].join(""))
+  })
+
+  it("throws for malformed percent encoding in URL password tokens", async () => {
+    await expect(createClient("https://default:%E0%A4%A@example.test/redis")).rejects.toThrow(
+      /URI malformed/,
+    )
+    expect(redisConstructed).toEqual([])
+  })
+
+  it("removes credentials and token query from the base URL passed to Upstash", async () => {
+    const url = new URL("https://example.test/redis?token=query-secret&db=0")
+    url.username = "default"
+    url.password = "secret"
+
+    await createClient(url.toString())
+
+    expect(redisConstructed).toEqual([
+      {
+        options: {
+          url: "https://example.test/redis?db=0",
+          token: "secret",
+        },
+      },
+    ])
+  })
+})

--- a/packages/utils/tests/redis-kv.test.ts
+++ b/packages/utils/tests/redis-kv.test.ts
@@ -1,6 +1,175 @@
 import { describe, expect, it } from "vitest"
 
+import type { LazyRedisClient, RedisClient } from "../src/redis-client.js"
 import { createRedisKvStore } from "../src/redis-kv.js"
+
+class FakeRedisClient implements RedisClient {
+  readonly values = new Map<string, string>()
+  readonly expiries = new Map<string, number>()
+  readonly deletions: string[] = []
+  leakedScanKeys: string[] | undefined
+
+  async get<T = unknown>(key: string): Promise<T | null> {
+    return (this.values.get(key) ?? null) as T | null
+  }
+
+  async set(key: string, value: string, options?: { ex?: number }): Promise<unknown> {
+    this.values.set(key, value)
+    if (options?.ex !== undefined) this.expiries.set(key, options.ex)
+  }
+
+  async del(key: string): Promise<unknown> {
+    this.deletions.push(key)
+    this.values.delete(key)
+    this.expiries.delete(key)
+  }
+
+  async scan(
+    cursor: number,
+    options?: { match?: string; count?: number },
+  ): Promise<[number | string, string[]]> {
+    if (cursor !== 0) return [0, []]
+    if (this.leakedScanKeys) return [0, this.leakedScanKeys]
+    const pattern = options?.match ?? "*"
+    return [0, [...this.values.keys()].filter((key) => redisGlobMatches(pattern, key)).sort()]
+  }
+
+  async incr(key: string): Promise<number> {
+    const next = Number(this.values.get(key) ?? "0") + 1
+    this.values.set(key, String(next))
+    return next
+  }
+
+  async expire(key: string, seconds: number): Promise<unknown> {
+    this.expiries.set(key, seconds)
+  }
+}
+
+function fakeClient(client: RedisClient): LazyRedisClient {
+  return { get: async () => client }
+}
+
+function redisGlobMatches(pattern: string, value: string): boolean {
+  let regex = "^"
+  for (let index = 0; index < pattern.length; index += 1) {
+    const char = pattern[index]
+    if (char === "\\") {
+      const next = pattern[index + 1]
+      regex += escapeRegExp(next ?? "\\")
+      if (next !== undefined) index += 1
+      continue
+    }
+    if (char === "*") {
+      regex += ".*"
+      continue
+    }
+    if (char === "?") {
+      regex += "."
+      continue
+    }
+    regex += escapeRegExp(char ?? "")
+  }
+  return new RegExp(`${regex}$`, "u").test(value)
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+describe("createRedisKvStore with keyPrefix", () => {
+  it("isolates adjacent namespaces and lists logical keys", async () => {
+    const client = new FakeRedisClient()
+    const eu = createRedisKvStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:eu:cache:",
+    })
+    const europe = createRedisKvStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:europe:cache:",
+    })
+
+    await eu.put("hotel:1", "eu")
+    await europe.put("hotel:1", "europe")
+    await eu.put("tour:1", "tour")
+
+    await expect(eu.get("hotel:1")).resolves.toBe("eu")
+    await expect(europe.get("hotel:1")).resolves.toBe("europe")
+    await expect(eu.list({ prefix: "hotel:" })).resolves.toEqual({
+      keys: [{ name: "hotel:1" }],
+    })
+  })
+
+  it("deletes only the prefixed physical key", async () => {
+    const client = new FakeRedisClient()
+    const kv = createRedisKvStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:ro:cache:",
+    })
+    client.values.set("key", "unprefixed")
+
+    await kv.put("key", "prefixed")
+    await kv.delete("key")
+
+    expect(client.values.get("key")).toBe("unprefixed")
+    expect(client.values.has("voyant:v1:ro:cache:key")).toBe(false)
+  })
+
+  it("applies TTL to the prefixed physical key", async () => {
+    const client = new FakeRedisClient()
+    const kv = createRedisKvStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:ro:cache:",
+    })
+
+    await kv.put("key", "value", { expirationTtl: 1.2 })
+
+    expect(client.expiries.get("voyant:v1:ro:cache:key")).toBe(2)
+  })
+
+  it("escapes Redis SCAN glob characters in the physical prefix", async () => {
+    const client = new FakeRedisClient()
+    const kv = createRedisKvStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:[ro]*?:cache:",
+    })
+    client.values.set("voyant:v1:[ro]*?:cache:hotel:1", "match")
+    client.values.set("voyant:v1:r:cache:hotel:2", "glob-leak")
+
+    await expect(kv.list({ prefix: "hotel:" })).resolves.toEqual({
+      keys: [{ name: "hotel:1" }],
+    })
+  })
+
+  it("filters leaked physical keys and returns logical names safe for delete", async () => {
+    const client = new FakeRedisClient()
+    const kv = createRedisKvStore("https://example.test?token=test-token", {
+      client: fakeClient(client),
+      keyPrefix: "voyant:v1:ro:cache:",
+    })
+    client.values.set("voyant:v1:ro:cache:hotel:1", "match")
+    client.leakedScanKeys = [
+      "voyant:v1:ro:cache:hotel:1",
+      "voyant:v1:ro:rate:hotel:2",
+      "voyant:v1:ro:cache:tour:1",
+      "unprefixed:hotel:3",
+    ]
+
+    const result = await kv.list({ prefix: "hotel:" })
+    await kv.delete(result.keys[0]!.name)
+
+    expect(result).toEqual({ keys: [{ name: "hotel:1" }] })
+    expect(client.deletions).toEqual(["voyant:v1:ro:cache:hotel:1"])
+  })
+
+  it("rejects control characters in keyPrefix", () => {
+    expect(() =>
+      createRedisKvStore("https://example.test?token=test-token", {
+        client: fakeClient(new FakeRedisClient()),
+        keyPrefix: "voyant:v1:bad\nnamespace:cache:",
+      }),
+    ).toThrow(/keyPrefix/)
+  })
+})
 
 const describeIfRedis = process.env.REDIS_URL ? describe : describe.skip
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,7 +1239,7 @@ importers:
         version: link:../hono
       '@voyant-travel/plugin-voyant-connect':
         specifier: ^0.3.2
-        version: 0.3.2(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
+        version: 0.3.2(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/tools':
         specifier: workspace:^
         version: link:../tools
@@ -2486,7 +2486,7 @@ importers:
         version: link:../operator-standard
       '@voyant-travel/plugin-voyant-connect':
         specifier: ^0.3.2
-        version: 0.3.2(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
+        version: 0.3.2(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/runtime-core':
         specifier: workspace:^
         version: link:../runtime-core
@@ -2517,6 +2517,9 @@ importers:
       pg:
         specifier: ^8.22.0
         version: 8.22.0
+      redis:
+        specifier: ^6.1.0
+        version: 6.1.0(@opentelemetry/api@1.9.0)
     devDependencies:
       '@hono/zod-openapi':
         specifier: 'catalog:'
@@ -7529,6 +7532,42 @@ packages:
       '@types/react':
         optional: true
 
+  '@redis/bloom@6.1.0':
+    resolution: {integrity: sha512-Rzascjd9J9bJsM45T/Z9CTg1QY/B63B6YO8QorLVMeXnbBDsKiSCVR/+GQ061hYPk8FpTzWmPY8tAv2sT+JEtQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
+  '@redis/client@6.1.0':
+    resolution: {integrity: sha512-7u1LefkezJF0HESlhO7ZFLEPfyY+NejP3SGv+Z4pGaT3oM5GVVLa0u3f4rDLUrcw+SRo8IlX9Y8JAONeDdg1Ag==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@node-rs/xxhash': ^1.1.0
+      '@opentelemetry/api': '>=1 <2'
+    peerDependenciesMeta:
+      '@node-rs/xxhash':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@redis/json@6.1.0':
+    resolution: {integrity: sha512-/GFjQA6bu5pG9ClCJAI5Xx4bNXe7UTpxBBlIupBNTrn1+nY860apGnYJuaSCDV2BmEbTidpa7O2qa28oxKx+rg==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
+  '@redis/search@6.1.0':
+    resolution: {integrity: sha512-kS5agg+3yZbrdrt8omrew7FLCD8eOm7tarG1CROekPBRe+QGDR9aOpnHIQaYsYi6wPRTH70nQiF06AIjgURefQ==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
+  '@redis/time-series@6.1.0':
+    resolution: {integrity: sha512-uIDBtV8MmG/xpJsRqbGSO4iX6ryj37MLMP82lRpFvI7ykAVe5GyqgxigEbU+uZNv9kDPNMKw3dvI/S/J1BNBzA==}
+    engines: {node: '>= 20.0.0'}
+    peerDependencies:
+      '@redis/client': ^6.1.0
+
   '@reduxjs/toolkit@2.12.0':
     resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
     peerDependencies:
@@ -8627,14 +8666,14 @@ packages:
   '@voyant-travel/bookings-contracts@0.109.1':
     resolution: {integrity: sha512-vSo3dLy/suexG0prhHmhnQY1b3DpKgvG98X5h0a6hv9K53+ydS8gAfKNF57poMIYAluaV3oQeRHWqKrUoTTBIw==}
 
-  '@voyant-travel/bookings@0.183.0':
-    resolution: {integrity: sha512-xZY16/bgICtG13MLIb3YE0YMTLScE/+71BRFiH+FuBudaTxrOcpAZB5g8n0Y58UfKYKL8s8eMFkIy1y6zvVLFg==}
+  '@voyant-travel/bookings@0.187.0':
+    resolution: {integrity: sha512-R9xZR7tcPGfm0BKUQWi/JPCiiy0bnGdI2FPnQDpLT3MTcimP867+wStwryMONC/IA9oxzPXGK8ds7IRKnEusRg==}
 
   '@voyant-travel/catalog-contracts@0.111.1':
     resolution: {integrity: sha512-xYI/dZpqyz24UUcjGzPcacE23BqZOSr1BNZw7NVzaywrp8rLjmMTP3LO7sfq/zZVE8oEE88X0D23av4KvjxdbA==}
 
-  '@voyant-travel/catalog@0.181.0':
-    resolution: {integrity: sha512-ozlH224y2HccqrlW02mQ+nPxj10SP8RNTuQ1BjtwletDruDhlwZkHUu0jJSaCFs0BLkvGadLBBGenBO1qODVnw==}
+  '@voyant-travel/catalog@0.185.0':
+    resolution: {integrity: sha512-4NaSPuu3ebyEghgvR9yloQew2CIH3zRxZxXLljfbyB2yC+2Jux+trsEgDRTSWQhNMyXShCefuTfqprySvV24pQ==}
 
   '@voyant-travel/cli@0.40.1':
     resolution: {integrity: sha512-D3JvVIll/zXMdqdyoCIDzEbgRFhsPdf+gUwr/78dlBqSzhfRvBJg3JKOYh/pUeKuPe4JxUsCiGo96BDDEICtKg==}
@@ -8688,8 +8727,8 @@ packages:
   '@voyant-travel/cruises-contracts@0.105.8':
     resolution: {integrity: sha512-878ng2rHCXXyXiJagjJk9TnARt5C5FMqdyulKhmOkCPcD5FxHu6Q6QIzvNzVux2vS6cSbJSn1FGXhSMs7RqE0A==}
 
-  '@voyant-travel/cruises@0.182.0':
-    resolution: {integrity: sha512-tPpAKEl0ZOycY/iBLcaHxmk9Cav8M1WPB4BTLbIkUePNRQGDoaZs8/HsNnYtIkpbzrlNL9FXZWSdZUGf8mwSRA==}
+  '@voyant-travel/cruises@0.186.0':
+    resolution: {integrity: sha512-bQlu3CFGY0OKFBilP0SIymNimTp/N/NTSP9ogT0SUnp6CDrqDVxUEWAgsmHrvxDpfgweP66yUFcwoanZQiPkNg==}
 
   '@voyant-travel/data-sdk@0.7.1':
     resolution: {integrity: sha512-sJvDL8cO0en81z9RpjuL7ugyecJGcYygt5QclHCbfW5HLhmL/5Cho+50etvPtNXoH50TyQQcdLucEqH5cpN3Cw==}
@@ -8702,8 +8741,8 @@ packages:
   '@voyant-travel/finance-contracts@0.107.1':
     resolution: {integrity: sha512-uYjfpiK/h+sk4HJym2sgjvyWubiOdiYQgCdoaSo44AGzzqqm0mBneXRU/6IpzYZoyxIva3vhsB7NQkFpumaymA==}
 
-  '@voyant-travel/finance@0.183.0':
-    resolution: {integrity: sha512-9Hg9Y1EOs5EcSdLGdiHMtC7Qk41S5A30CrMespCcWjJy8apxcPLaPMKMcdLd9QQ2PXNQjiDBRVbl5LqnUoB0xw==}
+  '@voyant-travel/finance@0.187.1':
+    resolution: {integrity: sha512-Qcu1QGmKYoGvKOmVmOTymlk14a6RG4Iuu/ohHEwfCm4oB0MGFIxaQ8e04DYMHzY1+Fw0+dDNhcPGuC4SB+VpMw==}
 
   '@voyant-travel/hono@0.132.0':
     resolution: {integrity: sha512-nxd9N5s9wPN/CtmnMc3Gl5TTh+I6B6FvdEhlEGHF85DzJkYL+zU5SpinzKDjV0lSU80lQe1cq6xh3n8hZWXfQw==}
@@ -8721,8 +8760,8 @@ packages:
       '@voyant-travel/catalog':
         optional: true
 
-  '@voyant-travel/public-document-delivery@0.4.9':
-    resolution: {integrity: sha512-NfB6tnezwfTiAGurNZPMOcOp+NSgDV+dvb8Cd9j3hBQBDWwtHAHA6uDDNKQZqIuuIfurLMrKN4dsEFUWE1HRgg==}
+  '@voyant-travel/public-document-delivery@0.4.10':
+    resolution: {integrity: sha512-LYu+kR9cjmqwF5DCzsIUVBENGfAzquCMVrkC02xJE9Bx0IFKsYJazsmPcimbM85DmuklgfqVhNemG3YEeDuXWg==}
 
   '@voyant-travel/reporting-contracts@0.3.0':
     resolution: {integrity: sha512-onyN8fTwoXf/Qa3g2bAQ4xkjge279sSQKiO7+qqy5tIv4vtNrkwoB6DxopPgUWw/I4KaLHMmwudCfqjQ7PUqdg==}
@@ -8730,8 +8769,8 @@ packages:
   '@voyant-travel/schema-kit@0.114.0':
     resolution: {integrity: sha512-b2NSdlXkYvUQJdaVpqCKmi0x55ac949EX6XUrAlOGzxqTgV9Kf8oDQf258HKmzZ7IrZ9BVpo7rIfxCYNtPISyA==}
 
-  '@voyant-travel/storage@0.112.0':
-    resolution: {integrity: sha512-HwdWaIr/bRzNzjTU9eEm25CZR3hFhDeA6Wz/7Xw9TBkg9jLTvhjtgWBZvJyiOyX1nQild/mYpDBOXDttJ6TBtw==}
+  '@voyant-travel/storage@0.113.1':
+    resolution: {integrity: sha512-WhYFBkSBGEEPL/NW2UFTU/BsQRRT/CxYKECND5jeggtcTjJQ4gaJtHBYXM3zrDhK2DjFwKuV1r0o/TicBwVkbg==}
     peerDependencies:
       hono: 4.12.25
       zod: ^4.0.0
@@ -9265,6 +9304,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -11525,6 +11568,10 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redis@6.1.0:
+    resolution: {integrity: sha512-0kvUPM8RHP/ZMa0xYaDTcG5e8tIGW6kz6MToVT0V8iOnk6bkXp2jncGRGe2bZEk41lZwiDspUqjZCSk5ohjcKw==}
+    engines: {node: '>= 20.0.0'}
 
   redux-thunk@3.1.0:
     resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
@@ -14157,6 +14204,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@redis/bloom@6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.1.0(@opentelemetry/api@1.9.0)
+
+  '@redis/client@6.1.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      cluster-key-slot: 1.1.2
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@redis/json@6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.1.0(@opentelemetry/api@1.9.0)
+
+  '@redis/search@6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.1.0(@opentelemetry/api@1.9.0)
+
+  '@redis/time-series@6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))':
+    dependencies:
+      '@redis/client': 6.1.0(@opentelemetry/api@1.9.0)
+
   '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -15586,7 +15655,7 @@ snapshots:
       '@voyant-travel/schema-kit': 0.114.0
       zod: 4.4.3
 
-  '@voyant-travel/bookings@0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
+  '@voyant-travel/bookings@0.187.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/action-ledger': 0.111.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -15637,17 +15706,17 @@ snapshots:
     dependencies:
       zod: 4.4.3
 
-  '@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+  '@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
-      '@voyant-travel/bookings': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/bookings': 0.187.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/catalog-contracts': 0.111.1
       '@voyant-travel/connect-sdk': 0.9.1
       '@voyant-travel/core': 0.130.0
       '@voyant-travel/db': 0.117.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/finance': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/finance': 0.187.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/hono': 0.132.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
+      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/tools': 0.3.0(zod@4.4.3)
       '@voyant-travel/workflows': 0.122.16(zod@4.4.3)
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -15687,17 +15756,17 @@ snapshots:
       - sqlite3
       - typesense
 
-  '@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+  '@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
-      '@voyant-travel/bookings': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/bookings': 0.187.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/catalog-contracts': 0.111.1
       '@voyant-travel/connect-sdk': 0.9.1
       '@voyant-travel/core': 0.130.0
       '@voyant-travel/db': 0.117.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/finance': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/finance': 0.187.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/hono': 0.132.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
+      '@voyant-travel/plugin-voyant-connect': 0.3.2(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)
       '@voyant-travel/tools': 0.3.0(zod@4.4.3)
       '@voyant-travel/workflows': 0.122.16(zod@4.4.3)
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -15789,14 +15858,14 @@ snapshots:
     optionalDependencies:
       typesense: 3.0.6(@babel/runtime@7.29.7)
 
-  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
     dependencies:
-      '@voyant-travel/catalog': 0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog': 0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/connect-sdk': 0.9.1
 
-  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+  '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
     dependencies:
-      '@voyant-travel/catalog': 0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog': 0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/connect-sdk': 0.9.1
 
   '@voyant-travel/connect-adapter@0.4.0(@voyant-travel/catalog@packages+catalog)':
@@ -15804,11 +15873,11 @@ snapshots:
       '@voyant-travel/catalog': link:packages/catalog
       '@voyant-travel/connect-sdk': 0.9.1
 
-  '@voyant-travel/connect-cruises@0.6.1(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
+  '@voyant-travel/connect-cruises@0.6.1(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))':
     dependencies:
       '@voyant-travel/connect-sdk': 0.9.1
     optionalDependencies:
-      '@voyant-travel/cruises': 0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/cruises': 0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
 
   '@voyant-travel/connect-cruises@0.6.1(@voyant-travel/cruises@packages+cruises)':
     dependencies:
@@ -15827,15 +15896,15 @@ snapshots:
       '@voyant-travel/catalog-contracts': 0.111.1
       zod: 4.4.3
 
-  '@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+  '@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
-      '@voyant-travel/bookings': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/catalog': 0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/bookings': 0.187.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/catalog': 0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/core': 0.130.0
       '@voyant-travel/cruises-contracts': 0.105.8
       '@voyant-travel/db': 0.117.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/finance': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/finance': 0.187.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/hono': 0.132.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/tools': 0.3.0(zod@4.4.3)
       '@voyant-travel/types': 0.109.8(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
@@ -15953,20 +16022,20 @@ snapshots:
       - sql.js
       - sqlite3
 
-  '@voyant-travel/finance@0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
+  '@voyant-travel/finance@0.187.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/action-ledger': 0.111.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
-      '@voyant-travel/bookings': 0.183.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
+      '@voyant-travel/bookings': 0.187.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/core': 0.130.0
       '@voyant-travel/data-sdk': 0.7.1
       '@voyant-travel/db': 0.117.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
       '@voyant-travel/finance-contracts': 0.107.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/hono': 0.132.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       '@voyant-travel/payments': 0.5.0
-      '@voyant-travel/public-document-delivery': 0.4.9(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
+      '@voyant-travel/public-document-delivery': 0.4.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       '@voyant-travel/reporting-contracts': 0.3.0
-      '@voyant-travel/storage': 0.112.0(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
+      '@voyant-travel/storage': 0.113.1(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       '@voyant-travel/tools': 0.3.0(zod@4.4.3)
       '@voyant-travel/types': 0.109.8(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
       '@voyant-travel/utils': 0.108.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
@@ -16052,25 +16121,25 @@ snapshots:
     dependencies:
       '@voyant-travel/core': 0.130.0
 
-  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)':
+  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)':
     dependencies:
-      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
-      '@voyant-travel/connect-cruises': 0.6.1(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-cruises': 0.6.1(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
       '@voyant-travel/connect-sdk': 0.9.1
-      '@voyant-travel/cruises': 0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/cruises': 0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
       '@voyant-travel/data-sdk': 0.7.1
     optionalDependencies:
-      '@voyant-travel/catalog': 0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.182.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog': 0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@0.186.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
 
-  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)':
+  '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)':
     dependencies:
-      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
+      '@voyant-travel/connect-adapter': 0.4.0(@voyant-travel/catalog@0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7)))
       '@voyant-travel/connect-cruises': 0.6.1(@voyant-travel/cruises@packages+cruises)
       '@voyant-travel/connect-sdk': 0.9.1
       '@voyant-travel/cruises': link:packages/cruises
       '@voyant-travel/data-sdk': 0.7.1
     optionalDependencies:
-      '@voyant-travel/catalog': 0.181.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
+      '@voyant-travel/catalog': 0.185.0(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))
 
   '@voyant-travel/plugin-voyant-connect@0.3.2(@voyant-travel/catalog@packages+catalog)(@voyant-travel/cruises@packages+cruises)(@voyant-travel/data-sdk@0.7.1)':
     dependencies:
@@ -16082,12 +16151,12 @@ snapshots:
     optionalDependencies:
       '@voyant-travel/catalog': link:packages/catalog
 
-  '@voyant-travel/public-document-delivery@0.4.9(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)':
+  '@voyant-travel/public-document-delivery@0.4.10(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)':
     dependencies:
       '@hono/zod-openapi': 1.4.0(hono@4.12.25)(zod@4.4.3)
       '@voyant-travel/core': 0.130.0
       '@voyant-travel/db': 0.117.1(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)
-      '@voyant-travel/storage': 0.112.0(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
+      '@voyant-travel/storage': 0.113.1(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)
       drizzle-orm: 0.45.2(@cloudflare/workers-types@4.20260702.1)(@electric-sql/pglite@0.5.4)(@neondatabase/serverless@1.1.0)(@opentelemetry/api@1.9.0)(@types/pg@8.20.0)(@upstash/redis@1.38.0)(kysely@0.29.2)(pg@8.22.0)(postgres@3.4.9)
       hono: 4.12.25
     transitivePeerDependencies:
@@ -16133,7 +16202,7 @@ snapshots:
       typeid-js: 1.2.0
       zod: 4.4.3
 
-  '@voyant-travel/storage@0.112.0(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)':
+  '@voyant-travel/storage@0.113.1(hono@4.12.25)(typesense@3.0.6(@babel/runtime@7.29.7))(zod@4.4.3)':
     dependencies:
       '@aws-sdk/client-s3': 3.1085.0
       '@aws-sdk/s3-request-presigner': 3.1085.0
@@ -16790,6 +16859,8 @@ snapshots:
       wrap-ansi: 9.0.2
 
   clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -19181,6 +19252,17 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - redux
+
+  redis@6.1.0(@opentelemetry/api@1.9.0):
+    dependencies:
+      '@redis/bloom': 6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))
+      '@redis/client': 6.1.0(@opentelemetry/api@1.9.0)
+      '@redis/json': 6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))
+      '@redis/search': 6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))
+      '@redis/time-series': 6.1.0(@redis/client@6.1.0(@opentelemetry/api@1.9.0))
+    transitivePeerDependencies:
+      - '@node-rs/xxhash'
+      - '@opentelemetry/api'
 
   redux-thunk@3.1.0(redux@5.0.1):
     dependencies:


### PR DESCRIPTION
## Summary

- add optional physical Redis namespace prefixes for cache, rate-limit, and shared-state keys
- add a Node-only native Redis adapter using `node-redis` for `redis://` and `rediss://` endpoints
- share one lazy TCP connection across Redis-backed runtime roles
- retain the existing Upstash REST adapter for HTTP(S) endpoints
- require a namespace and TLS `rediss://` URL in managed mode; reject plaintext managed Redis
- keep managed shared state on Postgres

## Managed runtime contract

The platform injects:

- `REDIS_URL=rediss://default:<password>@<regional-upstash-host>:6379`
- `REDIS_NAMESPACE=<stable app-environment id>`

Credentials are not exposed to application developers. Self-hosted runtimes may continue to use Redis TCP/TLS or HTTP(S) REST endpoints.

## Validation

- focused Framework, Hono, and shared-utils tests
- Framework, Hono, and shared-utils typechecks and lint
- secret scanning and diff checks
- commit and pre-push hooks
- retry coverage for failed initial TCP connections

The broad affected-package verification command exceeded the Node heap limit on the lab host; all focused checks and repository hooks passed.

## Rollout

This is the runtime prerequisite for the platform regional Redis pool change. The platform capability remains dormant until compatible runtime versions are enabled.