### PR TITLE
Fix managed booking traveler and room flow

### DIFF
--- a/.changeset/fix-protravel-booking-flow.md
+++ b/.changeset/fix-protravel-booking-flow.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/framework": patch
+---
+
+Keep live booking travelers authoritative at commit time and let room-based journeys reach their option picker before a quote is priceable.

--- a/packages/bookings-react/src/journey/components/booking-journey-rules.ts
+++ b/packages/bookings-react/src/journey/components/booking-journey-rules.ts
@@ -110,9 +110,8 @@ export function canAdvanceFromStep(
   step: JourneyStep,
   draft: Draft,
   shape: BookingDraftShape,
-  available: boolean,
+  _available: boolean,
 ): boolean {
-  if (!available) return false
   switch (step) {
     case "departure": {
       // Require a departure when the descriptor marks it required.

--- a/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
+++ b/packages/bookings-react/tests/unit/booking-journey-rules.test.ts
@@ -5,6 +5,7 @@ import {
   buildCommitPaymentIntent,
   canAdvanceFromStep,
   defaultMinimalShape,
+  stackedStepComplete,
   validationErrorsForStep,
 } from "../../src/journey/components/booking-journey-rules.js"
 import { emptyDraft, patchBilling, patchConfigure } from "../../src/journey/lib/draft-state.js"
@@ -16,6 +17,20 @@ const ENTITY = {
 } as const
 
 describe("booking-journey-rules", () => {
+  it("unlocks a selected departure while the room-shaped baseline quote is unavailable", () => {
+    const shape: ReturnType<typeof defaultMinimalShape> = {
+      ...defaultMinimalShape(),
+      configureSubSteps: [{ kind: "departure", required: true }, { kind: "option-units" }],
+    }
+    const draft = patchConfigure(emptyDraft(ENTITY), {
+      departureSlotId: "slot_1",
+    })
+
+    expect(canAdvanceFromStep("departure", draft, shape, false)).toBe(true)
+    expect(stackedStepComplete("departure", draft, shape, false)).toBe(true)
+    expect(canAdvanceFromStep("options", draft, shape, false)).toBe(false)
+  })
+
   it("allows a B2C billing contact with phone but no email to unlock the next step", () => {
     const shape = defaultMinimalShape()
     const draft = patchConfigure(

--- a/packages/catalog/src/booking-engine/routes.test.ts
+++ b/packages/catalog/src/booking-engine/routes.test.ts
@@ -501,6 +501,131 @@ describe("createCatalogBookingRoutes", () => {
     )
   })
 
+  it("prefers live commit travelers over a stale persisted draft", async () => {
+    vi.mocked(getBookingDraft).mockResolvedValue({
+      id: "draft_live",
+      source_kind: "voyant-connect",
+      source_connection_id: "conn_live",
+      source_ref: "pkg_live",
+      current_quote_id: "quote_stale",
+      draft_payload: {
+        entity: { module: "products", id: "pkg_live" },
+        configure: { roomTypeId: "ROOM:DOUBLE" },
+        travelers: [],
+      },
+    } as never)
+    vi.mocked(bookEntity).mockResolvedValue({
+      bookingId: "booking_live",
+      orderRef: "package:live",
+      status: "held",
+      snapshotId: "snap_live",
+      pricing,
+    })
+    const { app } = createTestApp()
+
+    const response = await app.request("/v1/public/catalog/book", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        draftId: "draft_live",
+        quoteId: "quote_live",
+        parameters: {
+          draft: {
+            entity: { module: "products", id: "pkg_live" },
+            configure: { roomTypeId: "ROOM:DOUBLE" },
+            travelers: [
+              {
+                firstName: "Live",
+                lastName: "Traveler",
+                band: "adult",
+                isPrimary: true,
+              },
+            ],
+          },
+        },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(bookEntity).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ registry }),
+      expect.objectContaining({
+        quoteId: "quote_live",
+        parameters: expect.objectContaining({
+          draft: expect.objectContaining({
+            travelers: [expect.objectContaining({ firstName: "Live", lastName: "Traveler" })],
+          }),
+          travelers: [expect.objectContaining({ firstName: "Live", lastName: "Traveler" })],
+          leadTraveler: expect.objectContaining({
+            firstName: "Live",
+            lastName: "Traveler",
+          }),
+        }),
+      }),
+    )
+  })
+
+  it("falls back to persisted draft travelers when the commit has no live draft", async () => {
+    vi.mocked(getBookingDraft).mockResolvedValue({
+      id: "draft_persisted",
+      source_kind: "voyant-connect",
+      source_connection_id: "conn_persisted",
+      source_ref: "pkg_persisted",
+      current_quote_id: "quote_persisted",
+      draft_payload: {
+        entity: { module: "products", id: "pkg_persisted" },
+        configure: { roomTypeId: "ROOM:TWIN" },
+        travelers: [
+          {
+            firstName: "Persisted",
+            lastName: "Traveler",
+            band: "adult",
+            isPrimary: true,
+          },
+        ],
+      },
+    } as never)
+    vi.mocked(bookEntity).mockResolvedValue({
+      bookingId: "booking_persisted",
+      orderRef: "package:persisted",
+      status: "held",
+      snapshotId: "snap_persisted",
+      pricing,
+    })
+    const { app } = createTestApp()
+
+    const response = await app.request("/v1/public/catalog/book", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        draftId: "draft_persisted",
+        quoteId: "quote_explicit",
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(bookEntity).toHaveBeenCalledWith(
+      db,
+      expect.objectContaining({ registry }),
+      expect.objectContaining({
+        quoteId: "quote_explicit",
+        parameters: expect.objectContaining({
+          travelers: [
+            expect.objectContaining({
+              firstName: "Persisted",
+              lastName: "Traveler",
+            }),
+          ],
+          leadTraveler: expect.objectContaining({
+            firstName: "Persisted",
+            lastName: "Traveler",
+          }),
+        }),
+      }),
+    )
+  })
+
   it("places and releases holds through the owned handler registry", async () => {
     const placeHold = vi.fn(async () => ({
       holdToken: "hold_1",

--- a/packages/catalog/src/booking-engine/routes.ts
+++ b/packages/catalog/src/booking-engine/routes.ts
@@ -727,19 +727,20 @@ async function prepareBookParameters(
     provenance: CatalogBookingProvenance
   },
 ): Promise<Record<string, unknown>> {
-  const parameters = engineParametersFromDraft(
-    input.body.parameters,
-    input.draftPayload ?? input.body.parameters?.draft,
-    {
-      entityModule: input.draftPayload
-        ? (stringValue(asRecord(input.draftPayload)?.entity_module) ??
-          stringValue(asRecord(asRecord(input.draftPayload)?.entity)?.module) ??
-          undefined)
-        : undefined,
-      sourceKind: input.provenance.sourceKind,
-      sourceProvider: input.provenance.sourceProvider,
-    },
-  )
+  // The commit request is the user's latest booking state. A persisted draft
+  // may lag behind it (for example, before newly selected travelers have been
+  // autosaved), so only use the stored payload when the caller does not send
+  // an explicit live draft.
+  const effectiveDraftPayload = input.body.parameters?.draft ?? input.draftPayload
+  const parameters = engineParametersFromDraft(input.body.parameters, effectiveDraftPayload, {
+    entityModule: effectiveDraftPayload
+      ? (stringValue(asRecord(effectiveDraftPayload)?.entity_module) ??
+        stringValue(asRecord(asRecord(effectiveDraftPayload)?.entity)?.module) ??
+        undefined)
+      : undefined,
+    sourceKind: input.provenance.sourceKind,
+    sourceProvider: input.provenance.sourceProvider,
+  })
 
   if (input.body.draftId) {
     parameters.availabilityHoldToken = input.body.draftId


### PR DESCRIPTION
## What changed

- Prefer the live booking draft submitted at confirmation over an older persisted autosave draft.
- Let users advance through booking steps while a room-based quote is intentionally unavailable before room selection.
- Add focused regressions for live traveler precedence, persisted-draft fallback, and the unavailable room baseline.
- Add patch changesets for Catalog, Bookings React, and Framework so the managed runtime can consume an immutable patch release.

## Why

A real Pro Travel managed-admin smoke test exposed two independent blockers:

1. Creating billing contacts and travelers succeeded, but confirming the booking returned `Add at least one traveler`. The browser sent the traveler correctly; the server then replaced the live payload with a stale persisted draft whose traveler list was empty.
2. Room-based products returned the expected `no_sell_amount_configured` baseline before a room was chosen, but quote availability was also used as a global step-navigation gate. That prevented users from reaching the room picker needed to make the quote priceable.

The final booking commit remains protected by the existing `quoteReady && !quoteBlocked` checks, so allowing step navigation does not permit an unpriced booking to be submitted.

## Validation

Validated from the exact branch snapshot on a disposable remote Sprite:

- `@voyant-travel/catalog`: 14 focused route tests passed.
- `@voyant-travel/bookings-react`: 14 focused journey tests passed.
- `git diff --check` passed.

The synthetic Pro Travel people and drafts used for reproduction were deleted; no booking was created.