### PR TITLE
Adopt durable created commands for Commerce and vessel roots

### DIFF
--- a/.changeset/calm-ships-create-once.md
+++ b/.changeset/calm-ships-create-once.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/commerce": major
+"@voyant-travel/charters": major
+"@voyant-travel/cruises": major
+---
+
+Require a stable `idempotencyKey` for cancellation-policy, price-catalog,
+charter-product, charter-yacht, and cruise-ship create Tools. Successful calls
+now return an immutable created-target reference (`status`, target `id`, and
+`replayed`) instead of a mutable full-row snapshot. Exact retries return the
+original reference and altered same-key commands conflict.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -2,6 +2,10 @@
 
 Per-minor consolidated migration notes for Voyant. Each page collects every breaking change in a release train into one read — removed exports across all packages, schema column changes, HTTP route changes, hook signature changes, activity-log enum changes, and the caller-code rewrites needed to land on the new minor.
 
+Unreleased caller migrations:
+
+- [Created local Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md)
+
 The full history (including patch-level changes and dependency updates) lives in the per-package `CHANGELOG.md` files; these pages exist because changeset entries land in *every* package's CHANGELOG that depends on the changed one, so the actual breaking signal is otherwise buried under dozens of `Updated dependencies [...]` lines per package.
 
 ## Available

--- a/docs/migrations/created-target-commerce-charters-cruises.md
+++ b/docs/migrations/created-target-commerce-charters-cruises.md
@@ -1,0 +1,47 @@
+# Created local Commerce, Charters, and Cruises targets
+
+The following MCP Tools now use the framework's transactional
+`handler-command-claim-v1` created-target protocol:
+
+- `create_cancellation_policy`
+- `create_price_catalog`
+- `create_charter_product`
+- `create_charter_yacht`
+- `create_cruise_ship`
+
+## Caller migration
+
+Every call must supply the same non-empty `idempotencyKey` in the Tool input and
+the `_voyant.idempotencyKey` invocation control. Keep that key stable for an
+exact logical command. Reusing it with different domain input is rejected.
+
+The response no longer contains a mutable database row. Read the generated id
+from the typed reference and call the corresponding get Tool when current state
+is required:
+
+```ts
+const result = await createPriceCatalog({
+  code: "PUBLIC",
+  name: "Public",
+  idempotencyKey: commandId,
+  _voyant: { idempotencyKey: commandId },
+})
+
+const catalogId = result.priceCatalog.id
+```
+
+Fresh and replayed responses have the same domain shape; `replayed` reports
+which path completed the call. Creation, the opaque command claim, and the
+canonical generated-target result commit in one database transaction.
+
+## Direct-consumer audit
+
+The package-local HTTP routes and domain service signatures are unchanged.
+Repository search found no direct consumers of these five Tool invocation names
+or Tool definition exports outside their owning Commerce, Charters, and Cruises
+packages. External MCP clients are the migration audience.
+
+The scoped primitives do not publish through `EventBus`; no post-commit event
+gap is hidden by this migration. Commerce promotion creation and cruise/charter
+product or booking commands with external or event effects are intentionally
+outside this change.

--- a/packages/charters/package.json
+++ b/packages/charters/package.json
@@ -35,6 +35,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/charters-contracts": "workspace:^",
     "@voyant-travel/core": "workspace:^",

--- a/packages/charters/src/created-target-policy.ts
+++ b/packages/charters/src/created-target-policy.ts
@@ -1,0 +1,100 @@
+import {
+  type BuildCreatedTargetCommandFingerprintInput,
+  buildCreatedTargetCommandFingerprint,
+} from "@voyant-travel/action-ledger"
+import type { HandlerActionPolicyExpectation } from "@voyant-travel/tools"
+
+interface ChartersCreatedTargetPolicy {
+  actionName: string
+  actionVersion: "v1"
+  toolName: string
+  toolCapabilityId: string
+  capabilityId: string
+  capabilityVersion: "v1"
+  commandTargetType: string
+  canonicalTargetType: string
+  resultReferenceType: string
+  evaluatedRisk: "medium"
+  approvalPolicy: "none"
+  approvalReasonCode: null
+}
+
+export const CHARTERS_CREATED_TARGET_POLICIES = {
+  product: {
+    actionName: "@voyant-travel/charters#action.create-charter-product",
+    actionVersion: "v1",
+    toolName: "create_charter_product",
+    toolCapabilityId: "@voyant-travel/charters#tool.create-charter-product",
+    capabilityId: "@voyant-travel/charters#action.create-charter-product",
+    capabilityVersion: "v1",
+    commandTargetType: "charter_product_create_command",
+    canonicalTargetType: "charter-product",
+    resultReferenceType: "charter-product",
+    evaluatedRisk: "medium",
+    approvalPolicy: "none",
+    approvalReasonCode: null,
+  },
+  yacht: {
+    actionName: "@voyant-travel/charters#action.create-charter-yacht",
+    actionVersion: "v1",
+    toolName: "create_charter_yacht",
+    toolCapabilityId: "@voyant-travel/charters#tool.create-charter-yacht",
+    capabilityId: "@voyant-travel/charters#action.create-charter-yacht",
+    capabilityVersion: "v1",
+    commandTargetType: "charter_yacht_create_command",
+    canonicalTargetType: "charter-yacht",
+    resultReferenceType: "charter-yacht",
+    evaluatedRisk: "medium",
+    approvalPolicy: "none",
+    approvalReasonCode: null,
+  },
+} as const satisfies Record<string, ChartersCreatedTargetPolicy>
+
+export function buildChartersCreatedTargetFingerprint(
+  policy: ChartersCreatedTargetPolicy,
+  commandTargetId: string,
+  commandInput: unknown,
+): Promise<string> {
+  const input: BuildCreatedTargetCommandFingerprintInput = {
+    actionName: policy.actionName,
+    actionVersion: policy.actionVersion,
+    commandTarget: { type: policy.commandTargetType, id: commandTargetId },
+    canonicalTargetType: policy.canonicalTargetType,
+    resultReferenceType: policy.resultReferenceType,
+    commandInput,
+    capabilityId: policy.capabilityId,
+    capabilityVersion: policy.capabilityVersion,
+    evaluatedRisk: policy.evaluatedRisk,
+    approvalPolicy: policy.approvalPolicy,
+    approvalReasonCode: policy.approvalReasonCode,
+  }
+  return buildCreatedTargetCommandFingerprint(input)
+}
+
+export function chartersHandlerActionPolicyExpectation(
+  policy: ChartersCreatedTargetPolicy,
+): HandlerActionPolicyExpectation {
+  return {
+    capabilityId: policy.toolCapabilityId,
+    capabilityVersion: policy.capabilityVersion,
+    canonicalName: policy.toolName,
+    actionPolicy: {
+      id: policy.actionName,
+      capabilityId: policy.capabilityId,
+      version: policy.actionVersion,
+      kind: "execute",
+      targetType: policy.canonicalTargetType,
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: policy.commandTargetType,
+        resultReferenceType: policy.resultReferenceType,
+        durability: "handler-command-claim-v1",
+      },
+      risk: policy.evaluatedRisk,
+      ledger: "required",
+      approval: "never",
+      reversible: false,
+      allowedActorTypes: ["staff"],
+    },
+  }
+}

--- a/packages/charters/src/mcp-runtime.ts
+++ b/packages/charters/src/mcp-runtime.ts
@@ -1,3 +1,12 @@
+import {
+  type ActionLedgerRequestContextValues,
+  buildCreatedTargetIdempotencyScope,
+  type ExecuteCreatedTargetCommandHandlers,
+  type ExecuteCreatedTargetCommandInput,
+  type ExecuteCreatedTargetCommandResult,
+  executeCreatedTargetCommand,
+  mapActionLedgerRequestContext,
+} from "@voyant-travel/action-ledger"
 import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
@@ -9,6 +18,10 @@ import type {
   SourceRef,
 } from "./adapters/index.js"
 import { listCharterAdapters, resolveCharterAdapter } from "./adapters/registry.js"
+import {
+  buildChartersCreatedTargetFingerprint,
+  CHARTERS_CREATED_TARGET_POLICIES,
+} from "./created-target-policy.js"
 import { parseUnifiedKey } from "./lib/key.js"
 import { chartersService } from "./service.js"
 import { chartersBookingService } from "./service-bookings.js"
@@ -17,15 +30,17 @@ import type { ChartersToolServices } from "./tools.js"
 
 export * from "./tools.js"
 
-type ChartersToolRequestEnv = { Variables: { userId?: string } }
+type ChartersToolRequestEnv = { Variables: ActionLedgerRequestContextValues }
 
 export const voyantToolContextContribution = defineToolContextContribution({
   context: ["charters"],
   contribute({ request, context }) {
     const db = context.db as PostgresJsDatabase
-    const userId = (request as Context<ChartersToolRequestEnv>).get("userId")
+    const c = request as Context<ChartersToolRequestEnv>
+    const userId = c.get("userId") ?? undefined
+    const requestContext = chartersActionLedgerContext(c)
     const publicOnly = context.actor !== "staff"
-    const execute: ChartersToolServices["execute"] = async (operation, input) => {
+    const execute: ChartersToolServices["execute"] = async (operation, input, admitted) => {
       const args = input as Record<string, unknown>
       switch (operation) {
         case "browseCharters":
@@ -46,8 +61,29 @@ export const voyantToolContextContribution = defineToolContextContribution({
           )
         case "quoteWholeYacht":
           return quoteWholeYacht(db, String(args.key), String(args.currency), publicOnly)
-        case "createProduct":
-          return chartersService.createProduct(db, args as never)
+        case "createProduct": {
+          if (!admitted) {
+            throw new ToolError(
+              "Created charter product action policy is required.",
+              "ACTION_POLICY_REQUIRED",
+            )
+          }
+          const { idempotencyKey, ...commandInput } = args
+          assertAdmittedIdempotencyKey(admitted, String(idempotencyKey))
+          const result = await executeChartersCreate(
+            db,
+            requestContext,
+            CHARTERS_CREATED_TARGET_POLICIES.product,
+            String(idempotencyKey),
+            commandInput,
+            admitted,
+            async (tx) => {
+              const row = await chartersService.createProduct(tx, commandInput as never)
+              return { id: row.id }
+            },
+          )
+          return { status: "created" as const, product: result.value, replayed: result.replayed }
+        }
         case "updateProduct": {
           const { id, ...data } = args
           return chartersService.updateProduct(db, String(id), data as never)
@@ -58,8 +94,29 @@ export const voyantToolContextContribution = defineToolContextContribution({
           const { id, ...data } = args
           return chartersService.updateVoyage(db, String(id), data as never)
         }
-        case "createYacht":
-          return chartersService.createYacht(db, args as never)
+        case "createYacht": {
+          if (!admitted) {
+            throw new ToolError(
+              "Created charter yacht action policy is required.",
+              "ACTION_POLICY_REQUIRED",
+            )
+          }
+          const { idempotencyKey, ...commandInput } = args
+          assertAdmittedIdempotencyKey(admitted, String(idempotencyKey))
+          const result = await executeChartersCreate(
+            db,
+            requestContext,
+            CHARTERS_CREATED_TARGET_POLICIES.yacht,
+            String(idempotencyKey),
+            commandInput,
+            admitted,
+            async (tx) => {
+              const row = await chartersService.createYacht(tx, commandInput as never)
+              return { id: row.id }
+            },
+          )
+          return { status: "created" as const, yacht: result.value, replayed: result.replayed }
+        }
         case "updateYacht": {
           const { id, ...data } = args
           return chartersService.updateYacht(db, String(id), data as never)
@@ -71,6 +128,114 @@ export const voyantToolContextContribution = defineToolContextContribution({
     return { charters: { execute } }
   },
 })
+
+type ChartersCreatedTargetPolicy =
+  (typeof CHARTERS_CREATED_TARGET_POLICIES)[keyof typeof CHARTERS_CREATED_TARGET_POLICIES]
+
+type ChartersCreatedCommandExecutor = (
+  db: PostgresJsDatabase,
+  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: string },
+  handlers: ExecuteCreatedTargetCommandHandlers<{ id: string }, string>,
+) => Promise<ExecuteCreatedTargetCommandResult<{ id: string }, string>>
+
+export async function executeChartersCreate(
+  db: PostgresJsDatabase,
+  context: ActionLedgerRequestContextValues,
+  policy: ChartersCreatedTargetPolicy,
+  idempotencyKey: string,
+  commandInput: unknown,
+  admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
+  create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
+  executor: ChartersCreatedCommandExecutor = executeCreatedTargetCommand,
+) {
+  const principal = mapActionLedgerRequestContext(context)
+  if (principal.principalId === "unknown_request") {
+    throw new TypeError("Charters created-target commands require a concrete principal")
+  }
+  const selectedActionName = admitted.actionPolicy.capabilityId
+  const selectedActionVersion = admitted.actionPolicy.version
+  const fingerprint = await buildChartersCreatedTargetFingerprint(
+    {
+      ...policy,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+    } as ChartersCreatedTargetPolicy,
+    idempotencyKey,
+    commandInput,
+  )
+  const scope = await buildCreatedTargetIdempotencyScope({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    principalType: principal.principalType,
+    principalId: principal.principalId,
+    organizationId: principal.organizationId,
+  })
+  return executor(
+    db,
+    {
+      context,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      actionKind: "create",
+      evaluatedRisk: policy.evaluatedRisk,
+      commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+      canonicalTargetType: policy.canonicalTargetType,
+      resultReferenceType: policy.resultReferenceType,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+      approvalPolicy: policy.approvalPolicy,
+      approvalReasonCode: policy.approvalReasonCode,
+      commandInput,
+      routeOrToolName: admitted.capabilityId,
+      authorizationSource: "selected_graph_mcp_handler",
+      idempotency: { scope, key: idempotencyKey, fingerprint },
+    },
+    {
+      async create(tx) {
+        const value = await create(tx as PostgresJsDatabase)
+        return { value, targetId: value.id }
+      },
+      async replay(_tx, result) {
+        return { id: result.reference.id }
+      },
+    },
+  )
+}
+
+function assertAdmittedIdempotencyKey(
+  admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
+  inputKey: string,
+): void {
+  if (admitted.invocation.idempotencyKey !== inputKey) {
+    throw new ToolError(
+      "Created-target command idempotency key does not match the selected invocation.",
+      "ACTION_POLICY_REQUIRED",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+}
+
+function chartersActionLedgerContext(
+  c: Context<ChartersToolRequestEnv>,
+): ActionLedgerRequestContextValues {
+  return {
+    userId: c.get("userId") ?? null,
+    agentId: c.get("agentId") ?? null,
+    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
+    principalSubtype: c.get("principalSubtype") ?? null,
+    sessionId: c.get("sessionId") ?? null,
+    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
+    callerType: c.get("callerType") ?? null,
+    actor: c.get("actor") ?? null,
+    isInternalRequest: c.get("isInternalRequest") ?? false,
+    organizationId: c.get("organizationId") ?? null,
+    workflowRunId: c.get("workflowRunId") ?? null,
+    workflowStepId: c.get("workflowStepId") ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
 
 async function browseCharters(
   db: PostgresJsDatabase,

--- a/packages/charters/src/mcp-runtime.ts
+++ b/packages/charters/src/mcp-runtime.ts
@@ -68,13 +68,12 @@ export const voyantToolContextContribution = defineToolContextContribution({
               "ACTION_POLICY_REQUIRED",
             )
           }
-          const { idempotencyKey, ...commandInput } = args
-          assertAdmittedIdempotencyKey(admitted, String(idempotencyKey))
+          const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = args
           const result = await executeChartersCreate(
             db,
             requestContext,
             CHARTERS_CREATED_TARGET_POLICIES.product,
-            String(idempotencyKey),
+            typeof legacyIdempotencyKey === "string" ? legacyIdempotencyKey : undefined,
             commandInput,
             admitted,
             async (tx) => {
@@ -101,13 +100,12 @@ export const voyantToolContextContribution = defineToolContextContribution({
               "ACTION_POLICY_REQUIRED",
             )
           }
-          const { idempotencyKey, ...commandInput } = args
-          assertAdmittedIdempotencyKey(admitted, String(idempotencyKey))
+          const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = args
           const result = await executeChartersCreate(
             db,
             requestContext,
             CHARTERS_CREATED_TARGET_POLICIES.yacht,
-            String(idempotencyKey),
+            typeof legacyIdempotencyKey === "string" ? legacyIdempotencyKey : undefined,
             commandInput,
             admitted,
             async (tx) => {
@@ -142,7 +140,7 @@ export async function executeChartersCreate(
   db: PostgresJsDatabase,
   context: ActionLedgerRequestContextValues,
   policy: ChartersCreatedTargetPolicy,
-  idempotencyKey: string,
+  legacyIdempotencyKey: string | undefined,
   commandInput: unknown,
   admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
   create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
@@ -152,6 +150,7 @@ export async function executeChartersCreate(
   if (principal.principalId === "unknown_request") {
     throw new TypeError("Charters created-target commands require a concrete principal")
   }
+  const idempotencyKey = admittedCreatedCommandIdempotencyKey(admitted, legacyIdempotencyKey)
   const selectedActionName = admitted.actionPolicy.capabilityId
   const selectedActionVersion = admitted.actionPolicy.version
   const fingerprint = await buildChartersCreatedTargetFingerprint(
@@ -204,17 +203,26 @@ export async function executeChartersCreate(
   )
 }
 
-function assertAdmittedIdempotencyKey(
+function admittedCreatedCommandIdempotencyKey(
   admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
-  inputKey: string,
-): void {
-  if (admitted.invocation.idempotencyKey !== inputKey) {
+  legacyIdempotencyKey: string | undefined,
+): string {
+  const idempotencyKey = admitted.invocation.idempotencyKey?.trim()
+  if (!idempotencyKey) {
     throw new ToolError(
-      "Created-target command idempotency key does not match the selected invocation.",
+      "Created-target command idempotency must come from the admitted Tool invocation.",
       "ACTION_POLICY_REQUIRED",
       { capabilityId: admitted.capabilityId },
     )
   }
+  if (legacyIdempotencyKey !== undefined && legacyIdempotencyKey !== idempotencyKey) {
+    throw new ToolError(
+      "The legacy top-level idempotency key does not match the admitted Tool invocation.",
+      "INVALID_INPUT",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+  return idempotencyKey
 }
 
 function chartersActionLedgerContext(

--- a/packages/charters/src/tools.ts
+++ b/packages/charters/src/tools.ts
@@ -405,6 +405,7 @@ const createdCommandInput = {
     .trim()
     .min(1)
     .max(255)
+    .optional()
     .describe("Stable key used to replay this exact create command."),
 }
 const createProductToolInputSchema = insertProductSchema.extend(createdCommandInput)

--- a/packages/charters/src/tools.ts
+++ b/packages/charters/src/tools.ts
@@ -1,9 +1,19 @@
 /** Provider-neutral charter Tools over local inventory and selected adapters. */
 
-import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import {
+  admitHandlerActionPolicy,
+  defineTool,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
-
+import {
+  CHARTERS_CREATED_TARGET_POLICIES,
+  chartersHandlerActionPolicyExpectation,
+} from "./created-target-policy.js"
 import {
   insertProductSchema,
   insertVoyageSchema,
@@ -32,6 +42,10 @@ const WRITE_RISK = {
   reversible: true,
   dryRunSupported: false,
   sideEffects: ["data-write"],
+} as const
+const CREATED_WRITE_RISK = {
+  ...WRITE_RISK,
+  reversible: false,
 } as const
 const COMMIT_RISK = {
   destructive: false,
@@ -285,7 +299,11 @@ export type ChartersToolOperation =
   | "updateYacht"
   | "createBooking"
 export interface ChartersToolServices {
-  execute(operation: ChartersToolOperation, input: unknown): Promise<unknown>
+  execute(
+    operation: ChartersToolOperation,
+    input: unknown,
+    admitted?: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
 }
 export type ChartersToolContext = ToolContext & { charters?: ChartersToolServices }
 const service = (ctx: ChartersToolContext) => requireService(ctx.charters, "charters")
@@ -381,15 +399,46 @@ export const quoteCharterWholeYachtTool = defineTool({
 })
 
 const idInput = z.object({ id: z.string().min(1) })
+const createdCommandInput = {
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Stable key used to replay this exact create command."),
+}
+const createProductToolInputSchema = insertProductSchema.extend(createdCommandInput)
+const createYachtToolInputSchema = insertYachtSchema.extend(createdCommandInput)
+const createdProductOutputSchema = z.object({
+  status: z.literal("created"),
+  product: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
+const createdYachtOutputSchema = z.object({
+  status: z.literal("created"),
+  yacht: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
 export const createCharterProductTool = defineTool({
   ...write,
+  riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-charter-product`,
   name: "create_charter_product",
-  description: "Create a locally managed charter product.",
-  inputSchema: insertProductSchema,
-  outputSchema: productRowSchema,
+  description:
+    "Create a locally managed charter product. Exact retries return the original immutable reference.",
+  inputSchema: createProductToolInputSchema,
+  outputSchema: createdProductOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: ChartersToolContext) {
-    return parse(productRowSchema, await service(ctx).execute("createProduct", input))
+    const admitted = admitHandlerActionPolicy(
+      ctx,
+      chartersHandlerActionPolicyExpectation(CHARTERS_CREATED_TARGET_POLICIES.product),
+    )
+    return parse(
+      createdProductOutputSchema,
+      await service(ctx).execute("createProduct", input, admitted),
+    )
   },
 })
 export const updateCharterProductTool = defineTool({
@@ -430,13 +479,24 @@ export const updateCharterVoyageTool = defineTool({
 })
 export const createCharterYachtTool = defineTool({
   ...write,
+  riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-charter-yacht`,
   name: "create_charter_yacht",
-  description: "Create a locally managed charter yacht.",
-  inputSchema: insertYachtSchema,
-  outputSchema: yachtRowSchema,
+  description:
+    "Create a locally managed charter yacht. Exact retries return the original immutable reference.",
+  inputSchema: createYachtToolInputSchema,
+  outputSchema: createdYachtOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: ChartersToolContext) {
-    return parse(yachtRowSchema, await service(ctx).execute("createYacht", input))
+    const admitted = admitHandlerActionPolicy(
+      ctx,
+      chartersHandlerActionPolicyExpectation(CHARTERS_CREATED_TARGET_POLICIES.yacht),
+    )
+    return parse(
+      createdYachtOutputSchema,
+      await service(ctx).execute("createYacht", input, admitted),
+    )
   },
 })
 export const updateCharterYachtTool = defineTool({

--- a/packages/charters/src/voyant.ts
+++ b/packages/charters/src/voyant.ts
@@ -158,11 +158,9 @@ export const chartersVoyantModule = defineModule({
     })),
     ...(
       [
-        "create-charter-product",
         "update-charter-product",
         "upsert-charter-voyage",
         "update-charter-voyage",
-        "create-charter-yacht",
         "update-charter-yacht",
       ] as const
     ).map((id) => ({
@@ -176,6 +174,35 @@ export const chartersVoyantModule = defineModule({
       approval: "never" as const,
       reversible: true,
       allowedActorTypes: ["staff" as const],
+      from: { tools: [`@voyant-travel/charters#tool.${id}`] },
+    })),
+    ...(
+      [
+        [
+          "create-charter-product",
+          "charter-product",
+          "charter_product_create_command",
+          "charter-product",
+        ],
+        ["create-charter-yacht", "charter-yacht", "charter_yacht_create_command", "charter-yacht"],
+      ] as const
+    ).map(([id, targetType, commandTargetType, resultReferenceType]) => ({
+      id: `@voyant-travel/charters#action.${id}`,
+      version: "v1" as const,
+      kind: "execute" as const,
+      targetType,
+      requiredScopes: ["charters:write"],
+      risk: "medium" as const,
+      ledger: "required" as const,
+      approval: "never" as const,
+      reversible: false,
+      allowedActorTypes: ["staff" as const],
+      targetLifecycle: "created" as const,
+      createdTarget: {
+        commandTargetType,
+        resultReferenceType,
+        durability: "handler-command-claim-v1" as const,
+      },
       from: { tools: [`@voyant-travel/charters#tool.${id}`] },
     })),
     {

--- a/packages/charters/tests/unit/created-target-policy.test.ts
+++ b/packages/charters/tests/unit/created-target-policy.test.ts
@@ -1,0 +1,237 @@
+import type { HandlerActionPolicyExpectation, ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import {
+  buildChartersCreatedTargetFingerprint,
+  CHARTERS_CREATED_TARGET_POLICIES,
+  chartersHandlerActionPolicyExpectation,
+} from "../../src/created-target-policy.js"
+import { executeChartersCreate } from "../../src/mcp-runtime.js"
+import {
+  type ChartersToolServices,
+  createCharterProductTool,
+  createCharterYachtTool,
+} from "../../src/tools.js"
+import { chartersVoyantModule } from "../../src/voyant.js"
+
+describe("charters created-target commands", () => {
+  it("declares product and yacht creates as immutable handler commands", () => {
+    for (const [policy, tool, outputKey] of [
+      [CHARTERS_CREATED_TARGET_POLICIES.product, createCharterProductTool, "product"],
+      [CHARTERS_CREATED_TARGET_POLICIES.yacht, createCharterYachtTool, "yacht"],
+    ] as const) {
+      expect(tool.actionPolicyEnforcement).toBe("handler")
+      expect(tool.riskPolicy.reversible).toBe(false)
+      expect(
+        chartersVoyantModule.actions?.find(({ id }) => id === policy.actionName),
+      ).toMatchObject({
+        targetType: policy.canonicalTargetType,
+        reversible: false,
+        targetLifecycle: "created",
+        createdTarget: {
+          commandTargetType: policy.commandTargetType,
+          resultReferenceType: policy.resultReferenceType,
+          durability: "handler-command-claim-v1",
+        },
+      })
+      expect(
+        tool.outputSchema.safeParse({
+          status: "created",
+          [outputKey]: { id: "generated_1" },
+          replayed: false,
+        }).success,
+      ).toBe(true)
+      expect(tool.outputSchema.safeParse({ id: "generated_1", name: "mutable" }).success).toBe(
+        false,
+      )
+    }
+    expect(() =>
+      createCharterProductTool.inputSchema.parse({ slug: "product", name: "Product" }),
+    ).toThrow()
+    expect(() =>
+      createCharterYachtTool.inputSchema.parse({
+        slug: "yacht",
+        name: "Yacht",
+        yachtClass: "luxury_motor",
+      }),
+    ).toThrow()
+  })
+
+  it("fingerprints drift and passes the exact executor transaction and Tool capability", async () => {
+    const policy = CHARTERS_CREATED_TARGET_POLICIES.product
+    const first = await buildChartersCreatedTargetFingerprint(policy, "key", { name: "A" })
+    expect(await buildChartersCreatedTargetFingerprint(policy, "key", { name: "A" })).toBe(first)
+    expect(await buildChartersCreatedTargetFingerprint(policy, "key", { name: "B" })).not.toBe(
+      first,
+    )
+
+    const tx = { owned: "executor" } as never
+    const admitted = admittedPolicy(chartersHandlerActionPolicyExpectation(policy), "key")
+    let createdId: string | undefined
+    let mutations = 0
+    const routes: Array<string | null | undefined> = []
+    const actionIdentities: Array<[string, string, string, string]> = []
+    const executor: NonNullable<Parameters<typeof executeChartersCreate>[7]> = async (
+      _db,
+      input,
+      handlers,
+    ) => {
+      routes.push(input.routeOrToolName)
+      actionIdentities.push([
+        input.actionName,
+        input.actionVersion,
+        input.capabilityId,
+        input.capabilityVersion,
+      ])
+      if (!createdId) {
+        const mutation = await handlers.create(tx)
+        createdId = mutation.targetId
+        return {
+          replayed: false,
+          value: mutation.value,
+          result: metadata(policy.resultReferenceType, createdId),
+        }
+      }
+      const result = metadata(policy.resultReferenceType, createdId)
+      return { replayed: true, value: await handlers.replay(tx, result), result }
+    }
+    const create: Parameters<typeof executeChartersCreate>[6] = async (receivedTx) => {
+      expect(receivedTx).toBe(tx)
+      mutations += 1
+      return { id: "product_1" }
+    }
+    const command = [
+      {} as never,
+      { userId: "usr_1", callerType: "session", organizationId: "org_1" },
+      policy,
+      "key",
+      { slug: "product", name: "Product" },
+      admitted,
+      create,
+      executor,
+    ] as const
+    await expect(executeChartersCreate(...command)).resolves.toMatchObject({
+      replayed: false,
+      value: { id: "product_1" },
+    })
+    await expect(executeChartersCreate(...command)).resolves.toMatchObject({
+      replayed: true,
+      value: { id: "product_1" },
+    })
+    expect(mutations).toBe(1)
+    expect(routes).toEqual([policy.toolCapabilityId, policy.toolCapabilityId])
+    expect(actionIdentities).toEqual([
+      [policy.capabilityId, policy.actionVersion, policy.capabilityId, policy.actionVersion],
+      [policy.capabilityId, policy.actionVersion, policy.capabilityId, policy.actionVersion],
+    ])
+  })
+
+  it("rejects missing, stale, and excluded-actor admission before service mutation", async () => {
+    for (const [policy, tool, input] of [
+      [
+        CHARTERS_CREATED_TARGET_POLICIES.product,
+        createCharterProductTool,
+        createCharterProductTool.inputSchema.parse({
+          slug: "product",
+          name: "Product",
+          idempotencyKey: "key",
+        }),
+      ],
+      [
+        CHARTERS_CREATED_TARGET_POLICIES.yacht,
+        createCharterYachtTool,
+        createCharterYachtTool.inputSchema.parse({
+          slug: "yacht",
+          name: "Yacht",
+          yachtClass: "luxury_motor",
+          idempotencyKey: "key",
+        }),
+      ],
+    ] as const) {
+      const expectation = chartersHandlerActionPolicyExpectation(policy)
+      for (const context of [
+        toolContext(undefined),
+        toolContext(admittedPolicy({ ...expectation, canonicalName: "stale_name" }, "key")),
+        toolContext(admittedPolicy(expectation, "key"), "customer"),
+      ]) {
+        let mutations = 0
+        context.charters = {
+          async execute() {
+            mutations += 1
+            return { status: "created", product: { id: "product_1" }, replayed: false }
+          },
+        }
+        await expect(tool.handler(input as never, context)).rejects.toMatchObject({
+          code: expect.stringMatching(/ACTION_POLICY_REQUIRED|AUTHORIZATION_DENIED/),
+        })
+        expect(mutations).toBe(0)
+      }
+    }
+  })
+
+  it("rejects an unknown principal before executor or mutation", async () => {
+    const policy = CHARTERS_CREATED_TARGET_POLICIES.yacht
+    let executorCalls = 0
+    let mutations = 0
+    await expect(
+      executeChartersCreate(
+        {} as never,
+        {},
+        policy,
+        "key",
+        { name: "Yacht" },
+        admittedPolicy(chartersHandlerActionPolicyExpectation(policy), "key"),
+        async () => {
+          mutations += 1
+          return { id: "never" }
+        },
+        async () => {
+          executorCalls += 1
+          throw new Error("must not execute")
+        },
+      ),
+    ).rejects.toThrow("concrete principal")
+    expect(executorCalls).toBe(0)
+    expect(mutations).toBe(0)
+  })
+})
+
+function admittedPolicy(expectation: HandlerActionPolicyExpectation, key: string) {
+  return {
+    capabilityId: expectation.capabilityId,
+    capabilityVersion: expectation.capabilityVersion,
+    canonicalName: expectation.canonicalName,
+    actionPolicy: {
+      ...expectation.actionPolicy,
+      enforcement: "handler" as const,
+      invocation: {
+        controlField: "_voyant" as const,
+        requiredFields: ["idempotencyKey"] as const,
+        optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"] as const,
+        fingerprintAlgorithm: "action-ledger-command-v1" as const,
+      },
+    },
+    invocation: { idempotencyKey: key },
+  }
+}
+
+function toolContext(
+  handlerActionPolicy?: ReturnType<typeof admittedPolicy>,
+  actor: ToolContext["actor"] = "staff",
+): ToolContext & { charters?: ChartersToolServices } {
+  return {
+    db: {},
+    actor,
+    audience: actor,
+    tenantId: "tenant",
+    resolverScope: { locale: "en", market: "default", actor, audience: actor },
+    ...(handlerActionPolicy ? { handlerActionPolicy } : {}),
+  }
+}
+
+function metadata(type: string, id: string) {
+  return {
+    entry: {} as never,
+    reference: { type, id, value: `${type}:${id}` as `${string}:${string}` },
+  }
+}

--- a/packages/charters/tests/unit/created-target-policy.test.ts
+++ b/packages/charters/tests/unit/created-target-policy.test.ts
@@ -45,16 +45,16 @@ describe("charters created-target commands", () => {
         false,
       )
     }
-    expect(() =>
-      createCharterProductTool.inputSchema.parse({ slug: "product", name: "Product" }),
-    ).toThrow()
-    expect(() =>
-      createCharterYachtTool.inputSchema.parse({
+    expect(
+      createCharterProductTool.inputSchema.safeParse({ slug: "product", name: "Product" }).success,
+    ).toBe(true)
+    expect(
+      createCharterYachtTool.inputSchema.safeParse({
         slug: "yacht",
         name: "Yacht",
         yachtClass: "luxury_motor",
-      }),
-    ).toThrow()
+      }).success,
+    ).toBe(true)
   })
 
   it("fingerprints drift and passes the exact executor transaction and Tool capability", async () => {
@@ -104,7 +104,7 @@ describe("charters created-target commands", () => {
       {} as never,
       { userId: "usr_1", callerType: "session", organizationId: "org_1" },
       policy,
-      "key",
+      undefined,
       { slug: "product", name: "Product" },
       admitted,
       create,

--- a/packages/charters/tests/unit/tools.test.ts
+++ b/packages/charters/tests/unit/tools.test.ts
@@ -51,7 +51,9 @@ describe("charter tools", () => {
     for (const tool of chartersTools.filter(
       ({ requiredScopes }) => requiredScopes[0] === "charters:write" && requiredScopes.length === 1,
     )) {
-      expect(tool.riskPolicy.reversible).toBe(true)
+      expect(tool.riskPolicy.reversible).toBe(
+        !["create_charter_product", "create_charter_yacht"].includes(tool.name),
+      )
       expect(tool.audience?.allowed).toEqual(["staff"])
     }
   })

--- a/packages/charters/tests/unit/voyant-manifest.test.ts
+++ b/packages/charters/tests/unit/voyant-manifest.test.ts
@@ -125,9 +125,9 @@ describe("charters deployment manifest", () => {
       expect(action).toMatchObject({
         ledger: "required",
         approval: "never",
-        reversible: true,
         allowedActorTypes: ["staff"],
       })
+      expect(action.reversible).toBe(action.targetLifecycle !== "created")
     }
   })
 })

--- a/packages/commerce/package.json
+++ b/packages/commerce/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/catalog": "workspace:^",
     "@voyant-travel/core": "workspace:^",

--- a/packages/commerce/src/created-target-policy.ts
+++ b/packages/commerce/src/created-target-policy.ts
@@ -1,0 +1,100 @@
+import {
+  type BuildCreatedTargetCommandFingerprintInput,
+  buildCreatedTargetCommandFingerprint,
+} from "@voyant-travel/action-ledger"
+import type { HandlerActionPolicyExpectation } from "@voyant-travel/tools"
+
+interface CommerceCreatedTargetPolicy {
+  actionName: string
+  actionVersion: "v1"
+  toolName: string
+  toolCapabilityId: string
+  capabilityId: string
+  capabilityVersion: "v1"
+  commandTargetType: string
+  canonicalTargetType: string
+  resultReferenceType: string
+  evaluatedRisk: "medium"
+  approvalPolicy: "none"
+  approvalReasonCode: null
+}
+
+export const COMMERCE_CREATED_TARGET_POLICIES = {
+  cancellationPolicy: {
+    actionName: "@voyant-travel/commerce#action.create-cancellation-policy",
+    actionVersion: "v1",
+    toolName: "create_cancellation_policy",
+    toolCapabilityId: "@voyant-travel/commerce#tool.create-cancellation-policy",
+    capabilityId: "@voyant-travel/commerce#action.create-cancellation-policy",
+    capabilityVersion: "v1",
+    commandTargetType: "cancellation_policy_create_command",
+    canonicalTargetType: "cancellation-policy",
+    resultReferenceType: "cancellation-policy",
+    evaluatedRisk: "medium",
+    approvalPolicy: "none",
+    approvalReasonCode: null,
+  },
+  priceCatalog: {
+    actionName: "@voyant-travel/commerce#action.create-price-catalog",
+    actionVersion: "v1",
+    toolName: "create_price_catalog",
+    toolCapabilityId: "@voyant-travel/commerce#tool.create-price-catalog",
+    capabilityId: "@voyant-travel/commerce#action.create-price-catalog",
+    capabilityVersion: "v1",
+    commandTargetType: "price_catalog_create_command",
+    canonicalTargetType: "price-catalog",
+    resultReferenceType: "price-catalog",
+    evaluatedRisk: "medium",
+    approvalPolicy: "none",
+    approvalReasonCode: null,
+  },
+} as const satisfies Record<string, CommerceCreatedTargetPolicy>
+
+export function buildCommerceCreatedTargetFingerprint(
+  policy: CommerceCreatedTargetPolicy,
+  commandTargetId: string,
+  commandInput: unknown,
+): Promise<string> {
+  const input: BuildCreatedTargetCommandFingerprintInput = {
+    actionName: policy.actionName,
+    actionVersion: policy.actionVersion,
+    commandTarget: { type: policy.commandTargetType, id: commandTargetId },
+    canonicalTargetType: policy.canonicalTargetType,
+    resultReferenceType: policy.resultReferenceType,
+    commandInput,
+    capabilityId: policy.capabilityId,
+    capabilityVersion: policy.capabilityVersion,
+    evaluatedRisk: policy.evaluatedRisk,
+    approvalPolicy: policy.approvalPolicy,
+    approvalReasonCode: policy.approvalReasonCode,
+  }
+  return buildCreatedTargetCommandFingerprint(input)
+}
+
+export function commerceHandlerActionPolicyExpectation(
+  policy: CommerceCreatedTargetPolicy,
+): HandlerActionPolicyExpectation {
+  return {
+    capabilityId: policy.toolCapabilityId,
+    capabilityVersion: policy.capabilityVersion,
+    canonicalName: policy.toolName,
+    actionPolicy: {
+      id: policy.actionName,
+      capabilityId: policy.capabilityId,
+      version: policy.actionVersion,
+      kind: "execute",
+      targetType: policy.canonicalTargetType,
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: policy.commandTargetType,
+        resultReferenceType: policy.resultReferenceType,
+        durability: "handler-command-claim-v1",
+      },
+      risk: policy.evaluatedRisk,
+      ledger: "required",
+      approval: "never",
+      reversible: false,
+      allowedActorTypes: ["staff"],
+    },
+  }
+}

--- a/packages/commerce/src/mcp-runtime.ts
+++ b/packages/commerce/src/mcp-runtime.ts
@@ -1,8 +1,25 @@
+import {
+  type ActionLedgerRequestContextValues,
+  buildCreatedTargetIdempotencyScope,
+  type ExecuteCreatedTargetCommandHandlers,
+  type ExecuteCreatedTargetCommandInput,
+  type ExecuteCreatedTargetCommandResult,
+  executeCreatedTargetCommand,
+  mapActionLedgerRequestContext,
+} from "@voyant-travel/action-ledger"
 import type { EventBus } from "@voyant-travel/core"
-import { defineToolContextContribution } from "@voyant-travel/tools"
+import {
+  defineToolContextContribution,
+  ToolError,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
+import {
+  buildCommerceCreatedTargetFingerprint,
+  COMMERCE_CREATED_TARGET_POLICIES,
+} from "./created-target-policy.js"
 import { pricingService } from "./pricing/service.js"
 import { promotionsService } from "./promotions/service.js"
 import { sellabilityService } from "./sellability/service.js"
@@ -14,7 +31,8 @@ export const voyantToolContextContribution = defineToolContextContribution({
   context: ["commerce"],
   contribute({ request, context }) {
     const db = context.db as PostgresJsDatabase
-    const c = request as Context
+    const c = request as Context<{ Variables: ActionLedgerRequestContextValues }>
+    const requestContext = commerceActionLedgerContext(c)
     const eventBus = (c.var as { eventBus?: EventBus }).eventBus
     const mutationRuntime = { eventBus }
     const json = <T>(value: T): T => JSON.parse(JSON.stringify(value)) as T
@@ -28,8 +46,27 @@ export const voyantToolContextContribution = defineToolContextContribution({
       async getCancellationPolicy(id) {
         return json(await pricingService.getCancellationPolicyById(db, id))
       },
-      async createCancellationPolicy(input) {
-        return json(await pricingService.createCancellationPolicy(db, input))
+      async createCancellationPolicy(input, admitted) {
+        const { idempotencyKey, ...commandInput } = input
+        assertAdmittedIdempotencyKey(admitted, idempotencyKey)
+        const result = await executeCommerceCreate(
+          db,
+          requestContext,
+          COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy,
+          idempotencyKey,
+          commandInput,
+          admitted,
+          async (tx) => {
+            const row = await pricingService.createCancellationPolicy(tx, commandInput)
+            if (!row) throw new Error("Cancellation policy creation returned no row")
+            return { id: row.id }
+          },
+        )
+        return json({
+          status: "created" as const,
+          cancellationPolicy: result.value,
+          replayed: result.replayed,
+        })
       },
       async updateCancellationPolicy(id, input) {
         return json(await pricingService.updateCancellationPolicy(db, id, input))
@@ -40,8 +77,26 @@ export const voyantToolContextContribution = defineToolContextContribution({
       async getPriceCatalog(id) {
         return json(await pricingService.getPriceCatalogById(db, id))
       },
-      async createPriceCatalog(input) {
-        return json(await pricingService.createPriceCatalog(db, input))
+      async createPriceCatalog(input, admitted) {
+        const { idempotencyKey, ...commandInput } = input
+        assertAdmittedIdempotencyKey(admitted, idempotencyKey)
+        const result = await executeCommerceCreate(
+          db,
+          requestContext,
+          COMMERCE_CREATED_TARGET_POLICIES.priceCatalog,
+          idempotencyKey,
+          commandInput,
+          admitted,
+          async (tx) => {
+            const row = await pricingService.createPriceCatalog(tx, commandInput)
+            return { id: row.id }
+          },
+        )
+        return json({
+          status: "created" as const,
+          priceCatalog: result.value,
+          replayed: result.replayed,
+        })
       },
       async updatePriceCatalog(id, input) {
         return json(await pricingService.updatePriceCatalog(db, id, input))
@@ -65,3 +120,111 @@ export const voyantToolContextContribution = defineToolContextContribution({
     return { commerce }
   },
 })
+
+type CommerceCreatedTargetPolicy =
+  (typeof COMMERCE_CREATED_TARGET_POLICIES)[keyof typeof COMMERCE_CREATED_TARGET_POLICIES]
+
+type CommerceCreatedCommandExecutor = (
+  db: PostgresJsDatabase,
+  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: string },
+  handlers: ExecuteCreatedTargetCommandHandlers<{ id: string }, string>,
+) => Promise<ExecuteCreatedTargetCommandResult<{ id: string }, string>>
+
+export async function executeCommerceCreate(
+  db: PostgresJsDatabase,
+  context: ActionLedgerRequestContextValues,
+  policy: CommerceCreatedTargetPolicy,
+  idempotencyKey: string,
+  commandInput: unknown,
+  admitted: ToolHandlerActionPolicyContext,
+  create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
+  executor: CommerceCreatedCommandExecutor = executeCreatedTargetCommand,
+) {
+  const principal = mapActionLedgerRequestContext(context)
+  if (principal.principalId === "unknown_request") {
+    throw new TypeError("Commerce created-target commands require a concrete principal")
+  }
+  const selectedActionName = admitted.actionPolicy.capabilityId
+  const selectedActionVersion = admitted.actionPolicy.version
+  const fingerprint = await buildCommerceCreatedTargetFingerprint(
+    {
+      ...policy,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+    } as CommerceCreatedTargetPolicy,
+    idempotencyKey,
+    commandInput,
+  )
+  const scope = await buildCreatedTargetIdempotencyScope({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    principalType: principal.principalType,
+    principalId: principal.principalId,
+    organizationId: principal.organizationId,
+  })
+  return executor(
+    db,
+    {
+      context,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      actionKind: "create",
+      evaluatedRisk: policy.evaluatedRisk,
+      commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+      canonicalTargetType: policy.canonicalTargetType,
+      resultReferenceType: policy.resultReferenceType,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+      approvalPolicy: policy.approvalPolicy,
+      approvalReasonCode: policy.approvalReasonCode,
+      commandInput,
+      routeOrToolName: admitted.capabilityId,
+      authorizationSource: "selected_graph_mcp_handler",
+      idempotency: { scope, key: idempotencyKey, fingerprint },
+    },
+    {
+      async create(tx) {
+        const value = await create(tx as PostgresJsDatabase)
+        return { value, targetId: value.id }
+      },
+      async replay(_tx, result) {
+        return { id: result.reference.id }
+      },
+    },
+  )
+}
+
+function assertAdmittedIdempotencyKey(
+  admitted: ToolHandlerActionPolicyContext,
+  inputKey: string,
+): void {
+  if (admitted.invocation.idempotencyKey !== inputKey) {
+    throw new ToolError(
+      "Created-target command idempotency key does not match the selected invocation.",
+      "ACTION_POLICY_REQUIRED",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+}
+
+function commerceActionLedgerContext(
+  c: Context<{ Variables: ActionLedgerRequestContextValues }>,
+): ActionLedgerRequestContextValues {
+  return {
+    userId: c.get("userId") ?? null,
+    agentId: c.get("agentId") ?? null,
+    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
+    principalSubtype: c.get("principalSubtype") ?? null,
+    sessionId: c.get("sessionId") ?? null,
+    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
+    callerType: c.get("callerType") ?? null,
+    actor: c.get("actor") ?? null,
+    isInternalRequest: c.get("isInternalRequest") ?? false,
+    organizationId: c.get("organizationId") ?? null,
+    workflowRunId: c.get("workflowRunId") ?? null,
+    workflowStepId: c.get("workflowStepId") ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}

--- a/packages/commerce/src/mcp-runtime.ts
+++ b/packages/commerce/src/mcp-runtime.ts
@@ -47,13 +47,12 @@ export const voyantToolContextContribution = defineToolContextContribution({
         return json(await pricingService.getCancellationPolicyById(db, id))
       },
       async createCancellationPolicy(input, admitted) {
-        const { idempotencyKey, ...commandInput } = input
-        assertAdmittedIdempotencyKey(admitted, idempotencyKey)
+        const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = input
         const result = await executeCommerceCreate(
           db,
           requestContext,
           COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy,
-          idempotencyKey,
+          legacyIdempotencyKey,
           commandInput,
           admitted,
           async (tx) => {
@@ -78,13 +77,12 @@ export const voyantToolContextContribution = defineToolContextContribution({
         return json(await pricingService.getPriceCatalogById(db, id))
       },
       async createPriceCatalog(input, admitted) {
-        const { idempotencyKey, ...commandInput } = input
-        assertAdmittedIdempotencyKey(admitted, idempotencyKey)
+        const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = input
         const result = await executeCommerceCreate(
           db,
           requestContext,
           COMMERCE_CREATED_TARGET_POLICIES.priceCatalog,
-          idempotencyKey,
+          legacyIdempotencyKey,
           commandInput,
           admitted,
           async (tx) => {
@@ -134,7 +132,7 @@ export async function executeCommerceCreate(
   db: PostgresJsDatabase,
   context: ActionLedgerRequestContextValues,
   policy: CommerceCreatedTargetPolicy,
-  idempotencyKey: string,
+  legacyIdempotencyKey: string | undefined,
   commandInput: unknown,
   admitted: ToolHandlerActionPolicyContext,
   create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
@@ -144,6 +142,7 @@ export async function executeCommerceCreate(
   if (principal.principalId === "unknown_request") {
     throw new TypeError("Commerce created-target commands require a concrete principal")
   }
+  const idempotencyKey = admittedCreatedCommandIdempotencyKey(admitted, legacyIdempotencyKey)
   const selectedActionName = admitted.actionPolicy.capabilityId
   const selectedActionVersion = admitted.actionPolicy.version
   const fingerprint = await buildCommerceCreatedTargetFingerprint(
@@ -196,17 +195,26 @@ export async function executeCommerceCreate(
   )
 }
 
-function assertAdmittedIdempotencyKey(
+function admittedCreatedCommandIdempotencyKey(
   admitted: ToolHandlerActionPolicyContext,
-  inputKey: string,
-): void {
-  if (admitted.invocation.idempotencyKey !== inputKey) {
+  legacyIdempotencyKey: string | undefined,
+): string {
+  const idempotencyKey = admitted.invocation.idempotencyKey?.trim()
+  if (!idempotencyKey) {
     throw new ToolError(
-      "Created-target command idempotency key does not match the selected invocation.",
+      "Created-target command idempotency must come from the admitted Tool invocation.",
       "ACTION_POLICY_REQUIRED",
       { capabilityId: admitted.capabilityId },
     )
   }
+  if (legacyIdempotencyKey !== undefined && legacyIdempotencyKey !== idempotencyKey) {
+    throw new ToolError(
+      "The legacy top-level idempotency key does not match the admitted Tool invocation.",
+      "INVALID_INPUT",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+  return idempotencyKey
 }
 
 function commerceActionLedgerContext(

--- a/packages/commerce/src/tools.test.ts
+++ b/packages/commerce/src/tools.test.ts
@@ -22,14 +22,15 @@ describe("commerce tools", () => {
     expect(resolveSellabilityTool.outputSchema.safeParse({ data: [] }).success).toBe(false)
   })
 
-  it("keeps authoring and archival writes reversible and staff-scoped", () => {
+  it("keeps writes staff-scoped and reports only concrete reversal support", () => {
     for (const tool of [createCancellationPolicyTool, archivePromotionTool]) {
       expect(tool.audience).toEqual({ source: "grant", allowed: ["staff"] })
       expect(tool.riskPolicy).toMatchObject({
         destructive: false,
-        reversible: true,
         sideEffects: ["data-write"],
       })
     }
+    expect(createCancellationPolicyTool.riskPolicy.reversible).toBe(false)
+    expect(archivePromotionTool.riskPolicy.reversible).toBe(true)
   })
 })

--- a/packages/commerce/src/tools.ts
+++ b/packages/commerce/src/tools.ts
@@ -58,6 +58,7 @@ const createdCommandInput = {
     .trim()
     .min(1)
     .max(255)
+    .optional()
     .describe("Stable key used to replay this exact create command."),
 }
 const createCancellationPolicyToolInputSchema =

--- a/packages/commerce/src/tools.ts
+++ b/packages/commerce/src/tools.ts
@@ -1,9 +1,19 @@
 /** Guarded Commerce Tools for sellability, pricing policy, and promotions. */
 
-import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import {
+  admitHandlerActionPolicy,
+  defineTool,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
-
+import {
+  COMMERCE_CREATED_TARGET_POLICIES,
+  commerceHandlerActionPolicyExpectation,
+} from "./created-target-policy.js"
 import {
   cancellationPolicyListQuerySchema,
   insertCancellationPolicySchema,
@@ -30,11 +40,29 @@ const reversibleWriteRisk = {
   confirmationRequired: false,
   sideEffects: ["data-write"],
 } as const
+const createdWriteRisk = {
+  destructive: false,
+  reversible: false,
+  dryRunSupported: false,
+  confirmationRequired: false,
+  sideEffects: ["data-write"],
+} as const
 
 const idSchema = z.object({ id: z.string().min(1) })
 const updateCancellationPolicyToolSchema = z.intersection(idSchema, updateCancellationPolicySchema)
 const updatePriceCatalogToolSchema = z.intersection(idSchema, updatePriceCatalogSchema)
 const updatePromotionToolSchema = z.intersection(idSchema, updatePromotionalOfferSchema)
+const createdCommandInput = {
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Stable key used to replay this exact create command."),
+}
+const createCancellationPolicyToolInputSchema =
+  insertCancellationPolicySchema.extend(createdCommandInput)
+const createPriceCatalogToolInputSchema = insertPriceCatalogSchema.extend(createdCommandInput)
 
 const cancellationPolicySchema = z.object({
   id: z.string(),
@@ -62,6 +90,16 @@ const priceCatalogSchema = z.object({
   metadata: z.record(z.string(), z.unknown()).nullable(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+})
+const createdCancellationPolicyOutputSchema = z.object({
+  status: z.literal("created"),
+  cancellationPolicy: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
+const createdPriceCatalogOutputSchema = z.object({
+  status: z.literal("created"),
+  priceCatalog: z.object({ id: z.string() }),
+  replayed: z.boolean(),
 })
 
 const resolvedComponentSchema = z.object({
@@ -143,11 +181,17 @@ export interface CommerceToolServices {
     input: z.infer<typeof cancellationPolicyListQuerySchema>,
   ): Promise<unknown>
   getCancellationPolicy(id: string): Promise<unknown>
-  createCancellationPolicy(input: z.infer<typeof insertCancellationPolicySchema>): Promise<unknown>
+  createCancellationPolicy(
+    input: z.infer<typeof createCancellationPolicyToolInputSchema>,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   updateCancellationPolicy(id: string, input: AnyServiceInput): Promise<unknown>
   listPriceCatalogs(input: z.infer<typeof priceCatalogListQuerySchema>): Promise<unknown>
   getPriceCatalog(id: string): Promise<unknown>
-  createPriceCatalog(input: z.infer<typeof insertPriceCatalogSchema>): Promise<unknown>
+  createPriceCatalog(
+    input: z.infer<typeof createPriceCatalogToolInputSchema>,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   updatePriceCatalog(id: string, input: AnyServiceInput): Promise<unknown>
   listPromotions(input: z.infer<typeof promotionalOfferListQuerySchema>): Promise<unknown>
   getPromotion(id: string): Promise<unknown>
@@ -226,13 +270,23 @@ export const getCancellationPolicyTool = defineTool({
 
 export const createCancellationPolicyTool = defineTool({
   ...writeMetadata(["pricing:write"]),
+  riskPolicy: createdWriteRisk,
   capabilityId: `${OWNER}#tool.create-cancellation-policy`,
   name: "create_cancellation_policy",
-  description: "Create a reversible cancellation policy configuration.",
-  inputSchema: insertCancellationPolicySchema,
-  outputSchema: cancellationPolicySchema,
+  description:
+    "Create a cancellation policy configuration. Exact retries return the original immutable reference.",
+  inputSchema: createCancellationPolicyToolInputSchema,
+  outputSchema: createdCancellationPolicyOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: CommerceToolContext) {
-    return cancellationPolicySchema.parse(await commerce(ctx).createCancellationPolicy(input))
+    const admitted = admitHandlerActionPolicy(
+      ctx,
+      commerceHandlerActionPolicyExpectation(COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy),
+    )
+    return createdCancellationPolicyOutputSchema.parse(
+      await commerce(ctx).createCancellationPolicy(input, admitted),
+    )
   },
 })
 
@@ -279,13 +333,23 @@ export const getPriceCatalogTool = defineTool({
 
 export const createPriceCatalogTool = defineTool({
   ...writeMetadata(["pricing:write"]),
+  riskPolicy: createdWriteRisk,
   capabilityId: `${OWNER}#tool.create-price-catalog`,
   name: "create_price_catalog",
-  description: "Create a price catalog for a commercial audience or channel.",
-  inputSchema: insertPriceCatalogSchema,
-  outputSchema: priceCatalogSchema,
+  description:
+    "Create a price catalog for a commercial audience or channel. Exact retries return the original immutable reference.",
+  inputSchema: createPriceCatalogToolInputSchema,
+  outputSchema: createdPriceCatalogOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: CommerceToolContext) {
-    return priceCatalogSchema.parse(await commerce(ctx).createPriceCatalog(input))
+    const admitted = admitHandlerActionPolicy(
+      ctx,
+      commerceHandlerActionPolicyExpectation(COMMERCE_CREATED_TARGET_POLICIES.priceCatalog),
+    )
+    return createdPriceCatalogOutputSchema.parse(
+      await commerce(ctx).createPriceCatalog(input, admitted),
+    )
   },
 })
 

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -71,19 +71,43 @@ function commerceToolAction(
   action: "read" | "write",
 ): VoyantGraphActionDeclaration {
   const write = action === "write"
+  const created =
+    suffix === "create-cancellation-policy"
+      ? {
+          targetType: "cancellation-policy",
+          commandTargetType: "cancellation_policy_create_command",
+          resultReferenceType: "cancellation-policy",
+        }
+      : suffix === "create-price-catalog"
+        ? {
+            targetType: "price-catalog",
+            commandTargetType: "price_catalog_create_command",
+            resultReferenceType: "price-catalog",
+          }
+        : null
   return {
     id: `@voyant-travel/commerce#action.${suffix}`,
     version: "v1",
     kind: write ? "execute" : "read",
-    targetType: resource,
+    targetType: created?.targetType ?? resource,
     resource,
     action,
     requiredScopes: [`${resource}:${action}`],
     risk: write ? "medium" : "low",
     ledger: write ? "required" : "optional",
     approval: "never",
-    reversible: write,
+    reversible: write && !created,
     allowedActorTypes: ["staff"],
+    ...(created
+      ? {
+          targetLifecycle: "created" as const,
+          createdTarget: {
+            commandTargetType: created.commandTargetType,
+            resultReferenceType: created.resultReferenceType,
+            durability: "handler-command-claim-v1" as const,
+          },
+        }
+      : {}),
     from: { tools: [`@voyant-travel/commerce#tool.${suffix}`] },
   }
 }

--- a/packages/commerce/tests/unit/created-target-policy.test.ts
+++ b/packages/commerce/tests/unit/created-target-policy.test.ts
@@ -1,0 +1,258 @@
+import type { HandlerActionPolicyExpectation, ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import {
+  buildCommerceCreatedTargetFingerprint,
+  COMMERCE_CREATED_TARGET_POLICIES,
+  commerceHandlerActionPolicyExpectation,
+} from "../../src/created-target-policy.js"
+import { executeCommerceCreate } from "../../src/mcp-runtime.js"
+import {
+  type CommerceToolServices,
+  createCancellationPolicyTool,
+  createPriceCatalogTool,
+} from "../../src/tools.js"
+import { commerceVoyantModule } from "../../src/voyant.js"
+
+describe("commerce created-target commands", () => {
+  it("declares handler-owned generated targets with immutable outputs", () => {
+    for (const [policy, tool, outputKey] of [
+      [
+        COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy,
+        createCancellationPolicyTool,
+        "cancellationPolicy",
+      ],
+      [COMMERCE_CREATED_TARGET_POLICIES.priceCatalog, createPriceCatalogTool, "priceCatalog"],
+    ] as const) {
+      expect(tool.actionPolicyEnforcement).toBe("handler")
+      expect(tool.riskPolicy.reversible).toBe(false)
+      expect(
+        commerceVoyantModule.actions?.find(({ id }) => id === policy.actionName),
+      ).toMatchObject({
+        targetType: policy.canonicalTargetType,
+        reversible: false,
+        targetLifecycle: "created",
+        createdTarget: {
+          commandTargetType: policy.commandTargetType,
+          resultReferenceType: policy.resultReferenceType,
+          durability: "handler-command-claim-v1",
+        },
+      })
+      expect(
+        tool.outputSchema.safeParse({
+          status: "created",
+          [outputKey]: { id: "generated_1" },
+          replayed: false,
+        }).success,
+      ).toBe(true)
+      expect(tool.outputSchema.safeParse({ id: "generated_1", name: "mutable" }).success).toBe(
+        false,
+      )
+    }
+    expect(() => createCancellationPolicyTool.inputSchema.parse({ name: "Policy" })).toThrow()
+    expect(() =>
+      createPriceCatalogTool.inputSchema.parse({ code: "PUBLIC", name: "Public" }),
+    ).toThrow()
+  })
+
+  it("fingerprints exact same-key commands and detects drift", async () => {
+    const policy = COMMERCE_CREATED_TARGET_POLICIES.priceCatalog
+    const first = await buildCommerceCreatedTargetFingerprint(policy, "same-key", {
+      code: "PUBLIC",
+      name: "Public",
+    })
+    expect(
+      await buildCommerceCreatedTargetFingerprint(policy, "same-key", {
+        code: "PUBLIC",
+        name: "Public",
+      }),
+    ).toBe(first)
+    expect(
+      await buildCommerceCreatedTargetFingerprint(policy, "same-key", {
+        code: "PRIVATE",
+        name: "Private",
+      }),
+    ).not.toBe(first)
+  })
+
+  it("uses the executor transaction, canonical Tool capability, and immutable replay id", async () => {
+    const tx = { owned: "executor" } as never
+    const policy = COMMERCE_CREATED_TARGET_POLICIES.priceCatalog
+    const admitted = admittedPolicy(commerceHandlerActionPolicyExpectation(policy), "same-key")
+    let createdId: string | undefined
+    let mutations = 0
+    const routes: Array<string | null | undefined> = []
+    const actionIdentities: Array<[string, string, string, string]> = []
+    const executor: NonNullable<Parameters<typeof executeCommerceCreate>[7]> = async (
+      _db,
+      input,
+      handlers,
+    ) => {
+      routes.push(input.routeOrToolName)
+      actionIdentities.push([
+        input.actionName,
+        input.actionVersion,
+        input.capabilityId,
+        input.capabilityVersion,
+      ])
+      if (!createdId) {
+        const mutation = await handlers.create(tx)
+        createdId = mutation.targetId
+        return result(false, policy.resultReferenceType, createdId, mutation.value)
+      }
+      const replayResult = resultMetadata(policy.resultReferenceType, createdId)
+      return {
+        replayed: true,
+        value: await handlers.replay(tx, replayResult),
+        result: replayResult,
+      }
+    }
+    const create: Parameters<typeof executeCommerceCreate>[6] = async (receivedTx) => {
+      expect(receivedTx).toBe(tx)
+      mutations += 1
+      return { id: "catalog_1" }
+    }
+    const args = [
+      {} as never,
+      { userId: "usr_1", callerType: "session", organizationId: "org_1" },
+      policy,
+      "same-key",
+      { code: "PUBLIC", name: "Public" },
+      admitted,
+      create,
+      executor,
+    ] as const
+    const fresh = await executeCommerceCreate(...args)
+    const replay = await executeCommerceCreate(...args)
+    expect(fresh).toMatchObject({ replayed: false, value: { id: "catalog_1" } })
+    expect(replay).toMatchObject({ replayed: true, value: { id: "catalog_1" } })
+    expect(mutations).toBe(1)
+    expect(routes).toEqual([policy.toolCapabilityId, policy.toolCapabilityId])
+    expect(actionIdentities).toEqual([
+      [policy.capabilityId, policy.actionVersion, policy.capabilityId, policy.actionVersion],
+      [policy.capabilityId, policy.actionVersion, policy.capabilityId, policy.actionVersion],
+    ])
+  })
+
+  it("rejects missing, stale, and excluded-actor admission before service mutation", async () => {
+    for (const [policy, tool, input] of [
+      [
+        COMMERCE_CREATED_TARGET_POLICIES.cancellationPolicy,
+        createCancellationPolicyTool,
+        createCancellationPolicyTool.inputSchema.parse({
+          name: "Policy",
+          idempotencyKey: "key",
+        }),
+      ],
+      [
+        COMMERCE_CREATED_TARGET_POLICIES.priceCatalog,
+        createPriceCatalogTool,
+        createPriceCatalogTool.inputSchema.parse({
+          code: "PUBLIC",
+          name: "Public",
+          idempotencyKey: "key",
+        }),
+      ],
+    ] as const) {
+      const expectation = commerceHandlerActionPolicyExpectation(policy)
+      for (const context of [
+        toolContext(undefined),
+        toolContext(admittedPolicy({ ...expectation, canonicalName: "stale_name" }, "key")),
+        toolContext(admittedPolicy(expectation, "key"), "customer"),
+      ]) {
+        let mutations = 0
+        context.commerce = serviceStub(async () => {
+          mutations += 1
+        })
+        await expect(tool.handler(input as never, context)).rejects.toMatchObject({
+          code: expect.stringMatching(/ACTION_POLICY_REQUIRED|AUTHORIZATION_DENIED/),
+        })
+        expect(mutations).toBe(0)
+      }
+    }
+  })
+
+  it("rejects an unknown principal before executor or mutation", async () => {
+    let executorCalls = 0
+    let mutations = 0
+    const policy = COMMERCE_CREATED_TARGET_POLICIES.priceCatalog
+    await expect(
+      executeCommerceCreate(
+        {} as never,
+        {},
+        policy,
+        "key",
+        { code: "PUBLIC" },
+        admittedPolicy(commerceHandlerActionPolicyExpectation(policy), "key"),
+        async () => {
+          mutations += 1
+          return { id: "never" }
+        },
+        async () => {
+          executorCalls += 1
+          throw new Error("must not execute")
+        },
+      ),
+    ).rejects.toThrow("concrete principal")
+    expect(executorCalls).toBe(0)
+    expect(mutations).toBe(0)
+  })
+})
+
+function admittedPolicy(expectation: HandlerActionPolicyExpectation, key: string) {
+  return {
+    capabilityId: expectation.capabilityId,
+    capabilityVersion: expectation.capabilityVersion,
+    canonicalName: expectation.canonicalName,
+    actionPolicy: {
+      ...expectation.actionPolicy,
+      enforcement: "handler" as const,
+      invocation: {
+        controlField: "_voyant" as const,
+        requiredFields: ["idempotencyKey"] as const,
+        optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"] as const,
+        fingerprintAlgorithm: "action-ledger-command-v1" as const,
+      },
+    },
+    invocation: { idempotencyKey: key },
+  }
+}
+
+function toolContext(
+  handlerActionPolicy?: ReturnType<typeof admittedPolicy>,
+  actor: ToolContext["actor"] = "staff",
+): ToolContext & { commerce?: CommerceToolServices } {
+  return {
+    db: {},
+    actor,
+    audience: actor,
+    tenantId: "tenant",
+    resolverScope: { locale: "en", market: "default", actor, audience: actor },
+    ...(handlerActionPolicy ? { handlerActionPolicy } : {}),
+  }
+}
+
+function serviceStub(onCreate: () => Promise<void>): CommerceToolServices {
+  return new Proxy(
+    {},
+    {
+      get() {
+        return async () => {
+          await onCreate()
+          return { status: "created", priceCatalog: { id: "catalog_1" }, replayed: false }
+        }
+      },
+    },
+  ) as CommerceToolServices
+}
+
+function resultMetadata(type: string, id: string) {
+  return {
+    entry: {} as never,
+    reference: { type, id, value: `${type}:${id}` as `${string}:${string}` },
+  }
+}
+
+function result(replayed: false, type: string, id: string, value: { id: string }) {
+  return { replayed, value, result: resultMetadata(type, id) }
+}

--- a/packages/commerce/tests/unit/created-target-policy.test.ts
+++ b/packages/commerce/tests/unit/created-target-policy.test.ts
@@ -49,10 +49,12 @@ describe("commerce created-target commands", () => {
         false,
       )
     }
-    expect(() => createCancellationPolicyTool.inputSchema.parse({ name: "Policy" })).toThrow()
-    expect(() =>
-      createPriceCatalogTool.inputSchema.parse({ code: "PUBLIC", name: "Public" }),
-    ).toThrow()
+    expect(createCancellationPolicyTool.inputSchema.safeParse({ name: "Policy" }).success).toBe(
+      true,
+    )
+    expect(
+      createPriceCatalogTool.inputSchema.safeParse({ code: "PUBLIC", name: "Public" }).success,
+    ).toBe(true)
   })
 
   it("fingerprints exact same-key commands and detects drift", async () => {
@@ -116,7 +118,7 @@ describe("commerce created-target commands", () => {
       {} as never,
       { userId: "usr_1", callerType: "session", organizationId: "org_1" },
       policy,
-      "same-key",
+      undefined,
       { code: "PUBLIC", name: "Public" },
       admitted,
       create,

--- a/packages/cruises/package.json
+++ b/packages/cruises/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:",
+    "@voyant-travel/action-ledger": "workspace:^",
     "@voyant-travel/bookings": "workspace:^",
     "@voyant-travel/core": "workspace:^",
     "@voyant-travel/db": "workspace:^",

--- a/packages/cruises/src/created-target-policy.ts
+++ b/packages/cruises/src/created-target-policy.ts
@@ -1,0 +1,65 @@
+import {
+  type BuildCreatedTargetCommandFingerprintInput,
+  buildCreatedTargetCommandFingerprint,
+} from "@voyant-travel/action-ledger"
+import type { HandlerActionPolicyExpectation } from "@voyant-travel/tools"
+
+export const CRUISE_SHIP_CREATED_TARGET_POLICY = {
+  actionName: "@voyant-travel/cruises#action.create-cruise-ship",
+  actionVersion: "v1",
+  toolName: "create_cruise_ship",
+  toolCapabilityId: "@voyant-travel/cruises#tool.create-cruise-ship",
+  capabilityId: "@voyant-travel/cruises#action.create-cruise-ship",
+  capabilityVersion: "v1",
+  commandTargetType: "cruise_ship_create_command",
+  canonicalTargetType: "cruise-ship",
+  resultReferenceType: "cruise-ship",
+  evaluatedRisk: "medium",
+  approvalPolicy: "none",
+  approvalReasonCode: null,
+} as const
+
+export function buildCruiseShipCreatedTargetFingerprint(
+  commandTargetId: string,
+  commandInput: unknown,
+): Promise<string> {
+  const policy = CRUISE_SHIP_CREATED_TARGET_POLICY
+  const input: BuildCreatedTargetCommandFingerprintInput = {
+    actionName: policy.actionName,
+    actionVersion: policy.actionVersion,
+    commandTarget: { type: policy.commandTargetType, id: commandTargetId },
+    canonicalTargetType: policy.canonicalTargetType,
+    resultReferenceType: policy.resultReferenceType,
+    commandInput,
+    capabilityId: policy.capabilityId,
+    capabilityVersion: policy.capabilityVersion,
+    evaluatedRisk: policy.evaluatedRisk,
+    approvalPolicy: policy.approvalPolicy,
+    approvalReasonCode: policy.approvalReasonCode,
+  }
+  return buildCreatedTargetCommandFingerprint(input)
+}
+
+export const CRUISE_SHIP_HANDLER_ACTION_POLICY = {
+  capabilityId: CRUISE_SHIP_CREATED_TARGET_POLICY.toolCapabilityId,
+  capabilityVersion: CRUISE_SHIP_CREATED_TARGET_POLICY.capabilityVersion,
+  canonicalName: CRUISE_SHIP_CREATED_TARGET_POLICY.toolName,
+  actionPolicy: {
+    id: CRUISE_SHIP_CREATED_TARGET_POLICY.actionName,
+    capabilityId: CRUISE_SHIP_CREATED_TARGET_POLICY.capabilityId,
+    version: CRUISE_SHIP_CREATED_TARGET_POLICY.actionVersion,
+    kind: "execute",
+    targetType: CRUISE_SHIP_CREATED_TARGET_POLICY.canonicalTargetType,
+    targetLifecycle: "created",
+    createdTarget: {
+      commandTargetType: CRUISE_SHIP_CREATED_TARGET_POLICY.commandTargetType,
+      resultReferenceType: CRUISE_SHIP_CREATED_TARGET_POLICY.resultReferenceType,
+      durability: "handler-command-claim-v1",
+    },
+    risk: CRUISE_SHIP_CREATED_TARGET_POLICY.evaluatedRisk,
+    ledger: "required",
+    approval: "never",
+    reversible: false,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation

--- a/packages/cruises/src/mcp-runtime.ts
+++ b/packages/cruises/src/mcp-runtime.ts
@@ -76,12 +76,11 @@ export const voyantToolContextContribution = defineToolContextContribution({
               "ACTION_POLICY_REQUIRED",
             )
           }
-          const { idempotencyKey, ...commandInput } = args
-          assertAdmittedIdempotencyKey(admitted, String(idempotencyKey))
+          const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = args
           const result = await executeCruiseShipCreate(
             db,
             requestContext,
-            String(idempotencyKey),
+            typeof legacyIdempotencyKey === "string" ? legacyIdempotencyKey : undefined,
             commandInput,
             admitted,
             async (tx) => {
@@ -112,7 +111,7 @@ type CruiseShipCreatedCommandExecutor = (
 export async function executeCruiseShipCreate(
   db: PostgresJsDatabase,
   context: ActionLedgerRequestContextValues,
-  idempotencyKey: string,
+  legacyIdempotencyKey: string | undefined,
   commandInput: unknown,
   admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
   create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
@@ -122,6 +121,7 @@ export async function executeCruiseShipCreate(
   if (principal.principalId === "unknown_request") {
     throw new TypeError("Cruise ship created-target commands require a concrete principal")
   }
+  const idempotencyKey = admittedCreatedCommandIdempotencyKey(admitted, legacyIdempotencyKey)
   const policy = CRUISE_SHIP_CREATED_TARGET_POLICY
   const selectedActionName = admitted.actionPolicy.capabilityId
   const selectedActionVersion = admitted.actionPolicy.version
@@ -177,17 +177,26 @@ export async function executeCruiseShipCreate(
   )
 }
 
-function assertAdmittedIdempotencyKey(
+function admittedCreatedCommandIdempotencyKey(
   admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
-  inputKey: string,
-): void {
-  if (admitted.invocation.idempotencyKey !== inputKey) {
+  legacyIdempotencyKey: string | undefined,
+): string {
+  const idempotencyKey = admitted.invocation.idempotencyKey?.trim()
+  if (!idempotencyKey) {
     throw new ToolError(
-      "Created-target command idempotency key does not match the selected invocation.",
+      "Created-target command idempotency must come from the admitted Tool invocation.",
       "ACTION_POLICY_REQUIRED",
       { capabilityId: admitted.capabilityId },
     )
   }
+  if (legacyIdempotencyKey !== undefined && legacyIdempotencyKey !== idempotencyKey) {
+    throw new ToolError(
+      "The legacy top-level idempotency key does not match the admitted Tool invocation.",
+      "INVALID_INPUT",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+  return idempotencyKey
 }
 
 function cruisesActionLedgerContext(

--- a/packages/cruises/src/mcp-runtime.ts
+++ b/packages/cruises/src/mcp-runtime.ts
@@ -1,3 +1,13 @@
+import {
+  type ActionLedgerRequestContextValues,
+  buildCreatedTargetCommandFingerprint,
+  buildCreatedTargetIdempotencyScope,
+  type ExecuteCreatedTargetCommandHandlers,
+  type ExecuteCreatedTargetCommandInput,
+  type ExecuteCreatedTargetCommandResult,
+  executeCreatedTargetCommand,
+  mapActionLedgerRequestContext,
+} from "@voyant-travel/action-ledger"
 import type { EventBus } from "@voyant-travel/core"
 import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -5,6 +15,7 @@ import type { Context } from "hono"
 
 import type { CruiseAdapter, ExternalSailing, ExternalShip, SourceRef } from "./adapters/index.js"
 import { resolveCruiseAdapter } from "./adapters/registry.js"
+import { CRUISE_SHIP_CREATED_TARGET_POLICY } from "./created-target-policy.js"
 import { makeExternalSourceKey, parseUnifiedKey, sourceRefFromExternalKeyRef } from "./lib/key.js"
 import {
   passengerCompositionMatches,
@@ -20,7 +31,9 @@ import type { CruisesToolServices } from "./tools.js"
 
 export * from "./tools.js"
 
-type CruisesToolRequestEnv = { Variables: { eventBus?: EventBus; userId?: string } }
+type CruisesToolRequestEnv = {
+  Variables: ActionLedgerRequestContextValues & { eventBus?: EventBus }
+}
 
 export const voyantToolContextContribution = defineToolContextContribution({
   context: ["cruises"],
@@ -28,9 +41,10 @@ export const voyantToolContextContribution = defineToolContextContribution({
     const c = request as Context<CruisesToolRequestEnv>
     const db = context.db as PostgresJsDatabase
     const eventBus = c.get("eventBus")
-    const userId = c.get("userId")
+    const userId = c.get("userId") ?? undefined
+    const requestContext = cruisesActionLedgerContext(c)
     const publicOnly = context.actor !== "staff"
-    const execute: CruisesToolServices["execute"] = async (operation, input) => {
+    const execute: CruisesToolServices["execute"] = async (operation, input, admitted) => {
       const args = input as Record<string, unknown>
       switch (operation) {
         case "searchCruises":
@@ -55,8 +69,28 @@ export const voyantToolContextContribution = defineToolContextContribution({
           const { id, ...data } = args
           return cruisesService.updateSailing(db, String(id), data as never)
         }
-        case "createShip":
-          return cruisesService.createShip(db, args as never)
+        case "createShip": {
+          if (!admitted) {
+            throw new ToolError(
+              "Created cruise ship action policy is required.",
+              "ACTION_POLICY_REQUIRED",
+            )
+          }
+          const { idempotencyKey, ...commandInput } = args
+          assertAdmittedIdempotencyKey(admitted, String(idempotencyKey))
+          const result = await executeCruiseShipCreate(
+            db,
+            requestContext,
+            String(idempotencyKey),
+            commandInput,
+            admitted,
+            async (tx) => {
+              const row = await cruisesService.createShip(tx, commandInput as never)
+              return { id: row.id }
+            },
+          )
+          return { status: "created" as const, ship: result.value, replayed: result.replayed }
+        }
         case "updateShip": {
           const { id, ...data } = args
           return cruisesService.updateShip(db, String(id), data as never)
@@ -68,6 +102,113 @@ export const voyantToolContextContribution = defineToolContextContribution({
     return { cruises: { execute } }
   },
 })
+
+type CruiseShipCreatedCommandExecutor = (
+  db: PostgresJsDatabase,
+  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: string },
+  handlers: ExecuteCreatedTargetCommandHandlers<{ id: string }, string>,
+) => Promise<ExecuteCreatedTargetCommandResult<{ id: string }, string>>
+
+export async function executeCruiseShipCreate(
+  db: PostgresJsDatabase,
+  context: ActionLedgerRequestContextValues,
+  idempotencyKey: string,
+  commandInput: unknown,
+  admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
+  create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
+  executor: CruiseShipCreatedCommandExecutor = executeCreatedTargetCommand,
+) {
+  const principal = mapActionLedgerRequestContext(context)
+  if (principal.principalId === "unknown_request") {
+    throw new TypeError("Cruise ship created-target commands require a concrete principal")
+  }
+  const policy = CRUISE_SHIP_CREATED_TARGET_POLICY
+  const selectedActionName = admitted.actionPolicy.capabilityId
+  const selectedActionVersion = admitted.actionPolicy.version
+  const fingerprint = await buildCreatedTargetCommandFingerprint({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+    canonicalTargetType: policy.canonicalTargetType,
+    resultReferenceType: policy.resultReferenceType,
+    commandInput,
+    capabilityId: selectedActionName,
+    capabilityVersion: selectedActionVersion,
+    evaluatedRisk: policy.evaluatedRisk,
+    approvalPolicy: policy.approvalPolicy,
+    approvalReasonCode: policy.approvalReasonCode,
+  })
+  const scope = await buildCreatedTargetIdempotencyScope({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    principalType: principal.principalType,
+    principalId: principal.principalId,
+    organizationId: principal.organizationId,
+  })
+  return executor(
+    db,
+    {
+      context,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      actionKind: "create",
+      evaluatedRisk: policy.evaluatedRisk,
+      commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+      canonicalTargetType: policy.canonicalTargetType,
+      resultReferenceType: policy.resultReferenceType,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+      approvalPolicy: policy.approvalPolicy,
+      approvalReasonCode: policy.approvalReasonCode,
+      commandInput,
+      routeOrToolName: admitted.capabilityId,
+      authorizationSource: "selected_graph_mcp_handler",
+      idempotency: { scope, key: idempotencyKey, fingerprint },
+    },
+    {
+      async create(tx) {
+        const value = await create(tx as PostgresJsDatabase)
+        return { value, targetId: value.id }
+      },
+      async replay(_tx, result) {
+        return { id: result.reference.id }
+      },
+    },
+  )
+}
+
+function assertAdmittedIdempotencyKey(
+  admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
+  inputKey: string,
+): void {
+  if (admitted.invocation.idempotencyKey !== inputKey) {
+    throw new ToolError(
+      "Created-target command idempotency key does not match the selected invocation.",
+      "ACTION_POLICY_REQUIRED",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+}
+
+function cruisesActionLedgerContext(
+  c: Context<CruisesToolRequestEnv>,
+): ActionLedgerRequestContextValues {
+  return {
+    userId: c.get("userId") ?? null,
+    agentId: c.get("agentId") ?? null,
+    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
+    principalSubtype: c.get("principalSubtype") ?? null,
+    sessionId: c.get("sessionId") ?? null,
+    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
+    callerType: c.get("callerType") ?? null,
+    actor: c.get("actor") ?? null,
+    isInternalRequest: c.get("isInternalRequest") ?? false,
+    organizationId: c.get("organizationId") ?? null,
+    workflowRunId: c.get("workflowRunId") ?? null,
+    workflowStepId: c.get("workflowStepId") ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
 
 async function searchCruises(
   db: PostgresJsDatabase,

--- a/packages/cruises/src/tools.ts
+++ b/packages/cruises/src/tools.ts
@@ -170,6 +170,7 @@ const createShipToolInputSchema = insertShipSchema.extend({
     .trim()
     .min(1)
     .max(255)
+    .optional()
     .describe("Stable key used to replay this exact create command."),
 })
 const createdShipOutputSchema = z.object({

--- a/packages/cruises/src/tools.ts
+++ b/packages/cruises/src/tools.ts
@@ -1,9 +1,16 @@
 /** Provider-neutral cruise Tools over the search index, local owner, and selected adapters. */
 
-import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import {
+  admitHandlerActionPolicy,
+  defineTool,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
-
+import { CRUISE_SHIP_HANDLER_ACTION_POLICY } from "./created-target-policy.js"
 import { createBookingPayloadSchema, quotePayloadSchema } from "./routes-booking-payloads.js"
 import {
   cruiseRowSchema,
@@ -40,6 +47,10 @@ const WRITE_RISK = {
   reversible: true,
   dryRunSupported: false,
   sideEffects: ["data-write"],
+} as const
+const CREATED_WRITE_RISK = {
+  ...WRITE_RISK,
+  reversible: false,
 } as const
 const COMMIT_RISK = {
   destructive: false,
@@ -153,6 +164,19 @@ const bookingInputSchema = z
   .object({ key: z.string().min(1) })
   .and(createBookingPayloadSchema.omit({ sailingId: true }))
 const idInput = z.object({ id: z.string().min(1) })
+const createShipToolInputSchema = insertShipSchema.extend({
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .describe("Stable key used to replay this exact create command."),
+})
+const createdShipOutputSchema = z.object({
+  status: z.literal("created"),
+  ship: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
 
 export type CruisesToolOperation =
   | "searchCruises"
@@ -168,7 +192,11 @@ export type CruisesToolOperation =
   | "updateShip"
   | "createBooking"
 export interface CruisesToolServices {
-  execute(operation: CruisesToolOperation, input: unknown): Promise<unknown>
+  execute(
+    operation: CruisesToolOperation,
+    input: unknown,
+    admitted?: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
 }
 export type CruisesToolContext = ToolContext & { cruises?: CruisesToolServices }
 const service = (ctx: CruisesToolContext) => requireService(ctx.cruises, "cruises")
@@ -303,13 +331,18 @@ export const updateCruiseSailingTool = defineTool({
 })
 export const createCruiseShipTool = defineTool({
   ...write,
+  riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-cruise-ship`,
   name: "create_cruise_ship",
-  description: "Create a locally managed cruise ship.",
-  inputSchema: insertShipSchema,
-  outputSchema: cruiseShipRowSchema,
+  description:
+    "Create a locally managed cruise ship. Exact retries return the original immutable reference.",
+  inputSchema: createShipToolInputSchema,
+  outputSchema: createdShipOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: CruisesToolContext) {
-    return parse(cruiseShipRowSchema, await service(ctx).execute("createShip", input))
+    const admitted = admitHandlerActionPolicy(ctx, CRUISE_SHIP_HANDLER_ACTION_POLICY)
+    return parse(createdShipOutputSchema, await service(ctx).execute("createShip", input, admitted))
   },
 })
 export const updateCruiseShipTool = defineTool({

--- a/packages/cruises/src/voyant.ts
+++ b/packages/cruises/src/voyant.ts
@@ -231,7 +231,6 @@ export const cruisesVoyantModule = defineModule({
         "update-cruise",
         "upsert-cruise-sailing",
         "update-cruise-sailing",
-        "create-cruise-ship",
         "update-cruise-ship",
       ] as const
     ).map((id) => ({
@@ -247,6 +246,25 @@ export const cruisesVoyantModule = defineModule({
       allowedActorTypes: ["staff" as const],
       from: { tools: [`@voyant-travel/cruises#tool.${id}`] },
     })),
+    {
+      id: "@voyant-travel/cruises#action.create-cruise-ship",
+      version: "v1",
+      kind: "execute",
+      targetType: "cruise-ship",
+      requiredScopes: ["cruises:write"],
+      risk: "medium",
+      ledger: "required",
+      approval: "never",
+      reversible: false,
+      allowedActorTypes: ["staff"],
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "cruise_ship_create_command",
+        resultReferenceType: "cruise-ship",
+        durability: "handler-command-claim-v1",
+      },
+      from: { tools: ["@voyant-travel/cruises#tool.create-cruise-ship"] },
+    },
     {
       id: "@voyant-travel/cruises#action.create-cruise-booking",
       version: "v1",

--- a/packages/cruises/tests/unit/created-target-policy.test.ts
+++ b/packages/cruises/tests/unit/created-target-policy.test.ts
@@ -1,0 +1,207 @@
+import type { HandlerActionPolicyExpectation, ToolContext } from "@voyant-travel/tools"
+import { describe, expect, it } from "vitest"
+
+import {
+  buildCruiseShipCreatedTargetFingerprint,
+  CRUISE_SHIP_CREATED_TARGET_POLICY,
+  CRUISE_SHIP_HANDLER_ACTION_POLICY,
+} from "../../src/created-target-policy.js"
+import { executeCruiseShipCreate } from "../../src/mcp-runtime.js"
+import { type CruisesToolServices, createCruiseShipTool } from "../../src/tools.js"
+import { cruisesVoyantModule } from "../../src/voyant.js"
+
+describe("cruise ship created-target command", () => {
+  it("declares an immutable handler-owned generated target", () => {
+    const policy = CRUISE_SHIP_CREATED_TARGET_POLICY
+    expect(createCruiseShipTool.actionPolicyEnforcement).toBe("handler")
+    expect(createCruiseShipTool.riskPolicy.reversible).toBe(false)
+    expect(cruisesVoyantModule.actions?.find(({ id }) => id === policy.actionName)).toMatchObject({
+      targetType: policy.canonicalTargetType,
+      reversible: false,
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: policy.commandTargetType,
+        resultReferenceType: policy.resultReferenceType,
+        durability: "handler-command-claim-v1",
+      },
+    })
+    expect(() =>
+      createCruiseShipTool.inputSchema.parse({
+        slug: "ship",
+        name: "Ship",
+        shipType: "ocean",
+      }),
+    ).toThrow()
+    expect(
+      createCruiseShipTool.outputSchema.safeParse({
+        status: "created",
+        ship: { id: "ship_1" },
+        replayed: false,
+      }).success,
+    ).toBe(true)
+    expect(
+      createCruiseShipTool.outputSchema.safeParse({ id: "ship_1", name: "mutable" }).success,
+    ).toBe(false)
+  })
+
+  it("fingerprints drift and passes the exact executor transaction and Tool capability", async () => {
+    const policy = CRUISE_SHIP_CREATED_TARGET_POLICY
+    const first = await buildCruiseShipCreatedTargetFingerprint("key", { name: "A" })
+    expect(await buildCruiseShipCreatedTargetFingerprint("key", { name: "A" })).toBe(first)
+    expect(await buildCruiseShipCreatedTargetFingerprint("key", { name: "B" })).not.toBe(first)
+
+    const tx = { owned: "executor" } as never
+    const admitted = admittedPolicy(CRUISE_SHIP_HANDLER_ACTION_POLICY, "key")
+    let createdId: string | undefined
+    let mutations = 0
+    const routes: Array<string | null | undefined> = []
+    const actionIdentities: Array<[string, string, string, string]> = []
+    const executor: NonNullable<Parameters<typeof executeCruiseShipCreate>[6]> = async (
+      _db,
+      input,
+      handlers,
+    ) => {
+      routes.push(input.routeOrToolName)
+      actionIdentities.push([
+        input.actionName,
+        input.actionVersion,
+        input.capabilityId,
+        input.capabilityVersion,
+      ])
+      if (!createdId) {
+        const mutation = await handlers.create(tx)
+        createdId = mutation.targetId
+        return {
+          replayed: false,
+          value: mutation.value,
+          result: metadata(policy.resultReferenceType, createdId),
+        }
+      }
+      const result = metadata(policy.resultReferenceType, createdId)
+      return { replayed: true, value: await handlers.replay(tx, result), result }
+    }
+    const create: Parameters<typeof executeCruiseShipCreate>[5] = async (receivedTx) => {
+      expect(receivedTx).toBe(tx)
+      mutations += 1
+      return { id: "ship_1" }
+    }
+    const command = [
+      {} as never,
+      { userId: "usr_1", callerType: "session", organizationId: "org_1" },
+      "key",
+      { slug: "ship", name: "Ship", shipType: "ocean" },
+      admitted,
+      create,
+      executor,
+    ] as const
+    await expect(executeCruiseShipCreate(...command)).resolves.toMatchObject({
+      replayed: false,
+      value: { id: "ship_1" },
+    })
+    await expect(executeCruiseShipCreate(...command)).resolves.toMatchObject({
+      replayed: true,
+      value: { id: "ship_1" },
+    })
+    expect(mutations).toBe(1)
+    expect(routes).toEqual([policy.toolCapabilityId, policy.toolCapabilityId])
+    expect(actionIdentities).toEqual([
+      [policy.capabilityId, policy.actionVersion, policy.capabilityId, policy.actionVersion],
+      [policy.capabilityId, policy.actionVersion, policy.capabilityId, policy.actionVersion],
+    ])
+  })
+
+  it("rejects missing, stale, and excluded-actor admission before service mutation", async () => {
+    const input = createCruiseShipTool.inputSchema.parse({
+      slug: "ship",
+      name: "Ship",
+      shipType: "ocean",
+      idempotencyKey: "key",
+    })
+    for (const context of [
+      toolContext(undefined),
+      toolContext(
+        admittedPolicy(
+          { ...CRUISE_SHIP_HANDLER_ACTION_POLICY, canonicalName: "stale_name" },
+          "key",
+        ),
+      ),
+      toolContext(admittedPolicy(CRUISE_SHIP_HANDLER_ACTION_POLICY, "key"), "customer"),
+    ]) {
+      let mutations = 0
+      context.cruises = {
+        async execute() {
+          mutations += 1
+          return { status: "created", ship: { id: "ship_1" }, replayed: false }
+        },
+      }
+      await expect(createCruiseShipTool.handler(input, context)).rejects.toMatchObject({
+        code: expect.stringMatching(/ACTION_POLICY_REQUIRED|AUTHORIZATION_DENIED/),
+      })
+      expect(mutations).toBe(0)
+    }
+  })
+
+  it("rejects an unknown principal before executor or mutation", async () => {
+    let executorCalls = 0
+    let mutations = 0
+    await expect(
+      executeCruiseShipCreate(
+        {} as never,
+        {},
+        "key",
+        { name: "Ship" },
+        admittedPolicy(CRUISE_SHIP_HANDLER_ACTION_POLICY, "key"),
+        async () => {
+          mutations += 1
+          return { id: "never" }
+        },
+        async () => {
+          executorCalls += 1
+          throw new Error("must not execute")
+        },
+      ),
+    ).rejects.toThrow("concrete principal")
+    expect(executorCalls).toBe(0)
+    expect(mutations).toBe(0)
+  })
+})
+
+function admittedPolicy(expectation: HandlerActionPolicyExpectation, key: string) {
+  return {
+    capabilityId: expectation.capabilityId,
+    capabilityVersion: expectation.capabilityVersion,
+    canonicalName: expectation.canonicalName,
+    actionPolicy: {
+      ...expectation.actionPolicy,
+      enforcement: "handler" as const,
+      invocation: {
+        controlField: "_voyant" as const,
+        requiredFields: ["idempotencyKey"] as const,
+        optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"] as const,
+        fingerprintAlgorithm: "action-ledger-command-v1" as const,
+      },
+    },
+    invocation: { idempotencyKey: key },
+  }
+}
+
+function toolContext(
+  handlerActionPolicy?: ReturnType<typeof admittedPolicy>,
+  actor: ToolContext["actor"] = "staff",
+): ToolContext & { cruises?: CruisesToolServices } {
+  return {
+    db: {},
+    actor,
+    audience: actor,
+    tenantId: "tenant",
+    resolverScope: { locale: "en", market: "default", actor, audience: actor },
+    ...(handlerActionPolicy ? { handlerActionPolicy } : {}),
+  }
+}
+
+function metadata(type: string, id: string) {
+  return {
+    entry: {} as never,
+    reference: { type, id, value: `${type}:${id}` as `${string}:${string}` },
+  }
+}

--- a/packages/cruises/tests/unit/created-target-policy.test.ts
+++ b/packages/cruises/tests/unit/created-target-policy.test.ts
@@ -25,13 +25,13 @@ describe("cruise ship created-target command", () => {
         durability: "handler-command-claim-v1",
       },
     })
-    expect(() =>
-      createCruiseShipTool.inputSchema.parse({
+    expect(
+      createCruiseShipTool.inputSchema.safeParse({
         slug: "ship",
         name: "Ship",
         shipType: "ocean",
-      }),
-    ).toThrow()
+      }).success,
+    ).toBe(true)
     expect(
       createCruiseShipTool.outputSchema.safeParse({
         status: "created",
@@ -88,7 +88,7 @@ describe("cruise ship created-target command", () => {
     const command = [
       {} as never,
       { userId: "usr_1", callerType: "session", organizationId: "org_1" },
-      "key",
+      undefined,
       { slug: "ship", name: "Ship", shipType: "ocean" },
       admitted,
       create,

--- a/packages/cruises/tests/unit/tools.test.ts
+++ b/packages/cruises/tests/unit/tools.test.ts
@@ -45,7 +45,7 @@ describe("cruise tools", () => {
     for (const tool of cruisesTools.filter(
       ({ requiredScopes }) => requiredScopes[0] === "cruises:write" && requiredScopes.length === 1,
     )) {
-      expect(tool.riskPolicy.reversible).toBe(true)
+      expect(tool.riskPolicy.reversible).toBe(tool.name !== "create_cruise_ship")
       expect(tool.audience?.allowed).toEqual(["staff"])
     }
   })

--- a/packages/cruises/tests/unit/voyant-manifest.test.ts
+++ b/packages/cruises/tests/unit/voyant-manifest.test.ts
@@ -191,9 +191,9 @@ describe("cruises deployment manifest", () => {
       expect(action).toMatchObject({
         ledger: "required",
         approval: "never",
-        reversible: true,
         allowedActorTypes: ["staff"],
       })
+      expect(action.reversible).toBe(action.targetLifecycle !== "created")
     }
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1397,6 +1397,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
@@ -1520,6 +1523,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings
@@ -1657,6 +1663,9 @@ importers:
       '@hono/zod-openapi':
         specifier: 'catalog:'
         version: 1.4.0(hono@4.12.25)(zod@4.4.3)
+      '@voyant-travel/action-ledger':
+        specifier: workspace:^
+        version: link:../action-ledger
       '@voyant-travel/bookings':
         specifier: workspace:^
         version: link:../bookings


### PR DESCRIPTION
Framework-wide follow-up to #3694, stacked on #3703.

Migrates Commerce cancellation-policy and price-catalog creation, Charters product/yacht creation, and Cruises ship creation to exact handler-admitted created-target commands. Claims use the selected graph action identity, stable Tool route, principal/org collision-safe scope, executor-owned transactions, and immutable replay references. Inputs must match the selected invocation idempotency key; staff policy failures occur before mutation; create metadata is honestly non-reversible.

Promotion, cruise creation, and booking flows are intentionally excluded because they still have non-transactional EventBus/external effects and must remain unavailable until an outbox/saga strategy is present.

Validation: Action Ledger 186 tests + typecheck; Commerce 167 tests; Charters 143 tests; Cruises 264 tests; scoped Biome and diff-check pass. The complete GitHub workflow is green, including build, tests, packaging, and database lanes.