### PR TITLE
fix(mcp): unblock Max catalog discovery for org keys and Date schemas

### DIFF
--- a/.changeset/mcp-max-catalog-blockers.md
+++ b/.changeset/mcp-max-catalog-blockers.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/auth": patch
+"@voyant-travel/mcp": patch
+---
+
+Keep org API-key MCP catalog composition available when team-management has no acting user, and project Date-bearing Tool input schemas to JSON Schema datetime strings so `tools/list` no longer fail-closes for Max discovery.

--- a/packages/auth/src/mcp-runtime.ts
+++ b/packages/auth/src/mcp-runtime.ts
@@ -14,9 +14,12 @@ type TeamMcpContext = Context<{
 /**
  * The guarded team runtime uses a concrete acting user for authorization,
  * self-mutation prevention, and last-owner invariants. Organization identity is
- * not a user identity and must never be promoted into one. Until an MCP grant
- * carries an explicit delegated user or service principal understood by this
- * port, organization-only API keys fail closed here.
+ * not a user identity and must never be promoted into one.
+ *
+ * Organization-only API keys must still compose the MCP catalog (initialize /
+ * tools/list / non-team tools). Until a grant carries an explicit delegated
+ * user or service principal understood by this port, team-management services
+ * deny at Tool execution time instead of failing closed during contribution.
  */
 export const voyantToolContextContribution = defineToolContextContribution({
   context: ["teamManagement"],
@@ -32,10 +35,7 @@ export const voyantToolContextContribution = defineToolContextContribution({
     const c = request as TeamMcpContext
     const userId = c.get("userId")
     if (!userId) {
-      throw new ToolError(
-        "Team management requires an authenticated acting user.",
-        "AUTHORIZATION_DENIED",
-      )
+      return { teamManagement: actingUserRequiredTeamManagement() }
     }
 
     const runtime = requireService(
@@ -60,3 +60,23 @@ export const voyantToolContextContribution = defineToolContextContribution({
     return { teamManagement }
   },
 })
+
+function actingUserRequiredTeamManagement(): TeamManagementToolServices {
+  const deny = async (): Promise<never> => {
+    throw new ToolError(
+      "Team management requires an authenticated acting user.",
+      "AUTHORIZATION_DENIED",
+    )
+  }
+  return {
+    getCapabilities: deny,
+    listMembers: deny,
+    listRoles: deny,
+    listInvitations: deny,
+    inviteMember: deny,
+    revokeInvitation: deny,
+    updateMemberRole: deny,
+    activateMember: deny,
+    deactivateMember: deny,
+  }
+}

--- a/packages/auth/tests/tools.test.ts
+++ b/packages/auth/tests/tools.test.ts
@@ -179,13 +179,37 @@ describe("auth team-management tools", () => {
     })
   })
 
-  it("rejects MCP context enrichment when the grant has no acting user", async () => {
+  it("keeps MCP catalog composition available when the grant has no acting user", async () => {
+    const contribution = await voyantToolContextContribution.contribute({
+      request: { env: {}, get: () => undefined },
+      context: toolContext(),
+      resources: { [teamManagementRuntimePort.id]: services() },
+    })
+
+    expect(contribution).toHaveProperty("teamManagement")
     await expect(
-      voyantToolContextContribution.contribute({
-        request: { env: {}, get: () => undefined },
-        context: toolContext(),
-        resources: { [teamManagementRuntimePort.id]: services() },
-      }),
+      (contribution.teamManagement as TeamManagementToolServices).listMembers(),
+    ).rejects.toMatchObject({
+      code: "AUTHORIZATION_DENIED",
+      message: "Team management requires an authenticated acting user.",
+    })
+  })
+
+  it("denies team-management Tool dispatch when enrichment omitted an acting user", async () => {
+    const contribution = await voyantToolContextContribution.contribute({
+      request: { env: {}, get: () => undefined },
+      context: toolContext(),
+      resources: { [teamManagementRuntimePort.id]: services() },
+    })
+    const registry = createToolRegistry()
+    registry.registerAll(teamManagementTools)
+
+    await expect(
+      registry.dispatch(
+        "list_team_members",
+        {},
+        toolContext(contribution.teamManagement as TeamManagementToolServices),
+      ),
     ).rejects.toMatchObject({
       code: "AUTHORIZATION_DENIED",
       message: "Team management requires an authenticated acting user.",

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -467,8 +467,8 @@ type ZodCompositionDef = {
  *
  * Date nodes are projected to JSON-Schema-safe datetime strings so `tools/list`
  * does not fail closed when a domain Tool reuses `z.date()` / `z.coerce.date()`.
- * Wire clients already send ISO strings; registry validation keeps the original
- * domain schema (including coerce) at dispatch.
+ * Wire clients send ISO strings; before registry dispatch those strings are
+ * revived to `Date` wherever the domain schema expects a date node.
  */
 function toMcpInputSchema(schema: z.ZodType, entry: ToolManifestEntry): z.ZodObject {
   const shape =
@@ -615,6 +615,73 @@ function toMcpOutputContract(schema: z.ZodType): McpOutputContract {
   }
 }
 
+/**
+ * MCP discovery advertises dates as ISO strings. Revive those strings back to
+ * `Date` before the registry validates the domain schema, including plain
+ * `z.date()` fields that reject strings.
+ */
+function reviveDateInputs(schema: z.ZodType, value: unknown): unknown {
+  if (value === undefined || value === null) return value
+  const def = (schema as { _zod?: { def?: ZodDiscoveryDef & { element?: unknown } } })._zod?.def
+  switch (def?.type) {
+    case "date": {
+      if (typeof value !== "string") return value
+      const parsed = new Date(value)
+      return Number.isNaN(parsed.getTime()) ? value : parsed
+    }
+    case "optional":
+    case "nullable":
+    case "default":
+    case "catch":
+    case "nonoptional":
+    case "readonly":
+      return reviveDateInputs(def.innerType as z.ZodType, value)
+    case "object": {
+      if (!isRecord(value)) return value
+      const shape = typeof def.shape === "function" ? def.shape() : (def.shape ?? {})
+      const next: Record<string, unknown> = { ...value }
+      for (const [key, field] of Object.entries(shape)) {
+        if (Object.hasOwn(next, key)) {
+          next[key] = reviveDateInputs(field as z.ZodType, next[key])
+        }
+      }
+      return next
+    }
+    case "array": {
+      if (!Array.isArray(value) || !def.element) return value
+      return value.map((item) => reviveDateInputs(def.element as z.ZodType, item))
+    }
+    case "union": {
+      if (typeof value === "string") {
+        for (const option of def.options ?? []) {
+          const optionDef = (option as { _zod?: { def?: ZodDiscoveryDef } })._zod?.def
+          if (optionDef?.type === "date") {
+            return reviveDateInputs(option as z.ZodType, value)
+          }
+        }
+      }
+      if (isRecord(value)) {
+        for (const option of def.options ?? []) {
+          const optionDef = (option as { _zod?: { def?: ZodDiscoveryDef } })._zod?.def
+          if (optionDef?.type === "object" || optionDef?.type === "intersection") {
+            return reviveDateInputs(option as z.ZodType, value)
+          }
+        }
+      }
+      return value
+    }
+    case "intersection":
+      return reviveDateInputs(
+        def.right as z.ZodType,
+        reviveDateInputs(def.left as z.ZodType, value),
+      )
+    case "pipe":
+      return reviveDateInputs((def.in ?? def.out) as z.ZodType, value)
+    default:
+      return value
+  }
+}
+
 /** Dispatch through the registry (validates in + out) and wrap pure data in an MCP envelope. */
 async function dispatchToResult(
   registry: ToolRegistry,
@@ -636,9 +703,14 @@ async function dispatchToResult(
         { capabilityId: entry.capabilityId },
       )
     }
+    const domainInputSchema = registry.get(name)?.inputSchema
+    const revivedCommandInput =
+      domainInputSchema === undefined
+        ? commandInput
+        : reviveDateInputs(domainInputSchema, commandInput)
     const baseDispatchContext = withoutHandlerActionPolicy(ctx)
     const dispatch = (dispatchContext: ToolContext = baseDispatchContext) =>
-      registry.dispatch(name, commandInput, dispatchContext)
+      registry.dispatch(name, revivedCommandInput, dispatchContext)
     if (
       entry.actionPolicy?.enforcement === "handler" &&
       entry.actionPolicy.invocation.requiredFields.includes("confirmed") &&
@@ -656,7 +728,7 @@ async function dispatchToResult(
             registry,
             invocationName: name,
             entry,
-            commandInput,
+            commandInput: revivedCommandInput,
             invocation,
             context: ctx,
           })

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -464,24 +464,97 @@ type ZodCompositionDef = {
  * pipes/effects, and wrappers into one loose object for transport discovery and
  * argument preservation. The registry still validates the untouched domain
  * schema before dispatch, including cross-field refinements and transforms.
+ *
+ * Date nodes are projected to JSON-Schema-safe datetime strings so `tools/list`
+ * does not fail closed when a domain Tool reuses `z.date()` / `z.coerce.date()`.
+ * Wire clients already send ISO strings; registry validation keeps the original
+ * domain schema (including coerce) at dispatch.
  */
 function toMcpInputSchema(schema: z.ZodType, entry: ToolManifestEntry): z.ZodObject {
   const shape =
     schema instanceof z.ZodObject
       ? schema.shape
       : Object.assign({}, ...collectInputObjectShapes(schema))
+  const projectedShape = projectShapeForMcpDiscovery(shape)
   if (!entry.actionPolicy) {
-    return schema instanceof z.ZodObject ? schema : z.looseObject(shape)
+    return z.looseObject(projectedShape)
   }
-  if (TOOL_ACTION_INVOCATION_FIELD in shape) {
+  if (TOOL_ACTION_INVOCATION_FIELD in projectedShape) {
     throw new Error(
       `Tool "${entry.name}" input conflicts with reserved action metadata field "${TOOL_ACTION_INVOCATION_FIELD}".`,
     )
   }
   return z.looseObject({
-    ...shape,
+    ...projectedShape,
     [TOOL_ACTION_INVOCATION_FIELD]: actionInvocationSchemaFor(entry).optional(),
   })
+}
+
+const mcpDateTimeSchema = z.iso.datetime({ offset: true })
+
+function projectShapeForMcpDiscovery(shape: z.ZodRawShape): z.ZodRawShape {
+  return Object.fromEntries(
+    Object.entries(shape).map(([key, value]) => [
+      key,
+      projectSchemaForMcpDiscovery(value as z.ZodType),
+    ]),
+  )
+}
+
+function projectSchemaForMcpDiscovery(schema: z.ZodType): z.ZodType {
+  try {
+    z.toJSONSchema(schema)
+    return schema
+  } catch {
+    return projectUnrepresentableSchema(schema)
+  }
+}
+
+type ZodDiscoveryDef = ZodCompositionDef & {
+  coerce?: boolean
+  options?: unknown[]
+  shape?: z.ZodRawShape | (() => z.ZodRawShape)
+  defaultValue?: unknown
+}
+
+function projectUnrepresentableSchema(schema: z.ZodType): z.ZodType {
+  const def = (schema as { _zod?: { def?: ZodDiscoveryDef } })._zod?.def
+  switch (def?.type) {
+    case "date":
+      return mcpDateTimeSchema
+    case "optional":
+      return projectSchemaForMcpDiscovery(def.innerType as z.ZodType).optional()
+    case "nullable":
+      return projectSchemaForMcpDiscovery(def.innerType as z.ZodType).nullable()
+    case "default": {
+      const inner = projectSchemaForMcpDiscovery(def.innerType as z.ZodType)
+      return def.defaultValue === undefined ? inner : inner.default(def.defaultValue as never)
+    }
+    case "catch":
+    case "nonoptional":
+    case "readonly":
+      return projectSchemaForMcpDiscovery(def.innerType as z.ZodType)
+    case "object": {
+      const shape = typeof def.shape === "function" ? def.shape() : (def.shape ?? {})
+      return z.looseObject(projectShapeForMcpDiscovery(shape))
+    }
+    case "union": {
+      const options = (def.options ?? []).map((option) =>
+        projectSchemaForMcpDiscovery(option as z.ZodType),
+      )
+      if (options.length === 0) return z.unknown()
+      if (options.length === 1) return options[0]!
+      return z.union(options as [z.ZodType, z.ZodType, ...z.ZodType[]])
+    }
+    case "intersection":
+      return projectSchemaForMcpDiscovery(def.left as z.ZodType).and(
+        projectSchemaForMcpDiscovery(def.right as z.ZodType),
+      )
+    case "pipe":
+      return projectSchemaForMcpDiscovery((def.in ?? def.out) as z.ZodType)
+    default:
+      return z.unknown()
+  }
 }
 
 function actionInvocationSchemaFor(entry: ToolManifestEntry): z.ZodObject {

--- a/packages/mcp/tests/date-input-discovery.test.ts
+++ b/packages/mcp/tests/date-input-discovery.test.ts
@@ -91,21 +91,55 @@ function buildContext(): ToolContext {
   }
 }
 
+const scheduleStrictDateTool = defineTool({
+  name: "schedule_strict_date",
+  description: "Schedule with plain z.date() fields (no coerce).",
+  inputSchema: z.object({
+    code: z.string().min(1),
+    startsAt: z.date(),
+  }),
+  outputSchema: z.object({
+    code: z.string(),
+    startsAt: z.string(),
+  }),
+  requiredScopes: ["records:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: false,
+    sideEffects: ["data-write"],
+  },
+  async handler(input) {
+    expect(input.startsAt).toBeInstanceOf(Date)
+    return {
+      code: input.code,
+      startsAt: input.startsAt.toISOString(),
+    }
+  },
+})
+
+function mcpAppFor(...tools: Array<typeof scheduleOfferTool | typeof scheduleStrictDateTool>) {
+  const registry = createToolRegistry()
+  for (const tool of tools) registry.register(tool)
+  const mcp = createMcpApiRoutes({
+    accessCatalog,
+    registry,
+    buildContext,
+  })
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("scopes", ["records:write"])
+    await next()
+  })
+  app.route("/", mcp)
+  return app
+}
+
 describe("MCP Date input discovery", () => {
-  it("lists and calls Tools whose input schemas include Date fields", async () => {
-    const registry = createToolRegistry()
-    registry.register(scheduleOfferTool)
-    const mcp = createMcpApiRoutes({
-      accessCatalog,
-      registry,
-      buildContext,
-    })
-    const app = new Hono()
-    app.use("*", async (c, next) => {
-      c.set("scopes", ["records:write"])
-      await next()
-    })
-    app.route("/", mcp)
+  it("lists and calls Tools whose input schemas include coerced Date fields", async () => {
+    const app = mcpAppFor(scheduleOfferTool)
 
     const listed = await readRpc(await app.request("/", rpc("tools/list", {})))
     expect(listed.error).toBeUndefined()
@@ -143,6 +177,40 @@ describe("MCP Date input discovery", () => {
         code: "spring",
         validFrom: "2026-07-01T00:00:00.000Z",
         validUntil: "2026-07-31T23:59:59.000Z",
+      },
+    })
+  })
+
+  it("revives ISO datetime strings for plain z.date() Tool inputs before registry validation", async () => {
+    const app = mcpAppFor(scheduleStrictDateTool)
+
+    const listed = await readRpc(await app.request("/", rpc("tools/list", {})))
+    expect(listed.error).toBeUndefined()
+    expect(
+      (
+        listed.result as {
+          tools?: Array<{ name: string }>
+        }
+      ).tools?.some(({ name }) => name === "schedule_strict_date"),
+    ).toBe(true)
+
+    const called = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "schedule_strict_date",
+          arguments: {
+            code: "summer",
+            startsAt: "2026-08-01T12:00:00.000Z",
+          },
+        }),
+      ),
+    )
+    expect(called.error).toBeUndefined()
+    expect(called.result).toMatchObject({
+      structuredContent: {
+        code: "summer",
+        startsAt: "2026-08-01T12:00:00.000Z",
       },
     })
   })

--- a/packages/mcp/tests/date-input-discovery.test.ts
+++ b/packages/mcp/tests/date-input-discovery.test.ts
@@ -1,0 +1,149 @@
+import { createToolRegistry, defineTool, type ToolContext } from "@voyant-travel/tools"
+import { Hono } from "hono"
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createMcpApiRoutes } from "../src/index.js"
+
+const accessCatalog = {
+  resources: [
+    {
+      id: "records",
+      unitId: "@voyant-travel/test",
+      resource: "records",
+      label: "Records",
+      description: "Test records",
+      wildcard: "allow" as const,
+      actions: [
+        { action: "read", label: "Read", description: "Read records" },
+        { action: "write", label: "Write", description: "Write records" },
+      ],
+    },
+  ],
+  presets: [],
+}
+
+const MCP_HEADERS = {
+  "content-type": "application/json",
+  accept: "application/json, text/event-stream",
+}
+
+function rpc(method: string, params: unknown, id: number | string = 1) {
+  return {
+    method: "POST",
+    headers: MCP_HEADERS,
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  }
+}
+
+async function readRpc(res: Response): Promise<Record<string, unknown>> {
+  const text = await res.text()
+  if ((res.headers.get("content-type") ?? "").includes("text/event-stream")) {
+    const line = text.split("\n").find((l) => l.startsWith("data:"))
+    return JSON.parse(line?.slice("data:".length).trim() ?? "{}")
+  }
+  return JSON.parse(text)
+}
+
+const scheduleOfferTool = defineTool({
+  name: "schedule_offer",
+  description: "Schedule an offer with Date-bearing validity bounds.",
+  inputSchema: z.object({
+    code: z.string().min(1),
+    validFrom: z.coerce.date().nullable().optional(),
+    validUntil: z.coerce.date().nullable().optional(),
+  }),
+  outputSchema: z.object({
+    code: z.string(),
+    validFrom: z.string().nullable(),
+    validUntil: z.string().nullable(),
+  }),
+  requiredScopes: ["records:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "write",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: false,
+    sideEffects: ["data-write"],
+  },
+  async handler(input) {
+    return {
+      code: input.code,
+      validFrom: input.validFrom?.toISOString() ?? null,
+      validUntil: input.validUntil?.toISOString() ?? null,
+    }
+  },
+})
+
+function buildContext(): ToolContext {
+  return {
+    db: {},
+    actor: "staff",
+    audience: "staff",
+    tenantId: "t1",
+    resolverScope: {
+      locale: "en-GB",
+      audience: "staff",
+      market: "default",
+      actor: "staff",
+    },
+  }
+}
+
+describe("MCP Date input discovery", () => {
+  it("lists and calls Tools whose input schemas include Date fields", async () => {
+    const registry = createToolRegistry()
+    registry.register(scheduleOfferTool)
+    const mcp = createMcpApiRoutes({
+      accessCatalog,
+      registry,
+      buildContext,
+    })
+    const app = new Hono()
+    app.use("*", async (c, next) => {
+      c.set("scopes", ["records:write"])
+      await next()
+    })
+    app.route("/", mcp)
+
+    const listed = await readRpc(await app.request("/", rpc("tools/list", {})))
+    expect(listed.error).toBeUndefined()
+    const tool = (
+      listed.result as {
+        tools?: Array<{
+          name: string
+          inputSchema?: {
+            properties?: Record<string, { type?: string; format?: string }>
+          }
+        }>
+      }
+    ).tools?.find(({ name }) => name === "schedule_offer")
+
+    expect(tool).toBeDefined()
+    const validFrom = tool?.inputSchema?.properties?.validFrom
+    expect(JSON.stringify(validFrom)).toMatch(/string|date-time/)
+
+    const called = await readRpc(
+      await app.request(
+        "/",
+        rpc("tools/call", {
+          name: "schedule_offer",
+          arguments: {
+            code: "spring",
+            validFrom: "2026-07-01T00:00:00.000Z",
+            validUntil: "2026-07-31T23:59:59.000Z",
+          },
+        }),
+      ),
+    )
+    expect(called.error).toBeUndefined()
+    expect(called.result).toMatchObject({
+      structuredContent: {
+        code: "spring",
+        validFrom: "2026-07-01T00:00:00.000Z",
+        validUntil: "2026-07-31T23:59:59.000Z",
+      },
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Soft-deny team-management without an acting user at Tool execution so org API-key MCP composition (initialize / tools/list / non-team calls) no longer 500s ([#3775](https://github.com/voyant-travel/voyant/issues/3775)).
- Project Date-bearing Tool input schemas to JSON Schema `date-time` strings so `tools/list` no longer fail-closes with `Date cannot be represented in JSON Schema` ([#3776](https://github.com/voyant-travel/voyant/issues/3776)).
- Adds focused auth + MCP discovery coverage and a changeset for `@voyant-travel/auth` / `@voyant-travel/mcp`.

## Test plan
- [x] `pnpm --filter @voyant-travel/auth exec vitest run tests/tools.test.ts`
- [x] `pnpm --filter @voyant-travel/mcp test`
- [ ] After release + sandbox deploy to the new framework train: org API-key `initialize` + `tools/list` succeed; Max tenant catalog loads; team Tools still deny without acting user; session `tools/call list_products` still works

Fixes #3775
Fixes #3776