### PR TITLE
fix(navigation-preferences): keep org-key MCP catalog composition available

### DIFF
--- a/.changeset/mcp-nav-prefs-org-key.md
+++ b/.changeset/mcp-nav-prefs-org-key.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/navigation-preferences": patch
+---
+
+Keep MCP catalog composition available for organization API keys when navigation preference Tools have no acting member.

--- a/packages/navigation-preferences/src/mcp-runtime.ts
+++ b/packages/navigation-preferences/src/mcp-runtime.ts
@@ -31,16 +31,19 @@ export function createNavigationPreferencesToolServices(
   }
 }
 
+/**
+ * Navigation preference Tools are member-scoped. Organization-only API keys
+ * must still compose the MCP catalog (initialize / tools/list / other Tools).
+ * Until a grant carries an acting member, these services deny at Tool
+ * execution time instead of failing closed during contribution.
+ */
 export const voyantToolContextContribution = defineToolContextContribution({
   context: ["navigationPreferences"],
   contribute: ({ context, request }) => {
     const variables = (request as { var?: { userId?: unknown; scopes?: unknown } }).var
     const memberId = variables?.userId
     if (typeof memberId !== "string" || memberId.length === 0) {
-      throw new ToolError(
-        "Navigation preference Tools require an authenticated member.",
-        "AUTHORIZATION_DENIED",
-      )
+      return { navigationPreferences: actingMemberRequiredNavigationPreferences() }
     }
     const scopes = Array.isArray(variables?.scopes)
       ? variables.scopes.filter((scope): scope is string => typeof scope === "string")
@@ -54,3 +57,17 @@ export const voyantToolContextContribution = defineToolContextContribution({
     }
   },
 })
+
+function actingMemberRequiredNavigationPreferences(): NavigationPreferencesToolServices {
+  const deny = async (): Promise<never> => {
+    throw new ToolError(
+      "Navigation preference Tools require an authenticated member.",
+      "AUTHORIZATION_DENIED",
+    )
+  }
+  return {
+    get: deny,
+    setOrganization: deny,
+    setMember: deny,
+  }
+}

--- a/packages/navigation-preferences/tests/unit/tools.test.ts
+++ b/packages/navigation-preferences/tests/unit/tools.test.ts
@@ -1,9 +1,12 @@
-import type { ToolContext } from "@voyant-travel/tools"
+import { createToolRegistry, type ToolContext } from "@voyant-travel/tools"
 import { describe, expect, it, vi } from "vitest"
 
+import { voyantToolContextContribution } from "../../src/mcp-runtime.js"
 import {
   getNavigationPreferencesTool,
   type NavigationPreferencesToolContext,
+  type NavigationPreferencesToolServices,
+  navigationPreferencesTools,
   setMyNavigationPreferencesTool,
   setOrganizationNavigationPreferencesTool,
 } from "../../src/tools.js"
@@ -55,6 +58,38 @@ describe("navigation preference Tools", () => {
   it("fails closed when the package service contribution is missing", async () => {
     await expect(getNavigationPreferencesTool.handler({}, baseContext)).rejects.toMatchObject({
       code: "MISSING_SERVICE",
+    })
+  })
+
+  it("keeps MCP catalog composition available when the grant has no acting member", async () => {
+    const contribution = await voyantToolContextContribution.contribute({
+      request: { var: {} },
+      context: baseContext,
+      resources: {},
+    })
+
+    expect(contribution).toHaveProperty("navigationPreferences")
+    await expect(
+      (contribution.navigationPreferences as NavigationPreferencesToolServices).get(),
+    ).rejects.toMatchObject({
+      code: "AUTHORIZATION_DENIED",
+      message: "Navigation preference Tools require an authenticated member.",
+    })
+
+    const registry = createToolRegistry()
+    registry.registerAll(navigationPreferencesTools)
+    await expect(
+      registry.dispatch(
+        "get_navigation_preferences",
+        {},
+        {
+          ...baseContext,
+          navigationPreferences:
+            contribution.navigationPreferences as NavigationPreferencesToolServices,
+        },
+      ),
+    ).rejects.toMatchObject({
+      code: "AUTHORIZATION_DENIED",
     })
   })
 })


### PR DESCRIPTION
## Summary
- Organization API keys have no acting member; navigation preference context contribution no longer throws during MCP compose.
- Return a denying facade so `initialize` / `tools/list` can succeed; navigation preference Tools still fail closed at execution.
- Unblocks Max tenant catalog discovery on sandbox after the auth/mcp org-key fixes.

## Test plan
- [ ] `pnpm --filter @voyant-travel/navigation-preferences test -- tests/unit/tools.test.ts`
- [ ] Org API key: `initialize` + `tools/list` succeed on a managed runtime with this pin
- [ ] Navigation preference tool call without acting member still returns `AUTHORIZATION_DENIED`
- [ ] Session-authenticated MCP path still lists and calls tools


Made with [Cursor](https://cursor.com)