### PR TITLE
Add durable notification send protocol

### DIFF
--- a/.changeset/restore-durable-notification-send.md
+++ b/.changeset/restore-durable-notification-send.md
@@ -1,0 +1,19 @@
+---
+"@voyant-travel/notifications": major
+"@voyant-travel/schema-kit": patch
+---
+
+Add the package-owned durable operation required to restore the approved
+`send_notification` action: exact command replay, transactional
+requested/completed events, leased retries, dead-letter visibility, and
+provider-side idempotency plus reconciliation. Notification providers can now
+declare the optional `notification-provider-idempotency-v1` capability;
+providers without it fail closed for agent sends while retaining their existing
+request-scoped behavior. The action remains quarantined until a production
+provider can satisfy the new contract.
+
+The agent Tool now targets the existing active notification template for
+approval/audit instead of writing the email address or phone number into the
+action ledger, and returns an immutable accepted/pending delivery snapshot.
+Delivery happens asynchronously; poll `get_notification_delivery` with the
+returned id for the mutable sent/failed state.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -351,6 +351,8 @@ jobs:
                 tests/integration/created-target-tools.test.ts
               pnpm --filter @voyant-travel/legal exec vitest run \
                 tests/integration/contract-lifecycle-command.test.ts
+              pnpm --filter @voyant-travel/notifications exec vitest run \
+                tests/integration/durable-send.test.ts
               ;;
           esac
 

--- a/packages/notifications/README.md
+++ b/packages/notifications/README.md
@@ -57,6 +57,41 @@ The bring-your-own path is first-class: any project can implement
 `NotificationProvider` against another transport (raw Resend, Twilio, SES, …)
 and register it in place of the cloud adapters.
 
+### Durable agent sends
+
+The durable `send_notification` path admits an approved, idempotent command,
+records an exact rendered request and a `notification.send-requested` outbox
+event atomically, then lets a package-owned scheduled job perform provider
+delivery. Exact replays return the immutable delivery snapshot captured at
+command acceptance.
+
+This changes the Tool contract from synchronous delivery to asynchronous
+acceptance: the immutable Tool result has `status: "pending"`. Poll
+`get_notification_delivery` with its `id` to observe the mutable `sent` or
+`failed` state. Approval and audit target the existing active notification
+template by slug; the exact command fingerprint separately binds the recipient
+address and every other input without putting that address in the
+action-ledger target.
+
+Providers used by this Tool must declare
+`durableDelivery.protocol = "notification-provider-idempotency-v1"` and
+implement both idempotent `send` and `reconcile`. The stable key passed to those
+methods is derived from the unique admitted command claim, so exact replays and
+retries share one provider delivery while separately admitted commands remain
+distinct even when their payloads match. Providers without that explicit
+capability remain usable by request-scoped application flows, but agent sends
+fail closed before an action claim or delivery row is committed. The bundled
+local and Voyant Cloud providers currently declare durable delivery unsupported
+because they cannot prove cross-process reconciliation. For that reason the
+graph action remains unavailable by default; it can be unquarantined only when
+a selected production provider implements this capability (or graph composition
+can express provider-conditional availability).
+
+After acceptance, a temporarily missing provider registration consumes the
+normal leased retry budget. A provider that is present but explicitly declares
+the durable protocol unsupported is a permanent configuration failure and is
+dead-lettered immediately.
+
 Email sends resolve the sender from the request `from`, the template
 `fromAddress`, or the provider's `defaultFromAddress` before dispatch. Custom
 email providers that use a provider-side default sender should expose it through

--- a/packages/notifications/migrations/0002_durable_send_operations.sql
+++ b/packages/notifications/migrations/0002_durable_send_operations.sql
@@ -1,0 +1,34 @@
+DO $$ BEGIN
+ CREATE TYPE "public"."notification_send_operation_status" AS ENUM('pending', 'processing', 'retry', 'sent', 'dead_letter');
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;--> statement-breakpoint
+CREATE TABLE "notification_send_operations" (
+	"id" text PRIMARY KEY NOT NULL,
+	"command_scope" text NOT NULL,
+	"idempotency_key" text NOT NULL,
+	"request_fingerprint" text NOT NULL,
+	"claim_action_id" text NOT NULL,
+	"organization_id" text,
+	"target_type" text NOT NULL,
+	"target_id" text NOT NULL,
+	"delivery_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"provider_idempotency_key" text NOT NULL,
+	"request_payload" jsonb NOT NULL,
+	"result_snapshot" jsonb NOT NULL,
+	"status" "notification_send_operation_status" DEFAULT 'pending' NOT NULL,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"max_attempts" integer DEFAULT 8 NOT NULL,
+	"next_attempt_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"lease_expires_at" timestamp with time zone,
+	"last_error" text,
+	"completed_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "notification_send_operations_claim_action_id_unique" UNIQUE("claim_action_id"),
+	CONSTRAINT "notification_send_operations_delivery_id_notification_deliveries_id_fk" FOREIGN KEY ("delivery_id") REFERENCES "public"."notification_deliveries"("id") ON DELETE restrict ON UPDATE no action
+);--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_notification_send_operations_command" ON "notification_send_operations" USING btree ("command_scope","idempotency_key");--> statement-breakpoint
+CREATE UNIQUE INDEX "uidx_notification_send_operations_provider_key" ON "notification_send_operations" USING btree ("provider","provider_idempotency_key");--> statement-breakpoint
+CREATE INDEX "idx_notification_send_operations_due" ON "notification_send_operations" USING btree ("status","next_attempt_at","lease_expires_at");--> statement-breakpoint
+CREATE INDEX "idx_notification_send_operations_delivery" ON "notification_send_operations" USING btree ("delivery_id");

--- a/packages/notifications/migrations/meta/_journal.json
+++ b/packages/notifications/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784116800000,
       "tag": "0001_delivery_idempotency",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1784898000000,
+      "tag": "0002_durable_send_operations",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -56,10 +56,12 @@ export type {
   NewNotificationDelivery,
   NewNotificationReminderRule,
   NewNotificationReminderRun,
+  NewNotificationSendOperation,
   NewNotificationTemplate,
   NotificationDelivery,
   NotificationReminderRule,
   NotificationReminderRun,
+  NotificationSendOperation,
   NotificationsApiModule,
   NotificationTemplate,
 } from "./schema.js"
@@ -72,6 +74,8 @@ export {
   notificationReminderRuns,
   notificationReminderStatusEnum,
   notificationReminderTargetTypeEnum,
+  notificationSendOperationStatusEnum,
+  notificationSendOperations,
   notificationsModule,
   notificationTargetTypeEnum,
   notificationTemplateStatusEnum,
@@ -169,6 +173,8 @@ export {
   notificationTemplateVariableCatalog,
 } from "./template-authoring.js"
 export type {
+  DurableNotificationDeliveryCapability,
+  DurableNotificationDeliveryContext,
   NotificationAttachment,
   NotificationChannel,
   NotificationPayload,

--- a/packages/notifications/src/mcp-runtime.ts
+++ b/packages/notifications/src/mcp-runtime.ts
@@ -1,7 +1,9 @@
+import type { ActionLedgerRequestContextValues } from "@voyant-travel/action-ledger"
 import { defineToolContextContribution, requireService } from "@voyant-travel/tools"
 import type { Context } from "hono"
 import { notificationsRuntimePort } from "./runtime-port.js"
 import { createNotificationService, notificationsService } from "./service.js"
+import { executeDurableNotificationSendCommand } from "./service-durable-send.js"
 import type { NotificationsToolServices } from "./tools.js"
 import type { NotificationProvider } from "./types.js"
 
@@ -25,12 +27,36 @@ export const voyantToolContextContribution = defineToolContextContribution({
     const notifications: NotificationsToolServices = {
       listDeliveries: (query) => notificationsService.listDeliveries(c.var.db, query),
       getDeliveryById: (id) => notificationsService.getDeliveryById(c.var.db, id),
-      sendTemplated: (input) =>
-        notificationsService.sendNotification(c.var.db, createNotificationService(providers), {
-          ...input,
-          targetType: "other",
-        }),
+      async sendTemplated(input, admitted) {
+        const result = await executeDurableNotificationSendCommand({
+          db: c.var.db,
+          context: actionLedgerContext(c),
+          admitted,
+          dispatcher: createNotificationService(providers),
+          input,
+        })
+        return result.value
+      },
     }
     return { notifications }
   },
 })
+
+function actionLedgerContext(c: Context): ActionLedgerRequestContextValues {
+  const vars = c.var as Record<string, unknown>
+  return {
+    userId: (vars.userId as string | undefined) ?? null,
+    agentId: (vars.agentId as string | undefined) ?? null,
+    workflowPrincipalId: (vars.workflowPrincipalId as string | undefined) ?? null,
+    principalSubtype: (vars.principalSubtype as string | undefined) ?? null,
+    sessionId: (vars.sessionId as string | undefined) ?? null,
+    apiTokenId: ((vars.apiTokenId ?? vars.apiKeyId) as string | undefined) ?? null,
+    callerType: (vars.callerType as ActionLedgerRequestContextValues["callerType"]) ?? null,
+    actor: (vars.actor as ActionLedgerRequestContextValues["actor"]) ?? null,
+    isInternalRequest: (vars.isInternalRequest as boolean | undefined) ?? false,
+    organizationId: (vars.organizationId as string | undefined) ?? null,
+    workflowRunId: (vars.workflowRunId as string | undefined) ?? null,
+    workflowStepId: (vars.workflowStepId as string | undefined) ?? null,
+    correlationId: c.req.header("x-correlation-id") ?? c.req.header("x-request-id") ?? null,
+  }
+}

--- a/packages/notifications/src/providers/local.ts
+++ b/packages/notifications/src/providers/local.ts
@@ -43,6 +43,11 @@ export function createLocalProvider(options: LocalProviderOptions = {}): Notific
     name,
     channels,
     defaultFromAddress,
+    durableDelivery: {
+      supported: false,
+      reason:
+        "The process-local provider cannot preserve provider idempotency across process restarts.",
+    },
     async send(payload): Promise<NotificationResult> {
       counter += 1
       sink(payload)

--- a/packages/notifications/src/providers/voyant-cloud-email.ts
+++ b/packages/notifications/src/providers/voyant-cloud-email.ts
@@ -62,6 +62,11 @@ export function createVoyantCloudEmailProvider(
     name: "voyant-cloud-email",
     channels: ["email"],
     defaultFromAddress: normalizeSenderAddress(options.from),
+    durableDelivery: {
+      supported: false,
+      reason:
+        "The current Voyant Cloud email client does not expose provider idempotency and reconciliation.",
+    },
     async send(payload): Promise<NotificationResult> {
       if (payload.channel !== "email") {
         throw new Error(

--- a/packages/notifications/src/providers/voyant-cloud-sms.ts
+++ b/packages/notifications/src/providers/voyant-cloud-sms.ts
@@ -35,6 +35,11 @@ export function createVoyantCloudSmsProvider(
   return {
     name: "voyant-cloud-sms",
     channels: ["sms"],
+    durableDelivery: {
+      supported: false,
+      reason:
+        "The current Voyant Cloud SMS client does not expose provider idempotency and reconciliation.",
+    },
     async send(payload): Promise<NotificationResult> {
       if (payload.channel !== "sms") {
         throw new Error(

--- a/packages/notifications/src/reminder-job.ts
+++ b/packages/notifications/src/reminder-job.ts
@@ -1,5 +1,7 @@
 import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
 import { notificationsReminderJobRuntimePort } from "./reminder-job-runtime-port.js"
+import { drainDurableNotificationSends } from "./service-durable-send.js"
+import { buildNotificationTaskRuntime } from "./task-runtime.js"
 import { sendDueNotificationReminders } from "./tasks/send-due-reminders.js"
 
 export { notificationsReminderJobRuntimePort } from "./reminder-job-runtime-port.js"
@@ -11,4 +13,14 @@ export async function runDueNotificationRemindersJob(
   const runtime = await context.getPort(notificationsReminderJobRuntimePort)
   const [db, env] = await Promise.all([runtime.resolveDb(), runtime.resolveEnv()])
   await sendDueNotificationReminders(db, env, {}, await runtime.resolveRuntimeOptions(env))
+}
+
+/** Reconcile and deliver package-owned durable notification send operations. */
+export async function runDueNotificationSendsJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  const runtime = await context.getPort(notificationsReminderJobRuntimePort)
+  const [db, env] = await Promise.all([runtime.resolveDb(), runtime.resolveEnv()])
+  const taskRuntime = buildNotificationTaskRuntime(env, await runtime.resolveRuntimeOptions(env))
+  await drainDurableNotificationSends(db, taskRuntime.providers)
 }

--- a/packages/notifications/src/schema.ts
+++ b/packages/notifications/src/schema.ts
@@ -30,6 +30,14 @@ export const notificationDeliveryStatusEnum = pgEnum("notification_delivery_stat
   "cancelled",
 ])
 
+export const notificationSendOperationStatusEnum = pgEnum("notification_send_operation_status", [
+  "pending",
+  "processing",
+  "retry",
+  "sent",
+  "dead_letter",
+])
+
 export const notificationTargetTypeEnum = pgEnum("notification_target_type", [
   "booking",
   "booking_payment_schedule",
@@ -184,6 +192,62 @@ export const notificationDeliveryRequests = pgTable(
   },
   (table) => [uniqueIndex("uidx_notification_delivery_requests_delivery").on(table.deliveryId)],
 )
+
+/**
+ * Package-owned durable state for agent-initiated notification sends.
+ *
+ * The action ledger owns immutable command admission. This row owns the exact
+ * rendered provider request, the stable provider idempotency key, retry lease,
+ * and canonical delivery result.
+ */
+export const notificationSendOperations = pgTable(
+  "notification_send_operations",
+  {
+    id: typeId("notification_send_operations"),
+    commandScope: text("command_scope").notNull(),
+    idempotencyKey: text("idempotency_key").notNull(),
+    requestFingerprint: text("request_fingerprint").notNull(),
+    claimActionId: text("claim_action_id").notNull().unique(),
+    organizationId: text("organization_id"),
+    targetType: text("target_type").notNull(),
+    targetId: text("target_id").notNull(),
+    deliveryId: typeIdRef("delivery_id")
+      .notNull()
+      .references(() => notificationDeliveries.id, { onDelete: "restrict" }),
+    provider: text("provider").notNull(),
+    providerIdempotencyKey: text("provider_idempotency_key").notNull(),
+    requestPayload: jsonb("request_payload").$type<Record<string, unknown>>().notNull(),
+    resultSnapshot: jsonb("result_snapshot").$type<Record<string, unknown>>().notNull(),
+    status: notificationSendOperationStatusEnum("status").notNull().default("pending"),
+    attempts: integer("attempts").notNull().default(0),
+    maxAttempts: integer("max_attempts").notNull().default(8),
+    nextAttemptAt: timestamp("next_attempt_at", { withTimezone: true }).notNull().defaultNow(),
+    leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+    lastError: text("last_error"),
+    completedAt: timestamp("completed_at", { withTimezone: true }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("uidx_notification_send_operations_command").on(
+      table.commandScope,
+      table.idempotencyKey,
+    ),
+    uniqueIndex("uidx_notification_send_operations_provider_key").on(
+      table.provider,
+      table.providerIdempotencyKey,
+    ),
+    index("idx_notification_send_operations_due").on(
+      table.status,
+      table.nextAttemptAt,
+      table.leaseExpiresAt,
+    ),
+    index("idx_notification_send_operations_delivery").on(table.deliveryId),
+  ],
+)
+
+export type NotificationSendOperation = typeof notificationSendOperations.$inferSelect
+export type NewNotificationSendOperation = typeof notificationSendOperations.$inferInsert
 
 export const notificationReminderRules = pgTable(
   "notification_reminder_rules",

--- a/packages/notifications/src/service-deliveries.ts
+++ b/packages/notifications/src/service-deliveries.ts
@@ -41,7 +41,7 @@ function normalizeSenderAddress(value: string | null | undefined) {
   return normalized ? normalized : null
 }
 
-function resolveDeliverySender(input: {
+export function resolveDeliverySender(input: {
   channel: string
   provider: NotificationProvider
   inputFrom?: string | null

--- a/packages/notifications/src/service-durable-send.ts
+++ b/packages/notifications/src/service-durable-send.ts
@@ -1,0 +1,689 @@
+// agent-quality: file-size exception -- owner: notifications; command admission, immutable replay, provider reconciliation, leases, and settlement intentionally share one durable operation protocol.
+import {
+  type ActionLedgerRequestContextValues,
+  type AdmittedExistingTargetCommand,
+  type ExistingTargetCommandPayload,
+  executeAdmittedExistingTargetCommand,
+} from "@voyant-travel/action-ledger"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { insertOutboxEvents } from "@voyant-travel/db/outbox"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import { and, eq, sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+import {
+  type NotificationSendOperation,
+  notificationDeliveries,
+  notificationSendOperations,
+  notificationTemplates,
+} from "./schema.js"
+import { resolveDeliverySender } from "./service-deliveries.js"
+import {
+  NotificationError,
+  type NotificationService,
+  renderNotificationTemplate,
+} from "./service-shared.js"
+import type { SendTemplatedNotificationInput } from "./tools.js"
+import type {
+  DurableNotificationDeliveryCapability,
+  NotificationPayload,
+  NotificationProvider,
+  NotificationResult,
+} from "./types.js"
+
+export const NOTIFICATION_SEND_REQUESTED_EVENT = "notification.send-requested"
+export const NOTIFICATION_SEND_COMPLETED_EVENT = "notification.sent"
+export const NOTIFICATION_SEND_DEAD_LETTERED_EVENT = "notification.send-dead-lettered"
+
+const DEFAULT_MAX_ATTEMPTS = 8
+const DEFAULT_VISIBILITY_TIMEOUT_MS = 2 * 60_000
+const DEFAULT_RETRY_BASE_MS = 5_000
+const PROVIDER_IDEMPOTENCY_KEY_PATTERN = /^[A-Za-z0-9:_-]{1,128}$/
+
+export class NotificationDurableProviderError extends NotificationError {
+  constructor(provider: string, reason: string) {
+    super(`Notification provider "${provider}" cannot execute durable sends: ${reason}`)
+    this.name = "NotificationDurableProviderError"
+  }
+}
+
+export interface ExecuteDurableNotificationSendInput {
+  db: AnyDrizzleDb
+  context: ActionLedgerRequestContextValues
+  admitted: ToolHandlerActionPolicyContext
+  dispatcher: NotificationService
+  input: SendTemplatedNotificationInput
+  testHooks?: {
+    afterPrepare?: (tx: AnyDrizzleDb, operationId: string) => Promise<void>
+  }
+}
+
+/**
+ * Admit an agent send as an existing-target command. The transaction records
+ * the rendered provider request and requested outbox event; no provider code
+ * runs on the request path.
+ */
+export async function executeDurableNotificationSendCommand(
+  input: ExecuteDurableNotificationSendInput,
+) {
+  return executeAdmittedExistingTargetCommand(
+    {
+      db: input.db,
+      context: input.context,
+      admitted: input.admitted,
+      commandInput: input.input,
+      evaluatedRisk: "high",
+    },
+    {
+      async prepare(tx, command, payload) {
+        const operationId = await prepareDurableNotificationSend(
+          tx,
+          input.dispatcher,
+          command,
+          payload,
+        )
+        await input.testHooks?.afterPrepare?.(tx, operationId)
+      },
+      execute: (command) => resolveDurableNotificationResult(input.db, command),
+      replay: (command) => resolveDurableNotificationResult(input.db, command),
+    },
+  )
+}
+
+async function prepareDurableNotificationSend(
+  tx: AnyDrizzleDb,
+  dispatcher: NotificationService,
+  command: AdmittedExistingTargetCommand,
+  input: ExistingTargetCommandPayload<SendTemplatedNotificationInput>,
+): Promise<string> {
+  assertOrganizationScope(command, input.organizationId)
+  const [template] = await tx
+    .select()
+    .from(notificationTemplates)
+    .where(eq(notificationTemplates.slug, input.templateSlug))
+    .limit(1)
+  if (!template) throw new NotificationError("Notification template not found")
+  if (template.status !== "active") {
+    throw new NotificationError(
+      `Notification template "${template.slug}" is not active and cannot be sent`,
+    )
+  }
+
+  const channel = input.channel ?? template.channel
+  const defaultProvider = dispatcher.getProvider(channel)
+  const providerName = template.provider ?? defaultProvider?.name
+  if (!providerName) {
+    throw new NotificationError(`No notification provider available for channel "${channel}"`)
+  }
+  const provider =
+    providerName === defaultProvider?.name
+      ? defaultProvider
+      : dispatcher.getProviderByName?.(providerName)
+  if (!provider) {
+    throw new NotificationError(`No notification provider registered with name "${providerName}"`)
+  }
+  requireDurableCapability(provider)
+
+  const data = input.data ?? {}
+  const fromAddress = resolveDeliverySender({
+    channel,
+    provider,
+    templateFrom: template.fromAddress,
+  })
+  const subject = renderNotificationTemplate(template.subjectTemplate, data)
+  const html = renderNotificationTemplate(template.htmlTemplate, data)
+  const text = renderNotificationTemplate(template.textTemplate, data)
+  const providerPayload: NotificationPayload & Record<string, unknown> = {
+    to: input.to,
+    channel,
+    provider: providerName,
+    template: template.slug,
+    data,
+    ...(fromAddress ? { from: fromAddress } : {}),
+    ...(subject ? { subject } : {}),
+    ...(html ? { html } : {}),
+    ...(text ? { text } : {}),
+  }
+
+  const [delivery] = await tx
+    .insert(notificationDeliveries)
+    .values({
+      templateId: template.id,
+      templateSlug: template.slug,
+      targetType: "other",
+      targetId: template.slug,
+      personId: input.personId ?? null,
+      organizationId: input.organizationId ?? null,
+      bookingId: input.bookingId ?? null,
+      invoiceId: input.invoiceId ?? null,
+      channel,
+      provider: providerName,
+      status: "pending",
+      toAddress: input.to,
+      fromAddress,
+      subject: subject ?? null,
+      htmlBody: html ?? null,
+      textBody: text ?? null,
+      payloadData: data,
+      metadata: {
+        durableCommand: true,
+        claimActionId: command.causation.claimActionId,
+      },
+    })
+    .returning()
+  if (!delivery) throw new NotificationError("Failed to prepare notification delivery")
+
+  const providerIdempotencyKey = providerDeliveryKey(command)
+  const [operation] = await tx
+    .insert(notificationSendOperations)
+    .values({
+      commandScope: command.idempotency.scope,
+      idempotencyKey: command.idempotency.key,
+      requestFingerprint: command.idempotency.fingerprint,
+      claimActionId: command.causation.claimActionId,
+      organizationId: command.authorization.organizationId,
+      targetType: command.target.type,
+      targetId: command.target.id,
+      deliveryId: delivery.id,
+      provider: providerName,
+      providerIdempotencyKey,
+      requestPayload: providerPayload,
+      resultSnapshot: toJsonRecord(delivery),
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    })
+    .returning()
+  if (!operation) throw new NotificationError("Failed to prepare durable notification operation")
+
+  await insertOutboxEvents(tx, [
+    {
+      name: NOTIFICATION_SEND_REQUESTED_EVENT,
+      data: {
+        operationId: operation.id,
+        deliveryId: delivery.id,
+        provider: providerName,
+        targetType: command.target.type,
+        targetId: command.target.id,
+      },
+      metadata: {
+        category: "domain",
+        source: "service",
+        eventId: requestedEventId(operation.id),
+        correlationId: command.causation.claimActionId,
+      },
+    },
+  ])
+  return operation.id
+}
+
+async function resolveDurableNotificationResult(
+  db: AnyDrizzleDb,
+  command: AdmittedExistingTargetCommand,
+) {
+  const [operation] = await db
+    .select()
+    .from(notificationSendOperations)
+    .where(
+      and(
+        eq(notificationSendOperations.commandScope, command.idempotency.scope),
+        eq(notificationSendOperations.idempotencyKey, command.idempotency.key),
+      ),
+    )
+    .limit(1)
+  if (
+    !operation ||
+    operation.requestFingerprint !== command.idempotency.fingerprint ||
+    operation.claimActionId !== command.causation.claimActionId ||
+    operation.targetType !== command.target.type ||
+    operation.targetId !== command.target.id ||
+    operation.organizationId !== command.authorization.organizationId
+  ) {
+    throw new NotificationError("Durable notification command state is missing or inconsistent")
+  }
+  return operation.resultSnapshot
+}
+
+export interface DrainDurableNotificationSendsOptions {
+  limit?: number
+  now?: Date
+  visibilityTimeoutMs?: number
+  retryBaseMs?: number
+  testHooks?: {
+    afterProviderAccepted?: (
+      operation: NotificationSendOperation,
+      result: NotificationResult,
+    ) => Promise<void>
+    beforeCompletionEvent?: (
+      tx: AnyDrizzleDb,
+      operation: NotificationSendOperation,
+    ) => Promise<void>
+  }
+}
+
+export interface DrainDurableNotificationSendsResult {
+  claimed: number
+  sent: number
+  retried: number
+  deadLettered: number
+}
+
+/**
+ * Claim and process recoverable provider work. Reconciliation always precedes
+ * send, and both paths use the same provider idempotency key.
+ */
+export async function drainDurableNotificationSends(
+  db: PostgresJsDatabase,
+  providers: ReadonlyArray<NotificationProvider>,
+  options: DrainDurableNotificationSendsOptions = {},
+): Promise<DrainDurableNotificationSendsResult> {
+  const now = options.now ?? new Date()
+  const operations = await claimDurableNotificationSends(db, {
+    limit: options.limit,
+    now,
+    visibilityTimeoutMs: options.visibilityTimeoutMs,
+  })
+  const byName = new Map(providers.map((provider) => [provider.name, provider]))
+  const result = {
+    claimed: operations.length,
+    sent: 0,
+    retried: 0,
+    deadLettered: 0,
+  }
+
+  for (const operation of operations) {
+    const provider = byName.get(operation.provider)
+    if (!provider) {
+      const terminal = operation.attempts >= operation.maxAttempts
+      const transitioned = await failDurableNotificationSend(
+        db,
+        operation,
+        "provider is not currently registered",
+        now,
+        options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS,
+        terminal,
+      )
+      if (transitioned) {
+        if (terminal) result.deadLettered += 1
+        else result.retried += 1
+      }
+      continue
+    }
+    const capability = provider.durableDelivery
+    if (!capability?.supported) {
+      const transitioned = await failDurableNotificationSend(
+        db,
+        operation,
+        capability?.reason ?? "provider does not declare durable delivery support",
+        now,
+        0,
+        true,
+      )
+      if (transitioned) result.deadLettered += 1
+      continue
+    }
+
+    try {
+      const context = { idempotencyKey: operation.providerIdempotencyKey }
+      const reconciled = await capability.reconcile(context)
+      const providerResult =
+        reconciled ??
+        (await capability.send(notificationPayload(operation.requestPayload), context))
+      if (providerResult.provider !== operation.provider) {
+        throw new NotificationError(
+          `Durable notification provider result mismatch: expected "${operation.provider}", received "${providerResult.provider}"`,
+        )
+      }
+      await options.testHooks?.afterProviderAccepted?.(operation, providerResult)
+      const transitioned = await settleDurableNotificationSend(
+        db,
+        operation,
+        providerResult,
+        now,
+        options.testHooks?.beforeCompletionEvent,
+      )
+      if (transitioned) result.sent += 1
+    } catch (error) {
+      const terminal = operation.attempts >= operation.maxAttempts
+      const transitioned = await failDurableNotificationSend(
+        db,
+        operation,
+        errorMessage(error),
+        now,
+        options.retryBaseMs ?? DEFAULT_RETRY_BASE_MS,
+        terminal,
+      )
+      if (transitioned) {
+        if (terminal) result.deadLettered += 1
+        else result.retried += 1
+      }
+    }
+  }
+
+  return result
+}
+
+async function claimDurableNotificationSends(
+  db: PostgresJsDatabase,
+  options: Pick<DrainDurableNotificationSendsOptions, "limit" | "now" | "visibilityTimeoutMs">,
+): Promise<NotificationSendOperation[]> {
+  const now = options.now ?? new Date()
+  const leaseExpiresAt = new Date(
+    now.getTime() + (options.visibilityTimeoutMs ?? DEFAULT_VISIBILITY_TIMEOUT_MS),
+  )
+  const nowIso = now.toISOString()
+  const leaseExpiresAtIso = leaseExpiresAt.toISOString()
+  // agent-quality: raw-sql reviewed -- owner: notifications; fixed table/column names with bound values implement one atomic SKIP LOCKED lease claim.
+  const raw = await db.execute(sql`
+    UPDATE notification_send_operations
+    SET
+      status = 'processing',
+      attempts = attempts + 1,
+      lease_expires_at = ${leaseExpiresAtIso},
+      updated_at = ${nowIso}
+    WHERE id IN (
+      SELECT id
+      FROM notification_send_operations
+      WHERE
+        (
+          status IN ('pending', 'retry')
+          AND attempts < max_attempts
+          AND next_attempt_at <= ${nowIso}
+        )
+        OR (status = 'processing' AND lease_expires_at <= ${nowIso})
+      ORDER BY next_attempt_at, created_at
+      FOR UPDATE SKIP LOCKED
+      LIMIT ${Math.max(1, Math.min(options.limit ?? 25, 100))}
+    )
+    RETURNING *
+  `)
+  return resultRows<Record<string, unknown>>(raw).map(normalizeClaimedOperation)
+}
+
+async function settleDurableNotificationSend(
+  db: PostgresJsDatabase,
+  operation: NotificationSendOperation,
+  result: NotificationResult,
+  now: Date,
+  beforeCompletionEvent:
+    | ((tx: AnyDrizzleDb, operation: NotificationSendOperation) => Promise<void>)
+    | undefined,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    const updated = await tx
+      .update(notificationSendOperations)
+      .set({
+        status: "sent",
+        leaseExpiresAt: null,
+        lastError: null,
+        completedAt: now,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(notificationSendOperations.id, operation.id),
+          eq(notificationSendOperations.status, "processing"),
+          eq(notificationSendOperations.leaseExpiresAt, operation.leaseExpiresAt!),
+        ),
+      )
+      .returning({ id: notificationSendOperations.id })
+    if (updated.length !== 1) return false
+    await tx
+      .update(notificationDeliveries)
+      .set({
+        status: "sent",
+        providerMessageId: result.id ?? null,
+        sentAt: now,
+        failedAt: null,
+        errorMessage: null,
+        updatedAt: now,
+      })
+      .where(eq(notificationDeliveries.id, operation.deliveryId))
+    await beforeCompletionEvent?.(tx, operation)
+    await insertOutboxEvents(tx, [
+      {
+        name: NOTIFICATION_SEND_COMPLETED_EVENT,
+        data: {
+          operationId: operation.id,
+          deliveryId: operation.deliveryId,
+          provider: result.provider,
+          providerMessageId: result.id ?? null,
+        },
+        metadata: {
+          category: "domain",
+          source: "service",
+          eventId: completedEventId(operation.id),
+          correlationId: operation.claimActionId,
+        },
+      },
+    ])
+    return true
+  })
+}
+
+async function failDurableNotificationSend(
+  db: PostgresJsDatabase,
+  operation: NotificationSendOperation,
+  message: string,
+  now: Date,
+  retryBaseMs: number,
+  terminal: boolean,
+): Promise<boolean> {
+  const lastError = message.slice(0, 2_000)
+  const nextAttemptAt = new Date(
+    now.getTime() + Math.min(retryBaseMs * 2 ** Math.max(0, operation.attempts - 1), 15 * 60_000),
+  )
+  return db.transaction(async (tx) => {
+    const updated = await tx
+      .update(notificationSendOperations)
+      .set({
+        status: terminal ? "dead_letter" : "retry",
+        leaseExpiresAt: null,
+        lastError,
+        nextAttemptAt,
+        completedAt: terminal ? now : null,
+        updatedAt: now,
+      })
+      .where(
+        and(
+          eq(notificationSendOperations.id, operation.id),
+          eq(notificationSendOperations.status, "processing"),
+          eq(notificationSendOperations.leaseExpiresAt, operation.leaseExpiresAt!),
+        ),
+      )
+      .returning({ id: notificationSendOperations.id })
+    if (updated.length !== 1) return false
+    if (!terminal) return true
+    await tx
+      .update(notificationDeliveries)
+      .set({
+        status: "failed",
+        failedAt: now,
+        errorMessage: lastError,
+        updatedAt: now,
+      })
+      .where(eq(notificationDeliveries.id, operation.deliveryId))
+    await insertOutboxEvents(tx, [
+      {
+        name: NOTIFICATION_SEND_DEAD_LETTERED_EVENT,
+        data: {
+          operationId: operation.id,
+          deliveryId: operation.deliveryId,
+          provider: operation.provider,
+          attempts: operation.attempts,
+          error: lastError,
+        },
+        metadata: {
+          category: "domain",
+          source: "service",
+          eventId: deadLetteredEventId(operation.id),
+          correlationId: operation.claimActionId,
+        },
+      },
+    ])
+    return true
+  })
+}
+
+function requireDurableCapability(
+  provider: NotificationProvider,
+): Extract<DurableNotificationDeliveryCapability, { supported: true }> {
+  const capability = provider.durableDelivery
+  if (!capability?.supported) {
+    throw new NotificationDurableProviderError(
+      provider.name,
+      capability?.reason ?? "provider does not declare durable delivery support",
+    )
+  }
+  if (
+    capability.protocol !== "notification-provider-idempotency-v1" ||
+    typeof capability.send !== "function" ||
+    typeof capability.reconcile !== "function"
+  ) {
+    throw new NotificationDurableProviderError(
+      provider.name,
+      "provider durable delivery capability is incomplete",
+    )
+  }
+  return capability
+}
+
+function assertOrganizationScope(
+  command: AdmittedExistingTargetCommand,
+  associatedOrganizationId: string | undefined,
+): void {
+  if (
+    associatedOrganizationId !== undefined &&
+    associatedOrganizationId !== command.authorization.organizationId
+  ) {
+    throw new NotificationError(
+      "Notification organization association does not match the admitted organization",
+    )
+  }
+}
+
+function providerDeliveryKey(command: AdmittedExistingTargetCommand): string {
+  const key = `voyant:notification:${command.causation.claimActionId}`
+  if (!PROVIDER_IDEMPOTENCY_KEY_PATTERN.test(key)) {
+    throw new NotificationError("Admitted notification command cannot form a provider-safe key")
+  }
+  return key
+}
+
+function resultRows<T>(result: unknown): T[] {
+  if (Array.isArray(result)) return result as T[]
+  if (
+    result &&
+    typeof result === "object" &&
+    "rows" in result &&
+    Array.isArray((result as { rows: unknown }).rows)
+  ) {
+    return (result as { rows: T[] }).rows
+  }
+  return []
+}
+
+function normalizeClaimedOperation(row: Record<string, unknown>): NotificationSendOperation {
+  return {
+    id: row.id,
+    commandScope: row.command_scope ?? row.commandScope,
+    idempotencyKey: row.idempotency_key ?? row.idempotencyKey,
+    requestFingerprint: row.request_fingerprint ?? row.requestFingerprint,
+    claimActionId: row.claim_action_id ?? row.claimActionId,
+    organizationId: row.organization_id ?? row.organizationId ?? null,
+    targetType: row.target_type ?? row.targetType,
+    targetId: row.target_id ?? row.targetId,
+    deliveryId: row.delivery_id ?? row.deliveryId,
+    provider: row.provider,
+    providerIdempotencyKey: row.provider_idempotency_key ?? row.providerIdempotencyKey,
+    requestPayload: row.request_payload ?? row.requestPayload,
+    resultSnapshot: row.result_snapshot ?? row.resultSnapshot,
+    status: row.status,
+    attempts: row.attempts,
+    maxAttempts: row.max_attempts ?? row.maxAttempts,
+    nextAttemptAt: coerceDate(row.next_attempt_at ?? row.nextAttemptAt),
+    leaseExpiresAt:
+      (row.lease_expires_at ?? row.leaseExpiresAt) == null
+        ? null
+        : coerceDate(row.lease_expires_at ?? row.leaseExpiresAt),
+    lastError: row.last_error ?? row.lastError ?? null,
+    completedAt:
+      (row.completed_at ?? row.completedAt) == null
+        ? null
+        : coerceDate(row.completed_at ?? row.completedAt),
+    createdAt: coerceDate(row.created_at ?? row.createdAt),
+    updatedAt: coerceDate(row.updated_at ?? row.updatedAt),
+  } as NotificationSendOperation
+}
+
+function coerceDate(value: unknown): Date {
+  return value instanceof Date ? value : new Date(String(value))
+}
+
+function toJsonRecord(value: object): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, nested]) => [key, toJsonValue(nested)] as const)
+      .filter(([, nested]) => nested !== undefined),
+  )
+}
+
+function toJsonValue(value: unknown): unknown {
+  if (value instanceof Date) return value.toISOString()
+  if (Array.isArray(value)) return value.map(toJsonValue)
+  if (typeof value !== "object" || value === null) return value
+  return toJsonRecord(value)
+}
+
+function notificationPayload(value: Record<string, unknown>): NotificationPayload {
+  const to = requiredPayloadString(value, "to")
+  const channel = requiredPayloadString(value, "channel")
+  const template = requiredPayloadString(value, "template")
+  const provider = optionalPayloadString(value, "provider")
+  const from = optionalPayloadString(value, "from")
+  const subject = optionalPayloadString(value, "subject")
+  const html = optionalPayloadString(value, "html")
+  const text = optionalPayloadString(value, "text")
+  return {
+    to,
+    channel,
+    template,
+    data: value.data,
+    ...(provider ? { provider } : {}),
+    ...(from ? { from } : {}),
+    ...(subject ? { subject } : {}),
+    ...(html ? { html } : {}),
+    ...(text ? { text } : {}),
+  }
+}
+
+function requiredPayloadString(value: Record<string, unknown>, field: string): string {
+  const candidate = value[field]
+  if (typeof candidate !== "string" || !candidate) {
+    throw new NotificationError(`Durable notification payload is missing "${field}"`)
+  }
+  return candidate
+}
+
+function optionalPayloadString(value: Record<string, unknown>, field: string): string | undefined {
+  const candidate = value[field]
+  if (candidate === undefined) return undefined
+  if (typeof candidate !== "string") {
+    throw new NotificationError(`Durable notification payload has invalid "${field}"`)
+  }
+  return candidate
+}
+
+function requestedEventId(operationId: string): string {
+  return `evt_notifications_send_requested_${operationId}`
+}
+
+function completedEventId(operationId: string): string {
+  return `evt_notifications_send_completed_${operationId}`
+}
+
+function deadLetteredEventId(operationId: string): string {
+  return `evt_notifications_send_dead_lettered_${operationId}`
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : "Notification provider delivery failed"
+}

--- a/packages/notifications/src/tools.ts
+++ b/packages/notifications/src/tools.ts
@@ -11,7 +11,15 @@
  * runtime. Sending is externally-committing (an email/SMS cannot be unsent) and
  * `notifications:send` is never granted by a wildcard — see the api-key taxonomy.
  */
-import { defineTool, READ_ONLY_RISK, requireService, type ToolContext } from "@voyant-travel/tools"
+import {
+  admitHandlerActionPolicy,
+  defineTool,
+  type HandlerActionPolicyExpectation,
+  READ_ONLY_RISK,
+  requireService,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { listResponseSchema } from "@voyant-travel/types"
 import { z } from "zod"
 
@@ -33,7 +41,10 @@ export interface SendTemplatedNotificationInput {
 export interface NotificationsToolServices {
   listDeliveries(query: z.infer<typeof notificationDeliveryListQuerySchema>): Promise<unknown>
   getDeliveryById(id: string): Promise<unknown>
-  sendTemplated(input: SendTemplatedNotificationInput): Promise<unknown>
+  sendTemplated(
+    input: SendTemplatedNotificationInput,
+    admitted: ToolHandlerActionPolicyContext,
+  ): Promise<unknown>
 }
 
 export type NotificationsToolContext = ToolContext & { notifications?: NotificationsToolServices }
@@ -107,16 +118,41 @@ const sendNotificationArgs = z.object({
   organizationId: z.string().optional().describe("Associate the delivery with a CRM organization."),
 })
 
+export const SEND_NOTIFICATION_HANDLER_POLICY = {
+  capabilityId: "@voyant-travel/notifications#tool.send-notification",
+  capabilityVersion: "v2",
+  canonicalName: "send_notification",
+  actionPolicy: {
+    id: "@voyant-travel/notifications#action.send-notification",
+    capabilityId: "@voyant-travel/notifications#action.send-notification",
+    version: "v2",
+    kind: "execute",
+    targetType: "notification-template",
+    commandTargetField: "templateSlug",
+    targetLifecycle: "existing",
+    existingTarget: { durability: "handler-command-result-v1" },
+    risk: "high",
+    ledger: "required",
+    approval: "required",
+    policy: "notifications-agent-send",
+    reversible: false,
+  },
+} as const satisfies HandlerActionPolicyExpectation
+
 export const sendNotificationTool = defineTool<
   z.infer<typeof sendNotificationArgs>,
   unknown,
   NotificationsToolContext
 >({
+  owner: "@voyant-travel/notifications",
+  capabilityId: "@voyant-travel/notifications#tool.send-notification",
+  capabilityVersion: "v2",
   name: "send_notification",
   description:
-    "Send a notification by rendering a vetted template to a recipient (externally-committing: an " +
-    "email/SMS cannot be unsent). Only template sends are allowed — arbitrary subject/html/text is " +
-    "not accepted. Requires the notifications:send grant and explicit confirmation.",
+    "Accept a notification for durable asynchronous delivery by rendering a vetted template to a " +
+    "recipient (externally-committing: an email/SMS cannot be unsent). Returns an immutable pending " +
+    "delivery snapshot; poll get_notification_delivery for mutable status. Only template sends are " +
+    "allowed. Requires the notifications:send grant and explicit confirmation.",
   inputSchema: sendNotificationArgs,
   outputSchema: notificationDeliverySchema,
   requiredScopes: ["notifications:send"],
@@ -128,10 +164,13 @@ export const sendNotificationTool = defineTool<
     confirmationRequired: true,
     sideEffects: ["email", "sms"],
   },
+  annotations: { idempotentHint: true },
+  actionPolicyEnforcement: "handler",
   async handler(input, ctx) {
+    const admitted = admitHandlerActionPolicy(ctx, SEND_NOTIFICATION_HANDLER_POLICY)
     return parseJsonResult(
       notificationDeliverySchema,
-      await notifications(ctx).sendTemplated(input),
+      await notifications(ctx).sendTemplated(input, admitted),
     )
   },
 })

--- a/packages/notifications/src/types.ts
+++ b/packages/notifications/src/types.ts
@@ -63,6 +63,37 @@ export interface NotificationResult {
   provider: string
 }
 
+export interface DurableNotificationDeliveryContext {
+  /**
+   * Stable across worker retries and process restarts. Providers must scope
+   * this key to their account/tenant and reject payload drift.
+   */
+  idempotencyKey: string
+}
+
+export type DurableNotificationDeliveryCapability =
+  | {
+      supported: false
+      reason: string
+    }
+  | {
+      supported: true
+      protocol: "notification-provider-idempotency-v1"
+      /**
+       * Deliver once for this key. Repeating the same key and payload must
+       * return the original provider result; key reuse with drift must reject.
+       */
+      send(
+        payload: NotificationPayload,
+        context: DurableNotificationDeliveryContext,
+      ): Promise<NotificationResult>
+      /**
+       * Resolve an already accepted send after an ambiguous worker crash.
+       * Returns null only when the provider can prove the key was not accepted.
+       */
+      reconcile(context: DurableNotificationDeliveryContext): Promise<NotificationResult | null>
+    }
+
 /**
  * A pluggable notification provider. Implementations target one or more
  * channels and handle the actual delivery (HTTP call, SMTP, etc.).
@@ -86,6 +117,13 @@ export interface NotificationProvider {
    * sender before dispatch.
    */
   readonly defaultFromAddress?: string | null
+  /**
+   * Explicit durable-send capability. Providers that omit it, or declare
+   * `supported: false`, remain valid for request-scoped application sends but
+   * are rejected by the agent send command before any durable intent is
+   * admitted.
+   */
+  readonly durableDelivery?: DurableNotificationDeliveryCapability
   /** Deliver the notification. Throws on failure. */
   send(payload: NotificationPayload): Promise<NotificationResult>
 }

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -106,6 +106,21 @@ export const notificationsVoyantModule = defineModule({
   ],
   jobs: [
     {
+      id: "notifications.deliver-durable-sends",
+      schedule: { cron: "* * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "* * * * *", overlap: "skip" },
+          economical: { cron: "*/5 * * * *", overlap: "skip" },
+        },
+      },
+      runtime: {
+        entry: "@voyant-travel/notifications/reminder-job",
+        export: "runDueNotificationSendsJob",
+      },
+    },
+    {
       id: "notifications.send-due-reminders",
       schedule: { cron: "0 * * * *", overlap: "skip" },
       scheduling: {
@@ -122,6 +137,62 @@ export const notificationsVoyantModule = defineModule({
     },
   ],
   events: [
+    {
+      id: "@voyant-travel/notifications#event.notification.send-requested",
+      eventType: "notification.send-requested",
+      version: "1.0.0",
+      payloadSchema: {
+        type: "object",
+        required: ["operationId", "deliveryId", "provider", "targetType", "targetId"],
+        properties: {
+          operationId: { type: "string" },
+          deliveryId: { type: "string" },
+          provider: { type: "string" },
+          targetType: { type: "string" },
+          targetId: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      visibility: "internal",
+      audit: { sourceModule: "notifications", category: "domain" },
+    },
+    {
+      id: "@voyant-travel/notifications#event.notification.sent",
+      eventType: "notification.sent",
+      version: "1.0.0",
+      payloadSchema: {
+        type: "object",
+        required: ["operationId", "deliveryId", "provider", "providerMessageId"],
+        properties: {
+          operationId: { type: "string" },
+          deliveryId: { type: "string" },
+          provider: { type: "string" },
+          providerMessageId: { anyOf: [{ type: "string" }, { type: "null" }] },
+        },
+        additionalProperties: false,
+      },
+      visibility: "internal",
+      audit: { sourceModule: "notifications", category: "domain" },
+    },
+    {
+      id: "@voyant-travel/notifications#event.notification.send-dead-lettered",
+      eventType: "notification.send-dead-lettered",
+      version: "1.0.0",
+      payloadSchema: {
+        type: "object",
+        required: ["operationId", "deliveryId", "provider", "attempts", "error"],
+        properties: {
+          operationId: { type: "string" },
+          deliveryId: { type: "string" },
+          provider: { type: "string" },
+          attempts: { type: "number" },
+          error: { type: "string" },
+        },
+        additionalProperties: false,
+      },
+      visibility: "internal",
+      audit: { sourceModule: "notifications", category: "domain" },
+    },
     {
       id: "@voyant-travel/notifications#event.booking.fully-paid",
       eventType: "booking.fully-paid",
@@ -198,20 +269,28 @@ export const notificationsVoyantModule = defineModule({
   actions: [
     {
       id: "@voyant-travel/notifications#action.send-notification",
-      version: "v1",
+      version: "v2",
       kind: "execute",
-      targetType: "notification",
+      targetType: "notification-template",
+      commandTargetField: "templateSlug",
+      targetLifecycle: "existing",
+      existingTarget: { durability: "handler-command-result-v1" },
       availability: {
         status: "unavailable",
-        reasonCode: "unsafe-nontransactional-effect",
+        reasonCode: "provider-idempotency-unavailable",
       },
       effectBoundary: "multistage",
+      durability: {
+        strategy: "saga",
+        testReference: "tests/integration/durable-send.test.ts",
+      },
       resource: "notifications",
       action: "send",
       requiredScopes: ["notifications:send"],
       risk: "high",
       ledger: "required",
       approval: "required",
+      policy: "notifications-agent-send",
       reversible: false,
       from: { tools: ["@voyant-travel/notifications#tool.send-notification"] },
     },

--- a/packages/notifications/tests/integration/durable-send.test.ts
+++ b/packages/notifications/tests/integration/durable-send.test.ts
@@ -1,0 +1,622 @@
+// agent-quality: file-size exception -- owner: notifications; one live database suite proves the full durable-send admission, lease, reconciliation, settlement, and dead-letter protocol.
+import { randomUUID } from "node:crypto"
+
+import {
+  type ActionLedgerRequestContextValues,
+  buildActionApprovalCommandFingerprint,
+  decideActionLedgerApproval,
+  requestActionLedgerApproval,
+} from "@voyant-travel/action-ledger"
+import { actionLedgerEntries } from "@voyant-travel/action-ledger/schema"
+import { createDbClient } from "@voyant-travel/db"
+import { eventOutboxTable } from "@voyant-travel/db/schema"
+import { cleanupTestDb } from "@voyant-travel/db/test-utils"
+import type { ToolHandlerActionPolicyContext } from "@voyant-travel/tools"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  notificationDeliveries,
+  notificationSendOperations,
+  notificationTemplates,
+} from "../../src/schema.js"
+import { createNotificationService } from "../../src/service.js"
+import {
+  drainDurableNotificationSends,
+  executeDurableNotificationSendCommand,
+  NOTIFICATION_SEND_COMPLETED_EVENT,
+  NOTIFICATION_SEND_DEAD_LETTERED_EVENT,
+  NOTIFICATION_SEND_REQUESTED_EVENT,
+} from "../../src/service-durable-send.js"
+import { SEND_NOTIFICATION_HANDLER_POLICY } from "../../src/tools.js"
+import type {
+  DurableNotificationDeliveryContext,
+  NotificationPayload,
+  NotificationProvider,
+  NotificationResult,
+} from "../../src/types.js"
+
+const DB_AVAILABLE = !!process.env.TEST_DATABASE_URL
+type ClosableTestDb = PostgresJsDatabase & {
+  $client: { end(options?: { timeout?: number | null }): Promise<unknown> }
+}
+
+describe.skipIf(!DB_AVAILABLE)("durable agent notification sends", () => {
+  let db: ClosableTestDb
+  let provider: ReturnType<typeof durableProvider>
+
+  beforeAll(() => {
+    db = createDbClient(process.env.TEST_DATABASE_URL as string, {
+      adapter: "node",
+      nodeMaxConnections: 2,
+      timeouts: { statementMs: false, queryMs: false, connectMs: false },
+    }) as ClosableTestDb
+  })
+  beforeEach(async () => {
+    await cleanupTestDb(db)
+    provider = durableProvider()
+    await db.insert(notificationTemplates).values({
+      slug: "agent-booking-confirmed",
+      name: "Agent booking confirmation",
+      channel: "email",
+      provider: provider.name,
+      status: "active",
+      subjectTemplate: "Booking {{ bookingId }} confirmed",
+      textTemplate: "Confirmed for {{ traveler }}",
+      fromAddress: "bookings@example.test",
+    })
+  })
+  afterAll(async () => {
+    await db.$client.end({ timeout: 0 })
+  })
+
+  it("atomically prepares once, replays canonically, and rejects payload and organization drift", async () => {
+    const command = await approvedCommand(`concurrent-${randomUUID()}`)
+    const [first, replay] = await Promise.all([execute(command), execute(command)])
+
+    expect([first.replayed, replay.replayed].sort()).toEqual([false, true])
+    expect(first.value).toMatchObject({ id: replay.value.id, status: "pending" })
+    expect(await db.select().from(notificationSendOperations)).toHaveLength(1)
+    expect(await db.select().from(notificationDeliveries)).toHaveLength(1)
+    const ledger = await db.select().from(actionLedgerEntries)
+    expect(ledger.some(({ targetId }) => targetId === "traveler@example.test")).toBe(false)
+    expect(
+      ledger.some(
+        ({ targetType, targetId }) =>
+          targetType === "notification-template" && targetId === "agent-booking-confirmed",
+      ),
+    ).toBe(true)
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_REQUESTED_EVENT,
+      ),
+    ).toHaveLength(1)
+
+    await expect(
+      execute({
+        ...command,
+        input: { ...command.input, data: { bookingId: "BK-DRIFT", traveler: "Other" } },
+      }),
+    ).rejects.toMatchObject({
+      name: expect.stringMatching(
+        /ActionLedgerCreatedCommand(?:Approval|FingerprintMismatch|Protocol)Error/,
+      ),
+    })
+
+    const wrongOrganization = await approvedCommand(`wrong-org-${randomUUID()}`, {
+      inputOrganizationId: "org_other",
+    })
+    await expect(execute(wrongOrganization)).rejects.toThrow(
+      "does not match the admitted organization",
+    )
+    expect(await db.select().from(notificationSendOperations)).toHaveLength(1)
+  })
+
+  it("delivers identical payloads once per distinct admitted command", async () => {
+    const firstCommand = await approvedCommand(`same-payload-a-${randomUUID()}`)
+    const secondCommand = await approvedCommand(`same-payload-b-${randomUUID()}`)
+    expect(secondCommand.context.userId).toBe(firstCommand.context.userId)
+    expect(secondCommand.input).toEqual(firstCommand.input)
+
+    const first = await execute(firstCommand)
+    const second = await execute(secondCommand)
+    const replay = await execute(firstCommand)
+    expect(replay).toMatchObject({ replayed: true, value: first.value })
+    expect(second.value.id).not.toBe(first.value.id)
+
+    const operations = await db.select().from(notificationSendOperations)
+    expect(operations).toHaveLength(2)
+    expect(
+      new Set(operations.map(({ providerIdempotencyKey }) => providerIdempotencyKey)).size,
+    ).toBe(2)
+
+    await expect(drainDurableNotificationSends(db, [provider])).resolves.toMatchObject({
+      claimed: 2,
+      sent: 2,
+    })
+    expect(provider.durableSend).toHaveBeenCalledTimes(2)
+  })
+
+  it("isolates provider delivery keys for identical payloads admitted in different organizations", async () => {
+    const sharedKey = `cross-org-${randomUUID()}`
+    const firstCommand = await approvedCommand(sharedKey, {
+      contextOrganizationId: "org_notifications_a",
+      omitInputOrganizationId: true,
+    })
+    const secondCommand = await approvedCommand(sharedKey, {
+      contextOrganizationId: "org_notifications_b",
+      omitInputOrganizationId: true,
+    })
+    expect(secondCommand.input).toEqual(firstCommand.input)
+
+    await execute(firstCommand)
+    await execute(secondCommand)
+    const operations = await db.select().from(notificationSendOperations)
+    expect(operations).toHaveLength(2)
+    expect(
+      new Set(operations.map(({ providerIdempotencyKey }) => providerIdempotencyKey)).size,
+    ).toBe(2)
+
+    await expect(drainDurableNotificationSends(db, [provider])).resolves.toMatchObject({
+      claimed: 2,
+      sent: 2,
+    })
+    expect(provider.durableSend).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    "draft",
+    "archived",
+  ] as const)("rejects a %s template before committing the command intent", async (status) => {
+    await db
+      .update(notificationTemplates)
+      .set({ status })
+      .where(eq(notificationTemplates.slug, "agent-booking-confirmed"))
+    const command = await approvedCommand(`inactive-${status}-${randomUUID()}`)
+
+    await expect(execute(command)).rejects.toThrow("is not active and cannot be sent")
+    expect(await db.select().from(notificationSendOperations)).toHaveLength(0)
+    expect(await db.select().from(notificationDeliveries)).toHaveLength(0)
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_REQUESTED_EVENT,
+      ),
+    ).toHaveLength(0)
+  })
+
+  it("rolls back the claim, delivery, operation, and requested event when preparation crashes", async () => {
+    const command = await approvedCommand(`prepare-crash-${randomUUID()}`)
+    await expect(
+      executeDurableNotificationSendCommand({
+        ...command,
+        db,
+        dispatcher: createNotificationService([provider]),
+        testHooks: {
+          async afterPrepare() {
+            throw new Error("injected prepare crash")
+          },
+        },
+      }),
+    ).rejects.toThrow("injected prepare crash")
+
+    expect(await db.select().from(notificationSendOperations)).toHaveLength(0)
+    expect(await db.select().from(notificationDeliveries)).toHaveLength(0)
+    expect(
+      await db
+        .select()
+        .from(actionLedgerEntries)
+        .where(eq(actionLedgerEntries.idempotencyKey, command.admitted.invocation.idempotencyKey!)),
+    ).toHaveLength(1)
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_REQUESTED_EVENT,
+      ),
+    ).toHaveLength(0)
+  })
+
+  it("fails closed before committing intent when the selected provider cannot reconcile", async () => {
+    const command = await approvedCommand(`unsupported-${randomUUID()}`)
+    const unsupported: NotificationProvider = {
+      name: provider.name,
+      channels: ["email"],
+      defaultFromAddress: "unsupported@example.test",
+      durableDelivery: {
+        supported: false,
+        reason: "provider has no durable idempotency API",
+      },
+      async send() {
+        throw new Error("must not dispatch")
+      },
+    }
+
+    await expect(
+      executeDurableNotificationSendCommand({
+        ...command,
+        db,
+        dispatcher: createNotificationService([unsupported]),
+      }),
+    ).rejects.toThrow("provider has no durable idempotency API")
+    expect(await db.select().from(notificationSendOperations)).toHaveLength(0)
+    expect(await db.select().from(notificationDeliveries)).toHaveLength(0)
+  })
+
+  it("reconciles provider success after a local settle crash without sending twice", async () => {
+    const command = await approvedCommand(`provider-crash-${randomUUID()}`)
+    const pending = await execute(command)
+    expect(pending.value.status).toBe("pending")
+
+    const acceptedCrash = vi.fn(async () => {
+      throw new Error("injected post-provider crash")
+    })
+    const firstDrain = await drainDurableNotificationSends(db, [provider], {
+      now: new Date("2026-07-24T12:00:00.000Z"),
+      retryBaseMs: 0,
+      testHooks: { afterProviderAccepted: acceptedCrash },
+    })
+    expect(firstDrain).toMatchObject({ claimed: 1, retried: 1, sent: 0 })
+    expect(provider.durableSend).toHaveBeenCalledOnce()
+
+    const recovered = await drainDurableNotificationSends(db, [provider], {
+      now: new Date("2026-07-24T12:00:01.000Z"),
+      retryBaseMs: 0,
+    })
+    expect(recovered).toMatchObject({ claimed: 1, sent: 1, retried: 0 })
+    expect(provider.durableSend).toHaveBeenCalledOnce()
+    expect(provider.reconcile).toHaveBeenCalledTimes(2)
+
+    const replay = await execute(command)
+    expect(replay.replayed).toBe(true)
+    expect(replay.value).toEqual(pending.value)
+    expect(replay.value).toMatchObject({ id: pending.value.id, status: "pending" })
+    expect(
+      (
+        await db
+          .select()
+          .from(notificationDeliveries)
+          .where(eq(notificationDeliveries.id, pending.value.id as string))
+      )[0],
+    ).toMatchObject({ status: "sent", providerMessageId: expect.any(String) })
+    const events = await db.select().from(eventOutboxTable)
+    expect(events.filter(({ name }) => name === NOTIFICATION_SEND_REQUESTED_EVENT)).toHaveLength(1)
+    expect(events.filter(({ name }) => name === NOTIFICATION_SEND_COMPLETED_EVENT)).toHaveLength(1)
+  })
+
+  it("rolls back mutable settlement when completion event capture fails", async () => {
+    const command = await approvedCommand(`settle-rollback-${randomUUID()}`)
+    const pending = await execute(command)
+    const failedSettle = await drainDurableNotificationSends(db, [provider], {
+      now: new Date("2026-07-24T12:00:00.000Z"),
+      retryBaseMs: 0,
+      testHooks: {
+        async beforeCompletionEvent() {
+          throw new Error("injected completion event failure")
+        },
+      },
+    })
+    expect(failedSettle).toMatchObject({ claimed: 1, retried: 1, sent: 0 })
+    expect((await db.select().from(notificationSendOperations))[0]).toMatchObject({
+      status: "retry",
+      lastError: "injected completion event failure",
+    })
+    expect(
+      (
+        await db
+          .select()
+          .from(notificationDeliveries)
+          .where(eq(notificationDeliveries.id, pending.value.id as string))
+      )[0],
+    ).toMatchObject({ status: "pending", providerMessageId: null, sentAt: null })
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_COMPLETED_EVENT,
+      ),
+    ).toHaveLength(0)
+
+    await expect(
+      drainDurableNotificationSends(db, [provider], {
+        now: new Date("2026-07-24T12:00:01.000Z"),
+        retryBaseMs: 0,
+      }),
+    ).resolves.toMatchObject({ sent: 1 })
+  })
+
+  it("reclaims an expired processing lease and completes exactly once", async () => {
+    const command = await approvedCommand(`lease-recovery-${randomUUID()}`)
+    await execute(command)
+    await db.update(notificationSendOperations).set({
+      status: "processing",
+      attempts: 1,
+      leaseExpiresAt: new Date("2026-07-24T11:59:00.000Z"),
+    })
+
+    const recovered = await drainDurableNotificationSends(db, [provider], {
+      now: new Date("2026-07-24T12:00:00.000Z"),
+    })
+    expect(recovered).toMatchObject({ claimed: 1, sent: 1 })
+    expect(provider.durableSend).toHaveBeenCalledOnce()
+    expect((await db.select().from(notificationSendOperations))[0]).toMatchObject({
+      status: "sent",
+      attempts: 2,
+    })
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_COMPLETED_EVENT,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("fences an expired worker after a successor settles the same provider result", async () => {
+    const command = await approvedCommand(`lease-fencing-${randomUUID()}`)
+    await execute(command)
+    let releaseFirst: () => void = () => undefined
+    const holdFirst = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let providerAccepted: () => void = () => undefined
+    const accepted = new Promise<void>((resolve) => {
+      providerAccepted = resolve
+    })
+    const firstDrain = drainDurableNotificationSends(db, [provider], {
+      now: new Date("2026-07-24T12:00:00.000Z"),
+      visibilityTimeoutMs: 1_000,
+      retryBaseMs: 0,
+      testHooks: {
+        async afterProviderAccepted() {
+          providerAccepted()
+          await holdFirst
+        },
+      },
+    })
+    await accepted
+
+    const successor = await drainDurableNotificationSends(db, [provider], {
+      now: new Date("2026-07-24T12:00:02.000Z"),
+      visibilityTimeoutMs: 1_000,
+      retryBaseMs: 0,
+    })
+    expect(successor).toMatchObject({ claimed: 1, sent: 1 })
+    releaseFirst()
+    await expect(firstDrain).resolves.toMatchObject({
+      claimed: 1,
+      retried: 0,
+      deadLettered: 0,
+      sent: 0,
+    })
+
+    expect(provider.durableSend).toHaveBeenCalledOnce()
+    expect((await db.select().from(notificationSendOperations))[0]).toMatchObject({
+      status: "sent",
+      attempts: 2,
+    })
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_COMPLETED_EVENT,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("retries missing provider configuration before dead-lettering at the lease budget", async () => {
+    const command = await approvedCommand(`provider-missing-${randomUUID()}`)
+    const pending = await execute(command)
+    await db.update(notificationSendOperations).set({ maxAttempts: 2 })
+
+    const first = await drainDurableNotificationSends(db, [], {
+      now: new Date("2026-07-24T12:00:00.000Z"),
+      retryBaseMs: 0,
+    })
+    expect(first).toMatchObject({ claimed: 1, retried: 1, deadLettered: 0, sent: 0 })
+    expect((await db.select().from(notificationSendOperations))[0]).toMatchObject({
+      status: "retry",
+      attempts: 1,
+      lastError: "provider is not currently registered",
+    })
+    expect(
+      (
+        await db
+          .select()
+          .from(notificationDeliveries)
+          .where(eq(notificationDeliveries.id, pending.value.id as string))
+      )[0],
+    ).toMatchObject({ status: "pending", errorMessage: null })
+
+    const exhausted = await drainDurableNotificationSends(db, [], {
+      now: new Date("2026-07-24T12:00:01.000Z"),
+      retryBaseMs: 0,
+    })
+    expect(exhausted).toMatchObject({ claimed: 1, deadLettered: 1, sent: 0 })
+    expect((await db.select().from(notificationSendOperations))[0]).toMatchObject({
+      status: "dead_letter",
+      attempts: 2,
+      lastError: "provider is not currently registered",
+      completedAt: expect.any(Date),
+    })
+    expect(
+      (
+        await db
+          .select()
+          .from(notificationDeliveries)
+          .where(eq(notificationDeliveries.id, pending.value.id as string))
+      )[0],
+    ).toMatchObject({ status: "failed", errorMessage: "provider is not currently registered" })
+    expect(
+      (await db.select().from(eventOutboxTable)).filter(
+        ({ name }) => name === NOTIFICATION_SEND_DEAD_LETTERED_EVENT,
+      ),
+    ).toHaveLength(1)
+  })
+
+  it("dead-letters immediately when the selected provider explicitly drops durable support", async () => {
+    const command = await approvedCommand(`provider-unsupported-${randomUUID()}`)
+    await execute(command)
+    const unsupported: NotificationProvider = {
+      name: provider.name,
+      channels: ["email"],
+      defaultFromAddress: "unsupported@example.test",
+      durableDelivery: { supported: false, reason: "durable protocol was disabled" },
+      async send() {
+        throw new Error("must not dispatch")
+      },
+    }
+
+    const drained = await drainDurableNotificationSends(db, [unsupported], {
+      now: new Date("2026-07-24T12:00:00.000Z"),
+    })
+    expect(drained).toMatchObject({ claimed: 1, deadLettered: 1, retried: 0 })
+    expect((await db.select().from(notificationSendOperations))[0]).toMatchObject({
+      status: "dead_letter",
+      attempts: 1,
+      lastError: "durable protocol was disabled",
+    })
+  })
+
+  async function execute(command: Awaited<ReturnType<typeof approvedCommand>>) {
+    return executeDurableNotificationSendCommand({
+      ...command,
+      db,
+      dispatcher: createNotificationService([provider]),
+    })
+  }
+
+  async function approvedCommand(
+    idempotencyKey: string,
+    options: {
+      inputOrganizationId?: string
+      contextOrganizationId?: string
+      omitInputOrganizationId?: boolean
+    } = {},
+  ) {
+    const organizationId = options.contextOrganizationId ?? "org_notifications"
+    const context: ActionLedgerRequestContextValues = {
+      userId: "usr_notifications_agent",
+      callerType: "session",
+      actor: "staff",
+      organizationId,
+    }
+    const input = {
+      templateSlug: "agent-booking-confirmed",
+      to: "traveler@example.test",
+      channel: "email" as const,
+      data: { bookingId: "BK-100", traveler: "Mihai" },
+      bookingId: "book_100",
+      ...(options.omitInputOrganizationId
+        ? {}
+        : { organizationId: options.inputOrganizationId ?? organizationId }),
+    }
+    const policy = SEND_NOTIFICATION_HANDLER_POLICY.actionPolicy
+    const reasonCode = "approved_agent_notification"
+    const fingerprint = await buildActionApprovalCommandFingerprint({
+      actionName: policy.capabilityId,
+      actionVersion: policy.version,
+      targetType: policy.targetType,
+      targetId: input.templateSlug,
+      commandInput: input,
+      approvalPolicy: "required",
+      capabilityId: policy.capabilityId,
+      capabilityVersion: policy.version,
+      evaluatedRisk: "high",
+      reasonCode,
+    })
+    const requested = await requestActionLedgerApproval(db, {
+      context,
+      actionName: policy.capabilityId,
+      actionVersion: policy.version,
+      actionKind: "execute",
+      evaluatedRisk: "high",
+      targetType: policy.targetType,
+      targetId: input.templateSlug,
+      routeOrToolName: SEND_NOTIFICATION_HANDLER_POLICY.capabilityId,
+      capabilityId: policy.capabilityId,
+      capabilityVersion: policy.version,
+      authorizationSource: "integration_test",
+      idempotencyScope: `${organizationId}:notifications-approval:${idempotencyKey}`,
+      idempotencyKey,
+      idempotencyFingerprint: fingerprint,
+      approval: {
+        assignedToPrincipalId: "usr_notifications_agent",
+        policyName: "notifications-agent-send",
+        policyVersion: policy.version,
+        riskSnapshot: "high",
+        reasonCode,
+        expiresAt: new Date(Date.now() + 60_000),
+      },
+    })
+    await decideActionLedgerApproval(db, {
+      context,
+      id: requested.approval.id,
+      status: "approved",
+      actionName: "notifications.approval.decision",
+      actionVersion: "v1",
+      evaluatedRisk: "high",
+      organizationId,
+    })
+    const admitted: ToolHandlerActionPolicyContext = {
+      capabilityId: SEND_NOTIFICATION_HANDLER_POLICY.capabilityId,
+      capabilityVersion: SEND_NOTIFICATION_HANDLER_POLICY.capabilityVersion,
+      canonicalName: SEND_NOTIFICATION_HANDLER_POLICY.canonicalName,
+      actionPolicy: {
+        ...policy,
+        enforcement: "handler",
+        invocation: {
+          controlField: "_voyant",
+          requiredFields: [
+            "confirmed",
+            "targetId",
+            "idempotencyKey",
+            "approvalId",
+            "idempotencyFingerprint",
+          ],
+          optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+          fingerprintAlgorithm: "action-ledger-command-v1",
+        },
+      },
+      invocation: {
+        confirmed: true,
+        targetId: input.templateSlug,
+        idempotencyKey,
+        approvalId: requested.approval.id,
+        idempotencyFingerprint: fingerprint,
+        reasonCode,
+      },
+    }
+    return { context, admitted, input }
+  }
+})
+
+function durableProvider() {
+  const accepted = new Map<string, NotificationResult>()
+  const durableSend = vi.fn(
+    async (_payload: NotificationPayload, context: DurableNotificationDeliveryContext) => {
+      const existing = accepted.get(context.idempotencyKey)
+      if (existing) return existing
+      const result = {
+        id: `provider_${context.idempotencyKey.slice(-12)}`,
+        provider: "durable-test-email",
+      }
+      accepted.set(context.idempotencyKey, result)
+      return result
+    },
+  )
+  const reconcile = vi.fn(async (context: DurableNotificationDeliveryContext) => {
+    return accepted.get(context.idempotencyKey) ?? null
+  })
+  return {
+    name: "durable-test-email",
+    channels: ["email"],
+    defaultFromAddress: "durable@example.test",
+    durableDelivery: {
+      supported: true,
+      protocol: "notification-provider-idempotency-v1",
+      send: durableSend,
+      reconcile,
+    },
+    send: vi.fn(async () => {
+      throw new Error("request-scoped send must not run for durable operations")
+    }),
+    durableSend,
+    reconcile,
+  } satisfies NotificationProvider & {
+    durableSend: ReturnType<typeof vi.fn>
+    reconcile: ReturnType<typeof vi.fn>
+  }
+}

--- a/packages/notifications/tests/tools.test.ts
+++ b/packages/notifications/tests/tools.test.ts
@@ -1,7 +1,16 @@
-import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
+import {
+  createToolRegistry,
+  type ToolContext,
+  type ToolHandlerActionPolicyContext,
+} from "@voyant-travel/tools"
 import { describe, expect, it } from "vitest"
 
-import { type NotificationsToolServices, notificationsTools } from "../src/tools.js"
+import {
+  type NotificationsToolServices,
+  notificationsTools,
+  SEND_NOTIFICATION_HANDLER_POLICY,
+  sendNotificationTool,
+} from "../src/tools.js"
 
 const occurredAt = new Date("2026-07-15T10:00:00.000Z")
 
@@ -47,7 +56,39 @@ function ctx(
     audience: "staff",
     tenantId: "default",
     resolverScope: { locale: "en-GB", audience: "staff", market: "default", actor: "staff" },
+    handlerActionPolicy: sendActionPolicy(),
     notifications: services as NotificationsToolServices | undefined,
+  }
+}
+
+function sendActionPolicy(): ToolHandlerActionPolicyContext {
+  return {
+    capabilityId: SEND_NOTIFICATION_HANDLER_POLICY.capabilityId,
+    capabilityVersion: SEND_NOTIFICATION_HANDLER_POLICY.capabilityVersion,
+    canonicalName: SEND_NOTIFICATION_HANDLER_POLICY.canonicalName,
+    actionPolicy: {
+      ...SEND_NOTIFICATION_HANDLER_POLICY.actionPolicy,
+      enforcement: "handler",
+      invocation: {
+        controlField: "_voyant",
+        requiredFields: [
+          "confirmed",
+          "targetId",
+          "idempotencyKey",
+          "approvalId",
+          "idempotencyFingerprint",
+        ],
+        optionalFields: ["reasonCode", "approvalId", "idempotencyFingerprint"],
+        fingerprintAlgorithm: "action-ledger-command-v1",
+      },
+    },
+    invocation: {
+      confirmed: true,
+      targetId: "booking-confirmed",
+      idempotencyKey: "send_1",
+      approvalId: "approval_1",
+      idempotencyFingerprint: "sha256:test",
+    },
   }
 }
 
@@ -63,8 +104,10 @@ describe("notifications tools", () => {
     ])
     const send = list.find((t) => t.name === "send_notification")
     expect(send?.tier).toBe("destructive")
+    expect(send?.capabilityVersion).toBe("v2")
     expect(send?.requiredScopes).toEqual(["notifications:send"])
     expect(send?.riskPolicy).toMatchObject({ destructive: true, confirmationRequired: true })
+    expect(sendNotificationTool.actionPolicyEnforcement).toBe("handler")
     // The send tool must NOT accept arbitrary content — only a vetted template slug.
     const props = (send?.inputSchema as { properties?: Record<string, unknown> }).properties ?? {}
     expect(props).toHaveProperty("templateSlug")
@@ -82,7 +125,11 @@ describe("notifications tools", () => {
     let sent: unknown
     const result = await registry.dispatch(
       "send_notification",
-      { templateSlug: "booking-confirmed", to: "guest@example.com", bookingId: "bk_1" },
+      {
+        templateSlug: "booking-confirmed",
+        to: "guest@example.com",
+        bookingId: "bk_1",
+      },
       ctx({
         async listDeliveries() {
           return { data: [], total: 0, limit: 50, offset: 0 }
@@ -90,14 +137,18 @@ describe("notifications tools", () => {
         async getDeliveryById() {
           return null
         },
-        async sendTemplated(input) {
+        async sendTemplated(input, admitted) {
           sent = input
+          expect(admitted.actionPolicy).toMatchObject(SEND_NOTIFICATION_HANDLER_POLICY.actionPolicy)
           return delivery({ id: "ndl_9" })
         },
       }),
     )
     expect(result).toMatchObject({ id: "ndl_9", status: "sent" })
-    expect(sent).toMatchObject({ templateSlug: "booking-confirmed", to: "guest@example.com" })
+    expect(sent).toMatchObject({
+      templateSlug: "booking-confirmed",
+      to: "guest@example.com",
+    })
   })
 
   it("dispatches delivery reads through the injected service", async () => {

--- a/packages/notifications/tests/unit/local.test.ts
+++ b/packages/notifications/tests/unit/local.test.ts
@@ -29,6 +29,7 @@ describe("createLocalProvider", () => {
     const provider = createLocalProvider({ sink: () => {} })
     expect(provider.channels).toEqual(["email", "sms"])
     expect(provider.defaultFromAddress).toBe("local@example.test")
+    expect(provider.durableDelivery).toMatchObject({ supported: false })
   })
 
   it("accepts a custom name and channel list", async () => {

--- a/packages/notifications/tests/unit/reminder-job.test.ts
+++ b/packages/notifications/tests/unit/reminder-job.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 
-const { sendDueNotificationReminders } = vi.hoisted(() => ({
+const { drainDurableNotificationSends, sendDueNotificationReminders } = vi.hoisted(() => ({
+  drainDurableNotificationSends: vi.fn(async () => ({
+    claimed: 0,
+    sent: 0,
+    retried: 0,
+    deadLettered: 0,
+  })),
   sendDueNotificationReminders: vi.fn(async () => ({
     processed: 0,
     sent: 0,
@@ -9,8 +15,12 @@ const { sendDueNotificationReminders } = vi.hoisted(() => ({
   })),
 }))
 vi.mock("../../src/tasks/send-due-reminders.js", () => ({ sendDueNotificationReminders }))
+vi.mock("../../src/service-durable-send.js", () => ({ drainDurableNotificationSends }))
 
-import { runDueNotificationRemindersJob } from "../../src/reminder-job.js"
+import {
+  runDueNotificationRemindersJob,
+  runDueNotificationSendsJob,
+} from "../../src/reminder-job.js"
 
 describe("due reminders job", () => {
   it("polls durable reminder state without accepting a run payload", async () => {
@@ -25,5 +35,19 @@ describe("due reminders job", () => {
       }),
     } as never)
     expect(sendDueNotificationReminders).toHaveBeenCalledWith(db, env, {}, options)
+  })
+
+  it("exports a fixed durable-send job that resolves deployment providers", async () => {
+    const db = {}
+    const env = { DATABASE_URL: "postgres://test" }
+    const providers = [{ name: "durable-provider" }]
+    await runDueNotificationSendsJob({
+      getPort: async () => ({
+        resolveDb: async () => db,
+        resolveEnv: async () => env,
+        resolveRuntimeOptions: async () => ({ providers }),
+      }),
+    } as never)
+    expect(drainDurableNotificationSends).toHaveBeenCalledWith(db, providers)
   })
 })

--- a/packages/notifications/tests/unit/voyant-cloud-email.test.ts
+++ b/packages/notifications/tests/unit/voyant-cloud-email.test.ts
@@ -27,6 +27,7 @@ describe("createVoyantCloudEmailProvider", () => {
     })
 
     expect(provider.defaultFromAddress).toBe("noreply@example.com")
+    expect(provider.durableDelivery).toMatchObject({ supported: false })
 
     const result = await provider.send({
       to: "traveler@example.com",

--- a/packages/notifications/tests/unit/voyant-cloud-sms.test.ts
+++ b/packages/notifications/tests/unit/voyant-cloud-sms.test.ts
@@ -21,6 +21,7 @@ describe("createVoyantCloudSmsProvider", () => {
       from: "+40000000000",
       renderTemplate: () => ({ text: "123456 is your code." }),
     })
+    expect(provider.durableDelivery).toMatchObject({ supported: false })
 
     const result = await provider.send({
       to: "+40123456789",

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -44,6 +44,21 @@ describe("notifications deployment manifest", () => {
       migrations: [{ id: "@voyant-travel/notifications#migrations" }],
       jobs: [
         {
+          id: "notifications.deliver-durable-sends",
+          schedule: { cron: "* * * * *", overlap: "skip" },
+          scheduling: {
+            required: true,
+            profiles: {
+              eager: { cron: "* * * * *", overlap: "skip" },
+              economical: { cron: "*/5 * * * *", overlap: "skip" },
+            },
+          },
+          runtime: {
+            entry: "@voyant-travel/notifications/reminder-job",
+            export: "runDueNotificationSendsJob",
+          },
+        },
+        {
           id: "notifications.send-due-reminders",
           schedule: { cron: "0 * * * *", overlap: "skip" },
           scheduling: {
@@ -86,17 +101,29 @@ describe("notifications deployment manifest", () => {
     expect(notificationsVoyantModule.actions).toContainEqual(
       expect.objectContaining({
         id: "@voyant-travel/notifications#action.send-notification",
+        version: "v2",
         resource: "notifications",
         action: "send",
+        targetType: "notification-template",
+        commandTargetField: "templateSlug",
+        targetLifecycle: "existing",
+        existingTarget: {
+          durability: "handler-command-result-v1",
+        },
         availability: {
           status: "unavailable",
-          reasonCode: "unsafe-nontransactional-effect",
+          reasonCode: "provider-idempotency-unavailable",
         },
         effectBoundary: "multistage",
+        durability: {
+          strategy: "saga",
+          testReference: "tests/integration/durable-send.test.ts",
+        },
         requiredScopes: ["notifications:send"],
         risk: "high",
         ledger: "required",
         approval: "required",
+        policy: "notifications-agent-send",
         reversible: false,
         from: { tools: ["@voyant-travel/notifications#tool.send-notification"] },
       }),

--- a/packages/schema-kit/src/typeid/typeid-prefixes.ts
+++ b/packages/schema-kit/src/typeid/typeid-prefixes.ts
@@ -43,6 +43,7 @@ export const PREFIXES = {
   customer_signals: "csig",
   notification_templates: "ntpl",
   notification_deliveries: "ntdl",
+  notification_send_operations: "nsop",
   notification_reminder_rules: "ntrl",
   notification_reminder_runs: "ntrn",
   notification_reminder_rule_stages: "ntrs",


### PR DESCRIPTION
## Summary

- add the package-owned durable operation required for safe agent-initiated notification sends
- atomically commit the action claim, immutable accepted Tool result, rendered provider request, and requested outbox event
- reconcile before idempotent provider send, with leased retries, fencing, transactional completion/dead-letter events, and observable terminal state
- target the validated active notification template in the ledger so recipient PII stays in Notifications-owned storage while the full command fingerprint binds the address and payload
- add the optional `notification-provider-idempotency-v1` capability; bundled providers explicitly fail closed because their current APIs cannot reconcile cross-process delivery
- document the v2 asynchronous accepted/poll contract and add migration/schema/job/CI coverage

## Validation

- changed-file Biome, quality scan, and `git diff --check`
- schema-kit remote typecheck
- three independent review passes; all findings fixed, final review clean
- Notifications typecheck/live PostgreSQL coverage delegated to GitHub CI after isolated remote workers OOMed/lost connection without code diagnostics

## Availability

This PR deliberately keeps `send_notification` quarantined as `provider-idempotency-unavailable`. It lands the safe foundation; unquarantine requires a selected production provider that implements stable idempotent `send` plus `reconcile`, or a truthful provider-conditional availability seam.