### PR TITLE
Route Finance checkout through the selected payment adapter

### DIFF
--- a/.changeset/finance-selected-payment-adapter.md
+++ b/.changeset/finance-selected-payment-adapter.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": minor
+"@voyant-travel/operator-standard": patch
+---
+
+Route Finance checkout collections through the deployment-selected `PaymentAdapter`. Providerless card-start requests now use that adapter, legacy provider hints remain compatible but cannot override deployment selection, and full generic billing metadata reaches hosted-checkout adapters.

--- a/docs/architecture/payment-adapter-boundary.md
+++ b/docs/architecture/payment-adapter-boundary.md
@@ -53,3 +53,8 @@ Deployments can adapt a selected `PaymentAdapter` through
 `createPaymentAdapterCardPaymentStarter(...)`, and verified callback events are
 applied to the finance payment-session state machine through
 `applyPaymentAdapterCallbackEvent(...)`.
+
+Finance checkout collection routes also consume the selected
+`payments.adapter.runtime` port directly. Clients request a card start without
+selecting or naming a processor; a legacy provider hint may be accepted for
+compatibility, but it never overrides the deployment-selected adapter.

--- a/packages/finance/src/card-payment.ts
+++ b/packages/finance/src/card-payment.ts
@@ -47,6 +47,7 @@ export interface CardPaymentStartArgs {
   billing: CardPaymentBilling
   description?: string
   returnUrl?: string
+  metadata?: Record<string, unknown>
 }
 
 /** Result of a card-payment start: the hosted-payment URL to redirect to. */
@@ -81,69 +82,98 @@ export interface PaymentAdapterCardPaymentStarterOptions {
   resolveNotifyUrl?(c: Context): string | undefined
 }
 
+export interface PaymentAdapterCardPaymentExecution {
+  context: PaymentAdapterRuntimeContext
+  runtime?: FinanceServiceRuntime
+  notifyUrl?: string
+  idempotencyKey?: string
+}
+
+/**
+ * Start a payment through a selected adapter without requiring an HTTP
+ * framework context. Package runtimes use this function; the Hono-oriented
+ * starter below remains the checkout-surface convenience wrapper.
+ */
+export async function startPaymentAdapterCardPayment(
+  adapter: PaymentAdapter,
+  args: CardPaymentStartArgs,
+  execution: PaymentAdapterCardPaymentExecution,
+): Promise<CardPaymentStartResult | null> {
+  const [session] = await args.db
+    .select()
+    .from(paymentSessions)
+    .where(eq(paymentSessions.id, args.sessionId))
+    .limit(1)
+  if (!session) return null
+
+  const idempotencyKey =
+    session.idempotencyKey ?? execution.idempotencyKey ?? `payment:${session.id}`
+  const metadata = {
+    ...(args.metadata ?? {}),
+    billing: args.billing,
+    ...(execution.notifyUrl ? { notifyUrl: execution.notifyUrl } : {}),
+  }
+  const result = await adapter.initiate(execution.context, {
+    paymentSessionId: session.id,
+    money: { amountMinor: session.amountCents, currency: session.currency },
+    description: args.description ?? session.notes ?? undefined,
+    returnUrl: args.returnUrl ?? session.returnUrl ?? undefined,
+    idempotencyKey,
+    customer: {
+      email: args.billing.email,
+      phone: args.billing.phone ?? null,
+      firstName: args.billing.firstName,
+      lastName: args.billing.lastName ?? null,
+    },
+    metadata,
+  })
+
+  const providerData = {
+    providerSessionId: result.processorSessionId ?? undefined,
+    providerPaymentId: result.processorPaymentId ?? undefined,
+    providerPayload: result.raw === undefined ? undefined : { initiation: result.raw },
+    metadata: { paymentAdapterInitiationIdempotencyKey: result.idempotencyKey },
+  }
+
+  if (result.nextState === "paid" || result.nextState === "authorized") {
+    await financePaymentSessionService.updatePaymentSession(args.db, session.id, {
+      provider: adapter.id,
+      redirectUrl: result.checkout?.url ?? undefined,
+      idempotencyKey,
+    })
+    await financePaymentSessionCompletionService.completePaymentSession(
+      args.db,
+      session.id,
+      {
+        status: result.nextState,
+        captureMode: "automatic",
+        ...providerData,
+      },
+      execution.runtime,
+    )
+  } else {
+    await financePaymentSessionService.updatePaymentSession(args.db, session.id, {
+      provider: adapter.id,
+      status: result.nextState,
+      redirectUrl: result.checkout?.url ?? undefined,
+      idempotencyKey,
+      ...providerData,
+    })
+  }
+
+  return { redirectUrl: result.checkout?.url ?? null }
+}
+
 export function createPaymentAdapterCardPaymentStarter(
   adapter: PaymentAdapter,
   options: PaymentAdapterCardPaymentStarterOptions = {},
 ): CardPaymentStarter {
   return async (c, args) => {
-    const [session] = await args.db
-      .select()
-      .from(paymentSessions)
-      .where(eq(paymentSessions.id, args.sessionId))
-      .limit(1)
-    if (!session) return null
-
-    const idempotencyKey =
-      session.idempotencyKey ?? options.idempotencyKey?.(session.id) ?? `payment:${session.id}`
-    const notifyUrl = options.resolveNotifyUrl?.(c)
-    const result = await adapter.initiate(options.resolveContext?.(c) ?? { env: c.env }, {
-      paymentSessionId: session.id,
-      money: { amountMinor: session.amountCents, currency: session.currency },
-      description: args.description ?? session.notes ?? undefined,
-      returnUrl: args.returnUrl ?? session.returnUrl ?? undefined,
-      idempotencyKey,
-      customer: {
-        email: args.billing.email,
-        phone: args.billing.phone ?? null,
-        firstName: args.billing.firstName,
-        lastName: args.billing.lastName ?? null,
-      },
-      ...(notifyUrl ? { metadata: { notifyUrl } } : {}),
+    return startPaymentAdapterCardPayment(adapter, args, {
+      context: options.resolveContext?.(c) ?? { env: c.env },
+      runtime: options.resolveRuntime?.(c),
+      notifyUrl: options.resolveNotifyUrl?.(c),
+      idempotencyKey: options.idempotencyKey?.(args.sessionId),
     })
-
-    const providerData = {
-      providerSessionId: result.processorSessionId ?? undefined,
-      providerPaymentId: result.processorPaymentId ?? undefined,
-      providerPayload: result.raw === undefined ? undefined : { initiation: result.raw },
-      metadata: { paymentAdapterInitiationIdempotencyKey: result.idempotencyKey },
-    }
-
-    if (result.nextState === "paid" || result.nextState === "authorized") {
-      await financePaymentSessionService.updatePaymentSession(args.db, session.id, {
-        provider: adapter.id,
-        redirectUrl: result.checkout?.url ?? undefined,
-        idempotencyKey,
-      })
-      await financePaymentSessionCompletionService.completePaymentSession(
-        args.db,
-        session.id,
-        {
-          status: result.nextState,
-          captureMode: "automatic",
-          ...providerData,
-        },
-        options.resolveRuntime?.(c),
-      )
-    } else {
-      await financePaymentSessionService.updatePaymentSession(args.db, session.id, {
-        provider: adapter.id,
-        status: result.nextState,
-        redirectUrl: result.checkout?.url ?? undefined,
-        idempotencyKey,
-        ...providerData,
-      })
-    }
-
-    return { redirectUrl: result.checkout?.url ?? null }
   }
 }

--- a/packages/finance/src/checkout-routes.ts
+++ b/packages/finance/src/checkout-routes.ts
@@ -49,6 +49,9 @@ export type CheckoutRoutesOptions = {
     bindings: Record<string, unknown>,
   ) => CheckoutNotificationDispatcher | null
   paymentStarters?: Record<string, CheckoutPaymentStarter>
+  resolveSelectedPaymentStarter?: (
+    bindings: Record<string, unknown>,
+  ) => CheckoutPaymentStarter | null
   resolvePaymentStarters?: (
     bindings: Record<string, unknown>,
   ) => Record<string, CheckoutPaymentStarter>
@@ -75,6 +78,7 @@ export interface CheckoutReminderRunList {
 export type CheckoutRouteRuntime = {
   bindings: Record<string, unknown>
   notificationDispatcher: CheckoutNotificationDispatcher | null
+  selectedPaymentStarter: CheckoutPaymentStarter | null
   paymentStarters: Record<string, CheckoutPaymentStarter>
   bankTransferDetails: CheckoutBankTransferDetails | null
   publicCheckoutBaseUrl?: string | null
@@ -246,7 +250,11 @@ function assertCheckoutRuntimeSupportsCollection(
   runtime: CheckoutRouteRuntime,
   input: { method: "card" | "bank_transfer" },
 ) {
-  if (input.method === "card" && Object.keys(runtime.paymentStarters).length === 0) {
+  if (
+    input.method === "card" &&
+    !runtime.selectedPaymentStarter &&
+    Object.keys(runtime.paymentStarters).length === 0
+  ) {
     throw new CheckoutRouteRuntimeNotConfiguredError()
   }
 }
@@ -259,6 +267,7 @@ export function buildCheckoutRouteRuntime(
     bindings,
     notificationDispatcher:
       options.resolveNotificationDispatcher?.(bindings) ?? options.notificationDispatcher ?? null,
+    selectedPaymentStarter: options.resolveSelectedPaymentStarter?.(bindings) ?? null,
     paymentStarters: options.resolvePaymentStarters?.(bindings) ?? options.paymentStarters ?? {},
     bankTransferDetails:
       options.resolveBankTransferDetails?.(bindings) ?? options.bankTransferDetails ?? null,

--- a/packages/finance/src/checkout-service-plan.ts
+++ b/packages/finance/src/checkout-service-plan.ts
@@ -145,6 +145,8 @@ export interface CheckoutRuntimeOptions {
   bindings?: Record<string, unknown>
   bankTransferDetails?: CheckoutBankTransferDetails | null
   notificationDispatcher?: CheckoutNotificationDispatcher | null
+  /** Deployment-selected PaymentAdapter bridge. Takes precedence over legacy keyed starters. */
+  selectedPaymentStarter?: CheckoutPaymentStarter | null
   paymentStarters?: Record<string, CheckoutPaymentStarter>
   publicCheckoutBaseUrl?: string | null
 }

--- a/packages/finance/src/checkout-service.ts
+++ b/packages/finance/src/checkout-service.ts
@@ -429,9 +429,19 @@ export async function initiateCheckoutCollection(
       throw new Error("No payment session available for provider start")
     }
 
-    const starter = runtime.paymentStarters?.[input.startProvider.provider]
+    // Processor selection belongs to the deployment. A selected PaymentAdapter
+    // therefore wins even when an older client still sends a provider hint.
+    // Keyed starters remain as a compatibility path for self-hosted plugins.
+    const requestedProvider = input.startProvider.provider
+    const starter =
+      runtime.selectedPaymentStarter ??
+      (requestedProvider ? runtime.paymentStarters?.[requestedProvider] : undefined)
     if (!starter) {
-      throw new Error(`Payment provider "${input.startProvider.provider}" is not configured`)
+      throw new Error(
+        requestedProvider
+          ? `Payment provider "${requestedProvider}" is not configured`
+          : "No payment adapter is selected for card collection",
+      )
     }
 
     providerStart = await starter({

--- a/packages/finance/src/checkout-validation.ts
+++ b/packages/finance/src/checkout-validation.ts
@@ -33,7 +33,12 @@ export const checkoutReminderTargetTypeSchema = z.enum([
   "invoice",
 ])
 export const checkoutProviderStartInputSchema = z.object({
-  provider: z.string().min(1).max(255),
+  /**
+   * Legacy provider hint. Deployments with a selected PaymentAdapter ignore
+   * this value and always use their selected adapter. New clients should omit
+   * it so processor selection remains deployment-owned.
+   */
+  provider: z.string().min(1).max(255).optional(),
   payload: z.record(z.string(), z.unknown()).optional().nullable(),
 })
 

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -6,6 +6,7 @@ import { customFieldsRuntimePort } from "@voyant-travel/core/custom-fields"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import { stampOpenApiRegistryApiId } from "@voyant-travel/hono"
 import type { ApiModule } from "@voyant-travel/hono/module"
+import { type PaymentAdapter, paymentAdapterRuntimePort } from "@voyant-travel/payments"
 import { financeBookingLifecycle } from "./booking-lifecycle.js"
 import { type BookingTaxRouteOptions, createBookingTaxSettingsRoutes } from "./booking-tax.js"
 import {
@@ -207,6 +208,9 @@ export const createFinanceVoyantRuntime = defineGraphRuntimeFactory(
           ? await getPort(financeCheckoutPaymentStartersRuntimePort)
           : undefined,
         await getPorts(financeInvoiceSettlementPollerRuntimePort),
+        hasPort(paymentAdapterRuntimePort)
+          ? await getPort<PaymentAdapter>(paymentAdapterRuntimePort)
+          : undefined,
       ),
     )
     const bootstrap = configured.module.bootstrap
@@ -293,8 +297,12 @@ export type {
   CardPaymentStarter,
   CardPaymentStartResult,
   PaymentAdapterCardPaymentStarterOptions,
+  PaymentAdapterCardPaymentExecution,
 } from "./card-payment.js"
-export { createPaymentAdapterCardPaymentStarter } from "./card-payment.js"
+export {
+  createPaymentAdapterCardPaymentStarter,
+  startPaymentAdapterCardPayment,
+} from "./card-payment.js"
 export {
   type DocumentDownloadEnvelope,
   type DocumentDownloadResolution,

--- a/packages/finance/src/index.ts
+++ b/packages/finance/src/index.ts
@@ -296,8 +296,8 @@ export type {
   CardPaymentStartArgs,
   CardPaymentStarter,
   CardPaymentStartResult,
-  PaymentAdapterCardPaymentStarterOptions,
   PaymentAdapterCardPaymentExecution,
+  PaymentAdapterCardPaymentStarterOptions,
 } from "./card-payment.js"
 export {
   createPaymentAdapterCardPaymentStarter,

--- a/packages/finance/src/runtime.ts
+++ b/packages/finance/src/runtime.ts
@@ -1,6 +1,9 @@
 import type { CustomFieldsRuntime } from "@voyant-travel/core/custom-fields"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import type { PaymentAdapter } from "@voyant-travel/payments"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { startPaymentAdapterCardPayment } from "./card-payment.js"
+import type { CheckoutPaymentStarter } from "./checkout-service.js"
 import type { FinanceApiModuleOptions } from "./index.js"
 import {
   createVoyantDataFxExchangeRateResolver,
@@ -18,6 +21,7 @@ import type {
   FinanceNotificationsRuntime,
   FinanceOperatorSettingsRuntime,
 } from "./runtime-port.js"
+import { financeService } from "./service.js"
 import type { InvoiceSettlementPoller } from "./service-settlement.js"
 
 /** Compose Finance's main HTTP runtime from generic host and selected providers. */
@@ -27,6 +31,7 @@ export function createFinanceRuntime(
   notifications: FinanceNotificationsRuntime,
   checkoutPaymentStarters?: FinanceCheckoutPaymentStartersRuntime,
   invoiceSettlementPollerProviders: readonly FinanceInvoiceSettlementPollerProvider[] = [],
+  selectedPaymentAdapter?: PaymentAdapter,
 ): FinanceApiModuleOptions {
   const { primitives } = host
   return {
@@ -55,11 +60,109 @@ export function createFinanceRuntime(
     resolveNotificationDispatcher: notifications.resolveNotificationDispatcher,
     resolvePaymentStarters: (bindings) =>
       checkoutPaymentStarters?.resolvePaymentStarters(bindings) ?? {},
+    resolveSelectedPaymentStarter: selectedPaymentAdapter
+      ? (bindings) => createSelectedPaymentAdapterStarter(host, selectedPaymentAdapter, bindings)
+      : undefined,
     resolveBankTransferDetails: (bindings) => resolveBankTransferDetails(primitives.env(bindings)),
     resolvePublicCheckoutBaseUrl: (bindings) =>
       resolvePublicCheckoutBaseUrl(primitives.env(bindings)),
     listBookingReminderRuns: notifications.listBookingReminderRuns,
   }
+}
+
+function createSelectedPaymentAdapterStarter(
+  host: FinanceHostRuntime,
+  adapter: PaymentAdapter,
+  bindings: Record<string, unknown>,
+): CheckoutPaymentStarter {
+  return async (checkout) => {
+    const payload = checkout.startProvider.payload ?? {}
+    const billing = readCardPaymentBilling(payload.billing)
+    const env = host.primitives.env(bindings)
+    const started = await startPaymentAdapterCardPayment(
+      adapter,
+      {
+        db: checkout.db,
+        sessionId: checkout.paymentSession.id,
+        billing,
+        description: stringValue(payload.description),
+        returnUrl: stringValue(payload.returnUrl) ?? checkout.paymentSession.returnUrl ?? undefined,
+        metadata: recordValue(payload.metadata),
+      },
+      {
+        context: { env },
+        notifyUrl: resolvePaymentCallbackUrl(env),
+      },
+    )
+    const session =
+      (await financeService.getPaymentSessionById(checkout.db, checkout.paymentSession.id)) ??
+      checkout.paymentSession
+    return {
+      provider: adapter.id,
+      paymentSessionId: session.id,
+      redirectUrl: started?.redirectUrl ?? null,
+      externalReference: session.externalReference,
+      providerSessionId: session.providerSessionId,
+      providerPaymentId: session.providerPaymentId,
+      response: null,
+    }
+  }
+}
+
+function readCardPaymentBilling(value: unknown) {
+  const billing = recordValue(value)
+  const email = nonEmpty(billing.email)
+  const firstName = nonEmpty(billing.firstName)
+  if (!email || !firstName) {
+    throw new Error("Card payment billing requires email and firstName")
+  }
+  const phone = nonEmpty(billing.phone)
+  const lastName = nonEmpty(billing.lastName)
+  const city = nonEmpty(billing.city)
+  const country =
+    typeof billing.country === "number" || typeof billing.country === "string"
+      ? billing.country
+      : undefined
+  const state = nonEmpty(billing.state)
+  const postalCode = nonEmpty(billing.postalCode)
+  const details = nonEmpty(billing.details)
+  return {
+    email,
+    firstName,
+    ...(phone ? { phone } : {}),
+    ...(lastName ? { lastName } : {}),
+    ...(city ? { city } : {}),
+    ...(country !== undefined ? { country } : {}),
+    ...(state ? { state } : {}),
+    ...(postalCode ? { postalCode } : {}),
+    ...(details ? { details } : {}),
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+}
+
+function resolvePaymentCallbackUrl(env: Readonly<Record<string, unknown>>): string | undefined {
+  const configured =
+    nonEmpty(env.PAYMENT_CALLBACK_BASE_URL) ??
+    nonEmpty(env.DASH_BASE_URL) ??
+    nonEmpty(env.APP_URL)?.replace(/\/api\/?$/, "")
+  if (!configured) return undefined
+  const url = new URL(configured)
+  if (
+    (url.protocol !== "http:" && url.protocol !== "https:") ||
+    url.username ||
+    url.password ||
+    url.pathname !== "/" ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("Payment callback base must be an absolute HTTP(S) origin")
+  }
+  return `${url.origin}/api/v1/public/payment-link/callback`
 }
 
 /** Compose Finance's payment schedule from statically selected domain providers. */

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -43,6 +43,8 @@ import {
   paymentCompletedPayloadSchema,
 } from "./voyant-event-schemas.js"
 
+const paymentAdapterRuntimePortReference = { id: "payments.adapter.runtime" } as const
+
 /** Import-cheap deployment declaration owned by the finance package. */
 export const financeVoyantModule = defineModule({
   id: "@voyant-travel/finance",
@@ -54,6 +56,7 @@ export const financeVoyantModule = defineModule({
     requirePort(customFieldsRuntimePort),
     requirePort(financeNotificationsRuntimePort),
     requirePort(financeCheckoutPaymentStartersRuntimePort, { optional: true }),
+    { ...paymentAdapterRuntimePortReference, optional: true },
     requirePort(financeInvoiceSettlementPollerRuntimePort, {
       optional: true,
       cardinality: "many",

--- a/packages/finance/tests/unit/checkout-routes.test.ts
+++ b/packages/finance/tests/unit/checkout-routes.test.ts
@@ -136,6 +136,60 @@ describe("createFinanceCheckoutRoutes", () => {
     expect(runtime.paymentStarters.netopia).toBe(paymentStarter)
   })
 
+  it("accepts a provider-neutral card start through the selected adapter", async () => {
+    serviceMocks.initiateCheckoutCollection.mockResolvedValue({
+      plan: { bookingId: "book_123", method: "card" },
+      invoice: null,
+      paymentSession: { id: "ps_123" },
+      invoiceNotification: null,
+      paymentSessionNotification: null,
+      bankTransferInstructions: null,
+      providerStart: {
+        provider: "connected-adapter",
+        paymentSessionId: "ps_123",
+        redirectUrl: "https://payments.example/checkout",
+      },
+    })
+    const selectedPaymentStarter = vi.fn()
+    const routes = createFinanceCheckoutRoutes({
+      resolveSelectedPaymentStarter: () => selectedPaymentStarter,
+    })
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", async (c, next) => {
+      c.set("db", {} as never)
+      await next()
+    })
+    app.route("/", routes)
+
+    const res = await app.request(
+      "/bookings/book_123/initiate-collection",
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", ...(await capabilityHeaders()) },
+        body: JSON.stringify({
+          method: "card",
+          startProvider: {
+            payload: {
+              billing: {
+                email: "traveler@example.com",
+                firstName: "Ana",
+                lastName: "Ionescu",
+              },
+            },
+          },
+        }),
+      },
+      TEST_CAPABILITY_ENV,
+    )
+
+    expect(res.status).toBe(201)
+    expect(serviceMocks.initiateCheckoutCollection).toHaveBeenCalledOnce()
+    expect(serviceMocks.initiateCheckoutCollection.mock.calls[0]?.[4]).toMatchObject({
+      selectedPaymentStarter,
+    })
+  })
+
   it("returns setup guidance when the checkout runtime provider is not registered", async () => {
     const routes = createFinanceCheckoutAdminRoutes()
     const app = new Hono()

--- a/packages/finance/tests/unit/checkout-service.test.ts
+++ b/packages/finance/tests/unit/checkout-service.test.ts
@@ -80,6 +80,55 @@ describe("finance checkout service", () => {
     )
   })
 
+  it("starts card collection through the deployment-selected payment adapter", async () => {
+    const db = createCheckoutDb({ insertedInvoices: [] })
+    const paymentSession = {
+      id: "ps_selected",
+      invoiceId: null,
+      targetType: "booking_payment_schedule",
+    }
+    const selectedPaymentStarter = vi.fn(async () => ({
+      provider: "connected-adapter",
+      paymentSessionId: paymentSession.id,
+      redirectUrl: "https://payments.example/checkout",
+      externalReference: null,
+      providerSessionId: "processor_session_123",
+      providerPaymentId: null,
+      response: null,
+    }))
+
+    vi.spyOn(financeService, "createPaymentSessionFromBookingSchedule").mockResolvedValue(
+      paymentSession as never,
+    )
+    vi.spyOn(financeService, "getPaymentSessionById").mockResolvedValue(paymentSession as never)
+
+    const result = await initiateCheckoutCollection(
+      db as never,
+      "booking_123",
+      {
+        method: "card",
+        stage: "initial",
+        startProvider: {
+          payload: {
+            billing: {
+              email: "traveler@example.com",
+              firstName: "Ana",
+              lastName: "Ionescu",
+            },
+          },
+        },
+      },
+      {},
+      { selectedPaymentStarter },
+    )
+
+    expect(selectedPaymentStarter).toHaveBeenCalledOnce()
+    expect(result?.providerStart).toMatchObject({
+      provider: "connected-adapter",
+      redirectUrl: "https://payments.example/checkout",
+    })
+  })
+
   it("keeps base paid cents null when creating a collection invoice without base currency", async () => {
     const insertedInvoices: Array<Record<string, unknown>> = []
     const db = createCheckoutDb({

--- a/packages/finance/tests/unit/checkout-service.test.ts
+++ b/packages/finance/tests/unit/checkout-service.test.ts
@@ -80,7 +80,7 @@ describe("finance checkout service", () => {
     )
   })
 
-  it("starts card collection through the deployment-selected payment adapter", async () => {
+  it("prefers the deployment-selected payment adapter over a legacy provider hint", async () => {
     const db = createCheckoutDb({ insertedInvoices: [] })
     const paymentSession = {
       id: "ps_selected",
@@ -96,6 +96,7 @@ describe("finance checkout service", () => {
       providerPaymentId: null,
       response: null,
     }))
+    const legacyPaymentStarter = vi.fn()
 
     vi.spyOn(financeService, "createPaymentSessionFromBookingSchedule").mockResolvedValue(
       paymentSession as never,
@@ -109,6 +110,7 @@ describe("finance checkout service", () => {
         method: "card",
         stage: "initial",
         startProvider: {
+          provider: "netopia",
           payload: {
             billing: {
               email: "traveler@example.com",
@@ -119,10 +121,14 @@ describe("finance checkout service", () => {
         },
       },
       {},
-      { selectedPaymentStarter },
+      {
+        selectedPaymentStarter,
+        paymentStarters: { netopia: legacyPaymentStarter },
+      },
     )
 
     expect(selectedPaymentStarter).toHaveBeenCalledOnce()
+    expect(legacyPaymentStarter).not.toHaveBeenCalled()
     expect(result?.providerStart).toMatchObject({
       provider: "connected-adapter",
       redirectUrl: "https://payments.example/checkout",

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -1,6 +1,10 @@
+import { createContainer } from "@voyant-travel/core"
 import { prepareExternalWebhookEvent } from "@voyant-travel/webhook-delivery"
 import { describe, expect, it } from "vitest"
-import { createFinanceVoyantRuntime } from "../../src/index.js"
+import {
+  createFinanceVoyantRuntime,
+  FINANCE_CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
+} from "../../src/index.js"
 import {
   financeBookingScheduleVoyantPlugin,
   financeBookingsCreateVoyantPlugin,
@@ -30,6 +34,7 @@ describe("finance deployment manifest", () => {
         { id: "custom-fields.runtime" },
         { id: "finance.notifications.runtime" },
         { id: "finance.checkout-payment-starters.runtime", optional: true },
+        { id: "payments.adapter.runtime", optional: true },
         { id: "finance.invoice-settlement-poller", optional: true, cardinality: "many" },
       ],
       api: [
@@ -427,6 +432,16 @@ describe("finance deployment manifest", () => {
             listBookingReminderRuns: async () => [],
           },
           "finance.checkout-payment-starters.runtime": { resolvePaymentStarters: () => ({}) },
+          "payments.adapter.runtime": {
+            id: "connected-adapter",
+            label: "Connected adapter",
+            contractVersion: "voyant.payment-adapter.v1",
+            mode: "test",
+            capabilities: { callbackSignatureVerification: true },
+            initiate: async () => ({}),
+            verifyCallback: async () => ({ verified: false, reason: "malformed" }),
+            health: async () => ({ status: "ok", checkedAt: new Date().toISOString() }),
+          },
         }
         return providers[port.id] as TProvider
       },
@@ -435,6 +450,13 @@ describe("finance deployment manifest", () => {
 
     expect(runtime.adminRoutes).toBeDefined()
     expect(runtime.publicRoutes).toBeUndefined()
+    const container = createContainer()
+    await runtime.module.bootstrap?.({ bindings: {}, container })
+    expect(
+      container.resolve<{ selectedPaymentStarter?: unknown }>(
+        FINANCE_CHECKOUT_ROUTE_RUNTIME_CONTAINER_KEY,
+      )?.selectedPaymentStarter,
+    ).toBeTypeOf("function")
   })
 
   it("owns the finance extensions", () => {


### PR DESCRIPTION
## Summary

- route Finance checkout collections through the deployment-selected `payments.adapter.runtime`
- preserve keyed checkout starters as a compatibility path for self-hosted deployments
- make the legacy provider hint optional and prevent it from overriding the selected adapter
- carry generic billing metadata through the neutral PaymentAdapter contract
- add service, route, and runtime-manifest regression tests

## Why

The managed runtime already contributes a remote PaymentAdapter, but Finance checkout collections only resolved the legacy provider-keyed starter map. That forced clients to name Netopia and fall back to a provider-specific route.

After this change the deployment owns processor selection. Managed clients can submit one provider-neutral Finance bootstrap request.

## Release coordination

This changeset releases:

- `@voyant-travel/finance`: minor
- `@voyant-travel/operator-standard`: patch

After publishing, voyant-travel/platform#1308 must update its package pins/lockfile to this release before the Pro Travel client cutover. No platform source bridge change is required.

## Validation

- regression tests added first for providerless selected-adapter checkout
- `git diff --check` passes
- Finance lint passes
- Finance typecheck passes
- Finance test command passes: 54 files passed, 17 DB-dependent files skipped without a database
- GitHub Depot CI is running on the exact PR head

No package publication or deployment is included.
