### PR TITLE
Add changesets for Marketplace installation upgrades

### DIFF
--- a/.changeset/upgrade-managed-marketplace-apps.md
+++ b/.changeset/upgrade-managed-marketplace-apps.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/apps": patch
+"@voyant-travel/apps-react": patch
+---
+
+Support consented upgrades of existing managed Marketplace installations and reconcile legacy unsigned webhook subscriptions before activation.


### PR DESCRIPTION
## What changed

Adds patch changesets for:

- `@voyant-travel/apps`
- `@voyant-travel/apps-react`

## Why

PR #3648 changed the public installation service and consent UI behavior but was merged without release metadata. These changesets ensure the fix is included in the next package release.

## Validation

- changeset package names match the affected publishable packages
- `git diff --check`
