### PR TITLE
fix(webhooks): align managed admin API mount

### DIFF
--- a/.changeset/tidy-webhooks-mount.md
+++ b/.changeset/tidy-webhooks-mount.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/webhook-delivery": patch
+---
+
+Mount the operator webhook administration API at the manifest-declared
+`/v1/admin/webhooks` path so the runtime matches the published OpenAPI contract
+and webhook settings UI.

--- a/packages/webhook-delivery/src/api-runtime.ts
+++ b/packages/webhook-delivery/src/api-runtime.ts
@@ -6,7 +6,7 @@ import { createOperatorWebhookAdminRoutes } from "./admin-routes.js"
 /** Compose operator webhook settings from the graph-selected external event catalog. */
 export const createOperatorWebhookVoyantRuntime = defineGraphRuntimeFactory(
   ({ graph }): ApiModule => ({
-    module: { name: "operator-webhooks" },
+    module: { name: "webhooks" },
     adminRoutes: createOperatorWebhookAdminRoutes({
       contracts: (graph.eventCatalog?.events ?? [])
         .filter((event) => event.visibility === "external")

--- a/packages/webhook-delivery/tests/openapi-ownership.test.ts
+++ b/packages/webhook-delivery/tests/openapi-ownership.test.ts
@@ -1,8 +1,11 @@
 import { readFileSync } from "node:fs"
 import { OpenAPIHono } from "@hono/zod-openapi"
+import { createApp } from "@voyant-travel/hono"
 import { describe, expect, it } from "vitest"
 
 import { createOperatorWebhookAdminRoutes } from "../src/admin-routes.js"
+import { createOperatorWebhookVoyantRuntime } from "../src/api-runtime.js"
+import operatorWebhooksVoyantModule from "../src/voyant.js"
 
 const apiId = "@voyant-travel/webhook-delivery#api.admin"
 const committed = JSON.parse(
@@ -14,6 +17,51 @@ const committed = JSON.parse(
 }
 
 describe("operator webhook OpenAPI ownership", () => {
+  it("keeps the runtime mount aligned with the manifest and published contract", async () => {
+    const runtime = await createOperatorWebhookVoyantRuntime({
+      graph: {
+        eventCatalog: { events: [] },
+      },
+    } as never)
+    const manifestMount = operatorWebhooksVoyantModule.api?.[0]?.mount
+
+    expect(manifestMount).toBe("webhooks")
+    expect(runtime.module.name).toBe(manifestMount)
+    expect(Object.keys(committed.paths)).toEqual(
+      expect.arrayContaining(["/v1/admin/webhooks/events", "/v1/admin/webhooks/subscriptions"]),
+    )
+
+    const app = createApp<Record<string, never>, Record<string, never>>({
+      manifest: { modules: ["@voyant-travel/webhook-delivery"] },
+      registry: {
+        modules: {
+          "@voyant-travel/webhook-delivery": () => runtime,
+        },
+      },
+      capabilities: {},
+      db: () => ({}) as never,
+      auth: {
+        resolve: () => ({
+          userId: "user_1",
+          actor: "staff",
+          realm: "admin",
+          scopes: ["webhooks:read"],
+        }),
+      },
+    })
+
+    const canonical = await app.request("/v1/admin/webhooks/events", {}, {} as never)
+    const staleRuntimeMount = await app.request(
+      "/v1/admin/operator-webhooks/events",
+      {},
+      {} as never,
+    )
+
+    expect(canonical.status).toBe(200)
+    await expect(canonical.json()).resolves.toEqual({ data: [] })
+    expect(staleRuntimeMount.status).toBe(404)
+  })
+
   it("claims every committed and live operation", () => {
     const mounted = new OpenAPIHono()
     mounted.route(


### PR DESCRIPTION
## Summary
- mount the managed admin webhook runtime at the canonical `/v1/admin/webhooks` path
- add an integration test through the real app composition proving the canonical route works and the accidental `/operator-webhooks` route does not
- add a patch changeset for `@voyant-travel/webhook-delivery`

## Validation
- `@voyant-travel/webhook-delivery` tests: 62/62 passed on a remote Sprite
- package typecheck passed on a remote Sprite
- Biome passed for the affected package
- independently reviewed with no blockers
