### PR TITLE
chore: advance managed runtime webhook release

### DIFF
--- a/.changeset/calm-webhooks-runtime.md
+++ b/.changeset/calm-webhooks-runtime.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Advance the managed runtime release train so platform images can include the
+canonical operator webhook administration route without mutating the existing
+0.62.7 image.


### PR DESCRIPTION
## Summary

- advance `@voyant-travel/framework` to the next patch release
- provide a new immutable managed-runtime image tag for the canonical webhook route fix
- preserve `0.62.7` as an unchanged rollback target

## Validation

- changeset-only release metadata
- `git diff --check`