### PR TITLE
chore(action-ledger): declare created-target contract for request-approval

### DIFF
--- a/.changeset/action-ledger-request-approval-created-target.md
+++ b/.changeset/action-ledger-request-approval-created-target.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/action-ledger": patch
+---
+
+Declare the `createdTarget` durable command contract (with `availability` and
+`effectBoundary` safety metadata) on `action.request-approval`. The handler
+already claims requested actions and approvals idempotently via
+`appendEntry`'s fingerprinted replay lookup, so this only makes the existing
+claim-safety explicit in the deployment graph; no runtime behavior changes.

--- a/packages/action-ledger/src/voyant.ts
+++ b/packages/action-ledger/src/voyant.ts
@@ -253,6 +253,14 @@ export const actionLedgerVoyantModule = defineModule({
       approval: "never",
       reversible: true,
       allowedActorTypes: ["staff"],
+      availability: { status: "available" },
+      effectBoundary: "local",
+      targetLifecycle: "created",
+      createdTarget: {
+        commandTargetType: "action-approval-request-command",
+        resultReferenceType: "action-approval",
+        durability: "handler-command-claim-v1",
+      },
       from: { tools: ["@voyant-travel/action-ledger#tool.request-approval"] },
     },
     {

--- a/scripts/fixtures/legacy-execute-tools-allowlist.json
+++ b/scripts/fixtures/legacy-execute-tools-allowlist.json
@@ -5,7 +5,6 @@
   "@voyant-travel/accommodations#action.set-room-block-nights",
   "@voyant-travel/action-ledger#action.approve-approval",
   "@voyant-travel/action-ledger#action.deny-approval",
-  "@voyant-travel/action-ledger#action.request-approval",
   "@voyant-travel/auth#team.action.activate-member",
   "@voyant-travel/auth#team.action.deactivate-member",
   "@voyant-travel/auth#team.action.revoke-invitation",


### PR DESCRIPTION
## Summary

Follow-up to #3760 (legacy execute+tools ratchet). Migrates one action off the
grandfathered allowlist as proof the ratchet shrinks cleanly when an action
adopts the safety contract.

- Declares `availability: { status: "available" }`, `effectBoundary: "local"`,
  `targetLifecycle: "created"`, and a `createdTarget` command contract
  (`durability: "handler-command-claim-v1"`) on
  `@voyant-travel/action-ledger#action.request-approval`.
- `mcp-runtime.ts` already special-cases `targetLifecycle === "created"` when
  building the command fingerprint for this action, and `requestApproval`
  already claims requested actions and their approvals idempotently through
  `appendEntry`'s fingerprinted replay lookup (a genuine retry with the same
  idempotency key returns the same approval instead of creating a duplicate).
  This change only makes that existing claim-safety explicit in the
  deployment graph — no runtime behavior changes.
- Removes the id from `scripts/fixtures/legacy-execute-tools-allowlist.json`
  (110 → 109); the ratchet check fails on stale allowlist entries, so this is
  required in the same commit.

`approve-approval` / `deny-approval` were also investigated for this batch,
but `decideApproval`'s conditional `status = 'pending'` update runs before any
idempotency check, so a genuine retry after a successful decision currently
throws a conflict error instead of replaying the prior result. Migrating those
two needs an actual behavior fix (check ledger idempotency before mutating
state), not just metadata, so they're left on the allowlist for a follow-up.

## Test plan
- [x] `pnpm --filter @voyant-travel/action-ledger typecheck`
- [x] `pnpm --filter @voyant-travel/action-ledger test`
- [x] `pnpm --filter operator prepare:verify` then `node scripts/check-legacy-execute-tools-ratchet.mjs` → OK (109 grandfathered actions)
- [x] `pnpm verify:deployment-graph`
- [x] `pnpm verify:agent-tool-coverage`
- [x] `pnpm verify:first-party-tool-output-schemas`
- [x] pre-commit/pre-push hooks (full workspace lint/typecheck/test) passed

Made with [Cursor](https://cursor.com)