### PR TITLE
Restore durable promotion creation

### DIFF
--- a/.changeset/restore-commerce-promotion.md
+++ b/.changeset/restore-commerce-promotion.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/commerce": major
+---
+
+Restore the `create_promotion` Tool with a fingerprinted created-target command, atomic product-scope materialization, and deterministic transactional-outbox delivery.
+
+The response is now an immutable `{ status, promotion: { id }, replayed }` envelope rather than the full mutable offer. See `docs/migrations/created-target-commerce-charters-cruises.md` for caller migration guidance.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,8 @@ jobs:
                 tests/integration/postgres-indexer.test.ts
               pnpm --filter @voyant-travel/catalog exec vitest run \
                 tests/integration/postgres-pgtrgm-indexer.test.ts
+              pnpm --filter @voyant-travel/commerce exec vitest run \
+                tests/integration/promotion-created-command.test.ts
               ;;
           esac
 

--- a/docs/architecture/promotions-architecture.md
+++ b/docs/architecture/promotions-architecture.md
@@ -628,7 +628,7 @@ Mirrors the `availability.slot.changed` precedent (PR3 of #493 + the lifecycle w
 - **Bridge subscription**: operator catalog-bridge subscribes and dispatches per `affected.kind`:
   - `products` → call `reindexEntity` for each ID.
   - `all` → walk the products module's owned set and reindex each. Global / large-scope changes are rare events; the cost is acceptable.
-- **Service runtime threading**: per the #510 audit, mutations accept an optional `RuleMutationRuntime` with `eventBus` (matching `availability.slot.changed`). Routes thread `c.get("eventBus")`.
+- **Service runtime threading**: per the #510 audit, mutations accept an optional `RuleMutationRuntime` with `eventBus` (matching `availability.slot.changed`). Routes thread `c.get("eventBus")`. The `create_promotion` Tool is stricter: handler-owned created-target admission fingerprints and claims the command before mutation, then inserts the offer, materialized product links, deterministic `promotion.changed` outbox event, ledger result, and canonical promotion reference in one transaction. The event id is derived from the globally unique canonical promotion id, so identical commands in separate principal or organization scopes cannot collide in the global outbox. Equal retries replay only that immutable reference, while same-key payload drift conflicts before another mutation or event.
 
 ### 9.2. Time-driven: boundary scheduler
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -5,7 +5,7 @@ Per-minor consolidated migration notes for Voyant. Each page collects every brea
 Unreleased caller migrations:
 
 - [Created-target Tool commands](./created-target-tool-commands.md)
-- [Created local Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md)
+- [Created Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md)
 
 The full history (including patch-level changes and dependency updates) lives in the per-package `CHANGELOG.md` files; these pages exist because changeset entries land in *every* package's CHANGELOG that depends on the changed one, so the actual breaking signal is otherwise buried under dozens of `Updated dependencies [...]` lines per package.
 

--- a/docs/migrations/created-target-commerce-charters-cruises.md
+++ b/docs/migrations/created-target-commerce-charters-cruises.md
@@ -1,19 +1,22 @@
-# Created local Commerce, Charters, and Cruises targets
+# Created Commerce, Charters, and Cruises targets
 
 The following MCP Tools now use the framework's transactional
 `handler-command-claim-v1` created-target protocol:
 
 - `create_cancellation_policy`
 - `create_price_catalog`
+- `create_promotion`
 - `create_charter_product`
 - `create_charter_yacht`
 - `create_cruise_ship`
 
 ## Caller migration
 
-Every call must supply the same non-empty `idempotencyKey` in the Tool input and
-the `_voyant.idempotencyKey` invocation control. Keep that key stable for an
-exact logical command. Reusing it with different domain input is rejected.
+Every call must supply a non-empty `_voyant.idempotencyKey` invocation control.
+Keep that key stable for an exact logical command. The legacy top-level
+`idempotencyKey` remains optional for compatibility; when supplied, it must
+equal `_voyant.idempotencyKey`. Reusing the admitted key with different domain
+input is rejected.
 
 The response no longer contains a mutable database row. Read the generated id
 from the typed reference and call the corresponding get Tool when current state
@@ -30,6 +33,23 @@ const result = await createPriceCatalog({
 const catalogId = result.priceCatalog.id
 ```
 
+`create_promotion` previously returned the full mutable promotional-offer row.
+It now returns an immutable created-target envelope:
+
+```ts
+const result = await createPromotion({
+  name: "Summer",
+  slug: "summer",
+  discountType: "percentage",
+  discountPercent: 10,
+  scope: { kind: "global" },
+  _voyant: { idempotencyKey: commandId },
+})
+
+// { status: "created", promotion: { id: "..." }, replayed: false }
+const promotion = await getPromotion({ id: result.promotion.id })
+```
+
 Fresh and replayed responses have the same domain shape; `replayed` reports
 which path completed the call. Creation, the opaque command claim, and the
 canonical generated-target result commit in one database transaction.
@@ -37,11 +57,12 @@ canonical generated-target result commit in one database transaction.
 ## Direct-consumer audit
 
 The package-local HTTP routes and domain service signatures are unchanged.
-Repository search found no direct consumers of these five Tool invocation names
+Repository search found no direct consumers of these six Tool invocation names
 or Tool definition exports outside their owning Commerce, Charters, and Cruises
 packages. External MCP clients are the migration audience.
 
-The scoped primitives do not publish through `EventBus`; no post-commit event
-gap is hidden by this migration. Commerce promotion creation and cruise/charter
-product or booking commands with external or event effects are intentionally
-outside this change.
+The five pre-existing local primitives do not publish through `EventBus`.
+Promotion creation atomically appends its deterministic `promotion.changed`
+event to the database outbox alongside the offer, materialized product links,
+command claim, and canonical result. Cruise/charter booking commands with
+external effects remain outside this migration.

--- a/packages/commerce/src/created-target-command.ts
+++ b/packages/commerce/src/created-target-command.ts
@@ -1,0 +1,114 @@
+import {
+  type ActionLedgerRequestContextValues,
+  buildCreatedTargetIdempotencyScope,
+  type ExecuteCreatedTargetCommandHandlers,
+  type ExecuteCreatedTargetCommandInput,
+  type ExecuteCreatedTargetCommandResult,
+  executeCreatedTargetCommand,
+  mapActionLedgerRequestContext,
+} from "@voyant-travel/action-ledger"
+import { ToolError, type ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  buildCommerceCreatedTargetFingerprint,
+  type COMMERCE_CREATED_TARGET_POLICIES,
+} from "./created-target-policy.js"
+
+type CommerceCreatedTargetPolicy =
+  (typeof COMMERCE_CREATED_TARGET_POLICIES)[keyof typeof COMMERCE_CREATED_TARGET_POLICIES]
+
+type CommerceCreatedCommandExecutor = (
+  db: PostgresJsDatabase,
+  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: string },
+  handlers: ExecuteCreatedTargetCommandHandlers<{ id: string }, string>,
+) => Promise<ExecuteCreatedTargetCommandResult<{ id: string }, string>>
+
+export async function executeCommerceCreate(
+  db: PostgresJsDatabase,
+  context: ActionLedgerRequestContextValues,
+  policy: CommerceCreatedTargetPolicy,
+  legacyIdempotencyKey: string | undefined,
+  commandInput: unknown,
+  admitted: ToolHandlerActionPolicyContext,
+  create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
+  executor: CommerceCreatedCommandExecutor = executeCreatedTargetCommand,
+) {
+  const principal = mapActionLedgerRequestContext(context)
+  if (principal.principalId === "unknown_request") {
+    throw new TypeError("Commerce created-target commands require a concrete principal")
+  }
+  const idempotencyKey = admittedCreatedCommandIdempotencyKey(admitted, legacyIdempotencyKey)
+  const selectedActionName = admitted.actionPolicy.capabilityId
+  const selectedActionVersion = admitted.actionPolicy.version
+  const fingerprint = await buildCommerceCreatedTargetFingerprint(
+    {
+      ...policy,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+    } as CommerceCreatedTargetPolicy,
+    idempotencyKey,
+    commandInput,
+  )
+  const scope = await buildCreatedTargetIdempotencyScope({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    principalType: principal.principalType,
+    principalId: principal.principalId,
+    organizationId: principal.organizationId,
+  })
+  return executor(
+    db,
+    {
+      context,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      actionKind: "create",
+      evaluatedRisk: policy.evaluatedRisk,
+      commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+      canonicalTargetType: policy.canonicalTargetType,
+      resultReferenceType: policy.resultReferenceType,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+      approvalPolicy: policy.approvalPolicy,
+      approvalReasonCode: policy.approvalReasonCode,
+      commandInput,
+      routeOrToolName: admitted.capabilityId,
+      authorizationSource: "selected_graph_mcp_handler",
+      idempotency: { scope, key: idempotencyKey, fingerprint },
+    },
+    {
+      async create(tx) {
+        const value = await create(tx as PostgresJsDatabase)
+        return { value, targetId: value.id }
+      },
+      async replay(_tx, result) {
+        return { id: result.reference.id }
+      },
+    },
+  )
+}
+
+function admittedCreatedCommandIdempotencyKey(
+  admitted: ToolHandlerActionPolicyContext,
+  legacyIdempotencyKey: string | undefined,
+): string {
+  const idempotencyKey = admitted.invocation.idempotencyKey?.trim()
+  if (!idempotencyKey) {
+    throw new ToolError(
+      "Created-target command idempotency must come from the admitted Tool invocation.",
+      "ACTION_POLICY_REQUIRED",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+  if (legacyIdempotencyKey !== undefined && legacyIdempotencyKey !== idempotencyKey) {
+    throw new ToolError(
+      "The legacy top-level idempotency key does not match the admitted Tool invocation.",
+      "INVALID_INPUT",
+      { capabilityId: admitted.capabilityId },
+    )
+  }
+  return idempotencyKey
+}

--- a/packages/commerce/src/created-target-policy.ts
+++ b/packages/commerce/src/created-target-policy.ts
@@ -48,6 +48,20 @@ export const COMMERCE_CREATED_TARGET_POLICIES = {
     approvalPolicy: "none",
     approvalReasonCode: null,
   },
+  promotion: {
+    actionName: "@voyant-travel/commerce#action.create-promotion",
+    actionVersion: "v1",
+    toolName: "create_promotion",
+    toolCapabilityId: "@voyant-travel/commerce#tool.create-promotion",
+    capabilityId: "@voyant-travel/commerce#action.create-promotion",
+    capabilityVersion: "v1",
+    commandTargetType: "promotion_create_command",
+    canonicalTargetType: "promotion",
+    resultReferenceType: "promotion",
+    evaluatedRisk: "medium",
+    approvalPolicy: "none",
+    approvalReasonCode: null,
+  },
 } as const satisfies Record<string, CommerceCreatedTargetPolicy>
 
 export function buildCommerceCreatedTargetFingerprint(

--- a/packages/commerce/src/mcp-runtime.ts
+++ b/packages/commerce/src/mcp-runtime.ts
@@ -1,30 +1,17 @@
-import {
-  type ActionLedgerRequestContextValues,
-  buildCreatedTargetIdempotencyScope,
-  type ExecuteCreatedTargetCommandHandlers,
-  type ExecuteCreatedTargetCommandInput,
-  type ExecuteCreatedTargetCommandResult,
-  executeCreatedTargetCommand,
-  mapActionLedgerRequestContext,
-} from "@voyant-travel/action-ledger"
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
 import type { EventBus } from "@voyant-travel/core"
-import {
-  defineToolContextContribution,
-  ToolError,
-  type ToolHandlerActionPolicyContext,
-} from "@voyant-travel/tools"
+import { defineToolContextContribution } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
-
-import {
-  buildCommerceCreatedTargetFingerprint,
-  COMMERCE_CREATED_TARGET_POLICIES,
-} from "./created-target-policy.js"
+import { executeCommerceCreate } from "./created-target-command.js"
+import { COMMERCE_CREATED_TARGET_POLICIES } from "./created-target-policy.js"
 import { pricingService } from "./pricing/service.js"
+import { executePromotionCreateCommand } from "./promotion-created-command.js"
 import { promotionsService } from "./promotions/service.js"
 import { sellabilityService } from "./sellability/service.js"
 import type { CommerceToolServices } from "./tools.js"
 
+export { executeCommerceCreate } from "./created-target-command.js"
 export * from "./tools.js"
 
 export const voyantToolContextContribution = defineToolContextContribution({
@@ -105,8 +92,18 @@ export const voyantToolContextContribution = defineToolContextContribution({
       async getPromotion(id) {
         return json(await promotionsService.getOfferById(db, id))
       },
-      async createPromotion(input) {
-        return json(await promotionsService.createOffer(db, input, mutationRuntime))
+      async createPromotion(input, admitted) {
+        const result = await executePromotionCreateCommand({
+          db,
+          context: requestContext,
+          input,
+          admitted,
+        })
+        return json({
+          status: "created" as const,
+          promotion: result.value,
+          replayed: result.replayed,
+        })
       },
       async updatePromotion(id, input) {
         return json(await promotionsService.updateOffer(db, id, input, mutationRuntime))
@@ -118,104 +115,6 @@ export const voyantToolContextContribution = defineToolContextContribution({
     return { commerce }
   },
 })
-
-type CommerceCreatedTargetPolicy =
-  (typeof COMMERCE_CREATED_TARGET_POLICIES)[keyof typeof COMMERCE_CREATED_TARGET_POLICIES]
-
-type CommerceCreatedCommandExecutor = (
-  db: PostgresJsDatabase,
-  input: ExecuteCreatedTargetCommandInput & { resultReferenceType: string },
-  handlers: ExecuteCreatedTargetCommandHandlers<{ id: string }, string>,
-) => Promise<ExecuteCreatedTargetCommandResult<{ id: string }, string>>
-
-export async function executeCommerceCreate(
-  db: PostgresJsDatabase,
-  context: ActionLedgerRequestContextValues,
-  policy: CommerceCreatedTargetPolicy,
-  legacyIdempotencyKey: string | undefined,
-  commandInput: unknown,
-  admitted: ToolHandlerActionPolicyContext,
-  create: (tx: PostgresJsDatabase) => Promise<{ id: string }>,
-  executor: CommerceCreatedCommandExecutor = executeCreatedTargetCommand,
-) {
-  const principal = mapActionLedgerRequestContext(context)
-  if (principal.principalId === "unknown_request") {
-    throw new TypeError("Commerce created-target commands require a concrete principal")
-  }
-  const idempotencyKey = admittedCreatedCommandIdempotencyKey(admitted, legacyIdempotencyKey)
-  const selectedActionName = admitted.actionPolicy.capabilityId
-  const selectedActionVersion = admitted.actionPolicy.version
-  const fingerprint = await buildCommerceCreatedTargetFingerprint(
-    {
-      ...policy,
-      actionName: selectedActionName,
-      actionVersion: selectedActionVersion,
-      capabilityId: selectedActionName,
-      capabilityVersion: selectedActionVersion,
-    } as CommerceCreatedTargetPolicy,
-    idempotencyKey,
-    commandInput,
-  )
-  const scope = await buildCreatedTargetIdempotencyScope({
-    actionName: selectedActionName,
-    actionVersion: selectedActionVersion,
-    principalType: principal.principalType,
-    principalId: principal.principalId,
-    organizationId: principal.organizationId,
-  })
-  return executor(
-    db,
-    {
-      context,
-      actionName: selectedActionName,
-      actionVersion: selectedActionVersion,
-      actionKind: "create",
-      evaluatedRisk: policy.evaluatedRisk,
-      commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
-      canonicalTargetType: policy.canonicalTargetType,
-      resultReferenceType: policy.resultReferenceType,
-      capabilityId: selectedActionName,
-      capabilityVersion: selectedActionVersion,
-      approvalPolicy: policy.approvalPolicy,
-      approvalReasonCode: policy.approvalReasonCode,
-      commandInput,
-      routeOrToolName: admitted.capabilityId,
-      authorizationSource: "selected_graph_mcp_handler",
-      idempotency: { scope, key: idempotencyKey, fingerprint },
-    },
-    {
-      async create(tx) {
-        const value = await create(tx as PostgresJsDatabase)
-        return { value, targetId: value.id }
-      },
-      async replay(_tx, result) {
-        return { id: result.reference.id }
-      },
-    },
-  )
-}
-
-function admittedCreatedCommandIdempotencyKey(
-  admitted: ToolHandlerActionPolicyContext,
-  legacyIdempotencyKey: string | undefined,
-): string {
-  const idempotencyKey = admitted.invocation.idempotencyKey?.trim()
-  if (!idempotencyKey) {
-    throw new ToolError(
-      "Created-target command idempotency must come from the admitted Tool invocation.",
-      "ACTION_POLICY_REQUIRED",
-      { capabilityId: admitted.capabilityId },
-    )
-  }
-  if (legacyIdempotencyKey !== undefined && legacyIdempotencyKey !== idempotencyKey) {
-    throw new ToolError(
-      "The legacy top-level idempotency key does not match the admitted Tool invocation.",
-      "INVALID_INPUT",
-      { capabilityId: admitted.capabilityId },
-    )
-  }
-  return idempotencyKey
-}
 
 function commerceActionLedgerContext(
   c: Context<{ Variables: ActionLedgerRequestContextValues }>,

--- a/packages/commerce/src/promotion-created-command.ts
+++ b/packages/commerce/src/promotion-created-command.ts
@@ -1,0 +1,49 @@
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
+import { insertOutboxEvents } from "@voyant-travel/db/outbox"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { executeCommerceCreate } from "./created-target-command.js"
+import { COMMERCE_CREATED_TARGET_POLICIES } from "./created-target-policy.js"
+import { PROMOTION_CHANGED_EVENT } from "./promotions/events.js"
+import { createOfferMutation, type OfferMutationRuntime } from "./promotions/service.js"
+import type { InsertPromotionalOffer } from "./promotions/validation.js"
+
+export async function executePromotionCreateCommand(input: {
+  db: PostgresJsDatabase
+  context: ActionLedgerRequestContextValues
+  input: InsertPromotionalOffer & { idempotencyKey?: string }
+  admitted: ToolHandlerActionPolicyContext
+  mutationRuntime?: Omit<OfferMutationRuntime, "eventBus" | "source">
+  /** Test-only failure seam after the domain rows and before outbox/result append. */
+  testHooks?: { afterDomainCreate?: (tx: PostgresJsDatabase, promotionId: string) => Promise<void> }
+}) {
+  const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = input.input
+  return executeCommerceCreate(
+    input.db,
+    input.context,
+    COMMERCE_CREATED_TARGET_POLICIES.promotion,
+    legacyIdempotencyKey,
+    commandInput,
+    input.admitted,
+    async (tx) => {
+      const mutation = await createOfferMutation(tx, commandInput, input.mutationRuntime)
+      await input.testHooks?.afterDomainCreate?.(tx, mutation.row.id)
+      await insertOutboxEvents(tx, [
+        {
+          name: PROMOTION_CHANGED_EVENT,
+          data: mutation.event,
+          metadata: {
+            category: "domain",
+            source: "service",
+            eventId: promotionCreatedEventId(mutation.row.id),
+          },
+        },
+      ])
+      return { id: mutation.row.id }
+    },
+  )
+}
+
+export function promotionCreatedEventId(promotionId: string): string {
+  return `evt_commerce_promotion_created_${promotionId}`
+}

--- a/packages/commerce/src/promotions/service.ts
+++ b/packages/commerce/src/promotions/service.ts
@@ -454,6 +454,16 @@ async function createOffer(
   input: InsertPromotionalOffer,
   runtime: OfferMutationRuntime = {},
 ): Promise<PromotionalOffer> {
+  const result = await createOfferMutation(db, input, runtime)
+  await emitChange(runtime, result.event)
+  return result.row
+}
+
+export async function createOfferMutation(
+  db: PostgresJsDatabase,
+  input: InsertPromotionalOffer,
+  runtime: OfferMutationRuntime = {},
+): Promise<{ row: PromotionalOffer; event: PromotionChangedEvent }> {
   await validatePromotionalOfferScopeReferences(db, input.scope, runtime)
 
   let row: PromotionalOffer | undefined
@@ -467,13 +477,14 @@ async function createOffer(
 
   const { productIds } = await recomputeOfferLinks(db, row.id, input.scope, runtime)
 
-  await emitChange(runtime, {
-    offerId: row.id,
-    source: runtime.source ?? "created",
-    affected: toAffected(productIds),
-  })
-
-  return row
+  return {
+    row,
+    event: {
+      offerId: row.id,
+      source: runtime.source ?? "created",
+      affected: toAffected(productIds),
+    },
+  }
 }
 
 async function updateOffer(

--- a/packages/commerce/src/tools.ts
+++ b/packages/commerce/src/tools.ts
@@ -64,6 +64,7 @@ const createdCommandInput = {
 const createCancellationPolicyToolInputSchema =
   insertCancellationPolicySchema.extend(createdCommandInput)
 const createPriceCatalogToolInputSchema = insertPriceCatalogSchema.extend(createdCommandInput)
+const createPromotionToolInputSchema = insertPromotionalOfferSchema.extend(createdCommandInput)
 
 const cancellationPolicySchema = z.object({
   id: z.string(),
@@ -100,6 +101,11 @@ const createdCancellationPolicyOutputSchema = z.object({
 const createdPriceCatalogOutputSchema = z.object({
   status: z.literal("created"),
   priceCatalog: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
+const createdPromotionOutputSchema = z.object({
+  status: z.literal("created"),
+  promotion: z.object({ id: z.string() }),
   replayed: z.boolean(),
 })
 
@@ -196,7 +202,10 @@ export interface CommerceToolServices {
   updatePriceCatalog(id: string, input: AnyServiceInput): Promise<unknown>
   listPromotions(input: z.infer<typeof promotionalOfferListQuerySchema>): Promise<unknown>
   getPromotion(id: string): Promise<unknown>
-  createPromotion(input: z.infer<typeof insertPromotionalOfferSchema>): Promise<unknown>
+  createPromotion(
+    input: z.infer<typeof createPromotionToolInputSchema>,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   updatePromotion(id: string, input: z.infer<typeof updatePromotionalOfferSchema>): Promise<unknown>
   archivePromotion(id: string): Promise<unknown>
 }
@@ -396,13 +405,21 @@ export const getPromotionTool = defineTool({
 
 export const createPromotionTool = defineTool({
   ...writeMetadata(["promotions:write"]),
+  riskPolicy: createdWriteRisk,
   capabilityId: `${OWNER}#tool.create-promotion`,
   name: "create_promotion",
-  description: "Create a promotional offer and materialize its affected product scope.",
-  inputSchema: insertPromotionalOfferSchema,
-  outputSchema: promotionalOfferSchema,
+  description:
+    "Create a promotional offer and materialize its affected product scope. Exact retries return the original immutable reference.",
+  inputSchema: createPromotionToolInputSchema,
+  outputSchema: createdPromotionOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: CommerceToolContext) {
-    return promotionalOfferSchema.parse(await commerce(ctx).createPromotion(input))
+    const admitted = admitHandlerActionPolicy(
+      ctx,
+      commerceHandlerActionPolicyExpectation(COMMERCE_CREATED_TARGET_POLICIES.promotion),
+    )
+    return createdPromotionOutputSchema.parse(await commerce(ctx).createPromotion(input, admitted))
   },
 })
 

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -84,7 +84,13 @@ function commerceToolAction(
             commandTargetType: "price_catalog_create_command",
             resultReferenceType: "price-catalog",
           }
-        : null
+        : suffix === "create-promotion"
+          ? {
+              targetType: "promotion",
+              commandTargetType: "promotion_create_command",
+              resultReferenceType: "promotion",
+            }
+          : null
   return {
     id: `@voyant-travel/commerce#action.${suffix}`,
     version: "v1",
@@ -92,11 +98,12 @@ function commerceToolAction(
     targetType: created?.targetType ?? resource,
     ...(suffix === "create-promotion"
       ? {
-          availability: {
-            status: "unavailable" as const,
-            reasonCode: "unsafe-nontransactional-effect",
-          },
+          availability: { status: "available" as const },
           effectBoundary: "multistage" as const,
+          durability: {
+            strategy: "outbox" as const,
+            testReference: "packages/commerce/tests/integration/promotion-created-command.test.ts",
+          },
         }
       : {}),
     resource,

--- a/packages/commerce/tests/integration/promotion-created-command.test.ts
+++ b/packages/commerce/tests/integration/promotion-created-command.test.ts
@@ -1,0 +1,238 @@
+import { actionLedgerEntries } from "@voyant-travel/action-ledger/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { eventOutboxTable } from "@voyant-travel/db/schema"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  COMMERCE_CREATED_TARGET_POLICIES,
+  commerceHandlerActionPolicyExpectation,
+} from "../../src/created-target-policy.js"
+import {
+  executePromotionCreateCommand,
+  promotionCreatedEventId,
+} from "../../src/promotion-created-command.js"
+import { promotionalOfferProducts, promotionalOffers } from "../../src/promotions/schema.js"
+import { insertPromotionalOfferSchema } from "../../src/promotions/validation.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+describe.skipIf(!DB_AVAILABLE)("Commerce promotion created-target command", () => {
+  let db: ClosableTestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  it("atomically creates, materializes, replays, conflicts, serializes, and enqueues once", async () => {
+    const idempotencyKey = "promotion-create-1"
+    const command = promotionCommand(idempotencyKey)
+    let releaseFirst: () => void = () => undefined
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let domainInserted: () => void = () => undefined
+    const inserted = new Promise<void>((resolve) => {
+      domainInserted = resolve
+    })
+
+    const firstPromise = executePromotionCreateCommand({
+      ...command,
+      testHooks: {
+        async afterDomainCreate() {
+          domainInserted()
+          await holdFirst
+        },
+      },
+    })
+    await inserted
+
+    let secondSettled = false
+    const secondPromise = executePromotionCreateCommand(command).finally(() => {
+      secondSettled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(secondSettled).toBe(false)
+
+    releaseFirst()
+    const [first, concurrentReplay] = await Promise.all([firstPromise, secondPromise])
+    expect(first.replayed).toBe(false)
+    expect(concurrentReplay).toMatchObject({ replayed: true, value: first.value })
+
+    await expect(
+      executePromotionCreateCommand({
+        ...command,
+        input: { ...command.input, name: "Drifted promotion" },
+      }),
+    ).rejects.toMatchObject({ name: "ActionLedgerIdempotencyConflictError" })
+
+    const offers = await db.select().from(promotionalOffers)
+    expect(offers).toHaveLength(1)
+    const links = await db.select().from(promotionalOfferProducts)
+    expect(links.map(({ productId }) => productId).sort()).toEqual(["product_1", "product_2"])
+    expect(links.every(({ offerId }) => offerId === first.value.id)).toBe(true)
+
+    const outbox = await db.select().from(eventOutboxTable)
+    expect(outbox).toHaveLength(1)
+    const expectedEventId = promotionCreatedEventId(first.value.id)
+    expect(outbox[0]).toMatchObject({
+      eventId: expectedEventId,
+      name: "promotion.changed",
+      payload: {
+        offerId: first.value.id,
+        source: "created",
+        affected: { kind: "products", productIds: ["product_1", "product_2"] },
+      },
+      metadata: {
+        category: "domain",
+        source: "service",
+        eventId: expectedEventId,
+      },
+    })
+
+    const canonical = await db
+      .select()
+      .from(actionLedgerEntries)
+      .where(eq(actionLedgerEntries.status, "succeeded"))
+    expect(canonical).toContainEqual(
+      expect.objectContaining({
+        targetType: "promotion",
+        targetId: first.value.id,
+        actionName: COMMERCE_CREATED_TARGET_POLICIES.promotion.actionName,
+        capabilityId: COMMERCE_CREATED_TARGET_POLICIES.promotion.capabilityId,
+        routeOrToolName: COMMERCE_CREATED_TARGET_POLICIES.promotion.toolCapabilityId,
+        causationActionId: expect.any(String),
+      }),
+    )
+  })
+
+  it("keeps identical cross-principal commands and their outbox events distinct", async () => {
+    const idempotencyKey = "promotion-create-cross-principal"
+    const first = await executePromotionCreateCommand(
+      promotionCommand(idempotencyKey, {
+        userId: "user_1",
+        organizationId: "organization_1",
+        active: false,
+      }),
+    )
+    const second = await executePromotionCreateCommand(
+      promotionCommand(idempotencyKey, {
+        userId: "user_2",
+        organizationId: "organization_2",
+        active: false,
+      }),
+    )
+
+    expect(first.replayed).toBe(false)
+    expect(second.replayed).toBe(false)
+    expect(second.value.id).not.toBe(first.value.id)
+    expect((await db.select().from(promotionalOffers)).map(({ id }) => id).sort()).toEqual(
+      [first.value.id, second.value.id].sort(),
+    )
+    expect((await db.select().from(eventOutboxTable)).map(({ eventId }) => eventId).sort()).toEqual(
+      [promotionCreatedEventId(first.value.id), promotionCreatedEventId(second.value.id)].sort(),
+    )
+  })
+
+  it("rolls back the claim, offer, links, outbox, and result after a post-insert crash", async () => {
+    const idempotencyKey = "promotion-create-crash"
+    const command = promotionCommand(idempotencyKey)
+    await expect(
+      executePromotionCreateCommand({
+        ...command,
+        input: {
+          ...command.input,
+          name: "Rollback promotion",
+          slug: "rollback-promotion",
+        },
+        testHooks: {
+          async afterDomainCreate() {
+            throw new Error("injected post-insert crash")
+          },
+        },
+      }),
+    ).rejects.toThrow("injected post-insert crash")
+
+    expect(
+      await db
+        .select()
+        .from(promotionalOffers)
+        .where(eq(promotionalOffers.name, "Rollback promotion")),
+    ).toHaveLength(0)
+    expect(await db.select().from(promotionalOfferProducts)).toHaveLength(0)
+    expect(await db.select().from(eventOutboxTable)).toHaveLength(0)
+    expect(
+      await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(eq(actionLedgerEntries.idempotencyKey, idempotencyKey)),
+    ).toHaveLength(0)
+  })
+
+  function promotionCommand(
+    idempotencyKey: string,
+    options: {
+      userId?: string
+      organizationId?: string
+      active?: boolean
+    } = {},
+  ) {
+    const input = {
+      ...insertPromotionalOfferSchema.parse({
+        name: "Atomic promotion",
+        slug: "atomic-promotion",
+        discountType: "percentage",
+        discountPercent: 10,
+        scope: { kind: "products", productIds: ["product_1", "product_2"] },
+        active: options.active,
+      }),
+      idempotencyKey,
+    }
+    const policy = COMMERCE_CREATED_TARGET_POLICIES.promotion
+    const expectation = commerceHandlerActionPolicyExpectation(policy)
+    return {
+      db,
+      context: {
+        userId: options.userId ?? "user_1",
+        callerType: "session" as const,
+        actor: "staff" as const,
+        organizationId: options.organizationId ?? "organization_1",
+      },
+      input,
+      admitted: {
+        capabilityId: expectation.capabilityId,
+        capabilityVersion: expectation.capabilityVersion,
+        canonicalName: expectation.canonicalName,
+        actionPolicy: {
+          ...expectation.actionPolicy,
+          enforcement: "handler" as const,
+          invocation: {
+            controlField: "_voyant" as const,
+            requiredFields: ["idempotencyKey"] as const,
+            optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"] as const,
+            fingerprintAlgorithm: "action-ledger-command-v1" as const,
+          },
+        },
+        invocation: { idempotencyKey },
+      },
+      mutationRuntime: {
+        async resolveExistingProductIds(_tx: PostgresJsDatabase, productIds: string[]) {
+          return productIds
+        },
+      },
+    }
+  }
+})

--- a/packages/commerce/tests/unit/created-target-policy.test.ts
+++ b/packages/commerce/tests/unit/created-target-policy.test.ts
@@ -11,6 +11,7 @@ import {
   type CommerceToolServices,
   createCancellationPolicyTool,
   createPriceCatalogTool,
+  createPromotionTool,
 } from "../../src/tools.js"
 import { commerceVoyantModule } from "../../src/voyant.js"
 
@@ -23,6 +24,7 @@ describe("commerce created-target commands", () => {
         "cancellationPolicy",
       ],
       [COMMERCE_CREATED_TARGET_POLICIES.priceCatalog, createPriceCatalogTool, "priceCatalog"],
+      [COMMERCE_CREATED_TARGET_POLICIES.promotion, createPromotionTool, "promotion"],
     ] as const) {
       expect(tool.actionPolicyEnforcement).toBe("handler")
       expect(tool.riskPolicy.reversible).toBe(false)
@@ -54,6 +56,15 @@ describe("commerce created-target commands", () => {
     )
     expect(
       createPriceCatalogTool.inputSchema.safeParse({ code: "PUBLIC", name: "Public" }).success,
+    ).toBe(true)
+    expect(
+      createPromotionTool.inputSchema.safeParse({
+        name: "Summer",
+        slug: "summer",
+        discountType: "percentage",
+        discountPercent: 10,
+        scope: { kind: "global" },
+      }).success,
     ).toBe(true)
   })
 
@@ -152,6 +163,18 @@ describe("commerce created-target commands", () => {
         createPriceCatalogTool.inputSchema.parse({
           code: "PUBLIC",
           name: "Public",
+          idempotencyKey: "key",
+        }),
+      ],
+      [
+        COMMERCE_CREATED_TARGET_POLICIES.promotion,
+        createPromotionTool,
+        createPromotionTool.inputSchema.parse({
+          name: "Summer",
+          slug: "summer",
+          discountType: "percentage",
+          discountPercent: 10,
+          scope: { kind: "global" },
           idempotencyKey: "key",
         }),
       ],

--- a/packages/commerce/tests/unit/package-exports.test.ts
+++ b/packages/commerce/tests/unit/package-exports.test.ts
@@ -8,6 +8,7 @@ import {
   createAcceptanceSignatureSubscriberGraphRuntime,
   createCheckoutFinalizeSubscriberGraphRuntime,
 } from "../../src/checkout/subscriber-runtime.js"
+import * as commerceToolSurface from "../../src/mcp-runtime.js"
 import {
   createPromotionRedemptionSubscriberGraphRuntime,
   promotionRedemptionDatabaseRuntimePort,
@@ -78,5 +79,10 @@ describe("@voyant-travel/commerce package exports", () => {
     expect(createPromotionRedemptionSubscriberGraphRuntime).toBeTypeOf("function")
     expect(promotionRedemptionDatabaseRuntimePort.id).toBe("commerce.promotion-redemption-database")
     expect(promotionsBulkReindexRuntimePort.id).toBe("commerce.promotions-bulk-reindex")
+  })
+
+  it("keeps promotion command internals out of the published Tool surface", () => {
+    expect(commerceToolSurface).not.toHaveProperty("executePromotionCreateCommand")
+    expect(commerceToolSurface).not.toHaveProperty("promotionCreatedEventId")
   })
 })

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -206,11 +206,19 @@ describe("commerce deployment manifest", () => {
         ({ id }) => id === "@voyant-travel/commerce#action.create-promotion",
       ),
     ).toMatchObject({
-      availability: {
-        status: "unavailable",
-        reasonCode: "unsafe-nontransactional-effect",
-      },
+      availability: { status: "available" },
       effectBoundary: "multistage",
+      targetType: "promotion",
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "promotion_create_command",
+        resultReferenceType: "promotion",
+        durability: "handler-command-claim-v1",
+      },
+      durability: {
+        strategy: "outbox",
+        testReference: "packages/commerce/tests/integration/promotion-created-command.test.ts",
+      },
     })
   })
 


### PR DESCRIPTION
## What changed

- Restore `@voyant-travel/commerce#action.create-promotion` as an explicitly available handler-owned created-target command.
- Atomically commit the command claim, offer, materialized product links, canonical result, and deterministic `promotion.changed` outbox event.
- Return an immutable created-reference envelope on first execution and exact replay; reject payload drift and serialize concurrent identical commands.
- Derive outbox IDs from the globally unique canonical promotion ID so identical commands in different principal/organization scopes retain distinct events.
- Add live PostgreSQL coverage for replay, drift, concurrency, rollback, and cross-scope event uniqueness, wired into the CI database lane.
- Add a major changeset and caller migration guidance for the Tool response contract.
- Keep command/test internals out of the published `./tools` surface.

## Why

The action was quarantined because its previous sequence could commit the offer before link materialization or lifecycle publication. It also had no exact immutable replay contract. This change moves the whole local workflow under the package-owned created-command transaction and transactional outbox.

No other quarantined action is restored by this PR.

## Validation

Executed remotely from the exact worktree snapshot:

- Fresh PostgreSQL with all 31 operator migrations applied.
- Focused Vitest: 6 files / 23 tests passed, including 3 live integration tests.
- Narrow strict TypeScript check passed for the command and MCP runtime files.
- `git diff --check` passed.
- Independent code review found the corrected transaction, admission, replay, event-ID, migration, and package-export behavior clean.

The full Commerce package typecheck exhausted available 2 GB and 6 GB remote V8 heaps before diagnostics; GitHub CI is the final full-package typecheck gate.