### PR TITLE
fix(auth): retarget cloud staff links after deploy cutover

### DIFF
--- a/.changeset/cloud-admin-redeploy-session-retarget.md
+++ b/.changeset/cloud-admin-redeploy-session-retarget.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/auth": patch
+---
+
+Retarget cloud-auth staff links to the active runtime deployment after a successful platform revalidation so managed deploy cutover does not strand signed-in admin sessions on `/v1/admin/*`.

--- a/packages/auth/src/cloud-admin-session-revalidation-store.ts
+++ b/packages/auth/src/cloud-admin-session-revalidation-store.ts
@@ -13,6 +13,8 @@ export async function markCloudAuthSessionRevalidated(
     userId: string
     now: Date
     revalidateAfterSeconds: number
+    /** Current runtime deployment id — retargets links after deploy cutover. */
+    deploymentId: string
   },
 ): Promise<void> {
   const revalidateAfter = new Date(input.now.getTime() + input.revalidateAfterSeconds * 1000)
@@ -20,6 +22,7 @@ export async function markCloudAuthSessionRevalidated(
     db
       .update(cloudAuthSessionLinks)
       .set({
+        deploymentId: input.deploymentId,
         lastRevalidatedAt: input.now,
         revalidateAfter,
         revokedAt: null,
@@ -29,6 +32,7 @@ export async function markCloudAuthSessionRevalidated(
     db
       .update(cloudAuthUserLinks)
       .set({
+        deploymentId: input.deploymentId,
         lastRevalidatedAt: input.now,
         revokedAt: null,
         updatedAt: input.now,
@@ -83,11 +87,14 @@ export async function markCloudAuthUserRevalidated(
   input: {
     userId: string
     now: Date
+    /** Current runtime deployment id — retargets links after deploy cutover. */
+    deploymentId: string
   },
 ): Promise<void> {
   await db
     .update(cloudAuthUserLinks)
     .set({
+      deploymentId: input.deploymentId,
       lastRevalidatedAt: input.now,
       revokedAt: null,
       updatedAt: input.now,

--- a/packages/auth/src/cloud-admin-session.ts
+++ b/packages/auth/src/cloud-admin-session.ts
@@ -197,7 +197,28 @@ export async function revalidateVoyantCloudAdminAuthSession({
     return { ok: false, status: "revoked", reason: "missing_or_revoked_session" }
   }
 
-  if (sessionLink.revalidateAfter > now) {
+  const currentDeploymentId = config.deploymentId.trim()
+  const [userLink] = await db
+    .select({
+      deploymentId: cloudAuthUserLinks.deploymentId,
+      revokedAt: cloudAuthUserLinks.revokedAt,
+    })
+    .from(cloudAuthUserLinks)
+    .where(eq(cloudAuthUserLinks.userId, sessionLink.userId))
+    .limit(1)
+
+  // Staff access binds to cloud_auth_user_links.deployment_id. After a managed
+  // deploy cutover that advances VOYANT_CLOUD_DEPLOYMENT_ID, a still-valid
+  // session can be cached against the previous deployment id and strand
+  // /v1/admin/* with 401 while /auth/me keeps working. Skip the revalidation
+  // cache whenever either link still points at a different deployment so we
+  // confirm platform access for the active runtime before retargeting.
+  const deploymentDrifted =
+    Boolean(currentDeploymentId) &&
+    (sessionLink.deploymentId !== currentDeploymentId ||
+      (userLink != null && !userLink.revokedAt && userLink.deploymentId !== currentDeploymentId))
+
+  if (sessionLink.revalidateAfter > now && !deploymentDrifted) {
     return { ok: true, status: "cached" }
   }
 
@@ -213,6 +234,7 @@ export async function revalidateVoyantCloudAdminAuthSession({
       userId: sessionLink.userId,
       now,
       revalidateAfterSeconds,
+      deploymentId: currentDeploymentId,
     })
     // Refresh the cached RBAC scopes so a permission change applied while the
     // member is signed in takes effect at the next revalidation, not only at
@@ -258,10 +280,14 @@ export async function revalidateVoyantCloudAdminAuthUser({
     return { ok: false, status: "revoked", reason: "missing_or_revoked_user" }
   }
 
+  const currentDeploymentId = config.deploymentId.trim()
+  const deploymentDrifted =
+    Boolean(currentDeploymentId) && userLink.deploymentId !== currentDeploymentId
+
   const nextRevalidationAt = userLink.lastRevalidatedAt
     ? new Date(userLink.lastRevalidatedAt.getTime() + revalidateAfterSeconds * 1000)
     : null
-  if (nextRevalidationAt && nextRevalidationAt > now) {
+  if (nextRevalidationAt && nextRevalidationAt > now && !deploymentDrifted) {
     return { ok: true, status: "cached" }
   }
 
@@ -275,6 +301,7 @@ export async function revalidateVoyantCloudAdminAuthUser({
     await markCloudAuthUserRevalidated(db, {
       userId: userLink.userId,
       now,
+      deploymentId: currentDeploymentId,
     })
     return { ok: true, status: "active" }
   }

--- a/packages/auth/tests/unit/cloud-admin-session-revalidation.test.ts
+++ b/packages/auth/tests/unit/cloud-admin-session-revalidation.test.ts
@@ -1,0 +1,264 @@
+import {
+  apikeyTable,
+  cloudAuthSessionLinks,
+  cloudAuthUserLinks,
+} from "@voyant-travel/db/schema/iam"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  revalidateVoyantCloudAdminAuthSession,
+  revalidateVoyantCloudAdminAuthUser,
+} from "../../src/cloud-admin-session.js"
+import { resolveStaffAccess } from "../../src/staff-access.js"
+
+const NOW = new Date("2026-07-26T12:00:00.000Z")
+const PREVIOUS_DEPLOYMENT_ID = "dep_previous"
+const CURRENT_DEPLOYMENT_ID = "dep_current"
+const ACCESS_CATALOG = { resources: [], presets: [] }
+
+type SessionLink = {
+  sessionId: string
+  userId: string
+  providerId: string
+  providerAccountId: string
+  deploymentId: string
+  revalidateAfter: Date
+  lastRevalidatedAt: Date | null
+  revokedAt: Date | null
+  updatedAt?: Date
+}
+
+type UserLink = {
+  userId: string
+  providerId: string
+  providerAccountId: string
+  deploymentId: string
+  platformOrganizationId: string
+  roleSlug: string | null
+  scopes: string[] | null
+  lastRevalidatedAt: Date | null
+  revokedAt: Date | null
+  updatedAt?: Date
+}
+
+function createLinkStore(input: { session?: SessionLink; user: UserLink }) {
+  const session = input.session ? { ...input.session } : null
+  const user = { ...input.user }
+  const apiKeys: Array<{ referenceId: string; enabled: boolean; updatedAt?: Date }> = [
+    { referenceId: user.userId, enabled: true },
+  ]
+
+  const db = {
+    select: () => ({
+      from: (table: unknown) => ({
+        where: () => ({
+          limit: async (count: number) => {
+            if (table === cloudAuthSessionLinks) {
+              return (session ? [session] : []).slice(0, count)
+            }
+            if (table === cloudAuthUserLinks) {
+              return [user].slice(0, count)
+            }
+            return []
+          },
+        }),
+      }),
+    }),
+    update: (table: unknown) => ({
+      set: (values: Record<string, unknown>) => ({
+        where: async () => {
+          if (table === cloudAuthSessionLinks && session) {
+            Object.assign(session, values)
+            return
+          }
+          if (table === cloudAuthUserLinks) {
+            Object.assign(user, values)
+            return
+          }
+          if (table === apikeyTable) {
+            for (const key of apiKeys) {
+              if (key.referenceId === user.userId) Object.assign(key, values)
+            }
+          }
+        },
+      }),
+    }),
+  }
+
+  return { db: db as never, session, user, apiKeys }
+}
+
+function sessionLink(overrides: Partial<SessionLink> = {}): SessionLink {
+  return {
+    sessionId: "sess_1",
+    userId: "user_1",
+    providerId: "voyant-cloud",
+    providerAccountId: "user_workos_1",
+    deploymentId: PREVIOUS_DEPLOYMENT_ID,
+    revalidateAfter: new Date("2026-07-26T11:00:00.000Z"),
+    lastRevalidatedAt: new Date("2026-07-26T10:45:00.000Z"),
+    revokedAt: null,
+    ...overrides,
+  }
+}
+
+function userLink(overrides: Partial<UserLink> = {}): UserLink {
+  return {
+    userId: "user_1",
+    providerId: "voyant-cloud",
+    providerAccountId: "user_workos_1",
+    deploymentId: PREVIOUS_DEPLOYMENT_ID,
+    platformOrganizationId: "org_platform_1",
+    roleSlug: "admin",
+    scopes: ["*"],
+    lastRevalidatedAt: new Date("2026-07-26T10:45:00.000Z"),
+    revokedAt: null,
+    ...overrides,
+  }
+}
+
+const revalidateConfig = {
+  revalidateUrl: "https://api.voyant.travel/cloud/v1/admin-auth/revalidate",
+  deploymentId: CURRENT_DEPLOYMENT_ID,
+  clientToken: "client_token_1",
+}
+
+describe("cloud admin session revalidation redeploy drift", () => {
+  it("retargets the cloud-auth user link to the current deployment after a successful revalidate", async () => {
+    const store = createLinkStore({
+      session: sessionLink(),
+      user: userLink(),
+    })
+    const fetch = vi.fn(async () => Response.json({ ok: true, status: "active" }))
+
+    const result = await revalidateVoyantCloudAdminAuthSession({
+      db: store.db,
+      sessionId: "sess_1",
+      config: revalidateConfig,
+      fetch: fetch as typeof globalThis.fetch,
+      now: NOW,
+    })
+
+    expect(result).toEqual({ ok: true, status: "active" })
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(store.user.deploymentId).toBe(CURRENT_DEPLOYMENT_ID)
+    expect(store.session?.deploymentId).toBe(CURRENT_DEPLOYMENT_ID)
+
+    const staffDb = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [store.user],
+          }),
+        }),
+      }),
+    }
+    await expect(
+      resolveStaffAccess({
+        accessCatalog: ACCESS_CATALOG,
+        authMode: "voyant-cloud",
+        db: staffDb as never,
+        deploymentId: CURRENT_DEPLOYMENT_ID,
+        userId: "user_1",
+      }),
+    ).resolves.toMatchObject({
+      organizationId: "org_platform_1",
+    })
+  })
+
+  it("forces platform revalidation and retargets when the cached session still points at a previous deployment", async () => {
+    const store = createLinkStore({
+      session: sessionLink({
+        revalidateAfter: new Date("2026-07-26T13:00:00.000Z"),
+      }),
+      user: userLink(),
+    })
+    const fetch = vi.fn(async () => Response.json({ ok: true, status: "active" }))
+
+    const result = await revalidateVoyantCloudAdminAuthSession({
+      db: store.db,
+      sessionId: "sess_1",
+      config: revalidateConfig,
+      fetch: fetch as typeof globalThis.fetch,
+      now: NOW,
+    })
+
+    expect(result).toEqual({ ok: true, status: "active" })
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(store.user.deploymentId).toBe(CURRENT_DEPLOYMENT_ID)
+    expect(store.session?.deploymentId).toBe(CURRENT_DEPLOYMENT_ID)
+  })
+
+  it("does not retarget or revive links when platform revalidation revokes access", async () => {
+    const store = createLinkStore({
+      session: sessionLink(),
+      user: userLink(),
+    })
+    const fetch = vi.fn(async () =>
+      Response.json({ ok: false, status: "revoked", reason: "no_membership" }, { status: 403 }),
+    )
+
+    const result = await revalidateVoyantCloudAdminAuthSession({
+      db: store.db,
+      sessionId: "sess_1",
+      config: revalidateConfig,
+      fetch: fetch as typeof globalThis.fetch,
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      status: "revoked",
+      reason: "no_membership",
+    })
+    expect(store.user.deploymentId).toBe(PREVIOUS_DEPLOYMENT_ID)
+    expect(store.user.revokedAt).toEqual(NOW)
+    expect(store.session?.revokedAt).toEqual(NOW)
+    expect(store.apiKeys[0]?.enabled).toBe(false)
+  })
+
+  it("keeps the revalidation cache when the link already matches the current deployment", async () => {
+    const store = createLinkStore({
+      session: sessionLink({
+        deploymentId: CURRENT_DEPLOYMENT_ID,
+        revalidateAfter: new Date("2026-07-26T13:00:00.000Z"),
+      }),
+      user: userLink({ deploymentId: CURRENT_DEPLOYMENT_ID }),
+    })
+    const fetch = vi.fn(async () => Response.json({ ok: true, status: "active" }))
+
+    await expect(
+      revalidateVoyantCloudAdminAuthSession({
+        db: store.db,
+        sessionId: "sess_1",
+        config: revalidateConfig,
+        fetch: fetch as typeof globalThis.fetch,
+        now: NOW,
+      }),
+    ).resolves.toEqual({ ok: true, status: "cached" })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("retargets the user link on successful user-level revalidation after deploy cutover", async () => {
+    const store = createLinkStore({
+      user: userLink({
+        lastRevalidatedAt: new Date("2026-07-26T11:00:00.000Z"),
+      }),
+    })
+    const fetch = vi.fn(async () => Response.json({ ok: true, status: "active" }))
+
+    const result = await revalidateVoyantCloudAdminAuthUser({
+      db: store.db,
+      userId: "user_1",
+      config: revalidateConfig,
+      fetch: fetch as typeof globalThis.fetch,
+      now: NOW,
+      revalidateAfterSeconds: 60,
+    })
+
+    expect(result).toEqual({ ok: true, status: "active" })
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(store.user.deploymentId).toBe(CURRENT_DEPLOYMENT_ID)
+    expect(store.user.revokedAt).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #3774: after a managed deploy advances `VOYANT_CLOUD_DEPLOYMENT_ID`, successful platform revalidation retargets `cloud_auth_user_links` / `cloud_auth_session_links` to the active deployment so `resolveStaffAccess` keeps authorizing `/v1/admin/*`.
- Skips the revalidation cache when either link still points at a previous deployment, so cutover does not leave sessions looking signed in via `/auth/me` while staff APIs 401.
- Leaves revoke behavior unchanged: failed platform revalidation still revokes and does not retarget.

## Test plan
- [x] `pnpm --filter @voyant-travel/auth test tests/unit/cloud-admin-session-revalidation.test.ts tests/unit/staff-access.test.ts`
- [ ] Deploy framework patch to a sandbox tenant, stay signed in across cutover, confirm `/v1/admin/*` and `/auth/me` both succeed without re-login
- [ ] Confirm revoked platform membership still 401s and does not revive the link onto the new deployment
- [ ] Confirm fresh cloud admin login still upserts a link bound to the current deployment


Made with [Cursor](https://cursor.com)