### PR TITLE
Allow Redis client runtime infrastructure

### DIFF
--- a/scripts/check-node-runtime-product-authority.mjs
+++ b/scripts/check-node-runtime-product-authority.mjs
@@ -216,6 +216,10 @@ const allowedInfrastructureImports = new Map([
   ["@voyant-travel/storage/runtime", "adapts the generic Node document object store"],
   ["@voyant-travel/storage/types", "types the provider-neutral object storage contract"],
   ["@voyant-travel/utils/cache", "types the generic cache resource"],
+  [
+    "@voyant-travel/utils/redis-client",
+    "provides the generic Redis client contract and REST client factory",
+  ],
   ["@voyant-travel/utils/redis-kv", "adapts Redis to the generic cache resource"],
   ["@voyant-travel/utils/tiered-kv", "composes process and durable cache resources"],
   ["@voyant-travel/workflows/client", "adapts the generic workflow driver to Voyant Cloud"],

--- a/scripts/generate-standard-product-distribution.mjs
+++ b/scripts/generate-standard-product-distribution.mjs
@@ -106,6 +106,7 @@ const frameworkDependencies = {
   "drizzle-orm": "catalog:",
   hono: "catalog:",
   pg: "^8.22.0",
+  redis: "^6.1.0",
 }
 
 // BOM dependencies include every standard product selection owner, not only


### PR DESCRIPTION
## Summary

- classify `@voyant-travel/utils/redis-client` as explicitly justified generic Node runtime infrastructure
- keep `redis` in the authoritative framework implementation dependency map
- keep the authority checker strict for every other first-party import
- make no runtime behavior changes

## Root cause

The Redis TCP runtime change merged in #3636 added a direct `node-runtime.ts` import for the generic Redis client contract and REST fallback factory. Two repository authorities were not updated with that change:

1. The Node runtime import allowlist omitted `@voyant-travel/utils/redis-client`.
2. The standard product distribution generator omitted the required `redis` implementation dependency, so its drift check attempted to remove it from `packages/framework/package.json`.

This PR updates both sources of truth while retaining the actual framework dependency.

## Validation

- `node scripts/generate-standard-product-distribution.mjs`
- `pnpm verify:generic-node-bootstrap-authority`
- `pnpm verify:node-runtime-authority`
- `pnpm verify:node-runtime-product-authority`
- `git diff --check`

The exact checks passed on lab1 with Node 24, including all bookings runtime authority tests.