### PR TITLE
fix(finance): link proforma onto schedule-targeted card checkout

### DIFF
--- a/.changeset/finance-schedule-card-proforma.md
+++ b/.changeset/finance-schedule-card-proforma.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/finance": patch
+---
+
+Link a proforma invoice onto schedule-targeted card checkout sessions so paid status can project.

--- a/packages/finance/src/checkout-service.ts
+++ b/packages/finance/src/checkout-service.ts
@@ -297,8 +297,7 @@ async function createCollectionInvoice(
       totalCents: amountCents,
       baseTotalCents: alignsWithBookingSell ? context.booking.baseSellAmountCents : null,
       paidCents: 0,
-      basePaidCents:
-        alignsWithBookingSell && context.booking.baseCurrency != null ? 0 : null,
+      basePaidCents: alignsWithBookingSell && context.booking.baseCurrency != null ? 0 : null,
       balanceDueCents: amountCents,
       baseBalanceDueCents: alignsWithBookingSell ? context.booking.baseSellAmountCents : null,
       commissionAmountCents: null,

--- a/packages/finance/src/checkout-service.ts
+++ b/packages/finance/src/checkout-service.ts
@@ -34,6 +34,7 @@ import {
   invoiceNumberSeries,
   invoices,
   type PaymentSession,
+  paymentSessions,
 } from "./schema.js"
 import { financeService } from "./service.js"
 
@@ -415,6 +416,19 @@ export async function initiateCheckoutCollection(
       throw new Error("No outstanding payment schedule available for collection")
     }
 
+    // Card settlement completion requires an outstanding booking invoice even
+    // when the session is schedule-targeted. Materialize a proforma for the
+    // collected amount so managed adapter status refresh can project paid.
+    invoice = await createCollectionInvoice(
+      db,
+      context,
+      {
+        ...plan,
+        documentType: plan.documentType ?? "proforma",
+      },
+      input.notes ?? null,
+    )
+
     paymentSession = await financeService.createPaymentSessionFromBookingSchedule(
       db,
       plan.selectedSchedule.id,
@@ -427,6 +441,13 @@ export async function initiateCheckoutCollection(
     if (!paymentSession) {
       throw new Error("Failed to create payment session from booking schedule")
     }
+
+    const [linkedSession] = await db
+      .update(paymentSessions)
+      .set({ invoiceId: invoice.id, updatedAt: new Date() })
+      .where(eq(paymentSessions.id, paymentSession.id))
+      .returning()
+    paymentSession = linkedSession ?? paymentSession
 
     if (
       runtime.notificationDispatcher?.sendPaymentSessionNotification &&

--- a/packages/finance/src/checkout-service.ts
+++ b/packages/finance/src/checkout-service.ts
@@ -263,6 +263,11 @@ async function createCollectionInvoice(
   notes?: string | null,
 ) {
   const amountCents = plan.amountCents
+  const currency = plan.currency
+  // Base FX columns only make sense when the document is in the booking sell
+  // currency. Schedule-targeted collections may charge a different currency;
+  // leave base amounts null rather than stamping an incorrect FX equivalent.
+  const alignsWithBookingSell = currency === context.booking.sellCurrency
   const issueDate = new Date().toISOString().slice(0, 10)
   const dueDate = plan.selectedSchedule?.dueDate ?? issueDate
   const documentType = plan.documentType ?? "invoice"
@@ -282,19 +287,20 @@ async function createCollectionInvoice(
       organizationId: context.booking.organizationId,
       invoiceType: documentType,
       status: "issued",
-      currency: context.booking.sellCurrency,
-      baseCurrency: context.booking.baseCurrency,
+      currency,
+      baseCurrency: alignsWithBookingSell ? context.booking.baseCurrency : null,
       fxRateSetId: null,
       subtotalCents: amountCents,
-      baseSubtotalCents: context.booking.baseSellAmountCents,
+      baseSubtotalCents: alignsWithBookingSell ? context.booking.baseSellAmountCents : null,
       taxCents: 0,
       baseTaxCents: null,
       totalCents: amountCents,
-      baseTotalCents: context.booking.baseSellAmountCents,
+      baseTotalCents: alignsWithBookingSell ? context.booking.baseSellAmountCents : null,
       paidCents: 0,
-      basePaidCents: context.booking.baseCurrency == null ? null : 0,
+      basePaidCents:
+        alignsWithBookingSell && context.booking.baseCurrency != null ? 0 : null,
       balanceDueCents: amountCents,
-      baseBalanceDueCents: context.booking.baseSellAmountCents,
+      baseBalanceDueCents: alignsWithBookingSell ? context.booking.baseSellAmountCents : null,
       commissionAmountCents: null,
       issueDate,
       dueDate,
@@ -416,19 +422,8 @@ export async function initiateCheckoutCollection(
       throw new Error("No outstanding payment schedule available for collection")
     }
 
-    // Card settlement completion requires an outstanding booking invoice even
-    // when the session is schedule-targeted. Materialize a proforma for the
-    // collected amount so managed adapter status refresh can project paid.
-    invoice = await createCollectionInvoice(
-      db,
-      context,
-      {
-        ...plan,
-        documentType: plan.documentType ?? "proforma",
-      },
-      input.notes ?? null,
-    )
-
+    // Create (or reuse) the schedule session first so idempotent retries return
+    // the existing row before we materialize any new proforma.
     paymentSession = await financeService.createPaymentSessionFromBookingSchedule(
       db,
       plan.selectedSchedule.id,
@@ -442,12 +437,40 @@ export async function initiateCheckoutCollection(
       throw new Error("Failed to create payment session from booking schedule")
     }
 
-    const [linkedSession] = await db
-      .update(paymentSessions)
-      .set({ invoiceId: invoice.id, updatedAt: new Date() })
-      .where(eq(paymentSessions.id, paymentSession.id))
-      .returning()
-    paymentSession = linkedSession ?? paymentSession
+    if (paymentSession.invoiceId) {
+      const [existingInvoice] = await db
+        .select()
+        .from(invoices)
+        .where(eq(invoices.id, paymentSession.invoiceId))
+        .limit(1)
+      if (!existingInvoice) {
+        throw new Error(
+          `Payment session ${paymentSession.id} references missing invoice ${paymentSession.invoiceId}`,
+        )
+      }
+      invoice = existingInvoice
+    } else {
+      // Card settlement completion requires an outstanding booking invoice even
+      // when the session is schedule-targeted. Materialize a proforma in the
+      // schedule currency so status refresh can project paid without FX drift.
+      invoice = await createCollectionInvoice(
+        db,
+        context,
+        {
+          ...plan,
+          documentType: plan.documentType ?? "proforma",
+          currency: plan.selectedSchedule.currency,
+        },
+        input.notes ?? null,
+      )
+
+      const [linkedSession] = await db
+        .update(paymentSessions)
+        .set({ invoiceId: invoice.id, updatedAt: new Date() })
+        .where(eq(paymentSessions.id, paymentSession.id))
+        .returning()
+      paymentSession = linkedSession ?? { ...paymentSession, invoiceId: invoice.id }
+    }
 
     if (
       runtime.notificationDispatcher?.sendPaymentSessionNotification &&

--- a/packages/finance/tests/unit/checkout-service.test.ts
+++ b/packages/finance/tests/unit/checkout-service.test.ts
@@ -11,6 +11,7 @@ import {
   invoiceLineItems,
   invoiceNumberSeries,
   invoices,
+  paymentSessions,
 } from "../../src/schema.js"
 import { financeService } from "../../src/service.js"
 
@@ -81,7 +82,13 @@ describe("finance checkout service", () => {
   })
 
   it("uses only the deployment-selected payment adapter", async () => {
-    const db = createCheckoutDb({ insertedInvoices: [] })
+    const insertedInvoices: Array<Record<string, unknown>> = []
+    const linkedSessions: Array<Record<string, unknown>> = []
+    const db = createCheckoutDb({
+      insertedInvoices,
+      linkedSessions,
+      linkSessionId: "ps_selected",
+    })
     const paymentSession = {
       id: "ps_selected",
       invoiceId: null,
@@ -101,7 +108,10 @@ describe("finance checkout service", () => {
     vi.spyOn(financeService, "createPaymentSessionFromBookingSchedule").mockResolvedValue(
       paymentSession as never,
     )
-    vi.spyOn(financeService, "getPaymentSessionById").mockResolvedValue(paymentSession as never)
+    vi.spyOn(financeService, "getPaymentSessionById").mockResolvedValue({
+      ...paymentSession,
+      invoiceId: "inv_collection",
+    } as never)
 
     const result = await initiateCheckoutCollection(
       db as never,
@@ -128,10 +138,56 @@ describe("finance checkout service", () => {
 
     expect(selectedPaymentStarter).toHaveBeenCalledOnce()
     expect(legacyPaymentStarter).not.toHaveBeenCalled()
+    expect(insertedInvoices).toHaveLength(1)
+    expect(insertedInvoices[0]?.invoiceType).toBe("proforma")
+    expect(linkedSessions).toEqual([{ id: "ps_selected", invoiceId: "inv_collection" }])
     expect(result?.providerStart).toMatchObject({
       provider: "connected-adapter",
       redirectUrl: "https://payments.example/checkout",
     })
+  })
+
+  it("links a proforma invoice onto schedule-targeted card payment sessions", async () => {
+    const insertedInvoices: Array<Record<string, unknown>> = []
+    const linkedSessions: Array<Record<string, unknown>> = []
+    const db = createCheckoutDb({
+      insertedInvoices,
+      linkedSessions,
+      linkSessionId: "ps_schedule",
+    })
+    const paymentSession = {
+      id: "ps_schedule",
+      invoiceId: null,
+      targetType: "booking_payment_schedule",
+      bookingPaymentScheduleId: "schedule_123",
+    }
+
+    vi.spyOn(financeService, "createPaymentSessionFromBookingSchedule").mockResolvedValue(
+      paymentSession as never,
+    )
+
+    const result = await initiateCheckoutCollection(db as never, "booking_123", {
+      method: "card",
+      stage: "initial",
+      amountCents: 5_000,
+    })
+
+    expect(insertedInvoices).toHaveLength(1)
+    expect(insertedInvoices[0]).toMatchObject({
+      invoiceType: "proforma",
+      totalCents: 5_000,
+    })
+    expect(linkedSessions).toEqual([{ id: "ps_schedule", invoiceId: "inv_collection" }])
+    expect(result?.invoice?.id).toBe("inv_collection")
+    expect(result?.paymentSession).toMatchObject({
+      id: "ps_schedule",
+      invoiceId: "inv_collection",
+    })
+    expect(financeService.createPaymentSessionFromBookingSchedule).toHaveBeenCalledWith(
+      db,
+      "schedule_123",
+      { notes: null },
+    )
   })
 
   it("rejects provider-neutral card start before creating invoice or session when no selected starter exists", async () => {
@@ -197,7 +253,8 @@ describe("finance checkout service", () => {
   })
 
   it("does not use keyed starters without a selected adapter", async () => {
-    const db = createCheckoutDb({ insertedInvoices: [] })
+    const insertedInvoices: Array<Record<string, unknown>> = []
+    const db = createCheckoutDb({ insertedInvoices })
     const paymentSession = {
       id: "ps_legacy",
       invoiceId: null,
@@ -242,6 +299,7 @@ describe("finance checkout service", () => {
     ).rejects.toThrow("No payment adapter is selected for card collection")
 
     expect(legacyPaymentStarter).not.toHaveBeenCalled()
+    expect(insertedInvoices).toHaveLength(0)
   })
 
   it("keeps base paid cents null when creating a collection invoice without base currency", async () => {
@@ -288,9 +346,13 @@ describe("finance checkout service", () => {
 
 function createCheckoutDb({
   insertedInvoices,
+  linkedSessions = [],
+  linkSessionId = "ps_schedule",
   booking: bookingOverrides = {},
 }: {
   insertedInvoices: Array<Record<string, unknown>>
+  linkedSessions?: Array<Record<string, unknown>>
+  linkSessionId?: string
   booking?: Partial<Record<string, unknown>>
 }) {
   const booking = {
@@ -316,6 +378,7 @@ function createCheckoutDb({
           scheduleType: "deposit",
           status: "pending",
           amountCents: 5_000,
+          currency: "EUR",
           dueDate: "2026-06-30",
           notes: null,
           createdAt: new Date("2026-06-01T00:00:00.000Z"),
@@ -362,6 +425,30 @@ function createCheckoutDb({
             return Promise.resolve(undefined)
           }
           return Promise.resolve(undefined)
+        },
+      }
+    },
+    update(table: unknown) {
+      return {
+        set(values: Record<string, unknown>) {
+          return {
+            where() {
+              return {
+                returning() {
+                  if (table !== paymentSessions) {
+                    return Promise.resolve([])
+                  }
+                  const row = {
+                    id: linkSessionId,
+                    invoiceId: values.invoiceId,
+                    targetType: "booking_payment_schedule",
+                  }
+                  linkedSessions.push({ id: row.id, invoiceId: row.invoiceId })
+                  return Promise.resolve([row])
+                },
+              }
+            },
+          }
         },
       }
     },

--- a/packages/finance/tests/unit/checkout-service.test.ts
+++ b/packages/finance/tests/unit/checkout-service.test.ts
@@ -175,6 +175,7 @@ describe("finance checkout service", () => {
     expect(insertedInvoices).toHaveLength(1)
     expect(insertedInvoices[0]).toMatchObject({
       invoiceType: "proforma",
+      currency: "EUR",
       totalCents: 5_000,
     })
     expect(linkedSessions).toEqual([{ id: "ps_schedule", invoiceId: "inv_collection" }])
@@ -188,6 +189,92 @@ describe("finance checkout service", () => {
       "schedule_123",
       { notes: null },
     )
+  })
+
+  it("stamps schedule-card proformas with the schedule currency", async () => {
+    const insertedInvoices: Array<Record<string, unknown>> = []
+    const linkedSessions: Array<Record<string, unknown>> = []
+    const db = createCheckoutDb({
+      insertedInvoices,
+      linkedSessions,
+      linkSessionId: "ps_schedule",
+      schedule: { currency: "USD", amountCents: 5_000 },
+    })
+    const paymentSession = {
+      id: "ps_schedule",
+      invoiceId: null,
+      targetType: "booking_payment_schedule",
+      bookingPaymentScheduleId: "schedule_123",
+      currency: "USD",
+      amountCents: 5_000,
+    }
+
+    vi.spyOn(financeService, "createPaymentSessionFromBookingSchedule").mockResolvedValue(
+      paymentSession as never,
+    )
+
+    await initiateCheckoutCollection(db as never, "booking_123", {
+      method: "card",
+      stage: "initial",
+      amountCents: 5_000,
+    })
+
+    expect(insertedInvoices).toHaveLength(1)
+    expect(insertedInvoices[0]).toMatchObject({
+      invoiceType: "proforma",
+      currency: "USD",
+      totalCents: 5_000,
+      baseCurrency: null,
+      baseSubtotalCents: null,
+      baseTotalCents: null,
+      basePaidCents: null,
+      baseBalanceDueCents: null,
+    })
+    expect(linkedSessions).toEqual([{ id: "ps_schedule", invoiceId: "inv_collection" }])
+  })
+
+  it("reuses an existing linked invoice on idempotent schedule session retries", async () => {
+    const insertedInvoices: Array<Record<string, unknown>> = []
+    const linkedSessions: Array<Record<string, unknown>> = []
+    const existingInvoice = {
+      id: "inv_existing",
+      invoiceType: "proforma",
+      status: "issued",
+      currency: "EUR",
+      totalCents: 5_000,
+      balanceDueCents: 5_000,
+    }
+    const db = createCheckoutDb({
+      insertedInvoices,
+      linkedSessions,
+      linkSessionId: "ps_schedule",
+      existingInvoices: [existingInvoice],
+    })
+    const paymentSession = {
+      id: "ps_schedule",
+      invoiceId: "inv_existing",
+      targetType: "booking_payment_schedule",
+      bookingPaymentScheduleId: "schedule_123",
+    }
+
+    vi.spyOn(financeService, "createPaymentSessionFromBookingSchedule").mockResolvedValue(
+      paymentSession as never,
+    )
+
+    const result = await initiateCheckoutCollection(db as never, "booking_123", {
+      method: "card",
+      stage: "initial",
+      amountCents: 5_000,
+      paymentSession: { idempotencyKey: "checkout-retry-1" },
+    })
+
+    expect(insertedInvoices).toHaveLength(0)
+    expect(linkedSessions).toHaveLength(0)
+    expect(result?.invoice).toMatchObject({ id: "inv_existing" })
+    expect(result?.paymentSession).toMatchObject({
+      id: "ps_schedule",
+      invoiceId: "inv_existing",
+    })
   })
 
   it("rejects provider-neutral card start before creating invoice or session when no selected starter exists", async () => {
@@ -348,11 +435,15 @@ function createCheckoutDb({
   insertedInvoices,
   linkedSessions = [],
   linkSessionId = "ps_schedule",
+  existingInvoices = [],
+  schedule: scheduleOverrides = {},
   booking: bookingOverrides = {},
 }: {
   insertedInvoices: Array<Record<string, unknown>>
   linkedSessions?: Array<Record<string, unknown>>
   linkSessionId?: string
+  existingInvoices?: Array<Record<string, unknown>>
+  schedule?: Partial<Record<string, unknown>>
   booking?: Partial<Record<string, unknown>>
 }) {
   const booking = {
@@ -367,25 +458,24 @@ function createCheckoutDb({
     ...bookingOverrides,
   }
 
+  const schedule = {
+    id: "schedule_123",
+    bookingId: "booking_123",
+    bookingItemId: null,
+    scheduleType: "deposit",
+    status: "pending",
+    amountCents: 5_000,
+    currency: "EUR",
+    dueDate: "2026-06-30",
+    notes: null,
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    ...scheduleOverrides,
+  }
+
   const rowsFor = (table: unknown) => {
     if (table === invoiceNumberSeries) return []
-    if (table === bookingPaymentSchedules) {
-      return [
-        {
-          id: "schedule_123",
-          bookingId: "booking_123",
-          bookingItemId: null,
-          scheduleType: "deposit",
-          status: "pending",
-          amountCents: 5_000,
-          currency: "EUR",
-          dueDate: "2026-06-30",
-          notes: null,
-          createdAt: new Date("2026-06-01T00:00:00.000Z"),
-        },
-      ]
-    }
-    if (table === invoices) return []
+    if (table === bookingPaymentSchedules) return [schedule]
+    if (table === invoices) return existingInvoices
     return []
   }
 
@@ -405,7 +495,14 @@ function createCheckoutDb({
           return Promise.resolve(rowsFor(selectedTable))
         },
         limit() {
-          return Promise.resolve(selectedTable === invoiceNumberSeries ? [] : [booking])
+          if (selectedTable === invoiceNumberSeries) return Promise.resolve([])
+          if (selectedTable === invoices) {
+            return Promise.resolve(existingInvoices.slice(0, 1))
+          }
+          if (selectedTable === bookingPaymentSchedules) {
+            return Promise.resolve([schedule])
+          }
+          return Promise.resolve([booking])
         },
       }
       return query


### PR DESCRIPTION
## Summary
- Schedule-targeted card checkout now materializes a proforma invoice and links it on the payment session.
- Fixes managed adapter status refresh failing with “Cannot complete a booking payment schedule session without an outstanding booking invoice,” which left paid Stripe attempts stuck at `requires_redirect` on the operator runtime.
- Adds unit coverage for the schedule-card proforma link path.

## Test plan
- [x] `vitest run tests/unit/checkout-service.test.ts` in `packages/finance`
- [x] Acme sandbox: card bootstrap creates `payment_sessions.invoice_id` proforma while `paymentSessionTarget` remains `schedule`
- [x] Acme sandbox: after linking an invoice, paid status projects session → `paid` and booking → `confirmed`
- [ ] Pay a fresh Stripe Checkout from bootstrap and confirm confirmation-page status poll projects without manual invoice repair


Made with [Cursor](https://cursor.com)