### PR TITLE
Tighten materialized adoption catalog checks

### DIFF
--- a/.changeset/steady-catalogs-verify.md
+++ b/.changeset/steady-catalogs-verify.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Tighten materialized migration adoption with fail-closed table identity, index state, and string-literal comparisons.

--- a/docs/architecture/migration-collector-d2.md
+++ b/docs/architecture/migration-collector-d2.md
@@ -164,11 +164,11 @@ pending allowlisted identity before a normal migration can commit:
 
 - if every table created by the immutable SQL is absent, the migration stays on
   the normal execution path;
-- if any table is present, the full footprint must match exactly: table and
-  column sets/order, PostgreSQL type, nullability, default, identity/generated
-  state, named primary/unique/foreign-key constraints and their actions, and
-  non-constraint index names, uniqueness, method, keys/expressions and
-  predicates;
+- if any table is present, the full footprint must match exactly: ordinary
+  permanent table identity, column sets/order, PostgreSQL type, nullability,
+  default, identity/generated state, named primary/unique/foreign-key
+  constraints and their actions, and non-constraint index names, validity,
+  readiness, uniqueness, method, keys/expressions and predicates;
 - a partial or mismatched footprint aborts without a ledger write or migration
   transaction;
 - an exact footprint is recorded with the current immutable SQL content hash and

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -830,7 +830,7 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     expect(ledgerRows).toEqual([])
   })
 
-  it("rejects E-string defaults that differ after a backslash-escaped quote", async () => {
+  it("fails closed for E-string defaults with backslash-escaped quotes", async () => {
     const source = src("escaped-literal-defaults", [
       `CREATE TABLE "escaped_literal_defaults" (
   "id" text PRIMARY KEY NOT NULL,
@@ -894,7 +894,7 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
           ],
         },
       ),
-    ).rejects.toThrow("does not exactly match")
+    ).rejects.toThrow("E-string default expressions are not supported")
     expect(ledgerRows).toEqual([])
   })
 

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework-migrations; deployment runner tests keep existing, baseline, adoption, and PostgreSQL conformance cases in one migration-contract harness.
 import { Client } from "pg"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 import type { MigrationClient, MigrationSource } from "./collector.js"
@@ -471,18 +472,29 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
       index_name: "uidx_product_day_service_translations_service_language",
       index_definition:
         "CREATE UNIQUE INDEX uidx_product_day_service_translations_service_language ON public.product_day_service_translations USING btree (service_id, language_tag)",
+      is_valid: true,
+      is_ready: true,
+      is_live: true,
     },
     {
       table_name: "product_itinerary_translations",
       index_name: "idx_product_itinerary_translations_itinerary",
       index_definition:
         "CREATE INDEX idx_product_itinerary_translations_itinerary ON public.product_itinerary_translations USING btree (itinerary_id)",
+      is_valid: true,
+      is_ready: true,
+      is_live: true,
     },
   ]
 
   function adoptionClient(options: {
     existing?: boolean
     tables?: string[]
+    tableRows?: Array<{
+      table_name: string
+      relation_kind: string
+      relation_persistence: string
+    }>
     columns?: typeof exactColumns
     constraints?: typeof exactConstraints
     indexes?: typeof exactIndexes
@@ -532,7 +544,15 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
           }
         }
         if (sql.includes("FROM pg_class c") && sql.includes("c.relkind")) {
-          return { rows: (options.tables ?? []).map((table_name) => ({ table_name })) }
+          return {
+            rows:
+              options.tableRows ??
+              (options.tables ?? []).map((table_name) => ({
+                table_name,
+                relation_kind: "r",
+                relation_persistence: "p",
+              })),
+          }
         }
         if (sql.includes("FROM pg_attribute a")) return { rows: options.columns ?? [] }
         if (sql.includes("FROM pg_constraint con")) return { rows: options.constraints ?? [] }
@@ -681,6 +701,48 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
         ),
       },
     ],
+    [
+      "relation kind",
+      {
+        tableRows: [
+          {
+            table_name: "product_day_service_translations",
+            relation_kind: "p",
+            relation_persistence: "p",
+          },
+          {
+            table_name: "product_itinerary_translations",
+            relation_kind: "r",
+            relation_persistence: "p",
+          },
+        ],
+      },
+    ],
+    [
+      "relation persistence",
+      {
+        tableRows: [
+          {
+            table_name: "product_day_service_translations",
+            relation_kind: "r",
+            relation_persistence: "u",
+          },
+          {
+            table_name: "product_itinerary_translations",
+            relation_kind: "r",
+            relation_persistence: "p",
+          },
+        ],
+      },
+    ],
+    [
+      "index validity",
+      {
+        indexes: exactIndexes.map((row, index) =>
+          index === 0 ? { ...row, is_valid: false } : row,
+        ),
+      },
+    ],
   ] as const)("rejects an exact-footprint %s mismatch", async (_kind, override) => {
     const { client, ledgerRows } = adoptionClient({
       tables: ["product_day_service_translations", "product_itinerary_translations"],
@@ -696,6 +758,71 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
         {},
         {
           materializedMigrationAdoptions: adoption,
+        },
+      ),
+    ).rejects.toThrow("does not exactly match")
+    expect(ledgerRows).toEqual([])
+  })
+
+  it("rejects default expressions that differ only inside a string literal", async () => {
+    const source = src("literal-defaults", [
+      `CREATE TABLE "literal_defaults" (
+  "id" text PRIMARY KEY NOT NULL,
+  "label" text DEFAULT 'a, b'::text NOT NULL
+);`,
+    ])
+    const { client, ledgerRows } = adoptionClient({
+      tables: ["literal_defaults"],
+      columns: [
+        {
+          table_name: "literal_defaults",
+          column_name: "id",
+          ordinal_position: "1",
+          data_type: "text",
+          not_null: true,
+          column_default: null,
+          identity_kind: "",
+          generated_kind: "",
+        },
+        {
+          table_name: "literal_defaults",
+          column_name: "label",
+          ordinal_position: "2",
+          data_type: "text",
+          not_null: true,
+          column_default: "'a,b'::text",
+          identity_kind: "",
+          generated_kind: "",
+        },
+      ],
+      constraints: [
+        {
+          table_name: "literal_defaults",
+          constraint_name: "literal_defaults_pkey",
+          constraint_type: "p",
+          column_names: ["id"],
+          referenced_schema: null,
+          referenced_table: null,
+          referenced_column_names: [],
+          update_action: " ",
+          delete_action: " ",
+          match_type: " ",
+          is_deferrable: false,
+          initially_deferred: false,
+        },
+      ],
+      indexes: [],
+    })
+
+    await expect(
+      runDeploymentMigrations(
+        client,
+        [source],
+        {},
+        {
+          materializedMigrationAdoptions: [
+            { source: "literal-defaults", tag: "0000_literal-defaults" },
+          ],
         },
       ),
     ).rejects.toThrow("does not exactly match")

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -830,6 +830,74 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     expect(ledgerRows).toEqual([])
   })
 
+  it("rejects E-string defaults that differ after a backslash-escaped quote", async () => {
+    const source = src("escaped-literal-defaults", [
+      `CREATE TABLE "escaped_literal_defaults" (
+  "id" text PRIMARY KEY NOT NULL,
+  "label" text DEFAULT E'a\\'B, C'::text NOT NULL
+);`,
+    ])
+    const { client, ledgerRows } = adoptionClient({
+      tables: ["escaped_literal_defaults"],
+      columns: [
+        {
+          table_name: "escaped_literal_defaults",
+          column_name: "id",
+          ordinal_position: "1",
+          data_type: "text",
+          not_null: true,
+          column_default: null,
+          identity_kind: "",
+          generated_kind: "",
+        },
+        {
+          table_name: "escaped_literal_defaults",
+          column_name: "label",
+          ordinal_position: "2",
+          data_type: "text",
+          not_null: true,
+          column_default: "E'a\\'b,c'::text",
+          identity_kind: "",
+          generated_kind: "",
+        },
+      ],
+      constraints: [
+        {
+          table_name: "escaped_literal_defaults",
+          constraint_name: "escaped_literal_defaults_pkey",
+          constraint_type: "p",
+          column_names: ["id"],
+          referenced_schema: null,
+          referenced_table: null,
+          referenced_column_names: [],
+          update_action: " ",
+          delete_action: " ",
+          match_type: " ",
+          is_deferrable: false,
+          initially_deferred: false,
+        },
+      ],
+      indexes: [],
+    })
+
+    await expect(
+      runDeploymentMigrations(
+        client,
+        [source],
+        {},
+        {
+          materializedMigrationAdoptions: [
+            {
+              source: "escaped-literal-defaults",
+              tag: "0000_escaped-literal-defaults",
+            },
+          ],
+        },
+      ),
+    ).rejects.toThrow("does not exactly match")
+    expect(ledgerRows).toEqual([])
+  })
+
   it("is idempotent and serializes concurrent adopters under the session lock", async () => {
     const { client, events, ledgerRows } = exactClient({ serializeLocks: true })
     const [first, second] = await Promise.all([

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -898,6 +898,38 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
     expect(ledgerRows).toEqual([])
   })
 
+  it("fails closed for parenthesized E-string defaults", async () => {
+    const source = src("parenthesized-escaped-literal-defaults", [
+      `CREATE TABLE "parenthesized_escaped_literal_defaults" (
+  "id" text PRIMARY KEY NOT NULL,
+  "label" text DEFAULT (( E'a\\'B, C'::text )) NOT NULL
+);`,
+    ])
+    const { client, ledgerRows } = adoptionClient({
+      tables: ["parenthesized_escaped_literal_defaults"],
+      columns: [],
+      constraints: [],
+      indexes: [],
+    })
+
+    await expect(
+      runDeploymentMigrations(
+        client,
+        [source],
+        {},
+        {
+          materializedMigrationAdoptions: [
+            {
+              source: "parenthesized-escaped-literal-defaults",
+              tag: "0000_parenthesized-escaped-literal-defaults",
+            },
+          ],
+        },
+      ),
+    ).rejects.toThrow("E-string default expressions are not supported")
+    expect(ledgerRows).toEqual([])
+  })
+
   it("is idempotent and serializes concurrent adopters under the session lock", async () => {
     const { client, events, ledgerRows } = exactClient({ serializeLocks: true })
     const [first, second] = await Promise.all([

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -545,13 +545,14 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
         }
         if (sql.includes("FROM pg_class c") && sql.includes("c.relkind")) {
           return {
-            rows:
+            rows: (
               options.tableRows ??
               (options.tables ?? []).map((table_name) => ({
                 table_name,
                 relation_kind: "r",
                 relation_persistence: "p",
-              })),
+              }))
+            ).map((row) => ({ ...row })),
           }
         }
         if (sql.includes("FROM pg_attribute a")) return { rows: options.columns ?? [] }

--- a/packages/framework-migrations/src/deployment-runner.test.ts
+++ b/packages/framework-migrations/src/deployment-runner.test.ts
@@ -490,7 +490,7 @@ CREATE INDEX "idx_product_itinerary_translations_itinerary" ON "product_itinerar
   function adoptionClient(options: {
     existing?: boolean
     tables?: string[]
-    tableRows?: Array<{
+    tableRows?: ReadonlyArray<{
       table_name: string
       relation_kind: string
       relation_persistence: string

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -432,7 +432,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
       if (tableNames.includes(table)) {
         unsupported(migration, `table ${table} is created more than once`)
       }
-      if (/\bDEFAULT\s+E'/i.test(create[2] as string)) {
+      if (/\bDEFAULT\s*(?:\(\s*)*E'/i.test(create[2] as string)) {
         unsupported(migration, `E-string default expressions are not supported in table ${table}`)
       }
       tableNames.push(table)

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -162,7 +162,6 @@ function normalizeOutsideStringLiterals(
   let result = ""
   let outside = ""
   let inLiteral = false
-  let backslashEscapes = false
   const flushOutside = () => {
     if (!outside) return
     result += normalizeOutside(outside)
@@ -170,31 +169,22 @@ function normalizeOutsideStringLiterals(
   }
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index] as string
-    if (inLiteral) {
-      if (backslashEscapes && character === "\\" && value[index + 1] !== undefined) {
-        result += character + value[index + 1]
-        index += 1
-        continue
-      }
+    if (character === "'") {
+      if (!inLiteral) flushOutside()
       result += character
-      if (character !== "'") continue
-      if (value[index + 1] === "'") {
+      if (inLiteral && value[index + 1] === "'") {
         result += "'"
         index += 1
       } else {
-        inLiteral = false
-        backslashEscapes = false
+        inLiteral = !inLiteral
       }
       continue
     }
-    if (character === "'") {
-      backslashEscapes = /(?:^|[^a-z0-9_$])e$/i.test(outside)
-      flushOutside()
+    if (inLiteral) {
       result += character
-      inLiteral = true
-      continue
+    } else {
+      outside += character
     }
-    outside += character
   }
   flushOutside()
   return result
@@ -441,6 +431,9 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
       const table = postgresIdentifier(create[1] as string)
       if (tableNames.includes(table)) {
         unsupported(migration, `table ${table} is created more than once`)
+      }
+      if (/\bDEFAULT\s+E'/i.test(create[2] as string)) {
+        unsupported(migration, `E-string default expressions are not supported in table ${table}`)
       }
       tableNames.push(table)
       let position = 0

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: framework-migrations; exact PostgreSQL footprint parsing and catalog comparison stay co-located so adoption fails closed through one reviewable verifier.
 import type { MigrationClient, PlannedMigration } from "./collector.js"
 
 /** An exact migration identity that may be adopted when its DDL already exists. */
@@ -15,6 +16,12 @@ interface ExpectedColumn {
   defaultExpression: string | null
   identity: string
   generated: string
+}
+
+interface ExpectedTable {
+  name: string
+  kind: "r"
+  persistence: "p"
 }
 
 interface ExpectedConstraint {
@@ -36,17 +43,24 @@ interface ExpectedIndex {
   table: string
   name: string
   definition: string
+  valid: boolean
+  ready: boolean
+  live: boolean
 }
 
 interface ExpectedFootprint {
-  tables: string[]
+  tables: ExpectedTable[]
   columns: ExpectedColumn[]
   constraints: ExpectedConstraint[]
   indexes: ExpectedIndex[]
 }
 
 interface LiveFootprint {
-  tables: string[]
+  tables: Array<{
+    name: string
+    kind: string
+    persistence: string
+  }>
   columns: ExpectedColumn[]
   constraints: ExpectedConstraint[]
   indexes: ExpectedIndex[]
@@ -141,6 +155,60 @@ function lowercaseOutsideQuotedValues(value: string): string {
   return result
 }
 
+function normalizeOutsideStringLiterals(
+  value: string,
+  normalizeOutside: (value: string) => string,
+): string {
+  let result = ""
+  let outside = ""
+  let inLiteral = false
+  const flushOutside = () => {
+    if (!outside) return
+    result += normalizeOutside(outside)
+    outside = ""
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index] as string
+    if (character === "'") {
+      if (!inLiteral) flushOutside()
+      result += character
+      if (inLiteral && value[index + 1] === "'") {
+        result += "'"
+        index += 1
+      } else {
+        inLiteral = !inLiteral
+      }
+      continue
+    }
+    if (inLiteral) {
+      result += character
+    } else {
+      outside += character
+    }
+  }
+  flushOutside()
+  return result
+}
+
+function normalizeSqlSyntaxOutsideStringLiterals(
+  value: string,
+  options: { stripPublicPrefix?: boolean; stripIndexCreationGuard?: boolean } = {},
+): string {
+  return normalizeOutsideStringLiterals(value, (outside) => {
+    let normalized = normalizeQuotedIdentifiers(outside)
+    if (options.stripIndexCreationGuard) {
+      normalized = normalized.replace(
+        /\b(CREATE\s+(?:UNIQUE\s+)?INDEX)\s+IF\s+NOT\s+EXISTS\b/i,
+        "$1",
+      )
+    }
+    if (options.stripPublicPrefix) normalized = normalized.replace(/\bpublic\./gi, "")
+    return lowercaseOutsideQuotedValues(
+      normalized.replace(/\s+/g, " ").replace(/\s*([(),])\s*/g, "$1"),
+    )
+  }).trim()
+}
+
 function normalizeType(value: string): string {
   return lowercaseOutsideQuotedValues(
     normalizeQuotedIdentifiers(value)
@@ -152,25 +220,18 @@ function normalizeType(value: string): string {
 
 function normalizeExpression(value: string | null | undefined): string | null {
   if (value == null) return null
-  let normalized = value.trim().replace(/;$/, "").replace(/\s+/g, " ")
+  let normalized = value.trim().replace(/;$/, "")
   while (normalized.startsWith("(") && normalized.endsWith(")")) {
     normalized = normalized.slice(1, -1).trim()
   }
-  return lowercaseOutsideQuotedValues(
-    normalizeQuotedIdentifiers(normalized).replace(/\s*([(),])\s*/g, "$1"),
-  )
+  return normalizeSqlSyntaxOutsideStringLiterals(normalized)
 }
 
 function normalizeIndexDefinition(value: string): string {
-  return lowercaseOutsideQuotedValues(
-    normalizeQuotedIdentifiers(value)
-      .trim()
-      .replace(/;$/, "")
-      .replace(/\b(CREATE\s+(?:UNIQUE\s+)?INDEX)\s+IF\s+NOT\s+EXISTS\b/i, "$1")
-      .replace(/\bpublic\./gi, "")
-      .replace(/\s+/g, " ")
-      .replace(/\s*([(),])\s*/g, "$1"),
-  )
+  return normalizeSqlSyntaxOutsideStringLiterals(value.trim().replace(/;$/, ""), {
+    stripPublicPrefix: true,
+    stripIndexCreationGuard: true,
+  })
 }
 
 function unsupported(migration: PlannedMigration, detail: string): never {
@@ -353,7 +414,7 @@ function parseColumn(
 }
 
 function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint {
-  const tables: string[] = []
+  const tableNames: string[] = []
   const columns: ExpectedColumn[] = []
   const constraints: ExpectedConstraint[] = []
   const indexes: ExpectedIndex[] = []
@@ -368,8 +429,10 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
     )
     if (create) {
       const table = postgresIdentifier(create[1] as string)
-      if (tables.includes(table)) unsupported(migration, `table ${table} is created more than once`)
-      tables.push(table)
+      if (tableNames.includes(table)) {
+        unsupported(migration, `table ${table} is created more than once`)
+      }
+      tableNames.push(table)
       let position = 0
       for (const item of splitTopLevel(create[2] as string)) {
         const tableConstraint = item.match(
@@ -400,7 +463,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
     )
     if (alterConstraint) {
       const table = postgresIdentifier(alterConstraint[1] as string)
-      if (!tables.includes(table)) {
+      if (!tableNames.includes(table)) {
         unsupported(
           migration,
           `constraint targets table ${table}, which this migration does not create`,
@@ -425,7 +488,7 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
     )
     if (index) {
       const table = postgresIdentifier(index[2] as string)
-      if (!tables.includes(table)) {
+      if (!tableNames.includes(table)) {
         unsupported(
           migration,
           `index ${index[1]} targets table ${table}, which this migration does not create`,
@@ -435,6 +498,9 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
         table,
         name: postgresIdentifier(index[1] as string),
         definition: normalizeIndexDefinition(statement),
+        valid: true,
+        ready: true,
+        live: true,
       })
       continue
     }
@@ -442,8 +508,13 @@ function parseExpectedFootprint(migration: PlannedMigration): ExpectedFootprint 
     unsupported(migration, `unsupported statement ${statement.slice(0, 80)}`)
   }
 
-  if (tables.length === 0) unsupported(migration, "the migration creates no tables")
-  return { tables, columns, constraints, indexes }
+  if (tableNames.length === 0) unsupported(migration, "the migration creates no tables")
+  return {
+    tables: tableNames.map((name) => ({ name, kind: "r", persistence: "p" })),
+    columns,
+    constraints,
+    indexes,
+  }
 }
 
 function createdTables(migration: PlannedMigration): string[] {
@@ -470,24 +541,29 @@ function strings(value: unknown): string[] {
 async function readLiveTables(
   client: MigrationClient,
   tables: readonly string[],
-): Promise<string[]> {
+): Promise<LiveFootprint["tables"]> {
   const tableRows = await client.query(
-    `SELECT c.relname AS table_name
+    `SELECT c.relname AS table_name,
+            c.relkind AS relation_kind,
+            c.relpersistence AS relation_persistence
        FROM pg_class c
        JOIN pg_namespace n ON n.oid = c.relnamespace
       WHERE n.nspname = 'public'
-        AND c.relkind IN ('r', 'p')
         AND c.relname = ANY($1::text[])
       ORDER BY c.relname`,
     [tables],
   )
-  return tableRows.rows.map((row) => String(row.table_name))
+  return tableRows.rows.map((row) => ({
+    name: String(row.table_name),
+    kind: String(row.relation_kind ?? ""),
+    persistence: String(row.relation_persistence ?? ""),
+  }))
 }
 
 async function readLiveFootprint(
   client: MigrationClient,
   tables: readonly string[],
-  liveTables: string[],
+  liveTables: LiveFootprint["tables"],
 ): Promise<LiveFootprint> {
   if (liveTables.length !== tables.length) {
     return { tables: liveTables, columns: [], constraints: [], indexes: [] }
@@ -553,7 +629,10 @@ async function readLiveFootprint(
   const indexRows = await client.query(
     `SELECT rel.relname AS table_name,
             idx.relname AS index_name,
-            pg_get_indexdef(idx.oid, 0, true) AS index_definition
+            pg_get_indexdef(idx.oid, 0, true) AS index_definition,
+            i.indisvalid AS is_valid,
+            i.indisready AS is_ready,
+            i.indislive AS is_live
        FROM pg_index i
        JOIN pg_class rel ON rel.oid = i.indrelid
        JOIN pg_namespace ns ON ns.oid = rel.relnamespace
@@ -596,6 +675,9 @@ async function readLiveFootprint(
       table: String(row.table_name),
       name: String(row.index_name),
       definition: normalizeIndexDefinition(String(row.index_definition)),
+      valid: Boolean(row.is_valid),
+      ready: Boolean(row.is_ready),
+      live: Boolean(row.is_live),
     })),
   }
 }
@@ -610,8 +692,8 @@ function compareFootprint(
   live: LiveFootprint,
 ): void {
   const problems: string[] = []
-  const expectedTables = [...expected.tables].sort()
-  const liveTables = [...live.tables].sort()
+  const expectedTables = [...expected.tables].sort((a, b) => stable(a).localeCompare(stable(b)))
+  const liveTables = [...live.tables].sort((a, b) => stable(a).localeCompare(stable(b)))
   if (stable(expectedTables) !== stable(liveTables)) {
     problems.push(`tables expected ${stable(expectedTables)}, found ${stable(liveTables)}`)
   }
@@ -652,7 +734,11 @@ export async function classifyMaterializedMigration(
   if (liveTables.length === 0) return { status: "absent" }
 
   const expected = parseExpectedFootprint(migration)
-  const live = await readLiveFootprint(client, expected.tables, liveTables)
+  const live = await readLiveFootprint(
+    client,
+    expected.tables.map((table) => table.name),
+    liveTables,
+  )
   compareFootprint(migration, expected, live)
   return { status: "materialized" }
 }

--- a/packages/framework-migrations/src/materialized-adoption.ts
+++ b/packages/framework-migrations/src/materialized-adoption.ts
@@ -162,6 +162,7 @@ function normalizeOutsideStringLiterals(
   let result = ""
   let outside = ""
   let inLiteral = false
+  let backslashEscapes = false
   const flushOutside = () => {
     if (!outside) return
     result += normalizeOutside(outside)
@@ -169,22 +170,31 @@ function normalizeOutsideStringLiterals(
   }
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index] as string
-    if (character === "'") {
-      if (!inLiteral) flushOutside()
+    if (inLiteral) {
+      if (backslashEscapes && character === "\\" && value[index + 1] !== undefined) {
+        result += character + value[index + 1]
+        index += 1
+        continue
+      }
       result += character
-      if (inLiteral && value[index + 1] === "'") {
+      if (character !== "'") continue
+      if (value[index + 1] === "'") {
         result += "'"
         index += 1
       } else {
-        inLiteral = !inLiteral
+        inLiteral = false
+        backslashEscapes = false
       }
       continue
     }
-    if (inLiteral) {
+    if (character === "'") {
+      backslashEscapes = /(?:^|[^a-z0-9_$])e$/i.test(outside)
+      flushOutside()
       result += character
-    } else {
-      outside += character
+      inLiteral = true
+      continue
     }
+    outside += character
   }
   flushOutside()
   return result


### PR DESCRIPTION
Follow-up to #3641 from the independent PostgreSQL review.

- require ordinary permanent table identity before adoption
- require non-constraint indexes to be valid, ready, and live
- preserve whitespace and punctuation inside SQL string literals during expression normalization
- retain `CREATE INDEX IF NOT EXISTS` normalization and quoted-identifier semantics from the merged implementation
- extend mismatch regression coverage

Because the original 0.10.5 release PR merged while this follow-up was validating, this PR now carries a new framework-migrations patch changeset for 0.10.6. Managed platform adoption must pin the corrected release.