### PR TITLE
Fix Redis runtime authority and graph-check race

### DIFF
--- a/.depot/workflows/ci.yml
+++ b/.depot/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on:
       size: 8x32
       image: 5ctgrq9prr.registry.depot.dev/voyant/ci:node24-pnpm10-playwright1.61.1-workspace
-    timeout-minutes: 10
+    timeout-minutes: 15
     env:
       NODE_OPTIONS: --conditions=development --max-old-space-size=24576
     steps:
@@ -41,6 +41,13 @@ jobs:
           filter: blob:none
 
       - uses: ./.depot/actions/setup-workspace
+
+      # Several architecture gates regenerate and then inspect the Operator's
+      # `.voyant` graph artifacts. Keep them outside the parallel block so the
+      # starter typecheck/test `prepare:verify` hooks cannot rewrite those
+      # files while a gate is reading them.
+      - name: Architecture checks
+        run: pnpm verify:architecture
 
       - fail-fast: false
         parallel:
@@ -52,11 +59,6 @@ jobs:
 
           - name: Test
             run: pnpm test --summarize --output-logs=new-only
-
-          # verify:architecture already runs the operator graph drift gate via
-          # `operator graph:check`; do not rebuild the full operator here.
-          - name: Architecture checks
-            run: pnpm verify:architecture
 
           - name: i18n checks
             run: pnpm i18n:check

--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -216,6 +216,7 @@ const allowedInfrastructureImports = new Map([
   ["@voyant-travel/storage/runtime", "adapts the generic Node document object store"],
   ["@voyant-travel/storage/types", "types the provider-neutral object storage contract"],
   ["@voyant-travel/utils/cache", "types the generic cache resource"],
+  ["@voyant-travel/utils/redis-client", "types the generic lazy Redis client contract"],
   ["@voyant-travel/utils/redis-kv", "adapts Redis to the generic cache resource"],
   ["@voyant-travel/utils/tiered-kv", "composes process and durable cache resources"],
   ["@voyant-travel/workflows/client", "adapts the generic workflow driver to Voyant Cloud"],

--- a/scripts/generate-standard-product-distribution.mjs
+++ b/scripts/generate-standard-product-distribution.mjs
@@ -106,6 +106,7 @@ const frameworkDependencies = {
   "drizzle-orm": "catalog:",
   hono: "catalog:",
   pg: "^8.22.0",
+  redis: "^6.1.0",
 }
 
 // BOM dependencies include every standard product selection owner, not only


### PR DESCRIPTION
Two independent default-branch CI regressions blocked unrelated migration work:

1. #3636 added the generic `@voyant-travel/utils/redis-client` infrastructure import without registering it in the exact Node runtime authority allowlist.
2. The checks job ran architecture gates in parallel with starter typecheck/test. All three invoke `operator prepare:verify`, so they concurrently rewrote `.voyant` graph artifacts while the architecture gate read them, producing contradictory admin-composition drift.

This PR adds the exact justified infrastructure exception and serializes architecture checks before the parallel lint/typecheck/test/i18n block. The checks timeout increases to 15 minutes to account for the intentionally serialized gate.

Validation:
- `node scripts/check-node-runtime-product-authority.mjs`
- `git diff --check`
- Depot CI must complete all lanes cleanly.