### PR TITLE
Resolve managed staff organization context

### DIFF
--- a/.changeset/active-cloud-staff-organization.md
+++ b/.changeset/active-cloud-staff-organization.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Resolve managed staff sessions with the active Voyant Cloud link's platform organization so organization-scoped admin routes authorize correctly.

--- a/packages/auth/src/node-runtime.ts
+++ b/packages/auth/src/node-runtime.ts
@@ -10,12 +10,7 @@
  */
 
 import { type NodeDatabaseEnv, openNodeDatabase } from "@voyant-travel/db/runtime"
-import {
-  authUser,
-  cloudAuthUserLinks,
-  type SelectApikey,
-  userProfilesTable,
-} from "@voyant-travel/db/schema/iam"
+import { authUser, type SelectApikey, userProfilesTable } from "@voyant-travel/db/schema/iam"
 import {
   parseJsonBody,
   type Reporter,
@@ -29,7 +24,6 @@ import {
 } from "@voyant-travel/hono/middleware/error-boundary"
 import { getRequestId } from "@voyant-travel/hono/observability"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
-import { accessCatalogScopesForRole, isFullAccessRole } from "@voyant-travel/types/member-roles"
 import { eq, sql } from "drizzle-orm"
 import { type Context, Hono } from "hono"
 import { z } from "zod"
@@ -68,6 +62,7 @@ import {
   handleApiTokenManagementRequest,
   handleOrganizationMembersRequest,
 } from "./server.js"
+import { resolveStaffAccess } from "./staff-access.js"
 import { StorefrontCustomerAuthResolutionError } from "./storefront-customer-auth-resolver.js"
 import { ensureCurrentUserProfile } from "./workspace.js"
 
@@ -917,56 +912,7 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
     })
   }
 
-  const FULL_ACCESS_SCOPES = ["*"]
-
-  function scopesForOperatorRole(role: string | null | undefined): string[] | null {
-    const base = accessCatalogScopesForRole(role, runtimeOptions.accessCatalog)
-    if (!base) return null
-    const normalizedRole = (role ?? "").trim().toLowerCase()
-    const presetId =
-      normalizedRole === "member"
-        ? "editor"
-        : normalizedRole === "guest"
-          ? "viewer"
-          : normalizedRole
-    const selected = runtimeOptions.accessCatalog.presets.find(
-      (preset) => preset.kind === "staff" && preset.id === presetId,
-    )
-    return [...new Set([...base, ...(selected?.grants ?? [])])].sort()
-  }
-
-  /**
-   * Resolve a member's RBAC scope set for the request (`resource:action` strings,
-   * shared with API keys — see @voyant-travel/types/member-roles, RFC voyant#2085).
-   *
-   * Phase 1: storage + seam are wired but default to full access, so behavior is
-   * unchanged until an admin assigns permissions (Phase 2) and routes gate on them
-   * (Phase 3).
-   *  - voyant-cloud: assertion-mirrored `cloud_auth_user_links.scopes` if the
-   *    platform sent them, else the role bundle for `roleSlug`, else full access.
-   *  - local: the member's `user_profiles.permissions` if assigned, else full
-   *    access (no local role concept yet).
-   */
-  async function resolveMemberScopes(db: VoyantDb, env: Env, userId: string): Promise<string[]> {
-    if (isVoyantCloudAuthMode(env)) {
-      const [link] = await db
-        .select({ scopes: cloudAuthUserLinks.scopes, roleSlug: cloudAuthUserLinks.roleSlug })
-        .from(cloudAuthUserLinks)
-        .where(eq(cloudAuthUserLinks.userId, userId))
-        .limit(1)
-      const fullAccessScopes = scopesForOperatorRole("admin") ?? FULL_ACCESS_SCOPES
-      const roleScopes = scopesForOperatorRole(link?.roleSlug) ?? fullAccessScopes
-      return isFullAccessRole(link?.roleSlug) ? roleScopes : (link?.scopes ?? roleScopes)
-    }
-
-    const [profile] = await db
-      .select({ permissions: userProfilesTable.permissions })
-      .from(userProfilesTable)
-      .where(eq(userProfilesTable.id, userId))
-      .limit(1)
-    return profile?.permissions ?? FULL_ACCESS_SCOPES
-  }
-
+  /** Resolve the authenticated session and its realm-specific access context. */
   async function resolveAuthRequest(
     request: Request,
     env: Env,
@@ -1072,10 +1018,19 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
         }
       }
 
+      const staffAccess = await resolveStaffAccess({
+        accessCatalog: runtimeOptions.accessCatalog,
+        authMode: resolveOperatorAuthMode(env),
+        db,
+        deploymentId: env.VOYANT_CLOUD_DEPLOYMENT_ID,
+        userId: session.user.id,
+      })
+      if (!staffAccess) return null
+
       return {
         userId: session.user.id,
         sessionId: session.session.id,
-        organizationId: null,
+        organizationId: staffAccess.organizationId,
         callerType: "session",
         actor: "staff",
         realm: "admin",
@@ -1083,7 +1038,7 @@ export function createOperatorAuthNodeRuntime<Env extends OperatorAuthNodeEnv>(
         // an admin assigns permissions, so existing deployments are unchanged.
         // `actor: "staff"` is retained, so actor-gated paths (incl. the
         // bookings-pii reveal, which short-circuits on staff) are unaffected.
-        scopes: await resolveMemberScopes(db, env, session.user.id),
+        scopes: staffAccess.scopes,
         email: session.user.email ?? null,
       }
     } finally {

--- a/packages/auth/src/staff-access.ts
+++ b/packages/auth/src/staff-access.ts
@@ -1,0 +1,91 @@
+import { cloudAuthUserLinks, userProfilesTable } from "@voyant-travel/db/schema/iam"
+import type { VoyantDb } from "@voyant-travel/hono"
+import type { AccessCatalog } from "@voyant-travel/types/api-keys"
+import { accessCatalogScopesForRole, isFullAccessRole } from "@voyant-travel/types/member-roles"
+import { and, eq, isNull } from "drizzle-orm"
+
+const FULL_ACCESS_SCOPES = ["*"]
+const VOYANT_CLOUD_PROVIDER_ID = "voyant-cloud"
+
+export type StaffAccessContext = {
+  organizationId: string | null
+  scopes: string[]
+}
+
+function scopesForOperatorRole(
+  role: string | null | undefined,
+  accessCatalog: AccessCatalog,
+): string[] | null {
+  const base = accessCatalogScopesForRole(role, accessCatalog)
+  if (!base) return null
+  const normalizedRole = (role ?? "").trim().toLowerCase()
+  const presetId =
+    normalizedRole === "member" ? "editor" : normalizedRole === "guest" ? "viewer" : normalizedRole
+  const selected = accessCatalog.presets.find(
+    (preset) => preset.kind === "staff" && preset.id === presetId,
+  )
+  return [...new Set([...base, ...(selected?.grants ?? [])])].sort()
+}
+
+export async function resolveStaffAccess(input: {
+  accessCatalog: AccessCatalog
+  authMode: "local" | "voyant-cloud"
+  db: VoyantDb
+  deploymentId?: string
+  userId: string
+}): Promise<StaffAccessContext | null> {
+  if (input.authMode === "voyant-cloud") {
+    const deploymentId = input.deploymentId?.trim()
+    if (!deploymentId) return null
+
+    const [link] = await input.db
+      .select({
+        deploymentId: cloudAuthUserLinks.deploymentId,
+        platformOrganizationId: cloudAuthUserLinks.platformOrganizationId,
+        providerId: cloudAuthUserLinks.providerId,
+        revokedAt: cloudAuthUserLinks.revokedAt,
+        roleSlug: cloudAuthUserLinks.roleSlug,
+        scopes: cloudAuthUserLinks.scopes,
+      })
+      .from(cloudAuthUserLinks)
+      .where(
+        and(
+          eq(cloudAuthUserLinks.userId, input.userId),
+          eq(cloudAuthUserLinks.providerId, VOYANT_CLOUD_PROVIDER_ID),
+          eq(cloudAuthUserLinks.deploymentId, deploymentId),
+          isNull(cloudAuthUserLinks.revokedAt),
+        ),
+      )
+      .limit(1)
+
+    if (
+      !link ||
+      link.providerId !== VOYANT_CLOUD_PROVIDER_ID ||
+      link.deploymentId !== deploymentId ||
+      link.revokedAt ||
+      !link.platformOrganizationId.trim()
+    ) {
+      return null
+    }
+
+    const fullAccessScopes =
+      scopesForOperatorRole("admin", input.accessCatalog) ?? FULL_ACCESS_SCOPES
+    const roleScopes = scopesForOperatorRole(link.roleSlug, input.accessCatalog) ?? fullAccessScopes
+    return {
+      organizationId: link.platformOrganizationId,
+      scopes: isFullAccessRole(link.roleSlug) ? roleScopes : (link.scopes ?? roleScopes),
+    }
+  }
+
+  // Local deployments have no staff organization context. Preserve the
+  // existing profile-permission lookup and full-access compatibility fallback.
+  const [profile] = await input.db
+    .select({ permissions: userProfilesTable.permissions })
+    .from(userProfilesTable)
+    .where(eq(userProfilesTable.id, input.userId))
+    .limit(1)
+  return {
+    organizationId: null,
+    scopes: profile?.permissions ?? FULL_ACCESS_SCOPES,
+  }
+}

--- a/packages/auth/tests/unit/staff-access.test.ts
+++ b/packages/auth/tests/unit/staff-access.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { resolveStaffAccess } from "../../src/staff-access.js"
+
+const ACCESS_CATALOG = { resources: [], presets: [] }
+
+function databaseReturning(rows: unknown[]) {
+  const limit = vi.fn(async () => rows)
+  const where = vi.fn(() => ({ limit }))
+  const from = vi.fn(() => ({ where }))
+  return {
+    db: { select: vi.fn(() => ({ from })) },
+    from,
+    limit,
+    where,
+  }
+}
+
+function cloudLink(overrides: Record<string, unknown> = {}) {
+  return {
+    deploymentId: "deployment_1",
+    platformOrganizationId: "org_platform_1",
+    providerId: "voyant-cloud",
+    revokedAt: null,
+    roleSlug: "custom",
+    scopes: ["storefronts:read", "storefronts:write"],
+    ...overrides,
+  }
+}
+
+async function resolveCloud(rows: unknown[]) {
+  const database = databaseReturning(rows)
+  const access = await resolveStaffAccess({
+    accessCatalog: ACCESS_CATALOG,
+    authMode: "voyant-cloud",
+    db: database.db as never,
+    deploymentId: "deployment_1",
+    userId: "user_staff_1",
+  })
+  return { access, database }
+}
+
+describe("resolveStaffAccess", () => {
+  it("returns the exact organization and scopes from the active managed staff link", async () => {
+    const { access } = await resolveCloud([cloudLink()])
+
+    expect(access).toEqual({
+      organizationId: "org_platform_1",
+      scopes: ["storefronts:read", "storefronts:write"],
+    })
+  })
+
+  it.each([
+    { label: "missing", rows: [] },
+    { label: "revoked", rows: [cloudLink({ revokedAt: new Date("2026-07-22") })] },
+    { label: "another deployment", rows: [cloudLink({ deploymentId: "deployment_2" })] },
+    { label: "another provider", rows: [cloudLink({ providerId: "other-provider" })] },
+    { label: "blank organization", rows: [cloudLink({ platformOrganizationId: "   " })] },
+  ])("fails closed for $label managed staff access", async ({ rows }) => {
+    await expect(resolveCloud(rows)).resolves.toMatchObject({ access: null })
+  })
+
+  it("fails closed before querying when the managed deployment is missing", async () => {
+    const database = databaseReturning([cloudLink()])
+
+    await expect(
+      resolveStaffAccess({
+        accessCatalog: ACCESS_CATALOG,
+        authMode: "voyant-cloud",
+        db: database.db as never,
+        deploymentId: "   ",
+        userId: "user_staff_1",
+      }),
+    ).resolves.toBeNull()
+    expect(database.db.select).not.toHaveBeenCalled()
+  })
+
+  it("preserves an explicitly empty managed scope set", async () => {
+    const { access } = await resolveCloud([cloudLink({ scopes: [] })])
+
+    expect(access).toEqual({ organizationId: "org_platform_1", scopes: [] })
+  })
+
+  it("keeps the existing role fallback when managed scopes are absent", async () => {
+    const { access } = await resolveCloud([cloudLink({ roleSlug: "viewer", scopes: null })])
+
+    expect(access).toEqual({
+      organizationId: "org_platform_1",
+      scopes: ["*:read", "*:search"],
+    })
+  })
+
+  it("keeps local staff organization-less and resolves profile permissions", async () => {
+    const database = databaseReturning([{ permissions: ["catalog:read"] }])
+
+    await expect(
+      resolveStaffAccess({
+        accessCatalog: ACCESS_CATALOG,
+        authMode: "local",
+        db: database.db as never,
+        userId: "user_staff_1",
+      }),
+    ).resolves.toEqual({ organizationId: null, scopes: ["catalog:read"] })
+  })
+})


### PR DESCRIPTION
## What changed

- resolve managed staff access from the active `voyant-cloud` user link for the current deployment
- propagate the exact platform organization ID into the staff auth context
- preserve explicit scopes and the existing role fallback
- fail closed for missing, revoked, foreign-provider, wrong-deployment, or blank-organization links
- preserve local-mode organization and permission behavior
- add a patch changeset for `@voyant-travel/auth`

## Root cause

Managed admin sessions always returned `organizationId: null`, even though `cloud_auth_user_links` already stored the platform organization. Organization-scoped routes such as Storefronts correctly rejected those sessions with `No active operator organization.`

## Impact

Managed staff sessions receive their platform organization from the already-validated deployment-scoped link. Storefront administration can authorize correctly without adding synthetic local organizations or weakening the route guard.

## Validation

Remote disposable environment:

- Biome: passed
- focused staff-access tests: 10/10
- auth package typecheck: passed
- full auth package: 25 files / 226 tests passed; 4 integration files / 12 tests skipped by existing environment gates
- `git diff --check`: passed