### PR TITLE
Enforce reviewed action safety contracts

### DIFF
--- a/.changeset/enforce-action-safety-contracts.md
+++ b/.changeset/enforce-action-safety-contracts.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Treat omitted action availability as callable once lifecycle, effect-boundary, or
+durability metadata is present, so removing an unavailable marker cannot bypass
+stable-target and tested-durability validation.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -127,6 +127,9 @@ runtime reference are omitted from lowering, so it cannot appear in MCP discover
 Lowering fails closed if an unavailable action's Tool is reintroduced. Actions explicitly marked
 `available` must name an existing/created target lifecycle; external or multi-stage effects must
 also name a transactional, outbox, or saga durability strategy and the test that proves it.
+For actions carrying any availability, effect-boundary, or durability metadata, omitted
+availability is validated with the same callable meaning used by runtime lowering. Removing only
+an `unavailable` marker therefore cannot bypass lifecycle or tested-durability checks.
 First-party actions that still cross an external or multi-stage boundary through event
 publication, provider calls, document generation, delivery, ticketing, or booking orchestration
 are declared unavailable with the `unsafe-nontransactional-effect` reason and the corresponding

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1038,7 +1038,7 @@ describe("deployment graph v1", () => {
     )
   })
 
-  it("validates explicit Tool action availability and durability completeness", () => {
+  it("validates safety-reviewed Tool action availability and durability completeness", () => {
     const baseAction = {
       id: "@acme/voyant-actions#action.run",
       version: "v1",
@@ -1088,6 +1088,25 @@ describe("deployment graph v1", () => {
         message: expect.stringContaining("tested durability"),
       }),
     )
+    expect(
+      validateGraphUnitManifest(
+        manifest({
+          effectBoundary: "external",
+        }),
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          facet: "actions[0].targetLifecycle",
+          message: expect.stringContaining("stable target anchor"),
+        }),
+        expect.objectContaining({
+          facet: "actions[0].durability",
+          message: expect.stringContaining("tested durability"),
+        }),
+      ]),
+    )
+    expect(validateGraphUnitManifest(manifest({}))).toEqual([])
     expect(
       validateGraphUnitManifest(
         manifest({

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -2019,10 +2019,19 @@ function validatePromotedFacets(
         )
       }
     }
-    const explicitlyAvailable = availability?.status === "available"
+    // Legacy actions may omit the whole safety contract. Once an action opts
+    // into any safety metadata, omitted availability has the same callable
+    // meaning as runtime lowering: available. This prevents removing only an
+    // `unavailable` block from bypassing lifecycle and durability validation.
+    const effectivelyAvailable = availability?.status !== "unavailable"
+    const safetyContractSelected =
+      availability !== undefined ||
+      entry.effectBoundary !== undefined ||
+      entry.durability !== undefined
     const toolBound = isRecord(entry.from) && Array.isArray(entry.from.tools)
     if (
-      explicitlyAvailable &&
+      effectivelyAvailable &&
+      safetyContractSelected &&
       entry.kind === "execute" &&
       toolBound &&
       entry.targetLifecycle === undefined
@@ -2035,7 +2044,8 @@ function validatePromotedFacets(
       )
     }
     if (
-      explicitlyAvailable &&
+      effectivelyAvailable &&
+      safetyContractSelected &&
       entry.kind === "execute" &&
       (entry.effectBoundary === "external" || entry.effectBoundary === "multistage") &&
       entry.durability === undefined


### PR DESCRIPTION
## What changed

- Treat omitted action availability as callable once an action declares availability, effect-boundary, or durability safety metadata.
- Apply stable-target and tested-durability validation to that effective callable state.
- Add a regression test proving that removing only an `unavailable` marker cannot bypass the safety checks.
- Preserve compatibility for legacy actions that have not opted into any safety metadata.
- Document the callable-availability contract and add a Framework patch changeset.

## Why

Runtime lowering and MCP dispatch already interpret omitted availability as available, while graph validation previously enforced lifecycle and durability only for an explicit `status: "available"`. Deleting an unavailable marker could therefore expose an action without the checks required for external or multi-stage effects.

This is the first prerequisite for restoring the currently quarantined action set. It does not expose any quarantined action by itself.

## Validation

Executed on a disposable Sprite from the exact worktree snapshot:

- `pnpm install --frozen-lockfile`
- `pnpm exec biome check packages/framework/src/deployment-graph.ts packages/framework/src/deployment-graph.test.ts docs/architecture/agent-tool-library.md .changeset/enforce-action-safety-contracts.md` (passed; reported two pre-existing unused-function warnings in `deployment-graph.ts`)
- `pnpm --filter @voyant-travel/framework test -- deployment-graph.test.ts` — 38 files / 333 tests passed
- `pnpm --filter @voyant-travel/framework typecheck` — passed

The initial lab1 validation attempt was blocked by host disk exhaustion before tests ran; the disposable Sprite run completed successfully.