### PR TITLE
Preserve setup steps in graph runtime lowering

### DIFF
--- a/.changeset/preserve-runtime-setup-steps.md
+++ b/.changeset/preserve-runtime-setup-steps.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Preserve package-declared setup steps while lowering selected graph units so runtime setup flows receive the selected project contract.

--- a/packages/framework/src/runtime-lowering.test.ts
+++ b/packages/framework/src/runtime-lowering.test.ts
@@ -90,6 +90,21 @@ function runtimeInput(load: () => Promise<unknown>) {
 }
 
 describe("graph runtime lowering", () => {
+  it("preserves selected setup steps on unit loaders and the aggregate runtime", () => {
+    const input = runtimeInput(async () => ({ createLoyaltyModule: () => ({}) }))
+    const setupSteps = [
+      { id: "@acme/voyant-loyalty#setup.connect", skippable: false },
+      { id: "@acme/voyant-loyalty#setup.import", skippable: true },
+    ]
+    const runtime = createVoyantGraphRuntime({
+      ...input,
+      modules: input.modules.map((module) => ({ ...module, setupSteps })),
+    })
+
+    expect(runtime.modules[0]?.setupSteps).toEqual(setupSteps)
+    expect(runtime.setupSteps).toEqual(setupSteps)
+  })
+
   it("exposes selected custom-field targets to graph runtime factories", () => {
     const input = runtimeInput(async () => ({ createLoyaltyModule: () => ({}) }))
     const runtime = createVoyantGraphRuntime({

--- a/packages/framework/src/runtime-lowering.ts
+++ b/packages/framework/src/runtime-lowering.ts
@@ -658,6 +658,7 @@ function createRuntimeUnitLoader(
     tools,
     jobs,
     actions: unit.actions,
+    setupSteps: unit.setupSteps,
     selectedIds: unit.selectedIds,
     routes,
     load: memoizePromise(() =>


### PR DESCRIPTION
## Summary

- preserve each selected unit's `setupSteps` on its runtime loader
- keep the aggregate `runtime.setupSteps` contract populated for setup runtime factories
- cover unit-level and aggregate preservation with a focused regression test

## Root cause

`lowerGraphRuntimeUnits` correctly copied package-declared setup steps into normalized unit definitions, but `createRuntimeUnitLoader` omitted that field from its explicit return object. The aggregate runtime then read setup steps from the loaders and always received an empty array.

## Validation

- [x] `pnpm --filter @voyant-travel/framework exec vitest run src/runtime-lowering.test.ts` (18/18)
- [x] `pnpm --filter @voyant-travel/framework typecheck`
- [x] `pnpm --filter @voyant-travel/framework lint` (passes with two pre-existing warnings)
