### PR TITLE
fix(inventory): resolve update_product_day action target from dayId

### DIFF
--- a/.changeset/inventory-dayid-action-target.md
+++ b/.changeset/inventory-dayid-action-target.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Resolve update_product_day action target from dayId via package-resolver when product id is omitted.

--- a/packages/inventory/src/day-tools.ts
+++ b/packages/inventory/src/day-tools.ts
@@ -80,6 +80,8 @@ export type UpdateProductDayInput = z.output<typeof updateProductDayArgs>
 export interface InventoryDayToolServices {
   listProductDays(productId: string): Promise<unknown[]>
   updateProductDay(input: UpdateProductDayInput): Promise<unknown | null>
+  /** Resolve the owning product id for a day (`pday_*`) when Max omits product id. */
+  resolveProductIdForDay(dayId: string): Promise<string | null>
 }
 
 type InventoryDayToolContext = ToolContext & {
@@ -113,7 +115,7 @@ export const updateProductDayTool = defineTool({
   capabilityVersion: VERSION,
   name: "update_product_day",
   description:
-    "Update an existing itinerary day's title, description, and/or location on a product. Resolve the day with `list_product_days` first. Does not create days — rebuild the itinerary with `compose_product` when the day structure is missing.",
+    "Update an existing itinerary day's title, description, and/or location on a product. Resolve the day with `list_product_days` first. Prefer dayId from that list; product id is optional when dayId is set. Does not create days — rebuild the itinerary with `compose_product` when the day structure is missing.",
   inputSchema: updateProductDayArgs,
   outputSchema: productDayToolSchema.nullable(),
   requiredScopes: ["products:write"],
@@ -121,6 +123,11 @@ export const updateProductDayTool = defineTool({
   tier: "write",
   riskPolicy: PRODUCT_WRITE_RISK,
   annotations: { idempotentHint: true },
+  async resolveActionTarget(input, ctx: InventoryDayToolContext) {
+    if (input.id) return input.id
+    if (!input.dayId) return ""
+    return (await inventory(ctx).resolveProductIdForDay(input.dayId)) ?? ""
+  },
   async handler(input, ctx: InventoryDayToolContext) {
     updateDaySchema.parse({
       title: input.title,

--- a/packages/inventory/src/mcp-runtime.ts
+++ b/packages/inventory/src/mcp-runtime.ts
@@ -143,6 +143,10 @@ export const voyantToolContextContribution = defineToolContextContribution({
         return row
       },
       listProductDays: (productId) => productsService.listDays(db, productId),
+      async resolveProductIdForDay(dayId) {
+        const day = await productsService.getDayForProductMutation(db, dayId)
+        return day?.productId ?? null
+      },
       async updateProductDay(input) {
         const patch = {
           ...(input.title !== undefined ? { title: input.title } : {}),

--- a/packages/inventory/src/tools.ts
+++ b/packages/inventory/src/tools.ts
@@ -197,6 +197,7 @@ export interface InventoryToolServices {
   updateProduct(id: string, input: z.output<typeof updateProductSchema>): Promise<unknown | null>
   listProductDays(productId: string): Promise<unknown[]>
   updateProductDay(input: UpdateProductDayInput): Promise<unknown | null>
+  resolveProductIdForDay(dayId: string): Promise<string | null>
 }
 
 export interface InventoryContentToolServices {

--- a/packages/inventory/tests/tools.test.ts
+++ b/packages/inventory/tests/tools.test.ts
@@ -62,6 +62,20 @@ function ctxWith(
   }
 }
 
+const UPDATE_PRODUCT_DAY_ACTION_POLICY = {
+  id: "@voyant-travel/inventory#action.update-product-day",
+  capabilityId: "@voyant-travel/inventory#action.update-product-day",
+  version: "v1",
+  kind: "execute" as const,
+  targetType: "product",
+  commandTargetField: "id",
+  risk: "medium" as const,
+  ledger: "required" as const,
+  approval: "never" as const,
+  reversible: true,
+  allowedActorTypes: ["staff" as const],
+}
+
 function makeRegistry() {
   const registry = createToolRegistry()
   for (const tool of inventoryTools) {
@@ -69,6 +83,8 @@ function makeRegistry() {
       registry.register(tool, { actionPolicy: CREATE_PRODUCT_HANDLER_POLICY.actionPolicy })
     } else if (tool.name === "compose_product") {
       registry.register(tool, { actionPolicy: COMPOSE_PRODUCT_HANDLER_POLICY.actionPolicy })
+    } else if (tool.name === "update_product_day") {
+      registry.register(tool, { actionPolicy: UPDATE_PRODUCT_DAY_ACTION_POLICY })
     } else {
       registry.register(tool)
     }
@@ -236,6 +252,10 @@ describe("inventory tools", () => {
       },
       ctxWith(
         {
+          async resolveProductIdForDay(dayId) {
+            expect(dayId).toBe("pday_1")
+            return "prod_1"
+          },
           async updateProductDay(input) {
             dayIdOnly = input
             return { ...day, title: "Alfama viewpoints + stress-test" }


### PR DESCRIPTION
## Summary
- Add `resolveActionTarget` on `update_product_day` so dayId-only calls resolve the owning product for the action ledger (package-resolver wins over `commandTargetField: id`).
- Wire `resolveProductIdForDay` through MCP runtime via `getDayForProductMutation`.
- Cover dayId-only dispatch under the real update-product-day action policy.

## Test plan
- [x] `pnpm --filter @voyant-travel/inventory test -- tests/tools.test.ts`
- [ ] Release `@voyant-travel/inventory` patch, pin operator-runtime, roll sandbox
- [ ] Max smoke: `update_product_day` with only `dayId` (no product id)


Made with [Cursor](https://cursor.com)