### PR TITLE
fix(bookings): re-bind cancel Tool for unavailable status action

### DIFF
--- a/.changeset/bookings-cancel-tool-bind.md
+++ b/.changeset/bookings-cancel-tool-bind.md
@@ -1,0 +1,12 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/operator-standard": patch
+---
+
+Re-bind `booking.status.cancel` to `@voyant-travel/bookings#tool.cancel-booking`
+and quarantine the graph action as unavailable
+(`unsafe-nonidempotent-transition`). Critical-risk Tool convergence requires the
+binding; admin cancel continues to authorize through package
+`BOOKING_STATUS_CAPABILITIES`. Update the operator-standard parity test so
+unavailable Tool bindings are not selected and unavailable capabilities are
+excluded from the graph-lowered ledger comparison.

--- a/packages/bookings/src/action-declarations.ts
+++ b/packages/bookings/src/action-declarations.ts
@@ -74,13 +74,23 @@ export const BOOKING_ACTION_DECLARATIONS = {
       graph: {
         ...bookingWriteCapability.graph,
         id: "booking.status.cancel",
-        // Keep cancel available for admin routes + action-ledger authorization.
-        // Do not bind the cancel Tool here: an available multistage Tool action
-        // would require tested durability, and marking the action unavailable
-        // would drop it from the graph-lowered action-ledger registry and break
-        // admin cancel. The Tool remains package-exported for direct callers;
-        // graph MCP selection follows action bindings.
-        from: adminRouteBinding,
+        // Quarantine the graph Tool surface: a same-key retry after the
+        // transition already committed hits
+        // `canTransitionBooking(cancelled, cancelled) === false` and throws
+        // `invalid_transition` instead of replaying success, and cancellation
+        // spans supplier/financial settlement. Admin cancel stays authorized
+        // via package `BOOKING_STATUS_CAPABILITIES` (not the graph-lowered
+        // ledger registry). Critical-risk Tool convergence still requires the
+        // Tool binding on this action.
+        availability: {
+          status: "unavailable",
+          reasonCode: "unsafe-nonidempotent-transition",
+        },
+        effectBoundary: "multistage",
+        from: {
+          ...adminRouteBinding,
+          tools: ["@voyant-travel/bookings#tool.cancel-booking"],
+        },
       },
     },
     start: {

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -103,9 +103,15 @@ describe("bookings deployment manifest", () => {
         ledger: "required",
         approval: "conditional",
         reversible: false,
-        from: {
-          routes: ["@voyant-travel/bookings#api.admin"],
+        availability: {
+          status: "unavailable",
+          reasonCode: "unsafe-nonidempotent-transition",
         },
+        effectBoundary: "multistage",
+        from: expect.objectContaining({
+          routes: ["@voyant-travel/bookings#api.admin"],
+          tools: ["@voyant-travel/bookings#tool.cancel-booking"],
+        }),
       }),
     )
     expect(bookingsVoyantModule.admin?.routes).toEqual(

--- a/packages/operator-standard/tests/booking-action-ledger-parity.test.ts
+++ b/packages/operator-standard/tests/booking-action-ledger-parity.test.ts
@@ -21,6 +21,20 @@ describe("standard booking action-ledger authority", () => {
         (action) => `${resource.resource}:${typeof action === "string" ? action : action.action}`,
       ),
     )
+    // Unavailable actions keep Tool bindings for first-party convergence, but
+    // runtime lowering must not select those Tools. Package-local admin cancel
+    // still uses BOOKING_STATUS_CAPABILITIES outside the graph-lowered registry.
+    const unavailableToolIds = new Set(
+      actions
+        .filter((action) => action.availability?.status === "unavailable")
+        .flatMap((action) => action.from?.tools ?? []),
+    )
+    const unavailableCapabilityIds = new Set(
+      actions
+        .filter((action) => action.availability?.status === "unavailable")
+        .map((action) => action.capabilityId)
+        .filter((id): id is string => typeof id === "string"),
+    )
     const runtime = createVoyantGraphRuntime({
       graphHash: "sha256:bookings-action-parity",
       accessCatalog: {
@@ -66,7 +80,9 @@ describe("standard booking action-ledger authority", () => {
           })),
           selectedIds: {
             routes: (bookingsVoyantModule.api ?? []).map(({ id }) => id),
-            tools: (bookingsVoyantModule.tools ?? []).map(({ id }) => id),
+            tools: (bookingsVoyantModule.tools ?? [])
+              .map(({ id }) => id)
+              .filter((id) => !unavailableToolIds.has(id)),
             events: (bookingsVoyantModule.events ?? []).map(({ id }) => id),
             webhooks: (bookingsVoyantModule.webhooks ?? []).map(({ id }) => id),
           },
@@ -77,9 +93,12 @@ describe("standard booking action-ledger authority", () => {
     })
 
     const lowered = lowerVoyantGraphActionsToActionLedgerRegistry(runtime).definitions
-    const canonical = [...bookingActionLedgerCapabilityRegistry.definitions].sort(
-      (left, right) => left.id.localeCompare(right.id) || left.version.localeCompare(right.version),
-    )
+    const canonical = [...bookingActionLedgerCapabilityRegistry.definitions]
+      .filter((definition) => !unavailableCapabilityIds.has(definition.id))
+      .sort(
+        (left, right) =>
+          left.id.localeCompare(right.id) || left.version.localeCompare(right.version),
+      )
 
     expect(lowered).toEqual(canonical)
   })


### PR DESCRIPTION
## Summary
- Re-bind `@voyant-travel/bookings#tool.cancel-booking` on `booking.status.cancel` and quarantine the graph action as `unavailable` (`unsafe-nonidempotent-transition`).
- Unblocks release verify: first-party convergence requires critical-risk Tools to bind a graph action.
- Admin cancel stays authorized via package `BOOKING_STATUS_CAPABILITIES`; update operator-standard parity so unavailable Tool bindings are not selected.

## Test plan
- [x] `pnpm run verify:first-party-manifest-convergence`
- [x] `@voyant-travel/operator-standard` booking-action-ledger-parity + standard-package-manifests
- [x] `@voyant-travel/bookings` voyant-manifest
- [ ] CI green; release publishes after merge


Made with [Cursor](https://cursor.com)