### PR TITLE
Fix Finance booking-create action policy ownership

### DIFF
--- a/.changeset/quiet-books-create-policy.md
+++ b/.changeset/quiet-books-create-policy.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Keep the composed `create_booking` action policy with its Finance handler so the
+generated booking ID remains the single authoritative action-ledger target.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -103,14 +103,20 @@ delegates to the Trips invariant service that pins a draft component. Tool outpu
 omit provider replay/economics payloads even though Trips retains them internally for
 later reservation.
 
-Finance owns two composed operator commands. `create_booking` delegates to the atomic
+Finance owns two composed operator commands. `create_booking` delegates to the
 booking-create service for product/slot conversion, travelers, room and item lines,
 payment schedules, optional credits, groups, invoice documents, ledger entries, and
-post-commit events. `issue_invoice_from_booking` delegates to the reusable invoice
-composer extracted from the HTTP route. Invoice/proforma issue requires an exact action
-approval: the command fingerprint is stable across request and execution, successful
-execution carries the approval/causation fields into the ledger, and a replay resolves
-the previously issued invoice instead of creating another.
+post-commit events. Its action policy is handler-owned because the canonical booking id
+is generated during the booking transaction and that service records the authoritative
+`booking.create` entry. The generic pre-dispatch gate must not invent a target or add a
+second ledger timeline. The later invoice, payment, document, and event stages are not
+part of the booking transaction, so callers must not treat the composed command as
+exactly replayable until its durable command workflow lands.
+`issue_invoice_from_booking` delegates to the reusable invoice composer extracted from
+the HTTP route. Invoice/proforma issue requires an exact action approval: the command
+fingerprint is stable across request and execution, successful execution carries the
+approval/causation fields into the ledger, and a replay resolves the previously issued
+invoice instead of creating another.
 
 ## Coverage posture
 

--- a/packages/finance/README.md
+++ b/packages/finance/README.md
@@ -5,9 +5,13 @@ Finance module for Voyant. Invoices, payments, credit notes, supplier payments, 
 ## Composed agent commands
 
 `create_booking` is owned by the Finance booking-create extension because that package
-already owns the atomic composer spanning product conversion, travelers, room/item
+already owns the composer spanning product conversion, travelers, room/item
 lines, payment schedules, optional credits and group membership, invoices, ledger
 records, and post-commit events. The Tool is a structural adapter over that service.
+Its selected action policy is handler-owned: the service records the canonical booking
+id in the authoritative `booking.create` ledger entry, while the generic pre-dispatch
+gate cannot know that id safely. The booking transaction commits before some finance
+and document stages, so this command is not yet an exact-replay boundary.
 
 `issue_invoice_from_booking` creates and issues either an invoice or proforma through
 the same package-owned composer used by the HTTP route. Agent execution requires an

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -268,7 +268,7 @@ export const createBookingTool = defineTool<
   name: "create_booking",
   aliases: ["bookings_create"],
   description:
-    "Atomically create a booking from a product or slot with travelers, room/item lines, payment schedules, optional credit, group membership, and invoice documents.",
+    "Create a booking from a product or slot with travelers, room/item lines, payment schedules, optional credit, group membership, and invoice documents.",
   inputSchema: createBookingToolInputSchema,
   outputSchema: bookingCreateSummarySchema,
   requiredScopes: ["bookings:write", "finance:write"],
@@ -281,6 +281,11 @@ export const createBookingTool = defineTool<
     confirmationRequired: true,
     sideEffects: ["data-write", "external-booking", "payment"],
   },
+  // Finance records the authoritative booking.create action with the generated
+  // booking id inside the booking transaction. The generic gate cannot know
+  // that id before dispatch and would create a second, caller-invented ledger
+  // timeline.
+  actionPolicyEnforcement: "handler",
   async handler({ booking }, ctx) {
     const outcome = await finance(ctx).createBooking(booking)
     if (outcome.status !== "ok") {

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -2,6 +2,7 @@ import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
 
 import { type FinanceToolServices, financeBookingsCreateTools, financeTools } from "../src/tools.js"
+import { financeBookingsCreateVoyantPlugin } from "../src/voyant.js"
 
 function ctx(
   services?: Partial<FinanceToolServices>,
@@ -201,7 +202,31 @@ describe("finance tools", () => {
 
   it("creates a booking through the composing Finance extension Tool", async () => {
     const registry = createToolRegistry()
-    registry.registerAll(financeBookingsCreateTools)
+    const [tool] = financeBookingsCreateTools
+    const [action] = financeBookingsCreateVoyantPlugin.actions ?? []
+    if (!tool || !action) throw new Error("Finance booking-create graph declarations are missing")
+    registry.register(tool, {
+      capabilityId: tool.capabilityId,
+      owner: tool.owner,
+      capabilityVersion: tool.capabilityVersion,
+      name: tool.name,
+      requiredScopes: tool.requiredScopes,
+      deploymentRisk: "high",
+      actionPolicy: action,
+    })
+    expect(registry.list()).toEqual([
+      expect.objectContaining({
+        name: "create_booking",
+        requiredScopes: ["bookings:write", "finance:write"],
+        actionPolicy: expect.objectContaining({
+          enforcement: "handler",
+          invocation: expect.objectContaining({
+            requiredFields: ["confirmed"],
+          }),
+        }),
+      }),
+    ])
+    expect(tool.actionPolicyEnforcement).toBe("handler")
     const services = {
       async createBooking() {
         return {

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -525,6 +525,7 @@ describe("finance deployment manifest", () => {
           expect.objectContaining({
             id: "@voyant-travel/finance#bookings-create-extension.tool.create-booking",
             name: "create_booking",
+            requiredScopes: ["bookings:write", "finance:write"],
           }),
         ],
         actions: [


### PR DESCRIPTION
## What changed

- make `create_booking` use its existing handler-owned action-policy path
- keep explicit MCP confirmation while removing the generic `targetId`/idempotency preflight requirements
- preserve the Finance service's canonical `booking.create` ledger entry under the generated booking ID
- correct documentation that previously described the whole composed operation as atomic
- retain the static `bookings:write` + `finance:write` scope contract

## Why

The generic MCP action gate requires a target before dispatch, but a booking ID is generated inside the booking transaction. A caller could only invent that target. The gate then produced a separate requested/result timeline while Finance recorded the authoritative action under the real booking ID.

The booking transaction also commits before later invoice, payment, document, and event stages, so the composed command is not yet an exact-replay boundary. This PR contains the unsafe generic gate immediately without claiming durable replay for the remaining stages.

## Validation

- `pnpm --filter @voyant-travel/finance exec vitest run tests/tools.test.ts tests/unit/voyant-manifest.test.ts` — 2 files, 12 tests passed
- `pnpm --filter @voyant-travel/finance typecheck` — passed
- validation ran in a disposable remote repository snapshot