### PR TITLE
Fix managed Marketplace existing-install upgrades

### DIFF
--- a/docs/architecture/event-delivery-and-durable-execution-policy.md
+++ b/docs/architecture/event-delivery-and-durable-execution-policy.md
@@ -213,6 +213,11 @@ proof never enter ordinary database rows, tokens, events, delivery payloads, or
 audit details. Delivery and replay fail closed unless the active
 subscription's persisted key id exactly matches host resolution.
 
+Legacy subscriptions that claim to be active without a persisted signing key
+are reconciled to inactive before an installation upgrade can remain pending or
+be activated. They retain their declaration but must complete the current
+signing-key possession ceremony before delivery can resume.
+
 These provider selections are durable intake boundaries, not HTTP delivery.
 The package workers own payload hydration, claiming, signing, retry attempts,
 and delivery/subscription outcomes. The app worker claims only rows whose

--- a/docs/architecture/remote-app-platform-rfc.md
+++ b/docs/architecture/remote-app-platform-rfc.md
@@ -205,11 +205,17 @@ host-verified acquisition envelope; the deployment stores that verifier as the
 active client credential. The raw secret never enters the catalog, artifact,
 setup assertion, browser, or Voyant database.
 
-Acquisition returns only local app and release IDs. The native Apps page then
-renders consent from the admitted normalized release: required and optional
-scopes, data classifications, external secret-custody disclosure, retention,
-webhooks, admin pages and slots, privacy policy, and support. The existing
-installation mutation remains the sole final approval and reconciliation path.
+Acquisition returns local app and release IDs plus, when present, the
+deployment-scoped identity and current release of the existing installation.
+The native Apps page then renders consent from the admitted normalized release:
+required and optional scopes, data classifications, external secret-custody
+disclosure, retention, webhooks, admin pages and slots, privacy policy, and
+support. Fresh consent uses the installation mutation. When an active
+installation already exists at a different admitted release, the same consent
+screen uses the explicit installation activation route, supplies the required
+scopes approved in that ceremony, advances the existing installation, and only
+then starts the setup handoff. Retrying either path is idempotent and never
+creates a second installation identity.
 
 After an active Marketplace installation is created, a host may create a
 one-time setup handoff. The public runtime sends only `installationId`, `appId`,

--- a/packages/apps-react/src/components/consent-screen.test.tsx
+++ b/packages/apps-react/src/components/consent-screen.test.tsx
@@ -1,6 +1,6 @@
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it } from "vitest"
-import { formatScopeLabel, ScopeLabel } from "./consent-screen.js"
+import { formatScopeLabel, ScopeLabel, shouldUpgradeManagedInstallation } from "./consent-screen.js"
 
 describe("consent scope labels", () => {
   it.each([
@@ -17,5 +17,27 @@ describe("consent scope labels", () => {
     const html = renderToStaticMarkup(<ScopeLabel scope="finance-documents:read" />)
     expect(html).toContain("Read finance documents")
     expect(html).toContain("finance-documents:read")
+  })
+})
+
+describe("managed Marketplace consent action", () => {
+  const activeInstallation = {
+    id: "installation_1",
+    releaseId: "release_1",
+    status: "active" as const,
+  }
+
+  it("upgrades an active installation when the verified intent admits a different release", () => {
+    expect(shouldUpgradeManagedInstallation("opaque-intent", activeInstallation, "release_2")).toBe(
+      true,
+    )
+  })
+
+  it("keeps fresh and idempotent installs on the install path", () => {
+    expect(shouldUpgradeManagedInstallation("opaque-intent", null, "release_2")).toBe(false)
+    expect(shouldUpgradeManagedInstallation("opaque-intent", activeInstallation, "release_1")).toBe(
+      false,
+    )
+    expect(shouldUpgradeManagedInstallation(undefined, activeInstallation, "release_2")).toBe(false)
   })
 })

--- a/packages/apps-react/src/components/consent-screen.tsx
+++ b/packages/apps-react/src/components/consent-screen.tsx
@@ -29,6 +29,7 @@ import { useInstallationActions } from "../hooks/use-installation-actions.js"
 import { useMarketplaceInstallIntent } from "../hooks/use-marketplace-install-intent.js"
 import { useAppsUiI18nOrDefault } from "../i18n/index.js"
 import type { AppReleaseRecord } from "../schemas.js"
+import type { MarketplaceInstallIntentResult } from "../schemas.js"
 import { ConsentDisclosures, readConsentDisclosures } from "./consent-disclosures.js"
 
 const UPDATE_POLICIES = ["compatible", "patch", "manual", "pinned"] as const
@@ -61,7 +62,7 @@ export function ConsentScreen({
   const [updatePolicy, setUpdatePolicy] = useState<(typeof UPDATE_POLICIES)[number]>("compatible")
   const app = useApp(appId)
   const releases = useAppReleases(appId)
-  const { install } = useInstallationActions()
+  const { activate, install } = useInstallationActions()
   const marketplace = useMarketplaceInstallIntent()
   const resolvedIntent = useRef<string | null>(null)
 
@@ -89,6 +90,12 @@ export function ConsentScreen({
 
   const grantedOptional = optional.filter((scope) => !denied.has(scope))
   const grantedCount = required.length + grantedOptional.length
+  const existingInstallation = marketplace.resolveIntent.data?.existingInstallation ?? null
+  const upgradeInstallation =
+    existingInstallation &&
+    shouldUpgradeManagedInstallation(installIntent, existingInstallation, releaseId)
+      ? existingInstallation
+      : null
 
   const toggleOptional = (scope: string, granted: boolean) => {
     setDenied((current) => {
@@ -103,6 +110,7 @@ export function ConsentScreen({
     setDenied(new Set())
     setReleaseId(undefined)
     install.reset()
+    activate.reset()
     marketplace.resolveIntent.reset()
     marketplace.createSetupHandoff.reset()
     resolvedIntent.current = null
@@ -110,13 +118,22 @@ export function ConsentScreen({
 
   const handleApprove = async () => {
     if (!appId || !releaseId) return
-    const result = await install.mutateAsync({
-      appId,
-      releaseId,
-      actorId,
-      grantedOptionalScopes: grantedOptional,
-      updatePolicy,
-    })
+    const result = upgradeInstallation
+      ? await activate.mutateAsync({
+          installationId: upgradeInstallation.id,
+          releaseId,
+          actorId,
+          grantedRequiredScopes: required,
+          grantedOptionalScopes: grantedOptional,
+          updatePolicy,
+        })
+      : await install.mutateAsync({
+          appId,
+          releaseId,
+          actorId,
+          grantedOptionalScopes: grantedOptional,
+          updatePolicy,
+        })
     onInstalled?.(result.installation.id)
     if ((installIntent || selectedApp?.distribution === "marketplace") && disclosure?.urls.setup) {
       try {
@@ -210,6 +227,17 @@ export function ConsentScreen({
             <Loader2 className="size-4 animate-spin" />
             {t.resolvingIntent}
           </div>
+        ) : null}
+
+        {upgradeInstallation ? (
+          <Alert>
+            <ShieldCheck className="size-4" />
+            <AlertDescription>
+              {formatMessage(t.upgradeDescription, {
+                version: release?.releaseVersion ?? "",
+              })}
+            </AlertDescription>
+          </Alert>
         ) : null}
 
         {release ? (
@@ -316,12 +344,12 @@ export function ConsentScreen({
           </Alert>
         ) : null}
 
-        {install.isError || marketplace.resolveIntent.isError ? (
+        {install.isError || activate.isError || marketplace.resolveIntent.isError ? (
           <Alert variant="destructive">
             <AlertCircle className="size-4" />
             <AlertDescription>
-              {(install.error ?? marketplace.resolveIntent.error) instanceof Error
-                ? (install.error ?? marketplace.resolveIntent.error)?.message
+              {(install.error ?? activate.error ?? marketplace.resolveIntent.error) instanceof Error
+                ? (install.error ?? activate.error ?? marketplace.resolveIntent.error)?.message
                 : messages.common.requestFailed}
             </AlertDescription>
           </Alert>
@@ -338,7 +366,7 @@ export function ConsentScreen({
           <Button
             variant="outline"
             onClick={() => onOpenChange(false)}
-            disabled={install.isPending}
+            disabled={install.isPending || activate.isPending}
           >
             {messages.common.cancel}
           </Button>
@@ -348,20 +376,38 @@ export function ConsentScreen({
               !releaseId ||
               !disclosure ||
               install.isPending ||
+              activate.isPending ||
               marketplace.resolveIntent.isPending ||
               marketplace.createSetupHandoff.isPending
             }
           >
-            {install.isPending || marketplace.createSetupHandoff.isPending ? (
+            {install.isPending || activate.isPending || marketplace.createSetupHandoff.isPending ? (
               <Loader2 className="size-4 animate-spin" />
             ) : null}
-            {install.isPending || marketplace.createSetupHandoff.isPending
-              ? t.approving
-              : t.approve}
+            {install.isPending || activate.isPending || marketplace.createSetupHandoff.isPending
+              ? upgradeInstallation
+                ? t.upgrading
+                : t.approving
+              : upgradeInstallation
+                ? t.upgrade
+                : t.approve}
           </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+export function shouldUpgradeManagedInstallation(
+  installIntent: string | undefined,
+  installation: MarketplaceInstallIntentResult["existingInstallation"],
+  releaseId: string | undefined,
+) {
+  return Boolean(
+    installIntent &&
+      releaseId &&
+      installation?.status === "active" &&
+      installation.releaseId !== releaseId,
   )
 }
 

--- a/packages/apps-react/src/components/consent-screen.tsx
+++ b/packages/apps-react/src/components/consent-screen.tsx
@@ -28,8 +28,7 @@ import { useApp, useAppReleases, useApps } from "../hooks/use-apps.js"
 import { useInstallationActions } from "../hooks/use-installation-actions.js"
 import { useMarketplaceInstallIntent } from "../hooks/use-marketplace-install-intent.js"
 import { useAppsUiI18nOrDefault } from "../i18n/index.js"
-import type { AppReleaseRecord } from "../schemas.js"
-import type { MarketplaceInstallIntentResult } from "../schemas.js"
+import type { AppReleaseRecord, MarketplaceInstallIntentResult } from "../schemas.js"
 import { ConsentDisclosures, readConsentDisclosures } from "./consent-disclosures.js"
 
 const UPDATE_POLICIES = ["compatible", "patch", "manual", "pinned"] as const

--- a/packages/apps-react/src/hooks/use-installation-actions.ts
+++ b/packages/apps-react/src/hooks/use-installation-actions.ts
@@ -25,6 +25,9 @@ export interface ActivateReleaseInput {
   installationId: string
   releaseId: string
   actorId: string
+  grantedRequiredScopes?: string[]
+  grantedOptionalScopes?: string[]
+  updatePolicy?: "manual" | "compatible" | "patch" | "pinned"
 }
 
 async function postLifecycle(client: FetchWithValidationOptions, path: string, body: object) {
@@ -75,10 +78,9 @@ export function useInstallationActions() {
   })
 
   const activate = useMutation({
-    mutationFn: ({ installationId, releaseId, actorId }: ActivateReleaseInput) =>
+    mutationFn: ({ installationId, ...body }: ActivateReleaseInput) =>
       postLifecycle(client, `/v1/admin/apps/installations/${installationId}/activate`, {
-        releaseId,
-        actorId,
+        ...body,
       }),
     onSuccess: (_data, input) => invalidate(input.installationId),
   })

--- a/packages/apps-react/src/i18n/en.ts
+++ b/packages/apps-react/src/i18n/en.ts
@@ -125,6 +125,10 @@ export const appsUiEn = {
     deniedSummary: "{count} optional scopes denied.",
     approve: "Approve & install",
     approving: "Installing…",
+    upgrade: "Approve & upgrade",
+    upgrading: "Upgrading…",
+    upgradeDescription:
+      "This app is already installed. Approval will upgrade the existing installation to version {version} and preserve its identity.",
     selectApp: "App",
     selectRelease: "Release",
     verifiedApp: "Verified app",

--- a/packages/apps-react/src/i18n/messages.ts
+++ b/packages/apps-react/src/i18n/messages.ts
@@ -120,6 +120,9 @@ export type AppsUiMessages = {
     deniedSummary: string
     approve: string
     approving: string
+    upgrade: string
+    upgrading: string
+    upgradeDescription: string
     selectApp: string
     selectRelease: string
     verifiedApp: string

--- a/packages/apps-react/src/i18n/ro.ts
+++ b/packages/apps-react/src/i18n/ro.ts
@@ -127,6 +127,10 @@ export const appsUiRo = {
     deniedSummary: "{count} permisiuni opționale refuzate.",
     approve: "Aprobă și instalează",
     approving: "Se instalează…",
+    upgrade: "Aprobă și actualizează",
+    upgrading: "Se actualizează…",
+    upgradeDescription:
+      "Această aplicație este deja instalată. Aprobarea va actualiza instalarea existentă la versiunea {version} și îi va păstra identitatea.",
     selectApp: "Aplicație",
     selectRelease: "Versiune",
     verifiedApp: "Aplicație verificată",

--- a/packages/apps-react/src/schemas.ts
+++ b/packages/apps-react/src/schemas.ts
@@ -212,6 +212,13 @@ export const marketplaceInstallIntentResponse = z.object({
     releaseId: z.string(),
     acquisitionId: z.string(),
     created: z.boolean(),
+    existingInstallation: z
+      .object({
+        id: z.string(),
+        releaseId: z.string(),
+        status: appInstallationStatus,
+      })
+      .nullable(),
   }),
 })
 export type MarketplaceInstallIntentResult = z.infer<

--- a/packages/apps/src/contracts.ts
+++ b/packages/apps/src/contracts.ts
@@ -290,6 +290,9 @@ export const activateInstallationBodySchema = z
   .object({
     releaseId: z.string().trim().min(1),
     actorId: z.string().trim().min(1).max(160),
+    grantedRequiredScopes: z.array(scopeSchema).optional(),
+    grantedOptionalScopes: z.array(scopeSchema).optional(),
+    updatePolicy: z.enum(appInstallationUpdatePolicyValues).optional(),
   })
   .strict()
 

--- a/packages/apps/src/installation-reconciliation.ts
+++ b/packages/apps/src/installation-reconciliation.ts
@@ -4,7 +4,7 @@ import {
   customFieldDefinitions,
 } from "@voyant-travel/custom-fields"
 import { ApiHttpError } from "@voyant-travel/hono"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, isNull, sql } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { NormalizedAppReleaseRecord } from "./compiler.js"
 import type { AppCredentialInput } from "./installation-service.js"
@@ -154,6 +154,29 @@ export async function deactivateResolvedRegistrations(
     .update(appWebhookSubscriptions)
     .set({ status: "inactive", deactivatedAt: now })
     .where(eq(appWebhookSubscriptions.installationId, installation.id))
+}
+
+/**
+ * Legacy rows created before the signing-key ceremony can claim to be active
+ * without a resolvable key. Fail them closed while retaining the declaration
+ * so the app can reactivate it only by completing the current ceremony.
+ */
+export async function deactivateKeylessActiveWebhooks(
+  db: PostgresJsDatabase,
+  installation: AppInstallation,
+) {
+  const rows = await db
+    .update(appWebhookSubscriptions)
+    .set({ status: "inactive", pausedAt: new Date() })
+    .where(
+      and(
+        eq(appWebhookSubscriptions.installationId, installation.id),
+        eq(appWebhookSubscriptions.status, "active"),
+        isNull(appWebhookSubscriptions.signingKeyId),
+      ),
+    )
+    .returning({ id: appWebhookSubscriptions.id })
+  return rows.length
 }
 
 export async function markAppDefinitionsInactive(

--- a/packages/apps/src/installation-routes.test.ts
+++ b/packages/apps/src/installation-routes.test.ts
@@ -262,6 +262,68 @@ describe.skipIf(!DB_AVAILABLE)("apps installation admin routes", () => {
     expect(subscriptions.every(({ status }) => status === "inactive")).toBe(true)
   })
 
+  it("activates a consented release upgrade and fails legacy keyless webhooks closed", async () => {
+    const { appId, releaseV1, releaseV2 } = await seedAppWithReleases()
+    const installation = await installV1(appId, releaseV1.id)
+    await db
+      .update(appWebhookSubscriptions)
+      .set({
+        status: "active",
+        signingKeyId: null,
+        pausedAt: null,
+        deactivatedAt: null,
+      })
+      .where(eq(appWebhookSubscriptions.installationId, installation.id))
+
+    const upgraded = await app.request(
+      `/installations/${installation.id}/activate`,
+      json({
+        actorId: "actor_1",
+        releaseId: releaseV2.id,
+        grantedRequiredScopes: ["customers:read"],
+        grantedOptionalScopes: [],
+        updatePolicy: "manual",
+      }),
+    )
+    expect(upgraded.status).toBe(200)
+    const body = (await upgraded.json()) as {
+      data: {
+        installation: { id: string; releaseId: string; status: string; updatePolicy: string }
+        outcome: string
+        missingScopes: string[]
+      }
+    }
+    expect(body.data).toMatchObject({
+      installation: {
+        id: installation.id,
+        releaseId: releaseV2.id,
+        status: "active",
+        updatePolicy: "manual",
+      },
+      outcome: "upgraded",
+      missingScopes: [],
+    })
+
+    const subscriptions = await db
+      .select({
+        status: appWebhookSubscriptions.status,
+        signingKeyId: appWebhookSubscriptions.signingKeyId,
+      })
+      .from(appWebhookSubscriptions)
+      .where(eq(appWebhookSubscriptions.installationId, installation.id))
+    expect(subscriptions).not.toHaveLength(0)
+    expect(subscriptions).toEqual(
+      expect.arrayContaining([expect.objectContaining({ status: "inactive", signingKeyId: null })]),
+    )
+
+    const retry = await app.request(
+      `/installations/${installation.id}/activate`,
+      json({ actorId: "actor_1", releaseId: releaseV2.id }),
+    )
+    expect(retry.status).toBe(200)
+    expect((await retry.json()).data.outcome).toBe("unchanged")
+  })
+
   it("creates an active installation via /install", async () => {
     const { appId, releaseV1 } = await seedAppWithReleases()
     const response = await app.request(

--- a/packages/apps/src/installation-service.ts
+++ b/packages/apps/src/installation-service.ts
@@ -165,19 +165,6 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
       const release = await requireReleaseForApp(tx, installation.appId, input.releaseId)
       assertReleaseAvailable(release)
       assertApiCompatible(release, options.platformApiVersion)
-      const managedBinding = await resolveManagedBinding(
-        options.managedInstallation,
-        installation.appId,
-        input.releaseId,
-      )
-      if (managedBinding) {
-        installation = await reconcileManagedInstallationBinding(
-          tx,
-          installation,
-          deploymentId(),
-          managedBinding,
-        )
-      }
       const deactivatedKeylessWebhooks = await deactivateKeylessActiveWebhooks(tx, installation)
       if (deactivatedKeylessWebhooks > 0) {
         await audit(
@@ -192,6 +179,7 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
         )
       }
       if (installation.releaseId === release.id) {
+        installation = await reconcileUpgradeManagedBinding(tx, installation, input.releaseId)
         await audit(tx, installation, input.actorId, "lifecycle", "upgrade.idempotent", {
           releaseId: release.id,
         })
@@ -222,6 +210,7 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
         }
       }
 
+      installation = await reconcileUpgradeManagedBinding(tx, installation, input.releaseId)
       await deactivateResolvedRegistrations(tx, installation)
       if (input.credential) {
         await rotateCredential(tx, installation, input.credential, input.actorId)
@@ -247,6 +236,20 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
       await emitLifecycle(row, "upgraded")
       return { installation: row, outcome: "upgraded" as const, missingScopes: [] }
     })
+  }
+
+  async function reconcileUpgradeManagedBinding(
+    db: PostgresJsDatabase,
+    installation: AppInstallation,
+    releaseId: string,
+  ) {
+    const managedBinding = await resolveManagedBinding(
+      options.managedInstallation,
+      installation.appId,
+      releaseId,
+    )
+    if (!managedBinding) return installation
+    return reconcileManagedInstallationBinding(db, installation, deploymentId(), managedBinding)
   }
 
   async function pause(db: PostgresJsDatabase, input: LifecycleActionInput) {

--- a/packages/apps/src/installation-service.ts
+++ b/packages/apps/src/installation-service.ts
@@ -6,6 +6,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import {
   audit,
   countInstallationRows,
+  deactivateKeylessActiveWebhooks,
   deactivateResolvedRegistrations,
   deactivateRuntimeState,
   markAppDefinitionsInactive,
@@ -64,6 +65,9 @@ export interface UpgradeAppInput {
   installationId: string
   releaseId: string
   actorId: string
+  grantedRequiredScopes?: readonly string[]
+  grantedOptionalScopes?: readonly string[]
+  updatePolicy?: AppInstallationUpdatePolicy
   credential?: AppCredentialInput
 }
 
@@ -154,28 +158,68 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
 
   async function upgrade(db: PostgresJsDatabase, input: UpgradeAppInput) {
     return db.transaction(async (tx) => {
-      const installation = await requireInstallation(tx, input.installationId, true)
+      let installation = await requireInstallation(tx, input.installationId, true)
       if (!["active", "paused", "degraded"].includes(installation.status)) {
         throw invalidTransition(installation.status, "upgrade")
       }
       const release = await requireReleaseForApp(tx, installation.appId, input.releaseId)
       assertReleaseAvailable(release)
       assertApiCompatible(release, options.platformApiVersion)
+      const managedBinding = await resolveManagedBinding(
+        options.managedInstallation,
+        installation.appId,
+        input.releaseId,
+      )
+      if (managedBinding) {
+        installation = await reconcileManagedInstallationBinding(
+          tx,
+          installation,
+          deploymentId(),
+          managedBinding,
+        )
+      }
+      const deactivatedKeylessWebhooks = await deactivateKeylessActiveWebhooks(tx, installation)
+      if (deactivatedKeylessWebhooks > 0) {
+        await audit(
+          tx,
+          installation,
+          input.actorId,
+          "reconciliation",
+          "webhooks.keyless_inactive",
+          {
+            count: deactivatedKeylessWebhooks,
+          },
+        )
+      }
+      if (installation.releaseId === release.id) {
+        await audit(tx, installation, input.actorId, "lifecycle", "upgrade.idempotent", {
+          releaseId: release.id,
+        })
+        return { installation, outcome: "unchanged" as const, missingScopes: [] }
+      }
       const missingScopes = await newlyRequiredScopes(tx, installation, release)
-      if (missingScopes.length > 0) {
+      const grantedRequiredScopes = new Set(input.grantedRequiredScopes ?? [])
+      const unapprovedScopes = missingScopes.filter((scope) => !grantedRequiredScopes.has(scope))
+      if (unapprovedScopes.length > 0) {
         const [pending] = await tx
           .update(appInstallations)
           .set({
             pendingReleaseId: release.id,
-            pendingReason: `New required scopes need consent: ${missingScopes.join(", ")}`,
+            pendingReason: `New required scopes need consent: ${unapprovedScopes.join(", ")}`,
             updatedAt: new Date(),
           })
           .where(eq(appInstallations.id, installation.id))
           .returning()
         const row = pending ?? installation
-        await audit(tx, row, input.actorId, "grant", "upgrade.pending_consent", { missingScopes })
+        await audit(tx, row, input.actorId, "grant", "upgrade.pending_consent", {
+          missingScopes: unapprovedScopes,
+        })
         await emitLifecycle(row, "upgrade_pending")
-        return { installation: row, outcome: "pending_consent" as const, missingScopes }
+        return {
+          installation: row,
+          outcome: "pending_consent" as const,
+          missingScopes: unapprovedScopes,
+        }
       }
 
       await deactivateResolvedRegistrations(tx, installation)
@@ -186,6 +230,7 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
         .update(appInstallations)
         .set({
           releaseId: release.id,
+          updatePolicy: input.updatePolicy ?? installation.updatePolicy,
           pendingReleaseId: null,
           pendingReason: null,
           updatedAt: new Date(),
@@ -194,8 +239,11 @@ export function createAppInstallationService(options: AppInstallationServiceOpti
         .returning()
       const row = upgraded ?? installation
       await reconcileRelease(tx, row, release, input.actorId, "upgrade", options)
-      await reconcileGrants(tx, row, release, input.actorId, [])
-      await audit(tx, row, input.actorId, "lifecycle", "upgrade.active", { releaseId: release.id })
+      await reconcileGrants(tx, row, release, input.actorId, input.grantedOptionalScopes)
+      await audit(tx, row, input.actorId, "lifecycle", "upgrade.active", {
+        releaseId: release.id,
+        grantedRequiredScopes: missingScopes,
+      })
       await emitLifecycle(row, "upgraded")
       return { installation: row, outcome: "upgraded" as const, missingScopes: [] }
     })

--- a/packages/apps/src/marketplace-acquisition.test.ts
+++ b/packages/apps/src/marketplace-acquisition.test.ts
@@ -208,7 +208,14 @@ describe.skipIf(!DB_AVAILABLE)("managed Marketplace acquisition", () => {
 
   it("advances the managed installation contract when activating an acquired release", async () => {
     const first = acquisition()
-    const nextManifest = { ...validManifest, releaseVersion: "1.1.0" }
+    const nextManifest = {
+      ...validManifest,
+      releaseVersion: "1.1.0",
+      scopes: {
+        ...validManifest.scopes,
+        requested: [...validManifest.scopes.requested, "customers:read"],
+      },
+    }
     const second = acquisition({
       acquisitionId: "acquisition_2",
       release: {
@@ -243,10 +250,26 @@ describe.skipIf(!DB_AVAILABLE)("managed Marketplace acquisition", () => {
     })
     await service.resolveAndAcquire(db, { intent: "opaque-2", actorId: "user_1" })
 
+    const pending = await installations.upgrade(db, {
+      installationId: installed.installation.id,
+      releaseId: second.release.id,
+      actorId: "user_1",
+    })
+    expect(pending).toMatchObject({
+      outcome: "pending_consent",
+      installation: {
+        id: installed.installation.id,
+        releaseId: first.release.id,
+        contractGeneration: 1,
+      },
+      missingScopes: ["customers:read"],
+    })
+
     const upgraded = await installations.upgrade(db, {
       installationId: installed.installation.id,
       releaseId: second.release.id,
       actorId: "user_1",
+      grantedRequiredScopes: ["customers:read"],
     })
 
     expect(upgraded).toMatchObject({

--- a/packages/apps/src/marketplace-acquisition.test.ts
+++ b/packages/apps/src/marketplace-acquisition.test.ts
@@ -206,12 +206,67 @@ describe.skipIf(!DB_AVAILABLE)("managed Marketplace acquisition", () => {
     ).rejects.toMatchObject({ status: 409, code: "app_marketplace_digest_mismatch" })
   })
 
+  it("advances the managed installation contract when activating an acquired release", async () => {
+    const first = acquisition()
+    const nextManifest = { ...validManifest, releaseVersion: "1.1.0" }
+    const second = acquisition({
+      acquisitionId: "acquisition_2",
+      release: {
+        ...first.release,
+        id: "marketplace_release_2",
+        manifest: nextManifest,
+        digest: compileAppManifest(nextManifest).digest,
+      },
+    })
+    const service = createMarketplaceAcquisitionService({
+      installationIdentity: {
+        deploymentId: "deployment_1",
+        workloadEnvironmentId: "workload_environment_1",
+      },
+      resolveAcquisitionIntent: async ({ intent }) => (intent === "opaque-2" ? second : first),
+      createSetupHandoff: vi.fn(),
+    })
+    await service.resolveAndAcquire(db, { intent: "opaque-1", actorId: "user_1" })
+    const installations = createAppInstallationService({
+      deploymentId: "deployment_1",
+      managedInstallation: {
+        workloadEnvironmentId: "workload_environment_1",
+        resolveInstallationContract: async ({ releaseId }) => ({
+          contractGeneration: releaseId === second.release.id ? 2 : 1,
+        }),
+      },
+    })
+    const installed = await installations.install(db, {
+      appId: first.app.id,
+      releaseId: first.release.id,
+      actorId: "user_1",
+    })
+    await service.resolveAndAcquire(db, { intent: "opaque-2", actorId: "user_1" })
+
+    const upgraded = await installations.upgrade(db, {
+      installationId: installed.installation.id,
+      releaseId: second.release.id,
+      actorId: "user_1",
+    })
+
+    expect(upgraded).toMatchObject({
+      outcome: "upgraded",
+      installation: {
+        id: installed.installation.id,
+        releaseId: second.release.id,
+        workloadEnvironmentId: "workload_environment_1",
+        contractGeneration: 2,
+      },
+    })
+  })
+
   it("creates setup only from active installation identity and an admitted setup origin", async () => {
     const current = acquisition()
     const createSetupHandoff = vi.fn(async () => ({
       redirectUrl: "https://app.example.com/setup?code=one-time-opaque",
     }))
     const service = createMarketplaceAcquisitionService({
+      installationIdentity: { deploymentId: "deployment_1" },
       resolveAcquisitionIntent: async () => current,
       createSetupHandoff,
     })
@@ -224,6 +279,16 @@ describe.skipIf(!DB_AVAILABLE)("managed Marketplace acquisition", () => {
         actorId: "user_1",
       },
     )
+
+    await expect(
+      service.resolveAndAcquire(db, { intent: "opaque-1", actorId: "user_1" }),
+    ).resolves.toMatchObject({
+      existingInstallation: {
+        id: installed.installation.id,
+        releaseId: current.release.id,
+        status: "active",
+      },
+    })
 
     await expect(service.createSetupHandoff(db, installed.installation.id)).resolves.toEqual({
       redirectUrl: "https://app.example.com/setup?code=one-time-opaque",

--- a/packages/apps/src/marketplace-acquisition.test.ts
+++ b/packages/apps/src/marketplace-acquisition.test.ts
@@ -284,7 +284,17 @@ describe.skipIf(!DB_AVAILABLE)("managed Marketplace acquisition", () => {
   })
 
   it("creates setup only from active installation identity and an admitted setup origin", async () => {
-    const current = acquisition()
+    const setupManifest = {
+      ...validManifest,
+      urls: { ...validManifest.urls, setup: "https://app.example.com/setup" },
+    }
+    const current = acquisition({
+      release: {
+        ...acquisition().release,
+        manifest: setupManifest,
+        digest: compileAppManifest(setupManifest).digest,
+      },
+    })
     const createSetupHandoff = vi.fn(async () => ({
       redirectUrl: "https://app.example.com/setup?code=one-time-opaque",
     }))

--- a/packages/apps/src/marketplace-acquisition.ts
+++ b/packages/apps/src/marketplace-acquisition.ts
@@ -9,6 +9,7 @@ import {
   compileAppManifest,
 } from "./compiler.js"
 import {
+  type AppInstallation,
   appCredentials,
   appInstallations,
   appRedirectUris,
@@ -79,6 +80,22 @@ export const marketplaceInstallIntentResultSchema = z.object({
       releaseId: z.string(),
       acquisitionId: z.string(),
       created: z.boolean(),
+      existingInstallation: z
+        .object({
+          id: z.string(),
+          releaseId: z.string(),
+          status: z.enum([
+            "pending",
+            "authorizing",
+            "active",
+            "paused",
+            "degraded",
+            "revoked",
+            "uninstalled",
+          ]),
+        })
+        .strict()
+        .nullable(),
     })
     .strict(),
 })
@@ -138,9 +155,14 @@ export interface MarketplaceInstallIntentResult {
   releaseId: string
   acquisitionId: string
   created: boolean
+  existingInstallation: Pick<AppInstallation, "id" | "releaseId" | "status"> | null
 }
 
 export interface MarketplaceAcquisitionServiceOptions extends CompileAppManifestOptions {
+  installationIdentity?: {
+    deploymentId?: string
+    workloadEnvironmentId?: string
+  }
   resolveAcquisitionIntent(input: {
     intent: string
   }): Promise<HostVerifiedMarketplaceAcquisition | null>
@@ -178,11 +200,17 @@ export function createMarketplaceAcquisitionService(options: MarketplaceAcquisit
         await reconcileOAuthClient(tx, app.id, acquisition.app.oauthClient.secretSha256)
         await reconcileRedirectUris(tx, app.id, acquisition.app.redirectUris)
         const release = await acquireRelease(tx, acquisition, compiled, input.actorId)
+        const existingInstallation = await selectExistingInstallation(
+          tx,
+          app.id,
+          options.installationIdentity,
+        )
         return {
           appId: app.id,
           releaseId: release.id,
           acquisitionId: acquisition.acquisitionId,
           created: release.created,
+          existingInstallation,
         }
       })
     },
@@ -224,6 +252,29 @@ export function createMarketplaceAcquisitionService(options: MarketplaceAcquisit
       return { redirectUrl }
     },
   }
+}
+
+async function selectExistingInstallation(
+  db: PostgresJsDatabase,
+  appId: string,
+  identity: MarketplaceAcquisitionServiceOptions["installationIdentity"],
+): Promise<Pick<AppInstallation, "id" | "releaseId" | "status"> | null> {
+  const binding = identity?.workloadEnvironmentId
+    ? eq(appInstallations.workloadEnvironmentId, identity.workloadEnvironmentId)
+    : identity?.deploymentId
+      ? eq(appInstallations.deploymentId, identity.deploymentId)
+      : null
+  if (!binding) return null
+  const [installation] = await db
+    .select({
+      id: appInstallations.id,
+      releaseId: appInstallations.releaseId,
+      status: appInstallations.status,
+    })
+    .from(appInstallations)
+    .where(and(eq(appInstallations.appId, appId), binding))
+    .limit(1)
+  return installation ?? null
 }
 
 async function acquireApp(

--- a/packages/apps/src/routes.ts
+++ b/packages/apps/src/routes.ts
@@ -130,6 +130,10 @@ export function createAppsAdminRoutes(options: AppsAdminRouteOptions = {}) {
   const marketplace = options.managedMarketplace
     ? createMarketplaceAcquisitionService({
         eventCatalog: options.eventCatalog,
+        installationIdentity: {
+          deploymentId: options.oauth?.deploymentId ?? options.deploymentId,
+          workloadEnvironmentId: options.oauth?.managedInstallation?.workloadEnvironmentId,
+        },
         resolveAcquisitionIntent: options.managedMarketplace.resolveAcquisitionIntent,
         createSetupHandoff: options.managedMarketplace.createSetupHandoff,
       })
@@ -373,6 +377,9 @@ export function createAppsAdminRoutes(options: AppsAdminRouteOptions = {}) {
       installationId,
       releaseId: body.releaseId,
       actorId: body.actorId,
+      grantedRequiredScopes: body.grantedRequiredScopes,
+      grantedOptionalScopes: body.grantedOptionalScopes,
+      updatePolicy: body.updatePolicy,
     })
     return c.json({ data: result }, 200)
   })


### PR DESCRIPTION
## What changed

- makes managed install-intent resolution expose the deployment/workload-scoped existing installation
- upgrades an active installation at a different release through the explicit activation route instead of attempting a conflicting fresh install
- preserves fresh-install and same-release behavior
- carries approved required/optional scopes and update policy into activation
- reconciles the managed installation contract only after consented activation
- deactivates legacy active webhook subscriptions that have no confirmed signing key before upgrade/activation
- adds backend/frontend coverage, translations, and architecture documentation

## Root cause

The Marketplace consent screen always called the fresh install endpoint. The installation service correctly rejects an active app installed at another release as `install_different_release`, so public Marketplace updates could be acquired but not activated.

Legacy SmartBill subscriptions also predate signing-key confirmation. Current delivery correctly fails closed for such active subscriptions, so upgrade must deactivate them until the setup ceremony issues and confirms a key.

## Validation

- lightweight diff/static review passed
- remote targeted validation is running on the first commit; exact-HEAD validation is delegated to PR CI because the safe Sprite snapshot refuses the repository's tracked credential-shaped `.npmrc`
