### PR TITLE
Accept empty streamed product job requests

### DIFF
--- a/.changeset/bounded-product-job-bodies.md
+++ b/.changeset/bounded-product-job-bodies.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Accept empty streamed product-job requests while rejecting non-empty request bodies with bounded memory use.

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -104,14 +104,6 @@ describe("Voyant Node product job host", () => {
       host.handleRequest(
         new Request(endpoint, {
           method: "POST",
-          headers: { "x-voyant-origin-trust": "secret", "transfer-encoding": "chunked" },
-        }),
-      ),
-    ).resolves.toMatchObject({ status: 400 })
-    await expect(
-      host.handleRequest(
-        new Request(endpoint, {
-          method: "POST",
           headers: {
             "x-voyant-origin-trust": "secret",
             "x-voyant-product-job-release": "rel_current",
@@ -141,6 +133,51 @@ describe("Voyant Node product job host", () => {
         executionToken: "00000000-0000-4000-8000-000000000001",
       }),
     )
+  })
+
+  it("accepts an empty streamed invocation body while rejecting actual request input", async () => {
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+    })
+    const endpoint = `https://operator.test${VOYANT_PRODUCT_JOB_ROUTE}/${encodeURIComponent(jobId)}`
+    const emptyStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.close()
+      },
+    })
+
+    const emptyResponse = await host.handleRequest(
+      new Request(endpoint, {
+        method: "POST",
+        headers: { "x-voyant-origin-trust": "secret", "transfer-encoding": "chunked" },
+        body: emptyStream,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    )
+    expect(emptyResponse?.status).toBe(202)
+    await host.settled(jobId)
+    expect(handler).toHaveBeenCalledOnce()
+
+    const bodyResponse = await host.handleRequest(
+      new Request(endpoint, {
+        method: "POST",
+        headers: { "x-voyant-origin-trust": "secret" },
+        body: "unexpected",
+      }),
+    )
+    expect(bodyResponse?.status).toBe(400)
+
+    const queryResponse = await host.handleRequest(
+      new Request(`${endpoint}?payload=unexpected`, {
+        method: "POST",
+        headers: { "x-voyant-origin-trust": "secret" },
+      }),
+    )
+    expect(queryResponse?.status).toBe(400)
+    expect(handler).toHaveBeenCalledOnce()
   })
 
   it("returns the closed managed-registration inventory envelope", async () => {

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -180,6 +180,36 @@ describe("Voyant Node product job host", () => {
     expect(handler).toHaveBeenCalledOnce()
   })
 
+  it("rejects and cancels a large invocation stream without waiting for EOF", async () => {
+    const handler = vi.fn(async () => {})
+    const cancel = vi.fn()
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      originTrustSecret: "secret",
+    })
+    const endpoint = `https://operator.test${VOYANT_PRODUCT_JOB_ROUTE}/${encodeURIComponent(jobId)}`
+    const neverEndingStream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(1024 * 1024))
+      },
+      cancel,
+    })
+
+    const response = await host.handleRequest(
+      new Request(endpoint, {
+        method: "POST",
+        headers: { "x-voyant-origin-trust": "secret", "transfer-encoding": "chunked" },
+        body: neverEndingStream,
+        duplex: "half",
+      } as RequestInit & { duplex: "half" }),
+    )
+
+    expect(response?.status).toBe(400)
+    expect(cancel).toHaveBeenCalledOnce()
+    expect(handler).not.toHaveBeenCalled()
+  })
+
   it("returns the closed managed-registration inventory envelope", async () => {
     const host = createVoyantNodeJobHost({
       runtime: jobRuntime(() => {}),

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -376,10 +376,15 @@ export function createVoyantNodeJobHost(
 
 async function requestHasBodyBytes(request: Request): Promise<boolean> {
   if (request.body === null) return false
+  const reader = request.body.getReader()
   try {
-    return (await request.arrayBuffer()).byteLength > 0
+    const { done } = await reader.read()
+    if (done) return false
+    void reader.cancel().catch(() => {})
+    return true
   } catch {
     // An unreadable stream cannot be validated as the required empty body.
+    void reader.cancel().catch(() => {})
     return true
   }
 }

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -286,13 +286,13 @@ export function createVoyantNodeJobHost(
     }
     if (url.pathname === VOYANT_PRODUCT_JOB_ROUTE) {
       if (request.method !== "GET") return new Response("Method Not Allowed", { status: 405 })
-      if (url.search || request.body !== null || request.headers.has("transfer-encoding")) {
+      if (url.search || (await requestHasBodyBytes(request))) {
         return new Response("Product job inventory requests do not accept input", { status: 400 })
       }
       return Response.json({ provisioning: { jobs: inventory } })
     }
     if (request.method !== "POST") return new Response("Method Not Allowed", { status: 405 })
-    if (url.search || request.body !== null || request.headers.has("transfer-encoding")) {
+    if (url.search || (await requestHasBodyBytes(request))) {
       return new Response("Product job invocations do not accept request input", { status: 400 })
     }
     const encodedId = url.pathname.slice(VOYANT_PRODUCT_JOB_ROUTE.length + 1)
@@ -371,6 +371,16 @@ export function createVoyantNodeJobHost(
       if (timer) clearInterval(timer)
       timer = undefined
     },
+  }
+}
+
+async function requestHasBodyBytes(request: Request): Promise<boolean> {
+  if (request.body === null) return false
+  try {
+    return (await request.arrayBuffer()).byteLength > 0
+  } catch {
+    // An unreadable stream cannot be validated as the required empty body.
+    return true
   }
 }
 


### PR DESCRIPTION
## Summary
- consume the product-job request body before deciding whether input was supplied
- accept streamed/chunked requests only when the consumed body is empty
- continue rejecting query input, non-empty bodies, and unreadable streams

## Why
Cloud Run presents an empty scheduler POST as a body stream/chunked request. The previous structural body check rejected it with 400, preventing every managed product job from running.

## Verification
- focused node job host tests: 11/11 passed remotely
- `@voyant-travel/framework` typecheck passed remotely
