### PR TITLE
fix(action-ledger): accept package-resolved targets without the command field

### DIFF
--- a/.changeset/action-ledger-package-resolved-target.md
+++ b/.changeset/action-ledger-package-resolved-target.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/action-ledger": patch
+---
+
+Stop rejecting package-resolved action targets when the command omits the declared target field. A tool with `resolveActionTarget` derives its target from server-owned state, so commands that address a child record (an itinerary day by `dayId` rather than the owning product `id`) no longer fail the command-target cross-check. A caller-supplied target field is still matched exactly.

--- a/packages/action-ledger/src/tool-action-policy.ts
+++ b/packages/action-ledger/src/tool-action-policy.ts
@@ -289,6 +289,17 @@ function assertCommandTargetMatches(
     typeof commandInput === "object" && commandInput !== null && !Array.isArray(commandInput)
       ? (commandInput as Record<string, unknown>)[field]
       : undefined
+  // A package resolver derives the target from server-owned state, so the
+  // command may legitimately omit the declared target field (e.g. addressing an
+  // itinerary day by `dayId` instead of the owning product `id`). There is no
+  // caller-named target to cross-check, and nothing to spoof. When the caller
+  // does name one it still has to match exactly.
+  if (
+    commandTarget === undefined &&
+    execution.actionPolicy.invocation.targetResolution === "package-resolver"
+  ) {
+    return
+  }
   if (typeof commandTarget !== "string" || !commandTarget.trim() || commandTarget !== targetId) {
     throw new ToolError(
       `Tool action targetId must exactly match command input field "${field}".`,

--- a/packages/action-ledger/tests/unit/tool-action-policy.test.ts
+++ b/packages/action-ledger/tests/unit/tool-action-policy.test.ts
@@ -274,6 +274,32 @@ describe("generic MCP action-policy gate", () => {
     expect(dispatch).not.toHaveBeenCalled()
   })
 
+  it("accepts a package-resolved target when the command omits the declared target field", async () => {
+    const selected = action({ commandTargetField: "id" })
+    const events: string[] = []
+    let sequence = 0
+    vi.spyOn(actionLedgerService, "appendEntry").mockImplementation(async (_db, input) => {
+      events.push(`ledger:${input.status}`)
+      sequence += 1
+      return { entry: { id: `action_${sequence}`, ...input }, replayed: false } as never
+    })
+
+    const result = await gate(selected).execute(
+      execution(selected, { confirmed: true, requestId }, { dayId: "pday_1", title: "Alfama" }),
+      async () => {
+        events.push("dispatch")
+        return { ok: true }
+      },
+    )
+
+    expect(result).toEqual({ ok: true })
+    expect(events).toEqual(["ledger:requested", "dispatch", "ledger:succeeded"])
+    expect(actionLedgerService.appendEntry).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ targetId: "target_1" }),
+    )
+  })
+
   it("rejects a padded command target before dispatching a Commerce-like mutation", async () => {
     const selected = action({ commandTargetField: "id" })
     const dispatch = vi.fn(async () => ({ ok: true }))


### PR DESCRIPTION
## Problem

A realistic Max request on the sandbox — *"On the Lisbon Boutique Escape tour, day 2 is wrong. Please rename it to …"* — produces this transcript:

- `List product days` ✅
- **`Update product day` failed: `Tool action targetId must exactly match command input field "id"`** ❌
- `Update product day` ✅ (agent retries, this time passing the product id)

The edit lands, but every itinerary-day edit burns a failed tool call first and shows a red error to a non-technical operator.

## Cause

`update_product_day` declares `resolveActionTarget`, so `genericTargetResolution` picks `targetResolution: "package-resolver"` and the owning product id is resolved from the day. The graph action still declares `commandTargetField: "id"`, and `assertCommandTargetMatches` unconditionally requires `commandInput.id === targetId`. `id` is optional on that tool, so a `dayId`-only call leaves it `undefined` and the guard throws.

## Fix

Skip the cross-check only when the target was package-resolved **and** the command names no target at all — there is no caller-named target to disagree with, and nothing to spoof. When the caller does supply the field it still has to match the resolved target exactly.

## Test plan

- [x] `pnpm --filter @voyant-travel/action-ledger test -- tests/unit/tool-action-policy.test.ts` (232 passed)
- [x] New case: package-resolved target dispatches when the command omits the declared field
- [x] Existing target-swap (`booking_A` vs `booking_B`) and padded-target cases still reject
- [ ] Release patch, pin operator-runtime, roll sandbox
- [ ] Re-run the Lisbon day-rename request and confirm a single clean `Update product day`