### PR TITLE
Allow anonymous storefront settings and departure previews

### DIFF
--- a/.changeset/quiet-starfishes-shop.md
+++ b/.changeset/quiet-starfishes-shop.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Allow guest storefronts to read public settings and preview departure prices without authentication.

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -209,9 +209,11 @@ export const storefrontModule: Module = {
 
 export const storefrontAnonymousPublicPaths = [
   "/bookings",
+  "/departures",
   "/leads",
   "/newsletter",
   "/offers",
+  "/settings",
 ] as const
 export const storefrontOptionalCustomerAuthPaths = ["/bookings"] as const
 

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -54,7 +54,7 @@ export const storefrontVoyantModule = defineModule({
       mount: "/",
       resource: "storefront",
       openapi: { document: "storefront" },
-      anonymous: ["/bookings", "/leads", "/newsletter", "/offers"],
+      anonymous: ["/bookings", "/departures", "/leads", "/newsletter", "/offers", "/settings"],
       runtime: {
         entry: "@voyant-travel/storefront",
         export: "createStorefrontApiModule",

--- a/packages/storefront/tests/unit/api-module.test.ts
+++ b/packages/storefront/tests/unit/api-module.test.ts
@@ -1,4 +1,5 @@
 import { createContainer } from "@voyant-travel/core"
+import { assembleAnonymousPaths } from "@voyant-travel/hono"
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -8,12 +9,45 @@ import {
 } from "../../src/index.js"
 
 describe("createStorefrontApiModule", () => {
-  it("declares anonymous storefront offer paths next to the owned public routes", () => {
+  it("declares only the guest storefront route families next to the owned public routes", () => {
     const module = createStorefrontApiModule()
 
     expect(module.publicPath).toBe("/")
     expect(module.anonymous).toBe(storefrontAnonymousPublicPaths)
-    expect(module.anonymous).toContain("/offers")
+    expect(module.anonymous).toEqual([
+      "/bookings",
+      "/departures",
+      "/leads",
+      "/newsletter",
+      "/offers",
+      "/settings",
+    ])
+    expect(assembleAnonymousPaths([module], [])).toEqual([
+      "/v1/public/bookings",
+      "/v1/public/departures",
+      "/v1/public/leads",
+      "/v1/public/newsletter",
+      "/v1/public/offers",
+      "/v1/public/settings",
+    ])
+
+    const anonymouslyMatchedDepartureAndSettingsRoutes = new Set(
+      module.publicRoutes?.routes
+        .filter(
+          ({ path }) =>
+            path === "/settings" ||
+            path.startsWith("/settings/") ||
+            path.startsWith("/departures/"),
+        )
+        .map(({ method, path }) => `${method} ${path}`),
+    )
+
+    expect([...anonymouslyMatchedDepartureAndSettingsRoutes]).toEqual([
+      "GET /settings",
+      "GET /departures/:departureId",
+      "POST /departures/:departureId/price",
+      "POST /departures/:departureId/eligibility",
+    ])
   })
 
   it("registers runtime dependencies without subscribing outside graph lowering", async () => {

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -56,7 +56,7 @@ describe("storefront deployment manifest", () => {
           mount: "/",
           resource: "storefront",
           openapi: { document: "storefront" },
-          anonymous: ["/bookings", "/leads", "/newsletter", "/offers"],
+          anonymous: ["/bookings", "/departures", "/leads", "/newsletter", "/offers", "/settings"],
           runtime: {
             entry: "@voyant-travel/storefront",
             export: "createStorefrontApiModule",


### PR DESCRIPTION
## What changed

- allow unauthenticated access to public storefront settings
- allow unauthenticated departure lookup, price preview, and eligibility evaluation
- keep runtime and import-cheap deployment manifests aligned
- add exact anonymous-route inventory regression coverage

## Why

Managed storefront requests currently reach the runtime but settings and departure pricing are intercepted with 401 before route matching. These endpoints are public storefront reads/evaluations and must work for guest visitors.

## Impact

Guest storefronts can load settings and preview departure pricing without a customer session. The audited route family contains no persistence mutations.

## Validation

- remote Sprite focused tests: 2 files, 9 tests passed
- `git show --check`
