### PR TITLE
fix(bookings): refuse bookings that reserve nothing; mint references via a Tool

### DIFF
--- a/.changeset/booking-create-reserves-something.md
+++ b/.changeset/booking-create-reserves-something.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/finance": patch
+---
+
+Refuse to create a booking that reserves nothing, and allocate booking references through a tool.
+
+`create_booking` used to return a booking id for a command that produced no items whenever the resolved option had several optional units and the caller sent no `itemLines`. The result was a booking holding no inventory, with no price and nothing to invoice, while the caller was told it had succeeded. The create now fails closed before writing anything and explains which choice is missing.
+
+`generate_booking_number` is the new sanctioned way to allocate the immutable `bookingNumber` that anchors the durable create. Callers previously invented their own reference, which is how agent-authored bookings ended up with references built from the traveller's name.

--- a/packages/bookings/src/booking-create-command-domain.ts
+++ b/packages/bookings/src/booking-create-command-domain.ts
@@ -1,1 +1,1 @@
-export { settleBookingCreateDomain } from "./service-core.js"
+export { BookingItemsUnresolvedError, settleBookingCreateDomain } from "./service-core.js"

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -270,6 +270,31 @@ function bookingAllowsItemMutation(status: BookingStatus) {
   return status !== "cancelled"
 }
 
+/**
+ * Raised when a product booking would end up with no items at all — the caller
+ * sent no `itemLines` and the resolved option has no single obvious unit to seed
+ * (several optional units, or none). Creating the booking anyway yields a shell
+ * that holds no inventory and carries no price, so the create fails closed and
+ * the caller is told to name the units it wants.
+ */
+export class BookingItemsUnresolvedError extends Error {
+  readonly productId: string
+  readonly optionId: string | null
+  readonly candidateUnitCount: number
+
+  constructor(productId: string, optionId: string | null, candidateUnitCount: number) {
+    super(
+      candidateUnitCount === 0
+        ? "This product has no bookable units on the selected option, so the booking would reserve nothing."
+        : "Several units are available and none is required, so the booking would reserve nothing. Choose which units to book.",
+    )
+    this.name = "BookingItemsUnresolvedError"
+    this.productId = productId
+    this.optionId = optionId
+    this.candidateUnitCount = candidateUnitCount
+  }
+}
+
 /** Product data needed for convertProductToBooking — supplied by the caller (template). */
 export interface ConvertProductData {
   product: {
@@ -2441,6 +2466,22 @@ const bookingsServiceInternal = {
       return null
     }
 
+    const unitsToSeed =
+      selectedUnits.filter((unit) => unit.isRequired).length > 0
+        ? selectedUnits.filter((unit) => unit.isRequired)
+        : selectedUnits.length === 1
+          ? selectedUnits
+          : []
+
+    // A booking with no items reserves nothing: it holds no inventory, carries
+    // no price, and cannot be invoiced. That used to be created silently
+    // whenever the resolved option had several optional units and the caller
+    // sent no `itemLines` — the caller got a booking id back and believed the
+    // places were held. Refuse instead, before anything is written.
+    if (requestedItemLines.length === 0 && unitsToSeed.length === 0) {
+      throw new BookingItemsUnresolvedError(product.id, option?.id ?? null, selectedUnits.length)
+    }
+
     const initialStatus = data.initialStatus ?? "draft"
     const bookingPax = Object.hasOwn(data, "pax") ? (data.pax ?? null) : product.pax
     // Map the booking lifecycle status onto the booking-item lifecycle.
@@ -2527,13 +2568,6 @@ const bookingsServiceInternal = {
         })),
       )
     }
-
-    const unitsToSeed =
-      selectedUnits.filter((unit) => unit.isRequired).length > 0
-        ? selectedUnits.filter((unit) => unit.isRequired)
-        : selectedUnits.length === 1
-          ? selectedUnits
-          : []
 
     // Slot-derived columns + catalog snapshot. `availabilitySlotId`
     // and `departureLabelSnapshot` carry the departure forward so the

--- a/packages/bookings/tests/unit/booking-items-unresolved.test.ts
+++ b/packages/bookings/tests/unit/booking-items-unresolved.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { BookingItemsUnresolvedError } from "../../src/booking-create-command-domain.js"
+
+describe("BookingItemsUnresolvedError", () => {
+  it("tells the operator what to do when several units are available", () => {
+    const error = new BookingItemsUnresolvedError("prod_1", "opt_1", 4)
+
+    expect(error.message).toBe(
+      "Several units are available and none is required, so the booking would reserve nothing. Choose which units to book.",
+    )
+    expect(error).toMatchObject({ productId: "prod_1", optionId: "opt_1", candidateUnitCount: 4 })
+  })
+
+  it("explains an option that has nothing bookable on it", () => {
+    const error = new BookingItemsUnresolvedError("prod_1", null, 0)
+
+    expect(error.message).toBe(
+      "This product has no bookable units on the selected option, so the booking would reserve nothing.",
+    )
+  })
+
+  it("carries no identifiers in the message shown to operators", () => {
+    const error = new BookingItemsUnresolvedError("prod_01abc", "opt_01xyz", 3)
+
+    expect(error.message).not.toContain("prod_01abc")
+    expect(error.message).not.toContain("opt_01xyz")
+  })
+})

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -137,6 +137,10 @@ function bookingCreateCommandError(
     case "travel_credit_not_found":
     case "group_not_found":
       return new ToolError("A booking-create dependency was not found.", "NOT_FOUND", { outcome })
+    case "booking_items_unresolved":
+      // Surfaced verbatim to the operator, so it has to read as a next step
+      // rather than an internal failure.
+      return new ToolError(outcome.message, "INVALID_INPUT", { outcome })
     case "duplicate_booking":
     case "travel_credit_inactive":
     case "travel_credit_not_started":

--- a/packages/finance/src/booking-number.ts
+++ b/packages/finance/src/booking-number.ts
@@ -1,0 +1,69 @@
+/**
+ * Canonical booking-reference minting.
+ *
+ * `bookingNumber` is the immutable idempotency anchor of the durable
+ * `create_booking` command, so it has to be stable *before* the command runs —
+ * minting it inside the create would hand a retry a fresh reference and duplicate
+ * the booking. Callers therefore allocate a reference first and pass the same
+ * value on every retry.
+ *
+ * Before this module every caller invented its own reference, which is how
+ * agent-authored bookings ended up with values derived from the traveller's
+ * name. `allocateBookingNumber` is the one sanctioned source.
+ */
+import { bookings } from "@voyant-travel/bookings/schema"
+import { eq } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+/** `BK-YYMM-NNNNNN` — the shape the storefront and admin already emit. */
+export const BOOKING_NUMBER_PATTERN = /^BK-\d{4}-\d{6}$/
+
+const SEQUENCE_MAX = 999_999
+const MAX_ATTEMPTS = 25
+
+export function formatBookingNumber(now: Date, sequence: number): string {
+  const year = now.getUTCFullYear().toString().slice(-2)
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0")
+  return `BK-${year}${month}-${String(sequence).padStart(6, "0")}`
+}
+
+function randomSequence(): number {
+  const buffer = new Uint32Array(1)
+  crypto.getRandomValues(buffer)
+  return ((buffer[0] ?? 0) % SEQUENCE_MAX) + 1
+}
+
+export interface AllocateBookingNumberOptions {
+  now?: Date
+  /** Injected in tests to make the candidate stream deterministic. */
+  nextSequence?: () => number
+}
+
+/**
+ * Allocate a booking reference that is free at allocation time.
+ *
+ * `bookings.booking_number` carries a unique constraint, so a create racing
+ * another allocation still fails closed at the database rather than silently
+ * reusing a reference; the probe here keeps that from being the common path.
+ */
+export async function allocateBookingNumber(
+  db: PostgresJsDatabase,
+  options: AllocateBookingNumberOptions = {},
+): Promise<string> {
+  const now = options.now ?? new Date()
+  const nextSequence = options.nextSequence ?? randomSequence
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    const candidate = formatBookingNumber(now, nextSequence())
+    const existing = await db
+      .select({ id: bookings.id })
+      .from(bookings)
+      .where(eq(bookings.bookingNumber, candidate))
+      .limit(1)
+    if (existing.length === 0) return candidate
+  }
+
+  throw new Error(
+    `Could not allocate a free booking reference after ${MAX_ATTEMPTS} attempts. The current period's reference space is exhausted.`,
+  )
+}

--- a/packages/finance/src/mcp-runtime.ts
+++ b/packages/finance/src/mcp-runtime.ts
@@ -3,9 +3,11 @@ import {
   buildActionLedgerApprovedExecutionFields,
 } from "@voyant-travel/action-ledger"
 import { defineToolContextContribution, ToolError } from "@voyant-travel/tools"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 import { executeFinanceBookingCreateCommand } from "./booking-create-command.js"
+import { allocateBookingNumber } from "./booking-number.js"
 import {
   authorizeFinanceInvoiceIssue,
   FINANCE_INVOICE_ISSUE_ACTION_NAME,
@@ -39,6 +41,9 @@ export const voyantToolContextContribution = defineToolContextContribution({
           financeService.getFinanceAggregates(db, query),
         voidInvoice: (id: string, input: { reason?: string }) =>
           financeService.voidInvoice(db, id, input),
+        generateBookingNumber: async () => ({
+          bookingNumber: await allocateBookingNumber(db as PostgresJsDatabase),
+        }),
         createBooking: (
           input: Parameters<typeof executeFinanceBookingCreateCommand>[0]["commandInput"],
           admitted: Parameters<typeof executeFinanceBookingCreateCommand>[0]["admitted"],

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -2,7 +2,10 @@
 
 import type { CreatedTargetMutationLease } from "@voyant-travel/action-ledger"
 import { bookingGroupsService } from "@voyant-travel/bookings"
-import { settleBookingCreateDomain } from "@voyant-travel/bookings/booking-create-command-domain"
+import {
+  BookingItemsUnresolvedError,
+  settleBookingCreateDomain,
+} from "@voyant-travel/bookings/booking-create-command-domain"
 import {
   type BookingDraftMismatch,
   type PricingAssignmentUnit,
@@ -337,7 +340,17 @@ const bookingCreateBaseSchema = z.object({
   slotId: z.string().optional().nullable(),
   /** Pre-booking availability hold converted inside the create transaction. */
   availabilityHoldToken: z.string().min(1).optional(),
-  bookingNumber: z.string().min(1),
+  /**
+   * Immutable booking reference and idempotency anchor for the durable create.
+   * Allocate it with `generate_booking_number` (or `allocateBookingNumber`) and
+   * replay the same value on retries — a fresh reference mints a second booking.
+   */
+  bookingNumber: z
+    .string()
+    .min(1)
+    .describe(
+      "Booking reference allocated by `generate_booking_number`. Never invent one and never derive it from traveller or client details. Pass the same value again when retrying the same create.",
+    ),
   personId: z.string().optional().nullable(),
   organizationId: z.string().optional().nullable(),
   pax: z.number().int().positive().optional().nullable(),
@@ -453,6 +466,13 @@ export type BookingCreateOutcome =
       shortfall: number
     }
   | { status: "duplicate_booking"; existingBooking: DuplicateBookingMatch }
+  | {
+      status: "booking_items_unresolved"
+      productId: string
+      optionId: string | null
+      candidateUnitCount: number
+      message: string
+    }
   | { status: "product_not_found" }
   | { status: "travel_credit_not_found" }
   | { status: "travel_credit_inactive" }
@@ -486,6 +506,30 @@ class BookingCreateAbort extends Error {
   constructor(readonly outcome: Exclude<BookingCreateOutcome, { status: "ok" }>) {
     super(`create aborted: ${outcome.status}`)
     this.name = "BookingCreateAbort"
+  }
+}
+
+/**
+ * The domain refuses to create a booking that would hold nothing. Translate that
+ * into the create outcome union so the caller gets the actionable reason instead
+ * of an opaque throw.
+ */
+async function settleBookingCreateWithItemGuard(
+  ...args: Parameters<typeof settleBookingCreateDomain>
+): Promise<Awaited<ReturnType<typeof settleBookingCreateDomain>>> {
+  try {
+    return await settleBookingCreateDomain(...args)
+  } catch (error) {
+    if (error instanceof BookingItemsUnresolvedError) {
+      throw new BookingCreateAbort({
+        status: "booking_items_unresolved",
+        productId: error.productId,
+        optionId: error.optionId,
+        candidateUnitCount: error.candidateUnitCount,
+        message: error.message,
+      })
+    }
+    throw error
   }
 }
 
@@ -1156,7 +1200,7 @@ export async function createBookingMutation(
         throw new BookingCreateAbort(roomOccupancyIssue)
       }
       // 1. Booking from product
-      const booking = await settleBookingCreateDomain(
+      const booking = await settleBookingCreateWithItemGuard(
         lease,
         tx,
         commandIdempotencyKey,

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -60,6 +60,7 @@ export interface FinanceToolServices {
     idempotencyKey: string
     approvalId?: string
   }): Promise<unknown>
+  generateBookingNumber(): Promise<{ bookingNumber: string }>
   createBooking(
     input: z.infer<typeof bookingCreateSchema>,
     admitted: ReturnType<typeof admitHandlerActionPolicy>,
@@ -258,7 +259,37 @@ export const createBookingTool = defineTool({
   },
 })
 
-export const financeBookingsCreateTools = [createBookingTool] as const
+const generateBookingNumberArgs = z.object({})
+
+const generateBookingNumberResultSchema = z.object({
+  bookingNumber: z
+    .string()
+    .describe("The allocated booking reference. Pass it to `create_booking` unchanged."),
+})
+
+export const generateBookingNumberTool = defineTool<
+  z.infer<typeof generateBookingNumberArgs>,
+  z.infer<typeof generateBookingNumberResultSchema>,
+  FinanceToolContext
+>({
+  owner: "@voyant-travel/finance#bookings-create-extension",
+  capabilityId: "@voyant-travel/finance#bookings-create-extension.tool.generate-booking-number",
+  capabilityVersion: "v1",
+  name: "generate_booking_number",
+  description:
+    "Allocate the booking reference for a new booking. Call this before `create_booking` and pass the result through as `bookingNumber`. Never invent a reference and never build one out of the traveller's or client's details — the reference is shown to travellers and printed on invoices. Re-use the same allocated value when retrying the same create so the retry resolves the original booking instead of making a second one.",
+  inputSchema: generateBookingNumberArgs,
+  outputSchema: generateBookingNumberResultSchema,
+  requiredScopes: ["bookings:write"],
+  audience: { source: "grant", allowed: ["staff"] },
+  tier: "read",
+  riskPolicy: READ_ONLY_RISK,
+  async handler(_args, ctx) {
+    return generateBookingNumberResultSchema.parse(await finance(ctx).generateBookingNumber())
+  },
+})
+
+export const financeBookingsCreateTools = [createBookingTool, generateBookingNumberTool] as const
 
 export const issueInvoiceFromBookingToolInputSchema = z.object({
   command: invoiceFromBookingSchema.describe("The exact invoice or proforma issue command."),

--- a/packages/finance/src/voyant.ts
+++ b/packages/finance/src/voyant.ts
@@ -557,6 +557,14 @@ export const financeBookingsCreateVoyantPlugin = defineExtension({
   localId: "finance.bookings-create-extension",
   tools: [
     {
+      id: "@voyant-travel/finance#bookings-create-extension.tool.generate-booking-number",
+      name: "generate_booking_number",
+      runtime: { entry: "@voyant-travel/finance/tools", export: "generateBookingNumberTool" },
+      requiredScopes: ["bookings:write"],
+      context: ["finance"],
+      risk: "low",
+    },
+    {
       id: "@voyant-travel/finance#bookings-create-extension.tool.create-booking",
       name: "create_booking",
       runtime: { entry: "@voyant-travel/finance/tools", export: "createBookingTool" },

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -206,9 +206,37 @@ describe("finance tools", () => {
     ).toMatchObject({ status: "approval_required", approval: { id: "apr_invoice_1" } })
   })
 
+  it("allocates the booking reference through a Tool instead of leaving it to the caller", async () => {
+    const registry = createToolRegistry()
+    const tool = financeBookingsCreateTools.find(
+      (entry) => entry.name === "generate_booking_number",
+    )
+    if (!tool) throw new Error("generate_booking_number is missing")
+    registry.register(tool, {
+      capabilityId: tool.capabilityId,
+      owner: tool.owner,
+      capabilityVersion: tool.capabilityVersion,
+      name: tool.name,
+      requiredScopes: tool.requiredScopes,
+      deploymentRisk: "low",
+    })
+
+    const result = await registry.dispatch(
+      "generate_booking_number",
+      {},
+      ctx({ async generateBookingNumber() {
+        return { bookingNumber: "BK-2607-000123" }
+      } }),
+    )
+
+    expect(result).toEqual({ bookingNumber: "BK-2607-000123" })
+    // Read-tier so allocating a reference never needs an approval round-trip.
+    expect(tool.tier).toBe("read")
+  })
+
   it("creates a booking through the composing Finance extension Tool", async () => {
     const registry = createToolRegistry()
-    const [tool] = financeBookingsCreateTools
+    const tool = financeBookingsCreateTools.find((entry) => entry.name === "create_booking")
     const [action] = financeBookingsCreateVoyantPlugin.actions ?? []
     if (!tool || !action) throw new Error("Finance booking-create graph declarations are missing")
     registry.register(tool, {

--- a/packages/finance/tests/unit/booking-number.test.ts
+++ b/packages/finance/tests/unit/booking-number.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  allocateBookingNumber,
+  BOOKING_NUMBER_PATTERN,
+  formatBookingNumber,
+} from "../../src/booking-number.js"
+
+/** Minimal stand-in for the drizzle chain `allocateBookingNumber` walks. */
+function dbWithTaken(taken: string[]) {
+  const probed: string[] = []
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: (predicate: unknown) => ({
+          limit: async () => {
+            // The predicate is an opaque drizzle SQL object, so the fake reads the
+            // candidate off the call order the allocator uses.
+            const candidate = probed[probed.length - 1]
+            return candidate && taken.includes(candidate) ? [{ id: "book_existing" }] : []
+          },
+        }),
+      }),
+    }),
+  }
+  return { db, probed }
+}
+
+describe("booking reference allocation", () => {
+  it("formats the reference as BK-YYMM-NNNNNN", () => {
+    const number = formatBookingNumber(new Date("2026-07-27T00:00:00Z"), 123)
+    expect(number).toBe("BK-2607-000123")
+    expect(number).toMatch(BOOKING_NUMBER_PATTERN)
+  })
+
+  it("pads a six-digit sequence and zero-pads a single-digit month", () => {
+    expect(formatBookingNumber(new Date("2026-01-05T00:00:00Z"), 999_999)).toBe("BK-2601-999999")
+  })
+
+  it("skips a reference that is already taken", async () => {
+    const { db, probed } = dbWithTaken(["BK-2607-000001"])
+    const sequences = [1, 2]
+    let index = 0
+
+    const allocated = await allocateBookingNumber(db as never, {
+      now: new Date("2026-07-27T00:00:00Z"),
+      nextSequence: () => {
+        const sequence = sequences[index++] ?? 99
+        probed.push(formatBookingNumber(new Date("2026-07-27T00:00:00Z"), sequence))
+        return sequence
+      },
+    })
+
+    expect(allocated).toBe("BK-2607-000002")
+  })
+
+  it("fails loudly rather than reusing a reference when the space is exhausted", async () => {
+    const { db, probed } = dbWithTaken(["BK-2607-000007"])
+
+    await expect(
+      allocateBookingNumber(db as never, {
+        now: new Date("2026-07-27T00:00:00Z"),
+        nextSequence: () => {
+          probed.push("BK-2607-000007")
+          return 7
+        },
+      }),
+    ).rejects.toThrow(/Could not allocate a free booking reference/)
+  })
+})

--- a/packages/finance/tests/unit/voyant-manifest.test.ts
+++ b/packages/finance/tests/unit/voyant-manifest.test.ts
@@ -515,6 +515,11 @@ describe("finance deployment manifest", () => {
         id: "@voyant-travel/finance#bookings-create-extension",
         tools: [
           expect.objectContaining({
+            id: "@voyant-travel/finance#bookings-create-extension.tool.generate-booking-number",
+            name: "generate_booking_number",
+            requiredScopes: ["bookings:write"],
+          }),
+          expect.objectContaining({
             id: "@voyant-travel/finance#bookings-create-extension.tool.create-booking",
             name: "create_booking",
             requiredScopes: ["bookings:write", "finance:write"],


### PR DESCRIPTION
Found stress-testing Max on the sandbox with an ordinary operator request: *"A client called and wants to book 2 places on the Coastal Day Cruise for 27 July."*

Max replied **"Done — the booking was created."** The booking held nothing.

## 1. `create_booking` succeeded while reserving nothing

`convertProductToBooking` seeds line items only when the resolved option has a required unit, or exactly one unit:

```ts
const unitsToSeed =
  selectedUnits.filter((u) => u.isRequired).length > 0 ? …
  : selectedUnits.length === 1 ? selectedUnits
  : []            // several optional units → nothing seeded
```

With several optional units and no `itemLines`, the booking row was inserted and no items were. Result: **no items, no Total, no Paid, no Cost**, not attached to the departure, no seats held — and a booking id handed back as success. An operator would tell the client their places were secured.

The create now fails closed **before any write** and returns the choice that is missing ("Several units are available and none is required… Choose which units to book."). The message is surfaced verbatim, so it has to read as a next step rather than an internal failure.

## 2. Booking references were invented by the caller

`bookingNumber` is the immutable idempotency anchor of the durable create — *"Exact retries resolve the original immutable booking reference."* It therefore has to be stable **before** the command runs, so minting it inside the create is not an option: a retry would mint a new reference and duplicate the booking. That left every caller inventing one, and the framework shipped no server-side minter at all — the only generator was client-side in the admin form.

Agent-authored bookings came out as `MANUAL-MARIA-SILVA-20260727` — the client's name inside a reference that is printed on invoices and travels in URLs — against `BK-2607-625220` everywhere else.

`generate_booking_number` now allocates the canonical `BK-YYMM-NNNNNN` reference server-side and probes that it is free (`bookings.booking_number` is unique, so a race still fails closed at the database). `bookingNumber` documents that it must come from that tool, must never be derived from client details, and must be replayed unchanged on retries.

## Test plan

- [x] `pnpm --filter @voyant-travel/bookings test` — 472 passed
- [x] `pnpm --filter @voyant-travel/finance test` — 453 passed
- [x] New: reference format/collision/exhaustion, and the unresolved-items message carries no ids
- [ ] `db-integration` (CI) covers the create path against a real database
- [ ] Release, pin operator-runtime, roll sandbox, re-run the Coastal Day Cruise request