### PR TITLE
fix(starter): refresh generated package versions

### DIFF
--- a/.changeset/refresh-starter-package-versions.md
+++ b/.changeset/refresh-starter-package-versions.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Generate starter archives with the current framework, runtime, and standard Operator package releases so new projects avoid stale dependency graphs.

--- a/packages/framework/src/standard-node-starter.json
+++ b/packages/framework/src/standard-node-starter.json
@@ -33,9 +33,9 @@
     "pg"
   ],
   "runtimeDependencyCoordinates": {
-    "@voyant-travel/framework": "0.45.0",
-    "@voyant-travel/runtime": "0.11.0",
-    "@voyant-travel/operator-standard": "0.5.0",
+    "@voyant-travel/framework": "0.63.2",
+    "@voyant-travel/runtime": "0.17.9",
+    "@voyant-travel/operator-standard": "0.12.3",
     "@tanstack/react-query": "5.101.2",
     "@tanstack/react-router": "1.170.17",
     "react": "19.2.7",

--- a/packages/framework/src/standard-node-starter.test.ts
+++ b/packages/framework/src/standard-node-starter.test.ts
@@ -67,9 +67,9 @@ describe("standard Node starter contract", () => {
         "runtimeDependencyCoordinates": {
           "@tanstack/react-query": "5.101.2",
           "@tanstack/react-router": "1.170.17",
-          "@voyant-travel/framework": "0.45.0",
-          "@voyant-travel/operator-standard": "0.5.0",
-          "@voyant-travel/runtime": "0.11.0",
+          "@voyant-travel/framework": "0.63.2",
+          "@voyant-travel/operator-standard": "0.12.3",
+          "@voyant-travel/runtime": "0.17.9",
           "pg": "8.22.0",
           "react": "19.2.7",
           "react-dom": "19.2.7",

--- a/packages/framework/src/standard-node-starter.ts
+++ b/packages/framework/src/standard-node-starter.ts
@@ -35,9 +35,9 @@ type StandardNodeStarterContract = {
     "pg",
   ]
   readonly runtimeDependencyCoordinates: {
-    readonly "@voyant-travel/framework": "0.45.0"
-    readonly "@voyant-travel/runtime": "0.11.0"
-    readonly "@voyant-travel/operator-standard": "0.5.0"
+    readonly "@voyant-travel/framework": "0.63.2"
+    readonly "@voyant-travel/runtime": "0.17.9"
+    readonly "@voyant-travel/operator-standard": "0.12.3"
     readonly "@tanstack/react-query": "5.101.2"
     readonly "@tanstack/react-router": "1.170.17"
     readonly react: "19.2.7"

--- a/scripts/package-starters.mjs
+++ b/scripts/package-starters.mjs
@@ -49,7 +49,9 @@ function stageMinimalOperatorStarter(stagingTemplate, localLinks) {
   const dependency = (name) =>
     localLinks && name.startsWith("@voyant-travel/")
       ? `link:${workspacePackageDirectory(name)}`
-      : standardNodeStarter.runtimeDependencyCoordinates[name]
+      : name.startsWith("@voyant-travel/")
+        ? workspacePackageVersion(name)
+        : standardNodeStarter.runtimeDependencyCoordinates[name]
   const localCliPackage = resolve(repoRoot, "..", "cli", "packages", "cli")
   const cliDependency =
     localLinks && existsSync(join(localCliPackage, "package.json"))
@@ -111,6 +113,11 @@ function workspacePackageDirectory(name) {
     }
   }
   throw new Error(`Missing workspace package directory for ${name}`)
+}
+
+function workspacePackageVersion(name) {
+  const packageDirectory = workspacePackageDirectory(name)
+  return readJson(join(packageDirectory, "package.json")).version
 }
 
 function readJson(path) {

--- a/scripts/tests/package-starters.test.mjs
+++ b/scripts/tests/package-starters.test.mjs
@@ -62,6 +62,31 @@ test("operator release archive contains only the minimal authored project", () =
   }
 })
 
+test("operator release archive pins the current core package releases", () => {
+  const fixture = packageAndExtract()
+  try {
+    const packageJson = JSON.parse(readFileSync(join(fixture.extractDir, "package.json"), "utf8"))
+    for (const packageName of [
+      "@voyant-travel/framework",
+      "@voyant-travel/runtime",
+      "@voyant-travel/operator-standard",
+    ]) {
+      const packageDirectory = packageName.replace("@voyant-travel/", "")
+      const manifest = JSON.parse(
+        readFileSync(join(repoRoot, "packages", packageDirectory, "package.json"), "utf8"),
+      )
+
+      assert.equal(
+        packageJson.dependencies[packageName],
+        manifest.version,
+        `${packageName} starter coordinate must match its current published version`,
+      )
+    }
+  } finally {
+    rmSync(fixture.tempDir, { recursive: true, force: true })
+  }
+})
+
 function packageAndExtract(extraArgs = []) {
   const tempDir = mkdtempSync(join(tmpdir(), "voyant-package-starters-test-"))
   const outDir = join(tempDir, "out")


### PR DESCRIPTION
## Summary

- refresh the package versions written into newly generated Voyant projects
- move generated projects off the stale runtime dependency chain that can retain `catalog:` in a published manifest
- verify the starter coordinates match the current framework, runtime, and operator-standard package versions

## Root cause

The `voyant create` starter contract pinned old framework, runtime, and operator-standard versions. New projects therefore resolved an outdated published dependency graph instead of the current validated releases.

## Validation

- `node --test scripts/tests/package-starters.test.mjs`
- `node --test scripts/tests/check-standard-node-starter.test.mjs`

Closes #3725.