### PR TITLE
Add durable catalog product reindex job

### DIFF
--- a/.changeset/calm-catalog-reindex.md
+++ b/.changeset/calm-catalog-reindex.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/catalog": minor
+"@voyant-travel/core": patch
+"@voyant-travel/framework": patch
+"@voyant-travel/inventory": patch
+---
+
+Add a provider-agnostic, durable catalog product reindex job that walks canonical inventory
+products in bounded pages and rebuilds their projections through the selected indexer runtime.
+Product job hosts now pass concrete deployment bindings to fixed job runtimes.

--- a/packages/catalog/migrations/0003_product_reindex_state.sql
+++ b/packages/catalog/migrations/0003_product_reindex_state.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "catalog_product_reindex_state" (
+	"tenant_id" text NOT NULL,
+	"reindex_key" text NOT NULL,
+	"requested_generation" bigint DEFAULT 0 NOT NULL,
+	"claimed_generation" bigint,
+	"completed_generation" bigint DEFAULT 0 NOT NULL,
+	"cursor_after_id" text,
+	"batches" integer DEFAULT 0 NOT NULL,
+	"scanned" integer DEFAULT 0 NOT NULL,
+	"indexed" integer DEFAULT 0 NOT NULL,
+	"retries" integer DEFAULT 0 NOT NULL,
+	"lease_owner" text,
+	"lease_until" timestamp with time zone,
+	"completed_at" timestamp with time zone,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "catalog_product_reindex_state_pk" PRIMARY KEY("tenant_id","reindex_key"),
+	CONSTRAINT "catalog_product_reindex_state_requested_nonnegative" CHECK ("catalog_product_reindex_state"."requested_generation" >= 0),
+	CONSTRAINT "catalog_product_reindex_state_completed_nonnegative" CHECK ("catalog_product_reindex_state"."completed_generation" >= 0),
+	CONSTRAINT "catalog_product_reindex_state_counters_nonnegative" CHECK ("catalog_product_reindex_state"."batches" >= 0 AND "catalog_product_reindex_state"."scanned" >= 0 AND "catalog_product_reindex_state"."indexed" >= 0 AND "catalog_product_reindex_state"."retries" >= 0)
+);

--- a/packages/catalog/migrations/meta/0003_snapshot.json
+++ b/packages/catalog/migrations/meta/0003_snapshot.json
@@ -1,0 +1,1411 @@
+{
+  "id": "6211dff3-1a3b-49c1-b0f7-e7c37d62eb5e",
+  "prevId": "dbd13dfb-a45f-4e5e-afbe-a15bbeac1e90",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.booking_catalog_snapshot": {
+      "name": "booking_catalog_snapshot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "booking_id": {
+          "name": "booking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_module": {
+          "name": "entity_module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_connection_id": {
+          "name": "source_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "frozen_payload": {
+          "name": "frozen_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlay_state_at_capture": {
+          "name": "overlay_state_at_capture",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_base_amount": {
+          "name": "pricing_base_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_taxes": {
+          "name": "pricing_taxes",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_fees": {
+          "name": "pricing_fees",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_surcharges": {
+          "name": "pricing_surcharges",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_currency": {
+          "name": "pricing_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_breakdown": {
+          "name": "pricing_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_applied_offers": {
+          "name": "pricing_applied_offers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "booking_catalog_snapshot_booking_entity_uniq": {
+          "name": "booking_catalog_snapshot_booking_entity_uniq",
+          "columns": [
+            {
+              "expression": "booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "booking_catalog_snapshot_idempotency_uniq": {
+          "name": "booking_catalog_snapshot_idempotency_uniq",
+          "columns": [
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "idempotency_key is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.booking_drafts": {
+      "name": "booking_drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_module": {
+          "name": "entity_module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_connection_id": {
+          "name": "source_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_payload": {
+          "name": "draft_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_step": {
+          "name": "current_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_quote_id": {
+          "name": "current_quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hold_expires_at": {
+          "name": "hold_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_booking_id": {
+          "name": "consumed_booking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_booking_drafts_entity": {
+          "name": "idx_booking_drafts_entity",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_drafts_expires": {
+          "name": "idx_booking_drafts_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_drafts_created_by": {
+          "name": "idx_booking_drafts_created_by",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_booking_drafts_consumed": {
+          "name": "idx_booking_drafts_consumed",
+          "columns": [
+            {
+              "expression": "consumed_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_overlay_history": {
+      "name": "catalog_overlay_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "overlay_id": {
+          "name": "overlay_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_module": {
+          "name": "entity_module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_kind": {
+          "name": "node_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'root'"
+        },
+        "node_key": {
+          "name": "node_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'root'"
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_value": {
+          "name": "previous_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_value": {
+          "name": "next_value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "previous_version": {
+          "name": "previous_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_version": {
+          "name": "next_version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "origin": {
+          "name": "origin",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "editorial_note": {
+          "name": "editorial_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalog_overlay_history_overlay_idx": {
+          "name": "catalog_overlay_history_overlay_idx",
+          "columns": [
+            {
+              "expression": "overlay_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_overlay_history_target_idx": {
+          "name": "catalog_overlay_history_target_idx",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_overlay": {
+      "name": "catalog_overlay",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_module": {
+          "name": "entity_module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_kind": {
+          "name": "node_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'root'"
+        },
+        "node_key": {
+          "name": "node_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'root'"
+        },
+        "field_path": {
+          "name": "field_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'default'"
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "editorial_note": {
+          "name": "editorial_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalog_overlay_variant_uniq": {
+          "name": "catalog_overlay_variant_uniq",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "node_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "field_path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "locale",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "audience",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "market",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_overlay\".\"deleted_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_overlay_entity_idx": {
+          "name": "catalog_overlay_entity_idx",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "deleted_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_overlay_origin_idx": {
+          "name": "catalog_overlay_origin_idx",
+          "columns": [
+            {
+              "expression": "origin",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_product_reindex_state": {
+      "name": "catalog_product_reindex_state",
+      "schema": "",
+      "columns": {
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reindex_key": {
+          "name": "reindex_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_generation": {
+          "name": "requested_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_generation": {
+          "name": "claimed_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_generation": {
+          "name": "completed_generation",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cursor_after_id": {
+          "name": "cursor_after_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "batches": {
+          "name": "batches",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "scanned": {
+          "name": "scanned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "indexed": {
+          "name": "indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "retries": {
+          "name": "retries",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_until": {
+          "name": "lease_until",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "catalog_product_reindex_state_pk": {
+          "name": "catalog_product_reindex_state_pk",
+          "columns": [
+            "tenant_id",
+            "reindex_key"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "catalog_product_reindex_state_requested_nonnegative": {
+          "name": "catalog_product_reindex_state_requested_nonnegative",
+          "value": "\"catalog_product_reindex_state\".\"requested_generation\" >= 0"
+        },
+        "catalog_product_reindex_state_completed_nonnegative": {
+          "name": "catalog_product_reindex_state_completed_nonnegative",
+          "value": "\"catalog_product_reindex_state\".\"completed_generation\" >= 0"
+        },
+        "catalog_product_reindex_state_counters_nonnegative": {
+          "name": "catalog_product_reindex_state_counters_nonnegative",
+          "value": "\"catalog_product_reindex_state\".\"batches\" >= 0 AND \"catalog_product_reindex_state\".\"scanned\" >= 0 AND \"catalog_product_reindex_state\".\"indexed\" >= 0 AND \"catalog_product_reindex_state\".\"retries\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.catalog_quotes": {
+      "name": "catalog_quotes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_module": {
+          "name": "entity_module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_connection_id": {
+          "name": "source_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available": {
+          "name": "available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invalid_reason": {
+          "name": "invalid_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "audience": {
+          "name": "audience",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "market": {
+          "name": "market",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_base_amount": {
+          "name": "pricing_base_amount",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_taxes": {
+          "name": "pricing_taxes",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_fees": {
+          "name": "pricing_fees",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_surcharges": {
+          "name": "pricing_surcharges",
+          "type": "numeric(18, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_currency": {
+          "name": "pricing_currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_breakdown": {
+          "name": "pricing_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pricing_applied_offers": {
+          "name": "pricing_applied_offers",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_payload": {
+          "name": "upstream_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consumed_booking_id": {
+          "name": "consumed_booking_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_catalog_quotes_entity": {
+          "name": "idx_catalog_quotes_entity",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_catalog_quotes_expires": {
+          "name": "idx_catalog_quotes_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_catalog_quotes_source": {
+          "name": "idx_catalog_quotes_source",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_catalog_quotes_consumed_booking": {
+          "name": "idx_catalog_quotes_consumed_booking",
+          "columns": [
+            {
+              "expression": "consumed_booking_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.catalog_sourced_entries": {
+      "name": "catalog_sourced_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_module": {
+          "name": "entity_module",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_provider": {
+          "name": "source_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_connection_id": {
+          "name": "source_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_ref": {
+          "name": "source_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_freshness": {
+          "name": "source_freshness",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_sourced_at": {
+          "name": "last_sourced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "first_seen_at": {
+          "name": "first_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "projection": {
+          "name": "projection",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "projection_etag": {
+          "name": "projection_etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "projection_seen_at": {
+          "name": "projection_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "catalog_sourced_entries_entity_uniq": {
+          "name": "catalog_sourced_entries_entity_uniq",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_sourced_entries_source_connected_uniq": {
+          "name": "catalog_sourced_entries_source_connected_uniq",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_sourced_entries\".\"source_connection_id\" IS NOT NULL AND \"catalog_sourced_entries\".\"source_ref\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_sourced_entries_source_connectionless_uniq": {
+          "name": "catalog_sourced_entries_source_connectionless_uniq",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"catalog_sourced_entries\".\"source_connection_id\" IS NULL AND \"catalog_sourced_entries\".\"source_ref\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_sourced_entries_module_kind_idx": {
+          "name": "catalog_sourced_entries_module_kind_idx",
+          "columns": [
+            {
+              "expression": "entity_module",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_sourced_entries_status_seen_idx": {
+          "name": "catalog_sourced_entries_status_seen_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_seen_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "catalog_sourced_entries_connection_age_idx": {
+          "name": "catalog_sourced_entries_connection_age_idx",
+          "columns": [
+            {
+              "expression": "source_kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "last_sourced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/catalog/migrations/meta/_journal.json
+++ b/packages/catalog/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781947489707,
       "tag": "0002_catalog_baseline",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1784794175178,
+      "tag": "0003_product_reindex_state",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -55,6 +55,7 @@
     "./booking-engine/operator-routes": "./src/booking-engine/operator-routes.ts",
     "./runtime-port": "./src/content-runtime-port.ts",
     "./draft-reaper-job": "./src/draft-reaper-job.ts",
+    "./reindex-job": "./src/reindex-job.ts",
     "./graph-runtime": "./src/graph-runtime.ts",
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./voyant": "./src/voyant.ts",
@@ -361,6 +362,11 @@
         "types": "./dist/draft-reaper-job.d.ts",
         "import": "./dist/draft-reaper-job.js",
         "default": "./dist/draft-reaper-job.js"
+      },
+      "./reindex-job": {
+        "types": "./dist/reindex-job.d.ts",
+        "import": "./dist/reindex-job.js",
+        "default": "./dist/reindex-job.js"
       },
       "./graph-runtime": {
         "types": "./dist/graph-runtime.d.ts",

--- a/packages/catalog/src/reindex-job-runtime-port.ts
+++ b/packages/catalog/src/reindex-job-runtime-port.ts
@@ -1,0 +1,101 @@
+import { definePort } from "@voyant-travel/core/project"
+
+export interface CatalogReindexProductsPage {
+  afterId?: string
+  limit: number
+}
+
+export interface CatalogReindexClaim {
+  tenantId: string
+  generation: number
+  leaseOwner: string
+  afterId?: string
+  batches: number
+  scanned: number
+  indexed: number
+  retries: number
+}
+
+export type CatalogReindexProgress =
+  | {
+      phase: "failure"
+      tenantId: string
+      generation: number
+      productId: string
+      attempts: number
+      error: string
+    }
+  | {
+      phase: "batch"
+      tenantId: string
+      generation: number
+      batches: number
+      scanned: number
+      indexed: number
+      retries: number
+      afterId: string
+    }
+  | {
+      phase: "complete"
+      tenantId: string
+      generation: number
+      batches: number
+      scanned: number
+      indexed: number
+      retries: number
+    }
+
+export interface CatalogReindexCheckpoint {
+  afterId?: string
+  batches: number
+  scanned: number
+  indexed: number
+  retries: number
+}
+
+export interface CatalogReindexJobRuntime {
+  requestGeneration(): Promise<number>
+  claimWork(leaseOwner: string): Promise<CatalogReindexClaim | null>
+  renewLease(claim: CatalogReindexClaim): Promise<boolean>
+  checkpoint(claim: CatalogReindexClaim, checkpoint: CatalogReindexCheckpoint): Promise<boolean>
+  complete(claim: CatalogReindexClaim, checkpoint: CatalogReindexCheckpoint): Promise<boolean>
+  releaseLease(claim: CatalogReindexClaim): Promise<void>
+  listProductIdsPage(input: CatalogReindexProductsPage): Promise<readonly string[]>
+  reindexProduct(productId: string): Promise<void>
+  reportProgress(progress: CatalogReindexProgress): void
+  sleep?(milliseconds: number): Promise<void>
+  createLeaseOwner?(): string
+}
+
+export interface CatalogReindexJobRuntimeProvider {
+  createRuntime(bindings: unknown): CatalogReindexJobRuntime | Promise<CatalogReindexJobRuntime>
+}
+
+const RUNTIME_METHODS = [
+  "requestGeneration",
+  "claimWork",
+  "renewLease",
+  "checkpoint",
+  "complete",
+  "releaseLease",
+  "listProductIdsPage",
+  "reindexProduct",
+  "reportProgress",
+] as const
+
+export const catalogReindexJobRuntimePort = definePort<CatalogReindexJobRuntimeProvider>({
+  id: "catalog.reindex-products-job",
+  test(provider) {
+    if (!provider || typeof provider.createRuntime !== "function") {
+      throw new Error("catalog.reindex-products-job provider must implement createRuntime().")
+    }
+  },
+})
+
+export function validateCatalogReindexJobRuntime(runtime: CatalogReindexJobRuntime): void {
+  for (const method of RUNTIME_METHODS) {
+    if (typeof runtime[method] !== "function") {
+      throw new Error(`catalog.reindex-products-job runtime must implement ${method}().`)
+    }
+  }
+}

--- a/packages/catalog/src/reindex-job.test.ts
+++ b/packages/catalog/src/reindex-job.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import {
+  CATALOG_REINDEX_BATCH_SIZE,
+  CatalogReindexError,
+  runCatalogReindexProducts,
+  runCatalogReindexProductsJob,
+} from "./reindex-job.js"
+import type {
+  CatalogReindexClaim,
+  CatalogReindexJobRuntime,
+  CatalogReindexProgress,
+} from "./reindex-job-runtime-port.js"
+
+const initialClaim: CatalogReindexClaim = {
+  tenantId: "tenant_pro_travel",
+  generation: 4,
+  leaseOwner: "lease_1",
+  batches: 0,
+  scanned: 0,
+  indexed: 0,
+  retries: 0,
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function createRuntime(
+  productIds: readonly string[],
+  claim: CatalogReindexClaim | null = initialClaim,
+) {
+  const indexed: string[] = []
+  const pages: Array<{ afterId?: string; limit: number }> = []
+  const progress: CatalogReindexProgress[] = []
+  const checkpoints: unknown[] = []
+  let completed = false
+  let released = false
+  const runtime: CatalogReindexJobRuntime = {
+    requestGeneration: vi.fn(async () => 4),
+    claimWork: vi.fn(async () => claim),
+    renewLease: vi.fn(async () => true),
+    checkpoint: vi.fn(async (_claim, checkpoint) => {
+      checkpoints.push(checkpoint)
+      return true
+    }),
+    complete: vi.fn(async () => {
+      completed = true
+      return true
+    }),
+    releaseLease: vi.fn(async () => {
+      released = true
+    }),
+    async listProductIdsPage(input) {
+      pages.push(input)
+      const start = input.afterId ? productIds.indexOf(input.afterId) + 1 : 0
+      return productIds.slice(start, start + input.limit)
+    },
+    async reindexProduct(productId) {
+      indexed.push(productId)
+    },
+    reportProgress(update) {
+      progress.push(update)
+    },
+    sleep: vi.fn(async () => undefined),
+    createLeaseOwner: () => "lease_1",
+  }
+  return {
+    checkpoints,
+    completed: () => completed,
+    indexed,
+    pages,
+    progress,
+    released: () => released,
+    runtime,
+  }
+}
+
+describe("catalog product reindex job", () => {
+  it("walks canonical product IDs in bounded pages and checkpoints every batch", async () => {
+    const productIds = Array.from(
+      { length: CATALOG_REINDEX_BATCH_SIZE * 2 + 5 },
+      (_, index) => `product_${String(index).padStart(3, "0")}`,
+    )
+    const harness = createRuntime(productIds)
+
+    await expect(runCatalogReindexProducts(harness.runtime)).resolves.toEqual({
+      tenantId: "tenant_pro_travel",
+      generation: 4,
+      afterId: "product_204",
+      batches: 3,
+      scanned: 205,
+      indexed: 205,
+      retries: 0,
+    })
+    expect(harness.indexed).toEqual(productIds)
+    expect(harness.pages).toEqual([
+      { afterId: undefined, limit: CATALOG_REINDEX_BATCH_SIZE },
+      { afterId: "product_099", limit: CATALOG_REINDEX_BATCH_SIZE },
+      { afterId: "product_199", limit: CATALOG_REINDEX_BATCH_SIZE },
+    ])
+    expect(harness.checkpoints).toHaveLength(3)
+    expect(harness.completed()).toBe(true)
+    expect(harness.released()).toBe(false)
+    expect(harness.progress.at(-1)).toEqual({
+      phase: "complete",
+      tenantId: "tenant_pro_travel",
+      generation: 4,
+      batches: 3,
+      scanned: 205,
+      indexed: 205,
+      retries: 0,
+    })
+  })
+
+  it("resumes after the durable cursor and counters", async () => {
+    const productIds = ["product_001", "product_002", "product_003"]
+    const harness = createRuntime(productIds, {
+      ...initialClaim,
+      afterId: "product_001",
+      batches: 1,
+      scanned: 1,
+      indexed: 1,
+      retries: 2,
+    })
+
+    await expect(runCatalogReindexProducts(harness.runtime)).resolves.toMatchObject({
+      afterId: "product_003",
+      batches: 2,
+      scanned: 3,
+      indexed: 3,
+      retries: 2,
+    })
+    expect(harness.indexed).toEqual(["product_002", "product_003"])
+    expect(harness.pages[0]).toEqual({
+      afterId: "product_001",
+      limit: CATALOG_REINDEX_BATCH_SIZE,
+    })
+  })
+
+  it("retries one projection, releases the lease, and preserves the previous checkpoint", async () => {
+    const harness = createRuntime(["product_001", "product_002", "product_003"])
+    const attempts = new Map<string, number>()
+    harness.runtime.reindexProduct = vi.fn(async (productId) => {
+      const attempt = (attempts.get(productId) ?? 0) + 1
+      attempts.set(productId, attempt)
+      if (productId === "product_002") throw new Error("permanent")
+      harness.indexed.push(productId)
+    })
+
+    const failure = await runCatalogReindexProducts(harness.runtime).catch((error) => error)
+
+    expect(failure).toBeInstanceOf(CatalogReindexError)
+    expect(failure.result).toMatchObject({
+      tenantId: "tenant_pro_travel",
+      generation: 4,
+      scanned: 2,
+      indexed: 1,
+      retries: 2,
+    })
+    expect(harness.checkpoints).toEqual([])
+    expect(harness.completed()).toBe(false)
+    expect(harness.released()).toBe(true)
+    expect(harness.progress).toContainEqual({
+      phase: "failure",
+      tenantId: "tenant_pro_travel",
+      generation: 4,
+      productId: "product_002",
+      attempts: 3,
+      error: "permanent",
+    })
+  })
+
+  it("threads the concrete job bindings through the runtime provider", async () => {
+    const harness = createRuntime([])
+    const bindings = { TENANT_ID: "tenant_pro_travel", DATABASE_URL: "postgres://tenant" }
+    const createJobRuntime = vi.fn(async () => harness.runtime)
+    const getPort = vi.fn(async () => ({ createRuntime: createJobRuntime }))
+
+    await runCatalogReindexProductsJob({ bindings, getPort } as never)
+
+    expect(createJobRuntime).toHaveBeenCalledWith(bindings)
+    expect(harness.runtime.requestGeneration).toHaveBeenCalledOnce()
+    expect(harness.runtime.claimWork).toHaveBeenCalledWith("lease_1")
+  })
+
+  it("stops heartbeats before draining a deferred renewal and committing success", async () => {
+    vi.useFakeTimers()
+    const harness = createRuntime(["product_001"])
+    let finishReindex: (() => void) | undefined
+    let finishRenewal: ((renewed: boolean) => void) | undefined
+    harness.runtime.reindexProduct = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishReindex = resolve
+        }),
+    )
+    harness.runtime.renewLease = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finishRenewal = resolve
+        }),
+    )
+
+    const execution = runCatalogReindexProducts(harness.runtime)
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(harness.runtime.renewLease).toHaveBeenCalledOnce()
+
+    finishReindex?.()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(harness.runtime.complete).not.toHaveBeenCalled()
+
+    finishRenewal?.(true)
+    await expect(execution).resolves.toMatchObject({ indexed: 1 })
+    expect(harness.runtime.complete).toHaveBeenCalledOnce()
+
+    await vi.advanceTimersByTimeAsync(30_000)
+    expect(harness.runtime.renewLease).toHaveBeenCalledOnce()
+  })
+
+  it("rejects job invocation without concrete deployment bindings", async () => {
+    await expect(runCatalogReindexProductsJob({ getPort: vi.fn() } as never)).rejects.toThrow(
+      "requires concrete deployment job bindings",
+    )
+  })
+})

--- a/packages/catalog/src/reindex-job.ts
+++ b/packages/catalog/src/reindex-job.ts
@@ -1,0 +1,213 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+
+import {
+  type CatalogReindexCheckpoint,
+  type CatalogReindexJobRuntime,
+  catalogReindexJobRuntimePort,
+  validateCatalogReindexJobRuntime,
+} from "./reindex-job-runtime-port.js"
+
+export {
+  type CatalogReindexJobRuntime,
+  type CatalogReindexJobRuntimeProvider,
+  type CatalogReindexProgress,
+  catalogReindexJobRuntimePort,
+} from "./reindex-job-runtime-port.js"
+
+export const CATALOG_REINDEX_BATCH_SIZE = 100
+export const CATALOG_REINDEX_MAX_ATTEMPTS = 3
+export const CATALOG_REINDEX_HEARTBEAT_MS = 30_000
+const INITIAL_RETRY_DELAY_MS = 250
+
+export interface CatalogReindexResult extends CatalogReindexCheckpoint {
+  tenantId: string
+  generation: number
+}
+
+export class CatalogReindexError extends Error {
+  constructor(
+    readonly result: CatalogReindexResult,
+    readonly productId: string,
+  ) {
+    super(
+      `Catalog product reindex failed for ${productId} in tenant ${result.tenantId} generation ${result.generation}.`,
+    )
+    this.name = "CatalogReindexError"
+  }
+}
+
+/**
+ * Persist one coalescing reindex generation, then drain it under a durable
+ * tenant-scoped lease. Host retries and duplicate wakeups resume the same
+ * checkpoint instead of starting competing full scans.
+ */
+export async function runCatalogReindexProductsJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  if (!context.bindings || typeof context.bindings !== "object") {
+    throw new Error("Catalog product reindex requires concrete deployment job bindings.")
+  }
+  const provider = await context.getPort(catalogReindexJobRuntimePort)
+  const runtime = await provider.createRuntime(context.bindings)
+  validateCatalogReindexJobRuntime(runtime)
+  await runtime.requestGeneration()
+  await runCatalogReindexProducts(runtime)
+}
+
+export async function runCatalogReindexProducts(
+  runtime: CatalogReindexJobRuntime,
+): Promise<CatalogReindexResult | null> {
+  const leaseOwner = runtime.createLeaseOwner?.() ?? crypto.randomUUID()
+  const claim = await runtime.claimWork(leaseOwner)
+  if (!claim) return null
+
+  let leaseLost = false
+  let renewal = Promise.resolve()
+  const renew = () => {
+    renewal = renewal
+      .then(async () => {
+        if (!(await runtime.renewLease(claim))) leaseLost = true
+      })
+      .catch(() => {
+        leaseLost = true
+      })
+  }
+  const heartbeat = setInterval(renew, CATALOG_REINDEX_HEARTBEAT_MS)
+  heartbeat.unref?.()
+  let heartbeatStopped = false
+  const stopHeartbeat = () => {
+    if (heartbeatStopped) return
+    heartbeatStopped = true
+    clearInterval(heartbeat)
+  }
+
+  const result: CatalogReindexResult = {
+    tenantId: claim.tenantId,
+    generation: claim.generation,
+    ...(claim.afterId ? { afterId: claim.afterId } : {}),
+    batches: claim.batches,
+    scanned: claim.scanned,
+    indexed: claim.indexed,
+    retries: claim.retries,
+  }
+
+  try {
+    let afterId = claim.afterId
+    while (true) {
+      assertLease(leaseLost)
+      const productIds = await runtime.listProductIdsPage({
+        afterId,
+        limit: CATALOG_REINDEX_BATCH_SIZE,
+      })
+      if (productIds.length === 0) break
+
+      let lastIndexedId = afterId
+      for (const productId of productIds) {
+        assertLease(leaseLost)
+        result.scanned++
+        const attempt = await reindexWithRetry(runtime, productId, result)
+        if (!attempt.ok) {
+          runtime.reportProgress({
+            phase: "failure",
+            tenantId: claim.tenantId,
+            generation: claim.generation,
+            productId,
+            attempts: CATALOG_REINDEX_MAX_ATTEMPTS,
+            error: errorMessage(attempt.error),
+          })
+          throw new CatalogReindexError(result, productId)
+        }
+        result.indexed++
+        lastIndexedId = productId
+      }
+
+      if (!lastIndexedId) break
+      afterId = lastIndexedId
+      result.afterId = afterId
+      result.batches++
+      const checkpoint = checkpointFrom(result, afterId)
+      if (!(await runtime.checkpoint(claim, checkpoint))) leaseLost = true
+      assertLease(leaseLost)
+      runtime.reportProgress({
+        phase: "batch",
+        tenantId: claim.tenantId,
+        generation: claim.generation,
+        ...checkpoint,
+        afterId,
+      })
+      if (productIds.length < CATALOG_REINDEX_BATCH_SIZE) break
+    }
+
+    stopHeartbeat()
+    await renewal
+    assertLease(leaseLost)
+    const checkpoint = checkpointFrom(result, result.afterId)
+    if (!(await runtime.complete(claim, checkpoint))) leaseLost = true
+    assertLease(leaseLost)
+    runtime.reportProgress({
+      phase: "complete",
+      tenantId: claim.tenantId,
+      generation: claim.generation,
+      batches: result.batches,
+      scanned: result.scanned,
+      indexed: result.indexed,
+      retries: result.retries,
+    })
+    return result
+  } catch (error) {
+    stopHeartbeat()
+    await runtime.releaseLease(claim)
+    throw error
+  } finally {
+    stopHeartbeat()
+    await renewal
+  }
+}
+
+async function reindexWithRetry(
+  runtime: CatalogReindexJobRuntime,
+  productId: string,
+  result: CatalogReindexResult,
+): Promise<{ ok: true } | { ok: false; error: unknown }> {
+  let delay = INITIAL_RETRY_DELAY_MS
+  for (let attempt = 1; attempt <= CATALOG_REINDEX_MAX_ATTEMPTS; attempt++) {
+    try {
+      await runtime.reindexProduct(productId)
+      return { ok: true }
+    } catch (error) {
+      if (attempt === CATALOG_REINDEX_MAX_ATTEMPTS) return { ok: false, error }
+      result.retries++
+      await (runtime.sleep ?? defaultSleep)(delay)
+      delay *= 2
+    }
+  }
+  return {
+    ok: false,
+    error: new Error(`Catalog reindex attempts exhausted for ${productId}.`),
+  }
+}
+
+function checkpointFrom(
+  result: CatalogReindexResult,
+  afterId: string | undefined,
+): CatalogReindexCheckpoint {
+  return {
+    ...(afterId ? { afterId } : {}),
+    batches: result.batches,
+    scanned: result.scanned,
+    indexed: result.indexed,
+    retries: result.retries,
+  }
+}
+
+function assertLease(leaseLost: boolean): void {
+  if (leaseLost) throw new Error("Catalog product reindex lease was lost before completion.")
+}
+
+function defaultSleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/catalog/src/reindex-state-schema.ts
+++ b/packages/catalog/src/reindex-state-schema.ts
@@ -1,0 +1,47 @@
+import { sql } from "drizzle-orm"
+import { bigint, check, integer, pgTable, primaryKey, text, timestamp } from "drizzle-orm/pg-core"
+
+/**
+ * Durable, tenant-scoped cursor and lease for a coalesced Catalog product
+ * reindex generation.
+ */
+export const catalogProductReindexStateTable = pgTable(
+  "catalog_product_reindex_state",
+  {
+    tenantId: text("tenant_id").notNull(),
+    reindexKey: text("reindex_key").notNull(),
+    requestedGeneration: bigint("requested_generation", { mode: "number" }).notNull().default(0),
+    claimedGeneration: bigint("claimed_generation", { mode: "number" }),
+    completedGeneration: bigint("completed_generation", { mode: "number" }).notNull().default(0),
+    cursorAfterId: text("cursor_after_id"),
+    batches: integer("batches").notNull().default(0),
+    scanned: integer("scanned").notNull().default(0),
+    indexed: integer("indexed").notNull().default(0),
+    retries: integer("retries").notNull().default(0),
+    leaseOwner: text("lease_owner"),
+    leaseUntil: timestamp("lease_until", { withTimezone: true }),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({
+      name: "catalog_product_reindex_state_pk",
+      columns: [table.tenantId, table.reindexKey],
+    }),
+    check(
+      "catalog_product_reindex_state_requested_nonnegative",
+      sql`${table.requestedGeneration} >= 0`,
+    ),
+    check(
+      "catalog_product_reindex_state_completed_nonnegative",
+      sql`${table.completedGeneration} >= 0`,
+    ),
+    check(
+      "catalog_product_reindex_state_counters_nonnegative",
+      sql`${table.batches} >= 0 AND ${table.scanned} >= 0 AND ${table.indexed} >= 0 AND ${table.retries} >= 0`,
+    ),
+  ],
+)
+
+export type SelectCatalogProductReindexState = typeof catalogProductReindexStateTable.$inferSelect
+export type InsertCatalogProductReindexState = typeof catalogProductReindexStateTable.$inferInsert

--- a/packages/catalog/src/runtime-contracts.ts
+++ b/packages/catalog/src/runtime-contracts.ts
@@ -122,6 +122,10 @@ export type CatalogProductQuoteEnricher = (input: {
 export interface CatalogInventoryRuntimeExtension {
   readonly productFieldPolicy: readonly FieldPolicy[]
   readonly extrasFieldPolicy: readonly FieldPolicy[]
+  listCanonicalProductIds(
+    db: AnyDrizzleDb,
+    input: { afterId?: string; limit: number },
+  ): Promise<readonly string[]>
   createDocumentBuilder(input: {
     db: AnyDrizzleDb
     sellerOperatorId: string

--- a/packages/catalog/src/runtime-contributor.test.ts
+++ b/packages/catalog/src/runtime-contributor.test.ts
@@ -1,6 +1,19 @@
 import { catalogSearchRuntimePort } from "@voyant-travel/catalog/api-runtime-ports"
+import { createFieldPolicyRegistry } from "@voyant-travel/catalog/contract"
 import { catalogIndexerProviderPort } from "@voyant-travel/catalog/indexer/provider"
-import { describe, expect, it } from "vitest"
+import { catalogReindexJobRuntimePort } from "@voyant-travel/catalog/reindex-job"
+import {
+  catalogAccommodationsRuntimeExtensionPort,
+  catalogChartersRuntimeExtensionPort,
+  catalogCommerceRuntimeExtensionPort,
+  catalogCruisesRuntimeExtensionPort,
+  catalogDistributionRuntimeExtensionPort,
+  catalogInventoryRuntimeExtensionPort,
+  catalogOperationsRuntimeExtensionPort,
+} from "@voyant-travel/catalog/runtime-contracts"
+import type { IndexerAdapter } from "@voyant-travel/catalog-contracts/indexer/contract"
+import { financeOperatorSettingsRuntimePort } from "@voyant-travel/finance/runtime-port"
+import { describe, expect, it, vi } from "vitest"
 
 import { createCatalogRuntimePortContribution } from "./runtime-contributor.js"
 
@@ -29,5 +42,129 @@ describe("createCatalogRuntimePortContribution", () => {
       "catalog.indexer must implement IndexerAdapter or IndexerProvider.create().",
     )
     await observed
+  })
+
+  it("fails explicitly when a product reindex is requested without an indexer", async () => {
+    const contribution = createCatalogRuntimePortContribution({
+      primitives: {} as never,
+      hasRuntimePort: () => false,
+      getRuntimePort: vi.fn() as never,
+    })
+    const provider = contribution[catalogReindexJobRuntimePort.id] as {
+      createRuntime(bindings: unknown): Promise<unknown>
+    }
+
+    await expect(provider.createRuntime({ TENANT_ID: "tenant_pro_travel" })).rejects.toThrow(
+      "requires a configured catalog indexer",
+    )
+    await Promise.allSettled(
+      Object.values(contribution).filter(
+        (value): value is Promise<unknown> => value instanceof Promise,
+      ),
+    )
+  })
+
+  it("uses the same non-default tenant bindings for inventory and the selected indexer", async () => {
+    const bindings = { TENANT_ID: "tenant_pro_travel", DATABASE_URL: "postgres://tenant" }
+    const transaction = vi.fn(async (receivedBindings, operation) => {
+      expect(receivedBindings).toBe(bindings)
+      return operation({})
+    })
+    const upsert = vi.fn(async () => undefined)
+    const adapter: IndexerAdapter = {
+      capabilities: {
+        supportsKeywordSearch: true,
+        supportsHybridSearch: false,
+        supportsVectorFields: false,
+        vectorDimensions: null,
+        maxVectorsPerDocument: null,
+        supportsCrossAudienceFederation: false,
+        supportsAdminDenormalization: true,
+      },
+      ensureCollection: vi.fn(async () => undefined),
+      upsert,
+      delete: vi.fn(async () => undefined),
+      search: vi.fn(async () => ({ hits: [], total: 0 })),
+      bulkReindex: vi.fn(async () => undefined),
+    }
+    const createIndexer = vi.fn(() => adapter)
+    const createProductBuilder = vi.fn(({ sellerOperatorId }) => {
+      expect(sellerOperatorId).toBe("tenant_pro_travel")
+      return async (entityId: string) => ({ id: entityId, fields: { sellerOperatorId } })
+    })
+    const emptyProjection = { name: "test", project: vi.fn(async () => new Map()) }
+    const extensions = {
+      [catalogAccommodationsRuntimeExtensionPort.id]: {
+        fieldPolicy: [],
+        propertyFieldPolicy: [],
+        createDocumentBuilder: vi.fn(() => async () => null),
+        createPropertyDocumentBuilder: vi.fn(() => async () => null),
+      },
+      [catalogChartersRuntimeExtensionPort.id]: { fieldPolicy: [] },
+      [catalogCommerceRuntimeExtensionPort.id]: {
+        loadSliceInputs: vi.fn(async () => ({ markets: [], locales: [] })),
+        createPromotionEvaluator: vi.fn(),
+        createPricingProjectionExtension: () => emptyProjection,
+        createPromotionsProjectionExtension: () => emptyProjection,
+      },
+      [catalogCruisesRuntimeExtensionPort.id]: {
+        fieldPolicy: [],
+        shipFieldPolicy: [],
+        createRegistry: () => createFieldPolicyRegistry([]),
+        createDocumentBuilder: vi.fn(() => async () => null),
+        createShipDocumentBuilder: vi.fn(() => async () => null),
+        createCabinFacetProjectionExtension: () => emptyProjection,
+      },
+      [catalogDistributionRuntimeExtensionPort.id]: {
+        loadActiveChannelIds: vi.fn(async () => []),
+        hasActiveSalesChannelMapping: vi.fn(async () => true),
+      },
+      [catalogInventoryRuntimeExtensionPort.id]: {
+        productFieldPolicy: [],
+        extrasFieldPolicy: [],
+        listCanonicalProductIds: vi.fn(async () => ["product_1"]),
+        createDocumentBuilder: createProductBuilder,
+        createStorefrontCardProjectionExtension: () => emptyProjection,
+        createDestinationsProjectionExtension: () => emptyProjection,
+        createTaxonomyProjectionExtension: () => emptyProjection,
+        getProductContent: vi.fn(),
+        getOwnedProductById: vi.fn(),
+        enrichProductQuoteShape: vi.fn(),
+        loadProductReservationPolicy: vi.fn(),
+      },
+      [catalogOperationsRuntimeExtensionPort.id]: {
+        createDeparturesProjectionExtension: () => emptyProjection,
+        listAvailabilitySlots: vi.fn(),
+      },
+      [financeOperatorSettingsRuntimePort.id]: {},
+    } as Record<string, unknown>
+    const contribution = createCatalogRuntimePortContribution({
+      primitives: {
+        env: (receivedBindings: unknown) => receivedBindings as never,
+        database: { transaction },
+      } as never,
+      hasRuntimePort: (port) => port.id === catalogIndexerProviderPort.id,
+      getRuntimePort: (port) =>
+        (port.id === catalogIndexerProviderPort.id
+          ? { create: createIndexer }
+          : extensions[port.id]) as never,
+    })
+    const provider = contribution[catalogReindexJobRuntimePort.id] as {
+      createRuntime(bindings: unknown): Promise<{
+        listProductIdsPage(input: { limit: number }): Promise<readonly string[]>
+        reindexProduct(productId: string): Promise<void>
+      }>
+    }
+
+    const runtime = await provider.createRuntime(bindings)
+    await expect(runtime.listProductIdsPage({ limit: 100 })).resolves.toEqual(["product_1"])
+    await runtime.reindexProduct("product_1")
+
+    expect(createIndexer).toHaveBeenCalledOnce()
+    expect(createProductBuilder).toHaveBeenCalled()
+    expect(upsert).toHaveBeenCalledWith(expect.objectContaining({ vertical: "products" }), [
+      expect.objectContaining({ id: "product_1" }),
+    ])
+    expect(transaction).toHaveBeenCalled()
   })
 })

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -28,7 +28,13 @@ import {
   type FinanceOperatorSettingsRuntime,
   financeOperatorSettingsRuntimePort,
 } from "@voyant-travel/finance/runtime-port"
+import { sql } from "drizzle-orm"
 import { catalogDraftReaperJobRuntimePort } from "./draft-reaper-job-runtime-port.js"
+import {
+  type CatalogReindexCheckpoint,
+  type CatalogReindexClaim,
+  catalogReindexJobRuntimePort,
+} from "./reindex-job-runtime-port.js"
 import { createCatalogRuntime } from "./runtime.js"
 import {
   type CatalogAccommodationsRuntimeExtension,
@@ -73,59 +79,56 @@ export function createCatalogRuntimePortContribution(
   host: CatalogRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
   const hasIndexerPort = host.hasRuntimePort?.(catalogIndexerProviderPort) === true
-  const contribution = Promise.resolve()
-    .then(() =>
-      Promise.all([
-        host.getRuntimePort<CatalogAccommodationsRuntimeExtension>(
-          catalogAccommodationsRuntimeExtensionPort,
-        ),
-        host.getRuntimePort<CatalogChartersRuntimeExtension>(catalogChartersRuntimeExtensionPort),
-        host.getRuntimePort<CatalogCommerceRuntimeExtension>(catalogCommerceRuntimeExtensionPort),
-        host.getRuntimePort<CatalogDistributionRuntimeExtension>(
-          catalogDistributionRuntimeExtensionPort,
-        ),
-        host.getRuntimePort<CatalogCruisesRuntimeExtension>(catalogCruisesRuntimeExtensionPort),
-        host.getRuntimePort<CatalogInventoryRuntimeExtension>(catalogInventoryRuntimeExtensionPort),
-        host.getRuntimePort<CatalogOperationsRuntimeExtension>(
-          catalogOperationsRuntimeExtensionPort,
-        ),
-        host.getRuntimePort<FinanceOperatorSettingsRuntime>(financeOperatorSettingsRuntimePort),
-        hasIndexerPort ? host.getRuntimePort<unknown>(catalogIndexerProviderPort) : undefined,
-      ]),
-    )
-    .then(
-      ([
-        accommodations,
-        charters,
-        commerce,
-        distribution,
-        cruises,
-        inventory,
-        operations,
+  const dependencies = Promise.resolve().then(() =>
+    Promise.all([
+      host.getRuntimePort<CatalogAccommodationsRuntimeExtension>(
+        catalogAccommodationsRuntimeExtensionPort,
+      ),
+      host.getRuntimePort<CatalogChartersRuntimeExtension>(catalogChartersRuntimeExtensionPort),
+      host.getRuntimePort<CatalogCommerceRuntimeExtension>(catalogCommerceRuntimeExtensionPort),
+      host.getRuntimePort<CatalogDistributionRuntimeExtension>(
+        catalogDistributionRuntimeExtensionPort,
+      ),
+      host.getRuntimePort<CatalogCruisesRuntimeExtension>(catalogCruisesRuntimeExtensionPort),
+      host.getRuntimePort<CatalogInventoryRuntimeExtension>(catalogInventoryRuntimeExtensionPort),
+      host.getRuntimePort<CatalogOperationsRuntimeExtension>(catalogOperationsRuntimeExtensionPort),
+      host.getRuntimePort<FinanceOperatorSettingsRuntime>(financeOperatorSettingsRuntimePort),
+      hasIndexerPort ? host.getRuntimePort<unknown>(catalogIndexerProviderPort) : undefined,
+    ]),
+  )
+  const contribution = dependencies.then(
+    ([
+      accommodations,
+      charters,
+      commerce,
+      distribution,
+      cruises,
+      inventory,
+      operations,
+      settings,
+      indexer,
+    ]) => {
+      let catalogIndexer: CatalogIndexer | undefined
+      if (hasIndexerPort) {
+        validateCatalogIndexer(indexer)
+        catalogIndexer = indexer
+      }
+      return createCatalogRuntime(
+        host.primitives,
+        {
+          accommodations,
+          charters,
+          commerce,
+          distribution,
+          cruises,
+          inventory,
+          operations,
+        },
         settings,
-        indexer,
-      ]) => {
-        let catalogIndexer: CatalogIndexer | undefined
-        if (hasIndexerPort) {
-          validateCatalogIndexer(indexer)
-          catalogIndexer = indexer
-        }
-        return createCatalogRuntime(
-          host.primitives,
-          {
-            accommodations,
-            charters,
-            commerce,
-            distribution,
-            cruises,
-            inventory,
-            operations,
-          },
-          settings,
-          { indexer: catalogIndexer },
-        )
-      },
-    )
+        { indexer: catalogIndexer },
+      )
+    },
+  )
   const cruisesRoutes = {
     resolveSourceAdapterRegistry: async (bindings: unknown) => {
       const runtime = await contribution
@@ -159,6 +162,188 @@ export function createCatalogRuntimePortContribution(
         console.error("[catalog-draft-reaper] operation failed", { error, ...details })
       },
     },
+    [catalogReindexJobRuntimePort.id]: {
+      async createRuntime(bindings: unknown) {
+        if (!bindings || typeof bindings !== "object") {
+          throw new Error("Catalog product reindex requires concrete deployment job bindings.")
+        }
+        if (!hasIndexerPort) {
+          throw new Error("Catalog product reindex requires a configured catalog indexer.")
+        }
+        const tenantId = stringValue(Reflect.get(bindings, "TENANT_ID"))
+        if (!tenantId) {
+          throw new Error("Catalog product reindex requires TENANT_ID in deployment bindings.")
+        }
+        const [, , , , , inventory] = await dependencies
+        const catalog = await contribution
+        const projectionProvider = await catalog.projection
+        const projection = await projectionProvider.createRuntime(bindings)
+        const withDb = <T>(operation: (db: AnyDrizzleDb) => Promise<T>) =>
+          host.primitives.database.transaction(bindings, (database) =>
+            operation(database as AnyDrizzleDb),
+          )
+
+        return {
+          requestGeneration: () =>
+            withDb(async (db) => {
+              const result = await db.execute(sql`
+                INSERT INTO catalog_product_reindex_state (
+                  tenant_id, reindex_key, requested_generation, completed_generation
+                )
+                VALUES (${tenantId}, 'products', 1, 0)
+                ON CONFLICT (tenant_id, reindex_key) DO UPDATE
+                SET requested_generation = CASE
+                      WHEN catalog_product_reindex_state.requested_generation >
+                           catalog_product_reindex_state.completed_generation
+                        THEN catalog_product_reindex_state.requested_generation
+                      ELSE catalog_product_reindex_state.requested_generation + 1
+                    END,
+                    updated_at = now()
+                RETURNING requested_generation
+              `)
+              return integerValue(firstRow(result)?.requested_generation)
+            }),
+          claimWork: (leaseOwner: string) =>
+            withDb(async (db) => {
+              const result = await db.execute(sql`
+                UPDATE catalog_product_reindex_state
+                SET claimed_generation = COALESCE(claimed_generation, requested_generation),
+                    cursor_after_id = CASE
+                      WHEN claimed_generation IS NULL THEN NULL
+                      ELSE cursor_after_id
+                    END,
+                    batches = CASE WHEN claimed_generation IS NULL THEN 0 ELSE batches END,
+                    scanned = CASE WHEN claimed_generation IS NULL THEN 0 ELSE scanned END,
+                    indexed = CASE WHEN claimed_generation IS NULL THEN 0 ELSE indexed END,
+                    retries = CASE WHEN claimed_generation IS NULL THEN 0 ELSE retries END,
+                    lease_owner = ${leaseOwner},
+                    lease_until = now() + interval '2 minutes',
+                    updated_at = now()
+                WHERE tenant_id = ${tenantId}
+                  AND reindex_key = 'products'
+                  AND requested_generation > completed_generation
+                  AND (lease_until IS NULL OR lease_until < now())
+                RETURNING claimed_generation, cursor_after_id, batches, scanned, indexed, retries
+              `)
+              const row = firstRow(result)
+              return row ? claimFromRow(tenantId, leaseOwner, row) : null
+            }),
+          renewLease: (claim: CatalogReindexClaim) =>
+            withDb(async (db) => {
+              const result = await db.execute(sql`
+                UPDATE catalog_product_reindex_state
+                SET lease_until = now() + interval '2 minutes', updated_at = now()
+                WHERE tenant_id = ${claim.tenantId}
+                  AND reindex_key = 'products'
+                  AND claimed_generation = ${claim.generation}
+                  AND lease_owner = ${claim.leaseOwner}
+                  AND lease_until > now()
+                RETURNING tenant_id
+              `)
+              return Boolean(firstRow(result))
+            }),
+          checkpoint: (claim: CatalogReindexClaim, checkpoint: CatalogReindexCheckpoint) =>
+            withDb(async (db) => {
+              const result = await db.execute(sql`
+                UPDATE catalog_product_reindex_state
+                SET cursor_after_id = ${checkpoint.afterId ?? null},
+                    batches = ${checkpoint.batches},
+                    scanned = ${checkpoint.scanned},
+                    indexed = ${checkpoint.indexed},
+                    retries = ${checkpoint.retries},
+                    lease_until = now() + interval '2 minutes',
+                    updated_at = now()
+                WHERE tenant_id = ${claim.tenantId}
+                  AND reindex_key = 'products'
+                  AND claimed_generation = ${claim.generation}
+                  AND lease_owner = ${claim.leaseOwner}
+                  AND lease_until > now()
+                RETURNING tenant_id
+              `)
+              return Boolean(firstRow(result))
+            }),
+          complete: (claim: CatalogReindexClaim, checkpoint: CatalogReindexCheckpoint) =>
+            withDb(async (db) => {
+              const result = await db.execute(sql`
+                UPDATE catalog_product_reindex_state
+                SET completed_generation = ${claim.generation},
+                    claimed_generation = NULL,
+                    cursor_after_id = NULL,
+                    batches = ${checkpoint.batches},
+                    scanned = ${checkpoint.scanned},
+                    indexed = ${checkpoint.indexed},
+                    retries = ${checkpoint.retries},
+                    lease_owner = NULL,
+                    lease_until = NULL,
+                    completed_at = now(),
+                    updated_at = now()
+                WHERE tenant_id = ${claim.tenantId}
+                  AND reindex_key = 'products'
+                  AND claimed_generation = ${claim.generation}
+                  AND lease_owner = ${claim.leaseOwner}
+                  AND lease_until > now()
+                RETURNING tenant_id
+              `)
+              return Boolean(firstRow(result))
+            }),
+          releaseLease: (claim: CatalogReindexClaim) =>
+            withDb(async (db) => {
+              await db.execute(sql`
+                UPDATE catalog_product_reindex_state
+                SET lease_owner = NULL, lease_until = NULL, updated_at = now()
+                WHERE tenant_id = ${claim.tenantId}
+                  AND reindex_key = 'products'
+                  AND claimed_generation = ${claim.generation}
+                  AND lease_owner = ${claim.leaseOwner}
+              `)
+            }),
+          listProductIdsPage: (input: { afterId?: string; limit: number }) =>
+            withDb((db) => inventory.listCanonicalProductIds(db, input)),
+          reindexProduct: (productId: string) =>
+            projection.reindexEntity({ entityModule: "products", entityId: productId }),
+          reportProgress(progress: unknown) {
+            console.info("[catalog-reindex-products]", progress)
+          },
+        }
+      },
+    },
     [cruisesRoutesRuntimePortReference.id]: cruisesRoutes,
   }
+}
+
+function firstRow(result: unknown): Record<string, unknown> | undefined {
+  const rows = Array.isArray(result)
+    ? result
+    : ((result as { rows?: Record<string, unknown>[] })?.rows ?? [])
+  return rows[0] as Record<string, unknown> | undefined
+}
+
+function integerValue(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Catalog product reindex received an invalid database counter: ${value}.`)
+  }
+  return parsed
+}
+
+function claimFromRow(
+  tenantId: string,
+  leaseOwner: string,
+  row: Record<string, unknown>,
+): CatalogReindexClaim {
+  const afterId = stringValue(row.cursor_after_id)
+  return {
+    tenantId,
+    leaseOwner,
+    generation: integerValue(row.claimed_generation),
+    ...(afterId ? { afterId } : {}),
+    batches: integerValue(row.batches),
+    scanned: integerValue(row.scanned),
+    indexed: integerValue(row.indexed),
+    retries: integerValue(row.retries),
+  }
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined
 }

--- a/packages/catalog/src/runtime.ts
+++ b/packages/catalog/src/runtime.ts
@@ -69,10 +69,11 @@ export function createCatalogRuntime(
     }
     return indexer
   }
-  let projectionRuntime:
+  const projectionRuntimes = new WeakMap<
+    object,
     | ReturnType<typeof createOperatorCatalogProjectionRuntime>
     | Promise<ReturnType<typeof createOperatorCatalogProjectionRuntime>>
-    | undefined
+  >()
   const services: CatalogRuntimeServices = {
     defaultSlices: DEFAULT_SLICES,
     ensureSourceRegistry: (env) => ensureBookingEngineRegistry(env as never),
@@ -147,7 +148,14 @@ export function createCatalogRuntime(
     content: { resolveRegistry: getBookingEngineRegistryFromContext },
     projection: {
       createRuntime(bindings) {
-        projectionRuntime ??= createOperatorCatalogProjectionRuntime(bindings, services)
+        if (!bindings || typeof bindings !== "object") {
+          throw new Error("Catalog projection runtime requires concrete deployment bindings.")
+        }
+        let projectionRuntime = projectionRuntimes.get(bindings)
+        if (!projectionRuntime) {
+          projectionRuntime = createOperatorCatalogProjectionRuntime(bindings, services)
+          projectionRuntimes.set(bindings, projectionRuntime)
+        }
         return projectionRuntime
       },
     },

--- a/packages/catalog/src/schema.ts
+++ b/packages/catalog/src/schema.ts
@@ -12,6 +12,7 @@
  *   - `catalogQuotesTable`            — booking-engine quote records
  *   - `catalogSourcedEntriesTable`    — durable sourced-entry store
  *                                       (sourced-content §2.5)
+ *   - `catalogProductReindexStateTable` — durable reindex lease + cursor
  */
 
 export {
@@ -36,6 +37,11 @@ export {
   type SelectCatalogOverlay,
   type SelectCatalogOverlayHistory,
 } from "./overlay/schema.js"
+export {
+  catalogProductReindexStateTable,
+  type InsertCatalogProductReindexState,
+  type SelectCatalogProductReindexState,
+} from "./reindex-state-schema.js"
 export {
   catalogSourcedEntriesTable,
   type InsertCatalogSourcedEntry,

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -15,6 +15,7 @@ import { catalogContentRuntimePort } from "./content-runtime-port.js"
 import { catalogDraftReaperJobRuntimePort } from "./draft-reaper-job-runtime-port.js"
 import { catalogIndexSubscriberDeclarations } from "./index-subscriber-declarations.js"
 import { catalogIndexerProviderPort } from "./indexer/provider.js"
+import { catalogReindexJobRuntimePort } from "./reindex-job-runtime-port.js"
 import {
   catalogAccommodationsRuntimeExtensionPort,
   catalogChartersRuntimeExtensionPort,
@@ -82,6 +83,7 @@ export const catalogVoyantModule = defineModule({
       providePort(catalogBookingSnapshotRuntimePort),
       providePort(catalogRuntimeServicesPort),
       providePort(catalogDraftReaperJobRuntimePort),
+      providePort(catalogReindexJobRuntimePort),
       cruisesRoutesRuntimePortReference,
     ],
   },
@@ -90,6 +92,7 @@ export const catalogVoyantModule = defineModule({
     requirePort(catalogProjectionRuntimePort),
     requirePort(catalogBookingSnapshotRuntimePort),
     requirePort(catalogDraftReaperJobRuntimePort),
+    requirePort(catalogReindexJobRuntimePort),
   ],
   api: [
     {
@@ -243,6 +246,14 @@ export const catalogVoyantModule = defineModule({
     },
   ],
   jobs: [
+    {
+      id: "catalog.reindex-products",
+      wakeup: true,
+      runtime: {
+        entry: "@voyant-travel/catalog/reindex-job",
+        export: "runCatalogReindexProductsJob",
+      },
+    },
     {
       id: "catalog.reap-expired-booking-drafts",
       schedule: { cron: "5 * * * *", overlap: "skip" },

--- a/packages/catalog/tests/unit/package-exports.test.ts
+++ b/packages/catalog/tests/unit/package-exports.test.ts
@@ -64,6 +64,12 @@ describe("@voyant-travel/catalog package exports", () => {
       import: "./dist/projection-runtime.js",
       default: "./dist/projection-runtime.js",
     })
+    expect(packageJson.exports["./reindex-job"]).toBe("./src/reindex-job.ts")
+    expect(packageJson.publishConfig.exports["./reindex-job"]).toEqual({
+      types: "./dist/reindex-job.d.ts",
+      import: "./dist/reindex-job.js",
+      default: "./dist/reindex-job.js",
+    })
   })
 
   it("publishes the index subscriber graph runtimes", () => {

--- a/packages/catalog/tests/unit/product-reindex-state-migration.test.ts
+++ b/packages/catalog/tests/unit/product-reindex-state-migration.test.ts
@@ -1,0 +1,40 @@
+import { getTableConfig } from "drizzle-orm/pg-core"
+import { describe, expect, it } from "vitest"
+
+import { catalogProductReindexStateTable } from "../../src/schema.js"
+
+describe("catalog product reindex state schema", () => {
+  it("exports the tenant-scoped lease and checkpoint table through the Catalog schema", () => {
+    const table = getTableConfig(catalogProductReindexStateTable)
+
+    expect(table.name).toBe("catalog_product_reindex_state")
+    expect(table.columns.map((column) => column.name)).toEqual([
+      "tenant_id",
+      "reindex_key",
+      "requested_generation",
+      "claimed_generation",
+      "completed_generation",
+      "cursor_after_id",
+      "batches",
+      "scanned",
+      "indexed",
+      "retries",
+      "lease_owner",
+      "lease_until",
+      "completed_at",
+      "updated_at",
+    ])
+    expect(table.primaryKeys).toHaveLength(1)
+    expect(table.primaryKeys[0]?.columns.map((column) => column.name)).toEqual([
+      "tenant_id",
+      "reindex_key",
+    ])
+    expect(table.checks.map((check) => check.name)).toEqual(
+      expect.arrayContaining([
+        "catalog_product_reindex_state_requested_nonnegative",
+        "catalog_product_reindex_state_completed_nonnegative",
+        "catalog_product_reindex_state_counters_nonnegative",
+      ]),
+    )
+  })
+})

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -26,6 +26,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.booking-snapshot-runtime" },
           { id: "catalog.runtime-services" },
           { id: "catalog.draft-reaper-job" },
+          { id: "catalog.reindex-products-job" },
           { id: "cruises.routes-runtime" },
         ],
       },
@@ -106,6 +107,7 @@ describe("catalog deployment manifest", () => {
       { id: "catalog.projection-runtime" },
       { id: "catalog.booking-snapshot-runtime" },
       { id: "catalog.draft-reaper-job" },
+      { id: "catalog.reindex-products-job" },
     ])
     expect(catalogVoyantModule.tools).toEqual(
       expect.arrayContaining([
@@ -114,6 +116,14 @@ describe("catalog deployment manifest", () => {
       ]),
     )
     expect(catalogVoyantModule.jobs).toEqual([
+      {
+        id: "catalog.reindex-products",
+        wakeup: true,
+        runtime: {
+          entry: "@voyant-travel/catalog/reindex-job",
+          export: "runCatalogReindexProductsJob",
+        },
+      },
       {
         id: "catalog.reap-expired-booking-drafts",
         schedule: { cron: "5 * * * *", overlap: "skip" },

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -186,6 +186,8 @@ export interface VoyantGraphRuntimeFactoryGraph {
 
 export interface VoyantGraphRuntimeFactoryContext {
   readonly unitId: string
+  /** Deployment bindings for fixed job invocations; absent on non-job facets. */
+  readonly bindings?: unknown
   /** Validated JSON config authored on this package-scoped project selection. */
   readonly projectConfig: Readonly<VoyantGraphJsonObject>
   /** Read validated config for another explicitly selected unit by exact graph id. */

--- a/packages/framework/src/node-job-host.test.ts
+++ b/packages/framework/src/node-job-host.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { createVoyantNodeJobHost, VOYANT_PRODUCT_JOB_ROUTE } from "./node-job-host.js"
-import { createVoyantGraphRuntime, type VoyantGraphRuntime } from "./runtime-lowering.js"
+import {
+  createVoyantGraphRuntime,
+  type VoyantGraphRuntime,
+  type VoyantGraphRuntimeJobHandler,
+} from "./runtime-lowering.js"
 
 const unitId = "@acme/notifications"
 const jobId = "notifications.deliver"
 
 function jobRuntime(
-  handler: () => Promise<void> | void,
+  handler: VoyantGraphRuntimeJobHandler,
   schedule:
     | { every: string | number; overlap?: "skip" | "queue" }
     | { cron: string; timezone?: string } = {
@@ -249,6 +253,21 @@ describe("Voyant Node product job host", () => {
       }),
     )
     expect(host.health()[0]?.lastReportFailure).toBe("control plane unavailable")
+  })
+
+  it("passes concrete deployment bindings to the fixed job runtime", async () => {
+    const bindings = { TENANT_ID: "tenant_pro_travel" }
+    const handler = vi.fn(async () => {})
+    const host = createVoyantNodeJobHost({
+      runtime: jobRuntime(handler),
+      jobs: inventory(),
+      bindings,
+    })
+
+    await host.invoke(jobId, "wakeup")
+    await host.settled(jobId)
+
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ bindings }))
   })
 
   it("bounds retries and exposes retry exhaustion without persisting generic runs", async () => {

--- a/packages/framework/src/node-job-host.ts
+++ b/packages/framework/src/node-job-host.ts
@@ -53,6 +53,8 @@ export interface CreateVoyantNodeJobHostOptions {
   /** Immutable host inventory copied from resolved provisioning.jobs. */
   jobs: readonly VoyantGraphProvisionedJob[]
   ports?: VoyantGraphRuntimePorts
+  /** Concrete deployment bindings passed to fixed product-job runtimes. */
+  bindings?: unknown
   retry?: VoyantNodeJobHostRetryOptions
   now?: () => Date
   sleep?: (milliseconds: number) => Promise<void>
@@ -161,7 +163,7 @@ export function createVoyantNodeJobHost(
       health.status = attempt === 1 ? "running" : "retrying"
       health.lastAttemptAt = now().toISOString()
       try {
-        await invokeVoyantGraphJob(options.runtime, jobId, options.ports)
+        await invokeVoyantGraphJob(options.runtime, jobId, options.ports, options.bindings)
         health.status = "succeeded"
         health.lastSuccessAt = now().toISOString()
         await report({

--- a/packages/framework/src/node-migration-runner.test.ts
+++ b/packages/framework/src/node-migration-runner.test.ts
@@ -146,6 +146,29 @@ describe("Node migration runner", () => {
     expect(source.priority).toBe(9)
     expect(source.migrations.length).toBeGreaterThan(0)
   })
+
+  it("loads Catalog's generated product reindex migration from its journal", async () => {
+    const source = await loadNodeSchemaMigrationSource(
+      {
+        id: "catalog#migrations",
+        migrationKind: "schema",
+        order: 3,
+        idempotencyKey: "schema:catalog#migrations",
+        owner: "catalog",
+        source: {
+          kind: "deployment",
+          path: "../catalog/migrations",
+        },
+      },
+      import.meta.url,
+    )
+
+    const migration = source.migrations.find((entry) => entry.tag === "0003_product_reindex_state")
+    expect(migration?.sql).toContain('CREATE TABLE "catalog_product_reindex_state"')
+    expect(migration?.sql).toContain(
+      'CONSTRAINT "catalog_product_reindex_state_pk" PRIMARY KEY("tenant_id","reindex_key")',
+    )
+  })
 })
 
 function plan(includeLater = false): VoyantProjectMigrationPlan {

--- a/packages/framework/src/node-runtime.ts
+++ b/packages/framework/src/node-runtime.ts
@@ -315,6 +315,7 @@ export async function loadVoyantNodeRuntime(
   const jobHost = createVoyantNodeJobHost({
     runtime: options.graphRuntime,
     jobs: options.jobs,
+    bindings: env,
     ...(options.runtimePorts ? { ports: options.runtimePorts } : {}),
     ...(env.ORIGIN_TRUST_SECRET ? { originTrustSecret: env.ORIGIN_TRUST_SECRET } : {}),
     ...(managedJobHealthReporter ? { reportExecution: managedJobHealthReporter } : {}),

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -257,6 +257,7 @@ export async function invokeVoyantGraphJob(
   runtime: VoyantGraphRuntime,
   jobId: string,
   ports?: VoyantGraphRuntimePorts,
+  bindings?: unknown,
 ): Promise<void> {
   const owner = allRuntimeUnits(runtime).find((unit) =>
     unit.jobs.some((job) => job.declaration.id === jobId),
@@ -266,7 +267,7 @@ export async function invokeVoyantGraphJob(
     throw new Error(`invokeVoyantGraphJob: job "${jobId}" is not selected by the graph.`)
   }
   const handler = await job.load()
-  await handler(createRuntimeFactoryContext(runtime, ports, owner))
+  await handler({ ...createRuntimeFactoryContext(runtime, ports, owner), bindings })
 }
 
 /** Load graph-owned subscriber metadata without composing API routes. */

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -491,6 +491,7 @@
       ],
       "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
+      "@voyant-travel/catalog/reindex-job": ["../catalog/dist/reindex-job.d.ts"],
       "@voyant-travel/catalog/runtime-contracts": ["../catalog/dist/runtime-contracts.d.ts"],
       "@voyant-travel/catalog/runtime-contributor": ["../catalog/dist/runtime-contributor.d.ts"],
       "@voyant-travel/catalog/runtime-port": ["../catalog/dist/content-runtime-port.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -492,6 +492,7 @@
       ],
       "@voyant-travel/catalog/projection-runtime": ["../catalog/dist/projection-runtime.d.ts"],
       "@voyant-travel/catalog/provenance": ["../catalog/dist/provenance.d.ts"],
+      "@voyant-travel/catalog/reindex-job": ["../catalog/dist/reindex-job.d.ts"],
       "@voyant-travel/catalog/runtime-contracts": ["../catalog/dist/runtime-contracts.d.ts"],
       "@voyant-travel/catalog/runtime-contributor": ["../catalog/dist/runtime-contributor.d.ts"],
       "@voyant-travel/catalog/runtime-port": ["../catalog/dist/content-runtime-port.d.ts"],

--- a/packages/inventory/src/catalog-runtime-extension.ts
+++ b/packages/inventory/src/catalog-runtime-extension.ts
@@ -1,6 +1,6 @@
 import type { CatalogInventoryRuntimeExtension } from "@voyant-travel/catalog/runtime-contracts"
 import { createProductQuoteShapeEnricher } from "@voyant-travel/catalog/runtime-support"
-import { eq } from "drizzle-orm"
+import { asc, eq, gt } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { registerProductBookingHandler } from "./booking-engine/product-runtime.js"
@@ -55,6 +55,14 @@ export const catalogInventoryRuntimeExtension = {
     ...productPromotionsCatalogPolicy,
   ],
   extrasFieldPolicy: extrasCatalogPolicy,
+  listCanonicalProductIds: (db, { afterId, limit }) =>
+    db
+      .select({ id: products.id })
+      .from(products)
+      .where(afterId ? gt(products.id, afterId) : undefined)
+      .orderBy(asc(products.id))
+      .limit(limit)
+      .then((rows) => rows.map((row) => row.id)),
   createDocumentBuilder: ({
     db,
     sellerOperatorId,


### PR DESCRIPTION
## What changed

- adds a provider-neutral, wakeable `catalog.reindex-products` job
- enumerates canonical inventory products with bounded keyset pagination
- rebuilds projections through the selected Catalog indexer rather than writing provider tables directly
- threads concrete deployment bindings through Node and Worker job hosts
- adds tenant-scoped durable generations, leases, heartbeats, checkpoints, retries, and resume behavior
- fails explicitly when bindings, `TENANT_ID`, or an indexer are missing
- adds the journaled Catalog reindex-state migration and schema export

## Why

Managed deployments switching to PostgreSQL can have valid catalog source rows but an empty search projection. Pro Travel needs a supported one-shot rebuild path that preserves Catalog visibility, pricing, locale, market, audience, and distribution rules without depending on Typesense or tenant-specific SQL.

## Validation

- Catalog focused tests: 26 passed
- Framework focused tests: 19 passed
- Catalog and Framework typechecks: passed remotely
- Catalog/Core/Framework/Inventory lint: passed; Framework retains two unrelated existing warnings
- independent review of tenancy, binding propagation, lease/checkpoint semantics, and migration loading: clean
- `git diff --check`: passed
