### PR TITLE
Restore the frozen action-ledger baseline hash

### DIFF
--- a/.changeset/calm-ledgers-remember.md
+++ b/.changeset/calm-ledgers-remember.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/action-ledger": patch
+---
+
+Restore the frozen action-ledger baseline migration bytes so databases adopted
+by the D.2 collector retain their historical content hash on runtime upgrades.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 packages/apps/src/session-token.ts text diff
+packages/action-ledger/migrations/0000_action_ledger_baseline.sql text whitespace=-trailing-space,-blank-at-eof

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 packages/apps/src/session-token.ts text diff
-packages/action-ledger/migrations/0000_action_ledger_baseline.sql text whitespace=-trailing-space,-blank-at-eof
+packages/action-ledger/migrations/0000_action_ledger_baseline.sql text eol=lf whitespace=-trailing-space,-blank-at-eof

--- a/packages/action-ledger/migrations/0000_action_ledger_baseline.sql
+++ b/packages/action-ledger/migrations/0000_action_ledger_baseline.sql
@@ -178,7 +178,7 @@ CREATE INDEX "idx_action_ledger_entries_correlation" ON "action_ledger_entries" 
 CREATE INDEX "idx_action_ledger_entries_causation" ON "action_ledger_entries" USING btree ("causation_action_id");--> statement-breakpoint
 CREATE INDEX "idx_action_ledger_entries_control_state" ON "action_ledger_entries" USING btree ("evaluated_risk","status","occurred_at");--> statement-breakpoint
 CREATE INDEX "idx_action_ledger_entries_capability" ON "action_ledger_entries" USING btree ("capability_id","capability_version","occurred_at");--> statement-breakpoint
-CREATE UNIQUE INDEX "idx_action_ledger_entries_idempotency" ON "action_ledger_entries" USING btree ("idempotency_scope","action_name","target_type","target_id","idempotency_key") WHERE
+CREATE UNIQUE INDEX "idx_action_ledger_entries_idempotency" ON "action_ledger_entries" USING btree ("idempotency_scope","action_name","target_type","target_id","idempotency_key") WHERE 
         "action_ledger_entries"."idempotency_key" IS NOT NULL
       ;--> statement-breakpoint
 CREATE INDEX "idx_action_ledger_payloads_action" ON "action_ledger_payloads" USING btree ("action_id");--> statement-breakpoint

--- a/packages/action-ledger/tests/unit/migration-baseline-hash.test.ts
+++ b/packages/action-ledger/tests/unit/migration-baseline-hash.test.ts
@@ -1,0 +1,19 @@
+import { createHash } from "node:crypto"
+import { readFile } from "node:fs/promises"
+
+import { describe, expect, it } from "vitest"
+
+const FROZEN_BASELINE_HASH =
+  "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c"
+
+describe("action-ledger migration baseline", () => {
+  it("preserves the historical collector content hash", async () => {
+    const sql = await readFile(
+      new URL("../../migrations/0000_action_ledger_baseline.sql", import.meta.url),
+    )
+
+    expect(createHash("sha256").update(sql).digest("hex")).toBe(
+      FROZEN_BASELINE_HASH,
+    )
+  })
+})

--- a/packages/action-ledger/tests/unit/migration-baseline-hash.test.ts
+++ b/packages/action-ledger/tests/unit/migration-baseline-hash.test.ts
@@ -3,8 +3,7 @@ import { readFile } from "node:fs/promises"
 
 import { describe, expect, it } from "vitest"
 
-const FROZEN_BASELINE_HASH =
-  "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c"
+const FROZEN_BASELINE_HASH = "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c"
 
 describe("action-ledger migration baseline", () => {
   it("preserves the historical collector content hash", async () => {
@@ -12,8 +11,6 @@ describe("action-ledger migration baseline", () => {
       new URL("../../migrations/0000_action_ledger_baseline.sql", import.meta.url),
     )
 
-    expect(createHash("sha256").update(sql).digest("hex")).toBe(
-      FROZEN_BASELINE_HASH,
-    )
+    expect(createHash("sha256").update(sql).digest("hex")).toBe(FROZEN_BASELINE_HASH)
   })
 })


### PR DESCRIPTION
## Summary

- restore `0000_action_ledger_baseline.sql` byte-for-byte to the historical D.2 collector hash
- freeze that SHA-256 in a regression test
- scope the whitespace exception to this one immutable SQL artifact
- add a patch changeset for `@voyant-travel/action-ledger`

## Why

The Protravel collector ledger records `action-ledger/0000_action_ledger_baseline` as `2c1f0573…`, while `@voyant-travel/action-ledger@0.111.10` ships `d63e6a73…`. The only differences are one historical trailing space and the absence of the final newline; nevertheless the collector correctly treats raw SQL bytes as immutable. Restoring the original bytes avoids a false immutability failure without adding a compatibility exception.

## Validation

- local read-only SHA-256: `2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c`
- `git diff --check` passes with the narrow `.gitattributes` rule
- focused remote tests/typecheck dispatched
