### PR TITLE
fix(release): allow explicit internal peer ranges

### DIFF
--- a/scripts/tests/release-plan.test.mjs
+++ b/scripts/tests/release-plan.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test"
 
 const require = createRequire(import.meta.url)
 const { getReleaseMode } = require("../release-plan.cjs")
+const { collectWorkspaceRangeProblems } = require("../verify-release-config.cjs")
 
 test("release PR creation takes priority over pending publication", () => {
   assert.equal(getReleaseMode(true, true), "version")
@@ -16,3 +17,99 @@ test("pending packages publish after all changesets are applied", () => {
 test("an up-to-date repository needs no release action", () => {
   assert.equal(getReleaseMode(false, false), "none")
 })
+
+test("accepts an exact future internal peer range covered by the release plan", () => {
+  assert.deepEqual(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.0.0",
+          peerDependencies: { "@fixture/provider": "^0.64.0" },
+        },
+        "@fixture/provider": { version: "0.63.4" },
+      }),
+      new Map([
+        ["@fixture/consumer", "1.1.0"],
+        ["@fixture/provider", "0.64.0"],
+      ]),
+    ),
+    [],
+  )
+})
+
+test("accepts a compatible published caret peer without creating a workspace edge", () => {
+  assert.deepEqual(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.1.0",
+          peerDependencies: { "@fixture/provider": "^0.64.0" },
+        },
+        "@fixture/provider": { version: "0.64.1" },
+      }),
+    ),
+    [],
+  )
+})
+
+test("rejects a future internal peer range when either package is absent from the release plan", () => {
+  const packages = createPackages({
+    "@fixture/consumer": {
+      version: "1.0.0",
+      peerDependencies: { "@fixture/provider": "^0.64.0" },
+    },
+    "@fixture/provider": { version: "0.63.4" },
+  })
+
+  assert.equal(
+    collectWorkspaceRangeProblems(packages, new Map([["@fixture/provider", "0.64.0"]])).length,
+    1,
+  )
+  assert.equal(
+    collectWorkspaceRangeProblems(packages, new Map([["@fixture/consumer", "1.1.0"]])).length,
+    1,
+  )
+})
+
+test("rejects non-exact staged ranges and staged runtime dependencies", () => {
+  const projectedVersions = new Map([
+    ["@fixture/consumer", "1.1.0"],
+    ["@fixture/provider", "0.64.0"],
+  ])
+
+  assert.equal(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.0.0",
+          peerDependencies: { "@fixture/provider": ">=0.64.0" },
+        },
+        "@fixture/provider": { version: "0.63.4" },
+      }),
+      projectedVersions,
+    ).length,
+    1,
+  )
+  assert.equal(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.0.0",
+          dependencies: { "@fixture/provider": "^0.64.0" },
+        },
+        "@fixture/provider": { version: "0.63.4" },
+      }),
+      projectedVersions,
+    ).length,
+    1,
+  )
+})
+
+function createPackages(manifests) {
+  return {
+    packages: Object.entries(manifests).map(([name, packageJson]) => ({
+      dir: `/fixtures/${name}`,
+      packageJson: { name, ...packageJson },
+    })),
+  }
+}

--- a/scripts/verify-release-config.cjs
+++ b/scripts/verify-release-config.cjs
@@ -3,6 +3,7 @@ const path = require("node:path")
 
 const { read } = require("@changesets/config")
 const { getPackages } = require("@manypkg/get-packages")
+const semver = require("semver")
 const { parse: parseYaml } = require("yaml")
 
 const { getPublishablePackages } = require("./release-utils.cjs")
@@ -87,15 +88,17 @@ const REQUIRED_WORKSPACE_RANGE = "workspace:^"
 const BOM_EXACT_PIN = "workspace:*"
 const BOM_EXACT_PIN_PACKAGES = new Set(["@voyant-travel/operator-standard"])
 
-function collectWorkspaceRangeProblems(packages) {
+function collectWorkspaceRangeProblems(packages, projectedVersions = new Map()) {
   const problems = []
-  const workspacePackageNames = new Set(
-    packages.packages.map((pkg) => pkg.packageJson.name).filter(Boolean),
+  const workspacePackageVersions = new Map(
+    packages.packages
+      .map((pkg) => [pkg.packageJson.name, pkg.packageJson.version])
+      .filter(([name, version]) => name && version),
   )
 
   for (const pkg of packages.packages) {
     const packageJsonPath = path.join(pkg.dir, "package.json")
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+    const packageJson = pkg.packageJson
     const isBom = BOM_EXACT_PIN_PACKAGES.has(packageJson.name)
 
     for (const field of DEPENDENCY_FIELDS) {
@@ -107,7 +110,23 @@ function collectWorkspaceRangeProblems(packages) {
       const expected = isBom && field === "dependencies" ? BOM_EXACT_PIN : REQUIRED_WORKSPACE_RANGE
 
       for (const [name, version] of Object.entries(dependencies)) {
-        if (workspacePackageNames.has(name) && version !== expected) {
+        if (!workspacePackageVersions.has(name) || version === expected) continue
+
+        const projectedConsumerVersion = projectedVersions.get(packageJson.name)
+        const projectedProviderVersion = projectedVersions.get(name)
+        const currentProviderVersion = workspacePackageVersions.get(name)
+        const isCompatiblePublishedPeerRange =
+          field === "peerDependencies" &&
+          /^\^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version) &&
+          semver.satisfies(currentProviderVersion, version)
+        const isExactStagedPeerRange =
+          field === "peerDependencies" &&
+          projectedConsumerVersion &&
+          projectedProviderVersion &&
+          !semver.satisfies(currentProviderVersion, version) &&
+          version === `^${projectedProviderVersion}`
+
+        if (!isCompatiblePublishedPeerRange && !isExactStagedPeerRange) {
           problems.push(
             `${packageJsonPath}: ${field}.${name} uses ${version}; expected ${expected}`,
           )
@@ -123,6 +142,11 @@ async function main() {
   const cwd = process.cwd()
   const packages = await getPackages(cwd)
   const config = await read(cwd, packages)
+  const { default: getReleasePlan } = await import("@changesets/get-release-plan")
+  const releasePlan = await getReleasePlan(cwd)
+  const projectedVersions = new Map(
+    releasePlan.releases.map(({ name, newVersion }) => [name, newVersion]),
+  )
   const publishableNames = new Set(
     getPublishablePackages(packages, config).map((pkg) => pkg.packageJson.name),
   )
@@ -155,7 +179,7 @@ async function main() {
     }
   }
 
-  problems.push(...collectWorkspaceRangeProblems(packages))
+  problems.push(...collectWorkspaceRangeProblems(packages, projectedVersions))
   problems.push(...collectReleaseWorkflowProblems(cwd))
 
   if (problems.length > 0) {
@@ -171,7 +195,11 @@ async function main() {
   )
 }
 
-main().catch((error) => {
-  console.error(error)
-  process.exit(1)
-})
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+}
+
+module.exports = { collectReleaseWorkflowProblems, collectWorkspaceRangeProblems }


### PR DESCRIPTION
## Summary

- allow a compatible published caret range for internal `peerDependencies` without requiring a `workspace:` protocol edge
- allow an exact future caret peer only when both consumer and provider are in the current Changesets release plan
- keep `workspace:^` mandatory for all internal runtime, dev, and optional dependencies

## Why

MCP must truthfully require framework `^0.64.0`, while a `workspace:^` peer creates the framework → operator distribution → MCP → framework workspace cycle. The release gate rejected the explicit peer even though it is the correct package boundary.

The exception is fail-closed: ordinary compatible peers must be strict caret ranges; future ranges require both releases and must exactly equal the projected provider caret version. A post-release probe with framework `0.64.0` confirmed the explicit compatible peer does not recreate the pnpm workspace cycle.

## Validation

- `pnpm exec biome check scripts/verify-release-config.cjs scripts/tests/release-plan.test.mjs`
- `pnpm verify:release-config` (7 tests; full repository release config passes)
- clean disposable Sprite install
- post-release version probe (`framework@0.64.0`): no framework/operator/MCP workspace cycle