### PR TITLE
Add exact-footprint materialized migration adoption

### DIFF
--- a/.changeset/gentle-migrations-adopt.md
+++ b/.changeset/gentle-migrations-adopt.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Add opt-in exact-footprint adoption for explicitly identified materialized migrations.

--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -235,6 +235,8 @@ jobs:
                 pnpm --filter operator db:migrate
               pnpm --filter @voyant-travel/relationships exec vitest run \
                 tests/integration/generic-custom-field-values.test.ts
+              pnpm --filter @voyant-travel/framework-migrations exec vitest run \
+                src/deployment-runner.test.ts
               ;;
           esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,8 @@ jobs:
                 pnpm --filter operator db:migrate
               pnpm --filter @voyant-travel/relationships exec vitest run \
                 tests/integration/generic-custom-field-values.test.ts
+              pnpm --filter @voyant-travel/framework-migrations exec vitest run \
+                src/deployment-runner.test.ts
               ;;
           esac
 

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -150,6 +150,35 @@ Plugins that own no schema (e.g. `@voyant-travel/plugin-netopia`) are unaffected
 they define no `pgTable` and ship no `migrations/`, so they resolve to `null` and
 need no migration step. Unblocks Slice 4 of platform#1016.
 
+## Explicit adoption of materialized post-cutline migrations
+
+An existing deployment may contain DDL from a package migration even when the
+collector ledger does not contain that exact `(source, tag)` row. This can occur
+when a legacy deployment materialized package schema outside the collector. The
+runner does not infer or broadly baseline such rows.
+
+`runDeploymentMigrations` accepts an explicit
+`materializedMigrationAdoptions` allowlist of exact source/tag identities. While
+holding the deployment migration session advisory lock, it classifies every
+pending allowlisted identity before a normal migration can commit:
+
+- if every table created by the immutable SQL is absent, the migration stays on
+  the normal execution path;
+- if any table is present, the full footprint must match exactly: table and
+  column sets/order, PostgreSQL type, nullability, default, identity/generated
+  state, named primary/unique/foreign-key constraints and their actions, and
+  non-constraint index names, uniqueness, method, keys/expressions and
+  predicates;
+- a partial or mismatched footprint aborts without a ledger write or migration
+  transaction;
+- an exact footprint is recorded with the current immutable SQL content hash and
+  reported through both `adopted` and the existing `baselined` result/hook.
+
+Fresh databases always execute from scratch. Migrations not named in the
+allowlist are never considered for materialized adoption. The verifier supports
+only DDL forms it can prove from PostgreSQL catalogs and fails closed for an
+unsupported allowlisted migration.
+
 ## References
 
 - `docs/architecture/migration-collector-d1.md` — the collector primitive + ledger D.2 reuses; the `assertSchemaAtBaseline` parity pattern.

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -350,7 +350,7 @@ CREATE TABLE "product_itinerary_translations" (
 --> statement-breakpoint
 ALTER TABLE "product_day_service_translations" ADD CONSTRAINT "product_day_service_translations_service_id_product_day_services_id_fk" FOREIGN KEY ("service_id") REFERENCES "public"."product_day_services"("id") ON DELETE cascade ON UPDATE no action;
 --> statement-breakpoint
-CREATE UNIQUE INDEX "uidx_product_day_service_translations_service_language" ON "product_day_service_translations" USING btree ("service_id","language_tag");
+CREATE UNIQUE INDEX IF NOT EXISTS "uidx_product_day_service_translations_service_language" ON "product_day_service_translations" USING btree ("service_id","language_tag");
 --> statement-breakpoint
 CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerary_translations" USING btree ("itinerary_id");`,
       },

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -436,7 +436,8 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     },
     {
       table_name: "product_day_service_translations",
-      constraint_name: "product_day_service_translations_service_id_product_day_services_id_fk",
+      // PostgreSQL truncates identifiers to NAMEDATALEN - 1 (63) bytes.
+      constraint_name: "product_day_service_translations_service_id_product_day_service",
       constraint_type: "f",
       column_names: ["service_id"],
       referenced_schema: "public",

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest"
+import { Client } from "pg"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import type { MigrationClient, MigrationSource } from "./collector.js"
 import { detectExisting, expectedSchema, runDeploymentMigrations } from "./deployment-runner.js"
 
@@ -735,6 +736,106 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     expect(result.baselined).toEqual([])
     expect(result.executed).toEqual(["inventory/0001_inventory_baseline"])
     expect(statements.some((sql) => sql.startsWith('CREATE TABLE "product_'))).toBe(true)
+  })
+})
+
+const DB_URL = process.env.TEST_DATABASE_URL
+
+describe.skipIf(!DB_URL)("materialized-migration adoption (PostgreSQL conformance)", () => {
+  let client: Client
+  const parentTable = "materialized_adoption_parent"
+  const childTable = "materialized_adoption_child"
+  const source: MigrationSource = {
+    name: "materialized-adoption-test",
+    priority: 1,
+    migrations: [
+      {
+        tag: "0001_materialized_baseline",
+        sql: `CREATE TABLE "${parentTable}" (
+  "id" text PRIMARY KEY NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "${childTable}" (
+  "id" text PRIMARY KEY NOT NULL,
+  "parent_id" text NOT NULL,
+  "state" text DEFAULT 'READY'::text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "${childTable}" ADD CONSTRAINT "materialized_adoption_child_parent_id_materialized_adoption_parent_id_fk_long_suffix" FOREIGN KEY ("parent_id") REFERENCES "public"."${parentTable}"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_materialized_adoption_child_parent" ON "${childTable}" USING btree ("parent_id");`,
+      },
+    ],
+  }
+
+  async function reset(): Promise<void> {
+    await client.query(`DROP TABLE IF EXISTS "${childTable}" CASCADE`)
+    await client.query(`DROP TABLE IF EXISTS "${parentTable}" CASCADE`)
+    await client.query(`CREATE SCHEMA IF NOT EXISTS "drizzle"`)
+    await client.query(
+      `CREATE TABLE IF NOT EXISTS "drizzle"."_voyant_migrations" (
+         "source" text NOT NULL,
+         "tag" text NOT NULL,
+         "content_hash" text NOT NULL,
+         "applied_at" timestamptz NOT NULL DEFAULT now(),
+         PRIMARY KEY ("source", "tag")
+       )`,
+    )
+    await client.query(
+      `DELETE FROM "drizzle"."_voyant_migrations"
+        WHERE "source" IN ('framework', 'materialized-adoption-test')
+          AND "tag" LIKE 'materialized-adoption-test-%' OR
+              ("source" = 'materialized-adoption-test' AND "tag" = '0001_materialized_baseline')`,
+    )
+    await client.query(
+      `INSERT INTO "drizzle"."_voyant_migrations" ("source", "tag", "content_hash")
+       VALUES ('framework', 'materialized-adoption-test-existing', 'test-seed')
+       ON CONFLICT ("source", "tag") DO UPDATE SET "content_hash" = EXCLUDED."content_hash"`,
+    )
+  }
+
+  beforeAll(async () => {
+    client = new Client({ connectionString: DB_URL })
+    await client.connect()
+  })
+
+  beforeEach(reset)
+
+  afterAll(async () => {
+    if (!client) return
+    await reset()
+    await client.query(
+      `DELETE FROM "drizzle"."_voyant_migrations"
+        WHERE "source" = 'framework' AND "tag" = 'materialized-adoption-test-existing'`,
+    )
+    await client.end()
+  })
+
+  it("adopts the PostgreSQL-canonical footprint, including truncated constraint names", async () => {
+    for (const statement of source.migrations[0]!.sql.split("--> statement-breakpoint")) {
+      await client.query(statement)
+    }
+
+    const result = await runDeploymentMigrations(
+      client,
+      [source],
+      {},
+      {
+        materializedMigrationAdoptions: [
+          { source: "materialized-adoption-test", tag: "0001_materialized_baseline" },
+        ],
+      },
+    )
+
+    expect(result.executed).toEqual([])
+    expect(result.adopted).toEqual(["materialized-adoption-test/0001_materialized_baseline"])
+    const ledger = await client.query(
+      `SELECT "content_hash" FROM "drizzle"."_voyant_migrations"
+        WHERE "source" = 'materialized-adoption-test'
+          AND "tag" = '0001_materialized_baseline'`,
+    )
+    expect(ledger.rows[0]?.content_hash).toMatch(/^[a-f0-9]{64}$/)
   })
 })
 

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -594,6 +594,24 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     expect(statements.some((sql) => sql.startsWith('CREATE TABLE "product_'))).toBe(true)
   })
 
+  it("does not require adoption parser support when an existing database has no footprint", async () => {
+    const source = src("custom", [
+      'CREATE TABLE "custom_table" ("id" text PRIMARY KEY);\n--> statement-breakpoint\nCOMMENT ON TABLE "custom_table" IS \'normal execution only\';',
+    ])
+    const { client } = adoptionClient({ existing: true, tables: [] })
+    const result = await runDeploymentMigrations(
+      client,
+      [source],
+      {},
+      {
+        materializedMigrationAdoptions: [{ source: "custom", tag: "0000_custom" }],
+      },
+    )
+
+    expect(result.adopted).toEqual([])
+    expect(result.executed).toEqual(["custom/0000_custom"])
+  })
+
   it("keeps a fresh database on the normal execute path even if adoption is allowlisted", async () => {
     const { client, statements } = adoptionClient({ existing: false, tables: [] })
     const result = await runDeploymentMigrations(

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -328,6 +328,397 @@ describe("runDeploymentMigrations on a partially adopted database", () => {
   })
 })
 
+describe("explicit materialized-migration adoption", () => {
+  const materializedSource: MigrationSource = {
+    name: "inventory",
+    priority: 1,
+    migrations: [
+      {
+        tag: "0001_inventory_baseline",
+        sql: `CREATE TABLE "product_day_service_translations" (
+  "id" text PRIMARY KEY NOT NULL,
+  "service_id" text NOT NULL,
+  "language_tag" text NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "product_itinerary_translations" (
+  "id" text PRIMARY KEY NOT NULL,
+  "itinerary_id" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "product_day_service_translations" ADD CONSTRAINT "product_day_service_translations_service_id_product_day_services_id_fk" FOREIGN KEY ("service_id") REFERENCES "public"."product_day_services"("id") ON DELETE cascade ON UPDATE no action;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_product_day_service_translations_service_language" ON "product_day_service_translations" USING btree ("service_id","language_tag");
+--> statement-breakpoint
+CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerary_translations" USING btree ("itinerary_id");`,
+      },
+    ],
+  }
+  const adoption = [{ source: "inventory", tag: "0001_inventory_baseline" }] as const
+
+  const exactColumns = [
+    {
+      table_name: "product_day_service_translations",
+      column_name: "id",
+      ordinal_position: "1",
+      data_type: "text",
+      not_null: true,
+      column_default: null,
+      identity_kind: "",
+      generated_kind: "",
+    },
+    {
+      table_name: "product_day_service_translations",
+      column_name: "service_id",
+      ordinal_position: "2",
+      data_type: "text",
+      not_null: true,
+      column_default: null,
+      identity_kind: "",
+      generated_kind: "",
+    },
+    {
+      table_name: "product_day_service_translations",
+      column_name: "language_tag",
+      ordinal_position: "3",
+      data_type: "text",
+      not_null: true,
+      column_default: null,
+      identity_kind: "",
+      generated_kind: "",
+    },
+    {
+      table_name: "product_day_service_translations",
+      column_name: "created_at",
+      ordinal_position: "4",
+      data_type: "timestamp with time zone",
+      not_null: true,
+      column_default: "now()",
+      identity_kind: "",
+      generated_kind: "",
+    },
+    {
+      table_name: "product_itinerary_translations",
+      column_name: "id",
+      ordinal_position: "1",
+      data_type: "text",
+      not_null: true,
+      column_default: null,
+      identity_kind: "",
+      generated_kind: "",
+    },
+    {
+      table_name: "product_itinerary_translations",
+      column_name: "itinerary_id",
+      ordinal_position: "2",
+      data_type: "text",
+      not_null: true,
+      column_default: null,
+      identity_kind: "",
+      generated_kind: "",
+    },
+  ]
+  const exactConstraints = [
+    {
+      table_name: "product_day_service_translations",
+      constraint_name: "product_day_service_translations_pkey",
+      constraint_type: "p",
+      column_names: ["id"],
+      referenced_schema: null,
+      referenced_table: null,
+      referenced_column_names: [],
+      update_action: " ",
+      delete_action: " ",
+      match_type: " ",
+      is_deferrable: false,
+      initially_deferred: false,
+    },
+    {
+      table_name: "product_day_service_translations",
+      constraint_name: "product_day_service_translations_service_id_product_day_services_id_fk",
+      constraint_type: "f",
+      column_names: ["service_id"],
+      referenced_schema: "public",
+      referenced_table: "product_day_services",
+      referenced_column_names: ["id"],
+      update_action: "a",
+      delete_action: "c",
+      match_type: "s",
+      is_deferrable: false,
+      initially_deferred: false,
+    },
+    {
+      table_name: "product_itinerary_translations",
+      constraint_name: "product_itinerary_translations_pkey",
+      constraint_type: "p",
+      column_names: ["id"],
+      referenced_schema: null,
+      referenced_table: null,
+      referenced_column_names: [],
+      update_action: " ",
+      delete_action: " ",
+      match_type: " ",
+      is_deferrable: false,
+      initially_deferred: false,
+    },
+  ]
+  const exactIndexes = [
+    {
+      table_name: "product_day_service_translations",
+      index_name: "uidx_product_day_service_translations_service_language",
+      index_definition:
+        "CREATE UNIQUE INDEX uidx_product_day_service_translations_service_language ON public.product_day_service_translations USING btree (service_id, language_tag)",
+    },
+    {
+      table_name: "product_itinerary_translations",
+      index_name: "idx_product_itinerary_translations_itinerary",
+      index_definition:
+        "CREATE INDEX idx_product_itinerary_translations_itinerary ON public.product_itinerary_translations USING btree (itinerary_id)",
+    },
+  ]
+
+  function adoptionClient(options: {
+    existing?: boolean
+    tables?: string[]
+    columns?: typeof exactColumns
+    constraints?: typeof exactConstraints
+    indexes?: typeof exactIndexes
+    serializeLocks?: boolean
+  }) {
+    const ledgerRows: Array<{ source: string; tag: string; content_hash: string }> = []
+    const statements: string[] = []
+    const events: string[] = []
+    let locked = false
+    const lockWaiters: Array<() => void> = []
+    const client: MigrationClient = {
+      async query(sql, params = []) {
+        statements.push(sql)
+        if (sql.includes("pg_advisory_lock")) {
+          if (options.serializeLocks && locked) {
+            await new Promise<void>((resolve) => lockWaiters.push(resolve))
+          }
+          locked = true
+          events.push("lock")
+          return { rows: [] }
+        }
+        if (sql.includes("pg_advisory_unlock")) {
+          events.push("unlock")
+          locked = false
+          lockWaiters.shift()?.()
+          return { rows: [] }
+        }
+        if (sql.startsWith("SELECT to_regclass")) return { rows: [{ reg: String(params[0]) }] }
+        if (sql.includes("count(*)")) {
+          if (sql.includes(`"source" = 'framework'`)) {
+            return { rows: [{ n: options.existing === false ? "0" : "1" }] }
+          }
+          return { rows: [{ n: "0" }] }
+        }
+        if (sql.includes('SELECT "source", "content_hash" FROM')) {
+          const sources = params[0] as string[]
+          const tag = String(params[1])
+          return {
+            rows: ledgerRows.filter((row) => sources.includes(row.source) && row.tag === tag),
+          }
+        }
+        if (sql.includes('SELECT "content_hash", "source" FROM')) {
+          const sources = params[0] as string[]
+          const tag = String(params[1])
+          return {
+            rows: ledgerRows.filter((row) => sources.includes(row.source) && row.tag === tag),
+          }
+        }
+        if (sql.includes("FROM pg_class c") && sql.includes("c.relkind")) {
+          return { rows: (options.tables ?? []).map((table_name) => ({ table_name })) }
+        }
+        if (sql.includes("FROM pg_attribute a")) return { rows: options.columns ?? [] }
+        if (sql.includes("FROM pg_constraint con")) return { rows: options.constraints ?? [] }
+        if (sql.includes("FROM pg_index i")) return { rows: options.indexes ?? [] }
+        if (sql.startsWith("INSERT INTO") && params.length === 3) {
+          ledgerRows.push({
+            source: String(params[0]),
+            tag: String(params[1]),
+            content_hash: String(params[2]),
+          })
+        }
+        return { rows: [] }
+      },
+    }
+    return { client, events, ledgerRows, statements }
+  }
+
+  function exactClient(options: { existing?: boolean; serializeLocks?: boolean } = {}) {
+    return adoptionClient({
+      ...options,
+      tables: ["product_day_service_translations", "product_itinerary_translations"],
+      columns: exactColumns,
+      constraints: exactConstraints,
+      indexes: exactIndexes,
+    })
+  }
+
+  it("adopts a fully present exact footprint with the current hash", async () => {
+    const { client, ledgerRows, statements } = exactClient()
+    const result = await runDeploymentMigrations(
+      client,
+      [materializedSource],
+      {},
+      {
+        materializedMigrationAdoptions: adoption,
+      },
+    )
+
+    expect(result.executed).toEqual([])
+    expect(result.adopted).toEqual(["inventory/0001_inventory_baseline"])
+    expect(result.baselined).toEqual(result.adopted)
+    expect(ledgerRows).toHaveLength(1)
+    expect(ledgerRows[0]?.content_hash).toMatch(/^[a-f0-9]{64}$/)
+    expect(statements.some((sql) => sql.startsWith('CREATE TABLE "product_'))).toBe(false)
+  })
+
+  it("leaves a wholly absent candidate on the normal execute path for an existing database", async () => {
+    const { client, statements } = adoptionClient({ existing: true, tables: [] })
+    const result = await runDeploymentMigrations(
+      client,
+      [materializedSource],
+      {},
+      {
+        materializedMigrationAdoptions: adoption,
+      },
+    )
+
+    expect(result.adopted).toEqual([])
+    expect(result.baselined).toEqual([])
+    expect(result.executed).toEqual(["inventory/0001_inventory_baseline"])
+    expect(statements.some((sql) => sql.startsWith('CREATE TABLE "product_'))).toBe(true)
+  })
+
+  it("keeps a fresh database on the normal execute path even if adoption is allowlisted", async () => {
+    const { client, statements } = adoptionClient({ existing: false, tables: [] })
+    const result = await runDeploymentMigrations(
+      client,
+      [materializedSource],
+      {},
+      {
+        materializedMigrationAdoptions: adoption,
+      },
+    )
+
+    expect(result.existing).toBe(false)
+    expect(result.adopted).toEqual([])
+    expect(result.executed).toEqual(["inventory/0001_inventory_baseline"])
+    expect(statements.some((sql) => sql.includes("FROM pg_attribute a"))).toBe(false)
+  })
+
+  it("fails a partial footprint before an earlier normal migration mutates anything", async () => {
+    const earlier = src("earlier", ['CREATE TABLE "earlier" ("id" text PRIMARY KEY);'])
+    const { client, ledgerRows, statements } = adoptionClient({
+      tables: ["product_day_service_translations"],
+    })
+
+    await expect(
+      runDeploymentMigrations(
+        client,
+        [earlier, materializedSource],
+        {},
+        {
+          materializedMigrationAdoptions: adoption,
+        },
+      ),
+    ).rejects.toThrow("does not exactly match")
+    expect(ledgerRows).toEqual([])
+    expect(statements).not.toContain("BEGIN")
+    expect(statements.some((sql) => sql.startsWith('CREATE TABLE "earlier"'))).toBe(false)
+    expect(statements.at(0)).toContain("pg_advisory_lock")
+    expect(statements.at(-1)).toContain("pg_advisory_unlock")
+  })
+
+  it.each([
+    [
+      "column",
+      {
+        columns: exactColumns.map((row, index) =>
+          index === 0 ? { ...row, data_type: "integer" } : row,
+        ),
+      },
+    ],
+    [
+      "constraint",
+      {
+        constraints: exactConstraints.map((row, index) =>
+          index === 1 ? { ...row, delete_action: "a" } : row,
+        ),
+      },
+    ],
+    [
+      "index",
+      {
+        indexes: exactIndexes.map((row, index) =>
+          index === 0
+            ? { ...row, index_definition: row.index_definition.replace("CREATE UNIQUE", "CREATE") }
+            : row,
+        ),
+      },
+    ],
+  ] as const)("rejects an exact-footprint %s mismatch", async (_kind, override) => {
+    const { client, ledgerRows } = adoptionClient({
+      tables: ["product_day_service_translations", "product_itinerary_translations"],
+      columns: exactColumns,
+      constraints: exactConstraints,
+      indexes: exactIndexes,
+      ...override,
+    })
+    await expect(
+      runDeploymentMigrations(
+        client,
+        [materializedSource],
+        {},
+        {
+          materializedMigrationAdoptions: adoption,
+        },
+      ),
+    ).rejects.toThrow("does not exactly match")
+    expect(ledgerRows).toEqual([])
+  })
+
+  it("is idempotent and serializes concurrent adopters under the session lock", async () => {
+    const { client, events, ledgerRows } = exactClient({ serializeLocks: true })
+    const [first, second] = await Promise.all([
+      runDeploymentMigrations(
+        client,
+        [materializedSource],
+        {},
+        {
+          materializedMigrationAdoptions: adoption,
+        },
+      ),
+      runDeploymentMigrations(
+        client,
+        [materializedSource],
+        {},
+        {
+          materializedMigrationAdoptions: adoption,
+        },
+      ),
+    ])
+
+    expect([first.adopted, second.adopted]).toContainEqual(["inventory/0001_inventory_baseline"])
+    expect([first.adopted, second.adopted]).toContainEqual([])
+    expect(ledgerRows).toHaveLength(1)
+    expect(events).toEqual(["lock", "unlock", "lock", "unlock"])
+  })
+
+  it("never adopts a materialized migration unless its exact identity is allowlisted", async () => {
+    const { client, statements } = exactClient()
+    const result = await runDeploymentMigrations(client, [materializedSource], {}, {})
+    expect(result.adopted).toEqual([])
+    expect(result.baselined).toEqual([])
+    expect(result.executed).toEqual(["inventory/0001_inventory_baseline"])
+    expect(statements.some((sql) => sql.startsWith('CREATE TABLE "product_'))).toBe(true)
+  })
+})
+
 describe("detectExisting", () => {
   it("recognizes graph-era package ledger source names", async () => {
     const client: MigrationClient = {

--- a/packages/framework-migrations/src/deployment-runner.ts
+++ b/packages/framework-migrations/src/deployment-runner.ts
@@ -18,8 +18,29 @@
  */
 
 import type { MigrationClient, MigrationSource } from "./collector.js"
-import { applyMigrations, planMigrations, VOYANT_MIGRATION_JOURNAL_LINEAGE } from "./collector.js"
+import {
+  applyMigrations,
+  MigrationImmutabilityError,
+  type PlannedMigration,
+  planMigrations,
+  VOYANT_MIGRATION_JOURNAL_LINEAGE,
+} from "./collector.js"
 import type { Cutline } from "./cutline.js"
+import {
+  classifyMaterializedMigration,
+  type MaterializedMigrationAdoption,
+} from "./materialized-adoption.js"
+
+export interface RunDeploymentMigrationsOptions {
+  onApplied?: (id: string) => void
+  onBaselined?: (id: string) => void
+  /**
+   * Exact migrations whose immutable DDL may already be materialized outside
+   * the collector ledger. Only these identities are eligible for exact-footprint
+   * adoption; omission preserves the normal execute path.
+   */
+  materializedMigrationAdoptions?: readonly MaterializedMigrationAdoption[]
+}
 
 export interface RunResult {
   /** True if the EXISTING (import-baseline) path was taken. */
@@ -28,6 +49,8 @@ export interface RunResult {
   executed: string[]
   /** `"{source}/{tag}"` ids import-baselined (recorded, not executed) this run. */
   baselined: string[]
+  /** Allowlisted materialized migrations included in `baselined`. */
+  adopted: string[]
 }
 
 /** Row count of a ledger table (0 if it doesn't exist), optional WHERE. */
@@ -55,6 +78,95 @@ async function recordedCollectorSources(client: MigrationClient): Promise<Set<st
   if (!exists.rows[0]?.reg) return new Set()
   const rows = await client.query(`SELECT DISTINCT "source" FROM ${collectorLedger}`)
   return new Set(rows.rows.map((row) => String(row.source)))
+}
+
+interface AdoptionCandidate {
+  migration: PlannedMigration
+  source: MigrationSource
+}
+
+function resolveAdoptionCandidates(
+  sources: MigrationSource[],
+  adoptions: readonly MaterializedMigrationAdoption[],
+): AdoptionCandidate[] {
+  const requested = new Set<string>()
+  for (const adoption of adoptions) {
+    const id = `${adoption.source}/${adoption.tag}`
+    if (requested.has(id)) throw new Error(`duplicate materialized migration adoption: ${id}`)
+    requested.add(id)
+  }
+  const sourceByName = new Map(sources.map((source) => [source.name, source]))
+  const candidates: AdoptionCandidate[] = []
+  for (const migration of planMigrations(sources)) {
+    const id = `${migration.source}/${migration.tag}`
+    if (!requested.delete(id)) continue
+    const source = sourceByName.get(migration.source)
+    if (!source) throw new Error(`migration source disappeared while resolving ${id}`)
+    candidates.push({ migration, source })
+  }
+  if (requested.size > 0) {
+    throw new Error(
+      `unknown materialized migration adoption(s): ${[...requested].sort().join(", ")}. ` +
+        "Every adoption must name an exact source/tag in the current migration plan.",
+    )
+  }
+  return candidates
+}
+
+async function pendingAdoptionCandidates(
+  client: MigrationClient,
+  candidates: readonly AdoptionCandidate[],
+): Promise<AdoptionCandidate[]> {
+  if (candidates.length === 0) return []
+  const exists = await client.query(`SELECT to_regclass($1) AS reg`, [
+    `${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerSchema}.${VOYANT_MIGRATION_JOURNAL_LINEAGE.ledgerTable}`,
+  ])
+  if (!exists.rows[0]?.reg) return [...candidates]
+
+  const pending: AdoptionCandidate[] = []
+  for (const candidate of candidates) {
+    const ledgerSources = [
+      ...new Set([candidate.migration.source, ...(candidate.migration.legacySources ?? [])]),
+    ]
+    const seen = await client.query(
+      `SELECT "source", "content_hash" FROM ${collectorLedger}
+        WHERE "source" = ANY($1::text[]) AND "tag" = $2`,
+      [ledgerSources, candidate.migration.tag],
+    )
+    if (seen.rows.length === 0) {
+      pending.push(candidate)
+      continue
+    }
+    for (const row of seen.rows) {
+      const ledgerHash = String(row.content_hash ?? "")
+      if (ledgerHash !== candidate.migration.contentHash) {
+        throw new MigrationImmutabilityError(
+          candidate.migration.source,
+          candidate.migration.tag,
+          ledgerHash,
+          candidate.migration.contentHash,
+        )
+      }
+    }
+  }
+  return pending
+}
+
+function sourcesForAdoptions(candidates: readonly AdoptionCandidate[]): MigrationSource[] {
+  const tagsBySource = new Map<string, Set<string>>()
+  for (const candidate of candidates) {
+    const tags = tagsBySource.get(candidate.source.name) ?? new Set<string>()
+    tags.add(candidate.migration.tag)
+    tagsBySource.set(candidate.source.name, tags)
+  }
+  return [...new Set(candidates.map((candidate) => candidate.source))]
+    .map((source) => ({
+      ...source,
+      migrations: source.migrations.filter((migration) =>
+        tagsBySource.get(source.name)?.has(migration.tag),
+      ),
+    }))
+    .filter((source) => source.migrations.length > 0)
 }
 
 const deploymentMigrationLockKey = "voyant.framework-migrations.runDeploymentMigrations"
@@ -361,12 +473,25 @@ export async function runDeploymentMigrations(
   client: MigrationClient,
   sources: MigrationSource[],
   cutline: Cutline,
-  hooks?: { onApplied?: (id: string) => void; onBaselined?: (id: string) => void },
+  options?: RunDeploymentMigrationsOptions,
 ): Promise<RunResult> {
   return withDeploymentMigrationLock(client, async () => {
+    const adoptionCandidates = resolveAdoptionCandidates(
+      sources,
+      options?.materializedMigrationAdoptions ?? [],
+    )
     const existing = await detectExisting(client)
     let effectiveCutline = cutline
+    const materialized: AdoptionCandidate[] = []
     if (existing) {
+      // Classify every pending opt-in candidate before any ledger write or
+      // normal migration transaction. A partial or definition mismatch aborts
+      // the whole run without mutation; wholly absent candidates execute later.
+      for (const candidate of await pendingAdoptionCandidates(client, adoptionCandidates)) {
+        const classification = await classifyMaterializedMigration(client, candidate.migration)
+        if (classification.status === "materialized") materialized.push(candidate)
+      }
+
       // Parity-gate only the cutline entries this run will import-baseline;
       // already-recorded entries' objects may have been legitimately reshaped by
       // applied post-cutline migrations.
@@ -399,12 +524,33 @@ export async function runDeploymentMigrations(
         }
       }
     }
+
+    // Record proven materialized migrations before normal migration commits.
+    // Reusing the collector's baseline path guarantees the exact current SQL
+    // hash, idempotent inserts, and the ordinary baseline hook semantics.
+    let adopted: string[] = []
+    if (materialized.length > 0) {
+      const materializedSources = sourcesForAdoptions(materialized)
+      const adoptionCutline = Object.fromEntries(
+        materializedSources.map((source) => [
+          source.name,
+          source.migrations.map((migration) => migration.tag),
+        ]),
+      )
+      const adoptionResult = await applyMigrations(client, materializedSources, {
+        existing: true,
+        cutline: adoptionCutline,
+        onBaselined: options?.onBaselined,
+      })
+      adopted = adoptionResult.baselined
+    }
+
     const { executed, baselined } = await applyMigrations(client, sources, {
       cutline: effectiveCutline,
       existing,
-      onApplied: hooks?.onApplied,
-      onBaselined: hooks?.onBaselined,
+      onApplied: options?.onApplied,
+      onBaselined: options?.onBaselined,
     })
-    return { existing, executed, baselined }
+    return { existing, executed, baselined: [...adopted, ...baselined], adopted }
   })
 }

--- a/packages/framework-migrations/src/index.ts
+++ b/packages/framework-migrations/src/index.ts
@@ -24,6 +24,7 @@ export {
   assertSchemaAtBaseline,
   detectExisting,
   expectedSchema,
+  type RunDeploymentMigrationsOptions,
   type RunResult,
   runDeploymentMigrations,
 } from "./deployment-runner.js"
@@ -36,6 +37,7 @@ export {
   packageRootOfSchemaPath,
 } from "./discover.js"
 export { loadMigrationFolder } from "./load-folder.js"
+export type { MaterializedMigrationAdoption } from "./materialized-adoption.js"
 export {
   type CollectDeploymentMigrationSourcesOptions,
   collectDeploymentMigrationSources,

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -100,7 +100,7 @@ function splitTopLevel(value: string): string[] {
 }
 
 function postgresIdentifier(value: string): string {
-  const identifierValue = value.replaceAll('"', "").trim()
+  const identifierValue = value.replace(/^"|"$/g, "").replaceAll('""', '"').trim()
   let result = ""
   let bytes = 0
   for (const character of identifierValue) {
@@ -112,33 +112,42 @@ function postgresIdentifier(value: string): string {
   return result
 }
 
-function normalizeType(value: string): string {
-  return value
-    .replaceAll('"', "")
-    .trim()
-    .replace(/^public\./i, "")
-    .replace(/\s+/g, " ")
-    .toLowerCase()
+function normalizeQuotedIdentifiers(value: string): string {
+  return value.replace(/"((?:[^"]|"")+)"/g, (_match, escaped: string) => {
+    const identifierValue = escaped.replaceAll('""', '"')
+    return /^[a-z_][a-z0-9_$]*$/.test(identifierValue)
+      ? identifierValue
+      : `"${identifierValue.replaceAll('"', '""')}"`
+  })
 }
 
-function lowercaseOutsideStringLiterals(value: string): string {
+function lowercaseOutsideQuotedValues(value: string): string {
   let result = ""
-  let inLiteral = false
+  let quote: "'" | '"' | null = null
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index] as string
-    if (character === "'") {
+    if ((character === "'" || character === '"') && (quote === null || quote === character)) {
       result += character
-      if (inLiteral && value[index + 1] === "'") {
-        result += "'"
+      if (quote === character && value[index + 1] === character) {
+        result += character
         index += 1
       } else {
-        inLiteral = !inLiteral
+        quote = quote === null ? character : null
       }
       continue
     }
-    result += inLiteral ? character : character.toLowerCase()
+    result += quote === null ? character.toLowerCase() : character
   }
   return result
+}
+
+function normalizeType(value: string): string {
+  return lowercaseOutsideQuotedValues(
+    normalizeQuotedIdentifiers(value)
+      .trim()
+      .replace(/^public\./i, "")
+      .replace(/\s+/g, " "),
+  )
 }
 
 function normalizeExpression(value: string | null | undefined): string | null {
@@ -147,17 +156,16 @@ function normalizeExpression(value: string | null | undefined): string | null {
   while (normalized.startsWith("(") && normalized.endsWith(")")) {
     normalized = normalized.slice(1, -1).trim()
   }
-  return lowercaseOutsideStringLiterals(
-    normalized.replaceAll('"', "").replace(/\s*([(),])\s*/g, "$1"),
+  return lowercaseOutsideQuotedValues(
+    normalizeQuotedIdentifiers(normalized).replace(/\s*([(),])\s*/g, "$1"),
   )
 }
 
 function normalizeIndexDefinition(value: string): string {
-  return lowercaseOutsideStringLiterals(
-    value
+  return lowercaseOutsideQuotedValues(
+    normalizeQuotedIdentifiers(value)
       .trim()
       .replace(/;$/, "")
-      .replaceAll('"', "")
       .replace(/\bpublic\./gi, "")
       .replace(/\s+/g, " ")
       .replace(/\s*([(),])\s*/g, "$1"),

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -406,16 +406,28 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
   return { tables, columns, constraints, indexes }
 }
 
+function createdTables(migration: PlannedMigration): string[] {
+  const tables: string[] = []
+  for (const statement of splitStatements(migration.sql)) {
+    const create = statement.match(
+      new RegExp(`^CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s*\\(`, "i"),
+    )
+    if (create && !tables.includes(create[1] as string)) tables.push(create[1] as string)
+  }
+  if (tables.length === 0) unsupported(migration, "the migration creates no tables")
+  return tables
+}
+
 function strings(value: unknown): string[] {
   if (Array.isArray(value)) return value.map(String)
   if (typeof value !== "string") return []
   return value.replace(/^\{/, "").replace(/\}$/, "").split(",").filter(Boolean)
 }
 
-async function readLiveFootprint(
+async function readLiveTables(
   client: MigrationClient,
   tables: readonly string[],
-): Promise<LiveFootprint> {
+): Promise<string[]> {
   const tableRows = await client.query(
     `SELECT c.relname AS table_name
        FROM pg_class c
@@ -426,7 +438,14 @@ async function readLiveFootprint(
       ORDER BY c.relname`,
     [tables],
   )
-  const liveTables = tableRows.rows.map((row) => String(row.table_name))
+  return tableRows.rows.map((row) => String(row.table_name))
+}
+
+async function readLiveFootprint(
+  client: MigrationClient,
+  tables: readonly string[],
+  liveTables: string[],
+): Promise<LiveFootprint> {
   if (liveTables.length !== tables.length) {
     return { tables: liveTables, columns: [], constraints: [], indexes: [] }
   }
@@ -582,9 +601,15 @@ export async function classifyMaterializedMigration(
   client: MigrationClient,
   migration: PlannedMigration,
 ): Promise<MaterializedMigrationClassification> {
+  // Absence needs only the CREATE TABLE identities. Do not reject an otherwise
+  // unsupported allowlisted migration when there is nothing to adopt: it must
+  // remain on the ordinary execute path.
+  const tables = createdTables(migration)
+  const liveTables = await readLiveTables(client, tables)
+  if (liveTables.length === 0) return { status: "absent" }
+
   const expected = parseExpectedFootprint(migration)
-  const live = await readLiveFootprint(client, expected.tables)
-  if (live.tables.length === 0) return { status: "absent" }
+  const live = await readLiveFootprint(client, expected.tables, liveTables)
   compareFootprint(migration, expected, live)
   return { status: "materialized" }
 }

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -379,7 +379,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
 
     const index = statement.match(
       new RegExp(
-        `^CREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s+ON\\s+${identifier}\\b[\\s\\S]*;?$`,
+        `^CREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s+ON\\s+${identifier}\\s+[\\s\\S]*;?$`,
         "i",
       ),
     )

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -99,15 +99,46 @@ function splitTopLevel(value: string): string[] {
   return parts.filter(Boolean)
 }
 
-function normalizeIdentifier(value: string): string {
-  return value.replaceAll('"', "").trim()
+function postgresIdentifier(value: string): string {
+  const identifierValue = value.replaceAll('"', "").trim()
+  let result = ""
+  let bytes = 0
+  for (const character of identifierValue) {
+    const width = new TextEncoder().encode(character).length
+    if (bytes + width > 63) break
+    result += character
+    bytes += width
+  }
+  return result
 }
 
 function normalizeType(value: string): string {
-  return normalizeIdentifier(value)
+  return value
+    .replaceAll('"', "")
+    .trim()
     .replace(/^public\./i, "")
     .replace(/\s+/g, " ")
     .toLowerCase()
+}
+
+function lowercaseOutsideStringLiterals(value: string): string {
+  let result = ""
+  let inLiteral = false
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index] as string
+    if (character === "'") {
+      result += character
+      if (inLiteral && value[index + 1] === "'") {
+        result += "'"
+        index += 1
+      } else {
+        inLiteral = !inLiteral
+      }
+      continue
+    }
+    result += inLiteral ? character : character.toLowerCase()
+  }
+  return result
 }
 
 function normalizeExpression(value: string | null | undefined): string | null {
@@ -116,21 +147,21 @@ function normalizeExpression(value: string | null | undefined): string | null {
   while (normalized.startsWith("(") && normalized.endsWith(")")) {
     normalized = normalized.slice(1, -1).trim()
   }
-  return normalized
-    .replaceAll('"', "")
-    .replace(/\s*([(),])\s*/g, "$1")
-    .toLowerCase()
+  return lowercaseOutsideStringLiterals(
+    normalized.replaceAll('"', "").replace(/\s*([(),])\s*/g, "$1"),
+  )
 }
 
 function normalizeIndexDefinition(value: string): string {
-  return value
-    .trim()
-    .replace(/;$/, "")
-    .replaceAll('"', "")
-    .replace(/\bpublic\./gi, "")
-    .replace(/\s+/g, " ")
-    .replace(/\s*([(),])\s*/g, "$1")
-    .toLowerCase()
+  return lowercaseOutsideStringLiterals(
+    value
+      .trim()
+      .replace(/;$/, "")
+      .replaceAll('"', "")
+      .replace(/\bpublic\./gi, "")
+      .replace(/\s+/g, " ")
+      .replace(/\s*([(),])\s*/g, "$1"),
+  )
 }
 
 function unsupported(migration: PlannedMigration, detail: string): never {
@@ -141,7 +172,7 @@ function unsupported(migration: PlannedMigration, detail: string): never {
 }
 
 function parseIdentifierList(value: string): string[] {
-  return splitTopLevel(value).map(normalizeIdentifier)
+  return splitTopLevel(value).map(postgresIdentifier)
 }
 
 function actionCode(action: string | undefined): string {
@@ -175,7 +206,7 @@ function constraintFromBody(
     }
     return {
       table,
-      name,
+      name: postgresIdentifier(name),
       type: "p",
       columns: parseIdentifierList(primary[1] as string),
       referencedSchema: null,
@@ -189,7 +220,7 @@ function constraintFromBody(
     }
   }
 
-  const unique = body.match(/^UNIQUE\s*(?:NULLS\s+(?:NOT\s+)?DISTINCT\s*)?\(([^)]+)\)(.*)$/i)
+  const unique = body.match(/^UNIQUE\s*\(([^)]+)\)(.*)$/i)
   if (unique) {
     const suffix = unique[2]?.trim() ?? ""
     if (suffix && !/^DEFERRABLE(?:\s+INITIALLY\s+(?:IMMEDIATE|DEFERRED))?$/i.test(suffix)) {
@@ -197,7 +228,7 @@ function constraintFromBody(
     }
     return {
       table,
-      name,
+      name: postgresIdentifier(name),
       type: "u",
       columns: parseIdentifierList(unique[1] as string),
       referencedSchema: null,
@@ -237,11 +268,11 @@ function constraintFromBody(
     if (known) unsupported(migration, `unsupported FOREIGN KEY definition for constraint ${name}`)
     return {
       table,
-      name,
+      name: postgresIdentifier(name),
       type: "f",
       columns: parseIdentifierList(foreign[1] as string),
-      referencedSchema: foreign[2] ?? "public",
-      referencedTable: foreign[3] as string,
+      referencedSchema: postgresIdentifier(foreign[2] ?? "public"),
+      referencedTable: postgresIdentifier(foreign[3] as string),
       referencedColumns: parseIdentifierList(foreign[4] as string),
       updateAction: actionCode(update),
       deleteAction: actionCode(deletion),
@@ -263,7 +294,7 @@ function parseColumn(
 ): ExpectedColumn {
   const match = definition.match(new RegExp(`^${identifier}\\s+([\\s\\S]+)$`))
   if (!match) unsupported(migration, `cannot parse a column in table ${table}`)
-  const name = match[1] as string
+  const name = postgresIdentifier(match[1] as string)
   const remainder = match[2] as string
   if (/\b(?:REFERENCES|CHECK|GENERATED|COLLATE|UNIQUE)\b/i.test(remainder)) {
     unsupported(migration, `unsupported inline clause on ${table}.${name}`)
@@ -286,7 +317,7 @@ function parseColumn(
   if (/\bPRIMARY\s+KEY\b/i.test(qualifiers)) {
     constraints.push({
       table,
-      name: `${table}_pkey`,
+      name: postgresIdentifier(`${table}_pkey`),
       type: "p",
       columns: [name],
       referencedSchema: null,
@@ -327,7 +358,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
       ),
     )
     if (create) {
-      const table = create[1] as string
+      const table = postgresIdentifier(create[1] as string)
       if (tables.includes(table)) unsupported(migration, `table ${table} is created more than once`)
       tables.push(table)
       let position = 0
@@ -359,7 +390,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
       ),
     )
     if (alterConstraint) {
-      const table = alterConstraint[1] as string
+      const table = postgresIdentifier(alterConstraint[1] as string)
       if (!tables.includes(table)) {
         unsupported(
           migration,
@@ -384,7 +415,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
       ),
     )
     if (index) {
-      const table = index[2] as string
+      const table = postgresIdentifier(index[2] as string)
       if (!tables.includes(table)) {
         unsupported(
           migration,
@@ -393,7 +424,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
       }
       indexes.push({
         table,
-        name: index[1] as string,
+        name: postgresIdentifier(index[1] as string),
         definition: normalizeIndexDefinition(statement),
       })
       continue
@@ -412,7 +443,10 @@ function createdTables(migration: PlannedMigration): string[] {
     const create = statement.match(
       new RegExp(`^CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s*\\(`, "i"),
     )
-    if (create && !tables.includes(create[1] as string)) tables.push(create[1] as string)
+    if (create) {
+      const table = postgresIdentifier(create[1] as string)
+      if (!tables.includes(table)) tables.push(table)
+    }
   }
   if (tables.length === 0) unsupported(migration, "the migration creates no tables")
   return tables

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -166,6 +166,7 @@ function normalizeIndexDefinition(value: string): string {
     normalizeQuotedIdentifiers(value)
       .trim()
       .replace(/;$/, "")
+      .replace(/\b(CREATE\s+(?:UNIQUE\s+)?INDEX)\s+IF\s+NOT\s+EXISTS\b/i, "$1")
       .replace(/\bpublic\./gi, "")
       .replace(/\s+/g, " ")
       .replace(/\s*([(),])\s*/g, "$1"),

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -1,0 +1,590 @@
+import type { MigrationClient, PlannedMigration } from "./collector.js"
+
+/** An exact migration identity that may be adopted when its DDL already exists. */
+export interface MaterializedMigrationAdoption {
+  source: string
+  tag: string
+}
+
+interface ExpectedColumn {
+  table: string
+  name: string
+  position: number
+  dataType: string
+  notNull: boolean
+  defaultExpression: string | null
+  identity: string
+  generated: string
+}
+
+interface ExpectedConstraint {
+  table: string
+  name: string
+  type: "p" | "u" | "f"
+  columns: string[]
+  referencedSchema: string | null
+  referencedTable: string | null
+  referencedColumns: string[]
+  updateAction: string
+  deleteAction: string
+  matchType: string
+  deferrable: boolean
+  initiallyDeferred: boolean
+}
+
+interface ExpectedIndex {
+  table: string
+  name: string
+  definition: string
+}
+
+interface ExpectedFootprint {
+  tables: string[]
+  columns: ExpectedColumn[]
+  constraints: ExpectedConstraint[]
+  indexes: ExpectedIndex[]
+}
+
+interface LiveFootprint {
+  tables: string[]
+  columns: ExpectedColumn[]
+  constraints: ExpectedConstraint[]
+  indexes: ExpectedIndex[]
+}
+
+export type MaterializedMigrationClassification = { status: "absent" } | { status: "materialized" }
+
+const identifier = `"([^"]+)"`
+
+function splitStatements(sql: string): string[] {
+  return sql
+    .split("--> statement-breakpoint")
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+}
+
+function splitTopLevel(value: string): string[] {
+  const parts: string[] = []
+  let start = 0
+  let depth = 0
+  let inSingle = false
+  let inDouble = false
+  for (let index = 0; index < value.length; index += 1) {
+    const char = value[index]
+    if (char === "'" && !inDouble) {
+      if (inSingle && value[index + 1] === "'") {
+        index += 1
+      } else {
+        inSingle = !inSingle
+      }
+      continue
+    }
+    if (char === '"' && !inSingle) {
+      if (inDouble && value[index + 1] === '"') {
+        index += 1
+      } else {
+        inDouble = !inDouble
+      }
+      continue
+    }
+    if (inSingle || inDouble) continue
+    if (char === "(") depth += 1
+    if (char === ")") depth -= 1
+    if (char === "," && depth === 0) {
+      parts.push(value.slice(start, index).trim())
+      start = index + 1
+    }
+  }
+  parts.push(value.slice(start).trim())
+  return parts.filter(Boolean)
+}
+
+function normalizeIdentifier(value: string): string {
+  return value.replaceAll('"', "").trim()
+}
+
+function normalizeType(value: string): string {
+  return normalizeIdentifier(value)
+    .replace(/^public\./i, "")
+    .replace(/\s+/g, " ")
+    .toLowerCase()
+}
+
+function normalizeExpression(value: string | null | undefined): string | null {
+  if (value == null) return null
+  let normalized = value.trim().replace(/;$/, "").replace(/\s+/g, " ")
+  while (normalized.startsWith("(") && normalized.endsWith(")")) {
+    normalized = normalized.slice(1, -1).trim()
+  }
+  return normalized
+    .replaceAll('"', "")
+    .replace(/\s*([(),])\s*/g, "$1")
+    .toLowerCase()
+}
+
+function normalizeIndexDefinition(value: string): string {
+  return value
+    .trim()
+    .replace(/;$/, "")
+    .replaceAll('"', "")
+    .replace(/\bpublic\./gi, "")
+    .replace(/\s+/g, " ")
+    .replace(/\s*([(),])\s*/g, "$1")
+    .toLowerCase()
+}
+
+function unsupported(migration: PlannedMigration, detail: string): never {
+  throw new Error(
+    `cannot adopt materialized migration ${migration.source}/${migration.tag}: ${detail}. ` +
+      "The verifier fails closed when it cannot prove the exact DDL footprint.",
+  )
+}
+
+function parseIdentifierList(value: string): string[] {
+  return splitTopLevel(value).map(normalizeIdentifier)
+}
+
+function actionCode(action: string | undefined): string {
+  switch ((action ?? "NO ACTION").replace(/\s+/g, " ").toUpperCase()) {
+    case "NO ACTION":
+      return "a"
+    case "RESTRICT":
+      return "r"
+    case "CASCADE":
+      return "c"
+    case "SET NULL":
+      return "n"
+    case "SET DEFAULT":
+      return "d"
+    default:
+      return "?"
+  }
+}
+
+function constraintFromBody(
+  migration: PlannedMigration,
+  table: string,
+  name: string,
+  body: string,
+): ExpectedConstraint {
+  const primary = body.match(/^PRIMARY\s+KEY\s*\(([^)]+)\)(.*)$/i)
+  if (primary) {
+    const suffix = primary[2]?.trim() ?? ""
+    if (suffix && !/^DEFERRABLE(?:\s+INITIALLY\s+(?:IMMEDIATE|DEFERRED))?$/i.test(suffix)) {
+      unsupported(migration, `unsupported PRIMARY KEY definition for constraint ${name}`)
+    }
+    return {
+      table,
+      name,
+      type: "p",
+      columns: parseIdentifierList(primary[1] as string),
+      referencedSchema: null,
+      referencedTable: null,
+      referencedColumns: [],
+      updateAction: " ",
+      deleteAction: " ",
+      matchType: " ",
+      deferrable: /\bDEFERRABLE\b/i.test(suffix),
+      initiallyDeferred: /\bINITIALLY\s+DEFERRED\b/i.test(suffix),
+    }
+  }
+
+  const unique = body.match(/^UNIQUE\s*(?:NULLS\s+(?:NOT\s+)?DISTINCT\s*)?\(([^)]+)\)(.*)$/i)
+  if (unique) {
+    const suffix = unique[2]?.trim() ?? ""
+    if (suffix && !/^DEFERRABLE(?:\s+INITIALLY\s+(?:IMMEDIATE|DEFERRED))?$/i.test(suffix)) {
+      unsupported(migration, `unsupported UNIQUE definition for constraint ${name}`)
+    }
+    return {
+      table,
+      name,
+      type: "u",
+      columns: parseIdentifierList(unique[1] as string),
+      referencedSchema: null,
+      referencedTable: null,
+      referencedColumns: [],
+      updateAction: " ",
+      deleteAction: " ",
+      matchType: " ",
+      deferrable: /\bDEFERRABLE\b/i.test(suffix),
+      initiallyDeferred: /\bINITIALLY\s+DEFERRED\b/i.test(suffix),
+    }
+  }
+
+  const foreign = body.match(
+    new RegExp(
+      `^FOREIGN\\s+KEY\\s*\\(([^)]+)\\)\\s+REFERENCES\\s+(?:(?:${identifier})\\.)?(?:${identifier})\\s*\\(([^)]+)\\)([\\s\\S]*)$`,
+      "i",
+    ),
+  )
+  if (foreign) {
+    const suffix = (foreign[5] ?? "").trim()
+    const update = suffix.match(
+      /\bON\s+UPDATE\s+(NO\s+ACTION|RESTRICT|CASCADE|SET\s+NULL|SET\s+DEFAULT)\b/i,
+    )?.[1]
+    const deletion = suffix.match(
+      /\bON\s+DELETE\s+(NO\s+ACTION|RESTRICT|CASCADE|SET\s+NULL|SET\s+DEFAULT)\b/i,
+    )?.[1]
+    const match = suffix.match(/\bMATCH\s+(SIMPLE|FULL|PARTIAL)\b/i)?.[1]?.toUpperCase() ?? "SIMPLE"
+    const known = suffix
+      .replace(/\bON\s+UPDATE\s+(NO\s+ACTION|RESTRICT|CASCADE|SET\s+NULL|SET\s+DEFAULT)\b/gi, "")
+      .replace(/\bON\s+DELETE\s+(NO\s+ACTION|RESTRICT|CASCADE|SET\s+NULL|SET\s+DEFAULT)\b/gi, "")
+      .replace(/\bMATCH\s+(SIMPLE|FULL|PARTIAL)\b/gi, "")
+      .replace(/\bNOT\s+DEFERRABLE\b/gi, "")
+      .replace(/\bDEFERRABLE\b/gi, "")
+      .replace(/\bINITIALLY\s+(IMMEDIATE|DEFERRED)\b/gi, "")
+      .trim()
+    if (known) unsupported(migration, `unsupported FOREIGN KEY definition for constraint ${name}`)
+    return {
+      table,
+      name,
+      type: "f",
+      columns: parseIdentifierList(foreign[1] as string),
+      referencedSchema: foreign[2] ?? "public",
+      referencedTable: foreign[3] as string,
+      referencedColumns: parseIdentifierList(foreign[4] as string),
+      updateAction: actionCode(update),
+      deleteAction: actionCode(deletion),
+      matchType: match === "FULL" ? "f" : match === "PARTIAL" ? "p" : "s",
+      deferrable: /\bDEFERRABLE\b/i.test(suffix) && !/\bNOT\s+DEFERRABLE\b/i.test(suffix),
+      initiallyDeferred: /\bINITIALLY\s+DEFERRED\b/i.test(suffix),
+    }
+  }
+
+  unsupported(migration, `unsupported constraint ${name}`)
+}
+
+function parseColumn(
+  migration: PlannedMigration,
+  table: string,
+  position: number,
+  definition: string,
+  constraints: ExpectedConstraint[],
+): ExpectedColumn {
+  const match = definition.match(new RegExp(`^${identifier}\\s+([\\s\\S]+)$`))
+  if (!match) unsupported(migration, `cannot parse a column in table ${table}`)
+  const name = match[1] as string
+  const remainder = match[2] as string
+  if (/\b(?:REFERENCES|CHECK|GENERATED|COLLATE|UNIQUE)\b/i.test(remainder)) {
+    unsupported(migration, `unsupported inline clause on ${table}.${name}`)
+  }
+  const clause = remainder.search(/\s+(?:DEFAULT|NOT\s+NULL|NULL|PRIMARY\s+KEY)\b/i)
+  const rawType = (clause === -1 ? remainder : remainder.slice(0, clause)).trim()
+  const qualifiers = clause === -1 ? "" : remainder.slice(clause).trim()
+  const defaultMatch = qualifiers.match(
+    /\bDEFAULT\s+([\s\S]*?)(?=\s+(?:NOT\s+NULL|NULL|PRIMARY\s+KEY)\b|$)/i,
+  )
+  const leftover = qualifiers
+    .replace(/\bDEFAULT\s+[\s\S]*?(?=\s+(?:NOT\s+NULL|NULL|PRIMARY\s+KEY)\b|$)/i, "")
+    .replace(/\bNOT\s+NULL\b/gi, "")
+    .replace(/\bNULL\b/gi, "")
+    .replace(/\bPRIMARY\s+KEY\b/gi, "")
+    .trim()
+  if (!rawType || leftover)
+    unsupported(migration, `unsupported column definition for ${table}.${name}`)
+
+  if (/\bPRIMARY\s+KEY\b/i.test(qualifiers)) {
+    constraints.push({
+      table,
+      name: `${table}_pkey`,
+      type: "p",
+      columns: [name],
+      referencedSchema: null,
+      referencedTable: null,
+      referencedColumns: [],
+      updateAction: " ",
+      deleteAction: " ",
+      matchType: " ",
+      deferrable: false,
+      initiallyDeferred: false,
+    })
+  }
+
+  return {
+    table,
+    name,
+    position,
+    dataType: normalizeType(rawType),
+    notNull: /\bNOT\s+NULL\b/i.test(qualifiers) || /\bPRIMARY\s+KEY\b/i.test(qualifiers),
+    defaultExpression: normalizeExpression(defaultMatch?.[1]),
+    identity: "",
+    generated: "",
+  }
+}
+
+function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint {
+  const tables: string[] = []
+  const columns: ExpectedColumn[] = []
+  const constraints: ExpectedConstraint[] = []
+  const indexes: ExpectedIndex[] = []
+  const statements = splitStatements(migration.sql)
+
+  for (const statement of statements) {
+    const create = statement.match(
+      new RegExp(
+        `^CREATE\\s+TABLE\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s*\\(([\\s\\S]*)\\)\\s*;?$`,
+        "i",
+      ),
+    )
+    if (create) {
+      const table = create[1] as string
+      if (tables.includes(table)) unsupported(migration, `table ${table} is created more than once`)
+      tables.push(table)
+      let position = 0
+      for (const item of splitTopLevel(create[2] as string)) {
+        const tableConstraint = item.match(
+          new RegExp(`^CONSTRAINT\\s+${identifier}\\s+([\\s\\S]+)$`, "i"),
+        )
+        if (tableConstraint) {
+          constraints.push(
+            constraintFromBody(
+              migration,
+              table,
+              tableConstraint[1] as string,
+              tableConstraint[2] as string,
+            ),
+          )
+          continue
+        }
+        position += 1
+        columns.push(parseColumn(migration, table, position, item, constraints))
+      }
+      continue
+    }
+
+    const alterConstraint = statement.match(
+      new RegExp(
+        `^ALTER\\s+TABLE\\s+${identifier}\\s+ADD\\s+CONSTRAINT\\s+${identifier}\\s+([\\s\\S]+?)\\s*;?$`,
+        "i",
+      ),
+    )
+    if (alterConstraint) {
+      const table = alterConstraint[1] as string
+      if (!tables.includes(table)) {
+        unsupported(
+          migration,
+          `constraint targets table ${table}, which this migration does not create`,
+        )
+      }
+      constraints.push(
+        constraintFromBody(
+          migration,
+          table,
+          alterConstraint[2] as string,
+          alterConstraint[3] as string,
+        ),
+      )
+      continue
+    }
+
+    const index = statement.match(
+      new RegExp(
+        `^CREATE\\s+(?:UNIQUE\\s+)?INDEX\\s+(?:IF\\s+NOT\\s+EXISTS\\s+)?${identifier}\\s+ON\\s+${identifier}\\b[\\s\\S]*;?$`,
+        "i",
+      ),
+    )
+    if (index) {
+      const table = index[2] as string
+      if (!tables.includes(table)) {
+        unsupported(
+          migration,
+          `index ${index[1]} targets table ${table}, which this migration does not create`,
+        )
+      }
+      indexes.push({
+        table,
+        name: index[1] as string,
+        definition: normalizeIndexDefinition(statement),
+      })
+      continue
+    }
+
+    unsupported(migration, `unsupported statement ${statement.slice(0, 80)}`)
+  }
+
+  if (tables.length === 0) unsupported(migration, "the migration creates no tables")
+  return { tables, columns, constraints, indexes }
+}
+
+function strings(value: unknown): string[] {
+  if (Array.isArray(value)) return value.map(String)
+  if (typeof value !== "string") return []
+  return value.replace(/^\{/, "").replace(/\}$/, "").split(",").filter(Boolean)
+}
+
+async function readLiveFootprint(
+  client: MigrationClient,
+  tables: readonly string[],
+): Promise<LiveFootprint> {
+  const tableRows = await client.query(
+    `SELECT c.relname AS table_name
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE n.nspname = 'public'
+        AND c.relkind IN ('r', 'p')
+        AND c.relname = ANY($1::text[])
+      ORDER BY c.relname`,
+    [tables],
+  )
+  const liveTables = tableRows.rows.map((row) => String(row.table_name))
+  if (liveTables.length !== tables.length) {
+    return { tables: liveTables, columns: [], constraints: [], indexes: [] }
+  }
+
+  const columnRows = await client.query(
+    `SELECT c.relname AS table_name,
+            a.attname AS column_name,
+            a.attnum::text AS ordinal_position,
+            format_type(a.atttypid, a.atttypmod) AS data_type,
+            a.attnotnull AS not_null,
+            pg_get_expr(d.adbin, d.adrelid, true) AS column_default,
+            a.attidentity AS identity_kind,
+            a.attgenerated AS generated_kind
+       FROM pg_attribute a
+       JOIN pg_class c ON c.oid = a.attrelid
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+      WHERE n.nspname = 'public'
+        AND c.relname = ANY($1::text[])
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+      ORDER BY c.relname, a.attnum`,
+    [tables],
+  )
+  const constraintRows = await client.query(
+    `SELECT rel.relname AS table_name,
+            con.conname AS constraint_name,
+            con.contype AS constraint_type,
+            COALESCE(
+              ARRAY(
+                SELECT att.attname
+                  FROM unnest(con.conkey) WITH ORDINALITY key(attnum, ordinality)
+                  JOIN pg_attribute att ON att.attrelid = con.conrelid AND att.attnum = key.attnum
+                 ORDER BY key.ordinality
+              ), ARRAY[]::name[]
+            ) AS column_names,
+            ref_ns.nspname AS referenced_schema,
+            ref_rel.relname AS referenced_table,
+            COALESCE(
+              ARRAY(
+                SELECT att.attname
+                  FROM unnest(con.confkey) WITH ORDINALITY key(attnum, ordinality)
+                  JOIN pg_attribute att ON att.attrelid = con.confrelid AND att.attnum = key.attnum
+                 ORDER BY key.ordinality
+              ), ARRAY[]::name[]
+            ) AS referenced_column_names,
+            con.confupdtype AS update_action,
+            con.confdeltype AS delete_action,
+            con.confmatchtype AS match_type,
+            con.condeferrable AS is_deferrable,
+            con.condeferred AS initially_deferred
+       FROM pg_constraint con
+       JOIN pg_class rel ON rel.oid = con.conrelid
+       JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+       LEFT JOIN pg_class ref_rel ON ref_rel.oid = con.confrelid
+       LEFT JOIN pg_namespace ref_ns ON ref_ns.oid = ref_rel.relnamespace
+      WHERE ns.nspname = 'public'
+        AND rel.relname = ANY($1::text[])
+      ORDER BY rel.relname, con.conname`,
+    [tables],
+  )
+  const indexRows = await client.query(
+    `SELECT rel.relname AS table_name,
+            idx.relname AS index_name,
+            pg_get_indexdef(idx.oid, 0, true) AS index_definition
+       FROM pg_index i
+       JOIN pg_class rel ON rel.oid = i.indrelid
+       JOIN pg_namespace ns ON ns.oid = rel.relnamespace
+       JOIN pg_class idx ON idx.oid = i.indexrelid
+       LEFT JOIN pg_constraint con ON con.conindid = idx.oid
+      WHERE ns.nspname = 'public'
+        AND rel.relname = ANY($1::text[])
+        AND con.oid IS NULL
+      ORDER BY rel.relname, idx.relname`,
+    [tables],
+  )
+
+  return {
+    tables: liveTables,
+    columns: columnRows.rows.map((row) => ({
+      table: String(row.table_name),
+      name: String(row.column_name),
+      position: Number(row.ordinal_position),
+      dataType: normalizeType(String(row.data_type)),
+      notNull: Boolean(row.not_null),
+      defaultExpression: normalizeExpression(row.column_default as string | null | undefined),
+      identity: String(row.identity_kind ?? ""),
+      generated: String(row.generated_kind ?? ""),
+    })),
+    constraints: constraintRows.rows.map((row) => ({
+      table: String(row.table_name),
+      name: String(row.constraint_name),
+      type: String(row.constraint_type) as ExpectedConstraint["type"],
+      columns: strings(row.column_names),
+      referencedSchema: row.referenced_schema == null ? null : String(row.referenced_schema),
+      referencedTable: row.referenced_table == null ? null : String(row.referenced_table),
+      referencedColumns: strings(row.referenced_column_names),
+      updateAction: String(row.update_action ?? " "),
+      deleteAction: String(row.delete_action ?? " "),
+      matchType: String(row.match_type ?? " "),
+      deferrable: Boolean(row.is_deferrable),
+      initiallyDeferred: Boolean(row.initially_deferred),
+    })),
+    indexes: indexRows.rows.map((row) => ({
+      table: String(row.table_name),
+      name: String(row.index_name),
+      definition: normalizeIndexDefinition(String(row.index_definition)),
+    })),
+  }
+}
+
+function stable(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+function compareFootprint(
+  migration: PlannedMigration,
+  expected: ExpectedFootprint,
+  live: LiveFootprint,
+): void {
+  const problems: string[] = []
+  const expectedTables = [...expected.tables].sort()
+  const liveTables = [...live.tables].sort()
+  if (stable(expectedTables) !== stable(liveTables)) {
+    problems.push(`tables expected ${stable(expectedTables)}, found ${stable(liveTables)}`)
+  }
+  if (liveTables.length === expectedTables.length) {
+    for (const [label, expectedRows, liveRows] of [
+      ["columns", expected.columns, live.columns],
+      ["constraints", expected.constraints, live.constraints],
+      ["indexes", expected.indexes, live.indexes],
+    ] as const) {
+      const orderedExpected = [...expectedRows].sort((a, b) => stable(a).localeCompare(stable(b)))
+      const orderedLive = [...liveRows].sort((a, b) => stable(a).localeCompare(stable(b)))
+      if (stable(orderedExpected) !== stable(orderedLive)) {
+        problems.push(`${label} expected ${stable(orderedExpected)}, found ${stable(orderedLive)}`)
+      }
+    }
+  }
+  if (problems.length > 0) {
+    throw new Error(
+      `cannot adopt materialized migration ${migration.source}/${migration.tag}: ` +
+        `the live schema does not exactly match its immutable SQL footprint.\n  • ${problems.join("\n  • ")}`,
+    )
+  }
+}
+
+/**
+ * Classify one explicitly allowlisted, unrecorded migration without changing the database.
+ * All created tables absent means normal execution; any presence must be an exact match.
+ */
+export async function classifyMaterializedMigration(
+  client: MigrationClient,
+  migration: PlannedMigration,
+): Promise<MaterializedMigrationClassification> {
+  const expected = parseExpectedFootprint(migration)
+  const live = await readLiveFootprint(client, expected.tables)
+  if (live.tables.length === 0) return { status: "absent" }
+  compareFootprint(migration, expected, live)
+  return { status: "materialized" }
+}

--- a/packages/framework/src/node-migration-runner.test.ts
+++ b/packages/framework/src/node-migration-runner.test.ts
@@ -271,9 +271,16 @@ function runnerFixture(events: string[]) {
       return { name: migration.idempotencyKey, priority: migration.order, migrations: [] }
     },
     async runSchema(_client, source) {
-      if (schemaLedger.has(source.name)) return { existing: false, executed: [], baselined: [] }
+      if (schemaLedger.has(source.name)) {
+        return { existing: false, executed: [], baselined: [], adopted: [] }
+      }
       schemaLedger.add(source.name)
-      return { existing: false, executed: [`${source.name}/0000`], baselined: [] }
+      return {
+        existing: false,
+        executed: [`${source.name}/0000`],
+        baselined: [],
+        adopted: [],
+      }
     },
   }
   return { dependencies, setupLedger }


### PR DESCRIPTION
## Summary

- add an opt-in `materializedMigrationAdoptions` path keyed by exact migration source/tag
- classify all pending candidates under the existing session advisory lock before normal migration commits
- execute wholly absent candidates normally, baseline exact catalog matches with the current immutable SQL hash, and fail closed on partial/unsupported/mismatched footprints
- compare exact table columns (order/type/nullability/default/identity/generated), named PK/unique/FK constraints, and explicit index definitions
- report explicit adoptions via `RunResult.adopted` and the existing `baselined` result/hook

Fresh databases and non-allowlisted migrations retain their existing execution behavior. This PR does not add an inventory allowlist to any deployment.

## Tests

Remote validation pending. Added coverage for exact present/adopt, existing absent/execute, fresh execute, partial failure before earlier DDL, column/constraint/index mismatches, idempotency, lock serialization, and no implicit adoption.
