### PR TITLE
add durable created command protocol

### DIFF
--- a/.changeset/quiet-otters-claim-created-commands.md
+++ b/.changeset/quiet-otters-claim-created-commands.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/action-ledger": minor
+---
+
+Add a reusable transactional created-target command protocol with advisory-lock
+claiming, exact replay, canonical typed result references, and distinct
+fail-closed errors for incomplete or corrupt durable results.

--- a/.changeset/quiet-otters-claim-created-commands.md
+++ b/.changeset/quiet-otters-claim-created-commands.md
@@ -2,6 +2,7 @@
 "@voyant-travel/action-ledger": minor
 ---
 
-Add a reusable transactional created-target command protocol with advisory-lock
-claiming, exact replay, canonical typed result references, and distinct
-fail-closed errors for incomplete or corrupt durable results.
+Add an owned-transaction created-target command executor with advisory-lock
+claiming, typed policy fingerprints, opaque claim revalidation, exact replay,
+canonical result references, and fail-closed approval handling where `none` is
+the only admitted no-approval policy.

--- a/.changeset/steady-badgers-create-safely.md
+++ b/.changeset/steady-badgers-create-safely.md
@@ -9,5 +9,5 @@
 
 Add explicit created-target action metadata and fail closed unless handler-owned
 Tools declare a durable command claim, replay, and canonical result-reference
-contract. Bind approvals to the pre-create command identity and stop asking MCP
-callers to invent generated target IDs.
+contract. Stop asking MCP callers to invent generated target IDs, and fail
+approval-bearing created commands closed until handler control propagation exists.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -12,6 +12,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -13,6 +13,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/action-ledger/README.md
+++ b/packages/action-ledger/README.md
@@ -36,25 +36,15 @@ canonical target does not exist before dispatch, so the caller cannot supply it 
 preflight cannot share the domain transaction. A created-target handler must implement the
 `handler-command-claim-v1` contract: claim a stable pre-create command identity and fingerprint
 before mutation, reject same-key/different-command reuse, replay a typed immutable result
-reference, and atomically append the canonical generated-target result. Approval requests for
-such actions bind to the declared command target type; the successful generated-target entry is
-then linked causally by the handler.
+reference, and atomically append the canonical generated-target result. Approval-bearing created
+commands fail closed until MCP can propagate their approved invocation controls into the handler.
 
-Package handlers implement that contract with `claimCreatedTargetCommand` and
-`completeCreatedTargetCommand` from `@voyant-travel/action-ledger/created-command`. Both helpers
-must receive the same open transaction handle used for the domain insert:
+Package handlers implement that contract with `executeCreatedTargetCommand` from
+`@voyant-travel/action-ledger/created-command`. It owns the transaction and keeps the claim
+opaque; domain callbacks receive only its exact transaction handle:
 
 ```ts
-const fingerprintInput = {
-  commandInput: input,
-  policyInputs: {
-    approval: "never",
-    capabilityId: "relationships:person:create",
-    capabilityVersion: "v1",
-    evaluatedRisk: "high",
-  },
-}
-const fingerprint = await buildCreatedTargetCommandFingerprint({
+const command = {
   actionName: "relationship.person.create",
   actionVersion: "v1",
   commandTarget: {
@@ -63,56 +53,58 @@ const fingerprint = await buildCreatedTargetCommandFingerprint({
   },
   canonicalTargetType: "relationship-person",
   resultReferenceType: "relationship-person-ref",
-  ...fingerprintInput,
-})
+  commandInput: input,
+  capabilityId: "relationships:person:create",
+  capabilityVersion: "v1",
+  evaluatedRisk: "high",
+  approvalPolicy: "none",
+  approvalReasonCode: null,
+}
+const fingerprint = await buildCreatedTargetCommandFingerprint(command)
 
-await db.transaction(async (tx) => {
-  const claimed = await claimCreatedTargetCommand(tx, {
+return executeCreatedTargetCommand(
+  db,
+  {
     context,
-    actionName: "relationship.person.create",
-    commandTarget: {
-      type: "relationship-person-create-command",
-      id: commandId,
-    },
-    canonicalTargetType: "relationship-person",
-    resultReferenceType: "relationship-person-ref",
+    ...command,
     idempotency: {
       scope: `relationships.create_person:${principalId}`,
       key: idempotencyKey,
       fingerprint,
     },
-    fingerprintInput,
-  })
-
-  if (claimed.replayed) {
-    return resolvePerson(claimed.result.reference.id)
-  }
-
-  const person = await insertPerson(tx, input)
-  await completeCreatedTargetCommand(tx, {
-    claim: claimed.claim,
-    targetId: person.id,
-  })
-  return person
-})
+  },
+  {
+    async create(tx) {
+      const person = await insertPerson(tx, input)
+      return { value: person, targetId: person.id }
+    },
+    async replay(tx, result) {
+      return resolvePerson(tx, result.reference.id)
+    },
+  },
+)
 ```
 
-The claim helper holds a Postgres transaction-scoped advisory lock for the idempotency scope and
-key, appends the requested command identity before the domain write, and rejects key reuse when
-the fingerprint or command identity differs. Exact replay reads the succeeded entry linked to the
-claim, validates its canonical target metadata and typed `<reference-type>:<target-id>` result,
-then returns only metadata for the owning package to resolve. A committed claim without a result
-throws `ActionLedgerCreatedCommandReplayIncompleteError`; malformed or inconsistent result
-metadata throws `ActionLedgerCreatedCommandReplayCorruptError`. Neither condition is dispatched
-again. Approval-required handlers pass the approved request as the claim's `causationActionId`
-and `approvalId`; completion always links the generated-target result to the claim.
+The executor requires a transaction-capable database, holds a Postgres transaction-scoped
+advisory lock for the idempotency scope and key, appends the requested command identity before
+calling domain code, re-reads that opaque claim, and appends the canonical result before commit.
+Exact replay validates full principal, tenant, workflow, capability, authorization, and approval
+continuity plus the typed `<reference-type>:<target-id>` result, then calls only `replay`. A
+committed claim without a result throws `ActionLedgerCreatedCommandReplayIncompleteError`;
+malformed or inconsistent result metadata throws
+`ActionLedgerCreatedCommandReplayCorruptError`. Neither condition is dispatched again.
 
 `buildCreatedTargetCommandFingerprint` covers the command identity and input,
-`canonicalTargetType`, `resultReferenceType`, and the selected risk/capability/approval policy
-metadata. `claimCreatedTargetCommand` recomputes that value from `fingerprintInput` and fails
-before taking the advisory lock if a caller supplies a partial or mismatched digest. A claim also
-requires a concrete user, agent, workflow, API-token, or explicit fallback principal; the helper
-never writes created-command records as `unknown_request`.
+`canonicalTargetType`, `resultReferenceType`, and typed risk/capability/approval/reason metadata.
+The executor derives those fields from the same top-level input and fails before the transaction
+if the supplied digest drifts. Principal admission uses `mapActionLedgerRequestContext`; mismatched
+caller types cannot smuggle an agent or API-token identity into the ledger.
+
+Approval-bearing created commands currently fail closed. MCP strips invocation controls before
+package dispatch and does not yet expose approval id, fingerprint, or reason code through a
+request-scoped handler context. Both the approval request Tool and
+`executeCreatedTargetCommand` reject created actions whose approval policy is not `none` until
+that propagation contract exists.
 
 Booking cancellation and invoice refund keep their existing package-owned two-phase guards: both
 fingerprint domain target state and pass approved causation into atomic domain services. Their

--- a/packages/action-ledger/README.md
+++ b/packages/action-ledger/README.md
@@ -40,6 +40,80 @@ reference, and atomically append the canonical generated-target result. Approval
 such actions bind to the declared command target type; the successful generated-target entry is
 then linked causally by the handler.
 
+Package handlers implement that contract with `claimCreatedTargetCommand` and
+`completeCreatedTargetCommand` from `@voyant-travel/action-ledger/created-command`. Both helpers
+must receive the same open transaction handle used for the domain insert:
+
+```ts
+const fingerprintInput = {
+  commandInput: input,
+  policyInputs: {
+    approval: "never",
+    capabilityId: "relationships:person:create",
+    capabilityVersion: "v1",
+    evaluatedRisk: "high",
+  },
+}
+const fingerprint = await buildCreatedTargetCommandFingerprint({
+  actionName: "relationship.person.create",
+  actionVersion: "v1",
+  commandTarget: {
+    type: "relationship-person-create-command",
+    id: commandId,
+  },
+  canonicalTargetType: "relationship-person",
+  resultReferenceType: "relationship-person-ref",
+  ...fingerprintInput,
+})
+
+await db.transaction(async (tx) => {
+  const claimed = await claimCreatedTargetCommand(tx, {
+    context,
+    actionName: "relationship.person.create",
+    commandTarget: {
+      type: "relationship-person-create-command",
+      id: commandId,
+    },
+    canonicalTargetType: "relationship-person",
+    resultReferenceType: "relationship-person-ref",
+    idempotency: {
+      scope: `relationships.create_person:${principalId}`,
+      key: idempotencyKey,
+      fingerprint,
+    },
+    fingerprintInput,
+  })
+
+  if (claimed.replayed) {
+    return resolvePerson(claimed.result.reference.id)
+  }
+
+  const person = await insertPerson(tx, input)
+  await completeCreatedTargetCommand(tx, {
+    claim: claimed.claim,
+    targetId: person.id,
+  })
+  return person
+})
+```
+
+The claim helper holds a Postgres transaction-scoped advisory lock for the idempotency scope and
+key, appends the requested command identity before the domain write, and rejects key reuse when
+the fingerprint or command identity differs. Exact replay reads the succeeded entry linked to the
+claim, validates its canonical target metadata and typed `<reference-type>:<target-id>` result,
+then returns only metadata for the owning package to resolve. A committed claim without a result
+throws `ActionLedgerCreatedCommandReplayIncompleteError`; malformed or inconsistent result
+metadata throws `ActionLedgerCreatedCommandReplayCorruptError`. Neither condition is dispatched
+again. Approval-required handlers pass the approved request as the claim's `causationActionId`
+and `approvalId`; completion always links the generated-target result to the claim.
+
+`buildCreatedTargetCommandFingerprint` covers the command identity and input,
+`canonicalTargetType`, `resultReferenceType`, and the selected risk/capability/approval policy
+metadata. `claimCreatedTargetCommand` recomputes that value from `fingerprintInput` and fails
+before taking the advisory lock if a caller supplies a partial or mismatched digest. A claim also
+requires a concrete user, agent, workflow, API-token, or explicit fallback principal; the helper
+never writes created-command records as `unknown_request`.
+
 Booking cancellation and invoice refund keep their existing package-owned two-phase guards: both
 fingerprint domain target state and pass approved causation into atomic domain services. Their
 Tool definitions explicitly advertise handler-owned enforcement so MCP does not double-gate them.

--- a/packages/action-ledger/package.json
+++ b/packages/action-ledger/package.json
@@ -8,6 +8,7 @@
     ".": "./src/index.ts",
     "./canary": "./src/canary.ts",
     "./capability": "./src/capability.ts",
+    "./created-command": "./src/created-command.ts",
     "./schema": "./src/schema.ts",
     "./service": "./src/service.ts",
     "./fingerprint": "./src/fingerprint.ts",
@@ -72,6 +73,11 @@
         "types": "./dist/capability.d.ts",
         "import": "./dist/capability.js",
         "default": "./dist/capability.js"
+      },
+      "./created-command": {
+        "types": "./dist/created-command.d.ts",
+        "import": "./dist/created-command.js",
+        "default": "./dist/created-command.js"
       },
       "./schema": {
         "types": "./dist/schema.d.ts",

--- a/packages/action-ledger/src/created-command.ts
+++ b/packages/action-ledger/src/created-command.ts
@@ -1,0 +1,609 @@
+// agent-quality: file-size exception -- owner: action-ledger; claim, replay validation, and canonical completion form one transactional state machine.
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { and, eq, sql } from "drizzle-orm"
+
+import { buildIdempotencyFingerprint } from "./fingerprint.js"
+import {
+  type ActionLedgerRequestContextValues,
+  type BuildActionLedgerMutationInput,
+  buildActionLedgerMutationEntryInput,
+} from "./request-context.js"
+import {
+  type ActionLedgerEntry,
+  actionLedgerEntries,
+  actionMutationDetails,
+} from "./schema.js"
+import { insertEntry } from "./service/entries.js"
+import { ActionLedgerIdempotencyConflictError } from "./service/errors.js"
+import type { AppendActionLedgerEntryInput } from "./service/types.js"
+
+const CLAIM_SCOPE_SUFFIX = ":created-command-claim"
+const RESULT_SCOPE_SUFFIX = ":created-command-result"
+
+export type CreatedTargetCommandResultReference<TReferenceType extends string = string> =
+  `${TReferenceType}:${string}`
+
+export type ActionLedgerCreatedCommandReplayCorruptReason =
+  | "malformed_result_reference"
+  | "wrong_result_reference_type"
+  | "result_target_id_mismatch"
+  | "result_target_type_mismatch"
+  | "result_action_mismatch"
+  | "result_fingerprint_mismatch"
+
+export class ActionLedgerCreatedCommandReplayIncompleteError extends Error {
+  readonly claimActionId: string
+
+  constructor(claimActionId: string) {
+    super(`Created-target command claim ${claimActionId} has no canonical succeeded result`)
+    this.name = "ActionLedgerCreatedCommandReplayIncompleteError"
+    this.claimActionId = claimActionId
+  }
+}
+
+export class ActionLedgerCreatedCommandReplayCorruptError extends Error {
+  readonly claimActionId: string
+  readonly resultActionId: string
+  readonly reason: ActionLedgerCreatedCommandReplayCorruptReason
+
+  constructor(
+    claimActionId: string,
+    resultActionId: string,
+    reason: ActionLedgerCreatedCommandReplayCorruptReason,
+  ) {
+    super(
+      `Created-target command result ${resultActionId} for claim ${claimActionId} is invalid: ${reason}`,
+    )
+    this.name = "ActionLedgerCreatedCommandReplayCorruptError"
+    this.claimActionId = claimActionId
+    this.resultActionId = resultActionId
+    this.reason = reason
+  }
+}
+
+export class ActionLedgerCreatedCommandFingerprintMismatchError extends Error {
+  readonly expectedFingerprint: string
+  readonly receivedFingerprint: string
+
+  constructor(expectedFingerprint: string, receivedFingerprint: string) {
+    super(
+      "Created-target command fingerprint does not cover its command, target, result-reference, and policy metadata",
+    )
+    this.name = "ActionLedgerCreatedCommandFingerprintMismatchError"
+    this.expectedFingerprint = expectedFingerprint
+    this.receivedFingerprint = receivedFingerprint
+  }
+}
+
+export interface BuildCreatedTargetCommandFingerprintInput {
+  actionName: string
+  actionVersion: string
+  commandTarget: {
+    type: string
+    id: string
+  }
+  canonicalTargetType: string
+  resultReferenceType: string
+  commandInput?: unknown
+  policyInputs: Record<string, unknown>
+}
+
+type CreatedCommandCommonInput = Omit<
+  BuildActionLedgerMutationInput,
+  | "actionKind"
+  | "status"
+  | "targetType"
+  | "targetId"
+  | "idempotencyScope"
+  | "idempotencyKey"
+  | "idempotencyFingerprint"
+  | "mutationDetail"
+>
+
+export interface ClaimCreatedTargetCommandInput extends CreatedCommandCommonInput {
+  context: ActionLedgerRequestContextValues
+  actionKind?: Extract<ActionLedgerEntry["actionKind"], "create" | "execute">
+  commandTarget: {
+    type: string
+    id: string
+  }
+  canonicalTargetType: string
+  resultReferenceType: string
+  idempotency: {
+    scope: string
+    key: string
+    fingerprint: string
+  }
+  fingerprintInput: {
+    commandInput?: unknown
+    policyInputs: Record<string, unknown>
+  }
+  mutationDetail?: Omit<
+    NonNullable<BuildActionLedgerMutationInput["mutationDetail"]>,
+    "commandResultRef"
+  >
+}
+
+export interface CreatedTargetCommandResultMetadata<TReferenceType extends string = string> {
+  entry: ActionLedgerEntry
+  reference: {
+    type: TReferenceType
+    id: string
+    value: CreatedTargetCommandResultReference<TReferenceType>
+  }
+}
+
+export interface CreatedTargetCommandClaim<TReferenceType extends string = string> {
+  entry: ActionLedgerEntry
+  canonicalTargetType: string
+  resultReferenceType: TReferenceType
+  idempotency: {
+    scope: string
+    key: string
+    fingerprint: string
+  }
+}
+
+export type ClaimCreatedTargetCommandResult<TReferenceType extends string = string> =
+  | {
+      claim: CreatedTargetCommandClaim<TReferenceType>
+      replayed: false
+      result: null
+    }
+  | {
+      claim: CreatedTargetCommandClaim<TReferenceType>
+      replayed: true
+      result: CreatedTargetCommandResultMetadata<TReferenceType>
+    }
+
+export interface CompleteCreatedTargetCommandInput<TReferenceType extends string = string> {
+  claim: CreatedTargetCommandClaim<TReferenceType>
+  targetId: string
+  mutationDetail?: Omit<
+    NonNullable<BuildActionLedgerMutationInput["mutationDetail"]>,
+    "commandResultRef"
+  >
+  payloads?: AppendActionLedgerEntryInput["payloads"]
+}
+
+export interface CompleteCreatedTargetCommandResult<TReferenceType extends string = string>
+  extends CreatedTargetCommandResultMetadata<TReferenceType> {
+  replayed: boolean
+}
+
+/**
+ * Claims a created-target command before its domain mutation.
+ *
+ * The caller must pass the same open transaction handle to this helper, the
+ * domain mutation, and `completeCreatedTargetCommand`. The transaction-scoped
+ * advisory lock serializes equal `(scope, key)` claims until that transaction
+ * commits or rolls back.
+ */
+export async function claimCreatedTargetCommand<TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  input: ClaimCreatedTargetCommandInput & { resultReferenceType: TReferenceType },
+): Promise<ClaimCreatedTargetCommandResult<TReferenceType>> {
+  assertConcretePrincipal(input)
+  const actionName = requiredValue(input.actionName, "action name")
+  const actionVersion = requiredValue(input.actionVersion ?? "v1", "action version")
+  const commandTargetType = requiredValue(input.commandTarget.type, "command target type")
+  const commandTargetId = requiredValue(input.commandTarget.id, "command target id")
+  const canonicalTargetType = requiredValue(input.canonicalTargetType, "canonical target type")
+  const resultReferenceType = validReferenceType(input.resultReferenceType)
+  const idempotencyScope = requiredValue(input.idempotency.scope, "idempotency scope")
+  const idempotencyKey = requiredValue(input.idempotency.key, "idempotency key")
+  const idempotencyFingerprint = requiredValue(
+    input.idempotency.fingerprint,
+    "idempotency fingerprint",
+  )
+  if (!input.fingerprintInput || typeof input.fingerprintInput !== "object") {
+    throw new TypeError("Created-target command fingerprint input is required")
+  }
+  const expectedFingerprint = await buildCreatedTargetCommandFingerprint({
+    actionName,
+    actionVersion,
+    commandTarget: {
+      type: commandTargetType,
+      id: commandTargetId,
+    },
+    canonicalTargetType,
+    resultReferenceType,
+    commandInput: input.fingerprintInput.commandInput,
+    policyInputs: input.fingerprintInput.policyInputs,
+  })
+  if (idempotencyFingerprint !== expectedFingerprint) {
+    throw new ActionLedgerCreatedCommandFingerprintMismatchError(
+      expectedFingerprint,
+      idempotencyFingerprint,
+    )
+  }
+
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${idempotencyScope}:${idempotencyKey}`}, 0))`,
+  )
+
+  const claimScope = `${idempotencyScope}${CLAIM_SCOPE_SUFFIX}`
+  const existing = await findClaim(tx, claimScope, idempotencyKey)
+  if (existing) {
+    assertExactClaim(existing, {
+      actionName,
+      actionVersion,
+      targetType: commandTargetType,
+      targetId: commandTargetId,
+      fingerprint: idempotencyFingerprint,
+    })
+    const claim = toClaim(existing, {
+      canonicalTargetType,
+      resultReferenceType,
+      scope: idempotencyScope,
+      key: idempotencyKey,
+      fingerprint: idempotencyFingerprint,
+    })
+    return {
+      claim,
+      replayed: true,
+      result: await readCompletedResult(tx, claim),
+    }
+  }
+
+  const entryInput = buildActionLedgerMutationEntryInput({
+    ...input,
+    actionName,
+    actionVersion,
+    actionKind: input.actionKind ?? "create",
+    status: "requested",
+    targetType: commandTargetType,
+    targetId: commandTargetId,
+    idempotencyScope: claimScope,
+    idempotencyKey,
+    idempotencyFingerprint,
+    mutationDetail: {
+      ...input.mutationDetail,
+      commandResultRef: null,
+      reversalKind: input.mutationDetail?.reversalKind ?? "none",
+    },
+  })
+  const inserted = await insertEntry(tx, entryInput)
+
+  return {
+    claim: toClaim(inserted.entry, {
+      canonicalTargetType,
+      resultReferenceType,
+      scope: idempotencyScope,
+      key: idempotencyKey,
+      fingerprint: idempotencyFingerprint,
+    }),
+    replayed: false,
+    result: null,
+  }
+}
+
+/** Appends the canonical generated-target result in the claim's transaction. */
+export async function completeCreatedTargetCommand<TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  input: CompleteCreatedTargetCommandInput<TReferenceType>,
+): Promise<CompleteCreatedTargetCommandResult<TReferenceType>> {
+  const targetId = requiredValue(input.targetId, "canonical target id")
+  const existing = await findResultEntry(tx, input.claim)
+  if (existing) {
+    const result = await validateCompletedResult(tx, input.claim, existing)
+    if (result.reference.id !== targetId) {
+      throw new ActionLedgerCreatedCommandReplayCorruptError(
+        input.claim.entry.id,
+        existing.id,
+        "result_target_id_mismatch",
+      )
+    }
+    return { ...result, replayed: true }
+  }
+
+  const commandResultRef = createCreatedTargetCommandResultReference(
+    input.claim.resultReferenceType,
+    targetId,
+  )
+  const inserted = await insertEntry(tx, {
+    ...copyClaimEntry(input.claim.entry),
+    status: "succeeded",
+    targetType: input.claim.canonicalTargetType,
+    targetId,
+    causationActionId: input.claim.entry.id,
+    idempotencyScope: resultScope(input.claim.idempotency.scope),
+    idempotencyKey: input.claim.idempotency.key,
+    idempotencyFingerprint: input.claim.idempotency.fingerprint,
+    payloads: input.payloads,
+    mutationDetail: {
+      ...input.mutationDetail,
+      commandResultRef,
+      reversalKind: input.mutationDetail?.reversalKind ?? "none",
+    },
+  })
+
+  return {
+    entry: inserted.entry,
+    reference: {
+      type: input.claim.resultReferenceType,
+      id: targetId,
+      value: commandResultRef,
+    },
+    replayed: false,
+  }
+}
+
+export function createCreatedTargetCommandResultReference<TReferenceType extends string>(
+  referenceType: TReferenceType,
+  targetId: string,
+): CreatedTargetCommandResultReference<TReferenceType> {
+  return `${validReferenceType(referenceType)}:${requiredValue(targetId, "canonical target id")}`
+}
+
+export async function buildCreatedTargetCommandFingerprint(
+  input: BuildCreatedTargetCommandFingerprintInput,
+): Promise<string> {
+  const actionName = requiredValue(input.actionName, "action name")
+  const actionVersion = requiredValue(input.actionVersion, "action version")
+  const commandTargetType = requiredValue(input.commandTarget.type, "command target type")
+  const commandTargetId = requiredValue(input.commandTarget.id, "command target id")
+  const canonicalTargetType = requiredValue(input.canonicalTargetType, "canonical target type")
+  const resultReferenceType = validReferenceType(input.resultReferenceType)
+  if (
+    !input.policyInputs ||
+    typeof input.policyInputs !== "object" ||
+    Array.isArray(input.policyInputs) ||
+    Object.keys(input.policyInputs).length === 0
+  ) {
+    throw new TypeError(
+      "Created-target command fingerprint policy inputs must be a non-empty object",
+    )
+  }
+
+  return buildIdempotencyFingerprint({
+    actionName,
+    actionVersion,
+    targetType: commandTargetType,
+    targetId: commandTargetId,
+    commandInput: input.commandInput ?? null,
+    policyInputs: {
+      createdTarget: {
+        canonicalTargetType,
+        resultReferenceType,
+      },
+      policy: input.policyInputs,
+    },
+  })
+}
+
+async function findClaim(
+  tx: AnyDrizzleDb,
+  idempotencyScope: string,
+  idempotencyKey: string,
+): Promise<ActionLedgerEntry | null> {
+  const [row] = await tx
+    .select({ claim: actionLedgerEntries })
+    .from(actionLedgerEntries)
+    .where(
+      and(
+        eq(actionLedgerEntries.idempotencyScope, idempotencyScope),
+        eq(actionLedgerEntries.idempotencyKey, idempotencyKey),
+      ),
+    )
+    .limit(1)
+  return row?.claim ?? null
+}
+
+async function findResultEntry<TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  claim: CreatedTargetCommandClaim<TReferenceType>,
+): Promise<ActionLedgerEntry | null> {
+  const [row] = await tx
+    .select({ result: actionLedgerEntries })
+    .from(actionLedgerEntries)
+    .where(
+      and(
+        eq(actionLedgerEntries.causationActionId, claim.entry.id),
+        eq(actionLedgerEntries.idempotencyScope, resultScope(claim.idempotency.scope)),
+        eq(actionLedgerEntries.idempotencyKey, claim.idempotency.key),
+        eq(actionLedgerEntries.status, "succeeded"),
+      ),
+    )
+    .limit(1)
+  return row?.result ?? null
+}
+
+async function readCompletedResult<TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  claim: CreatedTargetCommandClaim<TReferenceType>,
+): Promise<CreatedTargetCommandResultMetadata<TReferenceType>> {
+  const resultEntry = await findResultEntry(tx, claim)
+  if (!resultEntry) {
+    throw new ActionLedgerCreatedCommandReplayIncompleteError(claim.entry.id)
+  }
+  return validateCompletedResult(tx, claim, resultEntry)
+}
+
+async function validateCompletedResult<TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  claim: CreatedTargetCommandClaim<TReferenceType>,
+  resultEntry: ActionLedgerEntry,
+): Promise<CreatedTargetCommandResultMetadata<TReferenceType>> {
+  if (resultEntry.actionName !== claim.entry.actionName) {
+    throw corrupt(claim, resultEntry, "result_action_mismatch")
+  }
+  if (resultEntry.idempotencyFingerprint !== claim.idempotency.fingerprint) {
+    throw corrupt(claim, resultEntry, "result_fingerprint_mismatch")
+  }
+  if (resultEntry.targetType !== claim.canonicalTargetType) {
+    throw corrupt(claim, resultEntry, "result_target_type_mismatch")
+  }
+
+  const [detail] = await tx
+    .select({ commandResultRef: actionMutationDetails.commandResultRef })
+    .from(actionMutationDetails)
+    .where(eq(actionMutationDetails.actionId, resultEntry.id))
+    .limit(1)
+  const reference = parseResultReference(
+    claim,
+    resultEntry,
+    detail?.commandResultRef ?? null,
+  )
+  if (reference.id !== resultEntry.targetId) {
+    throw corrupt(claim, resultEntry, "result_target_id_mismatch")
+  }
+  return { entry: resultEntry, reference }
+}
+
+function parseResultReference<TReferenceType extends string>(
+  claim: CreatedTargetCommandClaim<TReferenceType>,
+  resultEntry: ActionLedgerEntry,
+  value: string | null,
+): CreatedTargetCommandResultMetadata<TReferenceType>["reference"] {
+  if (!value) {
+    throw corrupt(claim, resultEntry, "malformed_result_reference")
+  }
+  const separator = value.indexOf(":")
+  if (separator <= 0 || separator === value.length - 1) {
+    throw corrupt(claim, resultEntry, "malformed_result_reference")
+  }
+  const type = value.slice(0, separator)
+  const id = value.slice(separator + 1).trim()
+  if (!id) {
+    throw corrupt(claim, resultEntry, "malformed_result_reference")
+  }
+  if (type !== claim.resultReferenceType) {
+    throw corrupt(claim, resultEntry, "wrong_result_reference_type")
+  }
+  return {
+    type: claim.resultReferenceType,
+    id,
+    value: value as CreatedTargetCommandResultReference<TReferenceType>,
+  }
+}
+
+function assertExactClaim(
+  existing: ActionLedgerEntry,
+  expected: {
+    actionName: string
+    actionVersion: string
+    targetType: string
+    targetId: string
+    fingerprint: string
+  },
+): void {
+  if (
+    existing.actionName !== expected.actionName ||
+    existing.actionVersion !== expected.actionVersion ||
+    existing.targetType !== expected.targetType ||
+    existing.targetId !== expected.targetId ||
+    existing.idempotencyFingerprint !== expected.fingerprint
+  ) {
+    throw new ActionLedgerIdempotencyConflictError(existing.id)
+  }
+}
+
+function toClaim<TReferenceType extends string>(
+  entry: ActionLedgerEntry,
+  input: {
+    canonicalTargetType: string
+    resultReferenceType: TReferenceType
+    scope: string
+    key: string
+    fingerprint: string
+  },
+): CreatedTargetCommandClaim<TReferenceType> {
+  return {
+    entry,
+    canonicalTargetType: input.canonicalTargetType,
+    resultReferenceType: input.resultReferenceType,
+    idempotency: {
+      scope: input.scope,
+      key: input.key,
+      fingerprint: input.fingerprint,
+    },
+  }
+}
+
+function copyClaimEntry(entry: ActionLedgerEntry): Omit<
+  AppendActionLedgerEntryInput,
+  | "status"
+  | "targetType"
+  | "targetId"
+  | "causationActionId"
+  | "idempotencyScope"
+  | "idempotencyKey"
+  | "idempotencyFingerprint"
+> {
+  return {
+    actionName: entry.actionName,
+    actionVersion: entry.actionVersion,
+    actionKind: entry.actionKind,
+    evaluatedRisk: entry.evaluatedRisk,
+    actorType: entry.actorType,
+    principalType: entry.principalType,
+    principalId: entry.principalId,
+    principalSubtype: entry.principalSubtype,
+    sessionId: entry.sessionId,
+    apiTokenId: entry.apiTokenId,
+    internalRequest: entry.internalRequest,
+    delegatedByPrincipalType: entry.delegatedByPrincipalType,
+    delegatedByPrincipalId: entry.delegatedByPrincipalId,
+    delegationId: entry.delegationId,
+    callerType: entry.callerType,
+    organizationId: entry.organizationId,
+    routeOrToolName: entry.routeOrToolName,
+    workflowRunId: entry.workflowRunId,
+    workflowStepId: entry.workflowStepId,
+    correlationId: entry.correlationId,
+    capabilityId: entry.capabilityId,
+    capabilityVersion: entry.capabilityVersion,
+    authorizationSource: entry.authorizationSource,
+    approvalId: entry.approvalId,
+    amendsActionId: null,
+  }
+}
+
+function corrupt<TReferenceType extends string>(
+  claim: CreatedTargetCommandClaim<TReferenceType>,
+  resultEntry: ActionLedgerEntry,
+  reason: ActionLedgerCreatedCommandReplayCorruptReason,
+): ActionLedgerCreatedCommandReplayCorruptError {
+  return new ActionLedgerCreatedCommandReplayCorruptError(
+    claim.entry.id,
+    resultEntry.id,
+    reason,
+  )
+}
+
+function resultScope(scope: string): string {
+  return `${scope}${RESULT_SCOPE_SUFFIX}`
+}
+
+function assertConcretePrincipal(input: ClaimCreatedTargetCommandInput): void {
+  const context = input.context ?? {}
+  const candidates = [
+    context.userId,
+    context.agentId,
+    context.workflowPrincipalId,
+    context.workflowRunId,
+    context.apiTokenId,
+    context.apiKeyId,
+    input.fallbackPrincipalId,
+  ]
+  if (!candidates.some((value) => typeof value === "string" && value.trim().length > 0)) {
+    throw new TypeError("Created-target command claim requires a concrete request principal")
+  }
+}
+
+function requiredValue(value: string, label: string): string {
+  const normalized = value.trim()
+  if (!normalized) throw new TypeError(`Created-target command ${label} is required`)
+  return normalized
+}
+
+function validReferenceType<TReferenceType extends string>(
+  value: TReferenceType,
+): TReferenceType {
+  const normalized = requiredValue(value, "result reference type")
+  if (normalized.includes(":")) {
+    throw new TypeError("Created-target command result reference type cannot contain ':'")
+  }
+  return normalized as TReferenceType
+}

--- a/packages/action-ledger/src/created-command.ts
+++ b/packages/action-ledger/src/created-command.ts
@@ -458,7 +458,10 @@ async function appendCompletedResult<TValue, TReferenceType extends string>(
 
 function assertExactEntry(actual: ActionLedgerEntry, expected: AppendActionLedgerEntryInput): void {
   for (const field of CLAIM_IDENTITY_FIELDS) {
-    if (actual[field] !== expected[field]) {
+    // Drizzle/PostgreSQL persist omitted nullable columns as null. Treat an
+    // omitted expected field as that canonical database representation so an
+    // exact replay does not conflict solely on undefined-versus-null.
+    if (actual[field] !== (expected[field] ?? null)) {
       throw new ActionLedgerIdempotencyConflictError(actual.id)
     }
   }

--- a/packages/action-ledger/src/created-command.ts
+++ b/packages/action-ledger/src/created-command.ts
@@ -378,7 +378,7 @@ async function assertCurrentClaim<TReferenceType extends string>(
     throw new ActionLedgerCreatedCommandProtocolError("claim_changed_during_mutation")
   }
   try {
-    assertExactEntry(current, state.expectedClaim)
+    assertExactEntry(current, state.claim)
   } catch {
     throw new ActionLedgerCreatedCommandProtocolError("claim_changed_during_mutation")
   }
@@ -529,7 +529,10 @@ function toState<TReferenceType extends string>(
     idempotency: { scope: string; key: string; fingerprint: string }
   },
 ): CreatedCommandState<TReferenceType> {
-  return { claim, ...prepared }
+  // Keep an immutable value snapshot rather than the driver's row object. This
+  // lets the post-mutation re-read detect an in-transaction claim change even
+  // when a test double or adapter reuses object identities for selected rows.
+  return { claim: { ...claim }, ...prepared }
 }
 
 function copyClaimEntry(

--- a/packages/action-ledger/src/created-command.ts
+++ b/packages/action-ledger/src/created-command.ts
@@ -1,18 +1,20 @@
 // agent-quality: file-size exception -- owner: action-ledger; claim, replay validation, and canonical completion form one transactional state machine.
 import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { dbSupportsTransactions } from "@voyant-travel/db/transaction-capability"
 import { and, eq, sql } from "drizzle-orm"
 
-import { buildIdempotencyFingerprint } from "./fingerprint.js"
+import type {
+  ActionLedgerCapabilityApprovalPolicy,
+  ActionLedgerCapabilityRisk,
+} from "./capability.js"
+import { buildActionApprovalCommandFingerprint } from "./fingerprint.js"
 import {
   type ActionLedgerRequestContextValues,
   type BuildActionLedgerMutationInput,
   buildActionLedgerMutationEntryInput,
+  mapActionLedgerRequestContext,
 } from "./request-context.js"
-import {
-  type ActionLedgerEntry,
-  actionLedgerEntries,
-  actionMutationDetails,
-} from "./schema.js"
+import { type ActionLedgerEntry, actionLedgerEntries, actionMutationDetails } from "./schema.js"
 import { insertEntry } from "./service/entries.js"
 import { ActionLedgerIdempotencyConflictError } from "./service/errors.js"
 import type { AppendActionLedgerEntryInput } from "./service/types.js"
@@ -30,6 +32,7 @@ export type ActionLedgerCreatedCommandReplayCorruptReason =
   | "result_target_type_mismatch"
   | "result_action_mismatch"
   | "result_fingerprint_mismatch"
+  | "result_identity_mismatch"
 
 export class ActionLedgerCreatedCommandReplayIncompleteError extends Error {
   readonly claimActionId: string
@@ -66,57 +69,80 @@ export class ActionLedgerCreatedCommandFingerprintMismatchError extends Error {
   readonly receivedFingerprint: string
 
   constructor(expectedFingerprint: string, receivedFingerprint: string) {
-    super(
-      "Created-target command fingerprint does not cover its command, target, result-reference, and policy metadata",
-    )
+    super("Created-target command fingerprint does not match its selected action policy")
     this.name = "ActionLedgerCreatedCommandFingerprintMismatchError"
     this.expectedFingerprint = expectedFingerprint
     this.receivedFingerprint = receivedFingerprint
   }
 }
 
+export class ActionLedgerCreatedCommandTransactionRequiredError extends Error {
+  constructor() {
+    super("Created-target command execution requires a transaction-capable database")
+    this.name = "ActionLedgerCreatedCommandTransactionRequiredError"
+  }
+}
+
+export class ActionLedgerCreatedCommandProtocolError extends Error {
+  readonly reason:
+    | "approval_policy_unsupported"
+    | "claim_changed_during_mutation"
+    | "result_created_during_mutation"
+
+  constructor(reason: ActionLedgerCreatedCommandProtocolError["reason"]) {
+    super(`Created-target command protocol failed closed: ${reason}`)
+    this.name = "ActionLedgerCreatedCommandProtocolError"
+    this.reason = reason
+  }
+}
+
 export interface BuildCreatedTargetCommandFingerprintInput {
   actionName: string
   actionVersion: string
-  commandTarget: {
-    type: string
-    id: string
-  }
+  commandTarget: { type: string; id: string }
   canonicalTargetType: string
   resultReferenceType: string
   commandInput?: unknown
-  policyInputs: Record<string, unknown>
+  capabilityId: string
+  capabilityVersion: string
+  evaluatedRisk: ActionLedgerCapabilityRisk
+  approvalPolicy: ActionLedgerCapabilityApprovalPolicy
+  approvalReasonCode: string | null
 }
 
 type CreatedCommandCommonInput = Omit<
   BuildActionLedgerMutationInput,
+  | "actionVersion"
   | "actionKind"
   | "status"
+  | "evaluatedRisk"
   | "targetType"
   | "targetId"
+  | "capabilityId"
+  | "capabilityVersion"
   | "idempotencyScope"
   | "idempotencyKey"
   | "idempotencyFingerprint"
   | "mutationDetail"
 >
 
-export interface ClaimCreatedTargetCommandInput extends CreatedCommandCommonInput {
+export interface ExecuteCreatedTargetCommandInput extends CreatedCommandCommonInput {
   context: ActionLedgerRequestContextValues
+  actionVersion: string
   actionKind?: Extract<ActionLedgerEntry["actionKind"], "create" | "execute">
-  commandTarget: {
-    type: string
-    id: string
-  }
+  evaluatedRisk: ActionLedgerCapabilityRisk
+  commandTarget: { type: string; id: string }
   canonicalTargetType: string
   resultReferenceType: string
+  capabilityId: string
+  capabilityVersion: string
+  approvalPolicy: ActionLedgerCapabilityApprovalPolicy
+  approvalReasonCode: string | null
+  commandInput?: unknown
   idempotency: {
     scope: string
     key: string
     fingerprint: string
-  }
-  fingerprintInput: {
-    commandInput?: unknown
-    policyInputs: Record<string, unknown>
   }
   mutationDetail?: Omit<
     NonNullable<BuildActionLedgerMutationInput["mutationDetail"]>,
@@ -133,31 +159,8 @@ export interface CreatedTargetCommandResultMetadata<TReferenceType extends strin
   }
 }
 
-export interface CreatedTargetCommandClaim<TReferenceType extends string = string> {
-  entry: ActionLedgerEntry
-  canonicalTargetType: string
-  resultReferenceType: TReferenceType
-  idempotency: {
-    scope: string
-    key: string
-    fingerprint: string
-  }
-}
-
-export type ClaimCreatedTargetCommandResult<TReferenceType extends string = string> =
-  | {
-      claim: CreatedTargetCommandClaim<TReferenceType>
-      replayed: false
-      result: null
-    }
-  | {
-      claim: CreatedTargetCommandClaim<TReferenceType>
-      replayed: true
-      result: CreatedTargetCommandResultMetadata<TReferenceType>
-    }
-
-export interface CompleteCreatedTargetCommandInput<TReferenceType extends string = string> {
-  claim: CreatedTargetCommandClaim<TReferenceType>
+export interface CreatedTargetCommandMutation<TValue> {
+  value: TValue
   targetId: string
   mutationDetail?: Omit<
     NonNullable<BuildActionLedgerMutationInput["mutationDetail"]>,
@@ -166,167 +169,96 @@ export interface CompleteCreatedTargetCommandInput<TReferenceType extends string
   payloads?: AppendActionLedgerEntryInput["payloads"]
 }
 
-export interface CompleteCreatedTargetCommandResult<TReferenceType extends string = string>
-  extends CreatedTargetCommandResultMetadata<TReferenceType> {
-  replayed: boolean
+export interface ExecuteCreatedTargetCommandHandlers<TValue, TReferenceType extends string> {
+  create: (tx: AnyDrizzleDb) => Promise<CreatedTargetCommandMutation<TValue>>
+  replay: (
+    tx: AnyDrizzleDb,
+    result: CreatedTargetCommandResultMetadata<TReferenceType>,
+  ) => Promise<TValue>
+}
+
+export type ExecuteCreatedTargetCommandResult<TValue, TReferenceType extends string = string> =
+  | {
+      replayed: false
+      value: TValue
+      result: CreatedTargetCommandResultMetadata<TReferenceType>
+    }
+  | {
+      replayed: true
+      value: TValue
+      result: CreatedTargetCommandResultMetadata<TReferenceType>
+    }
+
+interface CreatedCommandState<TReferenceType extends string> {
+  claim: ActionLedgerEntry
+  expectedClaim: AppendActionLedgerEntryInput
+  canonicalTargetType: string
+  resultReferenceType: TReferenceType
+  idempotency: { scope: string; key: string; fingerprint: string }
 }
 
 /**
- * Claims a created-target command before its domain mutation.
+ * Owns BEGIN → claim → domain mutation → canonical result → COMMIT.
  *
- * The caller must pass the same open transaction handle to this helper, the
- * domain mutation, and `completeCreatedTargetCommand`. The transaction-scoped
- * advisory lock serializes equal `(scope, key)` claims until that transaction
- * commits or rolls back.
+ * The claim is never exposed. Domain code receives only the exact transaction
+ * handle owned by this helper. Exact replays resolve their immutable result
+ * through `handlers.replay` without invoking `handlers.create`.
  */
-export async function claimCreatedTargetCommand<TReferenceType extends string>(
-  tx: AnyDrizzleDb,
-  input: ClaimCreatedTargetCommandInput & { resultReferenceType: TReferenceType },
-): Promise<ClaimCreatedTargetCommandResult<TReferenceType>> {
-  assertConcretePrincipal(input)
-  const actionName = requiredValue(input.actionName, "action name")
-  const actionVersion = requiredValue(input.actionVersion ?? "v1", "action version")
-  const commandTargetType = requiredValue(input.commandTarget.type, "command target type")
-  const commandTargetId = requiredValue(input.commandTarget.id, "command target id")
-  const canonicalTargetType = requiredValue(input.canonicalTargetType, "canonical target type")
-  const resultReferenceType = validReferenceType(input.resultReferenceType)
-  const idempotencyScope = requiredValue(input.idempotency.scope, "idempotency scope")
-  const idempotencyKey = requiredValue(input.idempotency.key, "idempotency key")
-  const idempotencyFingerprint = requiredValue(
-    input.idempotency.fingerprint,
-    "idempotency fingerprint",
-  )
-  if (!input.fingerprintInput || typeof input.fingerprintInput !== "object") {
-    throw new TypeError("Created-target command fingerprint input is required")
-  }
-  const expectedFingerprint = await buildCreatedTargetCommandFingerprint({
-    actionName,
-    actionVersion,
-    commandTarget: {
-      type: commandTargetType,
-      id: commandTargetId,
-    },
-    canonicalTargetType,
-    resultReferenceType,
-    commandInput: input.fingerprintInput.commandInput,
-    policyInputs: input.fingerprintInput.policyInputs,
-  })
-  if (idempotencyFingerprint !== expectedFingerprint) {
-    throw new ActionLedgerCreatedCommandFingerprintMismatchError(
-      expectedFingerprint,
-      idempotencyFingerprint,
+export async function executeCreatedTargetCommand<TValue, TReferenceType extends string>(
+  db: AnyDrizzleDb,
+  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: TReferenceType },
+  handlers: ExecuteCreatedTargetCommandHandlers<TValue, TReferenceType>,
+): Promise<ExecuteCreatedTargetCommandResult<TValue, TReferenceType>> {
+  const prepared = await prepareCommand(input)
+  return requiredTransaction(db, async (tx) => {
+    await lockCommand(tx, prepared.idempotency.scope, prepared.idempotency.key)
+    const existing = await findClaim(
+      tx,
+      claimScope(prepared.idempotency.scope),
+      prepared.idempotency.key,
     )
-  }
-
-  await tx.execute(
-    sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${idempotencyScope}:${idempotencyKey}`}, 0))`,
-  )
-
-  const claimScope = `${idempotencyScope}${CLAIM_SCOPE_SUFFIX}`
-  const existing = await findClaim(tx, claimScope, idempotencyKey)
-  if (existing) {
-    assertExactClaim(existing, {
-      actionName,
-      actionVersion,
-      targetType: commandTargetType,
-      targetId: commandTargetId,
-      fingerprint: idempotencyFingerprint,
-    })
-    const claim = toClaim(existing, {
-      canonicalTargetType,
-      resultReferenceType,
-      scope: idempotencyScope,
-      key: idempotencyKey,
-      fingerprint: idempotencyFingerprint,
-    })
-    return {
-      claim,
-      replayed: true,
-      result: await readCompletedResult(tx, claim),
+    if (existing) {
+      assertExactEntry(existing, prepared.expectedClaim)
+      const state = toState(existing, prepared)
+      const result = await readCompletedResult(tx, state)
+      return {
+        replayed: true,
+        value: await handlers.replay(tx, result),
+        result,
+      }
     }
-  }
 
-  const entryInput = buildActionLedgerMutationEntryInput({
-    ...input,
-    actionName,
-    actionVersion,
-    actionKind: input.actionKind ?? "create",
-    status: "requested",
-    targetType: commandTargetType,
-    targetId: commandTargetId,
-    idempotencyScope: claimScope,
-    idempotencyKey,
-    idempotencyFingerprint,
-    mutationDetail: {
-      ...input.mutationDetail,
-      commandResultRef: null,
-      reversalKind: input.mutationDetail?.reversalKind ?? "none",
-    },
+    const inserted = await insertEntry(tx, prepared.expectedClaim)
+    const state = toState(inserted.entry, prepared)
+    const mutation = await handlers.create(tx)
+    await assertCurrentClaim(tx, state)
+    if (await findResultEntry(tx, state)) {
+      throw new ActionLedgerCreatedCommandProtocolError("result_created_during_mutation")
+    }
+    const result = await appendCompletedResult(tx, state, mutation)
+    return { replayed: false, value: mutation.value, result }
   })
-  const inserted = await insertEntry(tx, entryInput)
-
-  return {
-    claim: toClaim(inserted.entry, {
-      canonicalTargetType,
-      resultReferenceType,
-      scope: idempotencyScope,
-      key: idempotencyKey,
-      fingerprint: idempotencyFingerprint,
-    }),
-    replayed: false,
-    result: null,
-  }
 }
 
-/** Appends the canonical generated-target result in the claim's transaction. */
-export async function completeCreatedTargetCommand<TReferenceType extends string>(
-  tx: AnyDrizzleDb,
-  input: CompleteCreatedTargetCommandInput<TReferenceType>,
-): Promise<CompleteCreatedTargetCommandResult<TReferenceType>> {
-  const targetId = requiredValue(input.targetId, "canonical target id")
-  const existing = await findResultEntry(tx, input.claim)
-  if (existing) {
-    const result = await validateCompletedResult(tx, input.claim, existing)
-    if (result.reference.id !== targetId) {
-      throw new ActionLedgerCreatedCommandReplayCorruptError(
-        input.claim.entry.id,
-        existing.id,
-        "result_target_id_mismatch",
-      )
-    }
-    return { ...result, replayed: true }
-  }
-
-  const commandResultRef = createCreatedTargetCommandResultReference(
-    input.claim.resultReferenceType,
-    targetId,
-  )
-  const inserted = await insertEntry(tx, {
-    ...copyClaimEntry(input.claim.entry),
-    status: "succeeded",
-    targetType: input.claim.canonicalTargetType,
-    targetId,
-    causationActionId: input.claim.entry.id,
-    idempotencyScope: resultScope(input.claim.idempotency.scope),
-    idempotencyKey: input.claim.idempotency.key,
-    idempotencyFingerprint: input.claim.idempotency.fingerprint,
-    payloads: input.payloads,
-    mutationDetail: {
-      ...input.mutationDetail,
-      commandResultRef,
-      reversalKind: input.mutationDetail?.reversalKind ?? "none",
+export async function buildCreatedTargetCommandFingerprint(
+  input: BuildCreatedTargetCommandFingerprintInput,
+): Promise<string> {
+  return buildActionApprovalCommandFingerprint({
+    actionName: requiredValue(input.actionName, "action name"),
+    actionVersion: requiredValue(input.actionVersion, "action version"),
+    targetType: requiredValue(input.commandTarget.type, "command target type"),
+    targetId: requiredValue(input.commandTarget.id, "command target id"),
+    commandInput: input.commandInput ?? null,
+    approvalPolicy: input.approvalPolicy,
+    capabilityId: requiredValue(input.capabilityId, "capability id"),
+    capabilityVersion: requiredValue(input.capabilityVersion, "capability version"),
+    evaluatedRisk: input.evaluatedRisk,
+    reasonCode: input.approvalReasonCode,
+    createdTarget: {
+      canonicalTargetType: requiredValue(input.canonicalTargetType, "canonical target type"),
+      resultReferenceType: validReferenceType(input.resultReferenceType),
     },
   })
-
-  return {
-    entry: inserted.entry,
-    reference: {
-      type: input.claim.resultReferenceType,
-      id: targetId,
-      value: commandResultRef,
-    },
-    replayed: false,
-  }
 }
 
 export function createCreatedTargetCommandResultReference<TReferenceType extends string>(
@@ -336,40 +268,87 @@ export function createCreatedTargetCommandResultReference<TReferenceType extends
   return `${validReferenceType(referenceType)}:${requiredValue(targetId, "canonical target id")}`
 }
 
-export async function buildCreatedTargetCommandFingerprint(
-  input: BuildCreatedTargetCommandFingerprintInput,
-): Promise<string> {
+async function prepareCommand<TReferenceType extends string>(
+  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: TReferenceType },
+) {
+  const actor = mapActionLedgerRequestContext(input.context, input)
+  if (actor.principalId === "unknown_request") {
+    throw new TypeError("Created-target command execution requires a concrete request principal")
+  }
   const actionName = requiredValue(input.actionName, "action name")
   const actionVersion = requiredValue(input.actionVersion, "action version")
   const commandTargetType = requiredValue(input.commandTarget.type, "command target type")
   const commandTargetId = requiredValue(input.commandTarget.id, "command target id")
   const canonicalTargetType = requiredValue(input.canonicalTargetType, "canonical target type")
   const resultReferenceType = validReferenceType(input.resultReferenceType)
-  if (
-    !input.policyInputs ||
-    typeof input.policyInputs !== "object" ||
-    Array.isArray(input.policyInputs) ||
-    Object.keys(input.policyInputs).length === 0
-  ) {
-    throw new TypeError(
-      "Created-target command fingerprint policy inputs must be a non-empty object",
-    )
-  }
-
-  return buildIdempotencyFingerprint({
+  const scope = requiredValue(input.idempotency.scope, "idempotency scope")
+  const key = requiredValue(input.idempotency.key, "idempotency key")
+  const fingerprint = requiredValue(input.idempotency.fingerprint, "idempotency fingerprint")
+  const expectedFingerprint = await buildCreatedTargetCommandFingerprint({
     actionName,
     actionVersion,
+    commandTarget: { type: commandTargetType, id: commandTargetId },
+    canonicalTargetType,
+    resultReferenceType,
+    commandInput: input.commandInput,
+    capabilityId: input.capabilityId,
+    capabilityVersion: input.capabilityVersion,
+    evaluatedRisk: input.evaluatedRisk,
+    approvalPolicy: input.approvalPolicy,
+    approvalReasonCode: input.approvalReasonCode,
+  })
+  if (fingerprint !== expectedFingerprint) {
+    throw new ActionLedgerCreatedCommandFingerprintMismatchError(expectedFingerprint, fingerprint)
+  }
+  if (input.approvalPolicy !== "none" || input.approvalId) {
+    throw new ActionLedgerCreatedCommandProtocolError("approval_policy_unsupported")
+  }
+
+  const expectedClaim = buildActionLedgerMutationEntryInput({
+    ...input,
+    actionName,
+    actionVersion,
+    actionKind: input.actionKind ?? "create",
+    status: "requested",
     targetType: commandTargetType,
     targetId: commandTargetId,
-    commandInput: input.commandInput ?? null,
-    policyInputs: {
-      createdTarget: {
-        canonicalTargetType,
-        resultReferenceType,
-      },
-      policy: input.policyInputs,
+    capabilityId: requiredValue(input.capabilityId, "capability id"),
+    capabilityVersion: requiredValue(input.capabilityVersion, "capability version"),
+    idempotencyScope: claimScope(scope),
+    idempotencyKey: key,
+    idempotencyFingerprint: fingerprint,
+    mutationDetail: {
+      ...input.mutationDetail,
+      commandResultRef: null,
+      reversalKind: input.mutationDetail?.reversalKind ?? "none",
     },
   })
+  return {
+    expectedClaim,
+    canonicalTargetType,
+    resultReferenceType,
+    idempotency: { scope, key, fingerprint },
+  }
+}
+
+async function requiredTransaction<T>(
+  db: AnyDrizzleDb,
+  run: (tx: AnyDrizzleDb) => Promise<T>,
+): Promise<T> {
+  if (dbSupportsTransactions(db) === false) {
+    throw new ActionLedgerCreatedCommandTransactionRequiredError()
+  }
+  const transactional = db as AnyDrizzleDb & {
+    transaction?: (callback: (tx: AnyDrizzleDb) => Promise<T>) => Promise<T>
+  }
+  if (typeof transactional.transaction !== "function") {
+    throw new ActionLedgerCreatedCommandTransactionRequiredError()
+  }
+  return transactional.transaction(run)
+}
+
+async function lockCommand(tx: AnyDrizzleDb, scope: string, key: string): Promise<void> {
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${`${scope}:${key}`}, 0))`)
 }
 
 async function findClaim(
@@ -390,19 +369,32 @@ async function findClaim(
   return row?.claim ?? null
 }
 
+async function assertCurrentClaim<TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  state: CreatedCommandState<TReferenceType>,
+): Promise<void> {
+  const current = await findClaim(tx, claimScope(state.idempotency.scope), state.idempotency.key)
+  if (!current || current.id !== state.claim.id) {
+    throw new ActionLedgerCreatedCommandProtocolError("claim_changed_during_mutation")
+  }
+  try {
+    assertExactEntry(current, state.expectedClaim)
+  } catch {
+    throw new ActionLedgerCreatedCommandProtocolError("claim_changed_during_mutation")
+  }
+}
+
 async function findResultEntry<TReferenceType extends string>(
   tx: AnyDrizzleDb,
-  claim: CreatedTargetCommandClaim<TReferenceType>,
+  state: CreatedCommandState<TReferenceType>,
 ): Promise<ActionLedgerEntry | null> {
   const [row] = await tx
     .select({ result: actionLedgerEntries })
     .from(actionLedgerEntries)
     .where(
       and(
-        eq(actionLedgerEntries.causationActionId, claim.entry.id),
-        eq(actionLedgerEntries.idempotencyScope, resultScope(claim.idempotency.scope)),
-        eq(actionLedgerEntries.idempotencyKey, claim.idempotency.key),
-        eq(actionLedgerEntries.status, "succeeded"),
+        eq(actionLedgerEntries.idempotencyScope, resultScope(state.idempotency.scope)),
+        eq(actionLedgerEntries.idempotencyKey, state.idempotency.key),
       ),
     )
     .limit(1)
@@ -411,117 +403,138 @@ async function findResultEntry<TReferenceType extends string>(
 
 async function readCompletedResult<TReferenceType extends string>(
   tx: AnyDrizzleDb,
-  claim: CreatedTargetCommandClaim<TReferenceType>,
+  state: CreatedCommandState<TReferenceType>,
 ): Promise<CreatedTargetCommandResultMetadata<TReferenceType>> {
-  const resultEntry = await findResultEntry(tx, claim)
-  if (!resultEntry) {
-    throw new ActionLedgerCreatedCommandReplayIncompleteError(claim.entry.id)
-  }
-  return validateCompletedResult(tx, claim, resultEntry)
-}
-
-async function validateCompletedResult<TReferenceType extends string>(
-  tx: AnyDrizzleDb,
-  claim: CreatedTargetCommandClaim<TReferenceType>,
-  resultEntry: ActionLedgerEntry,
-): Promise<CreatedTargetCommandResultMetadata<TReferenceType>> {
-  if (resultEntry.actionName !== claim.entry.actionName) {
-    throw corrupt(claim, resultEntry, "result_action_mismatch")
-  }
-  if (resultEntry.idempotencyFingerprint !== claim.idempotency.fingerprint) {
-    throw corrupt(claim, resultEntry, "result_fingerprint_mismatch")
-  }
-  if (resultEntry.targetType !== claim.canonicalTargetType) {
-    throw corrupt(claim, resultEntry, "result_target_type_mismatch")
-  }
-
+  const entry = await findResultEntry(tx, state)
+  if (!entry) throw new ActionLedgerCreatedCommandReplayIncompleteError(state.claim.id)
+  assertResultIdentity(state, entry)
   const [detail] = await tx
     .select({ commandResultRef: actionMutationDetails.commandResultRef })
     .from(actionMutationDetails)
-    .where(eq(actionMutationDetails.actionId, resultEntry.id))
+    .where(eq(actionMutationDetails.actionId, entry.id))
     .limit(1)
-  const reference = parseResultReference(
-    claim,
-    resultEntry,
-    detail?.commandResultRef ?? null,
-  )
-  if (reference.id !== resultEntry.targetId) {
-    throw corrupt(claim, resultEntry, "result_target_id_mismatch")
+  const reference = parseResultReference(state, entry, detail?.commandResultRef ?? null)
+  if (reference.id !== entry.targetId) {
+    throw corrupt(state, entry, "result_target_id_mismatch")
   }
-  return { entry: resultEntry, reference }
+  return { entry, reference }
+}
+
+async function appendCompletedResult<TValue, TReferenceType extends string>(
+  tx: AnyDrizzleDb,
+  state: CreatedCommandState<TReferenceType>,
+  mutation: CreatedTargetCommandMutation<TValue>,
+): Promise<CreatedTargetCommandResultMetadata<TReferenceType>> {
+  const targetId = requiredValue(mutation.targetId, "canonical target id")
+  const commandResultRef = createCreatedTargetCommandResultReference(
+    state.resultReferenceType,
+    targetId,
+  )
+  const inserted = await insertEntry(tx, {
+    ...copyClaimEntry(state.claim),
+    status: "succeeded",
+    targetType: state.canonicalTargetType,
+    targetId,
+    causationActionId: state.claim.id,
+    idempotencyScope: resultScope(state.idempotency.scope),
+    idempotencyKey: state.idempotency.key,
+    idempotencyFingerprint: state.idempotency.fingerprint,
+    payloads: mutation.payloads,
+    mutationDetail: {
+      ...mutation.mutationDetail,
+      commandResultRef,
+      reversalKind: mutation.mutationDetail?.reversalKind ?? "none",
+    },
+  })
+  return {
+    entry: inserted.entry,
+    reference: {
+      type: state.resultReferenceType,
+      id: targetId,
+      value: commandResultRef,
+    },
+  }
+}
+
+function assertExactEntry(actual: ActionLedgerEntry, expected: AppendActionLedgerEntryInput): void {
+  for (const field of CLAIM_IDENTITY_FIELDS) {
+    if (actual[field] !== expected[field]) {
+      throw new ActionLedgerIdempotencyConflictError(actual.id)
+    }
+  }
+}
+
+function assertResultIdentity<TReferenceType extends string>(
+  state: CreatedCommandState<TReferenceType>,
+  entry: ActionLedgerEntry,
+): void {
+  if (entry.actionName !== state.claim.actionName) {
+    throw corrupt(state, entry, "result_action_mismatch")
+  }
+  if (entry.idempotencyFingerprint !== state.idempotency.fingerprint) {
+    throw corrupt(state, entry, "result_fingerprint_mismatch")
+  }
+  if (entry.targetType !== state.canonicalTargetType) {
+    throw corrupt(state, entry, "result_target_type_mismatch")
+  }
+  for (const field of RESULT_CONTINUITY_FIELDS) {
+    if (entry[field] !== state.claim[field]) {
+      throw corrupt(state, entry, "result_identity_mismatch")
+    }
+  }
+  if (
+    entry.status !== "succeeded" ||
+    entry.causationActionId !== state.claim.id ||
+    entry.idempotencyScope !== resultScope(state.idempotency.scope) ||
+    entry.idempotencyKey !== state.idempotency.key ||
+    entry.approvalId !== state.claim.approvalId
+  ) {
+    throw corrupt(state, entry, "result_identity_mismatch")
+  }
 }
 
 function parseResultReference<TReferenceType extends string>(
-  claim: CreatedTargetCommandClaim<TReferenceType>,
-  resultEntry: ActionLedgerEntry,
+  state: CreatedCommandState<TReferenceType>,
+  entry: ActionLedgerEntry,
   value: string | null,
 ): CreatedTargetCommandResultMetadata<TReferenceType>["reference"] {
-  if (!value) {
-    throw corrupt(claim, resultEntry, "malformed_result_reference")
-  }
+  if (!value) throw corrupt(state, entry, "malformed_result_reference")
   const separator = value.indexOf(":")
   if (separator <= 0 || separator === value.length - 1) {
-    throw corrupt(claim, resultEntry, "malformed_result_reference")
+    throw corrupt(state, entry, "malformed_result_reference")
   }
   const type = value.slice(0, separator)
-  const id = value.slice(separator + 1).trim()
-  if (!id) {
-    throw corrupt(claim, resultEntry, "malformed_result_reference")
+  const rawId = value.slice(separator + 1)
+  const id = rawId.trim()
+  if (!id) throw corrupt(state, entry, "malformed_result_reference")
+  if (type !== state.resultReferenceType) {
+    throw corrupt(state, entry, "wrong_result_reference_type")
   }
-  if (type !== claim.resultReferenceType) {
-    throw corrupt(claim, resultEntry, "wrong_result_reference_type")
+  if (value !== `${state.resultReferenceType}:${id}`) {
+    throw corrupt(state, entry, "malformed_result_reference")
   }
   return {
-    type: claim.resultReferenceType,
+    type: state.resultReferenceType,
     id,
     value: value as CreatedTargetCommandResultReference<TReferenceType>,
   }
 }
 
-function assertExactClaim(
-  existing: ActionLedgerEntry,
-  expected: {
-    actionName: string
-    actionVersion: string
-    targetType: string
-    targetId: string
-    fingerprint: string
-  },
-): void {
-  if (
-    existing.actionName !== expected.actionName ||
-    existing.actionVersion !== expected.actionVersion ||
-    existing.targetType !== expected.targetType ||
-    existing.targetId !== expected.targetId ||
-    existing.idempotencyFingerprint !== expected.fingerprint
-  ) {
-    throw new ActionLedgerIdempotencyConflictError(existing.id)
-  }
-}
-
-function toClaim<TReferenceType extends string>(
-  entry: ActionLedgerEntry,
-  input: {
+function toState<TReferenceType extends string>(
+  claim: ActionLedgerEntry,
+  prepared: {
+    expectedClaim: AppendActionLedgerEntryInput
     canonicalTargetType: string
     resultReferenceType: TReferenceType
-    scope: string
-    key: string
-    fingerprint: string
+    idempotency: { scope: string; key: string; fingerprint: string }
   },
-): CreatedTargetCommandClaim<TReferenceType> {
-  return {
-    entry,
-    canonicalTargetType: input.canonicalTargetType,
-    resultReferenceType: input.resultReferenceType,
-    idempotency: {
-      scope: input.scope,
-      key: input.key,
-      fingerprint: input.fingerprint,
-    },
-  }
+): CreatedCommandState<TReferenceType> {
+  return { claim, ...prepared }
 }
 
-function copyClaimEntry(entry: ActionLedgerEntry): Omit<
+function copyClaimEntry(
+  entry: ActionLedgerEntry,
+): Omit<
   AppendActionLedgerEntryInput,
   | "status"
   | "targetType"
@@ -561,35 +574,72 @@ function copyClaimEntry(entry: ActionLedgerEntry): Omit<
 }
 
 function corrupt<TReferenceType extends string>(
-  claim: CreatedTargetCommandClaim<TReferenceType>,
-  resultEntry: ActionLedgerEntry,
+  state: CreatedCommandState<TReferenceType>,
+  entry: ActionLedgerEntry,
   reason: ActionLedgerCreatedCommandReplayCorruptReason,
 ): ActionLedgerCreatedCommandReplayCorruptError {
-  return new ActionLedgerCreatedCommandReplayCorruptError(
-    claim.entry.id,
-    resultEntry.id,
-    reason,
-  )
+  return new ActionLedgerCreatedCommandReplayCorruptError(state.claim.id, entry.id, reason)
+}
+
+const CLAIM_IDENTITY_FIELDS = [
+  "actionName",
+  "actionVersion",
+  "actionKind",
+  "status",
+  "evaluatedRisk",
+  "actorType",
+  "principalType",
+  "principalId",
+  "principalSubtype",
+  "internalRequest",
+  "delegatedByPrincipalType",
+  "delegatedByPrincipalId",
+  "delegationId",
+  "organizationId",
+  "routeOrToolName",
+  "causationActionId",
+  "idempotencyScope",
+  "idempotencyKey",
+  "idempotencyFingerprint",
+  "targetType",
+  "targetId",
+  "capabilityId",
+  "capabilityVersion",
+  "authorizationSource",
+  "approvalId",
+] as const satisfies readonly (keyof ActionLedgerEntry)[]
+
+const RESULT_CONTINUITY_FIELDS = [
+  "actionVersion",
+  "actionKind",
+  "evaluatedRisk",
+  "actorType",
+  "principalType",
+  "principalId",
+  "principalSubtype",
+  "sessionId",
+  "apiTokenId",
+  "internalRequest",
+  "delegatedByPrincipalType",
+  "delegatedByPrincipalId",
+  "delegationId",
+  "callerType",
+  "organizationId",
+  "routeOrToolName",
+  "workflowRunId",
+  "workflowStepId",
+  "correlationId",
+  "capabilityId",
+  "capabilityVersion",
+  "authorizationSource",
+] as const satisfies readonly (keyof ActionLedgerEntry)[]
+
+function claimScope(scope: string): string {
+  return `${scope}${CLAIM_SCOPE_SUFFIX}`
 }
 
 function resultScope(scope: string): string {
   return `${scope}${RESULT_SCOPE_SUFFIX}`
-}
-
-function assertConcretePrincipal(input: ClaimCreatedTargetCommandInput): void {
-  const context = input.context ?? {}
-  const candidates = [
-    context.userId,
-    context.agentId,
-    context.workflowPrincipalId,
-    context.workflowRunId,
-    context.apiTokenId,
-    context.apiKeyId,
-    input.fallbackPrincipalId,
-  ]
-  if (!candidates.some((value) => typeof value === "string" && value.trim().length > 0)) {
-    throw new TypeError("Created-target command claim requires a concrete request principal")
-  }
 }
 
 function requiredValue(value: string, label: string): string {
@@ -598,9 +648,7 @@ function requiredValue(value: string, label: string): string {
   return normalized
 }
 
-function validReferenceType<TReferenceType extends string>(
-  value: TReferenceType,
-): TReferenceType {
+function validReferenceType<TReferenceType extends string>(value: TReferenceType): TReferenceType {
   const normalized = requiredValue(value, "result reference type")
   if (normalized.includes(":")) {
     throw new TypeError("Created-target command result reference type cannot contain ':'")

--- a/packages/action-ledger/src/fingerprint.ts
+++ b/packages/action-ledger/src/fingerprint.ts
@@ -48,6 +48,10 @@ export interface BuildActionApprovalCommandFingerprintInput {
   capabilityVersion: string
   evaluatedRisk: ActionLedgerCapabilityRisk
   reasonCode: string | null
+  createdTarget?: {
+    canonicalTargetType: string
+    resultReferenceType: string
+  } | null
 }
 
 export async function buildActionApprovalCommandFingerprint(
@@ -65,6 +69,7 @@ export async function buildActionApprovalCommandFingerprint(
       capabilityVersion: input.capabilityVersion,
       evaluatedRisk: input.evaluatedRisk,
       reasonCode: input.reasonCode,
+      ...(input.createdTarget ? { createdTarget: input.createdTarget } : {}),
     },
   })
 }

--- a/packages/action-ledger/src/index.ts
+++ b/packages/action-ledger/src/index.ts
@@ -27,6 +27,24 @@ export {
   getActionLedgerCapability,
 } from "./capability.js"
 export {
+  ActionLedgerCreatedCommandFingerprintMismatchError,
+  ActionLedgerCreatedCommandProtocolError,
+  ActionLedgerCreatedCommandReplayCorruptError,
+  type ActionLedgerCreatedCommandReplayCorruptReason,
+  ActionLedgerCreatedCommandReplayIncompleteError,
+  ActionLedgerCreatedCommandTransactionRequiredError,
+  type BuildCreatedTargetCommandFingerprintInput,
+  buildCreatedTargetCommandFingerprint,
+  type CreatedTargetCommandMutation,
+  type CreatedTargetCommandResultMetadata,
+  type CreatedTargetCommandResultReference,
+  createCreatedTargetCommandResultReference,
+  type ExecuteCreatedTargetCommandHandlers,
+  type ExecuteCreatedTargetCommandInput,
+  type ExecuteCreatedTargetCommandResult,
+  executeCreatedTargetCommand,
+} from "./created-command.js"
+export {
   type BuildActionApprovalCommandFingerprintInput,
   buildActionApprovalCommandFingerprint,
   buildIdempotencyFingerprint,
@@ -34,24 +52,6 @@ export {
   canonicalJson,
   sha256,
 } from "./fingerprint.js"
-export {
-  type ActionLedgerCreatedCommandReplayCorruptReason,
-  ActionLedgerCreatedCommandFingerprintMismatchError,
-  ActionLedgerCreatedCommandReplayCorruptError,
-  ActionLedgerCreatedCommandReplayIncompleteError,
-  type BuildCreatedTargetCommandFingerprintInput,
-  type ClaimCreatedTargetCommandInput,
-  type ClaimCreatedTargetCommandResult,
-  type CompleteCreatedTargetCommandInput,
-  type CompleteCreatedTargetCommandResult,
-  type CreatedTargetCommandClaim,
-  type CreatedTargetCommandResultMetadata,
-  type CreatedTargetCommandResultReference,
-  buildCreatedTargetCommandFingerprint,
-  claimCreatedTargetCommand,
-  completeCreatedTargetCommand,
-  createCreatedTargetCommandResultReference,
-} from "./created-command.js"
 export {
   type ActionLedgerDriftCheck,
   type ActionLedgerDriftCheckInput,

--- a/packages/action-ledger/src/index.ts
+++ b/packages/action-ledger/src/index.ts
@@ -35,6 +35,24 @@ export {
   sha256,
 } from "./fingerprint.js"
 export {
+  type ActionLedgerCreatedCommandReplayCorruptReason,
+  ActionLedgerCreatedCommandFingerprintMismatchError,
+  ActionLedgerCreatedCommandReplayCorruptError,
+  ActionLedgerCreatedCommandReplayIncompleteError,
+  type BuildCreatedTargetCommandFingerprintInput,
+  type ClaimCreatedTargetCommandInput,
+  type ClaimCreatedTargetCommandResult,
+  type CompleteCreatedTargetCommandInput,
+  type CompleteCreatedTargetCommandResult,
+  type CreatedTargetCommandClaim,
+  type CreatedTargetCommandResultMetadata,
+  type CreatedTargetCommandResultReference,
+  buildCreatedTargetCommandFingerprint,
+  claimCreatedTargetCommand,
+  completeCreatedTargetCommand,
+  createCreatedTargetCommandResultReference,
+} from "./created-command.js"
+export {
   type ActionLedgerDriftCheck,
   type ActionLedgerDriftCheckInput,
   type ActionLedgerDriftCheckResult,

--- a/packages/action-ledger/src/mcp-runtime.ts
+++ b/packages/action-ledger/src/mcp-runtime.ts
@@ -146,17 +146,14 @@ export function createActionLedgerToolServices(input: {
       const currentPrincipal = writePrincipal(input.requestContext)
       const selected = selectedApprovalRequestAction(input.selectedActions, request)
       const capabilityId = selected.capabilityId ?? selected.id
-      const approvalTargetType =
-        selected.targetLifecycle === "created"
-          ? selected.createdTarget?.commandTargetType
-          : selected.targetType
-      if (!approvalTargetType) {
+      if (selected.targetLifecycle === "created") {
         throw new ToolError(
-          "Created-target approval requires a declared pre-create command target type.",
+          "Approval-required created-target Tools fail closed until MCP propagates the approved command control context to the package handler.",
           "ACTION_POLICY_REQUIRED",
           { actionId: selected.id },
         )
       }
+      const approvalTargetType = selected.targetType
       const reasonCode = request.reasonCode ?? null
       const idempotencyFingerprint = await buildActionApprovalCommandFingerprint({
         actionName: capabilityId,

--- a/packages/action-ledger/tests/integration/created-command.test.ts
+++ b/packages/action-ledger/tests/integration/created-command.test.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from "node:crypto"
+
+import { and, eq, inArray } from "drizzle-orm"
+import { describe, expect, it } from "vitest"
+
+import {
+  buildCreatedTargetCommandFingerprint,
+  claimCreatedTargetCommand,
+  completeCreatedTargetCommand,
+} from "../../src/created-command.js"
+import { actionLedgerEntries } from "../../src/schema.js"
+
+const describeIfDb: typeof describe = describe.skipIf(!process.env.TEST_DATABASE_URL)
+
+describeIfDb("created-target command transaction protocol", () => {
+  it("rolls back an incomplete claim and replays a committed canonical result", async () => {
+    const { createTestDb } = await import("@voyant-travel/db/test-utils")
+    const db = createTestDb()
+    const unique = randomUUID()
+    const scope = `action-ledger.created-command.integration:${unique}`
+    const commandTarget = {
+      type: "test-resource-create-command",
+      id: `command_${unique}`,
+    }
+    const fingerprintInput = {
+      commandInput: { label: "Integration resource" },
+      policyInputs: {
+        approval: "never",
+        capabilityId: "test:resource:create",
+        capabilityVersion: "v1",
+        evaluatedRisk: "medium",
+      },
+    }
+    const fingerprint = await buildCreatedTargetCommandFingerprint({
+      actionName: "test.resource.create",
+      actionVersion: "v1",
+      commandTarget,
+      canonicalTargetType: "test-resource",
+      resultReferenceType: "test-resource-ref",
+      ...fingerprintInput,
+    })
+    const input = {
+      context: { userId: "usr_created_command_test", actor: "staff" },
+      actionName: "test.resource.create",
+      actionVersion: "v1",
+      evaluatedRisk: "medium" as const,
+      commandTarget,
+      canonicalTargetType: "test-resource",
+      resultReferenceType: "test-resource-ref",
+      idempotency: {
+        scope,
+        key: `key_${unique}`,
+        fingerprint,
+      },
+      fingerprintInput,
+    }
+
+    try {
+      await expect(
+        db.transaction(async (tx) => {
+          await claimCreatedTargetCommand(tx, input)
+          throw new Error("simulate domain mutation failure")
+        }),
+      ).rejects.toThrow("simulate domain mutation failure")
+
+      const afterRollback = await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(
+          and(
+            inArray(actionLedgerEntries.idempotencyScope, [
+              claimScope(scope),
+              resultScope(scope),
+            ]),
+            eq(actionLedgerEntries.idempotencyKey, input.idempotency.key),
+          ),
+        )
+      expect(afterRollback).toEqual([])
+
+      const first = await db.transaction(async (tx) => {
+        const claim = await claimCreatedTargetCommand(tx, input)
+        const result = await completeCreatedTargetCommand(tx, {
+          claim: claim.claim,
+          targetId: `resource_${unique}`,
+        })
+        return { claim, result }
+      })
+      const replay = await db.transaction((tx) => claimCreatedTargetCommand(tx, input))
+
+      expect(first.claim.replayed).toBe(false)
+      expect(first.result).toMatchObject({
+        replayed: false,
+        entry: {
+          causationActionId: first.claim.claim.entry.id,
+          targetType: "test-resource",
+          targetId: `resource_${unique}`,
+        },
+        reference: {
+          type: "test-resource-ref",
+          id: `resource_${unique}`,
+          value: `test-resource-ref:resource_${unique}`,
+        },
+      })
+      expect(replay).toMatchObject({
+        replayed: true,
+        result: {
+          entry: { id: first.result.entry.id },
+          reference: { id: `resource_${unique}` },
+        },
+      })
+    } finally {
+      await db
+        .delete(actionLedgerEntries)
+        .where(
+          inArray(actionLedgerEntries.idempotencyScope, [
+            claimScope(scope),
+            resultScope(scope),
+          ]),
+        )
+    }
+  })
+})
+
+function claimScope(scope: string): string {
+  return `${scope}:created-command-claim`
+}
+
+function resultScope(scope: string): string {
+  return `${scope}:created-command-result`
+}

--- a/packages/action-ledger/tests/integration/created-command.test.ts
+++ b/packages/action-ledger/tests/integration/created-command.test.ts
@@ -1,21 +1,28 @@
 import { randomUUID } from "node:crypto"
 
-import { and, eq, inArray } from "drizzle-orm"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { createDbClient } from "@voyant-travel/db"
+import { dbClientDispose } from "@voyant-travel/db/transaction-capability"
+import { inArray } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import { describe, expect, it } from "vitest"
 
 import {
   buildCreatedTargetCommandFingerprint,
-  claimCreatedTargetCommand,
-  completeCreatedTargetCommand,
+  executeCreatedTargetCommand,
 } from "../../src/created-command.js"
 import { actionLedgerEntries } from "../../src/schema.js"
 
-const describeIfDb: typeof describe = describe.skipIf(!process.env.TEST_DATABASE_URL)
+const TEST_DATABASE_URL = process.env.TEST_DATABASE_URL
+const describeIfDb: typeof describe = describe.skipIf(!TEST_DATABASE_URL)
 
 describeIfDb("created-target command transaction protocol", () => {
-  it("rolls back an incomplete claim and replays a committed canonical result", async () => {
-    const { createTestDb } = await import("@voyant-travel/db/test-utils")
-    const db = createTestDb()
+  it("rolls back failed mutation and serializes concurrent equal commands", async () => {
+    const db = createDbClient(TEST_DATABASE_URL!, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as PostgresJsDatabase
     const unique = randomUUID()
     const scope = `action-ledger.created-command.integration:${unique}`
     const commandTarget = {
@@ -23,103 +30,85 @@ describeIfDb("created-target command transaction protocol", () => {
       id: `command_${unique}`,
     }
     const fingerprintInput = {
+      actionName: "test.resource.create",
+      actionVersion: "v1",
+      commandTarget,
+      canonicalTargetType: "test-resource",
+      resultReferenceType: "test-resource-ref",
       commandInput: { label: "Integration resource" },
-      policyInputs: {
-        approval: "never",
-        capabilityId: "test:resource:create",
-        capabilityVersion: "v1",
-        evaluatedRisk: "medium",
-      },
-    }
-    const fingerprint = await buildCreatedTargetCommandFingerprint({
-      actionName: "test.resource.create",
-      actionVersion: "v1",
-      commandTarget,
-      canonicalTargetType: "test-resource",
-      resultReferenceType: "test-resource-ref",
-      ...fingerprintInput,
-    })
-    const input = {
-      context: { userId: "usr_created_command_test", actor: "staff" },
-      actionName: "test.resource.create",
-      actionVersion: "v1",
+      capabilityId: "test:resource:create",
+      capabilityVersion: "v1",
       evaluatedRisk: "medium" as const,
-      commandTarget,
-      canonicalTargetType: "test-resource",
-      resultReferenceType: "test-resource-ref",
+      approvalPolicy: "none" as const,
+      approvalReasonCode: null,
+    }
+    const input = {
+      context: {
+        userId: "usr_created_command_test",
+        callerType: "session",
+        actor: "staff",
+        organizationId: "org_created_command_test",
+      },
+      ...fingerprintInput,
       idempotency: {
         scope,
         key: `key_${unique}`,
-        fingerprint,
+        fingerprint: await buildCreatedTargetCommandFingerprint(fingerprintInput),
       },
-      fingerprintInput,
+    }
+    let createCalls = 0
+    const handlers = {
+      async create() {
+        createCalls += 1
+        return {
+          value: { id: `resource_${unique}` },
+          targetId: `resource_${unique}`,
+        }
+      },
+      async replay(_tx: AnyDrizzleDb, result: { reference: { id: string } }) {
+        return { id: result.reference.id }
+      },
     }
 
     try {
       await expect(
-        db.transaction(async (tx) => {
-          await claimCreatedTargetCommand(tx, input)
-          throw new Error("simulate domain mutation failure")
+        executeCreatedTargetCommand(db, input, {
+          ...handlers,
+          async create() {
+            throw new Error("simulate domain mutation failure")
+          },
         }),
       ).rejects.toThrow("simulate domain mutation failure")
 
-      const afterRollback = await db
-        .select()
-        .from(actionLedgerEntries)
-        .where(
-          and(
-            inArray(actionLedgerEntries.idempotencyScope, [
-              claimScope(scope),
-              resultScope(scope),
-            ]),
-            eq(actionLedgerEntries.idempotencyKey, input.idempotency.key),
-          ),
-        )
-      expect(afterRollback).toEqual([])
+      expect(await rowsForScopes(db, scope)).toEqual([])
 
-      const first = await db.transaction(async (tx) => {
-        const claim = await claimCreatedTargetCommand(tx, input)
-        const result = await completeCreatedTargetCommand(tx, {
-          claim: claim.claim,
-          targetId: `resource_${unique}`,
-        })
-        return { claim, result }
-      })
-      const replay = await db.transaction((tx) => claimCreatedTargetCommand(tx, input))
+      const [first, second] = await Promise.all([
+        executeCreatedTargetCommand(db, input, handlers),
+        executeCreatedTargetCommand(db, input, handlers),
+      ])
 
-      expect(first.claim.replayed).toBe(false)
-      expect(first.result).toMatchObject({
-        replayed: false,
-        entry: {
-          causationActionId: first.claim.claim.entry.id,
-          targetType: "test-resource",
-          targetId: `resource_${unique}`,
-        },
-        reference: {
-          type: "test-resource-ref",
-          id: `resource_${unique}`,
-          value: `test-resource-ref:resource_${unique}`,
-        },
-      })
-      expect(replay).toMatchObject({
-        replayed: true,
-        result: {
-          entry: { id: first.result.entry.id },
-          reference: { id: `resource_${unique}` },
-        },
-      })
+      expect(createCalls).toBe(1)
+      expect([first.replayed, second.replayed].sort()).toEqual([false, true])
+      expect(first.value.id).toBe(`resource_${unique}`)
+      expect(second.value.id).toBe(`resource_${unique}`)
+      expect(await rowsForScopes(db, scope)).toHaveLength(2)
     } finally {
       await db
         .delete(actionLedgerEntries)
         .where(
-          inArray(actionLedgerEntries.idempotencyScope, [
-            claimScope(scope),
-            resultScope(scope),
-          ]),
+          inArray(actionLedgerEntries.idempotencyScope, [claimScope(scope), resultScope(scope)]),
         )
+      await dbClientDispose(db)?.()
     }
   })
 })
+
+function rowsForScopes(db: PostgresJsDatabase, scope: string) {
+  return db
+    .select()
+    .from(actionLedgerEntries)
+    .where(inArray(actionLedgerEntries.idempotencyScope, [claimScope(scope), resultScope(scope)]))
+}
 
 function claimScope(scope: string): string {
   return `${scope}:created-command-claim`

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -1,0 +1,443 @@
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { describe, expect, it } from "vitest"
+
+import {
+  ActionLedgerCreatedCommandFingerprintMismatchError,
+  ActionLedgerCreatedCommandReplayCorruptError,
+  ActionLedgerCreatedCommandReplayIncompleteError,
+  buildCreatedTargetCommandFingerprint,
+  claimCreatedTargetCommand,
+  completeCreatedTargetCommand,
+  type ClaimCreatedTargetCommandInput,
+} from "../../src/created-command.js"
+import type {
+  ActionLedgerEntry,
+  ActionMutationDetail,
+  NewActionLedgerEntry,
+  NewActionMutationDetail,
+} from "../../src/schema.js"
+import { actionLedgerEntries, actionMutationDetails } from "../../src/schema.js"
+import { ActionLedgerIdempotencyConflictError } from "../../src/service.js"
+import { makeEntry, makeMutationDetail } from "./service-fixtures.js"
+
+describe("created-target command protocol", () => {
+  it("locks and appends the requested command claim before domain mutation", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+
+    const claimed = await claimCreatedTargetCommand(harness.db, baseInput)
+    harness.events.push("domain-mutation")
+    const completed = await completeCreatedTargetCommand(harness.db, {
+      claim: claimed.claim,
+      targetId: "person_1",
+      mutationDetail: {
+        summary: "Person created",
+        reversalKind: "domain_command",
+        reversalCommandId: "relationship.person.delete",
+        reversalCommandVersion: "v1",
+      },
+    })
+
+    expect(claimed).toMatchObject({
+      replayed: false,
+      result: null,
+      claim: {
+        entry: {
+          status: "requested",
+          targetType: "relationship-person-create-command",
+          targetId: "command_1",
+          approvalId: "appr_1",
+          causationActionId: "alge_approved_request",
+          idempotencyScope: claimScope("relationships.create_person:usr_1"),
+          idempotencyKey: "idem_1",
+          idempotencyFingerprint: baseInput.idempotency.fingerprint,
+        },
+      },
+    })
+    expect(completed).toMatchObject({
+      replayed: false,
+      entry: {
+        status: "succeeded",
+        targetType: "relationship-person",
+        targetId: "person_1",
+        causationActionId: claimed.claim.entry.id,
+        approvalId: "appr_1",
+        idempotencyScope: resultScope("relationships.create_person:usr_1"),
+        idempotencyKey: "idem_1",
+        idempotencyFingerprint: baseInput.idempotency.fingerprint,
+      },
+      reference: {
+        type: "relationship-person-ref",
+        id: "person_1",
+        value: "relationship-person-ref:person_1",
+      },
+    })
+    expect(harness.events.indexOf(`entry:${claimed.claim.entry.id}:requested`)).toBeLessThan(
+      harness.events.indexOf("domain-mutation"),
+    )
+    expect(harness.mutationDetails.find((row) => row.actionId === completed.entry.id)).toMatchObject(
+      {
+        commandResultRef: "relationship-person-ref:person_1",
+      },
+    )
+  })
+
+  it("returns canonical result metadata for an exact replay without another insert", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+    const first = await claimCreatedTargetCommand(harness.db, baseInput)
+    await completeCreatedTargetCommand(harness.db, {
+      claim: first.claim,
+      targetId: "person_1",
+    })
+    const entryCount = harness.entries.length
+
+    const replay = await claimCreatedTargetCommand(harness.db, baseInput)
+
+    expect(replay).toMatchObject({
+      replayed: true,
+      claim: { entry: { id: first.claim.entry.id } },
+      result: {
+        entry: {
+          targetType: "relationship-person",
+          targetId: "person_1",
+          causationActionId: first.claim.entry.id,
+        },
+        reference: {
+          type: "relationship-person-ref",
+          id: "person_1",
+          value: "relationship-person-ref:person_1",
+        },
+      },
+    })
+    expect(harness.entries).toHaveLength(entryCount)
+    expect(harness.advisoryLocks).toHaveLength(2)
+  })
+
+  it("rejects the same scope and key when the command fingerprint changes", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+    const first = await claimCreatedTargetCommand(harness.db, baseInput)
+    const differentCommand = await makeInput({
+      commandInput: { displayName: "Different person" },
+    })
+
+    await expect(
+      claimCreatedTargetCommand(harness.db, differentCommand),
+    ).rejects.toMatchObject({
+      name: ActionLedgerIdempotencyConflictError.name,
+      existingActionId: first.claim.entry.id,
+    })
+  })
+
+  it("rejects the same scope and key when the stable command identity changes", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+    const first = await claimCreatedTargetCommand(harness.db, baseInput)
+    const differentCommand = await makeInput({ commandTargetId: "command_2" })
+
+    await expect(
+      claimCreatedTargetCommand(harness.db, differentCommand),
+    ).rejects.toMatchObject({
+      name: ActionLedgerIdempotencyConflictError.name,
+      existingActionId: first.claim.entry.id,
+    })
+  })
+
+  it("fails replay distinctly when a committed claim has no result", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+    const first = await claimCreatedTargetCommand(harness.db, baseInput)
+
+    await expect(claimCreatedTargetCommand(harness.db, baseInput)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandReplayIncompleteError.name,
+      claimActionId: first.claim.entry.id,
+    })
+  })
+
+  it.each([
+    ["malformed_result_reference", "not-a-reference"],
+    ["wrong_result_reference_type", "wrong-ref:person_1"],
+    ["result_target_id_mismatch", "relationship-person-ref:person_2"],
+  ] as const)("fails closed for %s", async (reason, commandResultRef) => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+    const first = await claimCreatedTargetCommand(harness.db, baseInput)
+    const completed = await completeCreatedTargetCommand(harness.db, {
+      claim: first.claim,
+      targetId: "person_1",
+    })
+    const detail = harness.mutationDetails.find((row) => row.actionId === completed.entry.id)
+    if (!detail) throw new Error("expected result mutation detail")
+    detail.commandResultRef = commandResultRef
+
+    await expect(claimCreatedTargetCommand(harness.db, baseInput)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandReplayCorruptError.name,
+      claimActionId: first.claim.entry.id,
+      resultActionId: completed.entry.id,
+      reason,
+    })
+  })
+
+  it.each([
+    ["result_target_type_mismatch", { targetType: "wrong-target" }],
+    ["result_action_mismatch", { actionName: "wrong.action" }],
+    ["result_fingerprint_mismatch", { idempotencyFingerprint: "sha256:corrupt" }],
+  ] as const)("fails closed for corrupt result metadata: %s", async (reason, patch) => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+    const first = await claimCreatedTargetCommand(harness.db, baseInput)
+    const completed = await completeCreatedTargetCommand(harness.db, {
+      claim: first.claim,
+      targetId: "person_1",
+    })
+    Object.assign(completed.entry, patch)
+
+    await expect(claimCreatedTargetCommand(harness.db, baseInput)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandReplayCorruptError.name,
+      claimActionId: first.claim.entry.id,
+      resultActionId: completed.entry.id,
+      reason,
+    })
+  })
+
+  it("rejects fingerprints that omit the created-target and policy metadata", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+
+    await expect(
+      claimCreatedTargetCommand(harness.db, {
+        ...baseInput,
+        idempotency: {
+          ...baseInput.idempotency,
+          fingerprint: "sha256:caller-supplied-without-required-metadata",
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandFingerprintMismatchError.name,
+      receivedFingerprint: "sha256:caller-supplied-without-required-metadata",
+    })
+    expect(harness.advisoryLocks).toEqual([])
+  })
+
+  it("requires a concrete principal before acquiring the claim lock", async () => {
+    const harness = makeCreatedCommandDb()
+    const baseInput = await makeInput()
+
+    await expect(
+      claimCreatedTargetCommand(harness.db, {
+        ...baseInput,
+        context: {},
+      }),
+    ).rejects.toThrow("requires a concrete request principal")
+    expect(harness.advisoryLocks).toEqual([])
+  })
+
+  it("requires explicit policy inputs in the command fingerprint", async () => {
+    await expect(
+      buildCreatedTargetCommandFingerprint({
+        actionName: "relationship.person.create",
+        actionVersion: "v1",
+        commandTarget: {
+          type: "relationship-person-create-command",
+          id: "command_1",
+        },
+        canonicalTargetType: "relationship-person",
+        resultReferenceType: "relationship-person-ref",
+        commandInput: { displayName: "Example person" },
+        policyInputs: {},
+      }),
+    ).rejects.toThrow("policy inputs must be a non-empty object")
+  })
+})
+
+async function makeInput(
+  options: {
+    commandTargetId?: string
+    commandInput?: unknown
+  } = {},
+): Promise<ClaimCreatedTargetCommandInput> {
+  const commandTarget = {
+    type: "relationship-person-create-command",
+    id: options.commandTargetId ?? "command_1",
+  }
+  const commandInput = options.commandInput ?? { displayName: "Example person" }
+  const fingerprintInput = {
+    commandInput,
+    policyInputs: {
+      approval: "required",
+      capabilityId: "relationships:person:create",
+      capabilityVersion: "v1",
+      evaluatedRisk: "high",
+    },
+  }
+  const fingerprint = await buildCreatedTargetCommandFingerprint({
+    actionName: "relationship.person.create",
+    actionVersion: "v1",
+    commandTarget,
+    canonicalTargetType: "relationship-person",
+    resultReferenceType: "relationship-person-ref",
+    ...fingerprintInput,
+  })
+
+  return {
+    context: {
+      userId: "usr_1",
+      actor: "staff",
+      organizationId: "org_1",
+    },
+    actionName: "relationship.person.create",
+    actionVersion: "v1",
+    evaluatedRisk: "high",
+    commandTarget,
+    canonicalTargetType: "relationship-person",
+    resultReferenceType: "relationship-person-ref",
+    routeOrToolName: "relationships.create_person",
+    capabilityId: "relationships:person:create",
+    capabilityVersion: "v1",
+    authorizationSource: "relationships.create_person.handler",
+    approvalId: "appr_1",
+    causationActionId: "alge_approved_request",
+    idempotency: {
+      scope: "relationships.create_person:usr_1",
+      key: "idem_1",
+      fingerprint,
+    },
+    fingerprintInput,
+    mutationDetail: {
+      commandInputRef: "blob://commands/command_1",
+      summary: "Create person command claimed",
+    },
+  }
+}
+
+function makeCreatedCommandDb() {
+  const entries: ActionLedgerEntry[] = []
+  const mutationDetails: ActionMutationDetail[] = []
+  const events: string[] = []
+  const advisoryLocks: unknown[] = []
+
+  const db = {
+    execute(query: unknown) {
+      advisoryLocks.push(query)
+      events.push("advisory-lock")
+      return Promise.resolve([])
+    },
+    select(selection?: Record<string, unknown>) {
+      return {
+        from(table: unknown) {
+          return {
+            where() {
+              return {
+                limit() {
+                  if (table === actionLedgerEntries && selection && "claim" in selection) {
+                    const claim = entries.find((entry) =>
+                      entry.idempotencyScope?.endsWith(":created-command-claim"),
+                    )
+                    return Promise.resolve(claim ? [{ claim }] : [])
+                  }
+                  if (table === actionLedgerEntries && selection && "result" in selection) {
+                    const result = entries.find((entry) =>
+                      entry.idempotencyScope?.endsWith(":created-command-result"),
+                    )
+                    return Promise.resolve(result ? [{ result }] : [])
+                  }
+                  if (
+                    table === actionMutationDetails &&
+                    selection &&
+                    "commandResultRef" in selection
+                  ) {
+                    const result = entries.find((entry) =>
+                      entry.idempotencyScope?.endsWith(":created-command-result"),
+                    )
+                    const detail = mutationDetails.find((row) => row.actionId === result?.id)
+                    return Promise.resolve(
+                      detail ? [{ commandResultRef: detail.commandResultRef }] : [],
+                    )
+                  }
+                  return Promise.resolve([])
+                },
+              }
+            },
+          }
+        },
+      }
+    },
+    insert(table: unknown) {
+      return {
+        values(values: NewActionLedgerEntry | NewActionMutationDetail) {
+          if (table === actionLedgerEntries) {
+            return {
+              returning() {
+                const input = values as NewActionLedgerEntry
+                const entry = makeEntry({
+                  ...input,
+                  id: `alge_${entries.length + 1}`,
+                  occurredAt: input.occurredAt ?? new Date("2026-07-23T10:00:00.000Z"),
+                  createdAt: new Date("2026-07-23T10:00:00.000Z"),
+                  actorType: input.actorType ?? null,
+                  principalSubtype: input.principalSubtype ?? null,
+                  sessionId: input.sessionId ?? null,
+                  apiTokenId: input.apiTokenId ?? null,
+                  delegatedByPrincipalType: input.delegatedByPrincipalType ?? null,
+                  delegatedByPrincipalId: input.delegatedByPrincipalId ?? null,
+                  delegationId: input.delegationId ?? null,
+                  callerType: input.callerType ?? null,
+                  organizationId: input.organizationId ?? null,
+                  routeOrToolName: input.routeOrToolName ?? null,
+                  workflowRunId: input.workflowRunId ?? null,
+                  workflowStepId: input.workflowStepId ?? null,
+                  correlationId: input.correlationId ?? null,
+                  causationActionId: input.causationActionId ?? null,
+                  idempotencyScope: input.idempotencyScope ?? null,
+                  idempotencyKey: input.idempotencyKey ?? null,
+                  idempotencyFingerprint: input.idempotencyFingerprint ?? null,
+                  capabilityId: input.capabilityId ?? null,
+                  capabilityVersion: input.capabilityVersion ?? null,
+                  authorizationSource: input.authorizationSource ?? null,
+                  approvalId: input.approvalId ?? null,
+                  amendsActionId: input.amendsActionId ?? null,
+                })
+                entries.push(entry)
+                events.push(`entry:${entry.id}:${entry.status}`)
+                return Promise.resolve([entry])
+              },
+            }
+          }
+
+          const input = values as NewActionMutationDetail
+          const detail = makeMutationDetail({
+            ...input,
+            commandInputRef: input.commandInputRef ?? null,
+            commandResultRef: input.commandResultRef ?? null,
+            summary: input.summary ?? null,
+            reversalKind: input.reversalKind ?? "none",
+            reversalCommandId: input.reversalCommandId ?? null,
+            reversalCommandVersion: input.reversalCommandVersion ?? null,
+            reversalArgsRef: input.reversalArgsRef ?? null,
+            reversalStateProjection: input.reversalStateProjection ?? null,
+            reversalOutcomeProjection: input.reversalOutcomeProjection ?? null,
+            reversesActionId: input.reversesActionId ?? null,
+            reversedByActionIdProjection: input.reversedByActionIdProjection ?? null,
+          })
+          mutationDetails.push(detail)
+          events.push(`detail:${detail.actionId}`)
+          return {}
+        },
+      }
+    },
+    transaction() {
+      throw new Error("created-command helpers must use the supplied transaction handle directly")
+    },
+  } as unknown as AnyDrizzleDb
+
+  return { db, entries, mutationDetails, events, advisoryLocks }
+}
+
+function claimScope(scope: string): string {
+  return `${scope}:created-command-claim`
+}
+
+function resultScope(scope: string): string {
+  return `${scope}:created-command-result`
+}

--- a/packages/action-ledger/tests/unit/created-command.test.ts
+++ b/packages/action-ledger/tests/unit/created-command.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from "vitest"
 
 import {
   ActionLedgerCreatedCommandFingerprintMismatchError,
+  ActionLedgerCreatedCommandProtocolError,
   ActionLedgerCreatedCommandReplayCorruptError,
   ActionLedgerCreatedCommandReplayIncompleteError,
+  ActionLedgerCreatedCommandTransactionRequiredError,
   buildCreatedTargetCommandFingerprint,
-  claimCreatedTargetCommand,
-  completeCreatedTargetCommand,
-  type ClaimCreatedTargetCommandInput,
+  type ExecuteCreatedTargetCommandInput,
+  executeCreatedTargetCommand,
 } from "../../src/created-command.js"
 import type {
   ActionLedgerEntry,
@@ -20,88 +21,33 @@ import { actionLedgerEntries, actionMutationDetails } from "../../src/schema.js"
 import { ActionLedgerIdempotencyConflictError } from "../../src/service.js"
 import { makeEntry, makeMutationDetail } from "./service-fixtures.js"
 
+const POLICY_DRIFTS: Array<[string, Partial<ExecuteCreatedTargetCommandInput>]> = [
+  ["capability", { capabilityId: "relationships:person:create:v2" }],
+  ["capability version", { capabilityVersion: "v2" }],
+  ["risk", { evaluatedRisk: "critical" }],
+  ["approval", { approvalPolicy: "conditional" }],
+  ["reason", { approvalReasonCode: "different_reason" }],
+  ["canonical target", { canonicalTargetType: "relationship-organization" }],
+  ["reference type", { resultReferenceType: "wrong-ref" }],
+]
+
 describe("created-target command protocol", () => {
-  it("locks and appends the requested command claim before domain mutation", async () => {
+  it("owns claim, domain mutation, and canonical completion in one transaction", async () => {
     const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
+    const input = await makeInput()
 
-    const claimed = await claimCreatedTargetCommand(harness.db, baseInput)
-    harness.events.push("domain-mutation")
-    const completed = await completeCreatedTargetCommand(harness.db, {
-      claim: claimed.claim,
-      targetId: "person_1",
-      mutationDetail: {
-        summary: "Person created",
-        reversalKind: "domain_command",
-        reversalCommandId: "relationship.person.delete",
-        reversalCommandVersion: "v1",
-      },
-    })
+    const result = await executePersonCommand(harness.db, input)
 
-    expect(claimed).toMatchObject({
+    expect(result).toMatchObject({
       replayed: false,
-      result: null,
-      claim: {
-        entry: {
-          status: "requested",
-          targetType: "relationship-person-create-command",
-          targetId: "command_1",
-          approvalId: "appr_1",
-          causationActionId: "alge_approved_request",
-          idempotencyScope: claimScope("relationships.create_person:usr_1"),
-          idempotencyKey: "idem_1",
-          idempotencyFingerprint: baseInput.idempotency.fingerprint,
-        },
-      },
-    })
-    expect(completed).toMatchObject({
-      replayed: false,
-      entry: {
-        status: "succeeded",
-        targetType: "relationship-person",
-        targetId: "person_1",
-        causationActionId: claimed.claim.entry.id,
-        approvalId: "appr_1",
-        idempotencyScope: resultScope("relationships.create_person:usr_1"),
-        idempotencyKey: "idem_1",
-        idempotencyFingerprint: baseInput.idempotency.fingerprint,
-      },
-      reference: {
-        type: "relationship-person-ref",
-        id: "person_1",
-        value: "relationship-person-ref:person_1",
-      },
-    })
-    expect(harness.events.indexOf(`entry:${claimed.claim.entry.id}:requested`)).toBeLessThan(
-      harness.events.indexOf("domain-mutation"),
-    )
-    expect(harness.mutationDetails.find((row) => row.actionId === completed.entry.id)).toMatchObject(
-      {
-        commandResultRef: "relationship-person-ref:person_1",
-      },
-    )
-  })
-
-  it("returns canonical result metadata for an exact replay without another insert", async () => {
-    const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-    const first = await claimCreatedTargetCommand(harness.db, baseInput)
-    await completeCreatedTargetCommand(harness.db, {
-      claim: first.claim,
-      targetId: "person_1",
-    })
-    const entryCount = harness.entries.length
-
-    const replay = await claimCreatedTargetCommand(harness.db, baseInput)
-
-    expect(replay).toMatchObject({
-      replayed: true,
-      claim: { entry: { id: first.claim.entry.id } },
+      value: { id: "person_1" },
       result: {
         entry: {
+          status: "succeeded",
           targetType: "relationship-person",
           targetId: "person_1",
-          causationActionId: first.claim.entry.id,
+          approvalId: null,
+          idempotencyFingerprint: input.idempotency.fingerprint,
         },
         reference: {
           type: "relationship-person-ref",
@@ -110,203 +56,335 @@ describe("created-target command protocol", () => {
         },
       },
     })
-    expect(harness.entries).toHaveLength(entryCount)
-    expect(harness.advisoryLocks).toHaveLength(2)
+    const claim = harness.entries.find((entry) => entry.status === "requested")
+    expect(claim).toMatchObject({
+      targetType: "relationship-person-create-command",
+      targetId: "command_1",
+      causationActionId: "alge_parent",
+      approvalId: null,
+    })
+    expect(result.result.entry.causationActionId).toBe(claim?.id)
+    expect(harness.events).toEqual([
+      "begin",
+      "advisory-lock",
+      "entry:alge_1:requested",
+      "detail:alge_1",
+      "domain-create",
+      "entry:alge_2:succeeded",
+      "detail:alge_2",
+      "commit",
+    ])
   })
 
-  it("rejects the same scope and key when the command fingerprint changes", async () => {
+  it("replays the typed result without invoking domain creation twice", async () => {
     const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-    const first = await claimCreatedTargetCommand(harness.db, baseInput)
-    const differentCommand = await makeInput({
-      commandInput: { displayName: "Different person" },
-    })
+    const input = await makeInput()
+    await executePersonCommand(harness.db, input)
 
-    await expect(
-      claimCreatedTargetCommand(harness.db, differentCommand),
-    ).rejects.toMatchObject({
-      name: ActionLedgerIdempotencyConflictError.name,
-      existingActionId: first.claim.entry.id,
+    const replay = await executePersonCommand(harness.db, input)
+
+    expect(replay).toMatchObject({
+      replayed: true,
+      value: { id: "person_1" },
+      result: { reference: { id: "person_1" } },
     })
+    expect(harness.events.filter((event) => event === "domain-create")).toHaveLength(1)
+    expect(harness.events.filter((event) => event === "domain-replay")).toHaveLength(1)
   })
 
-  it("rejects the same scope and key when the stable command identity changes", async () => {
+  it("allows exact retries from a new session, correlation, and workflow step", async () => {
     const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-    const first = await claimCreatedTargetCommand(harness.db, baseInput)
-    const differentCommand = await makeInput({ commandTargetId: "command_2" })
+    const input = await makeInput()
+    await executePersonCommand(harness.db, input)
+    const retry = {
+      ...input,
+      context: {
+        ...input.context,
+        sessionId: "session_retry",
+        correlationId: "correlation_retry",
+        workflowStepId: "step_retry",
+      },
+    }
 
-    await expect(
-      claimCreatedTargetCommand(harness.db, differentCommand),
-    ).rejects.toMatchObject({
-      name: ActionLedgerIdempotencyConflictError.name,
-      existingActionId: first.claim.entry.id,
-    })
-  })
-
-  it("fails replay distinctly when a committed claim has no result", async () => {
-    const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-    const first = await claimCreatedTargetCommand(harness.db, baseInput)
-
-    await expect(claimCreatedTargetCommand(harness.db, baseInput)).rejects.toMatchObject({
-      name: ActionLedgerCreatedCommandReplayIncompleteError.name,
-      claimActionId: first.claim.entry.id,
-    })
-  })
-
-  it.each([
-    ["malformed_result_reference", "not-a-reference"],
-    ["wrong_result_reference_type", "wrong-ref:person_1"],
-    ["result_target_id_mismatch", "relationship-person-ref:person_2"],
-  ] as const)("fails closed for %s", async (reason, commandResultRef) => {
-    const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-    const first = await claimCreatedTargetCommand(harness.db, baseInput)
-    const completed = await completeCreatedTargetCommand(harness.db, {
-      claim: first.claim,
-      targetId: "person_1",
-    })
-    const detail = harness.mutationDetails.find((row) => row.actionId === completed.entry.id)
-    if (!detail) throw new Error("expected result mutation detail")
-    detail.commandResultRef = commandResultRef
-
-    await expect(claimCreatedTargetCommand(harness.db, baseInput)).rejects.toMatchObject({
-      name: ActionLedgerCreatedCommandReplayCorruptError.name,
-      claimActionId: first.claim.entry.id,
-      resultActionId: completed.entry.id,
-      reason,
-    })
-  })
-
-  it.each([
-    ["result_target_type_mismatch", { targetType: "wrong-target" }],
-    ["result_action_mismatch", { actionName: "wrong.action" }],
-    ["result_fingerprint_mismatch", { idempotencyFingerprint: "sha256:corrupt" }],
-  ] as const)("fails closed for corrupt result metadata: %s", async (reason, patch) => {
-    const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-    const first = await claimCreatedTargetCommand(harness.db, baseInput)
-    const completed = await completeCreatedTargetCommand(harness.db, {
-      claim: first.claim,
-      targetId: "person_1",
-    })
-    Object.assign(completed.entry, patch)
-
-    await expect(claimCreatedTargetCommand(harness.db, baseInput)).rejects.toMatchObject({
-      name: ActionLedgerCreatedCommandReplayCorruptError.name,
-      claimActionId: first.claim.entry.id,
-      resultActionId: completed.entry.id,
-      reason,
-    })
-  })
-
-  it("rejects fingerprints that omit the created-target and policy metadata", async () => {
-    const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
-
-    await expect(
-      claimCreatedTargetCommand(harness.db, {
-        ...baseInput,
-        idempotency: {
-          ...baseInput.idempotency,
-          fingerprint: "sha256:caller-supplied-without-required-metadata",
+    await expect(executePersonCommand(harness.db, retry)).resolves.toMatchObject({
+      replayed: true,
+      result: {
+        entry: {
+          sessionId: null,
+          correlationId: null,
+          workflowStepId: null,
         },
+      },
+    })
+  })
+
+  it.each([
+    ["principal", { userId: "usr_other" }],
+    ["organization", { organizationId: "org_other" }],
+  ])("rejects retry when immutable %s identity changes", async (_label, contextPatch) => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+    await executePersonCommand(harness.db, input)
+
+    await expect(
+      executePersonCommand(harness.db, {
+        ...input,
+        context: { ...input.context, ...contextPatch },
       }),
     ).rejects.toMatchObject({
+      name: ActionLedgerIdempotencyConflictError.name,
+      existingActionId: "alge_1",
+    })
+  })
+
+  it("uses mapped principal semantics and rejects mismatched caller types", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput({
+      context: { agentId: "agent_1", callerType: "session" },
+    })
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toThrow(
+      "requires a concrete request principal",
+    )
+    expect(harness.events).toEqual([])
+  })
+
+  it("rejects API-key identity when callerType does not select API-key mapping", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput({
+      context: { apiTokenId: "key_1", callerType: "agent" },
+    })
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toThrow(
+      "requires a concrete request principal",
+    )
+    expect(harness.events).toEqual([])
+  })
+
+  it.each(
+    POLICY_DRIFTS,
+  )("rejects %s drift against the supplied fingerprint", async (_label, patch) => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+
+    await expect(executePersonCommand(harness.db, { ...input, ...patch })).rejects.toMatchObject({
       name: ActionLedgerCreatedCommandFingerprintMismatchError.name,
-      receivedFingerprint: "sha256:caller-supplied-without-required-metadata",
+      receivedFingerprint: input.idempotency.fingerprint,
     })
-    expect(harness.advisoryLocks).toEqual([])
+    expect(harness.events).toEqual([])
   })
 
-  it("requires a concrete principal before acquiring the claim lock", async () => {
+  it("conflicts when the same scope/key identifies a different exact command", async () => {
     const harness = makeCreatedCommandDb()
-    const baseInput = await makeInput()
+    const first = await makeInput()
+    await executePersonCommand(harness.db, first)
+    const changed = await makeInput({ commandInput: { displayName: "Different person" } })
 
-    await expect(
-      claimCreatedTargetCommand(harness.db, {
-        ...baseInput,
-        context: {},
-      }),
-    ).rejects.toThrow("requires a concrete request principal")
-    expect(harness.advisoryLocks).toEqual([])
+    await expect(executePersonCommand(harness.db, changed)).rejects.toMatchObject({
+      name: ActionLedgerIdempotencyConflictError.name,
+      existingActionId: "alge_1",
+    })
   })
 
-  it("requires explicit policy inputs in the command fingerprint", async () => {
+  it("rejects replay when the stored claim tenant identity drifts", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+    await executePersonCommand(harness.db, input)
+    const claim = harness.entries.find((entry) => entry.status === "requested")
+    if (!claim) throw new Error("missing claim")
+    claim.organizationId = "org_other"
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toMatchObject({
+      name: ActionLedgerIdempotencyConflictError.name,
+      existingActionId: claim.id,
+    })
+  })
+
+  it("re-reads the opaque claim and fails if domain code changes it", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+
     await expect(
-      buildCreatedTargetCommandFingerprint({
-        actionName: "relationship.person.create",
-        actionVersion: "v1",
-        commandTarget: {
-          type: "relationship-person-create-command",
-          id: "command_1",
+      executeCreatedTargetCommand(harness.db, input, {
+        async create() {
+          const claim = harness.entries.find((entry) => entry.status === "requested")
+          if (!claim) throw new Error("missing claim")
+          claim.organizationId = "org_tampered"
+          return { value: { id: "person_1" }, targetId: "person_1" }
         },
-        canonicalTargetType: "relationship-person",
-        resultReferenceType: "relationship-person-ref",
-        commandInput: { displayName: "Example person" },
-        policyInputs: {},
+        async replay(_tx, result) {
+          return { id: result.reference.id }
+        },
       }),
-    ).rejects.toThrow("policy inputs must be a non-empty object")
+    ).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandProtocolError.name,
+      reason: "claim_changed_during_mutation",
+    })
+  })
+
+  it("fails closed if domain code manufactures a result during creation", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+
+    await expect(
+      executeCreatedTargetCommand(harness.db, input, {
+        async create() {
+          const claim = harness.entries.find((entry) => entry.status === "requested")
+          if (!claim) throw new Error("missing claim")
+          harness.entries.push(
+            makeEntry({
+              ...claim,
+              id: "alge_forged_result",
+              status: "succeeded",
+              targetType: "relationship-person",
+              targetId: "person_1",
+              causationActionId: claim.id,
+              idempotencyScope: resultScope(input.idempotency.scope),
+            }),
+          )
+          return { value: { id: "person_1" }, targetId: "person_1" }
+        },
+        async replay(_tx, result) {
+          return { id: result.reference.id }
+        },
+      }),
+    ).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandProtocolError.name,
+      reason: "result_created_during_mutation",
+    })
+  })
+
+  it.each([
+    ["organizationId", "org_other"],
+    ["principalId", "usr_other"],
+    ["approvalId", "appr_other"],
+    ["capabilityVersion", "v2"],
+    ["authorizationSource", "other_source"],
+    ["workflowRunId", "workflow_other"],
+    ["causationActionId", "alge_other_claim"],
+  ] as const)("validates immutable replay continuity for %s", async (field, value) => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+    const first = await executePersonCommand(harness.db, input)
+    Object.assign(first.result.entry, { [field]: value })
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandReplayCorruptError.name,
+      resultActionId: first.result.entry.id,
+      reason: "result_identity_mismatch",
+    })
+  })
+
+  it.each([
+    ["leading", "relationship-person-ref: person_1"],
+    ["trailing", "relationship-person-ref:person_1 "],
+  ])("rejects %s result-reference id whitespace as noncanonical", async (_label, value) => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+    const first = await executePersonCommand(harness.db, input)
+    const detail = harness.mutationDetails.find((row) => row.actionId === first.result.entry.id)
+    if (!detail) throw new Error("missing canonical result detail")
+    detail.commandResultRef = value
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandReplayCorruptError.name,
+      resultActionId: first.result.entry.id,
+      reason: "malformed_result_reference",
+    })
+  })
+
+  it("distinguishes a committed claim with no canonical result", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput()
+    await executePersonCommand(harness.db, input)
+    harness.entries.splice(
+      harness.entries.findIndex((entry) => entry.status === "succeeded"),
+      1,
+    )
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandReplayIncompleteError.name,
+      claimActionId: "alge_1",
+    })
+  })
+
+  it("requires a transaction-capable database before claiming", async () => {
+    const input = await makeInput()
+
+    await expect(executePersonCommand({} as AnyDrizzleDb, input)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandTransactionRequiredError.name,
+    })
+  })
+
+  it("fails closed for approval-bearing created commands until control propagation exists", async () => {
+    const harness = makeCreatedCommandDb()
+    const input = await makeInput({ approvalPolicy: "required" })
+
+    await expect(executePersonCommand(harness.db, input)).rejects.toMatchObject({
+      name: ActionLedgerCreatedCommandProtocolError.name,
+      reason: "approval_policy_unsupported",
+    })
+    expect(harness.events).toEqual([])
   })
 })
 
+async function executePersonCommand(db: AnyDrizzleDb, input: ExecuteCreatedTargetCommandInput) {
+  return executeCreatedTargetCommand(db, input, {
+    async create() {
+      const harness = db as AnyDrizzleDb & { __events?: string[] }
+      harness.__events?.push("domain-create")
+      return { value: { id: "person_1" }, targetId: "person_1" }
+    },
+    async replay(_tx, result) {
+      const harness = db as AnyDrizzleDb & { __events?: string[] }
+      harness.__events?.push("domain-replay")
+      return { id: result.reference.id }
+    },
+  })
+}
+
 async function makeInput(
   options: {
-    commandTargetId?: string
+    context?: ExecuteCreatedTargetCommandInput["context"]
     commandInput?: unknown
+    approvalPolicy?: ExecuteCreatedTargetCommandInput["approvalPolicy"]
   } = {},
-): Promise<ClaimCreatedTargetCommandInput> {
-  const commandTarget = {
-    type: "relationship-person-create-command",
-    id: options.commandTargetId ?? "command_1",
-  }
+): Promise<ExecuteCreatedTargetCommandInput> {
   const commandInput = options.commandInput ?? { displayName: "Example person" }
   const fingerprintInput = {
+    actionName: "relationship.person.create",
+    actionVersion: "v1",
+    commandTarget: {
+      type: "relationship-person-create-command",
+      id: "command_1",
+    },
+    canonicalTargetType: "relationship-person",
+    resultReferenceType: "relationship-person-ref",
     commandInput,
-    policyInputs: {
-      approval: "required",
-      capabilityId: "relationships:person:create",
-      capabilityVersion: "v1",
-      evaluatedRisk: "high",
-    },
-  }
-  const fingerprint = await buildCreatedTargetCommandFingerprint({
-    actionName: "relationship.person.create",
-    actionVersion: "v1",
-    commandTarget,
-    canonicalTargetType: "relationship-person",
-    resultReferenceType: "relationship-person-ref",
-    ...fingerprintInput,
-  })
-
-  return {
-    context: {
-      userId: "usr_1",
-      actor: "staff",
-      organizationId: "org_1",
-    },
-    actionName: "relationship.person.create",
-    actionVersion: "v1",
-    evaluatedRisk: "high",
-    commandTarget,
-    canonicalTargetType: "relationship-person",
-    resultReferenceType: "relationship-person-ref",
-    routeOrToolName: "relationships.create_person",
     capabilityId: "relationships:person:create",
     capabilityVersion: "v1",
+    evaluatedRisk: "high" as const,
+    approvalPolicy: options.approvalPolicy ?? ("none" as const),
+    approvalReasonCode: "agent_created_person",
+  }
+  return {
+    context:
+      options.context ??
+      ({
+        userId: "usr_1",
+        callerType: "session",
+        actor: "staff",
+        organizationId: "org_1",
+        workflowRunId: "workflow_1",
+      } satisfies ExecuteCreatedTargetCommandInput["context"]),
+    ...fingerprintInput,
+    routeOrToolName: "relationships.create_person",
     authorizationSource: "relationships.create_person.handler",
-    approvalId: "appr_1",
-    causationActionId: "alge_approved_request",
+    causationActionId: "alge_parent",
     idempotency: {
       scope: "relationships.create_person:usr_1",
       key: "idem_1",
-      fingerprint,
-    },
-    fingerprintInput,
-    mutationDetail: {
-      commandInputRef: "blob://commands/command_1",
-      summary: "Create person command claimed",
+      fingerprint: await buildCreatedTargetCommandFingerprint(fingerprintInput),
     },
   }
 }
@@ -315,11 +393,21 @@ function makeCreatedCommandDb() {
   const entries: ActionLedgerEntry[] = []
   const mutationDetails: ActionMutationDetail[] = []
   const events: string[] = []
-  const advisoryLocks: unknown[] = []
 
   const db = {
-    execute(query: unknown) {
-      advisoryLocks.push(query)
+    __events: events,
+    async transaction<T>(callback: (tx: AnyDrizzleDb) => Promise<T>) {
+      events.push("begin")
+      try {
+        const result = await callback(db as unknown as AnyDrizzleDb)
+        events.push("commit")
+        return result
+      } catch (error) {
+        events.push("rollback")
+        throw error
+      }
+    },
+    execute() {
       events.push("advisory-lock")
       return Promise.resolve([])
     },
@@ -404,7 +492,6 @@ function makeCreatedCommandDb() {
               },
             }
           }
-
           const input = values as NewActionMutationDetail
           const detail = makeMutationDetail({
             ...input,
@@ -412,13 +499,6 @@ function makeCreatedCommandDb() {
             commandResultRef: input.commandResultRef ?? null,
             summary: input.summary ?? null,
             reversalKind: input.reversalKind ?? "none",
-            reversalCommandId: input.reversalCommandId ?? null,
-            reversalCommandVersion: input.reversalCommandVersion ?? null,
-            reversalArgsRef: input.reversalArgsRef ?? null,
-            reversalStateProjection: input.reversalStateProjection ?? null,
-            reversalOutcomeProjection: input.reversalOutcomeProjection ?? null,
-            reversesActionId: input.reversesActionId ?? null,
-            reversedByActionIdProjection: input.reversedByActionIdProjection ?? null,
           })
           mutationDetails.push(detail)
           events.push(`detail:${detail.actionId}`)
@@ -426,16 +506,9 @@ function makeCreatedCommandDb() {
         },
       }
     },
-    transaction() {
-      throw new Error("created-command helpers must use the supplied transaction handle directly")
-    },
-  } as unknown as AnyDrizzleDb
+  } as unknown as AnyDrizzleDb & { __events: string[] }
 
-  return { db, entries, mutationDetails, events, advisoryLocks }
-}
-
-function claimScope(scope: string): string {
-  return `${scope}:created-command-claim`
+  return { db, entries, mutationDetails, events }
 }
 
 function resultScope(scope: string): string {

--- a/packages/action-ledger/tests/unit/fingerprint.test.ts
+++ b/packages/action-ledger/tests/unit/fingerprint.test.ts
@@ -115,4 +115,55 @@ describe("buildActionApprovalCommandFingerprint", () => {
 
     expect(first).not.toBe(second)
   })
+
+  test("binds created-target policy metadata into the approval envelope", async () => {
+    const base = {
+      actionName: "cruise.booking.create",
+      actionVersion: "v1",
+      targetType: "cruise-booking-create-command",
+      targetId: "command_123",
+      commandInput: { sailingId: "sailing_1" },
+      approvalPolicy: "required" as const,
+      capabilityId: "cruises:booking:create",
+      capabilityVersion: "v1",
+      evaluatedRisk: "high" as const,
+      reasonCode: "high_value_booking",
+    }
+    const first = await buildActionApprovalCommandFingerprint({
+      ...base,
+      createdTarget: {
+        canonicalTargetType: "cruise-booking",
+        resultReferenceType: "cruise-booking-ref",
+      },
+    })
+    const drifted = await buildActionApprovalCommandFingerprint({
+      ...base,
+      createdTarget: {
+        canonicalTargetType: "cruise-booking",
+        resultReferenceType: "wrong-ref",
+      },
+    })
+
+    expect(first).not.toBe(drifted)
+    await expect(
+      buildIdempotencyFingerprint({
+        actionName: base.actionName,
+        actionVersion: base.actionVersion,
+        targetType: base.targetType,
+        targetId: base.targetId,
+        commandInput: base.commandInput,
+        policyInputs: {
+          approvalPolicy: base.approvalPolicy,
+          capabilityId: base.capabilityId,
+          capabilityVersion: base.capabilityVersion,
+          evaluatedRisk: base.evaluatedRisk,
+          reasonCode: base.reasonCode,
+          createdTarget: {
+            canonicalTargetType: "cruise-booking",
+            resultReferenceType: "cruise-booking-ref",
+          },
+        },
+      }),
+    ).resolves.toBe(first)
+  })
 })

--- a/packages/action-ledger/tests/unit/tools.test.ts
+++ b/packages/action-ledger/tests/unit/tools.test.ts
@@ -188,18 +188,7 @@ describe("action-ledger Tool services", () => {
     )
   })
 
-  it("binds created-target approval to the pre-create command identity", async () => {
-    vi.spyOn(actionLedgerService, "requestApproval").mockResolvedValue({
-      requestedAction: makeEntry({
-        actionName: "bookings:status:cancel",
-        actionKind: "execute",
-        status: "awaiting_approval",
-        capabilityId: "bookings:status:cancel",
-        capabilityVersion: "v1",
-      }),
-      approval: makeApproval(),
-      replayed: false,
-    })
+  it("fails closed for created-target approval until handler controls propagate", async () => {
     const createdAction: VoyantGraphActionDeclaration = {
       ...selectedAction,
       targetType: "booking",
@@ -211,24 +200,18 @@ describe("action-ledger Tool services", () => {
       },
     }
 
-    await createServices([createdAction]).requestApproval({
-      actionId: createdAction.id,
-      actionVersion: "v1",
-      targetId: "client-command-17",
-      commandInput: { bookingNumber: "B-17" },
-      idempotencyKey: "create-book-17",
-    })
-
-    expect(actionLedgerService.requestApproval).toHaveBeenCalledWith(
-      db,
-      expect.objectContaining({
-        requestedAction: expect.objectContaining({
-          targetType: "booking-create-command",
-          targetId: "client-command-17",
-          idempotencyFingerprint: expect.stringMatching(/^sha256:/),
-        }),
+    await expect(
+      createServices([createdAction]).requestApproval({
+        actionId: createdAction.id,
+        actionVersion: "v1",
+        targetId: "client-command-17",
+        commandInput: { bookingNumber: "B-17" },
+        idempotencyKey: "create-book-17",
       }),
-    )
+    ).rejects.toMatchObject({
+      code: "ACTION_POLICY_REQUIRED",
+      message: expect.stringContaining("control context"),
+    })
   })
 
   it("fails closed for absent and conditional approval request policies", async () => {

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -65,6 +65,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -72,6 +72,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -65,6 +65,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -65,6 +65,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -71,6 +71,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -65,6 +65,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -71,6 +71,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -65,6 +65,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -71,6 +71,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -66,6 +66,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -36,7 +36,8 @@ data** validated by an `outputSchema` — never transport envelopes or presentat
   claims a stable command key before mutation, returns the prior typed reference on exact replay,
   and commits the claim, domain mutation, and canonical generated-target result together. MCP never
   asks callers to invent `_voyant.targetId` for these actions. A post-dispatch target extractor is
-  not a durable created-target strategy.
+  not a durable created-target strategy. Approval-bearing created targets remain unavailable until
+  MCP propagates their approval controls into the handler's request-scoped context.
 - Authorization is **not** enforced in the registry — the transport binds each tool's
   `requiredScopes` to `hasApiKeyPermission` (AND semantics).
 

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -64,6 +64,9 @@
       "@voyant-travel/action-ledger-react/provider": ["../action-ledger-react/dist/provider.d.ts"],
       "@voyant-travel/action-ledger/canary": ["../action-ledger/dist/canary.d.ts"],
       "@voyant-travel/action-ledger/capability": ["../action-ledger/dist/capability.d.ts"],
+      "@voyant-travel/action-ledger/created-command": [
+        "../action-ledger/dist/created-command.d.ts"
+      ],
       "@voyant-travel/action-ledger/fingerprint": ["../action-ledger/dist/fingerprint.d.ts"],
       "@voyant-travel/action-ledger/graph-runtime": ["../action-ledger/dist/graph-runtime.d.ts"],
       "@voyant-travel/action-ledger/health": ["../action-ledger/dist/health-routes.d.ts"],


### PR DESCRIPTION
## What changed

- add `executeCreatedTargetCommand`, an owned-transaction adapter for handler-generated canonical targets
- claim `(scope, key)` under a PostgreSQL transaction advisory lock before domain mutation
- execute the domain mutation and append its typed canonical result reference in the same transaction
- return the immutable prior result on exact replay and reject same-key command, principal, tenant, policy, or target drift
- bind fingerprints to action/capability versions, risk, approval policy, reason, command target, canonical target, and result-reference metadata
- validate the full immutable claim/result identity and reject incomplete, corrupt, or noncanonical replay rows
- require a transaction-capable database and a concrete mapped principal
- fail created-target approvals closed at both request and execution boundaries until handler invocation controls are propagated

## Safety properties

- claims are internal; callers cannot manufacture or complete a structural claim
- the adapter owns `BEGIN → claim → domain callback → canonical result → COMMIT`
- equal concurrent commands serialize; failed mutations roll back the claim
- retry trace/session metadata may change, but principal, organization, capability, policy, and command identity may not
- no-approval commands use the action-ledger capability vocabulary (`none`); `conditional` and `required` remain unsupported and fail closed

## Tests

- focused unit coverage for policy drift, principal/caller mismatches, claim/result corruption, transient retry provenance, and noncanonical references
- database integration coverage for rollback, exact replay, and concurrent advisory-lock serialization
- scoped Biome and `git diff --check` pass
- full GitHub CI was dispatched explicitly for this stacked branch: https://github.com/voyant-travel/voyant/actions/runs/30045176682

Stacked on #3698. Part of #3694.