### PR TITLE
fix(inventory): resolve update_product_day from dayId alone

### DIFF
--- a/.changeset/inventory-update-day-by-dayid.md
+++ b/.changeset/inventory-update-day-by-dayid.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Resolve update_product_day from dayId without requiring product id, so Max does not invent id=unknown and trigger a default-itinerary insert.

--- a/packages/inventory/src/day-tools.ts
+++ b/packages/inventory/src/day-tools.ts
@@ -36,7 +36,13 @@ const listProductDaysArgs = z.object({
 })
 export const updateProductDayArgs = z
   .object({
-    id: z.string().min(1).describe("The product id that owns the itinerary day."),
+    id: z
+      .string()
+      .min(1)
+      .optional()
+      .describe(
+        "Product id that owns the itinerary day. Required with dayNumber; optional when dayId is set (resolved from the day).",
+      ),
     dayId: z
       .string()
       .min(1)
@@ -47,7 +53,7 @@ export const updateProductDayArgs = z
       .int()
       .positive()
       .optional()
-      .describe("1-based day number when dayId is unknown."),
+      .describe("1-based day number when dayId is unknown (requires product id)."),
     title: z.string().max(255).nullable().optional(),
     description: z.string().nullable().optional(),
     location: z.string().max(255).nullable().optional(),
@@ -55,6 +61,10 @@ export const updateProductDayArgs = z
   .refine((value) => value.dayId != null || value.dayNumber != null, {
     message: "Provide dayId or dayNumber.",
     path: ["dayId"],
+  })
+  .refine((value) => value.dayId != null || value.id != null, {
+    message: "Provide product id when updating by dayNumber.",
+    path: ["id"],
   })
   .refine(
     (value) =>

--- a/packages/inventory/src/mcp-runtime.ts
+++ b/packages/inventory/src/mcp-runtime.ts
@@ -144,17 +144,31 @@ export const voyantToolContextContribution = defineToolContextContribution({
       },
       listProductDays: (productId) => productsService.listDays(db, productId),
       async updateProductDay(input) {
-        const days = await productsService.listDays(db, input.id)
-        const day =
-          input.dayId != null
-            ? days.find((row) => row.id === input.dayId)
-            : days.find((row) => row.dayNumber === input.dayNumber)
-        if (!day) return null
         const patch = {
           ...(input.title !== undefined ? { title: input.title } : {}),
           ...(input.description !== undefined ? { description: input.description } : {}),
           ...(input.location !== undefined ? { location: input.location } : {}),
         }
+        // Prefer dayId: resolve the owning product from the day row so Max can
+        // omit product id (and never call listDays("unknown") which would try
+        // to create a default itinerary for a fake product).
+        if (input.dayId != null) {
+          const existing = await productsService.getDayForProductMutation(db, input.dayId)
+          if (!existing) return null
+          if (input.id != null && input.id !== existing.productId) return null
+          const row = await productsService.updateDay(db, existing.id, patch)
+          if (row) {
+            await emitProductContentChanged(eventBus, {
+              id: existing.productId,
+              axis: "day",
+            })
+          }
+          return row
+        }
+        if (input.id == null) return null
+        const days = await productsService.listDays(db, input.id)
+        const day = days.find((row) => row.dayNumber === input.dayNumber)
+        if (!day) return null
         const row = await productsService.updateDay(db, day.id, patch)
         if (row) {
           await emitProductContentChanged(eventBus, { id: input.id, axis: "day" })

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -226,6 +226,29 @@ describe("inventory tools", () => {
       dayNumber: 2,
       description: "Morning at Miradouro da Senhora do Monte, then explore Alfama.",
     })
+
+    let dayIdOnly: unknown
+    await makeRegistry().dispatch(
+      "update_product_day",
+      {
+        dayId: "pday_1",
+        title: "Alfama viewpoints + stress-test",
+      },
+      ctxWith(
+        {
+          async updateProductDay(input) {
+            dayIdOnly = input
+            return { ...day, title: "Alfama viewpoints + stress-test" }
+          },
+        },
+        { actor: "staff", audience: "staff" },
+      ),
+    )
+    expect(dayIdOnly).toMatchObject({
+      dayId: "pday_1",
+      title: "Alfama viewpoints + stress-test",
+    })
+    expect(dayIdOnly).not.toHaveProperty("id")
   })
 
   it("lists products through the injected service", async () => {


### PR DESCRIPTION
## Summary
- Allow `update_product_day` without product `id` when `dayId` is provided.
- Resolve the owning product from the day row instead of calling `listDays(productId)` first (which invented itineraries for `id=unknown`).

## Test plan
- [x] Inventory tools vitest (dayId-only update args)
- [ ] Release + pin bump + sandbox roll
- [ ] Max: update day by dayId without product id


Made with [Cursor](https://cursor.com)