### PR TITLE
fix(release): sync MCP framework lockfile

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,7 +14,7 @@
     "kind": "module",
     "manifest": "./voyant",
     "compatibleWith": {
-      "framework": "^0.64.0",
+      "framework": "^0.64.1",
       "targets": [
         "node"
       ],

--- a/packages/mcp/tests/package-contract.test.ts
+++ b/packages/mcp/tests/package-contract.test.ts
@@ -19,7 +19,7 @@ describe("@voyant-travel/mcp package contract", () => {
     ) as McpPackageJson
     const frameworkRange = packageJson.peerDependencies?.["@voyant-travel/framework"]
 
-    expect(frameworkRange).toBe("^0.64.0")
+    expect(frameworkRange).toBe("^0.64.1")
     expect(packageJson.voyant?.compatibleWith?.framework).toBe(frameworkRange)
     expect(packageJson.dependencies?.["@voyant-travel/framework"]).toBeUndefined()
     expect(packageJson.peerDependenciesMeta?.["@voyant-travel/framework"]).toBeUndefined()

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3108,7 +3108,7 @@ importers:
         specifier: workspace:^
         version: link:../core
       '@voyant-travel/framework':
-        specifier: ^0.64.0
+        specifier: ^0.64.1
         version: link:../framework
       '@voyant-travel/hono':
         specifier: workspace:^


### PR DESCRIPTION
## Summary

- sync the `@voyant-travel/framework` peer specifier in the MCP lockfile importer after the release PR bumped the manifest to `^0.64.1`
- unblock the Release workflow frozen-lockfile install

## Evidence

Release run 30130593783 failed before publishing with `ERR_PNPM_OUTDATED_LOCKFILE`, reporting exactly this importer mismatch.