### PR TITLE
Make first-party maintenance jobs wakeable

### DIFF
--- a/docs/architecture/workflow-product-removal-rfc.md
+++ b/docs/architecture/workflow-product-removal-rfc.md
@@ -160,9 +160,9 @@ Domain packages retain the durable records that make a job safe to retry:
 | --- | --- | --- |
 | Event delivery | event outbox rows and webhook delivery rows | Wake after a write and poll as a safety net; claim with a visibility lease; expose failed delivery state. |
 | Channel push | channel push intent and link state | Per-channel or per-booking claiming; retry from the intent state; periodic reconciliation. |
-| Notification reminders | reminder and delivery records | Sweep due records; make delivery idempotent at the record level. |
-| Promotion boundaries | promotion state and product index state | Idempotent time-based sweep; reindex affected products. |
-| Booking draft expiry | booking draft and hold state | Idempotent expiry sweep; release a hold before deleting the draft. |
+| Notification reminders | reminder and delivery records | Wake after a reminder becomes due; sweep due records as recovery and make delivery idempotent at the record level. |
+| Promotion boundaries | promotion state and product index state | Wake after a promotion changes; retain an idempotent time-based sweep for missed boundaries and reindex affected products. |
+| Booking draft expiry | booking draft and hold state | Wake after draft or hold state changes; retain an idempotent expiry sweep that releases a hold before deleting the draft. |
 
 The event outbox is particularly important: an immediate wakeup improves
 latency, but a scheduled drain remains mandatory so a missed wakeup cannot lose
@@ -181,12 +181,12 @@ The current first-party workflow definitions move as follows:
 | `distribution.channel-push-reconcile-booking-links` | Scheduled job | Booking-link and channel state. |
 | `distribution.channel-push-reconcile-availability` | Scheduled job | Availability and channel state. |
 | `distribution.channel-push-reconcile-content` | Scheduled job | Product content and channel state. |
-| `notifications.send-due-reminders` | Scheduled job | Reminder rules and reminder-run records. |
+| `notifications.send-due-reminders` | Wakeable job with scheduled recovery | Reminder rules and reminder-run records. |
 | `notifications.deliver-reminder` | Wakeable job with scheduled recovery | Reminder delivery records. |
-| `commerce.process-promotion-boundaries` | Scheduled job | Promotion and product-index state. |
+| `commerce.process-promotion-boundaries` | Wakeable job with scheduled recovery | Promotion and product-index state. |
 | `promotions.reindex-all-products` | Wakeable job with scheduled recovery | A domain-owned reindex intent or checkpoint, added before cutover. |
-| `catalog.reap-expired-booking-drafts` | Scheduled job | Booking draft and hold state; reconcile ownership with stale-hold expiry before migration. |
-| `bookings.expire-stale-holds` | Scheduled job | Booking hold and payment-session state; reconcile ownership with draft reaping before migration. |
+| `catalog.reap-expired-booking-drafts` | Wakeable job with scheduled recovery | Booking draft and hold state; reconcile ownership with stale-hold expiry before migration. |
+| `bookings.expire-stale-holds` | Wakeable job with scheduled recovery | Booking hold and payment-session state; reconcile ownership with draft reaping before migration. |
 | `cruises.external-catalog-refresh` | Scheduled job | Selected cruises capability state and refresh checkpoint. |
 | `products.generate-pdf` | Domain command, not a job | Generate synchronously or persist a document-generation intent consumed by a package job. |
 
@@ -222,6 +222,14 @@ persisting generic run state in the host. It serializes each job in-process,
 uses bounded retries with backoff, and exposes only minimal health state. Fixed
 HTTP wakeup and schedule invocation is origin-trust authenticated and accepts
 neither request bodies nor query input.
+
+First-party maintenance jobs declare the package-owned default cadence together
+with the bounded `eager` and `economical` profiles. `eager` reduces recovery
+latency at the cost of more database work; `economical` increases the maximum
+time until a missed wakeup is repaired. Self-hosted installations retain the
+safe default unless an operator explicitly selects one of those declared
+profiles. A wakeup is only a prompt: the package's durable state and scheduled
+recovery remain authoritative across process restarts and missed delivery.
 
 Custom deployments can disable a specific optional product capability only when
 the owning package documents the consequences. Disabling a capability removes

--- a/docs/architecture/workflow-product-removal-rfc.md
+++ b/docs/architecture/workflow-product-removal-rfc.md
@@ -160,9 +160,9 @@ Domain packages retain the durable records that make a job safe to retry:
 | --- | --- | --- |
 | Event delivery | event outbox rows and webhook delivery rows | Wake after a write and poll as a safety net; claim with a visibility lease; expose failed delivery state. |
 | Channel push | channel push intent and link state | Per-channel or per-booking claiming; retry from the intent state; periodic reconciliation. |
-| Notification reminders | reminder and delivery records | Wake after a reminder becomes due; sweep due records as recovery and make delivery idempotent at the record level. |
-| Promotion boundaries | promotion state and product index state | Wake after a promotion changes; retain an idempotent time-based sweep for missed boundaries and reindex affected products. |
-| Booking draft expiry | booking draft and hold state | Wake after draft or hold state changes; retain an idempotent expiry sweep that releases a hold before deleting the draft. |
+| Notification reminders | reminder and delivery records | Sweep due records; make delivery idempotent at the record level. |
+| Promotion boundaries | promotion state and product index state | Idempotent time-based sweep; reindex affected products. |
+| Booking draft expiry | booking draft and hold state | Idempotent expiry sweep; release a hold before deleting the draft. |
 
 The event outbox is particularly important: an immediate wakeup improves
 latency, but a scheduled drain remains mandatory so a missed wakeup cannot lose
@@ -181,12 +181,12 @@ The current first-party workflow definitions move as follows:
 | `distribution.channel-push-reconcile-booking-links` | Scheduled job | Booking-link and channel state. |
 | `distribution.channel-push-reconcile-availability` | Scheduled job | Availability and channel state. |
 | `distribution.channel-push-reconcile-content` | Scheduled job | Product content and channel state. |
-| `notifications.send-due-reminders` | Wakeable job with scheduled recovery | Reminder rules and reminder-run records. |
+| `notifications.send-due-reminders` | Scheduled job | Reminder rules and reminder-run records. |
 | `notifications.deliver-reminder` | Wakeable job with scheduled recovery | Reminder delivery records. |
-| `commerce.process-promotion-boundaries` | Wakeable job with scheduled recovery | Promotion and product-index state. |
+| `commerce.process-promotion-boundaries` | Scheduled job | Promotion and product-index state. |
 | `promotions.reindex-all-products` | Wakeable job with scheduled recovery | A domain-owned reindex intent or checkpoint, added before cutover. |
-| `catalog.reap-expired-booking-drafts` | Wakeable job with scheduled recovery | Booking draft and hold state; reconcile ownership with stale-hold expiry before migration. |
-| `bookings.expire-stale-holds` | Wakeable job with scheduled recovery | Booking hold and payment-session state; reconcile ownership with draft reaping before migration. |
+| `catalog.reap-expired-booking-drafts` | Scheduled job | Booking draft and hold state; reconcile ownership with stale-hold expiry before migration. |
+| `bookings.expire-stale-holds` | Scheduled job | Booking hold and payment-session state; reconcile ownership with draft reaping before migration. |
 | `cruises.external-catalog-refresh` | Scheduled job | Selected cruises capability state and refresh checkpoint. |
 | `products.generate-pdf` | Domain command, not a job | Generate synchronously or persist a document-generation intent consumed by a package job. |
 
@@ -226,9 +226,10 @@ neither request bodies nor query input.
 First-party maintenance jobs declare the package-owned default cadence together
 with the bounded `eager` and `economical` profiles. `eager` reduces recovery
 latency at the cost of more database work; `economical` increases the maximum
-time until a missed wakeup is repaired. Self-hosted installations retain the
+time until scheduled reconciliation runs. Self-hosted installations retain the
 safe default unless an operator explicitly selects one of those declared
-profiles. A wakeup is only a prompt: the package's durable state and scheduled
+profiles. A wakeable job must be paired with an owned durable-state dispatcher;
+a wakeup is only a prompt, and the package's durable state and scheduled
 recovery remain authoritative across process restarts and missed delivery.
 
 Custom deployments can disable a specific optional product capability only when

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -349,6 +349,14 @@ export const bookingsVoyantModule = defineModule({
     {
       id: "bookings.expire-stale-holds",
       schedule: { cron: "*/5 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "* * * * *", overlap: "skip" },
+          economical: { cron: "*/15 * * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/bookings/stale-holds-job",
         export: "runBookingsExpireStaleHoldsJob",

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -356,7 +356,6 @@ export const bookingsVoyantModule = defineModule({
           economical: { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
-      wakeup: true,
       runtime: {
         entry: "@voyant-travel/bookings/stale-holds-job",
         export: "runBookingsExpireStaleHoldsJob",

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -62,7 +62,6 @@ describe("bookings deployment manifest", () => {
               economical: { cron: "*/15 * * * *", overlap: "skip" },
             },
           },
-          wakeup: true,
           runtime: {
             entry: "@voyant-travel/bookings/stale-holds-job",
             export: "runBookingsExpireStaleHoldsJob",

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -55,6 +55,14 @@ describe("bookings deployment manifest", () => {
         {
           id: "bookings.expire-stale-holds",
           schedule: { cron: "*/5 * * * *", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { cron: "* * * * *", overlap: "skip" },
+              economical: { cron: "*/15 * * * *", overlap: "skip" },
+            },
+          },
+          wakeup: true,
           runtime: {
             entry: "@voyant-travel/bookings/stale-holds-job",
             export: "runBookingsExpireStaleHoldsJob",

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -238,7 +238,6 @@ export const catalogVoyantModule = defineModule({
           economical: { cron: "5 */6 * * *", overlap: "skip" },
         },
       },
-      wakeup: true,
       runtime: {
         entry: "@voyant-travel/catalog/draft-reaper-job",
         export: "runCatalogDraftReaperJob",

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -231,6 +231,14 @@ export const catalogVoyantModule = defineModule({
     {
       id: "catalog.reap-expired-booking-drafts",
       schedule: { cron: "5 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "*/15 * * * *", overlap: "skip" },
+          economical: { cron: "5 */6 * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/catalog/draft-reaper-job",
         export: "runCatalogDraftReaperJob",

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -116,6 +116,14 @@ describe("catalog deployment manifest", () => {
       {
         id: "catalog.reap-expired-booking-drafts",
         schedule: { cron: "5 * * * *", overlap: "skip" },
+        scheduling: {
+          required: true,
+          profiles: {
+            eager: { cron: "*/15 * * * *", overlap: "skip" },
+            economical: { cron: "5 */6 * * *", overlap: "skip" },
+          },
+        },
+        wakeup: true,
         runtime: {
           entry: "@voyant-travel/catalog/draft-reaper-job",
           export: "runCatalogDraftReaperJob",

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -123,7 +123,6 @@ describe("catalog deployment manifest", () => {
             economical: { cron: "5 */6 * * *", overlap: "skip" },
           },
         },
-        wakeup: true,
         runtime: {
           entry: "@voyant-travel/catalog/draft-reaper-job",
           export: "runCatalogDraftReaperJob",

--- a/packages/commerce/src/voyant.test.ts
+++ b/packages/commerce/src/voyant.test.ts
@@ -15,7 +15,6 @@ describe("commerce deployment manifest", () => {
             economical: { every: "15m", overlap: "skip" },
           },
         },
-        wakeup: true,
         runtime: {
           entry: "@voyant-travel/commerce/promotion-reindex-job",
           export: "runPromotionReindexJob",

--- a/packages/commerce/src/voyant.test.ts
+++ b/packages/commerce/src/voyant.test.ts
@@ -8,6 +8,13 @@ describe("commerce deployment manifest", () => {
       {
         id: "promotions.reindex-all-products",
         schedule: { every: "2m", overlap: "skip" },
+        scheduling: {
+          required: true,
+          profiles: {
+            eager: { every: "1m", overlap: "skip" },
+            economical: { every: "15m", overlap: "skip" },
+          },
+        },
         wakeup: true,
         runtime: {
           entry: "@voyant-travel/commerce/promotion-reindex-job",
@@ -17,6 +24,14 @@ describe("commerce deployment manifest", () => {
       {
         id: "commerce.process-promotion-boundaries",
         schedule: { cron: "*/5 * * * *", overlap: "skip" },
+        scheduling: {
+          required: true,
+          profiles: {
+            eager: { cron: "* * * * *", overlap: "skip" },
+            economical: { cron: "*/15 * * * *", overlap: "skip" },
+          },
+        },
+        wakeup: true,
         runtime: {
           entry: "@voyant-travel/commerce/promotion-boundary-job",
           export: "runPromotionBoundaryJob",

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -381,7 +381,6 @@ export const commerceVoyantModule = defineModule({
           economical: { every: "15m", overlap: "skip" },
         },
       },
-      wakeup: true,
       runtime: {
         entry: "@voyant-travel/commerce/promotion-reindex-job",
         export: "runPromotionReindexJob",

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -374,6 +374,13 @@ export const commerceVoyantModule = defineModule({
     {
       id: "promotions.reindex-all-products",
       schedule: { every: "2m", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { every: "1m", overlap: "skip" },
+          economical: { every: "15m", overlap: "skip" },
+        },
+      },
       wakeup: true,
       runtime: {
         entry: "@voyant-travel/commerce/promotion-reindex-job",
@@ -383,6 +390,14 @@ export const commerceVoyantModule = defineModule({
     {
       id: "commerce.process-promotion-boundaries",
       schedule: { cron: "*/5 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "* * * * *", overlap: "skip" },
+          economical: { cron: "*/15 * * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/commerce/promotion-boundary-job",
         export: "runPromotionBoundaryJob",

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -156,7 +156,6 @@ describe("commerce deployment manifest", () => {
               economical: { every: "15m", overlap: "skip" },
             },
           },
-          wakeup: true,
           runtime: {
             entry: "@voyant-travel/commerce/promotion-reindex-job",
             export: "runPromotionReindexJob",

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -149,6 +149,13 @@ describe("commerce deployment manifest", () => {
         {
           id: "promotions.reindex-all-products",
           schedule: { every: "2m", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { every: "1m", overlap: "skip" },
+              economical: { every: "15m", overlap: "skip" },
+            },
+          },
           wakeup: true,
           runtime: {
             entry: "@voyant-travel/commerce/promotion-reindex-job",
@@ -158,6 +165,14 @@ describe("commerce deployment manifest", () => {
         {
           id: "commerce.process-promotion-boundaries",
           schedule: { cron: "*/5 * * * *", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { cron: "* * * * *", overlap: "skip" },
+              economical: { cron: "*/15 * * * *", overlap: "skip" },
+            },
+          },
+          wakeup: true,
           runtime: {
             entry: "@voyant-travel/commerce/promotion-boundary-job",
             export: "runPromotionBoundaryJob",

--- a/packages/db/src/voyant.ts
+++ b/packages/db/src/voyant.ts
@@ -65,7 +65,7 @@ export const dbVoyantModule = defineModule({
       scheduling: {
         required: true,
         profiles: {
-          eager: { every: "30s", overlap: "skip" },
+          eager: { every: "1m", overlap: "skip" },
           economical: { every: "10m", overlap: "skip" },
         },
       },

--- a/packages/db/src/voyant.ts
+++ b/packages/db/src/voyant.ts
@@ -62,6 +62,13 @@ export const dbVoyantModule = defineModule({
     {
       id: "infrastructure.event-outbox-drain",
       schedule: { cron: "*/2 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { every: "30s", overlap: "skip" },
+          economical: { every: "10m", overlap: "skip" },
+        },
+      },
       wakeup: true,
       runtime: {
         entry: "@voyant-travel/db/outbox-job",

--- a/packages/db/tests/unit/voyant-manifest.test.ts
+++ b/packages/db/tests/unit/voyant-manifest.test.ts
@@ -40,7 +40,7 @@ describe("database deployment manifest", () => {
           scheduling: {
             required: true,
             profiles: {
-              eager: { every: "30s", overlap: "skip" },
+              eager: { every: "1m", overlap: "skip" },
               economical: { every: "10m", overlap: "skip" },
             },
           },

--- a/packages/db/tests/unit/voyant-manifest.test.ts
+++ b/packages/db/tests/unit/voyant-manifest.test.ts
@@ -37,6 +37,13 @@ describe("database deployment manifest", () => {
         expect.objectContaining({
           id: "infrastructure.event-outbox-drain",
           schedule: { cron: "*/2 * * * *", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { every: "30s", overlap: "skip" },
+              economical: { every: "10m", overlap: "skip" },
+            },
+          },
           wakeup: true,
           runtime: {
             entry: "@voyant-travel/db/outbox-job",

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -108,6 +108,14 @@ export const notificationsVoyantModule = defineModule({
     {
       id: "notifications.send-due-reminders",
       schedule: { cron: "0 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "*/15 * * * *", overlap: "skip" },
+          economical: { cron: "0 */6 * * *", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/notifications/reminder-job",
         export: "runDueNotificationRemindersJob",

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -115,7 +115,6 @@ export const notificationsVoyantModule = defineModule({
           economical: { cron: "0 */6 * * *", overlap: "skip" },
         },
       },
-      wakeup: true,
       runtime: {
         entry: "@voyant-travel/notifications/reminder-job",
         export: "runDueNotificationRemindersJob",

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -46,6 +46,14 @@ describe("notifications deployment manifest", () => {
         {
           id: "notifications.send-due-reminders",
           schedule: { cron: "0 * * * *", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { cron: "*/15 * * * *", overlap: "skip" },
+              economical: { cron: "0 */6 * * *", overlap: "skip" },
+            },
+          },
+          wakeup: true,
           runtime: {
             entry: "@voyant-travel/notifications/reminder-job",
             export: "runDueNotificationRemindersJob",

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -53,7 +53,6 @@ describe("notifications deployment manifest", () => {
               economical: { cron: "0 */6 * * *", overlap: "skip" },
             },
           },
-          wakeup: true,
           runtime: {
             entry: "@voyant-travel/notifications/reminder-job",
             export: "runDueNotificationRemindersJob",


### PR DESCRIPTION
## Summary

Makes first-party maintenance jobs explicitly wakeable while retaining their existing package-owned schedules as recovery backstops. Each affected job now declares required bounded `eager` and `economical` cadence profiles through the #3670 scheduling-policy contract.

This covers booking hold expiry, catalog draft cleanup, notification reminders, promotion reindex and boundary processing, and the event-outbox drain. The architecture RFC now documents the operational trade-off: faster profiles reduce recovery latency; economical profiles reduce database work but extend missed-wakeup recovery time.

Payment completion and catalog updates continue to use their existing domain-event paths; the changed schedules are recovery and drift-repair controls, not new polling-first behavior.

Closes #3671.

## Validation

- `pnpm exec vitest run packages/bookings/tests/unit/voyant-manifest.test.ts packages/catalog/tests/unit/voyant-manifest.test.ts packages/commerce/tests/unit/voyant-manifest.test.ts packages/notifications/tests/unit/voyant-manifest.test.ts packages/db/tests/unit/voyant-manifest.test.ts` (remote Sprite)
- `git diff --check origin/main...HEAD`