### PR TITLE
chore(tools)!: remove callable Operator Tool name aliases

### DIFF
--- a/.changeset/remove-callable-tool-aliases.md
+++ b/.changeset/remove-callable-tool-aliases.md
@@ -9,7 +9,7 @@
 "@voyant-travel/inventory": major
 "@voyant-travel/finance": major
 "@voyant-travel/finance-react": major
-"@voyant-travel/operator-standard": patch
+"@voyant-travel/operator-standard": major
 ---
 
 Remove callable Tool name aliases from the standard Operator graph. MCP and
@@ -22,3 +22,7 @@ Stop publicly exporting the deprecated Relationships Tools
 `add_relationship_note`, `add_relationship_contact_method`, and
 `add_relationship_address`. Use the person- or organization-specific add Tools
 selected by the graph instead.
+
+See the consolidated [caller migration
+page](../docs/migrations/removed-tool-aliases.md) for the complete old →
+canonical name mapping.

--- a/.changeset/remove-callable-tool-aliases.md
+++ b/.changeset/remove-callable-tool-aliases.md
@@ -1,0 +1,24 @@
+---
+"@voyant-travel/setup": major
+"@voyant-travel/navigation-preferences": major
+"@voyant-travel/navigation-preferences-react": major
+"@voyant-travel/operations": major
+"@voyant-travel/legal": major
+"@voyant-travel/legal-react": major
+"@voyant-travel/relationships": major
+"@voyant-travel/inventory": major
+"@voyant-travel/finance": major
+"@voyant-travel/finance-react": major
+"@voyant-travel/operator-standard": patch
+---
+
+Remove callable Tool name aliases from the standard Operator graph. MCP and
+other callers must use canonical Tool names only; previous compatibility names
+(for example `crm_*`, `legal_contract_*`, `availability_*`, `dashboard_summary`,
+`read_setup_state`, `products_compose`, `invoices_issue_from_booking`) no longer
+dispatch.
+
+Stop publicly exporting the deprecated Relationships Tools
+`add_relationship_note`, `add_relationship_contact_method`, and
+`add_relationship_address`. Use the person- or organization-specific add Tools
+selected by the graph instead.

--- a/docs/migrations/README.md
+++ b/docs/migrations/README.md
@@ -4,6 +4,7 @@ Per-minor consolidated migration notes for Voyant. Each page collects every brea
 
 Unreleased caller migrations:
 
+- [Removed callable Tool name aliases](./removed-tool-aliases.md) — 35 removed compatibility Tool names across Setup, Navigation preferences, Operations, Legal, Relationships, Inventory, and Finance, plus 3 deprecated Relationships add Tools dropped entirely.
 - [Created-target Tool commands](./created-target-tool-commands.md)
 - [Created local Commerce, Charters, and Cruises targets](./created-target-commerce-charters-cruises.md) — includes the breaking `create_promotion` and `create_cruise` response-envelope migrations.
 - [Created Relationships people](./created-relationships-person.md) — restore atomic, replay-safe `create_person` with an immutable response envelope.

--- a/docs/migrations/removed-tool-aliases.md
+++ b/docs/migrations/removed-tool-aliases.md
@@ -1,0 +1,144 @@
+# Removed callable Tool name aliases
+
+## TL;DR
+
+- The standard Operator graph no longer dispatches 35 compatibility Tool-name
+  aliases (`crm_*`, `legal_contract_*`, `availability_*`, `dashboard_summary`,
+  `read_setup_state`, and others below); callers must use the canonical name.
+- Relationships stops publicly exporting three deprecated add Tools
+  (`add_relationship_note`, `add_relationship_contact_method`,
+  `add_relationship_address`); use the person- or organization-specific add
+  Tool the graph already selects instead.
+- No input/output schema, HTTP route, or hook signature changed — only Tool
+  dispatch names. Update the `name` (or MCP Tool id) used to invoke each Tool.
+- `@voyant-travel/operator-standard` is bumped major alongside every changed
+  module because it distributes all of them via
+  `STANDARD_OPERATOR_DISTRIBUTION_POLICY`; consumers on the standard
+  distribution get every alias removal in one release.
+- No database schema migration is required.
+
+## Removed exports
+
+None of these packages removed exported functions, types, or React hooks.
+The removals are Tool **dispatch names** — the `aliases` entry a caller could
+use in place of the canonical `name` when invoking the Tool through MCP or the
+in-process Tool registry. The canonical Tool (same handler, same
+input/output schema) is unaffected.
+
+### Setup (`@voyant-travel/setup`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `read_setup_state` | `get_setup_state` |
+| `start_setup` | `initialize_setup` |
+| `mark_setup_step_complete` | `complete_setup_step` |
+| `mark_setup_step_skipped` | `skip_setup_step` |
+
+### Navigation preferences (`@voyant-travel/navigation-preferences`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `read_navigation_preferences` | `get_navigation_preferences` |
+| `update_organization_navigation_preferences` | `set_organization_navigation_preferences` |
+| `update_my_navigation_preferences` | `set_my_navigation_preferences` |
+
+### Operations (`@voyant-travel/operations`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `availability_overview` | `get_availability_overview` |
+| `availability_rules_list` | `list_availability_rules` |
+| `availability_rule_get` | `get_availability_rule` |
+| `availability_start_times_list` | `list_availability_start_times` |
+| `departures_list_by_product` | `list_departures` |
+| `departures_get` | `get_departure` |
+| `availability_closeouts_list` | `list_availability_closeouts` |
+| `dashboard_summary` | `get_operator_dashboard_summary` |
+
+### Legal (`@voyant-travel/legal`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `legal_contract_list` | `list_legal_contracts` |
+| `legal_contract_get` | `get_legal_contract` |
+| `legal_contract_create` | `create_legal_contract_draft` |
+| `legal_contract_attachments_list` | `list_contract_attachments` |
+
+### Relationships (`@voyant-travel/relationships`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `crm_people_list` | `list_people` |
+| `crm_people_get` | `get_person` |
+| `crm_person_create` | `create_person` |
+| `crm_person_update` | `update_person` |
+| `crm_organizations_list` | `list_organizations` |
+| `crm_organizations_get` | `get_organization` |
+| `crm_organization_create` | `create_organization` |
+| `crm_organization_update` | `update_organization` |
+| `crm_notes_list` | `list_relationship_notes` |
+| `crm_note_update` | `update_relationship_note` |
+| `crm_contact_methods_list` | `list_relationship_contact_methods` |
+| `crm_contact_method_update` | `update_relationship_contact_method` |
+| `crm_addresses_list` | `list_relationship_addresses` |
+| `crm_address_update` | `update_relationship_address` |
+
+Three deprecated Tools are no longer exported at all (not just renamed) —
+their alias also stopped dispatching:
+
+| Removed deprecated Tool | Removed alias | Replacement |
+| --- | --- | --- |
+| `add_relationship_note` | `crm_note_add` | `add_person_note` / `add_organization_note` |
+| `add_relationship_contact_method` | `crm_contact_method_add` | `add_person_contact_method` / `add_organization_contact_method` |
+| `add_relationship_address` | `crm_address_add` | `add_person_address` / `add_organization_address` |
+
+The graph already selects the person- or organization-specific add Tool for
+the entity kind in scope; callers do not choose between them explicitly.
+
+### Inventory (`@voyant-travel/inventory`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `products_compose` | `compose_product` |
+
+### Finance (`@voyant-travel/finance`)
+
+| Removed alias | Canonical Tool |
+| --- | --- |
+| `invoices_issue_from_booking` | `issue_invoice_from_booking` |
+
+## Caller-code migrations
+
+Before:
+
+```ts
+await callTool("crm_person_create", { firstName: "Ana", lastName: "Popescu" })
+await callTool("dashboard_summary", {})
+await callTool("read_setup_state", {})
+```
+
+After:
+
+```ts
+await callTool("create_person", { firstName: "Ana", lastName: "Popescu" })
+await callTool("get_operator_dashboard_summary", {})
+await callTool("get_setup_state", {})
+```
+
+MCP clients that list Tools by name (rather than hardcoding an alias) are
+unaffected — the canonical names were already present alongside every alias
+removed here.
+
+## Per-package CHANGELOG links
+
+- [`@voyant-travel/setup`](../../packages/setup/CHANGELOG.md)
+- [`@voyant-travel/navigation-preferences`](../../packages/navigation-preferences/CHANGELOG.md)
+- [`@voyant-travel/navigation-preferences-react`](../../packages/navigation-preferences-react/CHANGELOG.md)
+- [`@voyant-travel/operations`](../../packages/operations/CHANGELOG.md)
+- [`@voyant-travel/legal`](../../packages/legal/CHANGELOG.md)
+- [`@voyant-travel/legal-react`](../../packages/legal-react/CHANGELOG.md)
+- [`@voyant-travel/relationships`](../../packages/relationships/CHANGELOG.md)
+- [`@voyant-travel/inventory`](../../packages/inventory/CHANGELOG.md)
+- [`@voyant-travel/finance`](../../packages/finance/CHANGELOG.md)
+- [`@voyant-travel/finance-react`](../../packages/finance-react/CHANGELOG.md)
+- [`@voyant-travel/operator-standard`](../../packages/operator-standard/CHANGELOG.md)

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -289,7 +289,6 @@ export const issueInvoiceFromBookingTool = defineTool<
   capabilityId: "@voyant-travel/finance#tool.issue-invoice-from-booking",
   capabilityVersion: "v1",
   name: "issue_invoice_from_booking",
-  aliases: ["invoices_issue_from_booking"],
   description:
     "Request approval to create and issue an invoice or proforma from a booking, or execute and idempotently replay the exact approved command.",
   inputSchema: issueInvoiceFromBookingToolInputSchema,

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -406,7 +406,6 @@ export const composeProductTool = defineTool({
   capabilityId: `${OWNER}#authoring.tool.compose-product`,
   capabilityVersion: VERSION,
   name: "compose_product",
-  aliases: ["products_compose"],
   description:
     "Atomically author a complete product graph through Inventory's category-aware composer: product, options, units, pricing rules, and itinerary. Invalid graphs return actionable issues without writing. Departures and publication remain separate confirmed operations.",
   inputSchema: composeProductToolInputSchema,

--- a/packages/legal/src/tools.ts
+++ b/packages/legal/src/tools.ts
@@ -1,3 +1,4 @@
+// agent-quality: file-size exception -- owner: legal; contract lifecycle tools stay co-located because create/read/update/document handlers share one admission and schema surface.
 import {
   admitHandlerActionPolicy,
   defineTool,
@@ -470,7 +471,6 @@ export const listLegalContractsTool = defineTool({
   ...readMetadata,
   capabilityId: `${OWNER}#tool.list-contracts`,
   name: "list_legal_contracts",
-  aliases: ["legal_contract_list"],
   description: "List compact contract records without rendered bodies or variable snapshots.",
   inputSchema: listContractsInputSchema,
   outputSchema: z.object({ data: z.array(legalContractSummarySchema), meta: pageSchema }),
@@ -480,7 +480,6 @@ export const getLegalContractTool = defineTool({
   ...readMetadata,
   capabilityId: `${OWNER}#tool.get-contract`,
   name: "get_legal_contract",
-  aliases: ["legal_contract_get"],
   description:
     "Read one contract including its rendered body, variables, metadata, and stage history.",
   inputSchema: idInputSchema,
@@ -496,7 +495,6 @@ export const createLegalContractDraftTool = defineTool({
   riskPolicy: { ...writeMetadata.riskPolicy, reversible: false },
   capabilityId: `${OWNER}#tool.create-contract-draft`,
   name: "create_legal_contract_draft",
-  aliases: ["legal_contract_create"],
   description: "Create a draft contract only. Lifecycle status cannot be supplied or spoofed.",
   inputSchema: createDraftInputSchema,
   outputSchema: z.object({
@@ -651,7 +649,6 @@ export const listContractAttachmentsTool = defineTool({
   ...readMetadata,
   capabilityId: `${OWNER}#tool.list-contract-attachments`,
   name: "list_contract_attachments",
-  aliases: ["legal_contract_attachments_list"],
   description: "List contract attachment metadata without exposing private storage keys.",
   inputSchema: listAttachmentsInputSchema,
   outputSchema: z.array(attachmentSchema),

--- a/packages/navigation-preferences/src/tools.ts
+++ b/packages/navigation-preferences/src/tools.ts
@@ -33,7 +33,6 @@ export const getNavigationPreferencesTool = defineTool<
   NavigationPreferencesToolContext
 >({
   name: "get_navigation_preferences",
-  aliases: ["read_navigation_preferences"],
   description:
     "Read organization defaults, the authenticated member's overrides, and effective admin navigation visibility. Read-only.",
   inputSchema: z.object({}),
@@ -53,7 +52,6 @@ export const setOrganizationNavigationPreferencesTool = defineTool<
   NavigationPreferencesToolContext
 >({
   name: "set_organization_navigation_preferences",
-  aliases: ["update_organization_navigation_preferences"],
   description:
     "Replace organization-wide admin navigation visibility defaults. Requires confirmation and affects all members unless they have overrides.",
   inputSchema: updateNavigationPreferencesSchema,
@@ -79,7 +77,6 @@ export const setMyNavigationPreferencesTool = defineTool<
   NavigationPreferencesToolContext
 >({
   name: "set_my_navigation_preferences",
-  aliases: ["update_my_navigation_preferences"],
   description: "Replace admin navigation visibility overrides for the authenticated member only.",
   inputSchema: updateNavigationPreferencesSchema,
   outputSchema: visibilityResultSchema,

--- a/packages/navigation-preferences/tests/unit/tools.test.ts
+++ b/packages/navigation-preferences/tests/unit/tools.test.ts
@@ -17,9 +17,9 @@ const baseContext: ToolContext = {
 }
 
 describe("navigation preference Tools", () => {
-  it("declares structural contracts, aliases, audience, and risk", () => {
+  it("declares structural contracts, audience, and risk", () => {
     expect(getNavigationPreferencesTool.inputSchema.safeParse({}).success).toBe(true)
-    expect(getNavigationPreferencesTool.aliases).toEqual(["read_navigation_preferences"])
+    expect(getNavigationPreferencesTool.aliases ?? []).toEqual([])
     expect(getNavigationPreferencesTool.audience?.allowed).toEqual(["staff"])
     expect(setOrganizationNavigationPreferencesTool.tier).toBe("sensitive")
     expect(setOrganizationNavigationPreferencesTool.riskPolicy.confirmationRequired).toBe(true)

--- a/packages/operations/README.md
+++ b/packages/operations/README.md
@@ -17,7 +17,7 @@ operations remain intentionally absent until their action-ledger and argument-de
 policies are designed.
 
 `@voyant-travel/operations/dashboard` is a separately selectable composed module. Its
-`get_operator_dashboard_summary` Tool (legacy alias `dashboard_summary`) coordinates the
+`get_operator_dashboard_summary` Tool coordinates the
 provider-neutral aggregate services injected by Bookings, Finance, Inventory, Distribution, and
 Operations. The Tool requires every underlying read scope with AND semantics; it does not query
 another module's tables or move aggregate authority into Operations. Its output carries the

--- a/packages/operations/src/dashboard-tool.ts
+++ b/packages/operations/src/dashboard-tool.ts
@@ -215,7 +215,6 @@ export const getOperatorDashboardSummaryDefinition = {
   capabilityId: "@voyant-travel/operations#dashboard#tool.get-operator-dashboard-summary",
   capabilityVersion: VERSION,
   name: "get_operator_dashboard_summary",
-  aliases: ["dashboard_summary"],
   description:
     "Compose an operator dashboard summary from the selected Bookings, Finance, Inventory, " +
     "Distribution, and Operations aggregate services. Staff-only and read-only.",

--- a/packages/operations/src/tools.ts
+++ b/packages/operations/src/tools.ts
@@ -191,7 +191,6 @@ export const getAvailabilityOverviewTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.get-availability-overview`,
   name: "get_availability_overview",
-  aliases: ["availability_overview"],
   description:
     "Summarize upcoming availability: open and constrained departures, active recurrence " +
     "rules and pickup points, products missing future departures, and the next constrained slots.",
@@ -234,7 +233,6 @@ export const listAvailabilityRulesTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.list-availability-rules`,
   name: "list_availability_rules",
-  aliases: ["availability_rules_list"],
   description:
     "List recurrence rules that generate departures, filtered by product, option, facility, or active status.",
   inputSchema: availabilityRuleListQuerySchema,
@@ -255,7 +253,6 @@ export const getAvailabilityRuleTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.get-availability-rule`,
   name: "get_availability_rule",
-  aliases: ["availability_rule_get"],
   description: "Read one availability recurrence rule by id. Returns null when not found.",
   inputSchema: idArgsSchema,
   outputSchema: availabilityRuleOutputSchema,
@@ -274,7 +271,6 @@ export const listAvailabilityStartTimesTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.list-availability-start-times`,
   name: "list_availability_start_times",
-  aliases: ["availability_start_times_list"],
   description:
     "List configured local departure start times, filtered by product, option, facility, or active status.",
   inputSchema: availabilityStartTimeListQuerySchema,
@@ -295,7 +291,6 @@ export const listDeparturesTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.list-departures`,
   name: "list_departures",
-  aliases: ["departures_list_by_product"],
   description:
     "List departures across the catalog or for one product, with local date, start window, " +
     "status, remaining capacity, product name, and pagination. Results are ordered by start time.",
@@ -323,7 +318,6 @@ export const getDepartureTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.get-departure`,
   name: "get_departure",
-  aliases: ["departures_get"],
   description:
     "Read one departure by id, including status, timing, remaining capacity, and local end date. Returns null when not found.",
   inputSchema: idArgsSchema,
@@ -343,7 +337,6 @@ export const listAvailabilityCloseoutsTool = defineTool<
   ...commonMetadata,
   capabilityId: `${OWNER}#tool.list-availability-closeouts`,
   name: "list_availability_closeouts",
-  aliases: ["availability_closeouts_list"],
   description:
     "List product/date or departure-specific closeouts, filtered by product, departure, or local date.",
   inputSchema: availabilityCloseoutListQuerySchema,

--- a/packages/operations/tests/tools.test.ts
+++ b/packages/operations/tests/tools.test.ts
@@ -71,15 +71,15 @@ describe("Operations tools", () => {
       expect(tool.outputSchema).toMatchObject({ type: "object" })
       expect(tool.outputSchema).not.toHaveProperty("x-voyant-schema-quality")
     }
-    expect(manifest.find((tool) => tool.name === "list_departures")?.aliases).toEqual([
-      "departures_list_by_product",
-    ])
+    for (const tool of manifest) {
+      expect(tool.aliases ?? []).toEqual([])
+    }
   })
 
-  it("dispatches the hosted overview alias through the domain service", async () => {
+  it("dispatches the availability overview through the domain service", async () => {
     let forwarded: unknown
     const result = await registry().dispatch(
-      "availability_overview",
+      "get_availability_overview",
       { productId: "prod_1", attentionLimit: 3 },
       contextWith({
         async getAvailabilityOverview(query) {
@@ -104,7 +104,7 @@ describe("Operations tools", () => {
     let forwarded: unknown
     const createdAt = new Date("2026-08-01T08:00:00.000Z")
     const result = await registry().dispatch<{ data: Array<Record<string, unknown>> }>(
-      "departures_list_by_product",
+      "list_departures",
       {
         productId: "prod_1",
         date: "2026-09-10",
@@ -183,7 +183,7 @@ describe("Operations tools", () => {
       departure: null,
     })
     await expect(
-      registry().dispatch("availability_rule_get", { id: "missing" }, ctx),
+      registry().dispatch("get_availability_rule", { id: "missing" }, ctx),
     ).resolves.toEqual({ rule: null })
   })
 
@@ -213,14 +213,14 @@ describe("Operations tools", () => {
 })
 
 describe("Operations dashboard Tool", () => {
-  it("publishes a structural, staff-only composed read with the hosted alias", () => {
+  it("publishes a structural, staff-only composed read", () => {
     const registry = createToolRegistry()
     registry.register(getOperatorDashboardSummaryTool)
     expect(registry.list()[0]).toMatchObject({
       capabilityId: "@voyant-travel/operations#dashboard#tool.get-operator-dashboard-summary",
       owner: "@voyant-travel/operations#dashboard",
       name: "get_operator_dashboard_summary",
-      aliases: ["dashboard_summary"],
+      aliases: [],
       audience: { source: "grant", allowed: ["staff"] },
       requiredScopes: [
         "operations:read",
@@ -242,7 +242,7 @@ describe("Operations dashboard Tool", () => {
       kpis: Record<string, unknown>
       alerts: unknown[]
     }>(
-      "dashboard_summary",
+      "get_operator_dashboard_summary",
       { range: "this-month" },
       {
         ...contextWith({

--- a/packages/relationships/src/tools.ts
+++ b/packages/relationships/src/tools.ts
@@ -1,4 +1,5 @@
 /** Module-owned CRM lifecycle tools backed by Relationships services. */
+// agent-quality: file-size exception -- owner: relationships; CRM entity tools stay co-located because person/org/address/contact handlers share one admission and schema surface.
 
 import {
   insertAddressForEntitySchema,
@@ -295,7 +296,6 @@ export const listPeopleTool = defineTool<
   ...readMetadata,
   capabilityId: `${OWNER}#tool.list-people`,
   name: "list_people",
-  aliases: ["crm_people_list"],
   description: "Search CRM people by name, contact point, organization, relationship, or status.",
   inputSchema: personListQuerySchema,
   outputSchema: peopleListOutputSchema,
@@ -312,7 +312,6 @@ export const getPersonTool = defineTool<
   ...readMetadata,
   capabilityId: `${OWNER}#tool.get-person`,
   name: "get_person",
-  aliases: ["crm_people_get"],
   description: "Read one CRM person by id. Returns null when not found.",
   inputSchema: idArgsSchema,
   outputSchema: personToolSchema.nullable(),
@@ -330,7 +329,6 @@ export const createPersonTool = defineTool<
   riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-person`,
   name: "create_person",
-  aliases: ["crm_person_create"],
   description:
     "Create a new CRM person with at least one real email or phone. Exact retries return the original immutable person reference; use read tools to resolve an existing person.",
   inputSchema: createPersonToolInputSchema,
@@ -360,7 +358,6 @@ export const updatePersonTool = defineTool<
   ...sensitiveWriteMetadata,
   capabilityId: `${OWNER}#tool.update-person`,
   name: "update_person",
-  aliases: ["crm_person_update"],
   description:
     "Update a CRM person's profile, inline primary contact, tags, or lifecycle status. Returns null when not found.",
   inputSchema: updatePersonToolInputSchema,
@@ -379,7 +376,6 @@ export const listOrganizationsTool = defineTool<
   ...readMetadata,
   capabilityId: `${OWNER}#tool.list-organizations`,
   name: "list_organizations",
-  aliases: ["crm_organizations_list"],
   description: "Search CRM organizations by name, website, exact tax id, relationship, or status.",
   inputSchema: organizationToolListInputSchema,
   outputSchema: organizationListOutputSchema,
@@ -404,7 +400,6 @@ export const getOrganizationTool = defineTool<
   ...readMetadata,
   capabilityId: `${OWNER}#tool.get-organization`,
   name: "get_organization",
-  aliases: ["crm_organizations_get"],
   description: "Read one CRM organization by id. Returns null when not found.",
   inputSchema: idArgsSchema,
   outputSchema: organizationSchema.nullable(),
@@ -422,7 +417,6 @@ export const createOrganizationTool = defineTool<
   riskPolicy: CREATED_WRITE_RISK,
   capabilityId: `${OWNER}#tool.create-organization`,
   name: "create_organization",
-  aliases: ["crm_organization_create"],
   description:
     "Create a CRM organization and optional billing address atomically. Exact retries return the original immutable organization reference.",
   inputSchema: createOrganizationToolInputSchema,
@@ -446,7 +440,6 @@ export const updateOrganizationTool = defineTool<
   ...routineWriteMetadata,
   capabilityId: `${OWNER}#tool.update-organization`,
   name: "update_organization",
-  aliases: ["crm_organization_update"],
   description:
     "Update an organization's profile, tags, or lifecycle status. Returns null when not found.",
   inputSchema: updateOrganizationToolInputSchema,
@@ -465,7 +458,6 @@ export const listRelationshipNotesTool = defineTool<
   ...sensitiveReadMetadata,
   capabilityId: `${OWNER}#tool.list-relationship-notes`,
   name: "list_relationship_notes",
-  aliases: ["crm_notes_list"],
   description: "List staff-authored notes on a CRM person or organization.",
   inputSchema: relationshipEntityArgsSchema,
   outputSchema: noteListOutputSchema,
@@ -503,24 +495,6 @@ export const addOrganizationNoteTool = defineTool(
   defineAddNoteTool("organization", organizationNoteSchema),
 )
 
-/** @deprecated Use the person- or organization-specific Tool selected by the graph. */
-const deprecatedAddRelationshipNoteTool = defineTool<
-  AddNoteInput,
-  z.infer<typeof noteSchema> | null,
-  RelationshipsToolContext
->({
-  ...sensitiveWriteMetadata,
-  capabilityId: `${OWNER}#tool.add-relationship-note`,
-  name: "add_relationship_note",
-  aliases: ["crm_note_add"],
-  description: "Add a staff-attributed note to a CRM person or organization.",
-  inputSchema: addNoteInputSchema,
-  outputSchema: noteSchema.nullable(),
-  async handler(input, ctx) {
-    return parseJsonResult(noteSchema.nullable(), await crm(ctx).addNote(input))
-  },
-})
-
 export const updateRelationshipNoteTool = defineTool<
   EditNoteInput,
   z.infer<typeof noteSchema> | null,
@@ -529,7 +503,6 @@ export const updateRelationshipNoteTool = defineTool<
   ...sensitiveWriteMetadata,
   capabilityId: `${OWNER}#tool.update-relationship-note`,
   name: "update_relationship_note",
-  aliases: ["crm_note_update"],
   description: "Edit an existing CRM person or organization note. Returns null when not found.",
   inputSchema: editNoteInputSchema,
   outputSchema: noteSchema.nullable(),
@@ -547,7 +520,6 @@ export const listRelationshipContactMethodsTool = defineTool<
   ...sensitiveReadMetadata,
   capabilityId: `${OWNER}#tool.list-relationship-contact-methods`,
   name: "list_relationship_contact_methods",
-  aliases: ["crm_contact_methods_list"],
   description: "List email, phone, messaging, website, and other contact methods for a CRM entity.",
   inputSchema: relationshipEntityArgsSchema,
   outputSchema: z.array(contactMethodSchema),
@@ -582,24 +554,6 @@ export const addOrganizationContactMethodTool = defineTool(
   defineAddContactMethodTool("organization"),
 )
 
-/** @deprecated Use the person- or organization-specific Tool selected by the graph. */
-const deprecatedAddRelationshipContactMethodTool = defineTool<
-  AddContactMethodInput,
-  z.infer<typeof contactMethodSchema> | null,
-  RelationshipsToolContext
->({
-  ...sensitiveWriteMetadata,
-  capabilityId: `${OWNER}#tool.add-relationship-contact-method`,
-  name: "add_relationship_contact_method",
-  aliases: ["crm_contact_method_add"],
-  description: "Add a contact method to a CRM person or organization.",
-  inputSchema: addContactMethodInputSchema,
-  outputSchema: contactMethodSchema.nullable(),
-  async handler(input, ctx) {
-    return parseJsonResult(contactMethodSchema.nullable(), await crm(ctx).addContactMethod(input))
-  },
-})
-
 export const updateRelationshipContactMethodTool = defineTool<
   EditContactMethodInput,
   z.infer<typeof contactMethodSchema> | null,
@@ -608,7 +562,6 @@ export const updateRelationshipContactMethodTool = defineTool<
   ...sensitiveWriteMetadata,
   capabilityId: `${OWNER}#tool.update-relationship-contact-method`,
   name: "update_relationship_contact_method",
-  aliases: ["crm_contact_method_update"],
   description: "Update a CRM contact method without re-parenting it. Returns null when not found.",
   inputSchema: editContactMethodInputSchema,
   outputSchema: contactMethodSchema.nullable(),
@@ -629,7 +582,6 @@ export const listRelationshipAddressesTool = defineTool<
   ...sensitiveReadMetadata,
   capabilityId: `${OWNER}#tool.list-relationship-addresses`,
   name: "list_relationship_addresses",
-  aliases: ["crm_addresses_list"],
   description: "List billing, legal, primary, and other addresses for a CRM entity.",
   inputSchema: relationshipEntityArgsSchema,
   outputSchema: z.array(addressSchema),
@@ -662,24 +614,6 @@ function defineAddAddressTool(ownerType: "person" | "organization") {
 export const addPersonAddressTool = defineTool(defineAddAddressTool("person"))
 export const addOrganizationAddressTool = defineTool(defineAddAddressTool("organization"))
 
-/** @deprecated Use the person- or organization-specific Tool selected by the graph. */
-const deprecatedAddRelationshipAddressTool = defineTool<
-  AddAddressInput,
-  z.infer<typeof addressSchema> | null,
-  RelationshipsToolContext
->({
-  ...sensitiveWriteMetadata,
-  capabilityId: `${OWNER}#tool.add-relationship-address`,
-  name: "add_relationship_address",
-  aliases: ["crm_address_add"],
-  description: "Add an address to a CRM person or organization.",
-  inputSchema: addAddressInputSchema,
-  outputSchema: addressSchema.nullable(),
-  async handler(input, ctx) {
-    return parseJsonResult(addressSchema.nullable(), await crm(ctx).addAddress(input))
-  },
-})
-
 export const updateRelationshipAddressTool = defineTool<
   EditAddressInput,
   z.infer<typeof addressSchema> | null,
@@ -688,7 +622,6 @@ export const updateRelationshipAddressTool = defineTool<
   ...sensitiveWriteMetadata,
   capabilityId: `${OWNER}#tool.update-relationship-address`,
   name: "update_relationship_address",
-  aliases: ["crm_address_update"],
   description: "Update a CRM address without re-parenting it. Returns null when not found.",
   inputSchema: editAddressInputSchema,
   outputSchema: addressSchema.nullable(),
@@ -720,12 +653,6 @@ export const relationshipsTools = [
   addOrganizationAddressTool,
   updateRelationshipAddressTool,
 ] as const
-
-export {
-  deprecatedAddRelationshipAddressTool as addRelationshipAddressTool,
-  deprecatedAddRelationshipContactMethodTool as addRelationshipContactMethodTool,
-  deprecatedAddRelationshipNoteTool as addRelationshipNoteTool,
-}
 
 function parseJsonResult<T extends z.ZodType>(schema: T, value: unknown): z.output<T> {
   return schema.parse(toJsonValue(value))

--- a/packages/relationships/tests/tools.test.ts
+++ b/packages/relationships/tests/tools.test.ts
@@ -5,9 +5,6 @@ import {
   RELATIONSHIPS_PERSON_HANDLER_ACTION_POLICY,
 } from "../src/created-target-policy.js"
 import {
-  addRelationshipAddressTool,
-  addRelationshipContactMethodTool,
-  addRelationshipNoteTool,
   createOrganizationTool,
   createPersonTool,
   type RelationshipsToolServices,
@@ -239,26 +236,28 @@ describe("relationships (crm) tools", () => {
     expect(manifest.find((tool) => tool.name === "create_organization")).toMatchObject({
       tier: "write",
       deploymentRisk: "medium",
-      aliases: ["crm_organization_create"],
     })
     expect(manifest.find((tool) => tool.name === "list_relationship_addresses")).toMatchObject({
       tier: "sensitive",
       deploymentRisk: "high",
       requiredScopes: ["crm:read"],
-      aliases: ["crm_addresses_list"],
     })
+    for (const tool of manifest) {
+      expect(tool.aliases ?? []).toEqual([])
+    }
   })
 
-  it("keeps deprecated generic add exports outside the selected Tool registry", () => {
-    const selected: ReadonlySet<unknown> = new Set(relationshipsTools)
-    expect(selected.has(addRelationshipNoteTool)).toBe(false)
-    expect(selected.has(addRelationshipContactMethodTool)).toBe(false)
-    expect(selected.has(addRelationshipAddressTool)).toBe(false)
+  it("does not export deprecated generic relationship add Tools", async () => {
+    const toolsModule = await import("../src/tools.js")
+    expect(toolsModule).not.toHaveProperty("addRelationshipNoteTool")
+    expect(toolsModule).not.toHaveProperty("addRelationshipContactMethodTool")
+    expect(toolsModule).not.toHaveProperty("addRelationshipAddressTool")
+    expect(relationshipsTools.some((tool) => tool.name.startsWith("add_relationship_"))).toBe(false)
   })
 
   it("normalizes typed person reads and strips encrypted profile envelopes", async () => {
     const result = await registry().dispatch<{ data: Array<Record<string, unknown>> }>(
-      "crm_people_list",
+      "list_people",
       { search: "Popescu" },
       ctx({
         async listPeople(query) {
@@ -285,7 +284,7 @@ describe("relationships (crm) tools", () => {
 
     let forwarded: unknown
     const result = await registry().dispatch(
-      "crm_person_create",
+      "create_person",
       { firstName: "Ana", lastName: "Popescu", email: "ana@example.com" },
       ctx(
         {
@@ -346,7 +345,7 @@ describe("relationships (crm) tools", () => {
   it("supports organization creation with a billing address and lifecycle updates", async () => {
     let listed: unknown
     await registry().dispatch(
-      "crm_organizations_list",
+      "list_organizations",
       { vatNumber: "RO123" },
       ctx({
         async listOrganizations(query) {
@@ -359,7 +358,7 @@ describe("relationships (crm) tools", () => {
 
     let created: unknown
     const createResult = await registry().dispatch(
-      "crm_organization_create",
+      "create_organization",
       {
         name: "Example Travel",
         vatNumber: "RO123",
@@ -400,7 +399,7 @@ describe("relationships (crm) tools", () => {
 
     let updated: unknown
     await registry().dispatch(
-      "crm_organization_update",
+      "update_organization",
       { id: "org_1", status: "inactive", tags: ["former-client"] },
       ctx({
         async updateOrganization(input) {
@@ -439,7 +438,7 @@ describe("relationships (crm) tools", () => {
       },
     })
     await registry().dispatch(
-      "crm_notes_list",
+      "list_relationship_notes",
       { entityType: "person", entityId: "pers_1" },
       services,
     )
@@ -482,7 +481,7 @@ describe("relationships (crm) tools", () => {
       services,
     )
     await registry().dispatch(
-      "crm_address_update",
+      "update_relationship_address",
       { id: "iadr_1", line1: "Calea Victoriei 2" },
       services,
     )

--- a/packages/setup/src/tools.ts
+++ b/packages/setup/src/tools.ts
@@ -45,7 +45,6 @@ export const getSetupStateTool = defineTool<
   SetupToolContext
 >({
   name: "get_setup_state",
-  aliases: ["read_setup_state"],
   description:
     "Read organization setup progress, graph-selected steps, and safe prefill data. Read-only.",
   inputSchema: z.object({}),
@@ -65,7 +64,6 @@ export const initializeSetupTool = defineTool<
   SetupToolContext
 >({
   name: "initialize_setup",
-  aliases: ["start_setup"],
   description:
     "Initialize organization setup using exactly the graph-selected step IDs returned by get_setup_state.",
   inputSchema: initializeSetupInputSchema,
@@ -91,7 +89,6 @@ export const completeSetupStepTool = defineTool<
   SetupToolContext
 >({
   name: "complete_setup_step",
-  aliases: ["mark_setup_step_complete"],
   description: "Mark one graph-selected organization setup step complete.",
   inputSchema: stepMutationInputSchema,
   outputSchema: setupStepStateSchema,
@@ -112,7 +109,6 @@ export const completeSetupStepTool = defineTool<
 
 export const skipSetupStepTool = defineTool<{ stepId: string }, SetupStepState, SetupToolContext>({
   name: "skip_setup_step",
-  aliases: ["mark_setup_step_skipped"],
   description: "Skip one graph-selected organization setup step when that step is skippable.",
   inputSchema: stepMutationInputSchema,
   outputSchema: setupStepStateSchema,

--- a/packages/setup/tests/unit/tools.test.ts
+++ b/packages/setup/tests/unit/tools.test.ts
@@ -18,7 +18,7 @@ const baseContext: ToolContext = {
 }
 
 describe("setup Tools", () => {
-  it("declares structural graph-aware contracts, aliases, audience, and risk", () => {
+  it("declares structural graph-aware contracts, audience, and risk", () => {
     expect(
       getSetupStateTool.outputSchema.safeParse({
         state: null,
@@ -26,7 +26,7 @@ describe("setup Tools", () => {
         canManage: true,
       }).success,
     ).toBe(true)
-    expect(getSetupStateTool.aliases).toEqual(["read_setup_state"])
+    expect(getSetupStateTool.aliases ?? []).toEqual([])
     expect(getSetupStateTool.audience?.allowed).toEqual(["staff"])
     expect(initializeSetupTool.tier).toBe("write")
     expect(completeSetupStepTool.riskPolicy.reversible).toBe(false)


### PR DESCRIPTION
## Summary
- Remove all 35 selected Operator Tool `aliases:` so only canonical tool names remain callable.
- Stop publicly exporting the deprecated Relationships tools `add_relationship_note`, `add_relationship_contact_method`, and `add_relationship_address`.
- Update alias-asserting tests and add a major changeset for affected packages.

## Test plan
- [ ] Focused tools tests green for setup, navigation-preferences, operations, relationships
- [ ] Confirm MCP/dispatch of old alias names fails closed
- [ ] Confirm canonical names still dispatch
- [ ] Confirm deprecated Relationships public exports are absent


Made with [Cursor](https://cursor.com)