### PR TITLE
Restore durable cruise creation

### DIFF
--- a/.changeset/restore-durable-cruise-create.md
+++ b/.changeset/restore-durable-cruise-create.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/cruises": major
+---
+
+Restore `create_cruise` as a handler-owned created-target command whose cruise,
+required search projection, canonical-cruise-scoped lifecycle outbox event,
+ledger, and immutable replay result commit atomically.
+
+This changes the Tool response from the mutable cruise row to
+`{ status, cruise: { id }, replayed }`. See
+[`docs/migrations/created-target-commerce-charters-cruises.md`](https://github.com/voyant-travel/voyant/blob/main/docs/migrations/created-target-commerce-charters-cruises.md)
+for caller migration guidance.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,8 @@ jobs:
                 tests/integration/postgres-pgtrgm-indexer.test.ts
               pnpm --filter @voyant-travel/commerce exec vitest run \
                 tests/integration/promotion-created-command.test.ts
+              pnpm --filter @voyant-travel/cruises exec vitest run \
+                tests/integration/created-target-tools.test.ts
               ;;
           esac
 

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -5,7 +5,7 @@ Per-minor consolidated migration notes for Voyant. Each page collects every brea
 Unreleased caller migrations:
 
 - [Created-target Tool commands](./created-target-tool-commands.md)
-- [Created Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md)
+- [Created local Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md) — includes the breaking `create_promotion` and `create_cruise` response-envelope migrations.
 
 The full history (including patch-level changes and dependency updates) lives in the per-package `CHANGELOG.md` files; these pages exist because changeset entries land in *every* package's CHANGELOG that depends on the changed one, so the actual breaking signal is otherwise buried under dozens of `Updated dependencies [...]` lines per package.
 

--- a/docs/migrations/created-target-commerce-charters-cruises.md
+++ b/docs/migrations/created-target-commerce-charters-cruises.md
@@ -8,15 +8,17 @@ The following MCP Tools now use the framework's transactional
 - `create_promotion`
 - `create_charter_product`
 - `create_charter_yacht`
+- `create_cruise`
 - `create_cruise_ship`
 
 ## Caller migration
 
 Every call must supply a non-empty `_voyant.idempotencyKey` invocation control.
-Keep that key stable for an exact logical command. The legacy top-level
-`idempotencyKey` remains optional for compatibility; when supplied, it must
-equal `_voyant.idempotencyKey`. Reusing the admitted key with different domain
-input is rejected.
+Keep that key stable across retries of one exact logical command. Reusing it
+with different domain input is rejected. The legacy top-level `idempotencyKey`
+field is optional compatibility input; when supplied, it must equal
+`_voyant.idempotencyKey`. New callers should treat the `_voyant` value as the
+source of truth.
 
 The response no longer contains a mutable database row. Read the generated id
 from the typed reference and call the corresponding get Tool when current state
@@ -50,6 +52,27 @@ const result = await createPromotion({
 const promotion = await getPromotion({ id: result.promotion.id })
 ```
 
+`create_cruise` previously returned the mutable cruise database row. Read the
+new immutable reference envelope instead:
+
+```ts
+const result = await createCruise({
+  slug: "danube-highlights",
+  name: "Danube Highlights",
+  cruiseType: "river",
+  nights: 7,
+  _voyant: { idempotencyKey: commandId },
+})
+
+const cruiseId = result.cruise.id
+// result.status === "created"
+// result.replayed distinguishes a fresh commit from an exact replay.
+```
+
+Fields such as `name`, `status`, and timestamps are no longer present in the
+`create_cruise` response. Use `get_cruise` when current mutable state is
+required.
+
 Fresh and replayed responses have the same domain shape; `replayed` reports
 which path completed the call. Creation, the opaque command claim, and the
 canonical generated-target result commit in one database transaction.
@@ -64,5 +87,10 @@ packages. External MCP clients are the migration audience.
 The five pre-existing local primitives do not publish through `EventBus`.
 Promotion creation atomically appends its deterministic `promotion.changed`
 event to the database outbox alongside the offer, materialized product links,
-command claim, and canonical result. Cruise/charter booking commands with
-external effects remain outside this migration.
+command claim, and canonical result.
+`create_cruise` transactionally captures its canonical-cruise-scoped
+`cruise.created` outbox event with the cruise, required search projection,
+command ledger, and immutable result. Distinct principals therefore retain
+distinct lifecycle events even when their caller-selected command keys and
+payloads match. Cruise and charter booking commands with external effects
+remain intentionally outside this migration.

--- a/packages/cruises/README.md
+++ b/packages/cruises/README.md
@@ -60,7 +60,11 @@ exposed.
 
 Read and quote Tools require `cruises:read` and are available to staff and
 customer actors. Local lifecycle writes require `cruises:write`, are staff
-only, and are ledgered. `create_cruise_booking` additionally requires
+only, and are ledgered. `create_cruise` is a handler-owned created-target
+command: its canonical row, required local search projection, deterministic
+`cruise.created` outbox envelope, command ledger, and immutable result reference
+commit in one transaction. Exact idempotency replays return that reference;
+reuse with different input conflicts. `create_cruise_booking` additionally requires
 `bookings:write`; because the external path commits upstream before local
 persistence, it is critical-risk, confirmation-gated, approval-required,
 ledger-required, and declared irreversible. Archive/delete and party booking

--- a/packages/cruises/src/created-target-policy.ts
+++ b/packages/cruises/src/created-target-policy.ts
@@ -4,6 +4,21 @@ import {
 } from "@voyant-travel/action-ledger"
 import type { HandlerActionPolicyExpectation } from "@voyant-travel/tools"
 
+export const CRUISE_CREATED_TARGET_POLICY = {
+  actionName: "@voyant-travel/cruises#action.create-cruise",
+  actionVersion: "v1",
+  toolName: "create_cruise",
+  toolCapabilityId: "@voyant-travel/cruises#tool.create-cruise",
+  capabilityId: "@voyant-travel/cruises#action.create-cruise",
+  capabilityVersion: "v1",
+  commandTargetType: "cruise_create_command",
+  canonicalTargetType: "cruise",
+  resultReferenceType: "cruise",
+  evaluatedRisk: "medium",
+  approvalPolicy: "none",
+  approvalReasonCode: null,
+} as const
+
 export const CRUISE_SHIP_CREATED_TARGET_POLICY = {
   actionName: "@voyant-travel/cruises#action.create-cruise-ship",
   actionVersion: "v1",
@@ -18,6 +33,27 @@ export const CRUISE_SHIP_CREATED_TARGET_POLICY = {
   approvalPolicy: "none",
   approvalReasonCode: null,
 } as const
+
+export function buildCruiseCreatedTargetFingerprint(
+  commandTargetId: string,
+  commandInput: unknown,
+): Promise<string> {
+  const policy = CRUISE_CREATED_TARGET_POLICY
+  const input: BuildCreatedTargetCommandFingerprintInput = {
+    actionName: policy.actionName,
+    actionVersion: policy.actionVersion,
+    commandTarget: { type: policy.commandTargetType, id: commandTargetId },
+    canonicalTargetType: policy.canonicalTargetType,
+    resultReferenceType: policy.resultReferenceType,
+    commandInput,
+    capabilityId: policy.capabilityId,
+    capabilityVersion: policy.capabilityVersion,
+    evaluatedRisk: policy.evaluatedRisk,
+    approvalPolicy: policy.approvalPolicy,
+    approvalReasonCode: policy.approvalReasonCode,
+  }
+  return buildCreatedTargetCommandFingerprint(input)
+}
 
 export function buildCruiseShipCreatedTargetFingerprint(
   commandTargetId: string,
@@ -39,6 +75,30 @@ export function buildCruiseShipCreatedTargetFingerprint(
   }
   return buildCreatedTargetCommandFingerprint(input)
 }
+
+export const CRUISE_HANDLER_ACTION_POLICY = {
+  capabilityId: CRUISE_CREATED_TARGET_POLICY.toolCapabilityId,
+  capabilityVersion: CRUISE_CREATED_TARGET_POLICY.capabilityVersion,
+  canonicalName: CRUISE_CREATED_TARGET_POLICY.toolName,
+  actionPolicy: {
+    id: CRUISE_CREATED_TARGET_POLICY.actionName,
+    capabilityId: CRUISE_CREATED_TARGET_POLICY.capabilityId,
+    version: CRUISE_CREATED_TARGET_POLICY.actionVersion,
+    kind: "execute",
+    targetType: CRUISE_CREATED_TARGET_POLICY.canonicalTargetType,
+    targetLifecycle: "created",
+    createdTarget: {
+      commandTargetType: CRUISE_CREATED_TARGET_POLICY.commandTargetType,
+      resultReferenceType: CRUISE_CREATED_TARGET_POLICY.resultReferenceType,
+      durability: "handler-command-claim-v1",
+    },
+    risk: CRUISE_CREATED_TARGET_POLICY.evaluatedRisk,
+    ledger: "required",
+    approval: "never",
+    reversible: false,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation
 
 export const CRUISE_SHIP_HANDLER_ACTION_POLICY = {
   capabilityId: CRUISE_SHIP_CREATED_TARGET_POLICY.toolCapabilityId,

--- a/packages/cruises/src/mcp-runtime.ts
+++ b/packages/cruises/src/mcp-runtime.ts
@@ -9,13 +9,17 @@ import {
   mapActionLedgerRequestContext,
 } from "@voyant-travel/action-ledger"
 import type { EventBus } from "@voyant-travel/core"
+import { insertOutboxEvents } from "@voyant-travel/db/outbox"
 import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 import type { CruiseAdapter, ExternalSailing, ExternalShip, SourceRef } from "./adapters/index.js"
 import { resolveCruiseAdapter } from "./adapters/registry.js"
-import { CRUISE_SHIP_CREATED_TARGET_POLICY } from "./created-target-policy.js"
+import {
+  CRUISE_CREATED_TARGET_POLICY,
+  CRUISE_SHIP_CREATED_TARGET_POLICY,
+} from "./created-target-policy.js"
 import { makeExternalSourceKey, parseUnifiedKey, sourceRefFromExternalKeyRef } from "./lib/key.js"
 import {
   passengerCompositionMatches,
@@ -28,6 +32,7 @@ import { cruisesBookingService } from "./service-bookings.js"
 import { composeQuote, pricingService } from "./service-pricing.js"
 import { cruisesSearchService } from "./service-search.js"
 import type { CruisesToolServices } from "./tools.js"
+import type { InsertCruise } from "./validation-core.js"
 
 export * from "./tools.js"
 
@@ -57,8 +62,23 @@ export const voyantToolContextContribution = defineToolContextContribution({
           return getShip(db, String(args.key), publicOnly)
         case "quoteSailing":
           return quoteSailing(db, args, publicOnly)
-        case "createCruise":
-          return cruisesService.createCruise(db, args as never, { eventBus })
+        case "createCruise": {
+          if (!admitted) {
+            throw new ToolError(
+              "Created cruise action policy is required.",
+              "ACTION_POLICY_REQUIRED",
+            )
+          }
+          const { idempotencyKey: legacyIdempotencyKey, ...commandInput } = args
+          const result = await executeCruiseCreate(
+            db,
+            requestContext,
+            typeof legacyIdempotencyKey === "string" ? legacyIdempotencyKey : undefined,
+            commandInput as InsertCruise,
+            admitted,
+          )
+          return { status: "created" as const, cruise: result.value, replayed: result.replayed }
+        }
         case "updateCruise": {
           const { id, ...data } = args
           return cruisesService.updateCruise(db, String(id), data as never, { eventBus })
@@ -107,6 +127,95 @@ type CruiseShipCreatedCommandExecutor = (
   input: ExecuteCreatedTargetCommandInput & { resultReferenceType: string },
   handlers: ExecuteCreatedTargetCommandHandlers<{ id: string }, string>,
 ) => Promise<ExecuteCreatedTargetCommandResult<{ id: string }, string>>
+
+type CruiseCreatedCommandExecutor = CruiseShipCreatedCommandExecutor
+
+export async function executeCruiseCreate(
+  db: PostgresJsDatabase,
+  context: ActionLedgerRequestContextValues,
+  legacyIdempotencyKey: string | undefined,
+  commandInput: InsertCruise,
+  admitted: import("@voyant-travel/tools").ToolHandlerActionPolicyContext,
+  testHooks?: {
+    /** Test-only failure/concurrency seam inside the handler-owned transaction. */
+    afterRequiredProjection?: (tx: PostgresJsDatabase, cruiseId: string) => Promise<void>
+  },
+  executor: CruiseCreatedCommandExecutor = executeCreatedTargetCommand,
+) {
+  const principal = mapActionLedgerRequestContext(context)
+  if (principal.principalId === "unknown_request") {
+    throw new TypeError("Cruise created-target commands require a concrete principal")
+  }
+  const idempotencyKey = admittedCreatedCommandIdempotencyKey(admitted, legacyIdempotencyKey)
+  const policy = CRUISE_CREATED_TARGET_POLICY
+  const selectedActionName = admitted.actionPolicy.capabilityId
+  const selectedActionVersion = admitted.actionPolicy.version
+  const fingerprint = await buildCreatedTargetCommandFingerprint({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+    canonicalTargetType: policy.canonicalTargetType,
+    resultReferenceType: policy.resultReferenceType,
+    commandInput,
+    capabilityId: selectedActionName,
+    capabilityVersion: selectedActionVersion,
+    evaluatedRisk: policy.evaluatedRisk,
+    approvalPolicy: policy.approvalPolicy,
+    approvalReasonCode: policy.approvalReasonCode,
+  })
+  const scope = await buildCreatedTargetIdempotencyScope({
+    actionName: selectedActionName,
+    actionVersion: selectedActionVersion,
+    principalType: principal.principalType,
+    principalId: principal.principalId,
+    organizationId: principal.organizationId,
+  })
+  return executor(
+    db,
+    {
+      context,
+      actionName: selectedActionName,
+      actionVersion: selectedActionVersion,
+      actionKind: "create",
+      evaluatedRisk: policy.evaluatedRisk,
+      commandTarget: { type: policy.commandTargetType, id: idempotencyKey },
+      canonicalTargetType: policy.canonicalTargetType,
+      resultReferenceType: policy.resultReferenceType,
+      capabilityId: selectedActionName,
+      capabilityVersion: selectedActionVersion,
+      approvalPolicy: policy.approvalPolicy,
+      approvalReasonCode: policy.approvalReasonCode,
+      commandInput,
+      routeOrToolName: admitted.capabilityId,
+      authorizationSource: "selected_graph_mcp_handler",
+      idempotency: { scope, key: idempotencyKey, fingerprint },
+    },
+    {
+      async create(tx) {
+        const transaction = tx as PostgresJsDatabase
+        const row = await cruisesService.createCruise(transaction, commandInput, {
+          projection: "required",
+        })
+        await testHooks?.afterRequiredProjection?.(transaction, row.id)
+        await insertOutboxEvents(tx, [
+          {
+            name: "cruise.created",
+            data: { id: row.id },
+            metadata: {
+              eventId: cruiseCreatedEventId(row.id),
+              category: "domain",
+              source: "service",
+            },
+          },
+        ])
+        return { value: { id: row.id }, targetId: row.id }
+      },
+      async replay(_tx, result) {
+        return { id: result.reference.id }
+      },
+    },
+  )
+}
 
 export async function executeCruiseShipCreate(
   db: PostgresJsDatabase,
@@ -175,6 +284,10 @@ export async function executeCruiseShipCreate(
       },
     },
   )
+}
+
+export function cruiseCreatedEventId(cruiseId: string): string {
+  return `evt_cruises_cruise_created_${cruiseId}`
 }
 
 function admittedCreatedCommandIdempotencyKey(

--- a/packages/cruises/src/service-core.ts
+++ b/packages/cruises/src/service-core.ts
@@ -28,6 +28,7 @@ import { cruisePrices } from "./schema-pricing.js"
 import {
   type CruiseMutationRuntime,
   paginate,
+  reprojectCruise,
   reprojectIfPossible,
   setUpdated,
 } from "./service-shared.js"
@@ -277,7 +278,11 @@ export const cruiseCoreService = {
       .values(data as NewCruise)
       .returning()
     if (!row) throw new Error("Failed to create cruise")
-    await reprojectIfPossible(db, row.id)
+    if (runtime.projection === "required") {
+      await reprojectCruise(db, row.id)
+    } else {
+      await reprojectIfPossible(db, row.id)
+    }
     await emitCruiseLifecycleEvent(runtime.eventBus, CRUISE_CREATED_EVENT, { id: row.id })
     return row
   },

--- a/packages/cruises/src/service-shared.ts
+++ b/packages/cruises/src/service-shared.ts
@@ -9,6 +9,14 @@ export function paginate(query: { limit: number; offset: number }) {
 
 export interface CruiseMutationRuntime {
   eventBus?: EventBus
+  /** Require the local search projection to commit with the canonical write. */
+  projection?: "best-effort" | "required"
+}
+
+/** Project a cruise and propagate failure so a surrounding transaction can roll back. */
+export async function reprojectCruise(db: PostgresJsDatabase, cruiseId: string): Promise<void> {
+  const { cruisesSearchService } = await import("./service-search.js")
+  await cruisesSearchService.projectLocalCruise(db, cruiseId)
 }
 
 /**
@@ -22,8 +30,7 @@ export async function reprojectIfPossible(
 ): Promise<void> {
   if (!cruiseId) return
   try {
-    const { cruisesSearchService } = await import("./service-search.js")
-    await cruisesSearchService.projectLocalCruise(db, cruiseId)
+    await reprojectCruise(db, cruiseId)
   } catch (err) {
     // Don't crash the caller. Operators can run the search-index rebuild route to repair drift.
     // eslint-disable-next-line no-console -- owner: cruises; existing suppression is intentional pending typed cleanup.

--- a/packages/cruises/src/tools.ts
+++ b/packages/cruises/src/tools.ts
@@ -10,7 +10,10 @@ import {
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
-import { CRUISE_SHIP_HANDLER_ACTION_POLICY } from "./created-target-policy.js"
+import {
+  CRUISE_HANDLER_ACTION_POLICY,
+  CRUISE_SHIP_HANDLER_ACTION_POLICY,
+} from "./created-target-policy.js"
 import { createBookingPayloadSchema, quotePayloadSchema } from "./routes-booking-payloads.js"
 import {
   cruiseRowSchema,
@@ -164,6 +167,20 @@ const bookingInputSchema = z
   .object({ key: z.string().min(1) })
   .and(createBookingPayloadSchema.omit({ sailingId: true }))
 const idInput = z.object({ id: z.string().min(1) })
+const createCruiseToolInputSchema = insertCruiseSchema.extend({
+  idempotencyKey: z
+    .string()
+    .trim()
+    .min(1)
+    .max(255)
+    .optional()
+    .describe("Stable key used to replay this exact create command."),
+})
+const createdCruiseOutputSchema = z.object({
+  status: z.literal("created"),
+  cruise: z.object({ id: z.string() }),
+  replayed: z.boolean(),
+})
 const createShipToolInputSchema = insertShipSchema.extend({
   idempotencyKey: z
     .string()
@@ -282,13 +299,21 @@ export const quoteCruiseSailingTool = defineTool({
 })
 export const createCruiseTool = defineTool({
   ...write,
+  riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-cruise`,
   name: "create_cruise",
-  description: "Create a locally managed cruise product.",
-  inputSchema: insertCruiseSchema,
-  outputSchema: cruiseRowSchema,
+  description:
+    "Create a locally managed cruise product. Exact retries return the original immutable reference.",
+  inputSchema: createCruiseToolInputSchema,
+  outputSchema: createdCruiseOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx: CruisesToolContext) {
-    return parse(cruiseRowSchema, await service(ctx).execute("createCruise", input))
+    const admitted = admitHandlerActionPolicy(ctx, CRUISE_HANDLER_ACTION_POLICY)
+    return parse(
+      createdCruiseOutputSchema,
+      await service(ctx).execute("createCruise", input, admitted),
+    )
   },
 })
 export const updateCruiseTool = defineTool({

--- a/packages/cruises/src/voyant.ts
+++ b/packages/cruises/src/voyant.ts
@@ -240,18 +240,25 @@ export const cruisesVoyantModule = defineModule({
       targetType: "cruise",
       ...(id === "create-cruise"
         ? {
-            availability: {
-              status: "unavailable" as const,
-              reasonCode: "unsafe-nontransactional-effect",
+            availability: { status: "available" as const },
+            targetLifecycle: "created" as const,
+            createdTarget: {
+              commandTargetType: "cruise_create_command",
+              resultReferenceType: "cruise",
+              durability: "handler-command-claim-v1" as const,
             },
             effectBoundary: "multistage" as const,
+            durability: {
+              strategy: "outbox" as const,
+              testReference: "tests/integration/created-target-tools.test.ts",
+            },
           }
         : {}),
       requiredScopes: ["cruises:write"],
       risk: "medium" as const,
       ledger: "required" as const,
       approval: "never" as const,
-      reversible: true,
+      reversible: id !== "create-cruise",
       allowedActorTypes: ["staff" as const],
       from: { tools: [`@voyant-travel/cruises#tool.${id}`] },
     })),

--- a/packages/cruises/tests/integration/created-target-tools.test.ts
+++ b/packages/cruises/tests/integration/created-target-tools.test.ts
@@ -1,0 +1,205 @@
+import { actionLedgerEntries } from "@voyant-travel/action-ledger/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { eventOutboxTable } from "@voyant-travel/db/schema"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import { CRUISE_HANDLER_ACTION_POLICY } from "../../src/created-target-policy.js"
+import { cruiseCreatedEventId, executeCruiseCreate } from "../../src/mcp-runtime.js"
+import { cruises } from "../../src/schema-core.js"
+import { cruiseSearchIndex } from "../../src/schema-search.js"
+import { cruisesService } from "../../src/service.js"
+import { insertCruiseSchema } from "../../src/validation-core.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+describe.skipIf(!DB_AVAILABLE)("Cruises created-target Tool wiring", () => {
+  let db: ClosableTestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  const admitted = (idempotencyKey: string) =>
+    ({
+      capabilityId: CRUISE_HANDLER_ACTION_POLICY.capabilityId,
+      capabilityVersion: CRUISE_HANDLER_ACTION_POLICY.capabilityVersion,
+      canonicalName: CRUISE_HANDLER_ACTION_POLICY.canonicalName,
+      actionPolicy: {
+        ...CRUISE_HANDLER_ACTION_POLICY.actionPolicy,
+        enforcement: "handler",
+        invocation: {
+          controlField: "_voyant",
+          requiredFields: [],
+          optionalFields: [],
+          fingerprintAlgorithm: "action-ledger-command-v1",
+        },
+      },
+      invocation: { idempotencyKey },
+    }) as never
+
+  const context = {
+    userId: "user_cruise_create",
+    callerType: "session",
+    actor: "staff",
+    organizationId: "org_cruise_create",
+  } as const
+
+  it("atomically creates, projects, enqueues, replays, conflicts, and serializes", async () => {
+    const idempotencyKey = "cruise-create-1"
+    const input = insertCruiseSchema.parse({
+      slug: "atomic-cruise",
+      name: "Atomic cruise",
+      cruiseType: "ocean",
+      nights: 7,
+    })
+    let releaseFirst: () => void = () => undefined
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let projectionReady: () => void = () => undefined
+    const projected = new Promise<void>((resolve) => {
+      projectionReady = resolve
+    })
+    const command = [db, context, undefined, input, admitted(idempotencyKey)] as const
+    const firstPromise = executeCruiseCreate(...command, {
+      async afterRequiredProjection() {
+        projectionReady()
+        await holdFirst
+      },
+    })
+    await projected
+    let secondSettled = false
+    const secondPromise = executeCruiseCreate(...command).finally(() => {
+      secondSettled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(secondSettled).toBe(false)
+    releaseFirst()
+
+    const [first, replay] = await Promise.all([firstPromise, secondPromise])
+    expect(first.replayed).toBe(false)
+    expect(replay).toMatchObject({ replayed: true, value: first.value })
+
+    await expect(
+      executeCruiseCreate(
+        db,
+        context,
+        undefined,
+        { ...input, name: "Drifted cruise" },
+        admitted(idempotencyKey),
+      ),
+    ).rejects.toMatchObject({ name: "ActionLedgerIdempotencyConflictError" })
+
+    expect(await db.select().from(cruises).where(eq(cruises.slug, input.slug))).toHaveLength(1)
+    expect(
+      await db
+        .select()
+        .from(cruiseSearchIndex)
+        .where(eq(cruiseSearchIndex.localCruiseId, first.value.id)),
+    ).toHaveLength(1)
+    expect(await db.select().from(eventOutboxTable)).toEqual([
+      expect.objectContaining({
+        name: "cruise.created",
+        payload: { id: first.value.id },
+        metadata: expect.objectContaining({ category: "domain", source: "service" }),
+      }),
+    ])
+    expect(
+      await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(eq(actionLedgerEntries.idempotencyKey, idempotencyKey)),
+    ).toHaveLength(2)
+  })
+
+  it("rolls back the claim, cruise, projection, outbox, and result together", async () => {
+    const idempotencyKey = "cruise-create-rollback"
+    const input = insertCruiseSchema.parse({
+      slug: "rolled-back-cruise",
+      name: "Rolled back cruise",
+      cruiseType: "river",
+      nights: 4,
+    })
+    await expect(
+      executeCruiseCreate(db, context, undefined, input, admitted(idempotencyKey), {
+        async afterRequiredProjection() {
+          throw new Error("injected post-projection failure")
+        },
+      }),
+    ).rejects.toThrow("injected post-projection failure")
+
+    expect(await db.select().from(cruises).where(eq(cruises.slug, input.slug))).toHaveLength(0)
+    expect(
+      await db.select().from(cruiseSearchIndex).where(eq(cruiseSearchIndex.slug, input.slug)),
+    ).toHaveLength(0)
+    expect(await db.select().from(eventOutboxTable)).toHaveLength(0)
+    expect(
+      await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(eq(actionLedgerEntries.idempotencyKey, idempotencyKey)),
+    ).toHaveLength(0)
+  })
+
+  it("keeps lifecycle events distinct for the same command fingerprint across principals", async () => {
+    const idempotencyKey = "shared-cross-principal-key"
+    const input = insertCruiseSchema.parse({
+      slug: "shared-cross-principal-cruise",
+      name: "Shared cross-principal cruise",
+      cruiseType: "ocean",
+      nights: 8,
+    })
+    const first = await executeCruiseCreate(
+      db,
+      {
+        userId: "user_cruise_create_a",
+        callerType: "session",
+        actor: "staff",
+        organizationId: "org_cruise_create_a",
+      },
+      undefined,
+      input,
+      admitted(idempotencyKey),
+    )
+
+    // The cruise slug and its required projection are globally unique. Move
+    // the first product to a new slug so a second principal can execute the
+    // exact same command input and reproduce the cross-scope fingerprint.
+    await cruisesService.updateCruise(db, first.value.id, {
+      slug: "shared-cross-principal-cruise-a",
+    })
+
+    const second = await executeCruiseCreate(
+      db,
+      {
+        userId: "user_cruise_create_b",
+        callerType: "session",
+        actor: "staff",
+        organizationId: "org_cruise_create_b",
+      },
+      undefined,
+      input,
+      admitted(idempotencyKey),
+    )
+
+    expect(second.value.id).not.toBe(first.value.id)
+    expect(await db.select().from(cruises)).toHaveLength(2)
+    expect((await db.select().from(eventOutboxTable)).map(({ eventId }) => eventId).sort()).toEqual(
+      [cruiseCreatedEventId(first.value.id), cruiseCreatedEventId(second.value.id)].sort(),
+    )
+  })
+})

--- a/packages/cruises/tests/unit/created-target-policy.test.ts
+++ b/packages/cruises/tests/unit/created-target-policy.test.ts
@@ -2,12 +2,19 @@ import type { HandlerActionPolicyExpectation, ToolContext } from "@voyant-travel
 import { describe, expect, it } from "vitest"
 
 import {
+  buildCruiseCreatedTargetFingerprint,
   buildCruiseShipCreatedTargetFingerprint,
+  CRUISE_CREATED_TARGET_POLICY,
+  CRUISE_HANDLER_ACTION_POLICY,
   CRUISE_SHIP_CREATED_TARGET_POLICY,
   CRUISE_SHIP_HANDLER_ACTION_POLICY,
 } from "../../src/created-target-policy.js"
 import { executeCruiseShipCreate } from "../../src/mcp-runtime.js"
-import { type CruisesToolServices, createCruiseShipTool } from "../../src/tools.js"
+import {
+  type CruisesToolServices,
+  createCruiseShipTool,
+  createCruiseTool,
+} from "../../src/tools.js"
 import { cruisesVoyantModule } from "../../src/voyant.js"
 
 describe("cruise ship created-target command", () => {
@@ -163,6 +170,55 @@ describe("cruise ship created-target command", () => {
     ).rejects.toThrow("concrete principal")
     expect(executorCalls).toBe(0)
     expect(mutations).toBe(0)
+  })
+})
+
+describe("cruise created-target command", () => {
+  it("declares an available immutable handler-owned command with tested outbox durability", () => {
+    const policy = CRUISE_CREATED_TARGET_POLICY
+    expect(createCruiseTool.actionPolicyEnforcement).toBe("handler")
+    expect(createCruiseTool.riskPolicy.reversible).toBe(false)
+    expect(cruisesVoyantModule.actions?.find(({ id }) => id === policy.actionName)).toMatchObject({
+      availability: { status: "available" },
+      targetType: policy.canonicalTargetType,
+      targetLifecycle: "created",
+      effectBoundary: "multistage",
+      durability: {
+        strategy: "outbox",
+        testReference: "tests/integration/created-target-tools.test.ts",
+      },
+      reversible: false,
+      createdTarget: {
+        commandTargetType: policy.commandTargetType,
+        resultReferenceType: policy.resultReferenceType,
+        durability: "handler-command-claim-v1",
+      },
+    })
+    expect(
+      createCruiseTool.inputSchema.safeParse({
+        slug: "cruise",
+        name: "Cruise",
+        cruiseType: "ocean",
+        nights: 7,
+      }).success,
+    ).toBe(true)
+    expect(
+      createCruiseTool.outputSchema.safeParse({
+        status: "created",
+        cruise: { id: "cruise_1" },
+        replayed: false,
+      }).success,
+    ).toBe(true)
+    expect(
+      createCruiseTool.outputSchema.safeParse({ id: "cruise_1", name: "mutable" }).success,
+    ).toBe(false)
+    expect(CRUISE_HANDLER_ACTION_POLICY.actionPolicy.capabilityId).toBe(policy.capabilityId)
+  })
+
+  it("fingerprints exact input and rejects drift", async () => {
+    const first = await buildCruiseCreatedTargetFingerprint("key", { name: "A" })
+    expect(await buildCruiseCreatedTargetFingerprint("key", { name: "A" })).toBe(first)
+    expect(await buildCruiseCreatedTargetFingerprint("key", { name: "B" })).not.toBe(first)
   })
 })
 

--- a/packages/cruises/tests/unit/tools.test.ts
+++ b/packages/cruises/tests/unit/tools.test.ts
@@ -33,7 +33,7 @@ describe("cruise tools", () => {
     )
   })
 
-  it("guards supplier-committing booking separately from reversible lifecycle writes", () => {
+  it("guards created targets and supplier-committing booking as irreversible writes", () => {
     expect(createCruiseBookingTool.requiredScopes).toEqual(["cruises:write", "bookings:write"])
     expect(createCruiseBookingTool.audience).toEqual({ source: "grant", allowed: ["staff"] })
     expect(createCruiseBookingTool.riskPolicy).toMatchObject({
@@ -45,7 +45,9 @@ describe("cruise tools", () => {
     for (const tool of cruisesTools.filter(
       ({ requiredScopes }) => requiredScopes[0] === "cruises:write" && requiredScopes.length === 1,
     )) {
-      expect(tool.riskPolicy.reversible).toBe(tool.name !== "create_cruise_ship")
+      expect(tool.riskPolicy.reversible).toBe(
+        tool.name !== "create_cruise" && tool.name !== "create_cruise_ship",
+      )
       expect(tool.audience?.allowed).toEqual(["staff"])
     }
   })

--- a/packages/cruises/tests/unit/voyant-manifest.test.ts
+++ b/packages/cruises/tests/unit/voyant-manifest.test.ts
@@ -195,11 +195,19 @@ describe("cruises deployment manifest", () => {
         ({ id }) => id === "@voyant-travel/cruises#action.create-cruise",
       ),
     ).toMatchObject({
-      availability: {
-        status: "unavailable",
-        reasonCode: "unsafe-nontransactional-effect",
+      availability: { status: "available" },
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "cruise_create_command",
+        resultReferenceType: "cruise",
+        durability: "handler-command-claim-v1",
+      },
+      durability: {
+        strategy: "outbox",
+        testReference: "tests/integration/created-target-tools.test.ts",
       },
       effectBoundary: "multistage",
+      reversible: false,
     })
     for (const action of cruisesVoyantModule.actions?.filter(
       ({ kind, risk }) => kind === "execute" && risk === "medium",


### PR DESCRIPTION
## What changed

- Restore `@voyant-travel/cruises#action.create-cruise` as an explicitly available handler-owned created-target command.
- Atomically commit the command claim, canonical cruise, required search projection, immutable result, and deterministic `cruise.created` outbox event.
- Return an immutable created-reference envelope on first execution and exact replay; reject input drift and serialize concurrent identical commands.
- Derive outbox IDs from the globally unique canonical cruise ID so identical commands in different principal/organization scopes retain distinct lifecycle events.
- Add rollback, concurrency, replay, drift, projection, outbox, and cross-scope PostgreSQL coverage wired into CI’s database lane.
- Add a major changeset and caller migration guidance for the Tool response contract and stable `_voyant.idempotencyKey`.

## Why

The action was quarantined because cruise insertion, best-effort projection, and lifecycle publication did not share one durable boundary. A failure could leave an unprojected cruise or lose its event, and retries had no exact immutable result.

No other quarantined action is restored by this PR; `create-cruise-booking` remains unavailable.

## Validation

Executed remotely from the exact worktree snapshot:

- Scoped Biome check passed.
- Cruises package typecheck passed with a 6 GB remote heap.
- Cruises tests passed: 32 files / 266 tests (database tests skip without `TEST_DATABASE_URL`).
- First-party manifest convergence passed during implementation.
- `git diff --check` passed.
- Independent code review confirmed transaction/admission/replay behavior, canonical event IDs, cross-scope coverage, and migration contract.

The new live PostgreSQL suite is wired into GitHub CI’s migrated database lane; CI is the final database execution gate.