### PR TITLE
Accept shipped action-ledger baseline hash variants

### DIFF
--- a/.changeset/warm-ledgers-agree.md
+++ b/.changeset/warm-ledgers-agree.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework-migrations": patch
+---
+
+Accept both shipped hashes of the formatting-equivalent action-ledger baseline migration.

--- a/packages/framework-migrations/src/collector.test.ts
+++ b/packages/framework-migrations/src/collector.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs"
+
 import { Client } from "pg"
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
 
@@ -139,6 +141,82 @@ describe("migration hash compatibility", () => {
 
     expect(result).toEqual({ executed: [], baselined: [] })
     expect(queries.some((sql) => sql === "BEGIN")).toBe(false)
+  })
+
+  const currentActionLedgerBaseline = readFileSync(
+    new URL("../../action-ledger/migrations/0000_action_ledger_baseline.sql", import.meta.url),
+    "utf8",
+  )
+  const formattedActionLedgerBaseline = `${currentActionLedgerBaseline.replace(
+    "WHERE \n",
+    "WHERE\n",
+  )}\n`
+  const actionLedgerHashes = {
+    formatted: "d63e6a73b58f985888e258b318255eba5181db307438b25f3d262350f837b2ce",
+    current: "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c",
+  } as const
+
+  it.each([
+    {
+      direction: "formatted ledger to current migration",
+      sql: currentActionLedgerBaseline,
+      expectedCurrentHash: actionLedgerHashes.current,
+      ledgerHash: actionLedgerHashes.formatted,
+    },
+    {
+      direction: "current ledger to formatted migration",
+      sql: formattedActionLedgerBaseline,
+      expectedCurrentHash: actionLedgerHashes.formatted,
+      ledgerHash: actionLedgerHashes.current,
+    },
+  ])("accepts the action-ledger baseline rewrite from $direction", async (testCase) => {
+    const queries: string[] = []
+    const client: MigrationClient = {
+      async query(sql: string) {
+        queries.push(sql)
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return { rows: [{ content_hash: testCase.ledgerHash }] }
+        }
+        return { rows: [] }
+      },
+    }
+    const source: MigrationSource = {
+      name: "action-ledger",
+      priority: 0,
+      migrations: [{ tag: "0000_action_ledger_baseline", sql: testCase.sql }],
+    }
+
+    expect(planMigrations([source])[0]?.contentHash).toBe(testCase.expectedCurrentHash)
+    await expect(applyMigrations(client, [source], ledgerOpts)).resolves.toEqual({
+      executed: [],
+      baselined: [],
+    })
+    expect(queries).not.toContain("BEGIN")
+  })
+
+  it("still rejects an unrelated hash for the action-ledger baseline", async () => {
+    const client: MigrationClient = {
+      async query(sql: string) {
+        if (sql.includes(`SELECT "content_hash"`)) {
+          return { rows: [{ content_hash: "unrelated-hash" }] }
+        }
+        return { rows: [] }
+      },
+    }
+
+    await expect(
+      applyMigrations(
+        client,
+        [
+          {
+            name: "action-ledger",
+            priority: 0,
+            migrations: [{ tag: "0000_action_ledger_baseline", sql: currentActionLedgerBaseline }],
+          },
+        ],
+        ledgerOpts,
+      ),
+    ).rejects.toBeInstanceOf(MigrationImmutabilityError)
   })
 })
 

--- a/packages/framework-migrations/src/collector.ts
+++ b/packages/framework-migrations/src/collector.ts
@@ -129,6 +129,14 @@ const FRAMEWORK_0004_HASHES = [
   "5ba3a342b91d2d48f6b27dd15bc0cbf46478003d73b497709c5f56d2628bac8d",
   "c089643f03ce56e76239ecd96582b9886d3bc4ae26adcbea48308bcf92a71ed3",
 ] as const
+// `action-ledger/0000_action_ledger_baseline`: a formatting-only rewrite
+// removed one trailing space and added a final newline. Both byte sequences
+// describe the same schema and have shipped, so deployments created by either
+// release must remain deployable by the other.
+const ACTION_LEDGER_0000_HASHES = [
+  "d63e6a73b58f985888e258b318255eba5181db307438b25f3d262350f837b2ce",
+  "2c1f05738aedd395ffdecc7d5000144a41e6af7e7a85b85563302e89bb1f4f6c",
+] as const
 
 function equivalenceClosure(
   key: string,
@@ -140,6 +148,7 @@ function equivalenceClosure(
 const EQUIVALENT_MIGRATION_HASHES = new Map<string, ReadonlySet<string>>([
   ...equivalenceClosure("db/0001_db_baseline", DB_0001_HASHES),
   ...equivalenceClosure("framework/0004_framework_baseline", FRAMEWORK_0004_HASHES),
+  ...equivalenceClosure("action-ledger/0000_action_ledger_baseline", ACTION_LEDGER_0000_HASHES),
 ])
 
 function isEquivalentMigrationHash(


### PR DESCRIPTION
## Summary

- accept both shipped byte hashes of `action-ledger/0000_action_ledger_baseline`
- keep migration immutability fail-closed for every unrelated hash
- cover compatibility symmetrically so rollback and forward deployment remain safe
- release `@voyant-travel/framework-migrations` as a patch

## Root cause

The canonical SQL and a briefly shipped formatting-only variant differ only by one trailing space and the final newline. Databases created by Action Ledger 0.111.10/0.111.11 recorded `d63e6a73…`; Action Ledger 0.111.12 correctly restored canonical bytes (`2c1f0573…`). Framework Migrations 0.10.6 rejected the older ledger cohort even though the SQL schema is identical.

Observed in the ACME managed migration task as `MigrationImmutabilityError` while deploying runtime 0.58.0.

## Verification

- focused formatter/linter check passes for both changed TypeScript files
- `git diff --check` passes
- focused tests cover both hash directions and unrelated-hash rejection
- full validation delegated to pull-request CI because the repository safe-snapshot validator rejects tracked `.npmrc` files before upload