### PR TITLE
chore(release): add hosted payments changeset

### DIFF
--- a/.changeset/hosted-voyant-payments.md
+++ b/.changeset/hosted-voyant-payments.md
@@ -3,7 +3,7 @@
 "@voyant-travel/operator-settings": minor
 "@voyant-travel/operator-settings-react": minor
 "@voyant-travel/storefront": minor
-"@voyant-travel/hono": minor
+"@voyant-travel/hono": patch
 "@voyant-travel/admin-host": patch
 "@voyant-travel/i18n": patch
 "@voyant-travel/trips": patch

--- a/.changeset/hosted-voyant-payments.md
+++ b/.changeset/hosted-voyant-payments.md
@@ -1,0 +1,17 @@
+---
+"@voyant-travel/payments": minor
+"@voyant-travel/operator-settings": minor
+"@voyant-travel/operator-settings-react": minor
+"@voyant-travel/storefront": minor
+"@voyant-travel/hono": minor
+"@voyant-travel/admin-host": patch
+"@voyant-travel/i18n": patch
+"@voyant-travel/trips": patch
+---
+
+Add the managed Voyant Payments transport and honest capability contract, hosted
+Stripe Connect onboarding for operators, and scheduled storefront reconciliation.
+
+Expose typed fail-closed adapter errors and onboarding state, render embedded
+onboarding with the required narrowly scoped security headers, and keep payment
+authorization distinct from completed settlement.

--- a/.changeset/hosted-voyant-payments.md
+++ b/.changeset/hosted-voyant-payments.md
@@ -15,3 +15,11 @@ Stripe Connect onboarding for operators, and scheduled storefront reconciliation
 Expose typed fail-closed adapter errors and onboarding state, render embedded
 onboarding with the required narrowly scoped security headers, and keep payment
 authorization distinct from completed settlement.
+
+Expand the public payment-adapter conformance kit across authorize, capture,
+void, refund, and status, with capability and fixture honesty, strict positive
+minor-unit money, typed fail-closed errors, full idempotency conflict checks,
+callback signature and replay semantics, stable processor identity and
+references, manual capture, partial-operation bounds, and typed health
+diagnostics. Add deterministic conforming and deliberately broken fake adapters
+that exercise every contract case.

--- a/packages/payments/CHANGELOG.md
+++ b/packages/payments/CHANGELOG.md
@@ -1,17 +1,5 @@
 # @voyant-travel/payments
 
-## Unreleased
-
-### Minor Changes
-
-- Expand the public payment-adapter conformance kit across authorize, capture,
-  void, refund, and status, with capability/fixture honesty, strict positive
-  minor-unit money, typed fail-closed errors, full idempotency conflict checks,
-  callback signature/replay semantics, stable processor identity and
-  references, manual capture, partial-operation bounds, and typed health
-  diagnostics. Add deterministic conforming and deliberately broken fake
-  adapters that exercise every contract case.
-
 ## 0.6.5
 
 ### Patch Changes


### PR DESCRIPTION
## Summary

- add the missing Changesets release entry for the hosted Voyant Payments work merged in #3749
- version the public API/capability additions as minor releases
- version the runtime, CSP, localization, and manifest compatibility updates as patches

## Why

The release workflow after #3749 correctly reported zero releasable changesets, so no `chore: release packages` PR could be created. This restores the repository's normal package release path.

## Verification

- changeset syntax inspected and `git diff --check` passed
- the repository Release workflow will validate the assembled release plan after merge

Follow-up to #3749.