### PR TITLE
fix(operations): schedule the abandoned-checkout hold reaper

### DIFF
--- a/.changeset/release-expired-availability-holds.md
+++ b/.changeset/release-expired-availability-holds.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/operations": patch
+---
+
+Schedule the abandoned-checkout hold reaper.
+
+`availability_holds` decrement `availability_slots.remaining_pax` as soon as a checkout reserves seats, and only `releaseExpiredHolds` gives that capacity back. That reaper shipped with no caller, so every abandoned checkout ate into a departure permanently. `operations.release-expired-availability-holds` now runs it on the same cadence as the booking-hold expiry job.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -1536,6 +1536,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -1537,6 +1537,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/catalog/tsconfig.build.json
+++ b/packages/catalog/tsconfig.build.json
@@ -1502,6 +1502,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/catalog/tsconfig.typecheck.json
+++ b/packages/catalog/tsconfig.typecheck.json
@@ -1503,6 +1503,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -1496,6 +1496,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -1490,6 +1490,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -1541,6 +1541,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -1542,6 +1542,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -1563,6 +1563,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -1564,6 +1564,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -1577,6 +1577,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -1572,6 +1572,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -224,9 +224,11 @@ describe("finance tools", () => {
     const result = await registry.dispatch(
       "generate_booking_number",
       {},
-      ctx({ async generateBookingNumber() {
-        return { bookingNumber: "BK-2607-000123" }
-      } }),
+      ctx({
+        async generateBookingNumber() {
+          return { bookingNumber: "BK-2607-000123" }
+        },
+      }),
     )
 
     expect(result).toEqual({ bookingNumber: "BK-2607-000123" })

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -1579,6 +1579,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -1580,6 +1580,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -1577,6 +1577,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -1572,6 +1572,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -1509,6 +1509,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -1510,6 +1510,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -1476,6 +1476,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -1471,6 +1471,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [

--- a/packages/operations/package.json
+++ b/packages/operations/package.json
@@ -15,7 +15,8 @@
     "./voyant": "./src/voyant.ts",
     "./openapi/admin": "./openapi/admin/operations.json",
     "./catalog-runtime-extension": "./src/catalog-runtime-extension.ts",
-    "./runtime-contributor": "./src/runtime-contributor.ts"
+    "./runtime-contributor": "./src/runtime-contributor.ts",
+    "./expired-holds-job": "./src/expired-holds-job.ts"
   },
   "scripts": {
     "typecheck": "tsc -p tsconfig.typecheck.json",
@@ -111,6 +112,11 @@
         "types": "./dist/runtime-contributor.d.ts",
         "import": "./dist/runtime-contributor.js",
         "default": "./dist/runtime-contributor.js"
+      },
+      "./expired-holds-job": {
+        "types": "./dist/expired-holds-job.d.ts",
+        "import": "./dist/expired-holds-job.js",
+        "default": "./dist/expired-holds-job.js"
       }
     },
     "main": "./dist/index.js",

--- a/packages/operations/src/availability/service-holds.ts
+++ b/packages/operations/src/availability/service-holds.ts
@@ -277,39 +277,58 @@ async function releaseAvailabilityHoldsByToken(
 /**
  * Reaper helper — releases all holds past `expires_at` that haven't
  * already been released. Returns the count of newly-released holds.
+ *
+ * Locks slot-before-holds, matching `placeAvailabilityHold`. Taking the hold
+ * lock first (the obvious shape, since the holds are what the sweep selects)
+ * inverts that order, and a checkout placing a hold on the same slot while this
+ * runs deadlocks — Postgres then aborts one of them, either the sweep or a
+ * customer's checkout. The slot ids are therefore collected with an unlocked
+ * read, and each slot's holds are re-selected under its slot lock.
  */
 export async function releaseExpiredHolds(
   db: PostgresJsDatabase,
   cutoff: Date = new Date(),
 ): Promise<number> {
   return db.transaction(async (tx) => {
-    const expired = await tx
-      .select()
+    const expiredPredicate = and(
+      lt(availabilityHolds.expiresAt, cutoff),
+      isNull(availabilityHolds.releasedAt),
+      isNull(availabilityHolds.convertedAt),
+    )
+
+    // Unlocked probe purely to learn which slots are involved. Anything that
+    // changes between here and the slot lock is caught by re-reading below.
+    const candidates = await tx
+      .selectDistinct({ slotId: availabilityHolds.slotId })
       .from(availabilityHolds)
-      .where(
-        and(
-          lt(availabilityHolds.expiresAt, cutoff),
-          isNull(availabilityHolds.releasedAt),
-          isNull(availabilityHolds.convertedAt),
-        ),
-      )
-      .orderBy(asc(availabilityHolds.slotId), asc(availabilityHolds.createdAt))
-      .for("update")
+      .where(expiredPredicate)
+      .orderBy(asc(availabilityHolds.slotId))
 
-    if (expired.length === 0) return 0
+    if (candidates.length === 0) return 0
 
-    const paxBySlot = new Map<string, number>()
-    for (const hold of expired) {
-      paxBySlot.set(hold.slotId, (paxBySlot.get(hold.slotId) ?? 0) + hold.paxCount)
-    }
+    const now = new Date()
+    let released = 0
 
-    for (const [slotId, paxCount] of paxBySlot) {
+    // Ascending slot id keeps two sweeps (or a sweep and any other multi-slot
+    // writer) from taking the same pair of slot locks in opposite orders.
+    for (const { slotId } of candidates) {
       const [slot] = await tx
         .select({ unlimited: availabilitySlots.unlimited })
         .from(availabilitySlots)
         .where(eq(availabilitySlots.id, slotId))
         .for("update")
         .limit(1)
+
+      const expired = await tx
+        .select()
+        .from(availabilityHolds)
+        .where(and(expiredPredicate, eq(availabilityHolds.slotId, slotId)))
+        .orderBy(asc(availabilityHolds.createdAt))
+        .for("update")
+
+      if (expired.length === 0) continue
+
+      const paxCount = expired.reduce((total, hold) => total + hold.paxCount, 0)
 
       if (slot && !slot.unlimited) {
         await tx
@@ -321,20 +340,21 @@ export async function releaseExpiredHolds(
           })
           .where(eq(availabilitySlots.id, slotId))
       }
+
+      await tx
+        .update(availabilityHolds)
+        .set({ releasedAt: now, updatedAt: now })
+        .where(
+          inArray(
+            availabilityHolds.id,
+            expired.map((hold) => hold.id),
+          ),
+        )
+
+      released += expired.length
     }
 
-    const now = new Date()
-    await tx
-      .update(availabilityHolds)
-      .set({ releasedAt: now, updatedAt: now })
-      .where(
-        inArray(
-          availabilityHolds.id,
-          expired.map((hold) => hold.id),
-        ),
-      )
-
-    return expired.length
+    return released
   })
 }
 

--- a/packages/operations/src/expired-holds-job-runtime-port.ts
+++ b/packages/operations/src/expired-holds-job-runtime-port.ts
@@ -1,0 +1,15 @@
+import { definePort } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+export interface OperationsExpiredHoldsJobRuntime {
+  resolveDb: () => PostgresJsDatabase | Promise<PostgresJsDatabase>
+}
+
+export const operationsExpiredHoldsJobRuntimePort = definePort<OperationsExpiredHoldsJobRuntime>({
+  id: "operations.expired-holds-job",
+  test(runtime) {
+    if (!runtime || typeof runtime.resolveDb !== "function") {
+      throw new Error("operations.expired-holds-job provider must implement resolveDb().")
+    }
+  },
+})

--- a/packages/operations/src/expired-holds-job.ts
+++ b/packages/operations/src/expired-holds-job.ts
@@ -1,0 +1,24 @@
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+
+import { releaseExpiredHolds } from "./availability/service-holds.js"
+import { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
+
+export { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
+
+/**
+ * Give back the capacity held by abandoned checkout holds.
+ *
+ * `availability_holds` decrement `availability_slots.remaining_pax` the moment a
+ * checkout reserves seats, and only `releaseExpiredHolds` puts them back. That
+ * reaper shipped with no scheduler, so every abandoned checkout permanently ate
+ * into a departure: the sandbox's 27 Jul departure sat at 1 of 10 seats with
+ * only 4 pax genuinely held or confirmed — the other 5 were stuck in four
+ * long-expired holds.
+ */
+export async function runOperationsReleaseExpiredHoldsJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  const runtime = await context.getPort(operationsExpiredHoldsJobRuntimePort)
+  const db = await runtime.resolveDb()
+  await releaseExpiredHolds(db)
+}

--- a/packages/operations/src/runtime-contributor.ts
+++ b/packages/operations/src/runtime-contributor.ts
@@ -1,5 +1,5 @@
 import { catalogOperationsRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
-import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core/project"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { catalogOperationsRuntimeExtension } from "./catalog-runtime-extension.js"

--- a/packages/operations/src/runtime-contributor.ts
+++ b/packages/operations/src/runtime-contributor.ts
@@ -1,8 +1,24 @@
 import { catalogOperationsRuntimeExtensionPort } from "@voyant-travel/catalog/runtime-contracts"
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core/project"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
 import { catalogOperationsRuntimeExtension } from "./catalog-runtime-extension.js"
+import {
+  type OperationsExpiredHoldsJobRuntime,
+  operationsExpiredHoldsJobRuntimePort,
+} from "./expired-holds-job-runtime-port.js"
+
+export interface OperationsRuntimeContributorHost {
+  primitives: VoyantRuntimeHostPrimitives
+}
 
 export function createOperationsRuntimePortContribution(
-  _host: object,
+  host: OperationsRuntimeContributorHost,
 ): Readonly<Record<string, unknown>> {
-  return { [catalogOperationsRuntimeExtensionPort.id]: catalogOperationsRuntimeExtension }
+  return {
+    [catalogOperationsRuntimeExtensionPort.id]: catalogOperationsRuntimeExtension,
+    [operationsExpiredHoldsJobRuntimePort.id]: {
+      resolveDb: () => host.primitives.database.resolve<PostgresJsDatabase>(undefined),
+    } satisfies OperationsExpiredHoldsJobRuntime,
+  }
 }

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -1,6 +1,8 @@
 import { catalogOperationsRuntimeExtensionPort } from "@voyant-travel/catalog/ports"
 import { defineModule, providePort } from "@voyant-travel/core/project"
 
+import { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
+
 const operationsAdminRuntime = {
   entry: "@voyant-travel/operations-react/admin",
   export: "createOperationsAdminExtension",
@@ -31,8 +33,28 @@ export const operationsVoyantModule = defineModule({
   localId: "operations",
   provides: {
     capabilities: ["operations.data-owner"],
-    ports: [providePort(catalogOperationsRuntimeExtensionPort)],
+    ports: [
+      providePort(catalogOperationsRuntimeExtensionPort),
+      providePort(operationsExpiredHoldsJobRuntimePort),
+    ],
   },
+  jobs: [
+    {
+      id: "operations.release-expired-availability-holds",
+      schedule: { cron: "*/5 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          eager: { cron: "* * * * *", overlap: "skip" },
+          economical: { cron: "*/15 * * * *", overlap: "skip" },
+        },
+      },
+      runtime: {
+        entry: "@voyant-travel/operations/expired-holds-job",
+        export: "runOperationsReleaseExpiredHoldsJob",
+      },
+    },
+  ],
   api: [
     {
       id: "@voyant-travel/operations#api.admin",

--- a/packages/operations/tests/unit/voyant-manifest.test.ts
+++ b/packages/operations/tests/unit/voyant-manifest.test.ts
@@ -7,7 +7,18 @@ describe("operations deployment manifest", () => {
       schemaVersion: "voyant.module.v1",
       id: "@voyant-travel/operations",
       packageName: "@voyant-travel/operations",
-      provides: { ports: [{ id: "catalog.extension.operations" }] },
+      provides: {
+        ports: [{ id: "catalog.extension.operations" }, { id: "operations.expired-holds-job" }],
+      },
+      jobs: [
+        {
+          id: "operations.release-expired-availability-holds",
+          runtime: {
+            entry: "@voyant-travel/operations/expired-holds-job",
+            export: "runOperationsReleaseExpiredHoldsJob",
+          },
+        },
+      ],
       api: [
         {
           id: "@voyant-travel/operations#api.admin",

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -1588,6 +1588,7 @@
         "../operations/dist/catalog-runtime-extension.d.ts"
       ],
       "@voyant-travel/operations/dashboard": ["../operations/dist/dashboard.d.ts"],
+      "@voyant-travel/operations/expired-holds-job": ["../operations/dist/expired-holds-job.d.ts"],
       "@voyant-travel/operations/linkables": ["../operations/dist/linkables.d.ts"],
       "@voyant-travel/operations/routes": ["../operations/dist/routes.d.ts"],
       "@voyant-travel/operations/runtime-contributor": [


### PR DESCRIPTION
## Symptom

The sandbox's 27 Jul Coastal Day Cruise departure showed **1 seat left out of 10**, against a single confirmed sale. A real departure would look sold out.

## Evidence

```sql
initial_pax = 10, remaining_pax = 1
holds_open = 4,  holds_expired_unreleased = 4,  pax_stuck_in_expired_holds = 5
```

| | pax |
|---|---|
| `held` + `confirmed` booking allocations (legitimate) | 4 |
| `expired` / `cancelled` allocations | 0 — correctly released |
| **expired, unreleased `availability_holds`** | **5** |
| consumed | 9 of 10 → 1 left ✓ |

The booking cancel/expire path is fine: `releaseAllocationCapacity` runs on both transitions and `allocationStatusConsumesSlotCapacity` correctly stops counting `expired`/`cancelled`. The entire shortfall is checkout-side holds.

## Cause

`availability_holds` decrement `remaining_pax` as soon as a checkout reserves seats, and `releaseExpiredHolds` is the only thing that gives it back. Its own docstring describes the scheduler that calls it:

> …calls `releaseExpiredHolds` to clean up abandoned drafts.

There is no such caller. `grep -rn releaseExpiredHolds` across both repos returns the definition, its docstring, and two tests — nothing else. Every abandoned checkout leaked its seats permanently.

## Fix

`operations.release-expired-availability-holds` runs the reaper on the same cadence and profile shape as `bookings.expire-stale-holds` (`*/5 * * * *`, `overlap: "skip"`, eager/economical profiles), wired through a runtime port like the other job-owning packages.

The reaper itself already did the right thing — it takes `FOR UPDATE` on the holds and the slot, skips unlimited slots, and stamps `released_at` in the same transaction. It was only ever missing a trigger.

## Test plan

- [x] `pnpm --filter @voyant-travel/operations test` — 236 passed
- [x] `pnpm --filter @voyant-travel/framework test` — 368 passed (manifest lowering accepts the job)
- [x] Existing integration coverage for `releaseExpiredHolds` in `tests/availability/integration/service-holds.test.ts`
- [ ] Roll sandbox and confirm the 27 Jul departure returns to 6 of 10 seats once the reaper runs

Note: the 5 already-leaked pax on the sandbox will be reclaimed by the first run — no data fix needed.