### PR TITLE
feat(framework)!: activate actions from verified provider ports

### DIFF
--- a/.changeset/add-provider-conditional-action-availability.md
+++ b/.changeset/add-provider-conditional-action-availability.md
@@ -1,0 +1,25 @@
+---
+"@voyant-travel/core": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/mcp": minor
+---
+
+Add fail-closed provider-conditional action availability. An unavailable action
+may name one-valued typed provider ports with explicit `all` or `any` semantics;
+the resolved graph keeps it provisional even for exactly selected provider declarations.
+Malformed, unknown, or ambiguous conditions fail graph validation, while
+missing or unselected providers keep the action out of Tool imports, MCP,
+action-ledger policy, and enumerable runtime lowering. The framework retains
+activation-only Tool loaders privately, instantiates the exact selected provider
+factory, runs the action owner's imported typed-port conformance kit, and only
+then creates a non-forgeable activated runtime view for composition, direct Tool
+registration, action-ledger lowering, and MCP discovery. MCP now accepts only a
+runtime whose object identity was minted by framework lowering, so a fabricated
+structural graph cannot expose a conditional Tool by claiming it is available.
+Framework lowering first takes a detached, deeply immutable metadata snapshot;
+raw and activated runtimes therefore cannot have actions, provider conditions,
+Tool/reference loaders, or provider selections rewritten after minting.
+The MCP graph adapter declares framework 0.64 as a required peer rather than a
+direct runtime dependency. This keeps the package contract explicit without
+introducing a direct framework → operator distribution → MCP → framework
+runtime dependency cycle.

--- a/docs/architecture/agent-tool-library.md
+++ b/docs/architecture/agent-tool-library.md
@@ -144,6 +144,35 @@ also name a transactional, outbox, or saga durability strategy and the test that
 For actions carrying any availability, effect-boundary, or durability metadata, omitted
 availability is validated with the same callable meaning used by runtime lowering. Removing only
 an `unavailable` marker therefore cannot bypass lifecycle or tested-durability checks.
+An unavailable action may opt into `enableWhen.selectedProviderPorts` with explicit `all` or
+`any` semantics. This is the only supported conditional activation path. The authored
+`status: unavailable` remains deliberately fail-closed for older framework versions. The current
+resolver keeps it unavailable even when every required (or at least one alternative) one-valued
+port is consumed by the action owner, closed by a graph provider declaration, and matched by the
+deployment's explicit provider role/value selection. Its Tool metadata, selected id, and runtime
+reference remain outside the enumerable graph runtime. Missing or unselected providers leave the
+action hidden; malformed, unknown, or ambiguously selected ports invalidate the graph before
+runtime generation. Host callbacks, environment inspection, package capability tokens, and
+provider-owned free-form flags cannot activate an action. The selected provider factory is
+instantiated during startup, and each activation runtime-port declaration carries an importable
+reference to its owning typed `VoyantPort`. The framework loads that exact port and runs its
+conformance kit against the exact selected provider instance before a module-private authority
+creates a sanitized activated runtime view. Only that view promotes the action to ordinary
+available metadata and exposes its Tool. Composition additionally rejects a host-substituted
+provider instance. Framework lowering records every authentic raw and activated runtime in a
+module-private identity registry; MCP verifies that identity through the narrow framework
+attestation boundary before inspecting actions or loading Tools. It accepts no assertion callback,
+structural available-action substitute, or conditional action shape. Provider
+import, factory, or port-conformance failure therefore leaves the provisional graph unchanged and
+cannot list the conditional Tool.
+The legitimate `createVoyantGraphRuntime` mint path takes a detached, recursively frozen metadata
+snapshot. Raw and activated runtime views therefore cannot be rewritten after minting: actions,
+availability requirements, provider selections and declarations, Tool and reference loaders,
+selected ids, catalogs, and nested binding arrays remain immutable while the selected provider
+instance itself remains usable and is checked by exact identity.
+`@voyant-travel/mcp` declares the matching framework line as a required peer, so the graph adapter
+can import that narrow attestation subpath without introducing a direct runtime dependency cycle
+through the standard operator distribution.
 First-party actions that still cross an external or multi-stage boundary through event
 publication, provider calls, document generation, delivery, ticketing, or booking orchestration
 are declared unavailable with the `unsafe-nontransactional-effect` reason and the corresponding

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1075,6 +1075,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1076,6 +1076,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1041,6 +1041,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1042,6 +1042,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1035,6 +1035,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1029,6 +1029,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/core/src/project-facets.ts
+++ b/packages/core/src/project-facets.ts
@@ -355,6 +355,19 @@ export interface VoyantGraphActionBindings {
   webhooks?: readonly string[]
 }
 
+/**
+ * A closed deployment-graph condition that can restore a quarantined action.
+ *
+ * The referenced ports must be one-valued typed runtime ports consumed by the
+ * action owner and provided by explicitly selected graph provider factories.
+ */
+export interface VoyantGraphActionAvailabilityCondition {
+  selectedProviderPorts: {
+    mode: "all" | "any"
+    ports: readonly string[]
+  }
+}
+
 export type VoyantGraphActionAvailability =
   | { status: "available" }
   | {
@@ -363,6 +376,11 @@ export type VoyantGraphActionAvailability =
       reasonCode: string
       /** Optional safe replacement capability that callers may migrate to. */
       replacementCapabilityId?: string
+      /**
+       * Opt-in activation condition. Older framework versions ignore this
+       * field and retain the fail-closed unavailable posture.
+       */
+      enableWhen?: VoyantGraphActionAvailabilityCondition
     }
 
 export interface VoyantGraphActionDurability {

--- a/packages/core/src/project.ts
+++ b/packages/core/src/project.ts
@@ -86,11 +86,15 @@ export interface VoyantGraphPortDeclaration {
   optional?: boolean
   /** Additive static contributor aggregation. Valid only in a unit's runtimePorts. */
   cardinality?: "many"
+  /** Lazy export of the owning typed VoyantPort used for startup conformance. */
+  conformance?: VoyantGraphRuntimeReference
 }
 
 export interface VoyantPort<TProvider> {
   readonly id: string
   readonly test: (provider: TProvider) => void | Promise<void>
+  /** Import-cheap reference back to this typed port for generic startup preflight. */
+  readonly conformance?: VoyantGraphRuntimeReference
 }
 
 export function definePort<TProvider>(input: VoyantPort<TProvider>): VoyantPort<TProvider> {
@@ -100,7 +104,11 @@ export function definePort<TProvider>(input: VoyantPort<TProvider>): VoyantPort<
   if (typeof input.test !== "function") {
     throw new Error(`Port "${input.id}" must provide a conformance test kit.`)
   }
-  return Object.freeze({ id: input.id, test: input.test })
+  return Object.freeze({
+    id: input.id,
+    test: input.test,
+    ...(input.conformance ? { conformance: input.conformance } : {}),
+  })
 }
 
 export function providePort<TProvider>(port: VoyantPort<TProvider>): VoyantGraphPortDeclaration {
@@ -115,6 +123,7 @@ export function requirePort<TProvider>(
     id: port.id,
     ...(options.optional ? { optional: true } : {}),
     ...(options.cardinality ? { cardinality: options.cardinality } : {}),
+    ...(port.conformance ? { conformance: port.conformance } : {}),
   }
 }
 

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1080,6 +1080,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1081,6 +1081,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1102,6 +1102,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1103,6 +1103,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1116,6 +1116,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1111,6 +1111,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/framework/package.json
+++ b/packages/framework/package.json
@@ -18,6 +18,7 @@
     "./project-artifacts": "./src/project-artifacts.ts",
     "./project": "./src/project.ts",
     "./project-runtime": "./src/project-runtime.ts",
+    "./runtime-attestation": "./src/runtime-attestation.ts",
     "./node-host": "./src/node-host.ts",
     "./node-runtime": "./src/node-runtime.ts",
     "./worker-job-host": "./src/worker-job-host.ts",
@@ -58,7 +59,6 @@
     "@voyant-travel/db": "workspace:^",
     "@voyant-travel/framework-migrations": "workspace:^",
     "@voyant-travel/hono": "workspace:^",
-    "@voyant-travel/mcp": "workspace:^",
     "@voyant-travel/operator-standard": "workspace:^",
     "@voyant-travel/plugin-voyant-connect": "^0.3.2",
     "@voyant-travel/runtime-core": "workspace:^",
@@ -144,6 +144,10 @@
         "types": "./dist/project-runtime.d.ts",
         "import": "./dist/project-runtime.js",
         "default": "./dist/project-runtime.js"
+      },
+      "./runtime-attestation": {
+        "types": "./dist/runtime-attestation.d.ts",
+        "import": "./dist/runtime-attestation.js"
       },
       "./node-host": {
         "types": "./dist/node-host.d.ts",

--- a/packages/framework/src/conditional-action-availability.ts
+++ b/packages/framework/src/conditional-action-availability.ts
@@ -1,0 +1,372 @@
+import type { VoyantPort } from "@voyant-travel/core/project"
+import type { VoyantGraphRuntimePorts } from "./runtime-composition.js"
+import { deepFreezeRuntimeSnapshot } from "./runtime-integrity.js"
+import type {
+  VoyantGraphActivatedRuntime,
+  VoyantGraphRuntime,
+  VoyantGraphRuntimeActionDefinition,
+  VoyantGraphRuntimePortConformanceLoader,
+  VoyantGraphRuntimeReferenceLoader,
+  VoyantGraphRuntimeToolLoader,
+  VoyantGraphRuntimeUnitLoader,
+} from "./runtime-lowering.js"
+
+export interface VoyantGraphConditionalActionProvisionalUnit {
+  unitId: string
+  references: readonly VoyantGraphRuntimeReferenceLoader[]
+  tools: readonly VoyantGraphRuntimeToolLoader[]
+}
+
+interface ConditionalPortPreflight {
+  provider: unknown
+  promise: Promise<void>
+}
+
+interface ConditionalRequirement {
+  action: VoyantGraphRuntimeActionDefinition
+  portId: string
+  conformance: VoyantGraphRuntimePortConformanceLoader
+}
+
+interface ActivatedRuntimeState {
+  base: VoyantGraphRuntime
+  attestations: ReadonlyMap<string, unknown>
+}
+
+const provisionalUnits = new WeakMap<
+  VoyantGraphRuntime,
+  ReadonlyMap<string, VoyantGraphConditionalActionProvisionalUnit>
+>()
+const conditionalPortPreflights = new WeakMap<
+  VoyantGraphRuntime,
+  Map<string, ConditionalPortPreflight>
+>()
+const conditionalPortAttestations = new WeakMap<VoyantGraphRuntime, Map<string, unknown>>()
+const activatedRuntimeStates = new WeakMap<VoyantGraphRuntime, ActivatedRuntimeState>()
+const activatedRuntimeViews = new WeakMap<VoyantGraphRuntime, VoyantGraphActivatedRuntime>()
+const frameworkOwnedRuntimes = new WeakSet<VoyantGraphRuntime>()
+
+/** Record a runtime minted by a framework-owned construction boundary. */
+function registerFrameworkOwnedRuntime(runtime: VoyantGraphRuntime): void {
+  frameworkOwnedRuntimes.add(runtime)
+}
+
+/**
+ * Keep the attestation registrar module-private while allowing framework
+ * lowering to assemble the runtime before its identity is recorded.
+ *
+ * This helper is an internal source-module seam; the framework package exports
+ * only the assertion at its public runtime-attestation subpath.
+ */
+export function createFrameworkOwnedRuntime<T extends VoyantGraphRuntime>(create: () => T): T {
+  const runtime = create()
+  registerFrameworkOwnedRuntime(runtime)
+  return runtime
+}
+
+/**
+ * Require an authentic framework runtime before crossing into MCP.
+ *
+ * Structural graph objects cannot satisfy this assertion, and selected
+ * conditional actions additionally require the post-preflight activated view.
+ */
+export function assertVoyantGraphMcpRuntime(
+  runtime: unknown,
+): asserts runtime is VoyantGraphActivatedRuntime {
+  if (
+    typeof runtime !== "object" ||
+    runtime === null ||
+    !frameworkOwnedRuntimes.has(runtime as VoyantGraphRuntime)
+  ) {
+    throw new Error(
+      "VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED: MCP registration requires a runtime created by the framework.",
+    )
+  }
+  assertConditionalActionRuntimeActivated(runtime as VoyantGraphRuntime)
+}
+
+/** Register activation-only loaders without adding them to the enumerable runtime graph. */
+export function registerConditionalActionRuntimeState(
+  runtime: VoyantGraphRuntime,
+  units: readonly VoyantGraphConditionalActionProvisionalUnit[],
+): void {
+  const byUnit = new Map(units.map((unit) => [unit.unitId, unit]))
+  const candidateToolIds = new Set(units.flatMap((unit) => unit.tools.map(({ id }) => id)))
+  const expectedToolIds = new Set(
+    selectedConditionalActions(runtime).flatMap((action) => action.from.tools),
+  )
+  if (
+    candidateToolIds.size !== expectedToolIds.size ||
+    [...candidateToolIds].some((id) => !expectedToolIds.has(id))
+  ) {
+    throw new Error(
+      "VOYANT_GRAPH_CONDITIONAL_ACTION_CANDIDATES_INVALID: provisional Tool loaders do not exactly match selected conditional actions.",
+    )
+  }
+  provisionalUnits.set(runtime, byUnit)
+}
+
+/**
+ * Run every action-owner conformance kit for an exactly selected graph
+ * provider before recording that its conditional actions may be activated.
+ */
+export async function preflightSelectedConditionalActionProvider(
+  runtimeView: VoyantGraphRuntime,
+  portId: string,
+  provider: unknown,
+): Promise<void> {
+  const runtime = baseRuntime(runtimeView)
+  const requirements = conditionalPortRequirements(runtime).filter(
+    (requirement) => requirement.portId === portId,
+  )
+  if (requirements.length === 0) return
+
+  let byPort = conditionalPortPreflights.get(runtime)
+  if (!byPort) {
+    byPort = new Map()
+    conditionalPortPreflights.set(runtime, byPort)
+  }
+  const existing = byPort.get(portId)
+  if (existing) {
+    if (!Object.is(existing.provider, provider)) {
+      throw new Error(
+        `VOYANT_GRAPH_CONDITIONAL_ACTION_PROVIDER_DRIFT: provider port "${portId}" changed after startup preflight.`,
+      )
+    }
+    return existing.promise
+  }
+
+  const promise = (async () => {
+    for (const requirement of requirements) {
+      const port = await requirement.conformance.load<unknown>()
+      assertTypedPortConformance(port, requirement)
+      await port.test(provider)
+    }
+    let attestations = conditionalPortAttestations.get(runtime)
+    if (!attestations) {
+      attestations = new Map()
+      conditionalPortAttestations.set(runtime, attestations)
+    }
+    attestations.set(portId, provider)
+  })()
+  byPort.set(portId, { provider, promise })
+  return promise
+}
+
+/** Provider ports whose exact selected instances must pass activation preflight. */
+export function conditionalActionProviderPortIds(runtimeView: VoyantGraphRuntime): string[] {
+  return [
+    ...new Set(conditionalPortRequirements(baseRuntime(runtimeView)).map(({ portId }) => portId)),
+  ].sort()
+}
+
+/**
+ * Produce the only runtime view that enumerates selected conditional actions
+ * and Tools. The view is registered in module-private state and cannot be
+ * manufactured by a structural callback or public marker.
+ */
+export function activateConditionalActionRuntime(
+  runtimeView: VoyantGraphRuntime,
+): VoyantGraphActivatedRuntime {
+  const runtime = baseRuntime(runtimeView)
+  const requirements = conditionalPortRequirements(runtime)
+  if (requirements.length === 0) return runtime as VoyantGraphActivatedRuntime
+  const cached = activatedRuntimeViews.get(runtime)
+  if (cached) return cached
+
+  const attestations = conditionalPortAttestations.get(runtime)
+  for (const { action, portId } of requirements) {
+    if (!attestations?.has(portId)) {
+      throw new Error(
+        `VOYANT_GRAPH_CONDITIONAL_ACTION_NOT_PREFLIGHTED: action "${action.id}" requires selected provider port "${portId}" to pass factory and typed-port conformance before activation.`,
+      )
+    }
+  }
+
+  const activatedActionIds = new Set(requirements.map(({ action }) => action.id))
+  const byUnit = provisionalUnits.get(runtime)
+  if (!byUnit) {
+    throw new Error(
+      "VOYANT_GRAPH_CONDITIONAL_ACTION_CANDIDATES_MISSING: activation-only runtime state was not registered by the framework.",
+    )
+  }
+  const activateUnits = (units: readonly VoyantGraphRuntimeUnitLoader[]) =>
+    units.map((unit) => activateRuntimeUnit(unit, byUnit.get(unit.id), activatedActionIds))
+  const modules = Object.freeze(activateUnits(runtime.modules))
+  const extensions = Object.freeze(activateUnits(runtime.extensions))
+  const plugins = Object.freeze(activateUnits(runtime.plugins))
+  const adapters = Object.freeze(activateUnits(runtime.adapters ?? []))
+  const providerUnits = Object.freeze(activateUnits(runtime.providerUnits ?? []))
+  const units = [...modules, ...extensions, ...plugins, ...adapters, ...providerUnits]
+  const references = Object.freeze(units.flatMap((unit) => unit.references))
+  const referenceById = new Map(references.map((reference) => [reference.id, reference]))
+  const activated: VoyantGraphActivatedRuntime = createFrameworkOwnedRuntime(() =>
+    deepFreezeRuntimeSnapshot({
+      ...runtime,
+      modules,
+      extensions,
+      plugins,
+      adapters,
+      providerUnits,
+      references,
+      tools: Object.freeze(units.flatMap((unit) => unit.tools)),
+      actions: Object.freeze(units.flatMap((unit) => unit.actions)),
+      selectedIds: Object.freeze({
+        ...runtime.selectedIds,
+        tools: Object.freeze(sortedUnique(units.flatMap((unit) => unit.selectedIds.tools))),
+      }),
+      loadReference: async <T = unknown>(referenceId: string): Promise<T> => {
+        const reference = referenceById.get(referenceId)
+        return reference ? reference.load<T>() : runtime.loadReference<T>(referenceId)
+      },
+    }),
+  )
+  const exactAttestations = new Map(attestations)
+  activatedRuntimeStates.set(activated, { base: runtime, attestations: exactAttestations })
+  activatedRuntimeViews.set(runtime, activated)
+  return activated
+}
+
+/**
+ * Require the framework-owned activated view. Composition may additionally
+ * require every conditional port binding to be the exact attested instance.
+ */
+export function assertConditionalActionRuntimeActivated(
+  runtime: VoyantGraphRuntime,
+  ports?: VoyantGraphRuntimePorts,
+  requireBoundPorts = false,
+): asserts runtime is VoyantGraphActivatedRuntime {
+  const activated = activatedRuntimeStates.get(runtime)
+  if (!activated) {
+    if (conditionalPortRequirements(runtime).length === 0) return
+    throw new Error(
+      "VOYANT_GRAPH_CONDITIONAL_ACTION_NOT_ACTIVATED: selected conditional actions require a framework-owned activated runtime view.",
+    )
+  }
+  for (const [portId, provider] of activated.attestations) {
+    if (
+      (requireBoundPorts || ports !== undefined) &&
+      (!ports || !Object.hasOwn(ports, portId) || !Object.is(ports[portId], provider))
+    ) {
+      throw new Error(
+        `VOYANT_GRAPH_CONDITIONAL_ACTION_PROVIDER_DRIFT: activated provider port "${portId}" is not the exact preflighted selected graph provider.`,
+      )
+    }
+  }
+}
+
+function activateRuntimeUnit(
+  unit: VoyantGraphRuntimeUnitLoader,
+  provisional: VoyantGraphConditionalActionProvisionalUnit | undefined,
+  activatedActionIds: ReadonlySet<string>,
+): VoyantGraphRuntimeUnitLoader {
+  const actions = Object.freeze(
+    unit.actions.map((action) =>
+      activatedActionIds.has(action.id)
+        ? Object.freeze({ ...action, availability: { status: "available" as const } })
+        : action,
+    ),
+  )
+  const references = Object.freeze([...unit.references, ...(provisional?.references ?? [])])
+  const tools = Object.freeze([...unit.tools, ...(provisional?.tools ?? [])])
+  return Object.freeze({
+    ...unit,
+    references,
+    tools,
+    actions,
+    selectedIds: Object.freeze({
+      ...unit.selectedIds,
+      tools: Object.freeze(sortedUnique([...unit.selectedIds.tools, ...tools.map(({ id }) => id)])),
+    }),
+  })
+}
+
+function conditionalPortRequirements(runtime: VoyantGraphRuntime): ConditionalRequirement[] {
+  const units = [
+    ...runtime.modules,
+    ...runtime.extensions,
+    ...runtime.plugins,
+    ...(runtime.adapters ?? []),
+    ...(runtime.providerUnits ?? []),
+  ]
+  const byUnitId = new Map(units.map((unit) => [unit.id, unit]))
+  return selectedConditionalActions(runtime).flatMap((action) => {
+    const condition =
+      action.availability?.status === "unavailable" ? action.availability.enableWhen : undefined
+    if (!condition) return []
+    const owner = byUnitId.get(action.unitId)
+    return selectedConditionalPorts(runtime, action).map((portId) => {
+      const conformance = owner?.runtimePortConformance?.find(
+        (candidate) => candidate.portId === portId,
+      )
+      if (!conformance) {
+        throw new Error(
+          `VOYANT_GRAPH_CONDITIONAL_ACTION_CONFORMANCE_MISSING: action "${action.id}" has no admitted typed-port conformance loader for "${portId}".`,
+        )
+      }
+      return { action, portId, conformance }
+    })
+  })
+}
+
+function selectedConditionalActions(
+  runtime: VoyantGraphRuntime,
+): VoyantGraphRuntimeActionDefinition[] {
+  return runtime.actions.filter((action) => {
+    if (action.availability?.status !== "unavailable" || !action.availability.enableWhen) {
+      return false
+    }
+    const ports = selectedConditionalPorts(runtime, action)
+    const condition = action.availability.enableWhen.selectedProviderPorts
+    return condition.mode === "all" ? ports.length === condition.ports.length : ports.length > 0
+  })
+}
+
+function selectedConditionalPorts(
+  runtime: VoyantGraphRuntime,
+  action: VoyantGraphRuntimeActionDefinition,
+): string[] {
+  const condition =
+    action.availability?.status === "unavailable" ? action.availability.enableWhen : undefined
+  if (!condition) return []
+  return condition.selectedProviderPorts.ports.filter((portId) => {
+    const selectedCount = runtime.providers.filter(({ declaration }) => {
+      const selection = declaration.selection
+      return (
+        declaration.port === portId &&
+        selection !== undefined &&
+        runtime.providerSelections[selection.role] === selection.value
+      )
+    }).length
+    if (selectedCount > 1) {
+      throw new Error(
+        `VOYANT_GRAPH_CONDITIONAL_ACTION_PROVIDER_AMBIGUOUS: action "${action.id}" resolves provider port "${portId}" more than once at runtime.`,
+      )
+    }
+    return selectedCount === 1
+  })
+}
+
+function assertTypedPortConformance(
+  value: unknown,
+  requirement: Pick<ConditionalRequirement, "action" | "portId">,
+): asserts value is VoyantPort<unknown> {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    (value as { id?: unknown }).id !== requirement.portId ||
+    typeof (value as { test?: unknown }).test !== "function"
+  ) {
+    throw new Error(
+      `VOYANT_GRAPH_CONDITIONAL_ACTION_CONFORMANCE_INVALID: action "${requirement.action.id}" conformance export for "${requirement.portId}" is not that typed VoyantPort.`,
+    )
+  }
+}
+
+function baseRuntime(runtime: VoyantGraphRuntime): VoyantGraphRuntime {
+  return activatedRuntimeStates.get(runtime)?.base ?? runtime
+}
+
+function sortedUnique(values: readonly string[]): string[] {
+  return [...new Set(values)].sort((left, right) => left.localeCompare(right))
+}

--- a/packages/framework/src/deployment-artifacts.test.ts
+++ b/packages/framework/src/deployment-artifacts.test.ts
@@ -21,6 +21,7 @@ import {
   defineModule,
   definePlugin,
   defineProject,
+  defineProvider,
   resolveDeploymentGraph,
   type VoyantGraphUnitManifest,
 } from "./deployment-graph.js"
@@ -65,10 +66,11 @@ async function graphWithSelectedUnits(
   modules: readonly VoyantGraphUnitManifest[],
   plugins: readonly VoyantGraphUnitManifest[] = [],
   extensions: readonly VoyantGraphUnitManifest[] = [],
+  providers: readonly VoyantGraphUnitManifest[] = [],
 ) {
-  const units = [...modules, ...extensions, ...plugins]
+  const units = [...modules, ...extensions, ...plugins, ...providers]
   return resolveDeploymentGraph({
-    project: defineProject({ modules, extensions, plugins }),
+    project: defineProject({ modules, extensions, plugins, providers }),
     target: "node",
     mode: "self-hosted",
     packageRecords: [
@@ -203,6 +205,88 @@ describe("deployment graph artifacts", () => {
     )
     expect(source).toContain("manyPortIds.has(id) ? [value] : value")
     expect(source).toContain("values.push(value)")
+  })
+
+  it("keeps conditional Tool import specifiers out of exported provisional metadata", async () => {
+    const portId = "notifications.durable-send"
+    const toolId = "@acme/notifications#tool.send"
+    const graph = await graphWithSelectedUnits(
+      [
+        defineModule({
+          id: "@acme/notifications",
+          runtimePorts: [
+            {
+              id: portId,
+              optional: true,
+              conformance: { entry: "./durable-port", export: "durablePort" },
+            },
+          ],
+          tools: [
+            {
+              id: toolId,
+              name: "send_notification",
+              runtime: { entry: "./tools", export: "sendNotificationTool" },
+            },
+          ],
+          actions: [
+            {
+              id: "@acme/notifications#action.send",
+              version: "v1",
+              kind: "execute",
+              targetType: "notification",
+              commandTargetField: "notificationId",
+              targetLifecycle: "existing",
+              availability: {
+                status: "unavailable",
+                reasonCode: "provider-not-durable",
+                enableWhen: {
+                  selectedProviderPorts: { mode: "all", ports: [portId] },
+                },
+              },
+              effectBoundary: "external",
+              durability: { strategy: "saga", testReference: "durable-send.test.ts" },
+              existingTarget: { durability: "handler-command-result-v1" },
+              risk: "high",
+              ledger: "required",
+              approval: "required",
+              from: { tools: [toolId] },
+            },
+          ],
+        }),
+      ],
+      [],
+      [],
+      [
+        defineProvider({
+          id: "@acme/notifications-provider",
+          provides: { ports: [{ id: portId }] },
+          providers: [
+            {
+              id: "@acme/notifications-provider#provider",
+              port: portId,
+              selection: { role: "notifications", value: "durable" },
+              runtime: { entry: "./provider", export: "createProvider" },
+            },
+          ],
+        }),
+      ],
+    )
+    const selectedGraph = {
+      ...graph,
+      deployment: {
+        ...graph.deployment,
+        providers: { notifications: "durable" },
+      },
+    }
+    const source = buildGraphRuntimeModule({ graph: selectedGraph })
+    const publicEntries = source.match(
+      /export const GENERATED_GRAPH_RUNTIME_ENTRY_SPECIFIERS = ([^\n]+)/,
+    )?.[1]
+
+    expect(publicEntries).toBeDefined()
+    expect(publicEntries).not.toContain("@acme/notifications/tools")
+    expect(source).toContain('import("@acme/notifications/tools")')
+    expect(source).toContain('"provisionalTools"')
   })
 
   it("selects a canonical package contributor when compatibility provenance is stale", async () => {

--- a/packages/framework/src/deployment-artifacts.ts
+++ b/packages/framework/src/deployment-artifacts.ts
@@ -155,7 +155,9 @@ export function createResolvedGraphRuntime(
   const entrySpecifiers = [
     ...new Set(
       [...modules, ...extensions, ...plugins, ...adapters, ...providers].flatMap((unit) =>
-        unit.references.map((reference) => reference.importEntry),
+        [...unit.references, ...unit.provisionalReferences].map(
+          (reference) => reference.importEntry,
+        ),
       ),
     ),
   ]
@@ -396,10 +398,19 @@ export function buildGraphRuntimeModule(input: BuildGraphRuntimeModuleInput): st
     input.graph,
     input.runtimeEntryOverrides,
   )
-  const entries = [
+  const publicEntries = [
     ...new Set(
       [...modules, ...extensions, ...plugins, ...adapters, ...providers].flatMap((unit) =>
         unit.references.map((definition) => definition.importEntry),
+      ),
+    ),
+  ].sort((left, right) => left.localeCompare(right))
+  const importerEntries = [
+    ...new Set(
+      [...modules, ...extensions, ...plugins, ...adapters, ...providers].flatMap((unit) =>
+        [...unit.references, ...unit.provisionalReferences].map(
+          (definition) => definition.importEntry,
+        ),
       ),
     ),
   ].sort((left, right) => left.localeCompare(right))
@@ -489,7 +500,7 @@ import type {
 } from "@voyant-travel/framework"
 
 export const GENERATED_GRAPH_RUNTIME_HASH = ${quote(input.graph.contentHash)} as const
-export const GENERATED_GRAPH_RUNTIME_ENTRY_SPECIFIERS = ${formatConstArray(entries)}
+export const GENERATED_GRAPH_RUNTIME_ENTRY_SPECIFIERS = ${formatConstArray(publicEntries)}
 export const GENERATED_GRAPH_RUNTIME_CONTRIBUTOR_SPECIFIERS = ${formatConstArray(
     contributors.map((contributor) => contributor.entry),
   )}
@@ -526,7 +537,7 @@ export const GENERATED_GRAPH_RUNTIME_WEBHOOK_PLAN = ${formatGeneratedValue(
     0,
   )} as const
 
-const GENERATED_GRAPH_RUNTIME_IMPORTERS = ${formatRuntimeImporters(entries)}
+const GENERATED_GRAPH_RUNTIME_IMPORTERS = ${formatRuntimeImporters(importerEntries)}
 
 const GENERATED_GRAPH_RUNTIME_CONTRIBUTORS: readonly VoyantGraphRuntimeContributor[] = [
 ${contributorFactories}

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -1198,6 +1198,304 @@ describe("deployment graph v1", () => {
         }),
       ),
     ).toEqual([])
+    expect(
+      validateGraphUnitManifest(
+        manifest({
+          availability: {
+            status: "unavailable",
+            reasonCode: "provider-not-durable",
+            enableWhen: {
+              selectedProviderPorts: {
+                mode: "all",
+                ports: ["notifications.durable-send"],
+              },
+            },
+          },
+          effectBoundary: "external",
+        }),
+      ),
+    ).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          facet: "actions[0].targetLifecycle",
+        }),
+        expect.objectContaining({
+          facet: "actions[0].durability",
+        }),
+      ]),
+    )
+  })
+
+  it("keeps selected provider-conditional actions provisional until runtime preflight", async () => {
+    const provider = (id: string, port: string, role: string, value: string) =>
+      defineProvider({
+        id,
+        provides: { ports: [{ id: port }] },
+        providers: [
+          {
+            id: `${id}#provider`,
+            port,
+            selection: { role, value },
+            runtime: { entry: "./provider", export: "createProvider" },
+          },
+        ],
+      })
+    const actionModule = (
+      mode: "all" | "any",
+      ports: readonly string[],
+      availability: "conditional" | "legacy" = "conditional",
+    ) =>
+      defineModule({
+        id: "@acme/voyant-actions",
+        runtimePorts: ports.map((id) => ({
+          id,
+          optional: true,
+          conformance: { entry: "./durable-port", export: "durablePort" },
+        })),
+        tools: [
+          {
+            id: "@acme/voyant-actions#tool.send",
+            name: "send",
+            runtime: { entry: "./tools", export: "sendTool" },
+          },
+        ],
+        actions: [
+          {
+            id: "@acme/voyant-actions#action.send",
+            version: "v1",
+            kind: "execute",
+            targetType: "message",
+            commandTargetField: "messageId",
+            targetLifecycle: "existing",
+            ...(availability === "conditional"
+              ? {
+                  availability: {
+                    status: "unavailable" as const,
+                    reasonCode: "provider-not-durable",
+                    enableWhen: {
+                      selectedProviderPorts: { mode, ports },
+                    },
+                  },
+                }
+              : {
+                  availability: {
+                    status: "unavailable" as const,
+                    reasonCode: "provider-not-durable",
+                  },
+                }),
+            effectBoundary: "external",
+            durability: { strategy: "saga", testReference: "send.test.ts" },
+            existingTarget: { durability: "handler-command-result-v1" },
+            risk: "high",
+            ledger: "required",
+            approval: "required",
+            from: { tools: ["@acme/voyant-actions#tool.send"] },
+          },
+        ],
+      })
+    const email = provider(
+      "@acme/voyant-email-provider",
+      "notifications.durable-email",
+      "email",
+      "durable",
+    )
+    const sms = provider("@acme/voyant-sms-provider", "notifications.durable-sms", "sms", "durable")
+    const resolve = (
+      mode: "all" | "any",
+      ports: readonly string[],
+      selections: Record<string, string>,
+    ) =>
+      resolveDeploymentGraph({
+        project: defineProject({
+          modules: [actionModule(mode, ports)],
+          providers: [email, sms],
+        }),
+        deployment: {
+          target: "node",
+          providers: selections,
+          requirements: { resources: [] },
+        },
+      })
+
+    const allSelected = await resolve(
+      "all",
+      ["notifications.durable-sms", "notifications.durable-email"],
+      { email: "durable", sms: "durable" },
+    )
+    expect(allSelected.diagnostics).toEqual([])
+    expect(allSelected.modules[0]?.actions?.[0]?.availability).toEqual({
+      status: "unavailable",
+      reasonCode: "provider-not-durable",
+      enableWhen: {
+        selectedProviderPorts: {
+          mode: "all",
+          ports: ["notifications.durable-email", "notifications.durable-sms"],
+        },
+      },
+    })
+
+    const missingOne = await resolve(
+      "all",
+      ["notifications.durable-email", "notifications.durable-sms"],
+      { email: "durable", sms: "none" },
+    )
+    expect(missingOne.modules[0]?.actions?.[0]?.availability?.status).toBe("unavailable")
+
+    const anySelected = await resolve(
+      "any",
+      ["notifications.durable-email", "notifications.durable-sms"],
+      { email: "none", sms: "durable" },
+    )
+    expect(anySelected.modules[0]?.actions?.[0]?.availability?.status).toBe("unavailable")
+
+    const oldManifest = await resolveDeploymentGraph({
+      project: defineProject({
+        modules: [actionModule("all", ["notifications.durable-email"], "legacy")],
+        providers: [email],
+      }),
+      deployment: {
+        target: "node",
+        providers: { email: "durable" },
+        requirements: { resources: [] },
+      },
+    })
+    expect(oldManifest.modules[0]?.actions?.[0]?.availability?.status).toBe("unavailable")
+
+    const reordered = await resolve(
+      "all",
+      ["notifications.durable-email", "notifications.durable-sms"],
+      { email: "durable", sms: "durable" },
+    )
+    expect(reordered.contentHash).toBe(allSelected.contentHash)
+    expect(missingOne.contentHash).not.toBe(allSelected.contentHash)
+    const disabledAll = await resolve(
+      "all",
+      ["notifications.durable-email", "notifications.durable-sms"],
+      { email: "none", sms: "none" },
+    )
+    const disabledAny = await resolve(
+      "any",
+      ["notifications.durable-email", "notifications.durable-sms"],
+      { email: "none", sms: "none" },
+    )
+    expect(disabledAny.contentHash).not.toBe(disabledAll.contentHash)
+  })
+
+  it("rejects malformed, unknown, and ambiguous conditional action providers", async () => {
+    const baseAction = {
+      id: "@acme/voyant-actions#action.send",
+      version: "v1",
+      kind: "execute" as const,
+      targetType: "message",
+      commandTargetField: "messageId",
+      targetLifecycle: "existing" as const,
+      effectBoundary: "external" as const,
+      durability: { strategy: "saga" as const, testReference: "send.test.ts" },
+      existingTarget: { durability: "handler-command-result-v1" as const },
+      risk: "high" as const,
+      ledger: "required" as const,
+    }
+    const malformed = defineModule({
+      id: "@acme/voyant-actions",
+      actions: [
+        {
+          ...baseAction,
+          availability: {
+            status: "unavailable",
+            reasonCode: "provider-not-durable",
+            enableWhen: {
+              selectedProviderPorts: {
+                mode: "some",
+                ports: ["notifications.durable-send", "notifications.durable-send"],
+                callback: "hostCanSend",
+              },
+            },
+          } as never,
+        },
+      ],
+    })
+    expect(validateGraphUnitManifest(malformed)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_INVALID_FACET",
+          facet: "actions[0].availability.enableWhen.selectedProviderPorts",
+        }),
+      ]),
+    )
+
+    const actionModule = defineModule({
+      id: "@acme/voyant-actions",
+      runtimePorts: [
+        {
+          id: "notifications.durable-send",
+          optional: true,
+          conformance: { entry: "./durable-port", export: "durablePort" },
+        },
+      ],
+      actions: [
+        {
+          ...baseAction,
+          availability: {
+            status: "unavailable",
+            reasonCode: "provider-not-durable",
+            enableWhen: {
+              selectedProviderPorts: {
+                mode: "all",
+                ports: ["notifications.durable-send"],
+              },
+            },
+          },
+        },
+      ],
+    })
+    const unknown = await resolveDeploymentGraph({
+      project: defineProject({ modules: [actionModule] }),
+    })
+    expect(unknown.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_UNKNOWN_REFERENCE",
+          facet: "actions[0].availability.enableWhen.selectedProviderPorts.ports",
+        }),
+      ]),
+    )
+
+    const selectedProvider = (id: string) =>
+      defineProvider({
+        id,
+        provides: { ports: [{ id: "notifications.durable-send" }] },
+        providers: [
+          {
+            id: `${id}#provider`,
+            port: "notifications.durable-send",
+            selection: { role: "notifications", value: "durable" },
+            runtime: { entry: "./provider", export: "createProvider" },
+          },
+        ],
+      })
+    const ambiguous = await resolveDeploymentGraph({
+      project: defineProject({
+        modules: [actionModule],
+        providers: [
+          selectedProvider("@acme/voyant-notifications-a"),
+          selectedProvider("@acme/voyant-notifications-b"),
+        ],
+      }),
+      deployment: {
+        target: "node",
+        providers: { notifications: "durable" },
+        requirements: { resources: [] },
+      },
+    })
+    expect(ambiguous.diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "VOYANT_GRAPH_INVALID_PROVIDER_SELECTION",
+          facet: "actions[0].availability.enableWhen.selectedProviderPorts.ports",
+        }),
+      ]),
+    )
+    expect(ambiguous.modules[0]?.actions?.[0]?.availability?.status).toBe("unavailable")
   })
 
   it("rejects action bindings that reference the wrong selected facet kind", async () => {

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -13,6 +13,7 @@ import {
   type VoyantGraphAccessDeclaration,
   type VoyantGraphAccessPreset,
   type VoyantGraphAccessResource,
+  type VoyantGraphActionAvailabilityCondition,
   type VoyantGraphActionDeclaration,
   type VoyantGraphAdminDeclaration,
   type VoyantGraphCapabilityDeclaration,
@@ -91,6 +92,7 @@ export {
   VOYANT_GRAPH_PROJECT_SCHEMA_VERSION,
   VOYANT_GRAPH_PROVIDER_SCHEMA_VERSION,
   type VoyantGraphAccessDeclaration,
+  type VoyantGraphActionAvailabilityCondition,
   type VoyantGraphActionDeclaration,
   type VoyantGraphAdminDeclaration,
   type VoyantGraphCapabilityDeclaration,
@@ -431,8 +433,17 @@ export interface ResolvedVoyantGraphUnit {
   reporting?: VoyantGraphReportingDeclaration
   tools?: readonly VoyantGraphToolDeclaration[]
   webhooks?: readonly VoyantGraphWebhookDeclaration[]
-  actions?: readonly VoyantGraphActionDeclaration[]
+  actions?: readonly ResolvedVoyantGraphActionDeclaration[]
   lifecycle?: VoyantGraphLifecycleDeclaration
+}
+
+export interface ResolvedVoyantGraphActionDeclaration
+  extends Omit<VoyantGraphActionDeclaration, "availability"> {
+  /**
+   * Conditional actions remain authored-unavailable in the resolved graph.
+   * Exact-provider activation is process-local and never changes graph metadata.
+   */
+  availability?: VoyantGraphActionDeclaration["availability"]
 }
 
 export interface ResolvedVoyantDeploymentGraph {
@@ -781,6 +792,7 @@ export async function resolveDeploymentGraph(
     ...validateDuplicateEntityIds(selectedUnits),
     ...validateAccessCatalog(selectedUnits, input.project.access?.presets ?? []),
     ...validateDeploymentProviderSelections(selectedUnits, deploymentProviders),
+    ...validateConditionalActionAvailability(selectedUnits, deploymentProviders),
     ...validatePackageAdmission(packageRecords, {
       frameworkVersion: input.frameworkVersion,
       target,
@@ -792,19 +804,19 @@ export async function resolveDeploymentGraph(
   ])
 
   const modules = selectedModules.map(({ original: _original, ...unit }) =>
-    applyResolvedJobSchedules(unit, provisionedJobsById),
+    applyResolvedJobSchedules(resolveConditionalActionAvailability(unit), provisionedJobsById),
   )
   const extensions = selectedExtensions.map(({ original: _original, ...unit }) =>
-    applyResolvedJobSchedules(unit, provisionedJobsById),
+    applyResolvedJobSchedules(resolveConditionalActionAvailability(unit), provisionedJobsById),
   )
   const plugins = selectedPlugins.map(({ original: _original, ...unit }) =>
-    applyResolvedJobSchedules(unit, provisionedJobsById),
+    applyResolvedJobSchedules(resolveConditionalActionAvailability(unit), provisionedJobsById),
   )
   const adapters = selectedAdapters.map(({ original: _original, ...unit }) =>
-    applyResolvedJobSchedules(unit, provisionedJobsById),
+    applyResolvedJobSchedules(resolveConditionalActionAvailability(unit), provisionedJobsById),
   )
   const providerUnits = selectedProviders.map(({ original: _original, ...unit }) =>
-    applyResolvedJobSchedules(unit, provisionedJobsById),
+    applyResolvedJobSchedules(resolveConditionalActionAvailability(unit), provisionedJobsById),
   )
   const graphWithoutHash: Omit<ResolvedVoyantDeploymentGraph, "contentHash"> = {
     schemaVersion: VOYANT_RESOLVED_GRAPH_SCHEMA_VERSION,
@@ -1459,6 +1471,14 @@ function validateRuntimePortDeclarations(
         }),
       )
     }
+    if (port.conformance !== undefined) {
+      validateRuntimeReference(
+        port.conformance,
+        `runtimePorts[${index}].conformance`,
+        source,
+        diagnostics,
+      )
+    }
   }
   return diagnostics
 }
@@ -1976,6 +1996,21 @@ function validatePromotedFacets(
           diagnostics,
         )
       }
+      if ("enableWhen" in availability) {
+        validateActionAvailabilityCondition(
+          availability.enableWhen,
+          `${facet}.availability.enableWhen`,
+          source,
+          diagnostics,
+        )
+      }
+    } else if (availability && "enableWhen" in availability) {
+      invalidFacet(
+        `${facet}.availability.enableWhen`,
+        source,
+        diagnostics,
+        'Action enableWhen is valid only with the fail-closed status "unavailable".',
+      )
     }
     if (
       entry.effectBoundary !== undefined &&
@@ -2023,7 +2058,9 @@ function validatePromotedFacets(
     // into any safety metadata, omitted availability has the same callable
     // meaning as runtime lowering: available. This prevents removing only an
     // `unavailable` block from bypassing lifecycle and durability validation.
-    const effectivelyAvailable = availability?.status !== "unavailable"
+    const effectivelyAvailable =
+      availability?.status !== "unavailable" ||
+      (availability !== undefined && "enableWhen" in availability)
     const safetyContractSelected =
       availability !== undefined ||
       entry.effectBoundary !== undefined ||
@@ -2327,6 +2364,55 @@ function validatePromotedFacets(
     }
   }
   return diagnostics
+}
+
+function validateActionAvailabilityCondition(
+  value: unknown,
+  facet: string,
+  source: string | undefined,
+  diagnostics: VoyantGraphDiagnostic[],
+): void {
+  if (!isRecord(value) || !hasExactKeys(value, ["selectedProviderPorts"])) {
+    invalidFacet(
+      facet,
+      source,
+      diagnostics,
+      "Action enableWhen must contain exactly one selectedProviderPorts condition.",
+    )
+    return
+  }
+  const selectedProviderPorts = value.selectedProviderPorts
+  if (!isRecord(selectedProviderPorts) || !hasExactKeys(selectedProviderPorts, ["mode", "ports"])) {
+    invalidFacet(
+      `${facet}.selectedProviderPorts`,
+      source,
+      diagnostics,
+      "selectedProviderPorts must contain exactly mode and ports.",
+    )
+    return
+  }
+  if (selectedProviderPorts.mode !== "all" && selectedProviderPorts.mode !== "any") {
+    invalidFacet(
+      `${facet}.selectedProviderPorts.mode`,
+      source,
+      diagnostics,
+      'selectedProviderPorts.mode must be "all" or "any".',
+    )
+  }
+  const ports = selectedProviderPorts.ports
+  if (
+    !Array.isArray(ports) ||
+    ports.length === 0 ||
+    ports.some((port) => typeof port !== "string" || !PORT_ID_PATTERN.test(port)) ||
+    new Set(ports).size !== ports.length
+  ) {
+    invalidFacet(
+      `${facet}.selectedProviderPorts.ports`,
+      source,
+      diagnostics,
+      "selectedProviderPorts.ports must be a non-empty array of unique dot-case typed port ids.",
+    )
+  }
 }
 
 function facetEntityIds(value: unknown): Set<string> {
@@ -4154,6 +4240,141 @@ function validateDeploymentProviderSelections(
   return [...validatePaymentProviderSelection(units, providers)]
 }
 
+function validateConditionalActionAvailability(
+  units: readonly (ResolvedVoyantGraphUnit & { original: VoyantGraphUnitManifest })[],
+  selections: Partial<Record<VoyantDeploymentProviderRole | string, string>>,
+): VoyantGraphDiagnostic[] {
+  const diagnostics: VoyantGraphDiagnostic[] = []
+  for (const unit of units) {
+    for (const [actionIndex, action] of (unit.actions ?? []).entries()) {
+      const condition = normalizedActionAvailabilityCondition(action)
+      if (!condition) continue
+      for (const port of condition.selectedProviderPorts.ports) {
+        const facet = `actions[${actionIndex}].availability.enableWhen.selectedProviderPorts.ports`
+        const consumerPort = unit.runtimePorts?.find((candidate) => candidate.id === port)
+        if (
+          !consumerPort ||
+          consumerPort.cardinality === "many" ||
+          consumerPort.conformance === undefined
+        ) {
+          diagnostics.push(
+            diagnostic({
+              code: "VOYANT_GRAPH_INVALID_FACET",
+              source: unit.id,
+              facet,
+              message: `Conditional action "${action.id}" must consume one-valued typed runtime port "${port}" with an importable conformance reference in its owning unit runtimePorts.`,
+              hint: "Declare the dedicated typed port with definePort({ conformance }) and consume it as an optional or required one-valued runtime port.",
+            }),
+          )
+        }
+
+        const candidates = closedProviderDeclarationsForPort(units, port)
+        if (candidates.length === 0) {
+          diagnostics.push(
+            diagnostic({
+              code: "VOYANT_GRAPH_UNKNOWN_REFERENCE",
+              source: unit.id,
+              facet,
+              message: `Conditional action "${action.id}" references provider port "${port}", but no selected graph unit closes that port with an explicitly selectable provider declaration.`,
+              hint: "Select a provider package that both provides the typed port and declares its deployment provider role/value.",
+            }),
+          )
+          continue
+        }
+
+        const selected = candidates.filter(({ declaration }) =>
+          providerDeclarationIsSelected(declaration, selections),
+        )
+        if (selected.length > 1) {
+          diagnostics.push(
+            diagnostic({
+              code: "VOYANT_GRAPH_INVALID_PROVIDER_SELECTION",
+              source: unit.id,
+              facet,
+              message: `Conditional action "${action.id}" resolves provider port "${port}" ambiguously to ${selected.length} selected provider declarations.`,
+              hint: `Select exactly one provider declaration for "${port}".`,
+            }),
+          )
+        }
+      }
+    }
+  }
+  return diagnostics
+}
+
+function resolveConditionalActionAvailability(
+  unit: ResolvedVoyantGraphUnit,
+): ResolvedVoyantGraphUnit {
+  if (!unit.actions?.some((action) => normalizedActionAvailabilityCondition(action))) return unit
+  return {
+    ...unit,
+    actions: unit.actions.map((action) => {
+      const condition = normalizedActionAvailabilityCondition(action)
+      if (!condition) return action
+      const availability = action.availability
+      if (availability?.status !== "unavailable") return action
+      return {
+        ...action,
+        availability: { ...availability, enableWhen: condition },
+      }
+    }),
+  }
+}
+
+function normalizedActionAvailabilityCondition(
+  action: VoyantGraphActionDeclaration | ResolvedVoyantGraphActionDeclaration,
+): VoyantGraphActionAvailabilityCondition | undefined {
+  const availability = action.availability
+  if (availability?.status !== "unavailable") return undefined
+  const condition = availability.enableWhen
+  if (!isRecord(condition) || !hasExactKeys(condition, ["selectedProviderPorts"])) return undefined
+  const selectedProviderPorts = condition.selectedProviderPorts
+  if (
+    !isRecord(selectedProviderPorts) ||
+    !hasExactKeys(selectedProviderPorts, ["mode", "ports"]) ||
+    (selectedProviderPorts.mode !== "all" && selectedProviderPorts.mode !== "any") ||
+    !Array.isArray(selectedProviderPorts.ports) ||
+    selectedProviderPorts.ports.length === 0 ||
+    selectedProviderPorts.ports.some(
+      (port) => typeof port !== "string" || !PORT_ID_PATTERN.test(port),
+    ) ||
+    new Set(selectedProviderPorts.ports).size !== selectedProviderPorts.ports.length
+  ) {
+    return undefined
+  }
+  return {
+    selectedProviderPorts: {
+      mode: selectedProviderPorts.mode,
+      ports: sortedUnique(selectedProviderPorts.ports as string[]),
+    },
+  }
+}
+
+function closedProviderDeclarationsForPort(
+  units: readonly (ResolvedVoyantGraphUnit & { original?: VoyantGraphUnitManifest })[],
+  port: string,
+): { unitId: string; declaration: VoyantGraphProviderDeclaration }[] {
+  return units.flatMap((unit) => {
+    if (!unit.provides.ports.some((provided) => provided.id === port)) return []
+    return (unit.providers ?? [])
+      .filter(
+        (declaration) =>
+          declaration.port === port &&
+          typeof declaration.selection?.role === "string" &&
+          typeof declaration.selection.value === "string",
+      )
+      .map((declaration) => ({ unitId: unit.id, declaration }))
+  })
+}
+
+function providerDeclarationIsSelected(
+  declaration: VoyantGraphProviderDeclaration,
+  selections: Partial<Record<VoyantDeploymentProviderRole | string, string>>,
+): boolean {
+  const selection = declaration.selection
+  return selection !== undefined && selections[selection.role] === selection.value
+}
+
 function validatePaymentProviderSelection(
   units: readonly (ResolvedVoyantGraphUnit & { original: VoyantGraphUnitManifest })[],
   providers: Partial<Record<VoyantDeploymentProviderRole | string, string>>,
@@ -4719,6 +4940,12 @@ function bytesToHex(bytes: Uint8Array): string {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const expected = new Set(keys)
+  const actual = Object.keys(value)
+  return actual.length === expected.size && actual.every((key) => expected.has(key))
 }
 
 function errorMessage(error: unknown): string {

--- a/packages/framework/src/graph-action-ledger.test.ts
+++ b/packages/framework/src/graph-action-ledger.test.ts
@@ -15,12 +15,15 @@ function actionRuntime(
   overrides: {
     accessScopes?: readonly string[]
     selectedIds?: VoyantGraphRuntimeSelectedIds
+    conditionalEnabled?: boolean
     unavailable?: boolean
   } = {},
 ) {
   const accessScopes = overrides.accessScopes ?? ["loyalty:write"]
+  const conditionalPortId = "notifications.durable-send"
   return createVoyantGraphRuntime({
     graphHash: "sha256:actions",
+    providerSelections: overrides.conditionalEnabled ? { notifications: "durable" } : {},
     accessCatalog: {
       resources: accessScopes.includes("loyalty:write")
         ? [
@@ -37,7 +40,15 @@ function actionRuntime(
         : [],
       presets: [],
     },
-    entries: {},
+    entries: overrides.conditionalEnabled
+      ? {
+          "@acme/loyalty/provider": async () => ({ createProvider: () => ({}) }),
+          "@acme/loyalty/durable-port": async () => ({
+            durableNotificationPort: { id: conditionalPortId, test: () => undefined },
+          }),
+          "@acme/loyalty/tool": async () => ({}),
+        }
+      : {},
     modules: [
       {
         id: "@acme/loyalty",
@@ -45,6 +56,70 @@ function actionRuntime(
         packageName: "@acme/loyalty",
         order: 0,
         accessScopes,
+        ...(overrides.conditionalEnabled
+          ? {
+              references: [
+                {
+                  id: "notification-provider",
+                  unitId: "@acme/loyalty",
+                  facet: "providers.runtime" as const,
+                  entityId: "@acme/loyalty#provider.durable",
+                  runtime: { entry: "./provider", export: "createProvider" },
+                  importEntry: "@acme/loyalty/provider",
+                },
+                {
+                  id: "notification-port-conformance",
+                  unitId: "@acme/loyalty",
+                  facet: "runtimePorts.conformance" as const,
+                  entityId: conditionalPortId,
+                  runtime: {
+                    entry: "./durable-port",
+                    export: "durableNotificationPort",
+                  },
+                  importEntry: "@acme/loyalty/durable-port",
+                },
+              ],
+              provisionalReferences: [
+                {
+                  id: "loyalty-tool-reference",
+                  unitId: "@acme/loyalty",
+                  facet: "tools.runtime" as const,
+                  entityId: "loyalty.tool",
+                  runtime: { entry: "./tool", export: "loyaltyTool" },
+                  importEntry: "@acme/loyalty/tool",
+                },
+              ],
+              provisionalTools: [
+                {
+                  id: "loyalty.tool",
+                  unitId: "@acme/loyalty",
+                  name: "loyalty_tool",
+                  referenceId: "loyalty-tool-reference",
+                  requiredScopes: ["loyalty:write"],
+                },
+              ],
+              providers: [
+                {
+                  unitId: "@acme/loyalty",
+                  declaration: {
+                    id: "@acme/loyalty#provider.durable",
+                    port: conditionalPortId,
+                    selection: { role: "notifications", value: "durable" },
+                    runtime: { entry: "./provider", export: "createProvider" },
+                  },
+                  referenceId: "notification-provider",
+                },
+              ],
+              requiredPorts: [conditionalPortId],
+              runtimePorts: [conditionalPortId],
+              runtimePortConformance: [
+                {
+                  portId: conditionalPortId,
+                  referenceId: "notification-port-conformance",
+                },
+              ],
+            }
+          : {}),
         actions: [
           {
             id: "loyalty.points.adjust",
@@ -60,7 +135,20 @@ function actionRuntime(
                     reasonCode: "unsafe-nontransactional-effect",
                   },
                 }
-              : {}),
+              : overrides.conditionalEnabled
+                ? {
+                    availability: {
+                      status: "unavailable" as const,
+                      reasonCode: "provider-not-durable",
+                      enableWhen: {
+                        selectedProviderPorts: {
+                          mode: "all" as const,
+                          ports: [conditionalPortId],
+                        },
+                      },
+                    },
+                  }
+                : {}),
             resource: "loyalty_balance",
             action: "adjust_points",
             requiredScopes: ["loyalty:write"],
@@ -77,7 +165,9 @@ function actionRuntime(
             },
           },
         ],
-        selectedIds: overrides.selectedIds ?? selectedIds,
+        selectedIds:
+          overrides.selectedIds ??
+          (overrides.conditionalEnabled ? { ...selectedIds, tools: [] } : selectedIds),
         routes: [],
       },
     ],
@@ -126,6 +216,12 @@ describe("graph action-ledger lowering", () => {
     })
 
     expect(lowerVoyantGraphActionsToActionLedgerRegistry(runtime).definitions).toEqual([])
+  })
+
+  it("rejects a selected conditional action before framework activation", () => {
+    const runtime = actionRuntime({ conditionalEnabled: true })
+
+    expect(() => lowerVoyantGraphActionsToActionLedgerRegistry(runtime)).toThrow(/NOT_ACTIVATED/)
   })
 
   it.each([

--- a/packages/framework/src/graph-action-ledger.ts
+++ b/packages/framework/src/graph-action-ledger.ts
@@ -6,6 +6,7 @@ import {
   createActionLedgerCapabilityRegistry,
 } from "@voyant-travel/action-ledger/capability"
 
+import { assertConditionalActionRuntimeActivated } from "./conditional-action-availability.js"
 import type {
   VoyantGraphRuntime,
   VoyantGraphRuntimeActionDefinition,
@@ -35,6 +36,7 @@ export function lowerVoyantGraphActionsToActionLedgerRegistry<TContext = unknown
   runtime: VoyantGraphRuntime,
   options: LowerVoyantGraphActionsOptions<TContext> = {},
 ): ActionLedgerCapabilityRegistry<ActionLedgerCapabilityDefinition<TContext>> {
+  assertConditionalActionRuntimeActivated(runtime)
   validateSelectedGraphActions(runtime)
 
   const definitions = runtime.actions

--- a/packages/framework/src/graph-runtime-generation.ts
+++ b/packages/framework/src/graph-runtime-generation.ts
@@ -1,12 +1,14 @@
 import {
   packageNameFromSpecifier,
   type ResolvedVoyantDeploymentGraph,
+  type ResolvedVoyantGraphActionDeclaration,
   type ResolvedVoyantGraphUnit,
 } from "./deployment-graph.js"
 import type {
   VoyantGraphRuntimeActionDefinition,
   VoyantGraphRuntimeConfigDefinition,
   VoyantGraphRuntimeJobDefinition,
+  VoyantGraphRuntimePortConformanceDefinition,
   VoyantGraphRuntimeProviderDefinition,
   VoyantGraphRuntimeReferenceDefinition,
   VoyantGraphRuntimeReferenceFacet,
@@ -36,11 +38,16 @@ export interface GeneratedRuntimeUnitDefinition {
   providers: VoyantGraphRuntimeProviderDefinition[]
   requiredPorts: string[]
   runtimePorts: string[]
+  runtimePortConformance: VoyantGraphRuntimePortConformanceDefinition[]
   customFieldTargets: ResolvedVoyantGraphUnit["customFieldTargets"]
   manyRuntimePorts: string[]
   requiredRuntimePorts: string[]
   accessScopes: string[]
   tools: VoyantGraphRuntimeToolDefinition[]
+  /** Selected conditional Tools retained only for framework-owned post-preflight activation. */
+  provisionalTools: VoyantGraphRuntimeToolDefinition[]
+  /** Tool references retained only for framework-owned post-preflight activation. */
+  provisionalReferences: VoyantGraphRuntimeReferenceDefinition[]
   jobs: VoyantGraphRuntimeJobDefinition[]
   actions: VoyantGraphRuntimeActionDefinition[]
   setupSteps: { id: string; skippable: boolean }[]
@@ -58,15 +65,11 @@ export function lowerGraphRuntimeUnits(
   graph: ResolvedVoyantDeploymentGraph,
   runtimeEntryOverrides: Readonly<Record<string, string>> | undefined,
 ): GeneratedRuntimeUnitDefinition[] {
-  const unavailableToolIds = unavailableActionToolIds(units)
-  const availableToolIds = new Set(
-    units.flatMap((unit) =>
-      (unit.actions ?? [])
-        .filter((action) => action.availability?.status !== "unavailable")
-        .flatMap((action) => action.from?.tools ?? []),
-    ),
+  const { unavailableToolIds, provisionalToolIds, availableToolIds } =
+    classifyActionToolPostures(graph)
+  const conflictingToolId = [...unavailableToolIds, ...provisionalToolIds].find(
+    (id) => availableToolIds.has(id) || (unavailableToolIds.has(id) && provisionalToolIds.has(id)),
   )
-  const conflictingToolId = [...unavailableToolIds].find((id) => availableToolIds.has(id))
   if (conflictingToolId) {
     throw new Error(
       `VOYANT_GRAPH_UNAVAILABLE_TOOL_SHARED: action Tool "${conflictingToolId}" is bound by both available and unavailable actions.`,
@@ -80,6 +83,13 @@ export function lowerGraphRuntimeUnits(
         graph,
         runtimeEntryOverrides,
         unavailableToolIds,
+        provisionalToolIds,
+      )
+      const provisionalReferences = collectProvisionalToolReferences(
+        unit,
+        graph,
+        runtimeEntryOverrides,
+        provisionalToolIds,
       )
       const config = (unit.config ?? []).map((declaration) => ({
         unitId: unit.id,
@@ -135,7 +145,21 @@ export function lowerGraphRuntimeUnits(
         ),
       ].sort((left, right) => left.localeCompare(right))
       const tools = (unit.tools ?? [])
-        .filter((tool) => !unavailableToolIds.has(tool.id))
+        .filter((tool) => !unavailableToolIds.has(tool.id) && !provisionalToolIds.has(tool.id))
+        .map((tool) => ({
+          id: tool.id,
+          unitId: unit.id,
+          name: tool.name,
+          referenceId: runtimeReferenceId(unit.id, "tools.runtime", tool.id),
+          requiredScopes: [...(tool.requiredScopes ?? [])].sort((left, right) =>
+            left.localeCompare(right),
+          ),
+          ...(tool.context?.length ? { context: [...tool.context].sort() } : {}),
+          ...(tool.risk ? { risk: tool.risk } : {}),
+        }))
+        .sort((left, right) => left.id.localeCompare(right.id))
+      const provisionalTools = (unit.tools ?? [])
+        .filter((tool) => provisionalToolIds.has(tool.id))
         .map((tool) => ({
           id: tool.id,
           unitId: unit.id,
@@ -193,6 +217,13 @@ export function lowerGraphRuntimeUnits(
           .map((port) => port.id)
           .sort(),
         runtimePorts: (unit.runtimePorts ?? []).map((port) => port.id).sort(),
+        runtimePortConformance: (unit.runtimePorts ?? [])
+          .filter((port) => port.conformance !== undefined)
+          .map((port) => ({
+            portId: port.id,
+            referenceId: runtimeReferenceId(unit.id, "runtimePorts.conformance", port.id),
+          }))
+          .sort((left, right) => left.portId.localeCompare(right.portId)),
         customFieldTargets: unit.customFieldTargets,
         manyRuntimePorts: (unit.runtimePorts ?? [])
           .filter((port) => port.cardinality === "many")
@@ -204,6 +235,8 @@ export function lowerGraphRuntimeUnits(
           .sort(),
         accessScopes,
         tools,
+        provisionalTools,
+        provisionalReferences,
         jobs,
         actions,
         setupSteps: (unit.admin?.setupSteps ?? []).map(({ id, skippable }) => ({
@@ -213,7 +246,7 @@ export function lowerGraphRuntimeUnits(
         selectedIds: {
           routes: unit.api.map(({ id }) => id).sort(),
           tools: (unit.tools ?? [])
-            .filter(({ id }) => !unavailableToolIds.has(id))
+            .filter(({ id }) => !unavailableToolIds.has(id) && !provisionalToolIds.has(id))
             .map(({ id }) => id)
             .sort(),
           events: unit.events.map(({ id }) => id).sort(),
@@ -241,6 +274,7 @@ function collectRuntimeReferences(
   graph: ResolvedVoyantDeploymentGraph,
   runtimeEntryOverrides: Readonly<Record<string, string>> | undefined,
   unavailableToolIds: ReadonlySet<string>,
+  provisionalToolIds: ReadonlySet<string>,
 ): VoyantGraphRuntimeReferenceDefinition[] {
   const admittedPackages = new Set(graph.packageRecords.map((record) => record.packageName))
   const references: VoyantGraphRuntimeReferenceDefinition[] = []
@@ -288,7 +322,12 @@ function collectRuntimeReferences(
     add("reporting.datasets.runtime", dataset.id, dataset.runtime)
   }
   for (const tool of unit.tools ?? []) {
-    if (!unavailableToolIds.has(tool.id)) add("tools.runtime", tool.id, tool.runtime)
+    if (!unavailableToolIds.has(tool.id) && !provisionalToolIds.has(tool.id)) {
+      add("tools.runtime", tool.id, tool.runtime)
+    }
+  }
+  for (const port of unit.runtimePorts ?? []) {
+    if (port.conformance) add("runtimePorts.conformance", port.id, port.conformance)
   }
   for (const job of unit.jobs ?? []) add("jobs.runtime", job.id, job.runtime)
   for (const subscriber of unit.subscribers) {
@@ -301,14 +340,95 @@ function collectRuntimeReferences(
   )
 }
 
-function unavailableActionToolIds(units: readonly ResolvedVoyantGraphUnit[]): Set<string> {
-  return new Set(
-    units.flatMap((unit) =>
-      (unit.actions ?? [])
-        .filter((action) => action.availability?.status === "unavailable")
-        .flatMap((action) => action.from?.tools ?? []),
-    ),
+function collectProvisionalToolReferences(
+  unit: ResolvedVoyantGraphUnit,
+  graph: ResolvedVoyantDeploymentGraph,
+  runtimeEntryOverrides: Readonly<Record<string, string>> | undefined,
+  provisionalToolIds: ReadonlySet<string>,
+): VoyantGraphRuntimeReferenceDefinition[] {
+  const admittedPackages = new Set(graph.packageRecords.map((record) => record.packageName))
+  return (unit.tools ?? [])
+    .filter((tool) => provisionalToolIds.has(tool.id))
+    .map((tool) => {
+      const referencedPackage = tool.runtime.entry.startsWith(".")
+        ? unit.packageName
+        : packageNameFromSpecifier(tool.runtime.entry)
+      if (!admittedPackages.has(referencedPackage)) {
+        throw new Error(
+          `VOYANT_GRAPH_RUNTIME_PACKAGE_UNADMITTED: buildGraphRuntimeModule: runtime entry "${tool.runtime.entry}" for ${unit.id} tools.runtime ${tool.id} resolves to package "${referencedPackage}", which is not admitted by the graph.`,
+        )
+      }
+      const loweredEntry = lowerRuntimeImportEntry(unit, tool.runtime.entry)
+      return {
+        id: runtimeReferenceId(unit.id, "tools.runtime", tool.id),
+        unitId: unit.id,
+        facet: "tools.runtime" as const,
+        entityId: tool.id,
+        runtime: tool.runtime,
+        importEntry: runtimeEntryOverrides?.[loweredEntry] ?? loweredEntry,
+      }
+    })
+    .sort((left, right) => left.entityId.localeCompare(right.entityId))
+}
+
+function allResolvedGraphUnits(graph: ResolvedVoyantDeploymentGraph): ResolvedVoyantGraphUnit[] {
+  return [
+    ...graph.modules,
+    ...graph.extensions,
+    ...graph.plugins,
+    ...graph.adapters,
+    ...graph.providers,
+  ]
+}
+
+function classifyActionToolPostures(graph: ResolvedVoyantDeploymentGraph): {
+  unavailableToolIds: Set<string>
+  provisionalToolIds: Set<string>
+  availableToolIds: Set<string>
+} {
+  const unavailableToolIds = new Set<string>()
+  const provisionalToolIds = new Set<string>()
+  const availableToolIds = new Set<string>()
+  for (const unit of allResolvedGraphUnits(graph)) {
+    for (const action of unit.actions ?? []) {
+      const target =
+        action.availability?.status !== "unavailable"
+          ? availableToolIds
+          : selectedConditionalAction(action, graph)
+            ? provisionalToolIds
+            : unavailableToolIds
+      for (const toolId of action.from?.tools ?? []) target.add(toolId)
+    }
+  }
+  return { unavailableToolIds, provisionalToolIds, availableToolIds }
+}
+
+function selectedConditionalAction(
+  action: ResolvedVoyantGraphActionDeclaration,
+  graph: ResolvedVoyantDeploymentGraph,
+): boolean {
+  const availability = action.availability
+  const condition = availability?.status === "unavailable" ? availability.enableWhen : undefined
+  if (!condition) return false
+  const units = allResolvedGraphUnits(graph)
+  const selectedCounts = condition.selectedProviderPorts.ports.map(
+    (portId) =>
+      units.flatMap((unit) =>
+        unit.provides.ports.some(({ id }) => id === portId)
+          ? (unit.providers ?? []).filter(({ port, selection }) => {
+              return (
+                port === portId &&
+                selection !== undefined &&
+                graph.deployment.providers[selection.role] === selection.value
+              )
+            })
+          : [],
+      ).length,
   )
+  if (selectedCounts.some((count) => count > 1)) return false
+  return condition.selectedProviderPorts.mode === "all"
+    ? selectedCounts.every((count) => count === 1)
+    : selectedCounts.some((count) => count === 1)
 }
 
 function runtimeReferenceId(

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -17,6 +17,7 @@
  * for deployment-local units.
  */
 
+export { assertVoyantGraphMcpRuntime } from "./conditional-action-availability.js"
 export {
   type CreateVoyantAppConfig,
   createVoyantApp,
@@ -118,6 +119,7 @@ export {
   createVoyantGraphRuntime,
   registerVoyantGraphTools,
   VOYANT_GRAPH_RUNTIME_LOAD_ERROR_CODES,
+  type VoyantGraphActivatedRuntime,
   type VoyantGraphRuntime,
   type VoyantGraphRuntimeActionDefinition,
   type VoyantGraphRuntimeConfigDefinition,

--- a/packages/framework/src/package-exports.test.ts
+++ b/packages/framework/src/package-exports.test.ts
@@ -13,6 +13,21 @@ const packageJson = JSON.parse(
 ) as PackageJson
 
 describe("@voyant-travel/framework package exports", () => {
+  it("publishes only the runtime attestation assertion, never its registrar", async () => {
+    expect(packageJson.exports["./runtime-attestation"]).toBe("./src/runtime-attestation.ts")
+    expect(packageJson.publishConfig.exports["./runtime-attestation"]).toEqual({
+      types: "./dist/runtime-attestation.d.ts",
+      import: "./dist/runtime-attestation.js",
+    })
+    expect(packageJson.exports["./conditional-action-availability"]).toBeUndefined()
+    expect(packageJson.publishConfig.exports["./conditional-action-availability"]).toBeUndefined()
+
+    const framework = await import("./index.js")
+    const attestation = await import("./runtime-attestation.js")
+    expect("registerFrameworkOwnedRuntime" in framework).toBe(false)
+    expect(Object.keys(attestation)).toEqual(["assertVoyantGraphMcpRuntime"])
+  })
+
   it("publishes the self-host export contract for external generators", () => {
     expect(packageJson.exports["./self-host-export"]).toBe("./src/self-host-export.ts")
     expect(packageJson.publishConfig.exports["./self-host-export"]).toEqual({

--- a/packages/framework/src/runtime-attestation.ts
+++ b/packages/framework/src/runtime-attestation.ts
@@ -1,0 +1,2 @@
+export { assertVoyantGraphMcpRuntime } from "./conditional-action-availability.js"
+export type { VoyantGraphActivatedRuntime, VoyantGraphRuntime } from "./runtime-lowering.js"

--- a/packages/framework/src/runtime-composition.ts
+++ b/packages/framework/src/runtime-composition.ts
@@ -11,7 +11,7 @@ import {
   type VoyantPort,
 } from "@voyant-travel/core/project"
 import type { ApiExtension, ApiModule } from "@voyant-travel/hono/module"
-
+import { assertConditionalActionRuntimeActivated } from "./conditional-action-availability.js"
 import type { VoyantGraphRuntime, VoyantGraphRuntimeUnitLoader } from "./runtime-lowering.js"
 
 export interface VoyantGraphRuntimeBindingContext<TCapabilities> {
@@ -276,6 +276,7 @@ export async function composeVoyantGraphRuntimeFacetModules(
   runtime: VoyantGraphRuntime,
   ports?: VoyantGraphRuntimePorts,
 ): Promise<ApiModule[]> {
+  assertConditionalActionRuntimeActivated(runtime, ports, true)
   return composeRuntimeFacetModules(runtime, createRuntimeFactoryContexts(runtime, ports))
 }
 
@@ -302,6 +303,7 @@ async function composeRuntimeFacetModules(
 export async function composeVoyantGraphRuntime<TCapabilities>(
   input: ComposeVoyantGraphRuntimeInput<TCapabilities>,
 ): Promise<VoyantGraphRuntimeComposition> {
+  assertConditionalActionRuntimeActivated(input.runtime, input.ports, true)
   const modules: ApiModule[] = []
   const extensions: ApiExtension[] = []
   const factoryContexts = createRuntimeFactoryContexts(input.runtime, input.ports)

--- a/packages/framework/src/runtime-integrity.ts
+++ b/packages/framework/src/runtime-integrity.ts
@@ -1,0 +1,111 @@
+/**
+ * Validate untouched generated metadata without reading any property value.
+ *
+ * This must run before normalization because spreading or iterating an
+ * untrusted record/container could otherwise execute an accessor or erase a
+ * caller-controlled prototype before the immutable snapshot sees it.
+ */
+export function assertPlainRuntimeMetadataGraph(value: unknown): void {
+  const visited = new WeakSet<object>()
+
+  const inspect = (current: unknown): void => {
+    if (typeof current !== "object" || current === null || visited.has(current)) return
+    visited.add(current)
+
+    const prototype = Object.getPrototypeOf(current)
+    const validPrototype = Array.isArray(current)
+      ? prototype === Array.prototype
+      : prototype === Object.prototype || prototype === null
+    if (!validPrototype) {
+      throw new Error(
+        "createVoyantGraphRuntime: runtime metadata must contain only plain records and genuine arrays with no custom prototype.",
+      )
+    }
+
+    for (const key of Reflect.ownKeys(current)) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key)
+      if (!descriptor) continue
+      if (!("value" in descriptor)) {
+        throw new Error(
+          "createVoyantGraphRuntime: runtime metadata must not contain accessor properties.",
+        )
+      }
+      inspect(descriptor.value)
+    }
+  }
+
+  inspect(value)
+}
+
+/**
+ * Create an immutable, detached snapshot of framework runtime metadata.
+ *
+ * Runtime metadata is plain data plus lazy loader functions. Functions are
+ * preserved by identity; every record and array that can redirect a loader or
+ * change graph policy is copied before it is recursively frozen.
+ *
+ * Custom prototypes and accessors are rejected. Accepting either would let a
+ * caller change inherited policy after minting even though the snapshot's own
+ * properties are frozen. Opaque provider, Tool, and schema objects are loaded
+ * later through the preserved functions and never cross this metadata boundary.
+ */
+export function cloneAndDeepFreezeRuntimeSnapshot<T>(value: T): T {
+  const copies = new WeakMap<object, unknown>()
+
+  const clone = (current: unknown): unknown => {
+    if (typeof current !== "object" || current === null) return current
+    const existing = copies.get(current)
+    if (existing !== undefined) return existing
+
+    if (Array.isArray(current)) {
+      const copy: unknown[] = []
+      copies.set(current, copy)
+      for (const item of current) copy.push(clone(item))
+      return Object.freeze(copy)
+    }
+
+    const prototype = Object.getPrototypeOf(current)
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error(
+        "createVoyantGraphRuntime: runtime metadata must contain only plain records with no custom prototype.",
+      )
+    }
+
+    const copy: Record<PropertyKey, unknown> = {}
+    copies.set(current, copy)
+    for (const key of Reflect.ownKeys(current)) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key)
+      if (!descriptor) continue
+      if (!("value" in descriptor)) {
+        throw new Error(
+          "createVoyantGraphRuntime: runtime metadata must not contain accessor properties.",
+        )
+      }
+      Object.defineProperty(copy, key, {
+        ...descriptor,
+        value: clone(descriptor.value),
+      })
+    }
+    return Object.freeze(copy)
+  }
+
+  return clone(value) as T
+}
+
+/** Recursively freeze a newly assembled runtime view without cloning loaders. */
+export function deepFreezeRuntimeSnapshot<T>(value: T): T {
+  const visited = new WeakSet<object>()
+
+  const freeze = (current: unknown): void => {
+    if (typeof current !== "object" || current === null || visited.has(current)) return
+    visited.add(current)
+    for (const key of Reflect.ownKeys(current)) {
+      const descriptor = Object.getOwnPropertyDescriptor(current, key)
+      if (descriptor && "value" in descriptor) freeze(descriptor.value)
+    }
+    Object.freeze(current)
+  }
+
+  freeze(value)
+  return value
+}

--- a/packages/framework/src/runtime-lowering.test.ts
+++ b/packages/framework/src/runtime-lowering.test.ts
@@ -3,7 +3,13 @@
 import type { VoyantGraphCustomFieldTarget } from "@voyant-travel/core/project"
 import { createToolRegistry } from "@voyant-travel/tools"
 import { describe, expect, it, vi } from "vitest"
-import { defineModule, defineProject, resolveDeploymentGraph } from "./deployment-graph.js"
+import {
+  defineExtension,
+  defineModule,
+  defineProject,
+  defineProvider,
+  resolveDeploymentGraph,
+} from "./deployment-graph.js"
 import { lowerGraphRuntimeUnits } from "./graph-runtime-generation.js"
 import { invokeVoyantGraphJob } from "./runtime-composition.js"
 import {
@@ -236,6 +242,232 @@ describe("graph runtime lowering", () => {
     expect(toolOwnerDefinition?.selectedIds.tools).toEqual([])
     expect(toolOwnerDefinition?.references).not.toEqual(
       expect.arrayContaining([expect.objectContaining({ facet: "tools.runtime" })]),
+    )
+  })
+
+  it("keeps selected conditional Tools private until framework activation", async () => {
+    const toolId = "@acme/voyant-notifications#tool.send"
+    const actionOwner = defineModule({
+      id: "@acme/voyant-notifications",
+      runtimePorts: [
+        {
+          id: "notifications.durable-send",
+          optional: true,
+          conformance: { entry: "./durable-port", export: "durablePort" },
+        },
+      ],
+      tools: [
+        {
+          id: toolId,
+          name: "send_notification",
+          runtime: { entry: "./tools", export: "sendNotificationTool" },
+        },
+      ],
+      actions: [
+        {
+          id: "@acme/voyant-notifications#action.send",
+          version: "v1",
+          kind: "execute",
+          targetType: "notification",
+          commandTargetField: "notificationId",
+          targetLifecycle: "existing",
+          availability: {
+            status: "unavailable",
+            reasonCode: "provider-not-durable",
+            enableWhen: {
+              selectedProviderPorts: {
+                mode: "all",
+                ports: ["notifications.durable-send"],
+              },
+            },
+          },
+          effectBoundary: "external",
+          durability: { strategy: "saga", testReference: "send.test.ts" },
+          existingTarget: { durability: "handler-command-result-v1" },
+          risk: "high",
+          ledger: "required",
+          approval: "required",
+          from: { tools: [toolId] },
+        },
+      ],
+    })
+    const provider = defineProvider({
+      id: "@acme/voyant-notifications-provider",
+      provides: { ports: [{ id: "notifications.durable-send" }] },
+      providers: [
+        {
+          id: "@acme/voyant-notifications-provider#provider",
+          port: "notifications.durable-send",
+          selection: { role: "notifications", value: "durable" },
+          runtime: { entry: "./provider", export: "createProvider" },
+        },
+      ],
+    })
+    const resolve = (value: string) =>
+      resolveDeploymentGraph({
+        project: defineProject({ modules: [actionOwner], providers: [provider] }),
+        deployment: {
+          target: "node",
+          providers: { notifications: value },
+          requirements: { resources: [] },
+        },
+      })
+
+    const enabledGraph = await resolve("durable")
+    const enabled = lowerGraphRuntimeUnits(enabledGraph.modules, enabledGraph, undefined)[0]!
+    expect(enabled.actions[0]?.availability).toEqual(
+      expect.objectContaining({ status: "unavailable" }),
+    )
+    expect(enabled.tools).toEqual([])
+    expect(enabled.selectedIds.tools).toEqual([])
+    expect(enabled.provisionalTools.map(({ id }) => id)).toEqual([toolId])
+    expect(enabled.runtimePortConformance).toEqual([
+      {
+        portId: "notifications.durable-send",
+        referenceId: expect.any(String),
+      },
+    ])
+    expect(enabled.references).toEqual(
+      expect.arrayContaining([expect.objectContaining({ facet: "runtimePorts.conformance" })]),
+    )
+    expect(enabled.references).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ facet: "tools.runtime" })]),
+    )
+    expect(enabled.provisionalReferences).toEqual([
+      expect.objectContaining({ facet: "tools.runtime", entityId: toolId }),
+    ])
+    const enabledProviderUnits = lowerGraphRuntimeUnits(
+      enabledGraph.providers,
+      enabledGraph,
+      undefined,
+    )
+    const importRuntime = vi.fn(async () => ({}))
+    const entries = Object.fromEntries(
+      [
+        ...enabled.references,
+        ...enabled.provisionalReferences,
+        ...enabledProviderUnits.flatMap((unit) => [
+          ...unit.references,
+          ...unit.provisionalReferences,
+        ]),
+      ].map(({ importEntry }) => [importEntry, importRuntime]),
+    )
+    const runtime = createVoyantGraphRuntime({
+      graphHash: "sha256:conditional-tool-preflight",
+      providerSelections: { notifications: "durable" },
+      entries,
+      modules: [enabled],
+      plugins: [],
+      providerUnits: enabledProviderUnits,
+    })
+
+    await expect(registerVoyantGraphTools(runtime, createToolRegistry())).rejects.toThrow(
+      /VOYANT_GRAPH_CONDITIONAL_ACTION_NOT_ACTIVATED/,
+    )
+    expect(runtime.actions[0]?.availability?.status).toBe("unavailable")
+    expect(runtime.tools).toEqual([])
+    expect(runtime.references).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ facet: "tools.runtime" })]),
+    )
+    expect(Object.keys(runtime.modules[0] ?? {})).not.toContain("provisionalTools")
+    expect(importRuntime).not.toHaveBeenCalled()
+
+    const disabledGraph = await resolve("none")
+    const disabled = lowerGraphRuntimeUnits(disabledGraph.modules, disabledGraph, undefined)[0]!
+    expect(disabled.actions[0]?.availability).toEqual(
+      expect.objectContaining({ status: "unavailable" }),
+    )
+    expect(disabled.tools).toEqual([])
+    expect(disabled.provisionalTools).toEqual([])
+    expect(disabled.provisionalReferences).toEqual([])
+    expect(disabled.selectedIds.tools).toEqual([])
+    expect(disabled.references).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ facet: "tools.runtime" })]),
+    )
+  })
+
+  it("rejects a Tool shared by enabled and disabled conditional actions across graph kinds", async () => {
+    const toolId = "@acme/voyant-tools#tool.send"
+    const toolOwner = defineModule({
+      id: "@acme/voyant-tools",
+      tools: [
+        {
+          id: toolId,
+          name: "send",
+          runtime: { entry: "./tools", export: "sendTool" },
+        },
+      ],
+    })
+    const action = (id: string, port: string, mode: "available" | "conditional") => ({
+      id,
+      version: "v1",
+      kind: "execute" as const,
+      targetType: "message",
+      commandTargetField: "messageId",
+      targetLifecycle: "existing" as const,
+      availability:
+        mode === "available"
+          ? ({ status: "available" } as const)
+          : ({
+              status: "unavailable",
+              reasonCode: "provider-not-durable",
+              enableWhen: {
+                selectedProviderPorts: { mode: "all", ports: [port] },
+              },
+            } as const),
+      effectBoundary: "external" as const,
+      durability: { strategy: "saga" as const, testReference: "send.test.ts" },
+      existingTarget: { durability: "handler-command-result-v1" as const },
+      risk: "high" as const,
+      ledger: "required" as const,
+      approval: "required" as const,
+      from: { tools: [toolId] },
+    })
+    const extension = defineExtension({
+      id: "@acme/voyant-action-owner",
+      actions: [action("@acme/voyant-action-owner#action.enabled", "", "available")],
+    })
+    const providerUnit = defineProvider({
+      id: "@acme/voyant-action-provider",
+      runtimePorts: [
+        {
+          id: "notifications.durable-send",
+          optional: true,
+          conformance: { entry: "./durable-port", export: "durablePort" },
+        },
+      ],
+      actions: [
+        action(
+          "@acme/voyant-action-provider#action.disabled",
+          "notifications.durable-send",
+          "conditional",
+        ),
+      ],
+      provides: { ports: [{ id: "notifications.durable-send" }] },
+      providers: [
+        {
+          id: "@acme/voyant-action-provider#provider",
+          port: "notifications.durable-send",
+          selection: { role: "notifications", value: "durable" },
+          runtime: { entry: "./provider", export: "createProvider" },
+        },
+      ],
+    })
+    const graph = await resolveDeploymentGraph({
+      project: defineProject({
+        modules: [toolOwner],
+        extensions: [extension],
+        providers: [providerUnit],
+      }),
+      deployment: {
+        target: "node",
+        providers: { notifications: "none" },
+        requirements: { resources: [] },
+      },
+    })
+
+    expect(() => lowerGraphRuntimeUnits(graph.modules, graph, undefined)).toThrow(
+      /VOYANT_GRAPH_UNAVAILABLE_TOOL_SHARED/,
     )
   })
 

--- a/packages/framework/src/runtime-lowering.ts
+++ b/packages/framework/src/runtime-lowering.ts
@@ -3,7 +3,6 @@ import {
   isExternalWebhookPayloadSchema,
   VOYANT_EVENT_CATALOG_SCHEMA_VERSION,
   type VoyantGraphActionBindings,
-  type VoyantGraphActionDeclaration,
   type VoyantGraphConfigDeclaration,
   type VoyantGraphEventCatalog,
   type VoyantGraphJob,
@@ -18,12 +17,23 @@ import {
 } from "@voyant-travel/core/project"
 import type { ToolRegistry } from "@voyant-travel/tools"
 import type { AccessCatalog } from "@voyant-travel/types/api-keys"
-
+import {
+  assertConditionalActionRuntimeActivated,
+  createFrameworkOwnedRuntime,
+  registerConditionalActionRuntimeState,
+  type VoyantGraphConditionalActionProvisionalUnit,
+} from "./conditional-action-availability.js"
 import type {
+  ResolvedVoyantGraphActionDeclaration,
   VoyantGraphInboundWebhookPlanEntry,
   VoyantGraphOutboundWebhookPlanEntry,
   VoyantGraphWebhookPlan,
 } from "./deployment-graph.js"
+import {
+  assertPlainRuntimeMetadataGraph,
+  cloneAndDeepFreezeRuntimeSnapshot,
+  deepFreezeRuntimeSnapshot,
+} from "./runtime-integrity.js"
 
 export type VoyantGraphRuntimeReferenceFacet =
   | "runtime"
@@ -35,6 +45,7 @@ export type VoyantGraphRuntimeReferenceFacet =
   | "admin.routes.runtime"
   | "admin.contributions.runtime"
   | "reporting.datasets.runtime"
+  | "runtimePorts.conformance"
   | "tools.runtime"
   | "jobs.runtime"
   | "subscribers.runtime"
@@ -143,6 +154,16 @@ export interface VoyantGraphRuntimeProviderDefinition {
   referenceId: string
 }
 
+export interface VoyantGraphRuntimePortConformanceDefinition {
+  portId: string
+  referenceId: string
+}
+
+export interface VoyantGraphRuntimePortConformanceLoader
+  extends VoyantGraphRuntimePortConformanceDefinition {
+  load<T = unknown>(): Promise<T>
+}
+
 export interface VoyantGraphRuntimeSelectedIds {
   routes: readonly string[]
   tools: readonly string[]
@@ -151,7 +172,7 @@ export interface VoyantGraphRuntimeSelectedIds {
 }
 
 export interface VoyantGraphRuntimeActionDefinition
-  extends Omit<VoyantGraphActionDeclaration, "requiredScopes" | "from"> {
+  extends Omit<ResolvedVoyantGraphActionDeclaration, "requiredScopes" | "from"> {
   unitId: string
   requiredScopes: readonly string[]
   from: Required<VoyantGraphActionBindings>
@@ -172,11 +193,16 @@ export interface VoyantGraphRuntimeUnitDefinition {
   providers?: readonly VoyantGraphRuntimeProviderDefinition[]
   requiredPorts?: readonly string[]
   runtimePorts?: readonly string[]
+  runtimePortConformance?: readonly VoyantGraphRuntimePortConformanceDefinition[]
   customFieldTargets?: readonly import("@voyant-travel/core/project").VoyantGraphCustomFieldTarget[]
   manyRuntimePorts?: readonly string[]
   requiredRuntimePorts?: readonly string[]
   accessScopes?: readonly string[]
   tools?: readonly VoyantGraphRuntimeToolDefinition[]
+  /** Framework-private candidates omitted from the provisional runtime view. */
+  provisionalTools?: readonly VoyantGraphRuntimeToolDefinition[]
+  /** Framework-private Tool references omitted from the provisional runtime view. */
+  provisionalReferences?: readonly VoyantGraphRuntimeReferenceDefinition[]
   jobs?: readonly VoyantGraphRuntimeJobDefinition[]
   actions?: readonly VoyantGraphRuntimeActionDefinition[]
   setupSteps?: readonly { id: string; skippable: boolean }[]
@@ -234,6 +260,7 @@ export interface VoyantGraphRuntimeUnitLoader
   providers: readonly VoyantGraphRuntimeProviderLoader[]
   requiredPorts: readonly string[]
   runtimePorts: readonly string[]
+  runtimePortConformance?: readonly VoyantGraphRuntimePortConformanceLoader[]
   manyRuntimePorts: readonly string[]
   requiredRuntimePorts: readonly string[]
   accessScopes: readonly string[]
@@ -281,6 +308,11 @@ export interface VoyantGraphRuntime {
   loadReference: <T = unknown>(referenceId: string) => Promise<T>
 }
 
+/** Framework-created post-preflight runtime view. Runtime checks enforce this brand. */
+export interface VoyantGraphActivatedRuntime extends VoyantGraphRuntime {
+  readonly __voyantGraphActivatedRuntime?: never
+}
+
 export interface CreateVoyantGraphRuntimeInput {
   graphHash: string
   accessCatalog?: AccessCatalog
@@ -301,12 +333,13 @@ export interface CreateVoyantGraphRuntimeInput {
  * loaders. Target adapters decide how to invoke the loaded package exports.
  */
 export function createVoyantGraphRuntime(input: CreateVoyantGraphRuntimeInput): VoyantGraphRuntime {
-  const definitions = normalizeRuntimeDefinition(input)
+  assertPlainRuntimeMetadataGraph(input)
+  const definitions = cloneAndDeepFreezeRuntimeSnapshot(normalizeRuntimeDefinition(input))
   const usedEntries = validateRuntimeDefinition(definitions)
   const importEntries = new Map<string, () => Promise<unknown>>()
 
   for (const entry of usedEntries) {
-    const importEntry = input.entries[entry]
+    const importEntry = definitions.entries[entry]
     if (!importEntry) {
       throw new Error(
         `createVoyantGraphRuntime: no lazy importer was generated for runtime entry "${entry}".`,
@@ -348,43 +381,57 @@ export function createVoyantGraphRuntime(input: CreateVoyantGraphRuntimeInput): 
   const referenceById = new Map(references.map((reference) => [reference.id, reference]))
   const webhooks = createRuntimeWebhookPlan(definitions.webhookPlan)
 
-  return {
-    graphHash: input.graphHash,
-    providerSelections: { ...(input.providerSelections ?? {}) },
-    customFieldTargets,
-    modules,
-    extensions,
-    plugins,
-    adapters,
-    providerUnits,
-    references,
-    config,
-    secrets,
-    resources,
-    providers,
-    requiredPorts,
-    accessCatalog: definitions.accessCatalog,
-    eventCatalog: definitions.eventCatalog,
-    reportingCatalog: definitions.reportingCatalog,
-    accessScopes,
-    tools,
-    jobs,
-    actions,
-    setupSteps,
-    selectedIds,
-    webhooks,
-    loadReference: async <T = unknown>(referenceId: string): Promise<T> => {
-      const reference = referenceById.get(referenceId)
-      if (!reference) {
-        throw new VoyantGraphRuntimeLoadError(
-          "VOYANT_GRAPH_RUNTIME_REFERENCE_UNKNOWN",
-          { referenceId },
-          "the reference is not present in the admitted generated graph",
-        )
-      }
-      return reference.load<T>()
-    },
-  }
+  const runtime: VoyantGraphRuntime = createFrameworkOwnedRuntime(() =>
+    deepFreezeRuntimeSnapshot({
+      graphHash: definitions.graphHash,
+      providerSelections: { ...(definitions.providerSelections ?? {}) },
+      customFieldTargets,
+      modules,
+      extensions,
+      plugins,
+      adapters,
+      providerUnits,
+      references,
+      config,
+      secrets,
+      resources,
+      providers,
+      requiredPorts,
+      accessCatalog: definitions.accessCatalog,
+      eventCatalog: definitions.eventCatalog,
+      reportingCatalog: definitions.reportingCatalog,
+      accessScopes,
+      tools,
+      jobs,
+      actions,
+      setupSteps,
+      selectedIds,
+      webhooks,
+      loadReference: async <T = unknown>(referenceId: string): Promise<T> => {
+        const reference = referenceById.get(referenceId)
+        if (!reference) {
+          throw new VoyantGraphRuntimeLoadError(
+            "VOYANT_GRAPH_RUNTIME_REFERENCE_UNKNOWN",
+            { referenceId },
+            "the reference is not present in the admitted generated graph",
+          )
+        }
+        return reference.load<T>()
+      },
+    }),
+  )
+  registerConditionalActionRuntimeState(
+    runtime,
+    definitions.modules
+      .concat(
+        definitions.extensions,
+        definitions.plugins,
+        definitions.adapters,
+        definitions.providerUnits,
+      )
+      .map((unit) => createProvisionalConditionalActionUnit(unit, importEntries)),
+  )
+  return runtime
 }
 
 interface NormalizedVoyantGraphRuntimeUnitDefinition
@@ -403,6 +450,8 @@ interface NormalizedVoyantGraphRuntimeUnitDefinition
     | "secrets"
     | "selectedIds"
     | "tools"
+    | "provisionalTools"
+    | "provisionalReferences"
     | "jobs"
   > {
   projectConfig: VoyantGraphJsonObject
@@ -413,10 +462,13 @@ interface NormalizedVoyantGraphRuntimeUnitDefinition
   providers: readonly VoyantGraphRuntimeProviderDefinition[]
   requiredPorts: readonly string[]
   runtimePorts: readonly string[]
+  runtimePortConformance: readonly VoyantGraphRuntimePortConformanceDefinition[]
   manyRuntimePorts: readonly string[]
   requiredRuntimePorts: readonly string[]
   accessScopes: readonly string[]
   tools: readonly VoyantGraphRuntimeToolDefinition[]
+  provisionalTools: readonly VoyantGraphRuntimeToolDefinition[]
+  provisionalReferences: readonly VoyantGraphRuntimeReferenceDefinition[]
   jobs: readonly VoyantGraphRuntimeJobDefinition[]
   actions: readonly VoyantGraphRuntimeActionDefinition[]
   selectedIds: VoyantGraphRuntimeSelectedIds
@@ -546,6 +598,7 @@ function normalizeRuntimeUnitDefinition(
     providers: [...(unit.providers ?? [])],
     requiredPorts: sortedUnique(unit.requiredPorts ?? []),
     runtimePorts,
+    runtimePortConformance: [...(unit.runtimePortConformance ?? [])],
     customFieldTargets: [...(unit.customFieldTargets ?? [])],
     manyRuntimePorts: sortedUnique(unit.manyRuntimePorts ?? []),
     requiredRuntimePorts:
@@ -554,6 +607,8 @@ function normalizeRuntimeUnitDefinition(
         : sortedUnique(unit.requiredRuntimePorts),
     accessScopes: sortedUnique(unit.accessScopes ?? []),
     tools: [...(unit.tools ?? [])],
+    provisionalTools: [...(unit.provisionalTools ?? [])],
+    provisionalReferences: [...(unit.provisionalReferences ?? [])],
     jobs: [...(unit.jobs ?? [])],
     actions: [...(unit.actions ?? [])],
     setupSteps: [...(unit.setupSteps ?? [])],
@@ -591,6 +646,19 @@ function createRuntimeUnitLoader(
       definition.declaration.id,
       definition.referenceId,
       "providers.runtime",
+      referenceById,
+    )
+    return {
+      ...definition,
+      load: <T = unknown>() => reference.load<T>(),
+    }
+  })
+  const runtimePortConformance = unit.runtimePortConformance.map((definition) => {
+    const reference = requireDeclarationReference(
+      unit.id,
+      definition.portId,
+      definition.referenceId,
+      "runtimePorts.conformance",
       referenceById,
     )
     return {
@@ -651,6 +719,7 @@ function createRuntimeUnitLoader(
     providers,
     requiredPorts: unit.requiredPorts,
     runtimePorts: unit.runtimePorts,
+    runtimePortConformance,
     customFieldTargets: unit.customFieldTargets,
     manyRuntimePorts: unit.manyRuntimePorts,
     requiredRuntimePorts: unit.requiredRuntimePorts,
@@ -667,6 +736,30 @@ function createRuntimeUnitLoader(
         : Promise.all(uniqueRuntimeRouteLoaders(routes).map((route) => route.load())),
     ),
   }
+}
+
+function createProvisionalConditionalActionUnit(
+  unit: NormalizedVoyantGraphRuntimeUnitDefinition,
+  entries: ReadonlyMap<string, () => Promise<unknown>>,
+): VoyantGraphConditionalActionProvisionalUnit {
+  const references = unit.provisionalReferences.map((definition) =>
+    createRuntimeReferenceLoader(definition, entries),
+  )
+  const referenceById = new Map(references.map((reference) => [reference.id, reference]))
+  const tools = unit.provisionalTools.map((definition) => {
+    const reference = requireDeclarationReference(
+      definition.unitId,
+      definition.id,
+      definition.referenceId,
+      "tools.runtime",
+      referenceById,
+    )
+    return {
+      ...definition,
+      load: <T = unknown>() => loadDeclaredTool<T>(definition, reference),
+    }
+  })
+  return deepFreezeRuntimeSnapshot({ unitId: unit.id, references, tools })
 }
 
 function createRuntimeValueDeclarationLoader<
@@ -869,7 +962,7 @@ function validateRuntimeDefinition(input: NormalizedVoyantGraphRuntimeInput): st
           `createVoyantGraphRuntime: ${expectedKind} loader "${unit.id}" declares kind "${unit.kind}".`,
         )
       }
-      for (const reference of unit.references) {
+      for (const reference of [...unit.references, ...unit.provisionalReferences]) {
         if (reference.unitId !== unit.id) {
           throw new Error(
             `createVoyantGraphRuntime: reference "${reference.id}" belongs to unit "${reference.unitId}", not "${unit.id}".`,
@@ -920,7 +1013,7 @@ function validateRuntimeDefinition(input: NormalizedVoyantGraphRuntimeInput): st
           )
         }
       }
-      for (const tool of unit.tools) {
+      for (const tool of [...unit.tools, ...unit.provisionalTools]) {
         if (tool.unitId !== unit.id) {
           throw new Error(
             `createVoyantGraphRuntime: tool "${tool.id}" belongs to unit "${tool.unitId}", not "${unit.id}".`,
@@ -1137,6 +1230,7 @@ export async function registerVoyantGraphTools(
   runtime: VoyantGraphRuntime,
   registry: ToolRegistry,
 ): Promise<void> {
+  assertConditionalActionRuntimeActivated(runtime)
   for (const tool of runtime.tools) {
     registry.register(await tool.load<RegisteredTool>())
   }

--- a/packages/framework/src/runtime-providers.test.ts
+++ b/packages/framework/src/runtime-providers.test.ts
@@ -1,6 +1,15 @@
+import { z } from "@hono/zod-openapi"
+import { createToolRegistry, defineTool } from "@voyant-travel/tools"
 import { describe, expect, it, type Mock, vi } from "vitest"
 
-import { type CreateVoyantGraphRuntimeInput, createVoyantGraphRuntime } from "./runtime-lowering.js"
+import { assertVoyantGraphMcpRuntime } from "./conditional-action-availability.js"
+import { lowerVoyantGraphActionsToActionLedgerRegistry } from "./graph-action-ledger.js"
+import { composeVoyantGraphRuntime } from "./runtime-composition.js"
+import {
+  type CreateVoyantGraphRuntimeInput,
+  createVoyantGraphRuntime,
+  registerVoyantGraphTools,
+} from "./runtime-lowering.js"
 import {
   resolveVoyantGraphRuntimeProviders,
   VoyantGraphRuntimeProviderError,
@@ -98,6 +107,147 @@ function createRuntime(options: {
     plugins: [],
   }
   return { importProvider, runtime: createVoyantGraphRuntime(input) }
+}
+
+function createConditionalRuntimeInput(options: {
+  createProvider: () => unknown
+  testProvider: (provider: unknown) => void | Promise<void>
+}) {
+  const unitId = "@acme/notifications"
+  const portId = "notifications.durable-send"
+  const toolId = "@acme/notifications#tool.send"
+  const loadTool = vi.fn(async () => ({
+    sendNotificationTool: defineTool({
+      name: "send_notification",
+      description: "Send a notification",
+      inputSchema: z.object({ message: z.string() }),
+      outputSchema: z.object({ sent: z.boolean() }),
+      requiredScopes: [],
+      tier: "write",
+      riskPolicy: {
+        destructive: false,
+        reversible: false,
+        dryRunSupported: false,
+        sideEffects: ["email"],
+      },
+      actionPolicyEnforcement: "handler",
+      async handler() {
+        return { sent: true }
+      },
+    }),
+  }))
+  const input: CreateVoyantGraphRuntimeInput = {
+    graphHash: "sha256:conditional-provider",
+    providerSelections: { notifications: "durable" },
+    entries: {
+      "@acme/notifications/provider": async () => ({
+        createProvider: options.createProvider,
+      }),
+      "@acme/notifications/durable-port": async () => ({
+        durableNotificationPort: {
+          id: portId,
+          test: options.testProvider,
+        },
+      }),
+      "@acme/notifications/tools": loadTool,
+    },
+    modules: [
+      {
+        id: unitId,
+        kind: "module",
+        packageName: unitId,
+        order: 0,
+        references: [
+          {
+            id: "notification-provider",
+            unitId,
+            facet: "providers.runtime",
+            entityId: "@acme/notifications#provider.durable",
+            runtime: { entry: "./provider", export: "createProvider" },
+            importEntry: "@acme/notifications/provider",
+          },
+          {
+            id: "notification-port-conformance",
+            unitId,
+            facet: "runtimePorts.conformance",
+            entityId: portId,
+            runtime: {
+              entry: "./durable-port",
+              export: "durableNotificationPort",
+            },
+            importEntry: "@acme/notifications/durable-port",
+          },
+        ],
+        providers: [
+          {
+            unitId,
+            declaration: {
+              id: "@acme/notifications#provider.durable",
+              port: portId,
+              selection: { role: "notifications", value: "durable" },
+              runtime: { entry: "./provider", export: "createProvider" },
+            },
+            referenceId: "notification-provider",
+          },
+        ],
+        provisionalReferences: [
+          {
+            id: "notification-tool",
+            unitId,
+            facet: "tools.runtime",
+            entityId: toolId,
+            runtime: { entry: "./tools", export: "sendNotificationTool" },
+            importEntry: "@acme/notifications/tools",
+          },
+        ],
+        provisionalTools: [
+          {
+            id: toolId,
+            unitId,
+            name: "send_notification",
+            referenceId: "notification-tool",
+            requiredScopes: [],
+            risk: "high",
+          },
+        ],
+        requiredPorts: [portId],
+        runtimePorts: [portId],
+        runtimePortConformance: [{ portId, referenceId: "notification-port-conformance" }],
+        actions: [
+          {
+            id: "@acme/notifications#action.send",
+            unitId,
+            version: "v1",
+            kind: "execute",
+            targetType: "notification",
+            availability: {
+              status: "unavailable",
+              reasonCode: "provider-not-durable",
+              enableWhen: {
+                selectedProviderPorts: { mode: "all", ports: [portId] },
+              },
+            },
+            risk: "high",
+            ledger: "required",
+            requiredScopes: [],
+            from: { routes: [], tools: [toolId], events: [], webhooks: [] },
+          },
+        ],
+        selectedIds: { routes: [], tools: [], events: [], webhooks: [] },
+        routes: [],
+      },
+    ],
+    plugins: [],
+  }
+  return { input, loadTool, portId, toolId }
+}
+
+function createConditionalRuntime(options: {
+  createProvider: () => unknown
+  testProvider: (provider: unknown) => void | Promise<void>
+}) {
+  const setup = createConditionalRuntimeInput(options)
+  return { ...setup, runtime: createVoyantGraphRuntime(setup.input) }
 }
 
 describe("graph runtime providers", () => {
@@ -198,5 +348,385 @@ describe("graph runtime providers", () => {
         },
       ],
     })
+  })
+
+  it("fails conditional action startup when the selected provider factory throws", async () => {
+    const testProvider = vi.fn()
+    const { loadTool, portId, runtime } = createConditionalRuntime({
+      createProvider: () => {
+        throw new Error("provider factory failed")
+      },
+      testProvider,
+    })
+    const providers = await resolveVoyantGraphRuntimeProviders(runtime, { ports: [portId] })
+
+    expect(loadTool).not.toHaveBeenCalled()
+    await expect(providers.activateRuntime()).rejects.toThrow("provider factory failed")
+    expect(testProvider).not.toHaveBeenCalled()
+    expect(runtime.actions[0]?.availability?.status).toBe("unavailable")
+    expect(runtime.tools).toEqual([])
+    expect(loadTool).not.toHaveBeenCalled()
+    expect(() => lowerVoyantGraphActionsToActionLedgerRegistry(runtime)).toThrow(/NOT_ACTIVATED/)
+    await expect(
+      composeVoyantGraphRuntime({
+        runtime,
+        capabilities: {},
+        ports: { [portId]: {} },
+      }),
+    ).rejects.toThrow(/NOT_ACTIVATED/)
+  })
+
+  it("fails conditional action startup when the selected provider fails typed port conformance", async () => {
+    const provider = { send: vi.fn() }
+    const testProvider = vi.fn(() => {
+      throw new Error("durable reconciliation is missing")
+    })
+    const { loadTool, portId, runtime } = createConditionalRuntime({
+      createProvider: () => provider,
+      testProvider,
+    })
+    const providers = await resolveVoyantGraphRuntimeProviders(runtime, { ports: [portId] })
+
+    expect(loadTool).not.toHaveBeenCalled()
+    await expect(providers.activateRuntime()).rejects.toThrow("durable reconciliation is missing")
+    expect(testProvider).toHaveBeenCalledWith(provider)
+    expect(runtime.actions[0]?.availability?.status).toBe("unavailable")
+    expect(loadTool).not.toHaveBeenCalled()
+    expect(() => lowerVoyantGraphActionsToActionLedgerRegistry(runtime)).toThrow(/NOT_ACTIVATED/)
+  })
+
+  it("attests only the exact selected provider instance for conditional action composition", async () => {
+    class DurableProvider {
+      readonly send = vi.fn()
+      readonly reconcile = vi.fn()
+    }
+    const provider = new DurableProvider()
+    const testProvider = vi.fn()
+    const { loadTool, portId, runtime, toolId } = createConditionalRuntime({
+      createProvider: () => provider,
+      testProvider,
+    })
+    const providers = await resolveVoyantGraphRuntimeProviders(runtime, { ports: [portId] })
+    const selected = await providers.getProvider(portId)
+    const activated = await providers.activateRuntime()
+
+    expect(Object.isFrozen(provider)).toBe(false)
+    expect(testProvider).toHaveBeenCalledWith(provider)
+    expect(runtime.actions[0]?.availability?.status).toBe("unavailable")
+    expect(activated.actions[0]?.availability).toEqual({ status: "available" })
+    expect(activated.tools.map(({ id }) => id)).toEqual([toolId])
+    expect(lowerVoyantGraphActionsToActionLedgerRegistry(activated).definitions).toEqual([
+      expect.objectContaining({ id: "@acme/notifications#action.send" }),
+    ])
+    const registry = createToolRegistry()
+    await registerVoyantGraphTools(activated, registry)
+    expect(registry.names()).toEqual(["send_notification"])
+    expect(loadTool).toHaveBeenCalledOnce()
+    await expect(
+      composeVoyantGraphRuntime({
+        runtime: activated,
+        capabilities: {},
+        ports: { [portId]: selected },
+      }),
+    ).resolves.toBeDefined()
+    await expect(
+      composeVoyantGraphRuntime({
+        runtime: activated,
+        capabilities: {},
+        ports: { [portId]: { ...provider } },
+      }),
+    ).rejects.toThrow(/PROVIDER_DRIFT/)
+  })
+
+  it("rejects a custom-prototype top-level input before inherited metadata is read", () => {
+    const { input } = createConditionalRuntimeInput({
+      createProvider: () => ({ send: vi.fn() }),
+      testProvider: vi.fn(),
+    })
+    const { modules, ...ownInput } = input
+    const prototype = { modules }
+    const inheritedInput = Object.assign(Object.create(prototype), ownInput)
+
+    expect(() => createVoyantGraphRuntime(inheritedInput)).toThrow(
+      /plain records and genuine arrays with no custom prototype/,
+    )
+    expect(Reflect.set(prototype, "modules", [])).toBe(true)
+  })
+
+  it("rejects a custom-prototype modules container before normalization can iterate it", () => {
+    const { input } = createConditionalRuntimeInput({
+      createProvider: () => ({ send: vi.fn() }),
+      testProvider: vi.fn(),
+    })
+    Object.setPrototypeOf(input.modules, Object.create(Array.prototype))
+
+    expect(() => createVoyantGraphRuntime(input)).toThrow(
+      /plain records and genuine arrays with no custom prototype/,
+    )
+  })
+
+  it("rejects an accessor-backed modules container without invoking its getter", () => {
+    const { input } = createConditionalRuntimeInput({
+      createProvider: () => ({ send: vi.fn() }),
+      testProvider: vi.fn(),
+    })
+    const getter = vi.fn(() => input.modules)
+    const accessorInput = { ...input }
+    Object.defineProperty(accessorInput, "modules", {
+      configurable: true,
+      enumerable: true,
+      get: getter,
+    })
+
+    expect(() => createVoyantGraphRuntime(accessorInput)).toThrow(
+      /must not contain accessor properties/,
+    )
+    expect(getter).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    "actions",
+    "providers",
+    "runtimePortConformance",
+    "references",
+  ] as const)("rejects a custom-prototype unit %s container before normalization reads it", (field) => {
+    const { input } = createConditionalRuntimeInput({
+      createProvider: () => ({ send: vi.fn() }),
+      testProvider: vi.fn(),
+    })
+    const container = input.modules[0]![field]!
+    Object.setPrototypeOf(container, Object.create(Array.prototype))
+
+    expect(() => createVoyantGraphRuntime(input)).toThrow(
+      /plain records and genuine arrays with no custom prototype/,
+    )
+  })
+
+  it.each([
+    "actions",
+    "providers",
+    "runtimePortConformance",
+    "references",
+  ] as const)("rejects an accessor-backed unit %s container without invoking its getter", (field) => {
+    const { input } = createConditionalRuntimeInput({
+      createProvider: () => ({ send: vi.fn() }),
+      testProvider: vi.fn(),
+    })
+    const unit = input.modules[0]!
+    const getter = vi.fn(() => unit[field])
+    Object.defineProperty(unit, field, {
+      configurable: true,
+      enumerable: true,
+      get: getter,
+    })
+
+    expect(() => createVoyantGraphRuntime(input)).toThrow(/must not contain accessor properties/)
+    expect(getter).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      surface: "action availability",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const unit = input.modules[0]!
+        const action = unit.actions![0]!
+        const { availability, ...ownAction } = action
+        const prototype = { availability }
+        ;(unit.actions as unknown[])[0] = Object.assign(Object.create(prototype), ownAction)
+        return () => Object.assign(prototype, { availability: { status: "available" } })
+      },
+    },
+    {
+      surface: "action enableWhen",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const availability = input.modules[0]!.actions![0]!.availability!
+        if (availability.status !== "unavailable") throw new Error("expected unavailable action")
+        const { enableWhen, ...ownAvailability } = availability
+        const prototype = { enableWhen }
+        input.modules[0]!.actions![0]!.availability = Object.assign(
+          Object.create(prototype),
+          ownAvailability,
+        )
+        return () => Reflect.deleteProperty(prototype, "enableWhen")
+      },
+    },
+    {
+      surface: "action Tool bindings",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const action = input.modules[0]!.actions![0]!
+        const { tools, ...ownBindings } = action.from
+        const prototype = { tools }
+        action.from = Object.assign(Object.create(prototype), ownBindings)
+        return () => Object.assign(prototype, { tools: ["@acme/notifications#tool.forged"] })
+      },
+    },
+    {
+      surface: "provisional Tool reference",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const unit = input.modules[0]!
+        const tool = unit.provisionalTools![0]!
+        const { referenceId, ...ownTool } = tool
+        const prototype = { referenceId }
+        ;(unit.provisionalTools as unknown[])[0] = Object.assign(Object.create(prototype), ownTool)
+        return () => Object.assign(prototype, { referenceId: "forged-reference" })
+      },
+    },
+    {
+      surface: "provider reference requirement",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const unit = input.modules[0]!
+        const provider = unit.providers![0]!
+        const { referenceId, ...ownProvider } = provider
+        const prototype = { referenceId }
+        ;(unit.providers as unknown[])[0] = Object.assign(Object.create(prototype), ownProvider)
+        return () => Object.assign(prototype, { referenceId: "forged-provider-reference" })
+      },
+    },
+    {
+      surface: "provider selection",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const declaration = input.modules[0]!.providers![0]!.declaration
+        const selection = declaration.selection!
+        const { value, ...ownSelection } = selection
+        const prototype = { value }
+        declaration.selection = Object.assign(Object.create(prototype), ownSelection)
+        return () => Object.assign(prototype, { value: "forged" })
+      },
+    },
+    {
+      surface: "typed-port conformance binding",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const unit = input.modules[0]!
+        const conformance = unit.runtimePortConformance![0]!
+        const { referenceId, ...ownConformance } = conformance
+        const prototype = { referenceId }
+        ;(unit.runtimePortConformance as unknown[])[0] = Object.assign(
+          Object.create(prototype),
+          ownConformance,
+        )
+        return () => Object.assign(prototype, { referenceId: "forged-conformance" })
+      },
+    },
+    {
+      surface: "reference runtime export",
+      poison(input: CreateVoyantGraphRuntimeInput) {
+        const runtime = input.modules[0]!.references![0]!.runtime
+        const { export: exportName, ...ownRuntime } = runtime
+        const prototype = { export: exportName }
+        input.modules[0]!.references![0]!.runtime = Object.assign(
+          Object.create(prototype),
+          ownRuntime,
+        )
+        return () => Object.assign(prototype, { export: "forgedExport" })
+      },
+    },
+  ])("rejects inherited $surface metadata before it can become runtime authority", ({ poison }) => {
+    const { input } = createConditionalRuntimeInput({
+      createProvider: () => ({ send: vi.fn() }),
+      testProvider: vi.fn(),
+    })
+    const mutatePrototype = poison(input)
+
+    expect(() => createVoyantGraphRuntime(input)).toThrow(/plain records.*no custom prototype/)
+    expect(() => mutatePrototype()).not.toThrow()
+  })
+
+  it("detaches and deeply freezes raw and activated conditional runtime authority", async () => {
+    const provider = { send: vi.fn(), mutableAfterCreation: false }
+    const testProvider = vi.fn()
+    const { input, loadTool, portId, runtime, toolId } = createConditionalRuntime({
+      createProvider: () => provider,
+      testProvider,
+    })
+    const inputUnit = input.modules[0]!
+    const inputAction = inputUnit.actions![0]!
+    const inputTool = inputUnit.provisionalTools![0]!
+    const inputToolReference = inputUnit.provisionalReferences![0]!
+    const inputProvider = inputUnit.providers![0]!
+
+    Object.assign(input.providerSelections as Record<string, string>, {
+      notifications: "forged",
+    })
+    Object.assign(inputAction.availability!, { status: "available" })
+    Reflect.deleteProperty(inputAction.availability!, "enableWhen")
+    Object.assign(inputAction.from.tools, ["@acme/notifications#tool.forged"])
+    Object.assign(inputTool, { name: "forged_tool", referenceId: "forged-reference" })
+    Object.assign(inputToolReference.runtime, { export: "forgedExport" })
+    Object.assign(inputProvider.declaration.selection!, { value: "forged" })
+    Object.assign(inputProvider, { referenceId: "forged-provider-reference" })
+    Reflect.deleteProperty(inputUnit, "runtimePortConformance")
+
+    expect(runtime.providerSelections).toEqual({ notifications: "durable" })
+    expect(runtime.actions[0]?.availability).toEqual({
+      status: "unavailable",
+      reasonCode: "provider-not-durable",
+      enableWhen: {
+        selectedProviderPorts: { mode: "all", ports: [portId] },
+      },
+    })
+    expect(runtime.providers[0]?.declaration.selection).toEqual({
+      role: "notifications",
+      value: "durable",
+    })
+    expect(Reflect.set(runtime.providerSelections, "notifications", "forged")).toBe(false)
+    expect(Reflect.set(runtime.actions[0]!.availability!, "status", "available")).toBe(false)
+    const runtimeAvailability = runtime.actions[0]!.availability as {
+      status: "unavailable"
+      enableWhen: {
+        selectedProviderPorts: {
+          ports: readonly string[]
+        }
+      }
+    }
+    expect(
+      Reflect.deleteProperty(runtimeAvailability.enableWhen.selectedProviderPorts, "ports"),
+    ).toBe(false)
+    expect(
+      Reflect.set(runtime.actions[0]!.from.tools, "0", "@acme/notifications#tool.forged"),
+    ).toBe(false)
+    expect(Reflect.set(runtime.references[0]!, "load", vi.fn())).toBe(false)
+    expect(Reflect.set(runtime.providers[0]!.declaration.selection!, "value", "forged")).toBe(false)
+    expect(Reflect.deleteProperty(runtime.providers[0]!, "referenceId")).toBe(false)
+    expect(Reflect.deleteProperty(runtime.modules[0]!, "runtimePortConformance")).toBe(false)
+    expect(runtime.providers[0]?.referenceId).toBe("notification-provider")
+    expect(runtime.modules[0]?.runtimePortConformance).toEqual([
+      { portId, referenceId: "notification-port-conformance", load: expect.any(Function) },
+    ])
+    expect(Object.isFrozen(runtime)).toBe(true)
+    expect(Object.isFrozen(runtime.modules[0]!.actions[0]!.availability)).toBe(true)
+    expect(Object.isFrozen(runtime.modules[0]!.runtimePortConformance)).toBe(true)
+    expect(() => assertVoyantGraphMcpRuntime(runtime)).toThrow(/NOT_ACTIVATED/)
+    expect(() => lowerVoyantGraphActionsToActionLedgerRegistry(runtime)).toThrow(/NOT_ACTIVATED/)
+    expect(loadTool).not.toHaveBeenCalled()
+
+    const providers = await resolveVoyantGraphRuntimeProviders(runtime, { ports: [portId] })
+    const selected = await providers.getProvider(portId)
+    const activated = await providers.activateRuntime()
+    expect(selected).toBe(provider)
+    expect(Reflect.set(provider, "mutableAfterCreation", true)).toBe(true)
+    expect(provider.mutableAfterCreation).toBe(true)
+    expect(testProvider).toHaveBeenCalledWith(provider)
+    expect(activated.tools.map(({ id }) => id)).toEqual([toolId])
+    expect(activated.tools[0]?.name).toBe("send_notification")
+    expect(
+      activated.references.find(({ facet }) => facet === "tools.runtime")?.runtime.export,
+    ).toBe("sendNotificationTool")
+    expect(Reflect.set(activated.actions[0]!.availability!, "status", "unavailable")).toBe(false)
+    expect(Reflect.set(activated.actions[0]!.from.tools, "0", "forged")).toBe(false)
+    expect(Reflect.set(activated.tools[0]!, "load", vi.fn())).toBe(false)
+    expect(
+      Reflect.set(
+        activated.references.find(({ facet }) => facet === "tools.runtime")!,
+        "loadModule",
+        vi.fn(),
+      ),
+    ).toBe(false)
+    expect(Object.isFrozen(activated)).toBe(true)
+    expect(Object.isFrozen(activated.modules[0]!.tools[0])).toBe(true)
+
+    const registry = createToolRegistry()
+    await registerVoyantGraphTools(activated, registry)
+    expect(registry.names()).toEqual(["send_notification"])
+    expect(loadTool).toHaveBeenCalledOnce()
   })
 })

--- a/packages/framework/src/runtime-providers.ts
+++ b/packages/framework/src/runtime-providers.ts
@@ -1,6 +1,11 @@
 import type { VoyantGraphJsonObject } from "@voyant-travel/core/project"
-
+import {
+  activateConditionalActionRuntime,
+  conditionalActionProviderPortIds,
+  preflightSelectedConditionalActionProvider,
+} from "./conditional-action-availability.js"
 import type {
+  VoyantGraphActivatedRuntime,
   VoyantGraphRuntime,
   VoyantGraphRuntimeProviderLoader,
   VoyantGraphRuntimeResourceDefinition,
@@ -78,6 +83,8 @@ export interface ResolvedVoyantGraphRuntimeProviders {
   /** Redacted selection metadata. Provider instances and runtime values are not enumerable. */
   selectedProviders: readonly SelectedVoyantGraphRuntimeProvider[]
   getProvider: <T = unknown>(port: string) => Promise<T>
+  /** Preflight every selected conditional provider and return the framework-owned activated view. */
+  activateRuntime: () => Promise<VoyantGraphActivatedRuntime>
 }
 
 /** Validate explicit selections, then instantiate each selected provider only on first use. */
@@ -138,22 +145,32 @@ export async function resolveVoyantGraphRuntimeProviders(
     }
   })
 
+  const getProvider = async <T = unknown>(port: string): Promise<T> => {
+    const provider = byPort.get(port)?.[0]
+    if (!provider) {
+      throw new VoyantGraphRuntimeProviderError([
+        { code: "VOYANT_GRAPH_RUNTIME_PROVIDER_UNKNOWN", port, declarationIds: [] },
+      ])
+    }
+    let load = loads.get(provider.declaration.id)
+    if (!load) {
+      load = instantiateProvider(provider, runtime, values, resourceValues)
+      loads.set(provider.declaration.id, load)
+    }
+    const instance = await load
+    await preflightSelectedConditionalActionProvider(runtime, port, instance)
+    return instance as T
+  }
+
   return {
     graphHash: runtime.graphHash,
     selectedProviders,
-    getProvider: async <T = unknown>(port: string): Promise<T> => {
-      const provider = byPort.get(port)?.[0]
-      if (!provider) {
-        throw new VoyantGraphRuntimeProviderError([
-          { code: "VOYANT_GRAPH_RUNTIME_PROVIDER_UNKNOWN", port, declarationIds: [] },
-        ])
+    getProvider,
+    activateRuntime: async () => {
+      for (const portId of conditionalActionProviderPortIds(runtime)) {
+        await getProvider(portId)
       }
-      let load = loads.get(provider.declaration.id)
-      if (!load) {
-        load = instantiateProvider(provider, runtime, values, resourceValues)
-        loads.set(provider.declaration.id, load)
-      }
-      return load as Promise<T>
+      return activateConditionalActionRuntime(runtime)
     },
   }
 }

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1122,6 +1122,7 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "./dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": ["./dist/runtime-attestation.d.ts"],
       "@voyant-travel/framework/scheduled-jobs": ["./dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": ["./dist/selected-graph-openapi.d.ts"],
       "@voyant-travel/framework/self-host-export": ["./dist/self-host-export.d.ts"],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1123,6 +1123,7 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "./dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": ["./dist/runtime-attestation.d.ts"],
       "@voyant-travel/framework/scheduled-jobs": ["./dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": ["./dist/selected-graph-openapi.d.ts"],
       "@voyant-travel/framework/self-host-export": ["./dist/self-host-export.d.ts"],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1134,6 +1134,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1129,6 +1129,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1128,6 +1128,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1129,6 +1129,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
     "kind": "module",
     "manifest": "./voyant",
     "compatibleWith": {
-      "framework": ">=0.38.0",
+      "framework": "^0.64.0",
       "targets": [
         "node"
       ],
@@ -76,6 +76,9 @@
     "@voyant-travel/voyant-typescript-config": "workspace:^",
     "typescript": "catalog:",
     "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "@voyant-travel/framework": "^0.64.0"
   },
   "repository": {
     "type": "git",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -21,6 +21,10 @@ import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js"
 import {
+  assertVoyantGraphMcpRuntime,
+  type VoyantGraphRuntime,
+} from "@voyant-travel/framework/runtime-attestation"
+import {
   admitHandlerActionPolicy,
   createToolRegistry,
   TOOL_ACTION_INVOCATION_FIELD,
@@ -61,7 +65,7 @@ export interface McpApiRoutesOptions {
 }
 
 export interface GraphMcpApiRoutesOptions {
-  runtime: GraphMcpRuntime
+  runtime: unknown
   buildContext(c: Context): ToolContext
   buildResources?(c: Context): Readonly<Record<string, unknown>>
   /** Resources visible only to context contributors owned by the selected unit. */
@@ -71,65 +75,7 @@ export interface GraphMcpApiRoutesOptions {
   serverInfo?: McpServerInfo
 }
 
-export interface GraphMcpRuntime {
-  accessCatalog: AccessCatalog
-  tools: readonly {
-    /** Stable package Tool id from the selected graph. */
-    id?: string
-    /** Package/module owning the selected Tool. */
-    unitId?: string
-    /** Capability version; legacy graph runtimes default to v1. */
-    capabilityVersion?: string
-    name?: string
-    requiredScopes?: readonly string[]
-    risk?: "low" | "medium" | "high" | "critical"
-    referenceId: string
-    context?: readonly string[]
-    load<T = unknown>(): Promise<T>
-  }[]
-  actions?: readonly {
-    id: string
-    capabilityId?: string
-    version: string
-    kind: "execute" | "read" | "sensitive-read"
-    targetType: string
-    commandTargetField?: string
-    targetLifecycle?: "existing" | "created"
-    availability?:
-      | { status: "available" }
-      | {
-          status: "unavailable"
-          reasonCode: string
-          replacementCapabilityId?: string
-        }
-    existingTarget?: {
-      durability: "handler-command-result-v1"
-    }
-    createdTarget?: {
-      commandTargetType: string
-      resultReferenceType: string
-      durability: "handler-command-claim-v1"
-      parentAnchor?: {
-        targetIdField: string
-        targetType?: string
-        targetTypeField?: string
-        relatedTargetIdField?: string
-      }
-    }
-    risk: "low" | "medium" | "high" | "critical"
-    ledger: "required" | "optional"
-    approval?: "never" | "conditional" | "required"
-    policy?: string
-    reversible?: boolean
-    allowedActorTypes?: readonly string[]
-    from?: { tools?: readonly string[] }
-  }[]
-  references: readonly {
-    id: string
-    importEntry: string
-    loadModule<T extends Record<string, unknown> = Record<string, unknown>>(): Promise<T>
-  }[]
-}
+export type GraphMcpRuntime = VoyantGraphRuntime
 
 const DEFAULT_SERVER_INFO: McpServerInfo = { name: "voyant-mcp", version: "0.1.0" }
 const mcpAdminApiId = "@voyant-travel/mcp#api.admin"
@@ -234,6 +180,18 @@ export function createMcpApiRoutes(options: McpApiRoutesOptions): OpenAPIHono {
 export async function createGraphMcpApiRoutes(
   options: GraphMcpApiRoutesOptions,
 ): Promise<OpenAPIHono> {
+  assertVoyantGraphMcpRuntime(options.runtime)
+  if (
+    options.runtime.actions.some(
+      (action) =>
+        action.availability?.status === "unavailable" &&
+        action.availability.enableWhen !== undefined,
+    )
+  ) {
+    throw new Error(
+      "Conditional graph actions require the framework-owned activated runtime view before MCP registration.",
+    )
+  }
   const registry = createToolRegistry()
   const contributions = new Map<string, { contribution: ToolContextContribution; unitId: string }>()
   const requiredContext = new Set<string>()
@@ -261,10 +219,11 @@ export async function createGraphMcpApiRoutes(
         `Selected MCP Tool "${tool.name ?? tool.id ?? "unknown"}" has no selected graph action policy.`,
       )
     }
+    const capabilityVersion = (tool as { capabilityVersion?: unknown }).capabilityVersion
     registry.register(definition, {
       ...(tool.id ? { capabilityId: tool.id } : {}),
       ...(tool.unitId ? { owner: tool.unitId } : {}),
-      ...(tool.capabilityVersion ? { capabilityVersion: tool.capabilityVersion } : {}),
+      ...(typeof capabilityVersion === "string" ? { capabilityVersion } : {}),
       ...(tool.name ? { name: tool.name } : {}),
       ...(tool.requiredScopes ? { requiredScopes: tool.requiredScopes } : {}),
       ...(tool.risk ? { deploymentRisk: tool.risk } : {}),

--- a/packages/mcp/tests/package-contract.test.ts
+++ b/packages/mcp/tests/package-contract.test.ts
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises"
+import { describe, expect, it } from "vitest"
+
+interface McpPackageJson {
+  dependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, unknown>
+  voyant?: {
+    compatibleWith?: {
+      framework?: string
+    }
+  }
+}
+
+describe("@voyant-travel/mcp package contract", () => {
+  it("requires the same framework line that its graph adapter imports", async () => {
+    const packageJson = JSON.parse(
+      await readFile(new URL("../package.json", import.meta.url), "utf8"),
+    ) as McpPackageJson
+    const frameworkRange = packageJson.peerDependencies?.["@voyant-travel/framework"]
+
+    expect(frameworkRange).toBe("^0.64.0")
+    expect(packageJson.voyant?.compatibleWith?.framework).toBe(frameworkRange)
+    expect(packageJson.dependencies?.["@voyant-travel/framework"]).toBeUndefined()
+    expect(packageJson.peerDependenciesMeta?.["@voyant-travel/framework"]).toBeUndefined()
+  })
+})

--- a/packages/mcp/tests/server.test.ts
+++ b/packages/mcp/tests/server.test.ts
@@ -1,4 +1,11 @@
 import { readFile } from "node:fs/promises"
+import type { VoyantGraphActionDeclaration } from "@voyant-travel/core/project"
+import {
+  createVoyantGraphRuntime,
+  resolveVoyantGraphRuntimeProviders,
+  type VoyantGraphRuntime,
+  type VoyantGraphRuntimeToolDefinition,
+} from "@voyant-travel/framework"
 import { requireAuth } from "@voyant-travel/hono/middleware/auth"
 import {
   createToolRegistry,
@@ -187,6 +194,215 @@ function buildContext(audience: ToolContext["audience"] = "staff"): ToolContext 
   }
 }
 
+interface TestGraphTool extends VoyantGraphRuntimeToolDefinition {
+  load<T = unknown>(): Promise<T>
+}
+
+interface TestGraphReference {
+  id: string
+  importEntry: string
+  loadModule<T extends Record<string, unknown> = Record<string, unknown>>(): Promise<T>
+}
+
+function frameworkRuntime(input: {
+  accessCatalog: VoyantGraphRuntime["accessCatalog"]
+  tools: readonly TestGraphTool[]
+  actions?: readonly VoyantGraphActionDeclaration[]
+  references: readonly TestGraphReference[]
+}): VoyantGraphRuntime {
+  const toolById = new Map(input.tools.map((tool) => [tool.id, tool]))
+  const exportByReferenceId = new Map(
+    input.tools.map((tool, index) => [tool.referenceId, `testTool${index}`]),
+  )
+  const referencesById = new Map(input.references.map((reference) => [reference.id, reference]))
+  const entries = Object.fromEntries(
+    [...new Set(input.references.map(({ importEntry }) => importEntry))].map((importEntry) => [
+      importEntry,
+      async () => {
+        const reference = input.references.find(
+          (candidate) => candidate.importEntry === importEntry,
+        )
+        const namespace = reference ? await reference.loadModule() : {}
+        for (const tool of input.tools) {
+          const owner = referencesById.get(tool.referenceId)
+          if (owner?.importEntry !== importEntry) continue
+          namespace[exportByReferenceId.get(tool.referenceId)!] = await tool.load()
+        }
+        return namespace
+      },
+    ]),
+  )
+  const unitIds = [...new Set(input.tools.map(({ unitId }) => unitId))]
+  const accessScopes = input.accessCatalog.resources.flatMap((resource) =>
+    resource.actions.map((action) => `${resource.resource}:${action.action}`),
+  )
+  return createVoyantGraphRuntime({
+    graphHash: "sha256:mcp-test",
+    accessCatalog: input.accessCatalog,
+    entries,
+    modules: unitIds.map((unitId, order) => {
+      const tools = input.tools.filter((tool) => tool.unitId === unitId)
+      const referenceIds = new Set(tools.map(({ referenceId }) => referenceId))
+      const actions = (input.actions ?? [])
+        .filter((action) =>
+          (action.from?.tools ?? []).some((toolId) => toolById.get(toolId)?.unitId === unitId),
+        )
+        .map((action) => ({
+          ...action,
+          unitId,
+          requiredScopes: action.requiredScopes ?? [],
+          from: {
+            routes: action.from?.routes ?? [],
+            tools: action.from?.tools ?? [],
+            events: action.from?.events ?? [],
+            webhooks: action.from?.webhooks ?? [],
+          },
+        }))
+      return {
+        id: unitId,
+        kind: "module" as const,
+        packageName: unitId,
+        order,
+        accessScopes: order === 0 ? accessScopes : [],
+        references: input.references
+          .filter(({ id }) => referenceIds.has(id))
+          .map((reference) => ({
+            id: reference.id,
+            unitId,
+            facet: "tools.runtime" as const,
+            entityId: tools.find(({ referenceId }) => referenceId === reference.id)!.id,
+            runtime: {
+              entry: reference.importEntry,
+              export: exportByReferenceId.get(reference.id)!,
+            },
+            importEntry: reference.importEntry,
+          })),
+        tools,
+        actions,
+        selectedIds: {
+          routes: [],
+          tools: tools.map(({ id }) => id),
+          events: [],
+          webhooks: [],
+        },
+        routes: [],
+      }
+    }),
+    plugins: [],
+  })
+}
+
+function conditionalFrameworkRuntime() {
+  const unitId = "@voyant-travel/test"
+  const portId = "catalog.durable-echo"
+  const toolId = "@voyant-travel/test#tool.echo"
+  const loadTool = vi.fn(async () => ({ echoTool }))
+  const provider = { echo: vi.fn() }
+  const testProvider = vi.fn()
+  const runtime = createVoyantGraphRuntime({
+    graphHash: "sha256:mcp-conditional-test",
+    providerSelections: { catalog: "durable" },
+    accessCatalog,
+    entries: {
+      "@voyant-travel/catalog/provider": async () => ({
+        createProvider: () => provider,
+      }),
+      "@voyant-travel/catalog/port": async () => ({
+        durableEchoPort: { id: portId, test: testProvider },
+      }),
+      "@voyant-travel/catalog/tools": loadTool,
+    },
+    modules: [
+      {
+        id: unitId,
+        kind: "module",
+        packageName: unitId,
+        order: 0,
+        references: [
+          {
+            id: "catalog-provider",
+            unitId,
+            facet: "providers.runtime",
+            entityId: "@voyant-travel/test#provider.durable",
+            runtime: { entry: "./provider", export: "createProvider" },
+            importEntry: "@voyant-travel/catalog/provider",
+          },
+          {
+            id: "catalog-port-conformance",
+            unitId,
+            facet: "runtimePorts.conformance",
+            entityId: portId,
+            runtime: { entry: "./port", export: "durableEchoPort" },
+            importEntry: "@voyant-travel/catalog/port",
+          },
+        ],
+        providers: [
+          {
+            unitId,
+            declaration: {
+              id: "@voyant-travel/test#provider.durable",
+              port: portId,
+              selection: { role: "catalog", value: "durable" },
+              runtime: { entry: "./provider", export: "createProvider" },
+            },
+            referenceId: "catalog-provider",
+          },
+        ],
+        provisionalReferences: [
+          {
+            id: "catalog-echo-runtime",
+            unitId,
+            facet: "tools.runtime",
+            entityId: toolId,
+            runtime: { entry: "./tools", export: "echoTool" },
+            importEntry: "@voyant-travel/catalog/tools",
+          },
+        ],
+        provisionalTools: [
+          {
+            id: toolId,
+            unitId,
+            name: "echo",
+            referenceId: "catalog-echo-runtime",
+            requiredScopes: ["catalog:read"],
+            risk: "low",
+          },
+        ],
+        requiredPorts: [portId],
+        runtimePorts: [portId],
+        runtimePortConformance: [{ portId, referenceId: "catalog-port-conformance" }],
+        accessScopes: accessCatalog.resources.flatMap((resource) =>
+          resource.actions.map((action) => `${resource.resource}:${action.action}`),
+        ),
+        actions: [
+          {
+            id: "@voyant-travel/test#action.echo",
+            unitId,
+            version: "v1",
+            kind: "read",
+            targetType: "echo",
+            availability: {
+              status: "unavailable",
+              reasonCode: "provider-not-durable",
+              enableWhen: {
+                selectedProviderPorts: { mode: "all", ports: [portId] },
+              },
+            },
+            risk: "low",
+            ledger: "optional",
+            requiredScopes: ["catalog:read"],
+            from: { routes: [], tools: [toolId], events: [], webhooks: [] },
+          },
+        ],
+        selectedIds: { routes: [], tools: [], events: [], webhooks: [] },
+        routes: [],
+      },
+    ],
+    plugins: [],
+  })
+  return { loadTool, portId, provider, runtime, testProvider }
+}
+
 /** Mount the MCP app behind a middleware that seeds the caller's granted scopes. */
 function appWithScopes(scopes: string[], audience: ToolContext["audience"] = "staff"): Hono {
   const registry = createToolRegistry()
@@ -222,9 +438,8 @@ async function selectedRuntimeRoutes() {
     },
   }
   const module = await createMcpVoyantRuntime({
-    graph: {
+    graph: frameworkRuntime({
       accessCatalog,
-      providerSelections: {},
       tools: [runtimeTool],
       references: [
         {
@@ -235,7 +450,7 @@ async function selectedRuntimeRoutes() {
           },
         },
       ],
-    },
+    }),
     runtimePorts: {},
   } as never)
   const routes = await module.lazyAdminRoutes?.()
@@ -389,12 +604,12 @@ describe("createMcpApiRoutes", () => {
       },
     ]
     const graphApp = await createGraphMcpApiRoutes({
-      runtime: {
+      runtime: frameworkRuntime({
         accessCatalog,
         tools: [runtimeTool],
         actions,
         references,
-      },
+      }),
       buildContext: () => buildContext(),
       providedContext: ["toolActionPolicy"],
     })
@@ -415,14 +630,14 @@ describe("createMcpApiRoutes", () => {
 
     await expect(
       createGraphMcpApiRoutes({
-        runtime: { accessCatalog, tools: [runtimeTool], actions, references },
+        runtime: frameworkRuntime({ accessCatalog, tools: [runtimeTool], actions, references }),
         buildContext: () => buildContext(),
       }),
     ).rejects.toThrow(/toolActionPolicy/)
 
     await expect(
       createGraphMcpApiRoutes({
-        runtime: {
+        runtime: frameworkRuntime({
           accessCatalog,
           tools: [{ ...runtimeTool, name: "drifted_echo" }],
           actions: [
@@ -437,44 +652,133 @@ describe("createMcpApiRoutes", () => {
             },
           ],
           references,
-        },
+        }),
         buildContext: () => buildContext(),
       }),
-    ).rejects.toThrow(/name "echo" does not match graph binding "drifted_echo"/)
+    ).rejects.toThrow(/must declare name "drifted_echo"/)
 
     await expect(
       createGraphMcpApiRoutes({
-        runtime: {
+        runtime: frameworkRuntime({
           accessCatalog,
           tools: [{ ...runtimeTool, risk: "high" }],
           actions: [],
           references,
-        },
+        }),
         buildContext: () => buildContext(),
       }),
     ).rejects.toThrow(/no selected graph action policy/)
 
     const unavailableToolLoad = vi.fn(runtimeTool.load)
+    expect(() =>
+      frameworkRuntime({
+        accessCatalog,
+        tools: [{ ...runtimeTool, load: unavailableToolLoad }],
+        actions: [
+          {
+            ...actions[0],
+            availability: {
+              status: "unavailable" as const,
+              reasonCode: "unsafe-nontransactional-effect",
+            },
+          },
+        ],
+        references,
+      }),
+    ).toThrow(/unavailable action .* exposes Tool/)
+    expect(unavailableToolLoad).not.toHaveBeenCalled()
+
+    const provisionalToolLoad = vi.fn(runtimeTool.load)
+    const provisionalRuntime = {
+      accessCatalog,
+      tools: [{ ...runtimeTool, load: provisionalToolLoad }],
+      actions: [
+        {
+          ...actions[0],
+          availability: {
+            status: "unavailable" as const,
+            reasonCode: "provider-not-durable",
+            enableWhen: {
+              selectedProviderPorts: {
+                mode: "all" as const,
+                ports: ["notifications.durable-send"],
+              },
+            },
+          },
+        },
+      ],
+      references,
+    }
+    await expect(
+      createGraphMcpApiRoutes({
+        runtime: provisionalRuntime as never,
+        buildContext: () => buildContext(),
+        providedContext: ["toolActionPolicy"],
+      }),
+    ).rejects.toThrow(/NOT_FRAMEWORK_OWNED/)
+    expect(provisionalToolLoad).not.toHaveBeenCalled()
+
+    const activatedToolLoad = vi.fn(runtimeTool.load)
     await expect(
       createGraphMcpApiRoutes({
         runtime: {
-          accessCatalog,
-          tools: [{ ...runtimeTool, load: unavailableToolLoad }],
+          ...provisionalRuntime,
+          tools: [{ ...runtimeTool, load: activatedToolLoad }],
           actions: [
             {
               ...actions[0],
-              availability: {
-                status: "unavailable" as const,
-                reasonCode: "unsafe-nontransactional-effect",
-              },
+              availability: { status: "available" as const },
             },
           ],
-          references,
-        },
+        } as never,
+        buildContext: () => buildContext(),
+        providedContext: ["toolActionPolicy"],
+      }),
+    ).rejects.toThrow(/NOT_FRAMEWORK_OWNED/)
+    expect(activatedToolLoad).not.toHaveBeenCalled()
+  })
+
+  it("exposes a conditional Tool only from the provider-preflighted framework view", async () => {
+    const { loadTool, portId, provider, runtime, testProvider } = conditionalFrameworkRuntime()
+
+    expect(Reflect.set(runtime.actions[0]!.availability!, "status", "available")).toBe(false)
+    expect(
+      Reflect.deleteProperty(
+        runtime.actions[0]!.availability!.enableWhen!.selectedProviderPorts,
+        "ports",
+      ),
+    ).toBe(false)
+    expect(Reflect.set(runtime.references[0]!, "load", vi.fn())).toBe(false)
+    await expect(
+      createGraphMcpApiRoutes({
+        runtime,
         buildContext: () => buildContext(),
       }),
-    ).rejects.toThrow(/bound by an unavailable graph action/)
-    expect(unavailableToolLoad).not.toHaveBeenCalled()
+    ).rejects.toThrow(/NOT_ACTIVATED/)
+    expect(loadTool).not.toHaveBeenCalled()
+
+    const providers = await resolveVoyantGraphRuntimeProviders(runtime, { ports: [portId] })
+    const activated = await providers.activateRuntime()
+    expect(testProvider).toHaveBeenCalledWith(provider)
+    expect(Reflect.set(activated.actions[0]!.availability!, "status", "unavailable")).toBe(false)
+    expect(Reflect.set(activated.tools[0]!, "load", vi.fn())).toBe(false)
+
+    const routes = await createGraphMcpApiRoutes({
+      runtime: activated,
+      buildContext: () => buildContext(),
+      providedContext: ["toolActionPolicy"],
+    })
+    const app = new Hono()
+    app.use("*", async (c, next) => {
+      c.set("scopes", ["catalog:read"])
+      await next()
+    })
+    app.route("/", routes)
+    const manifest = (await (await app.request("/manifest")).json()) as {
+      tools: Array<{ name: string }>
+    }
+    expect(manifest.tools.map(({ name }) => name)).toEqual(["echo"])
+    expect(loadTool).toHaveBeenCalledOnce()
   })
 
   it("propagates created-target handler policy without advertising caller-owned target identity", async () => {
@@ -500,7 +804,7 @@ describe("createMcpApiRoutes", () => {
     })
     const toolId = "@voyant-travel/notifications#tool.create-notification"
     const graphApp = await createGraphMcpApiRoutes({
-      runtime: {
+      runtime: frameworkRuntime({
         accessCatalog,
         tools: [
           {
@@ -542,7 +846,7 @@ describe("createMcpApiRoutes", () => {
             },
           },
         ],
-      },
+      }),
       buildContext: () => buildContext(),
     })
     const outer = new Hono()
@@ -646,7 +950,7 @@ describe("createMcpApiRoutes", () => {
     const toolId = "@voyant-travel/catalog#tool.conflicting-control"
 
     const routes = await createGraphMcpApiRoutes({
-      runtime: {
+      runtime: frameworkRuntime({
         accessCatalog,
         tools: [
           {
@@ -681,7 +985,7 @@ describe("createMcpApiRoutes", () => {
             },
           },
         ],
-      },
+      }),
       buildContext: () => buildContext(),
     })
     const outer = new Hono()

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1134,6 +1134,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1129,6 +1129,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1127,6 +1127,9 @@
       "@voyant-travel/framework/project-subscriber-link-conventions": [
         "../framework/dist/project-subscriber-link-conventions.d.ts"
       ],
+      "@voyant-travel/framework/runtime-attestation": [
+        "../framework/dist/runtime-attestation.d.ts"
+      ],
       "@voyant-travel/framework/scheduled-jobs": ["../framework/dist/scheduled-jobs.d.ts"],
       "@voyant-travel/framework/selected-graph-openapi": [
         "../framework/dist/selected-graph-openapi.d.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2472,9 +2472,6 @@ importers:
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono
-      '@voyant-travel/mcp':
-        specifier: workspace:^
-        version: link:../mcp
       '@voyant-travel/operator-standard':
         specifier: workspace:^
         version: link:../operator-standard
@@ -3113,6 +3110,9 @@ importers:
       '@voyant-travel/core':
         specifier: workspace:^
         version: link:../core
+      '@voyant-travel/framework':
+        specifier: ^0.64.0
+        version: link:../framework
       '@voyant-travel/hono':
         specifier: workspace:^
         version: link:../hono

--- a/scripts/check-deployment-graph.ts
+++ b/scripts/check-deployment-graph.ts
@@ -4,6 +4,8 @@ import { readFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
+import getReleasePlan from "@changesets/get-release-plan"
+
 import {
   buildDeploymentArtifactManifest,
   buildDeploymentGraphJson,
@@ -54,18 +56,22 @@ async function main(): Promise<void> {
   const frameworkPackage = JSON.parse(
     await readFile(join(repoRoot, "packages/framework/package.json"), "utf8"),
   ) as { version: string }
+  const releasePlan = await getReleasePlan(repoRoot)
+  const frameworkVersion =
+    releasePlan.releases.find(({ name }) => name === "@voyant-travel/framework")?.newVersion ??
+    frameworkPackage.version
   const authoredOperatorProject = operatorProject as OperatorAuthoredProject
   const resolvedOperator = await resolveOperatorDeploymentGraph({
     project: authoredOperatorProject,
     projectRoot: operatorRoot,
     repoRoot,
-    frameworkVersion: frameworkPackage.version,
+    frameworkVersion,
   })
   const repeatedOperator = await resolveOperatorDeploymentGraph({
     project: authoredOperatorProject,
     projectRoot: operatorRoot,
     repoRoot,
-    frameworkVersion: frameworkPackage.version,
+    frameworkVersion,
   })
   const first = resolvedOperator.graph
   const second = repeatedOperator.graph

--- a/scripts/generate-standard-product-distribution.mjs
+++ b/scripts/generate-standard-product-distribution.mjs
@@ -91,7 +91,6 @@ const frameworkDependencies = {
   "@voyant-travel/db": "workspace:^",
   "@voyant-travel/framework-migrations": "workspace:^",
   "@voyant-travel/hono": "workspace:^",
-  "@voyant-travel/mcp": "workspace:^",
   "@voyant-travel/operator-standard": "workspace:^",
   "@voyant-travel/plugin-voyant-connect": "^0.3.2",
   "@voyant-travel/runtime-core": "workspace:^",

--- a/scripts/lib/packed-install.mjs
+++ b/scripts/lib/packed-install.mjs
@@ -4,7 +4,39 @@ import os from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
 
+import semver from "semver"
+
 const execFileAsync = promisify(execFile)
+
+export function collectStagedPeerInstallExclusions(packedPackages, projectedVersions) {
+  const packedVersions = new Map(
+    packedPackages.map(({ manifest }) => [manifest.name, manifest.version]),
+  )
+  const exclusions = new Set()
+
+  for (const { manifest } of packedPackages) {
+    for (const [peerName, peerRange] of Object.entries(manifest.peerDependencies ?? {})) {
+      const packedPeerVersion = packedVersions.get(peerName)
+      if (!packedPeerVersion || semver.satisfies(packedPeerVersion, peerRange)) continue
+
+      const projectedPeerVersion = projectedVersions.get(peerName)
+      const projectedConsumerVersion = projectedVersions.get(manifest.name)
+      if (
+        !projectedConsumerVersion ||
+        !projectedPeerVersion ||
+        !semver.satisfies(projectedPeerVersion, peerRange)
+      ) {
+        throw new Error(
+          `Packed peer mismatch is not covered by the release plan: ${manifest.name}@${manifest.version} requires ${peerName}@${peerRange}, packed ${packedPeerVersion}, projected ${projectedPeerVersion ?? "unreleased"}`,
+        )
+      }
+
+      exclusions.add(manifest.name)
+    }
+  }
+
+  return exclusions
+}
 
 export function createPackedInstallManifest(packedPackages) {
   const dependencies = Object.fromEntries(

--- a/scripts/tests/packed-install.test.mjs
+++ b/scripts/tests/packed-install.test.mjs
@@ -6,7 +6,11 @@ import path from "node:path"
 import { afterEach, test } from "node:test"
 import { promisify } from "node:util"
 
-import { createPackedInstallManifest, verifyPackedPackageInstall } from "../lib/packed-install.mjs"
+import {
+  collectStagedPeerInstallExclusions,
+  createPackedInstallManifest,
+  verifyPackedPackageInstall,
+} from "../lib/packed-install.mjs"
 
 const execFileAsync = promisify(execFile)
 const temporaryDirectories = []
@@ -61,6 +65,67 @@ test("does not install an optional provider peer", async () => {
   await verifyPackedPackageInstall([{ name: "@fixture/consumer", tarballPath: consumerTarball }])
 })
 
+test("defers only peer mismatches covered by the release plan", () => {
+  const exclusions = collectStagedPeerInstallExclusions(
+    [
+      {
+        manifest: {
+          name: "@fixture/provider",
+          version: "0.9.0",
+        },
+      },
+      {
+        manifest: {
+          name: "@fixture/consumer",
+          version: "1.0.0",
+          peerDependencies: { "@fixture/provider": "^1.0.0" },
+        },
+      },
+      {
+        manifest: {
+          name: "@fixture/current-consumer",
+          version: "1.0.0",
+          peerDependencies: { "@fixture/provider": ">=0.9.0" },
+        },
+      },
+    ],
+    new Map([
+      ["@fixture/provider", "1.0.0"],
+      ["@fixture/consumer", "1.1.0"],
+    ]),
+  )
+
+  assert.deepEqual([...exclusions], ["@fixture/consumer"])
+})
+
+test("rejects a peer mismatch not covered by the release plan", () => {
+  assert.throws(
+    () =>
+      collectStagedPeerInstallExclusions(
+        [
+          {
+            manifest: {
+              name: "@fixture/provider",
+              version: "0.9.0",
+            },
+          },
+          {
+            manifest: {
+              name: "@fixture/consumer",
+              version: "1.0.0",
+              peerDependencies: { "@fixture/provider": "^1.0.0" },
+            },
+          },
+        ],
+        new Map([
+          ["@fixture/provider", "0.10.0"],
+          ["@fixture/consumer", "1.1.0"],
+        ]),
+      ),
+    /not covered by the release plan/,
+  )
+})
+
 function createTemporaryDirectory(prefix) {
   const directory = fs.mkdtempSync(path.join(os.tmpdir(), prefix))
   temporaryDirectories.push(directory)
@@ -79,6 +144,9 @@ async function packFixture(root, directoryName, manifest) {
     ["pack", "--json", "--ignore-scripts", "--pack-destination", packDir],
     { cwd: packageDir, encoding: "utf8" },
   )
-  const [packInfo] = JSON.parse(stdout)
+  const packOutput = JSON.parse(stdout)
+  const packInfo = Array.isArray(packOutput)
+    ? packOutput[0]
+    : (packOutput.filename ?? Object.values(packOutput)[0])
   return path.join(packDir, packInfo.filename)
 }

--- a/scripts/verify-package-tarballs.mjs
+++ b/scripts/verify-package-tarballs.mjs
@@ -22,8 +22,13 @@ import os from "node:os"
 import path from "node:path"
 import { promisify } from "node:util"
 
+import getReleasePlan from "@changesets/get-release-plan"
+
 import { packedFileExportsName } from "./lib/packed-exports.mjs"
-import { verifyPackedPackageInstall } from "./lib/packed-install.mjs"
+import {
+  collectStagedPeerInstallExclusions,
+  verifyPackedPackageInstall,
+} from "./lib/packed-install.mjs"
 import { collectPackedManifestProtocolDependencies } from "./lib/packed-manifest.mjs"
 import { collectPackedSourceMapProblems } from "./lib/packed-sourcemaps.mjs"
 
@@ -594,7 +599,13 @@ async function verifyPackage(packageDir) {
     ;({ problems } = collectTarballProblems(inspection, sourceFiles))
   }
 
-  return { name: pkg.name, packageDir, problems, packedTarball: inspection.packedTarball }
+  return {
+    name: pkg.name,
+    packageDir,
+    problems,
+    packedManifest: inspection.packedManifest,
+    packedTarball: inspection.packedTarball,
+  }
 }
 
 const results = []
@@ -625,7 +636,23 @@ if (failures.length > 0) {
 }
 
 try {
-  await verifyPackedPackageInstall(results.map((result) => result.packedTarball))
+  const releasePlan = await getReleasePlan(rootDir)
+  const projectedVersions = new Map(
+    releasePlan.releases.map(({ name, newVersion }) => [name, newVersion]),
+  )
+  const packedPackages = results.map((result) => ({
+    manifest: result.packedManifest,
+    ...result.packedTarball,
+  }))
+  const stagedPeerExclusions = collectStagedPeerInstallExclusions(packedPackages, projectedVersions)
+  await verifyPackedPackageInstall(
+    packedPackages.filter(({ name }) => !stagedPeerExclusions.has(name)),
+  )
+  if (stagedPeerExclusions.size > 0) {
+    console.log(
+      `Deferred aggregate install for ${[...stagedPeerExclusions].sort().join(", ")} until the release plan applies its required peer versions.`,
+    )
+  }
 } catch (error) {
   console.error(`Publish tarball verification failed:\n\n${error.message}`)
   for (const result of results) result.packedTarball?.cleanup()


### PR DESCRIPTION
## Summary

- add provider-conditional action availability with `all` / `any` typed-port requirements
- keep raw runtimes, conditional Tools, references, and loaders unavailable until provider factories return exact instances that pass `VoyantPort.test`
- mint an immutable activated runtime view and require framework attestation before Graph MCP exposure
- make MCP's framework peer contract explicit and remove the direct framework-to-MCP runtime dependency edge

## Security properties

- exact provider identity is enforced; selection or instance drift fails closed
- factory and typed-port conformance failures fail before Tool/ledger/MCP execution
- raw and activated metadata is detached and recursively immutable
- untouched constructor input is descriptor-validated before normalization: custom prototypes and accessors are rejected, and getters are never invoked
- direct structural runtimes cannot pass MCP attestation
- the registrar/private construction path is not exported; packed public attestation exposes only the assertion

## Compatibility

`@voyant-travel/mcp` now requires the matching `@voyant-travel/framework` `^0.64.0` peer. This avoids a direct runtime dependency cycle while making the static attestation import truthful.

## Validation

- Framework: typecheck + 364 tests
- MCP: typecheck + 26 tests
- framework/MCP builds and packs
- frozen-lockfile install
- packed public/private export probes
- required-peer missing/install probes
- independent adversarial review: approved, no findings

Intentional unavailable actions remain unchanged: Setup `action.initialize-setup`, Storefront `action.start-my-verification`, and Auth `team.action.invite-member`.