### PR TITLE
Share framework runtime attestation across bundled module copies

### DIFF
--- a/.changeset/framework-realm-runtime-attestation.md
+++ b/.changeset/framework-realm-runtime-attestation.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/framework": patch
+---
+
+Share framework runtime ownership and activation attestation across bundled module copies via Symbol.for registries on globalThis, so MCP no longer fail-closes with NOT_FRAMEWORK_OWNED when Vite SSR duplicates the framework package.

--- a/.changeset/framework-realm-runtime-attestation.md
+++ b/.changeset/framework-realm-runtime-attestation.md
@@ -2,4 +2,4 @@
 "@voyant-travel/framework": patch
 ---
 
-Share framework runtime ownership and activation attestation across bundled module copies via Symbol.for registries on globalThis, so MCP no longer fail-closes with NOT_FRAMEWORK_OWNED when Vite SSR duplicates the framework package.
+Share framework runtime ownership and activation attestation across bundled module copies via a frozen Symbol.for facade on globalThis (WeakSet/WeakMap stay closed over), so MCP no longer fail-closes with NOT_FRAMEWORK_OWNED when Vite SSR duplicates the framework package.

--- a/packages/admin/tests/setup.ts
+++ b/packages/admin/tests/setup.ts
@@ -23,7 +23,7 @@ function createStorage(): Storage {
   }
 }
 
-if (typeof window !== "undefined" && typeof window.localStorage.clear !== "function") {
+if (typeof window !== "undefined" && typeof window.localStorage?.clear !== "function") {
   Object.defineProperty(window, "localStorage", {
     configurable: true,
     value: createStorage(),

--- a/packages/framework/src/conditional-action-availability.attestation.test.ts
+++ b/packages/framework/src/conditional-action-availability.attestation.test.ts
@@ -3,8 +3,15 @@ import { describe, expect, it } from "vitest"
 import { assertVoyantGraphMcpRuntime } from "./conditional-action-availability.js"
 import { createVoyantGraphRuntime } from "./runtime-lowering.js"
 
-/** Must stay aligned with the realm registry keys in conditional-action-availability.ts. */
-const FRAMEWORK_OWNED_RUNTIMES_KEY = Symbol.for("@voyant-travel/framework:graph-runtime-owned")
+/** Must stay aligned with the realm facade key in conditional-action-availability.ts. */
+const GRAPH_RUNTIME_ATTESTATION_KEY = Symbol.for(
+  "@voyant-travel/framework:graph-runtime-attestation",
+)
+
+interface GraphRuntimeAttestationApi {
+  readonly markOwned: (runtime: object) => void
+  readonly isOwned: (runtime: object) => boolean
+}
 
 function emptyRuntime() {
   return createVoyantGraphRuntime({
@@ -19,14 +26,27 @@ function emptyRuntime() {
   })
 }
 
+function realmAttestationApi(): GraphRuntimeAttestationApi {
+  const api = (globalThis as Record<symbol, GraphRuntimeAttestationApi | undefined>)[
+    GRAPH_RUNTIME_ATTESTATION_KEY
+  ]
+  if (!api) throw new Error("expected realm attestation facade")
+  return api
+}
+
 describe("framework runtime realm attestation", () => {
-  it("records ownership in a Symbol.for registry on globalThis", () => {
+  it("installs a frozen facade on globalThis without exposing WeakSet/WeakMap stores", () => {
     const runtime = emptyRuntime()
-    const registry = (globalThis as Record<symbol, WeakSet<object> | undefined>)[
-      FRAMEWORK_OWNED_RUNTIMES_KEY
-    ]
-    expect(registry).toBeInstanceOf(WeakSet)
-    expect(registry?.has(runtime)).toBe(true)
+    const api = realmAttestationApi()
+
+    expect(Object.isFrozen(api)).toBe(true)
+    expect(api.isOwned(runtime)).toBe(true)
+    expect(api).not.toBeInstanceOf(WeakSet)
+    expect(api).not.toBeInstanceOf(WeakMap)
+    for (const value of Object.values(api)) {
+      expect(value).not.toBeInstanceOf(WeakSet)
+      expect(value).not.toBeInstanceOf(WeakMap)
+    }
   })
 
   it("accepts a framework-owned runtime that has no conditional actions", () => {
@@ -40,18 +60,14 @@ describe("framework runtime realm attestation", () => {
     )
   })
 
-  it("lets a second realm-local assert agree when it only shares the Symbol.for registry", () => {
+  it("lets a second realm-local assert agree when it only shares the frozen facade", () => {
     const runtime = emptyRuntime()
-    const registry = (globalThis as Record<symbol, WeakSet<object> | undefined>)[
-      FRAMEWORK_OWNED_RUNTIMES_KEY
-    ]
-    expect(registry).toBeInstanceOf(WeakSet)
-    if (!registry) throw new Error("expected realm ownership registry")
+    const api = realmAttestationApi()
 
     // Mimic a Vite-bundled duplicate of this module: it does not share the
-    // original module binding, only the realm-wide Symbol.for registry.
+    // original module binding, only the realm-wide Symbol.for facade.
     const assertFromBundledCopy = (value: unknown) => {
-      if (typeof value !== "object" || value === null || !registry.has(value)) {
+      if (typeof value !== "object" || value === null || !api.isOwned(value)) {
         throw new Error(
           "VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED: MCP registration requires a runtime created by the framework.",
         )

--- a/packages/framework/src/conditional-action-availability.attestation.test.ts
+++ b/packages/framework/src/conditional-action-availability.attestation.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest"
+
+import { assertVoyantGraphMcpRuntime } from "./conditional-action-availability.js"
+import { createVoyantGraphRuntime } from "./runtime-lowering.js"
+
+/** Must stay aligned with the realm registry keys in conditional-action-availability.ts. */
+const FRAMEWORK_OWNED_RUNTIMES_KEY = Symbol.for("@voyant-travel/framework:graph-runtime-owned")
+
+function emptyRuntime() {
+  return createVoyantGraphRuntime({
+    graphHash: "sha256:realm-attestation",
+    providerSelections: {},
+    entries: {},
+    modules: [],
+    extensions: [],
+    plugins: [],
+    adapters: [],
+    providerUnits: [],
+  })
+}
+
+describe("framework runtime realm attestation", () => {
+  it("records ownership in a Symbol.for registry on globalThis", () => {
+    const runtime = emptyRuntime()
+    const registry = (globalThis as Record<symbol, WeakSet<object> | undefined>)[
+      FRAMEWORK_OWNED_RUNTIMES_KEY
+    ]
+    expect(registry).toBeInstanceOf(WeakSet)
+    expect(registry?.has(runtime)).toBe(true)
+  })
+
+  it("accepts a framework-owned runtime that has no conditional actions", () => {
+    expect(() => assertVoyantGraphMcpRuntime(emptyRuntime())).not.toThrow()
+  })
+
+  it("rejects a structural copy that never crossed createFrameworkOwnedRuntime", () => {
+    const runtime = emptyRuntime()
+    expect(() => assertVoyantGraphMcpRuntime({ ...runtime })).toThrow(
+      /VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED/,
+    )
+  })
+
+  it("lets a second realm-local assert agree when it only shares the Symbol.for registry", () => {
+    const runtime = emptyRuntime()
+    const registry = (globalThis as Record<symbol, WeakSet<object> | undefined>)[
+      FRAMEWORK_OWNED_RUNTIMES_KEY
+    ]
+    expect(registry).toBeInstanceOf(WeakSet)
+    if (!registry) throw new Error("expected realm ownership registry")
+
+    // Mimic a Vite-bundled duplicate of this module: it does not share the
+    // original module binding, only the realm-wide Symbol.for registry.
+    const assertFromBundledCopy = (value: unknown) => {
+      if (typeof value !== "object" || value === null || !registry.has(value)) {
+        throw new Error(
+          "VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED: MCP registration requires a runtime created by the framework.",
+        )
+      }
+    }
+
+    expect(() => assertFromBundledCopy(runtime)).not.toThrow()
+    expect(() => assertFromBundledCopy({ ...runtime })).toThrow(
+      /VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED/,
+    )
+  })
+})

--- a/packages/framework/src/conditional-action-availability.ts
+++ b/packages/framework/src/conditional-action-availability.ts
@@ -34,16 +34,25 @@ interface ActivatedRuntimeState {
 }
 
 /**
- * Realm-shared attestation keys. Vite SSR `noExternal` for `@voyant-travel/*`
+ * Realm-shared attestation facade. Vite SSR `noExternal` for `@voyant-travel/*`
  * can bundle a second copy of this module into the host while MCP still loads
  * from `node_modules`. Module-local WeakMaps/WeakSets then diverge and MCP
- * fail-closes with NOT_FRAMEWORK_OWNED / NOT_ACTIVATED. `Symbol.for` +
- * `globalThis` keep one registry per JS realm across those copies.
+ * fail-closes with NOT_FRAMEWORK_OWNED / NOT_ACTIVATED.
+ *
+ * Install one frozen API on `globalThis` under `Symbol.for`. The WeakSet /
+ * WeakMap stay closed over inside the first installer — callers only get
+ * mark/is/get/set methods, never the mutable stores.
  */
-const FRAMEWORK_OWNED_RUNTIMES_KEY = Symbol.for("@voyant-travel/framework:graph-runtime-owned")
-const ACTIVATED_RUNTIME_STATES_KEY = Symbol.for(
-  "@voyant-travel/framework:graph-runtime-activated-states",
+const GRAPH_RUNTIME_ATTESTATION_KEY = Symbol.for(
+  "@voyant-travel/framework:graph-runtime-attestation",
 )
+
+interface GraphRuntimeAttestationApi {
+  readonly markOwned: (runtime: object) => void
+  readonly isOwned: (runtime: object) => boolean
+  readonly setActivatedState: (runtime: VoyantGraphRuntime, state: ActivatedRuntimeState) => void
+  readonly getActivatedState: (runtime: VoyantGraphRuntime) => ActivatedRuntimeState | undefined
+}
 
 const provisionalUnits = new WeakMap<
   VoyantGraphRuntime,
@@ -56,45 +65,39 @@ const conditionalPortPreflights = new WeakMap<
 const conditionalPortAttestations = new WeakMap<VoyantGraphRuntime, Map<string, unknown>>()
 const activatedRuntimeViews = new WeakMap<VoyantGraphRuntime, VoyantGraphActivatedRuntime>()
 
-function realmWeakSet(key: symbol): WeakSet<object> {
-  const bag = globalThis as Record<symbol, WeakSet<object> | undefined>
-  const existing = bag[key]
+function realmAttestationApi(): GraphRuntimeAttestationApi {
+  const bag = globalThis as Record<symbol, GraphRuntimeAttestationApi | undefined>
+  const existing = bag[GRAPH_RUNTIME_ATTESTATION_KEY]
   if (existing) return existing
-  const created = new WeakSet<object>()
-  Object.defineProperty(globalThis, key, {
-    value: created,
+
+  const ownedRuntimes = new WeakSet<object>()
+  const activatedStates = new WeakMap<VoyantGraphRuntime, ActivatedRuntimeState>()
+  const api: GraphRuntimeAttestationApi = Object.freeze({
+    markOwned(runtime: object) {
+      ownedRuntimes.add(runtime)
+    },
+    isOwned(runtime: object) {
+      return ownedRuntimes.has(runtime)
+    },
+    setActivatedState(runtime: VoyantGraphRuntime, state: ActivatedRuntimeState) {
+      activatedStates.set(runtime, state)
+    },
+    getActivatedState(runtime: VoyantGraphRuntime) {
+      return activatedStates.get(runtime)
+    },
+  })
+  Object.defineProperty(globalThis, GRAPH_RUNTIME_ATTESTATION_KEY, {
+    value: api,
     enumerable: false,
     configurable: false,
     writable: false,
   })
-  return created
-}
-
-function realmWeakMap<K extends object, V>(key: symbol): WeakMap<K, V> {
-  const bag = globalThis as Record<symbol, WeakMap<K, V> | undefined>
-  const existing = bag[key]
-  if (existing) return existing
-  const created = new WeakMap<K, V>()
-  Object.defineProperty(globalThis, key, {
-    value: created,
-    enumerable: false,
-    configurable: false,
-    writable: false,
-  })
-  return created
-}
-
-function frameworkOwnedRuntimes(): WeakSet<object> {
-  return realmWeakSet(FRAMEWORK_OWNED_RUNTIMES_KEY)
-}
-
-function activatedRuntimeStates(): WeakMap<VoyantGraphRuntime, ActivatedRuntimeState> {
-  return realmWeakMap(ACTIVATED_RUNTIME_STATES_KEY)
+  return api
 }
 
 /** Record a runtime minted by a framework-owned construction boundary. */
 function registerFrameworkOwnedRuntime(runtime: VoyantGraphRuntime): void {
-  frameworkOwnedRuntimes().add(runtime)
+  realmAttestationApi().markOwned(runtime)
 }
 
 /**
@@ -122,7 +125,7 @@ export function assertVoyantGraphMcpRuntime(
   if (
     typeof runtime !== "object" ||
     runtime === null ||
-    !frameworkOwnedRuntimes().has(runtime as VoyantGraphRuntime)
+    !realmAttestationApi().isOwned(runtime as VoyantGraphRuntime)
   ) {
     throw new Error(
       "VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED: MCP registration requires a runtime created by the framework.",
@@ -268,7 +271,10 @@ export function activateConditionalActionRuntime(
     }),
   )
   const exactAttestations = new Map(attestations)
-  activatedRuntimeStates().set(activated, { base: runtime, attestations: exactAttestations })
+  realmAttestationApi().setActivatedState(activated, {
+    base: runtime,
+    attestations: exactAttestations,
+  })
   activatedRuntimeViews.set(runtime, activated)
   return activated
 }
@@ -282,7 +288,7 @@ export function assertConditionalActionRuntimeActivated(
   ports?: VoyantGraphRuntimePorts,
   requireBoundPorts = false,
 ): asserts runtime is VoyantGraphActivatedRuntime {
-  const activated = activatedRuntimeStates().get(runtime)
+  const activated = realmAttestationApi().getActivatedState(runtime)
   if (!activated) {
     if (conditionalPortRequirements(runtime).length === 0) return
     throw new Error(
@@ -410,7 +416,7 @@ function assertTypedPortConformance(
 }
 
 function baseRuntime(runtime: VoyantGraphRuntime): VoyantGraphRuntime {
-  return activatedRuntimeStates().get(runtime)?.base ?? runtime
+  return realmAttestationApi().getActivatedState(runtime)?.base ?? runtime
 }
 
 function sortedUnique(values: readonly string[]): string[] {

--- a/packages/framework/src/conditional-action-availability.ts
+++ b/packages/framework/src/conditional-action-availability.ts
@@ -33,6 +33,18 @@ interface ActivatedRuntimeState {
   attestations: ReadonlyMap<string, unknown>
 }
 
+/**
+ * Realm-shared attestation keys. Vite SSR `noExternal` for `@voyant-travel/*`
+ * can bundle a second copy of this module into the host while MCP still loads
+ * from `node_modules`. Module-local WeakMaps/WeakSets then diverge and MCP
+ * fail-closes with NOT_FRAMEWORK_OWNED / NOT_ACTIVATED. `Symbol.for` +
+ * `globalThis` keep one registry per JS realm across those copies.
+ */
+const FRAMEWORK_OWNED_RUNTIMES_KEY = Symbol.for("@voyant-travel/framework:graph-runtime-owned")
+const ACTIVATED_RUNTIME_STATES_KEY = Symbol.for(
+  "@voyant-travel/framework:graph-runtime-activated-states",
+)
+
 const provisionalUnits = new WeakMap<
   VoyantGraphRuntime,
   ReadonlyMap<string, VoyantGraphConditionalActionProvisionalUnit>
@@ -42,13 +54,47 @@ const conditionalPortPreflights = new WeakMap<
   Map<string, ConditionalPortPreflight>
 >()
 const conditionalPortAttestations = new WeakMap<VoyantGraphRuntime, Map<string, unknown>>()
-const activatedRuntimeStates = new WeakMap<VoyantGraphRuntime, ActivatedRuntimeState>()
 const activatedRuntimeViews = new WeakMap<VoyantGraphRuntime, VoyantGraphActivatedRuntime>()
-const frameworkOwnedRuntimes = new WeakSet<VoyantGraphRuntime>()
+
+function realmWeakSet(key: symbol): WeakSet<object> {
+  const bag = globalThis as Record<symbol, WeakSet<object> | undefined>
+  const existing = bag[key]
+  if (existing) return existing
+  const created = new WeakSet<object>()
+  Object.defineProperty(globalThis, key, {
+    value: created,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  })
+  return created
+}
+
+function realmWeakMap<K extends object, V>(key: symbol): WeakMap<K, V> {
+  const bag = globalThis as Record<symbol, WeakMap<K, V> | undefined>
+  const existing = bag[key]
+  if (existing) return existing
+  const created = new WeakMap<K, V>()
+  Object.defineProperty(globalThis, key, {
+    value: created,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  })
+  return created
+}
+
+function frameworkOwnedRuntimes(): WeakSet<object> {
+  return realmWeakSet(FRAMEWORK_OWNED_RUNTIMES_KEY)
+}
+
+function activatedRuntimeStates(): WeakMap<VoyantGraphRuntime, ActivatedRuntimeState> {
+  return realmWeakMap(ACTIVATED_RUNTIME_STATES_KEY)
+}
 
 /** Record a runtime minted by a framework-owned construction boundary. */
 function registerFrameworkOwnedRuntime(runtime: VoyantGraphRuntime): void {
-  frameworkOwnedRuntimes.add(runtime)
+  frameworkOwnedRuntimes().add(runtime)
 }
 
 /**
@@ -76,7 +122,7 @@ export function assertVoyantGraphMcpRuntime(
   if (
     typeof runtime !== "object" ||
     runtime === null ||
-    !frameworkOwnedRuntimes.has(runtime as VoyantGraphRuntime)
+    !frameworkOwnedRuntimes().has(runtime as VoyantGraphRuntime)
   ) {
     throw new Error(
       "VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED: MCP registration requires a runtime created by the framework.",
@@ -222,7 +268,7 @@ export function activateConditionalActionRuntime(
     }),
   )
   const exactAttestations = new Map(attestations)
-  activatedRuntimeStates.set(activated, { base: runtime, attestations: exactAttestations })
+  activatedRuntimeStates().set(activated, { base: runtime, attestations: exactAttestations })
   activatedRuntimeViews.set(runtime, activated)
   return activated
 }
@@ -236,7 +282,7 @@ export function assertConditionalActionRuntimeActivated(
   ports?: VoyantGraphRuntimePorts,
   requireBoundPorts = false,
 ): asserts runtime is VoyantGraphActivatedRuntime {
-  const activated = activatedRuntimeStates.get(runtime)
+  const activated = activatedRuntimeStates().get(runtime)
   if (!activated) {
     if (conditionalPortRequirements(runtime).length === 0) return
     throw new Error(
@@ -364,7 +410,7 @@ function assertTypedPortConformance(
 }
 
 function baseRuntime(runtime: VoyantGraphRuntime): VoyantGraphRuntime {
-  return activatedRuntimeStates.get(runtime)?.base ?? runtime
+  return activatedRuntimeStates().get(runtime)?.base ?? runtime
 }
 
 function sortedUnique(values: readonly string[]): string[] {


### PR DESCRIPTION
## Summary
- Move framework graph-runtime ownership and activation attestation from module-local WeakSet/WeakMap to realm-shared `Symbol.for` registries on `globalThis`.
- Fixes tenant MCP fail-closing with `VOYANT_GRAPH_RUNTIME_NOT_FRAMEWORK_OWNED` when Vite SSR `noExternal` bundles a second copy of `@voyant-travel/framework` while MCP still loads from `node_modules`.
- Includes a one-line admin vitest setup guard for Node builds that omit `window.localStorage` without `--localstorage-file`.

## Test plan
- [x] Framework attestation unit tests (`conditional-action-availability.attestation.test.ts`)
- [x] Framework package tests + monorepo pre-push suite
- [ ] After release: bump managed operator runtime, register release, upgrade sandbox, confirm `/api/v1/admin/mcp` and Max tenant tools succeed