### PR TITLE
Restore durable organization creation

### DIFF
--- a/.changeset/restore-relationships-organization.md
+++ b/.changeset/restore-relationships-organization.md
@@ -1,0 +1,11 @@
+---
+"@voyant-travel/relationships": major
+---
+
+Restore `create_organization` as a handler-owned created-target command whose
+organization, optional billing address, deterministic `organization.changed`
+outbox event, ledger, and immutable result commit atomically.
+
+The Tool now returns `{ status, organization: { id }, replayed }` instead of
+the mutable organization and billing-address rows. See
+`docs/migrations/created-relationships-organization.md` for caller guidance.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,8 @@ jobs:
                 pnpm --filter operator db:migrate
               pnpm --filter @voyant-travel/relationships exec vitest run \
                 tests/integration/generic-custom-field-values.test.ts
+              pnpm --filter @voyant-travel/relationships exec vitest run \
+                tests/integration/organization-created-command.test.ts
               pnpm --filter @voyant-travel/framework-migrations exec vitest run \
                 src/deployment-runner.test.ts
               pnpm --filter @voyant-travel/catalog exec vitest run \

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -6,6 +6,7 @@ Unreleased caller migrations:
 
 - [Created-target Tool commands](./created-target-tool-commands.md)
 - [Created local Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md) — includes the breaking `create_promotion` and `create_cruise` response-envelope migrations.
+- [Created Relationships organizations](./created-relationships-organization.md) — restore atomic, replay-safe `create_organization` with an immutable response envelope.
 
 The full history (including patch-level changes and dependency updates) lives in the per-package `CHANGELOG.md` files; these pages exist because changeset entries land in *every* package's CHANGELOG that depends on the changed one, so the actual breaking signal is otherwise buried under dozens of `Updated dependencies [...]` lines per package.
 

--- a/docs/migrations/created-relationships-organization.md
+++ b/docs/migrations/created-relationships-organization.md
@@ -1,0 +1,42 @@
+# Created Relationships organizations
+
+The `create_organization` MCP Tool now uses the framework's transactional
+`handler-command-claim-v1` created-target protocol.
+
+## Caller migration
+
+Every call must supply a non-empty `_voyant.idempotencyKey`. Keep that key
+stable across retries of one exact logical command. Reusing it with different
+organization or billing-address input is rejected. The legacy top-level
+`idempotencyKey` field remains optional compatibility input; when supplied, it
+must equal `_voyant.idempotencyKey`.
+
+The Tool previously returned mutable organization and billing-address rows. It
+now returns an immutable created-target envelope:
+
+```ts
+const result = await createOrganization({
+  name: "Example Travel",
+  vatNumber: "RO123",
+  billingAddress: {
+    label: "billing",
+    line1: "Calea Victoriei 1",
+    country: "RO",
+  },
+  _voyant: { idempotencyKey: commandId },
+})
+
+// { status: "created", organization: { id: "..." }, replayed: false }
+const organization = await getOrganization({ id: result.organization.id })
+```
+
+Fresh and replayed responses have the same shape. `replayed` distinguishes a
+fresh commit from an exact replay.
+
+The command claim, organization, optional billing address, canonical
+organization-scoped `organization.changed` outbox event, and immutable result
+commit in one transaction. Identical command keys in different principal or
+organization scopes create distinct organizations and distinct lifecycle
+events.
+
+The package-local HTTP routes and domain-service signatures are unchanged.

--- a/packages/relationships/src/created-target-policy.ts
+++ b/packages/relationships/src/created-target-policy.ts
@@ -1,0 +1,36 @@
+import type { HandlerActionPolicyExpectation } from "@voyant-travel/tools"
+
+export const RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY = {
+  actionName: "@voyant-travel/relationships#action.create-organization",
+  actionVersion: "v1",
+  toolName: "create_organization",
+  toolCapabilityId: "@voyant-travel/relationships#tool.create-organization",
+  commandTargetType: "organization_create_command",
+  canonicalTargetType: "organization",
+  resultReferenceType: "organization",
+  evaluatedRisk: "medium",
+} as const
+
+export const RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY = {
+  capabilityId: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.toolCapabilityId,
+  capabilityVersion: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionVersion,
+  canonicalName: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.toolName,
+  actionPolicy: {
+    id: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionName,
+    capabilityId: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionName,
+    version: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionVersion,
+    kind: "execute",
+    targetType: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.canonicalTargetType,
+    targetLifecycle: "created",
+    createdTarget: {
+      commandTargetType: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.commandTargetType,
+      resultReferenceType: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.resultReferenceType,
+      durability: "handler-command-claim-v1",
+    },
+    risk: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.evaluatedRisk,
+    ledger: "required",
+    approval: "never",
+    reversible: false,
+    allowedActorTypes: ["staff"],
+  },
+} as const satisfies HandlerActionPolicyExpectation

--- a/packages/relationships/src/mcp-runtime.ts
+++ b/packages/relationships/src/mcp-runtime.ts
@@ -1,9 +1,15 @@
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
 import type { EventBus } from "@voyant-travel/core"
-import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
+import {
+  defineToolContextContribution,
+  ToolError,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 import { emitOrganizationChanged, emitPersonChanged } from "./events.js"
+import { executeOrganizationCreateCommand } from "./organization-created-command.js"
 import { relationshipsService } from "./service/index.js"
 import {
   personListQuerySchema,
@@ -14,9 +20,7 @@ import {
 export * from "./tools.js"
 
 type RelationshipsMcpEnv = {
-  Variables: {
-    userId?: string
-    apiTokenId?: string
+  Variables: ActionLedgerRequestContextValues & {
     apiKeyId?: string
     eventBus?: EventBus
   }
@@ -28,6 +32,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
     const c = request as Context<RelationshipsMcpEnv>
     const db = context.db as PostgresJsDatabase
     const eventBus = c.get("eventBus")
+    const requestContext = relationshipsActionLedgerContext(c)
     const authorId = () => {
       const id = c.get("userId") ?? c.get("apiTokenId") ?? c.get("apiKeyId")
       if (!id) {
@@ -85,41 +90,38 @@ export const voyantToolContextContribution = defineToolContextContribution({
         listOrganizations: (query: Parameters<typeof relationshipsService.listOrganizations>[1]) =>
           relationshipsService.listOrganizations(db, query),
         getOrganizationById: (id: string) => relationshipsService.getOrganizationById(db, id),
-        async createOrganization(input: {
-          taxId?: string | null
-          vatNumber?: string
-          billingAddress?: Record<string, unknown>
-          [key: string]: unknown
-        }) {
-          const { vatNumber, billingAddress, ...rawOrganization } = input
+        async createOrganization(
+          input: {
+            taxId?: string | null
+            vatNumber?: string
+            billingAddress?: Record<string, unknown>
+            idempotencyKey?: string
+            [key: string]: unknown
+          },
+          admitted: ToolHandlerActionPolicyContext,
+        ) {
+          const { idempotencyKey, vatNumber, billingAddress, ...rawOrganization } = input
           const organizationData = {
             ...rawOrganization,
             taxId: rawOrganization.taxId ?? vatNumber,
           } as Parameters<typeof relationshipsService.createOrganization>[1]
-          const result = await db.transaction(async (tx) => {
-            const organization = await relationshipsService.createOrganization(tx, organizationData)
-            if (!organization) {
-              throw new ToolError("CRM organization creation returned no row.", "PROVIDER_ERROR")
-            }
-            const address = billingAddress
-              ? await relationshipsService.createAddress(
-                  tx,
-                  "organization",
-                  organization.id,
-                  billingAddress as Parameters<typeof relationshipsService.createAddress>[3],
-                )
-              : null
-            if (billingAddress && !address) {
-              throw new ToolError("CRM billing address creation returned no row.", "PROVIDER_ERROR")
-            }
-            return { organization, billingAddress: address }
+          const result = await executeOrganizationCreateCommand({
+            db,
+            context: requestContext,
+            commandInput: {
+              organization: organizationData,
+              billingAddress: billingAddress
+                ? (billingAddress as Parameters<typeof relationshipsService.createAddress>[3])
+                : null,
+            },
+            admitted,
+            legacyIdempotencyKey: idempotencyKey,
           })
-          await emitOrganizationChanged(
-            eventBus,
-            { id: result.organization.id, action: "created" },
-            "service",
-          )
-          return result
+          return {
+            status: "created" as const,
+            organization: result.value,
+            replayed: result.replayed,
+          }
         },
         async updateOrganization(input: {
           id: string
@@ -235,6 +237,26 @@ export const voyantToolContextContribution = defineToolContextContribution({
     }
   },
 })
+
+function relationshipsActionLedgerContext(
+  c: Context<RelationshipsMcpEnv>,
+): ActionLedgerRequestContextValues {
+  return {
+    userId: c.get("userId") ?? null,
+    agentId: c.get("agentId") ?? null,
+    workflowPrincipalId: c.get("workflowPrincipalId") ?? null,
+    principalSubtype: c.get("principalSubtype") ?? null,
+    sessionId: c.get("sessionId") ?? null,
+    apiTokenId: c.get("apiTokenId") ?? c.get("apiKeyId") ?? null,
+    callerType: c.get("callerType") ?? null,
+    actor: c.get("actor") ?? null,
+    isInternalRequest: c.get("isInternalRequest") ?? false,
+    organizationId: c.get("organizationId") ?? null,
+    workflowRunId: c.get("workflowRunId") ?? null,
+    workflowStepId: c.get("workflowStepId") ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}
 
 function isCompatibleSameName(
   row: Record<string, unknown>,

--- a/packages/relationships/src/organization-created-command.ts
+++ b/packages/relationships/src/organization-created-command.ts
@@ -1,0 +1,88 @@
+import {
+  type ActionLedgerRequestContextValues,
+  executeAdmittedCreatedTargetCommand,
+} from "@voyant-travel/action-ledger"
+import { insertOutboxEvents } from "@voyant-travel/db/outbox"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY as POLICY } from "./created-target-policy.js"
+import { ORGANIZATION_CHANGED_EVENT } from "./events.js"
+import type {
+  CreateAddressForEntityInput,
+  CreateOrganizationInput,
+} from "./service/accounts-shared.js"
+import { relationshipsService } from "./service/index.js"
+
+export interface OrganizationCreateCommandInput {
+  organization: CreateOrganizationInput
+  billingAddress: CreateAddressForEntityInput | null
+}
+
+export async function executeOrganizationCreateCommand(input: {
+  db: PostgresJsDatabase
+  context: ActionLedgerRequestContextValues
+  commandInput: OrganizationCreateCommandInput
+  admitted: ToolHandlerActionPolicyContext
+  legacyIdempotencyKey?: string
+  testHooks?: {
+    /** Test-only failure/concurrency seam inside the handler-owned transaction. */
+    afterDomainCreate?: (tx: PostgresJsDatabase, organizationId: string) => Promise<void>
+  }
+}) {
+  return executeAdmittedCreatedTargetCommand(
+    {
+      db: input.db,
+      context: input.context,
+      admitted: input.admitted,
+      idempotencyKey: input.legacyIdempotencyKey,
+      commandTargetType: POLICY.commandTargetType,
+      canonicalTargetType: POLICY.canonicalTargetType,
+      resultReferenceType: POLICY.resultReferenceType,
+      commandInput: input.commandInput,
+      evaluatedRisk: POLICY.evaluatedRisk,
+    },
+    {
+      async create(tx) {
+        const transaction = tx as PostgresJsDatabase
+        const organization = await relationshipsService.createOrganization(
+          transaction,
+          input.commandInput.organization,
+        )
+        if (!organization) {
+          throw new TypeError("CRM organization creation returned no row")
+        }
+        if (input.commandInput.billingAddress) {
+          const address = await relationshipsService.createAddress(
+            transaction,
+            "organization",
+            organization.id,
+            input.commandInput.billingAddress,
+          )
+          if (!address) {
+            throw new TypeError("CRM billing address creation returned no row")
+          }
+        }
+        await input.testHooks?.afterDomainCreate?.(transaction, organization.id)
+        await insertOutboxEvents(transaction, [
+          {
+            name: ORGANIZATION_CHANGED_EVENT,
+            data: { id: organization.id, action: "created" },
+            metadata: {
+              category: "domain",
+              source: "service",
+              eventId: organizationCreatedEventId(organization.id),
+            },
+          },
+        ])
+        return { value: { id: organization.id }, targetId: organization.id }
+      },
+      async replay(_tx, result) {
+        return { id: result.reference.id }
+      },
+    },
+  )
+}
+
+export function organizationCreatedEventId(organizationId: string): string {
+  return `evt_relationships_organization_created_${organizationId}`
+}

--- a/packages/relationships/src/tools.ts
+++ b/packages/relationships/src/tools.ts
@@ -7,15 +7,18 @@ import {
   updateContactPointSchema,
 } from "@voyant-travel/identity/validation"
 import {
+  admitHandlerActionPolicy,
   defineTool,
   READ_ONLY_RISK,
   requireService,
   type ToolContext,
   ToolError,
+  type ToolHandlerActionPolicyContext,
 } from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
 
+import { RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY } from "./created-target-policy.js"
 import {
   addressSchema,
   contactMethodSchema,
@@ -53,6 +56,13 @@ const ROUTINE_WRITE_RISK = {
 const SENSITIVE_WRITE_RISK = {
   ...ROUTINE_WRITE_RISK,
   confirmationRequired: false,
+} as const
+const CREATED_WRITE_RISK = {
+  destructive: false,
+  reversible: false,
+  dryRunSupported: false,
+  confirmationRequired: false,
+  sideEffects: ["data-write"],
 } as const
 
 const idArgsSchema = z.object({ id: z.string().min(1).describe("The CRM record id.") })
@@ -122,6 +132,13 @@ const billingAddressSchema = insertAddressForEntitySchema.omit({ metadata: true 
 export const createOrganizationToolInputSchema = insertOrganizationSchema
   .omit({ ownerId: true, source: true, sourceRef: true, customFields: true })
   .extend({
+    idempotencyKey: z
+      .string()
+      .trim()
+      .min(1)
+      .max(255)
+      .optional()
+      .describe("Compatibility copy of the admitted created-command idempotency key."),
     vatNumber: z.string().optional().describe("Compatibility alias for taxId."),
     billingAddress: billingAddressSchema,
   })
@@ -138,8 +155,9 @@ const createPersonOutputSchema = z.object({
   alreadyExists: z.boolean(),
 })
 const createOrganizationOutputSchema = z.object({
-  organization: organizationSchema,
-  billingAddress: addressSchema.nullable(),
+  status: z.literal("created"),
+  organization: z.object({ id: z.string().min(1) }),
+  replayed: z.boolean(),
 })
 
 const noteSchema = z.union([personNoteSchema, organizationNoteSchema])
@@ -199,7 +217,10 @@ export interface RelationshipsToolServices {
   updatePerson(input: UpdatePersonInput): Promise<unknown>
   listOrganizations(query: OrganizationListQuery): Promise<unknown>
   getOrganizationById(id: string): Promise<unknown>
-  createOrganization(input: CreateOrganizationInput): Promise<unknown>
+  createOrganization(
+    input: CreateOrganizationInput,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
   updateOrganization(input: UpdateOrganizationInput): Promise<unknown>
   listNotes(input: EntityArgs): Promise<unknown>
   addNote(input: AddNoteInput): Promise<unknown>
@@ -376,15 +397,22 @@ export const createOrganizationTool = defineTool<
   RelationshipsToolContext
 >({
   ...routineWriteMetadata,
+  riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-organization`,
   name: "create_organization",
   aliases: ["crm_organization_create"],
   description:
-    "Create a CRM organization and, when supplied, its billing address in the same transaction.",
+    "Create a CRM organization and optional billing address atomically. Exact retries return the original immutable organization reference.",
   inputSchema: createOrganizationToolInputSchema,
   outputSchema: createOrganizationOutputSchema,
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx) {
-    return parseJsonResult(createOrganizationOutputSchema, await crm(ctx).createOrganization(input))
+    const admitted = admitHandlerActionPolicy(ctx, RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY)
+    return parseJsonResult(
+      createOrganizationOutputSchema,
+      await crm(ctx).createOrganization(input, admitted),
+    )
   },
 })
 

--- a/packages/relationships/src/voyant.ts
+++ b/packages/relationships/src/voyant.ts
@@ -441,16 +441,25 @@ export const relationshipsVoyantModule = defineModule({
       version: "v1",
       kind: "execute",
       targetType: "organization",
-      availability: {
-        status: "unavailable",
-        reasonCode: "unsafe-nontransactional-effect",
-      },
+      availability: { status: "available" },
       effectBoundary: "multistage",
+      durability: {
+        strategy: "outbox",
+        testReference:
+          "packages/relationships/tests/integration/organization-created-command.test.ts",
+      },
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "organization_create_command",
+        resultReferenceType: "organization",
+        durability: "handler-command-claim-v1",
+      },
       requiredScopes: ["crm:write"],
       risk: "medium",
       ledger: "required",
       approval: "never",
-      reversible: true,
+      reversible: false,
+      allowedActorTypes: ["staff"],
       from: { tools: ["@voyant-travel/relationships#tool.create-organization"] },
     },
     {

--- a/packages/relationships/tests/integration/organization-created-command.test.ts
+++ b/packages/relationships/tests/integration/organization-created-command.test.ts
@@ -1,0 +1,236 @@
+import { actionLedgerEntries } from "@voyant-travel/action-ledger/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { eventOutboxTable } from "@voyant-travel/db/schema"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import { identityAddresses } from "@voyant-travel/identity"
+import { insertAddressForEntitySchema } from "@voyant-travel/identity/validation"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest"
+
+import {
+  RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY,
+  RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY,
+} from "../../src/created-target-policy.js"
+import {
+  executeOrganizationCreateCommand,
+  organizationCreatedEventId,
+} from "../../src/organization-created-command.js"
+import { organizations } from "../../src/schema.js"
+import { insertOrganizationSchema } from "../../src/validation.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+describe.skipIf(!DB_AVAILABLE)("Relationships organization created-target command", () => {
+  let db: ClosableTestDb
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(() => cleanupTestDb(db))
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  it("atomically creates, replays, conflicts, serializes, and enqueues once", async () => {
+    const idempotencyKey = "organization-create-1"
+    const command = organizationCommand(idempotencyKey)
+    let releaseFirst: () => void = () => undefined
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let domainInserted: () => void = () => undefined
+    const inserted = new Promise<void>((resolve) => {
+      domainInserted = resolve
+    })
+
+    const firstPromise = executeOrganizationCreateCommand({
+      ...command,
+      testHooks: {
+        async afterDomainCreate() {
+          domainInserted()
+          await holdFirst
+        },
+      },
+    })
+    await inserted
+    let secondSettled = false
+    const secondPromise = executeOrganizationCreateCommand(command).finally(() => {
+      secondSettled = true
+    })
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    expect(secondSettled).toBe(false)
+
+    releaseFirst()
+    const [first, concurrentReplay] = await Promise.all([firstPromise, secondPromise])
+    expect(first.replayed).toBe(false)
+    expect(concurrentReplay).toMatchObject({ replayed: true, value: first.value })
+
+    const exactReplay = await executeOrganizationCreateCommand(command)
+    expect(exactReplay).toMatchObject({ replayed: true, value: first.value })
+    await expect(
+      executeOrganizationCreateCommand({
+        ...command,
+        commandInput: {
+          ...command.commandInput,
+          organization: { ...command.commandInput.organization, name: "Drifted organization" },
+        },
+      }),
+    ).rejects.toMatchObject({ name: "ActionLedgerIdempotencyConflictError" })
+
+    const organizationRows = await db.select().from(organizations)
+    expect(organizationRows).toHaveLength(1)
+    expect(organizationRows[0]).toMatchObject({
+      id: first.value.id,
+      name: "Atomic organization",
+      taxId: "RO123",
+    })
+    const addresses = await db.select().from(identityAddresses)
+    expect(addresses).toHaveLength(1)
+    expect(addresses[0]).toMatchObject({
+      entityType: "organization",
+      entityId: first.value.id,
+      label: "billing",
+      line1: "Calea Victoriei 1",
+      country: "RO",
+    })
+
+    const expectedEventId = organizationCreatedEventId(first.value.id)
+    const outbox = await db.select().from(eventOutboxTable)
+    expect(outbox).toHaveLength(1)
+    expect(outbox[0]).toMatchObject({
+      eventId: expectedEventId,
+      name: "organization.changed",
+      payload: { id: first.value.id, action: "created" },
+      metadata: {
+        category: "domain",
+        source: "service",
+        eventId: expectedEventId,
+      },
+    })
+
+    const canonical = await db
+      .select()
+      .from(actionLedgerEntries)
+      .where(eq(actionLedgerEntries.status, "succeeded"))
+    expect(canonical).toContainEqual(
+      expect.objectContaining({
+        targetType: "organization",
+        targetId: first.value.id,
+        actionName: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionName,
+        capabilityId: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionName,
+        routeOrToolName: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.toolCapabilityId,
+        causationActionId: expect.any(String),
+      }),
+    )
+  })
+
+  it("keeps identical cross-principal commands and lifecycle events distinct", async () => {
+    const idempotencyKey = "organization-create-cross-principal"
+    const first = await executeOrganizationCreateCommand(
+      organizationCommand(idempotencyKey, {
+        userId: "user_1",
+        organizationId: "tenant_1",
+      }),
+    )
+    const second = await executeOrganizationCreateCommand(
+      organizationCommand(idempotencyKey, {
+        userId: "user_2",
+        organizationId: "tenant_2",
+      }),
+    )
+
+    expect(first.replayed).toBe(false)
+    expect(second.replayed).toBe(false)
+    expect(second.value.id).not.toBe(first.value.id)
+    expect((await db.select().from(organizations)).map(({ id }) => id).sort()).toEqual(
+      [first.value.id, second.value.id].sort(),
+    )
+    expect((await db.select().from(eventOutboxTable)).map(({ eventId }) => eventId).sort()).toEqual(
+      [
+        organizationCreatedEventId(first.value.id),
+        organizationCreatedEventId(second.value.id),
+      ].sort(),
+    )
+  })
+
+  it("rolls back the claim, organization, billing address, outbox, and result", async () => {
+    const idempotencyKey = "organization-create-crash"
+    const command = organizationCommand(idempotencyKey, {
+      name: "Rollback organization",
+    })
+    await expect(
+      executeOrganizationCreateCommand({
+        ...command,
+        testHooks: {
+          async afterDomainCreate() {
+            throw new Error("injected post-insert crash")
+          },
+        },
+      }),
+    ).rejects.toThrow("injected post-insert crash")
+
+    expect(
+      await db.select().from(organizations).where(eq(organizations.name, "Rollback organization")),
+    ).toHaveLength(0)
+    expect(await db.select().from(identityAddresses)).toHaveLength(0)
+    expect(await db.select().from(eventOutboxTable)).toHaveLength(0)
+    expect(
+      await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(eq(actionLedgerEntries.idempotencyKey, idempotencyKey)),
+    ).toHaveLength(0)
+  })
+
+  function organizationCommand(
+    idempotencyKey: string,
+    options: {
+      userId?: string
+      organizationId?: string
+      name?: string
+    } = {},
+  ) {
+    return {
+      db,
+      context: {
+        userId: options.userId ?? "user_1",
+        callerType: "session" as const,
+        actor: "staff" as const,
+        organizationId: options.organizationId ?? "tenant_1",
+      },
+      commandInput: {
+        organization: insertOrganizationSchema.parse({
+          name: options.name ?? "Atomic organization",
+          taxId: "RO123",
+        }),
+        billingAddress: insertAddressForEntitySchema.parse({
+          label: "billing",
+          line1: "Calea Victoriei 1",
+          country: "RO",
+        }),
+      },
+      admitted: {
+        ...RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY,
+        actionPolicy: {
+          ...RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY.actionPolicy,
+          enforcement: "handler" as const,
+          invocation: {
+            controlField: "_voyant" as const,
+            requiredFields: ["idempotencyKey"] as const,
+            optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"] as const,
+            fingerprintAlgorithm: "action-ledger-command-v1" as const,
+          },
+        },
+        invocation: { idempotencyKey },
+      },
+    }
+  }
+})

--- a/packages/relationships/tests/tools.test.ts
+++ b/packages/relationships/tests/tools.test.ts
@@ -1,6 +1,6 @@
 import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
-
+import { RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY } from "../src/created-target-policy.js"
 import {
   addRelationshipAddressTool,
   addRelationshipContactMethodTool,
@@ -11,6 +11,7 @@ import {
 
 function ctx(
   overrides: Partial<RelationshipsToolServices> = {},
+  contextOverrides: Partial<ToolContext> = {},
 ): ToolContext & { relationships: RelationshipsToolServices } {
   const unavailable = async () => {
     throw new Error("Unexpected Relationships tool service call")
@@ -21,6 +22,7 @@ function ctx(
     audience: "staff",
     tenantId: "default",
     resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+    ...contextOverrides,
     relationships: {
       listPeople: unavailable,
       getPersonById: unavailable,
@@ -287,17 +289,37 @@ describe("relationships (crm) tools", () => {
         vatNumber: "RO123",
         billingAddress: { label: "billing", line1: "Calea Victoriei 1", country: "RO" },
       },
-      ctx({
-        async createOrganization(input) {
-          created = input
-          return { organization: organization(), billingAddress: address() }
+      ctx(
+        {
+          async createOrganization(input, admitted) {
+            created = input
+            expect(admitted.invocation.idempotencyKey).toBe("organization-create-1")
+            return { status: "created", organization: { id: "org_1" }, replayed: false }
+          },
         },
-      }),
+        {
+          handlerActionPolicy: {
+            ...RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY,
+            actionPolicy: {
+              ...RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY.actionPolicy,
+              enforcement: "handler",
+              invocation: {
+                controlField: "_voyant",
+                requiredFields: ["idempotencyKey"],
+                optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+                fingerprintAlgorithm: "action-ledger-command-v1",
+              },
+            },
+            invocation: { idempotencyKey: "organization-create-1" },
+          },
+        },
+      ),
     )
     expect(created).toMatchObject({ name: "Example Travel", vatNumber: "RO123" })
     expect(createResult).toMatchObject({
+      status: "created",
       organization: { id: "org_1" },
-      billingAddress: { id: "iadr_1" },
+      replayed: false,
     })
 
     let updated: unknown

--- a/packages/relationships/tests/unit/created-target-policy.test.ts
+++ b/packages/relationships/tests/unit/created-target-policy.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY,
+  RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY,
+} from "../../src/created-target-policy.js"
+
+describe("Relationships created-target policy", () => {
+  it("binds organization creation to one handler-owned immutable reference contract", () => {
+    expect(RELATIONSHIPS_ORGANIZATION_HANDLER_ACTION_POLICY).toMatchObject({
+      capabilityId: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.toolCapabilityId,
+      canonicalName: "create_organization",
+      actionPolicy: {
+        id: RELATIONSHIPS_ORGANIZATION_CREATED_TARGET_POLICY.actionName,
+        targetType: "organization",
+        targetLifecycle: "created",
+        createdTarget: {
+          commandTargetType: "organization_create_command",
+          resultReferenceType: "organization",
+          durability: "handler-command-claim-v1",
+        },
+        risk: "medium",
+        ledger: "required",
+        approval: "never",
+        reversible: false,
+        allowedActorTypes: ["staff"],
+      },
+    })
+  })
+})

--- a/packages/relationships/tests/unit/voyant-manifest.test.ts
+++ b/packages/relationships/tests/unit/voyant-manifest.test.ts
@@ -75,7 +75,7 @@ describe("relationships deployment manifest", () => {
           kind: "execute",
           ledger: "required",
           approval: "never",
-          reversible: true,
+          reversible: action?.targetLifecycle !== "created",
         })
       }
       if (tool.risk === "high" && tool.requiredScopes.includes("crm:read")) {
@@ -86,18 +86,39 @@ describe("relationships deployment manifest", () => {
         })
       }
     }
-    for (const actionId of [
-      "@voyant-travel/relationships#action.create-person",
-      "@voyant-travel/relationships#action.create-organization",
-    ]) {
-      expect(relationshipsVoyantModule.actions?.find(({ id }) => id === actionId)).toMatchObject({
-        availability: {
-          status: "unavailable",
-          reasonCode: "unsafe-nontransactional-effect",
-        },
-        effectBoundary: "multistage",
-      })
-    }
+    expect(
+      relationshipsVoyantModule.actions?.find(
+        ({ id }) => id === "@voyant-travel/relationships#action.create-person",
+      ),
+    ).toMatchObject({
+      availability: {
+        status: "unavailable",
+        reasonCode: "unsafe-nontransactional-effect",
+      },
+      effectBoundary: "multistage",
+    })
+    expect(
+      relationshipsVoyantModule.actions?.find(
+        ({ id }) => id === "@voyant-travel/relationships#action.create-organization",
+      ),
+    ).toMatchObject({
+      availability: { status: "available" },
+      effectBoundary: "multistage",
+      targetType: "organization",
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "organization_create_command",
+        resultReferenceType: "organization",
+        durability: "handler-command-claim-v1",
+      },
+      durability: {
+        strategy: "outbox",
+        testReference:
+          "packages/relationships/tests/integration/organization-created-command.test.ts",
+      },
+      reversible: false,
+      allowedActorTypes: ["staff"],
+    })
     for (const ownerType of ["person", "organization"] as const) {
       for (const childType of ["note", "contact-method", "address"] as const) {
         const toolId = `@voyant-travel/relationships#tool.add-${ownerType}-${childType}`


### PR DESCRIPTION
## Summary

- restore `create_organization` as an explicitly available handler-owned created-target action
- commit the action-ledger claim, organization, optional billing address, immutable result, and deterministic `organization.changed` outbox event atomically
- return a stable created-target envelope and document the breaking caller migration
- add drift, replay, concurrency, scope-isolation, and rollback coverage plus CI live-Postgres wiring

## Validation

- remote `@voyant-travel/relationships` typecheck
- 11 focused remote tool/unit tests
- scoped Biome and `git diff --check`
- independent static contract review: no findings
- live PostgreSQL integration is wired into GitHub CI and is the remaining gate

## Notes

`create_person` remains quarantined and is intentionally out of scope.