### PR TITLE
fix(operations): require the expired-hold job's runtime port

### DIFF
--- a/.changeset/operations-expired-holds-port-requirement.md
+++ b/.changeset/operations-expired-holds-port-requirement.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operations": patch
+---
+
+Declare the expired-hold job's runtime port as a requirement, not only as something provided. Composition accepted the provide-only declaration and then rejected the port when the job actually fired, so the reaper failed on every run with `composeVoyantGraphRuntime: module "@voyant-travel/operations" requested undeclared port "operations.expired-holds-job"`.

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -1,5 +1,5 @@
 import { catalogOperationsRuntimeExtensionPort } from "@voyant-travel/catalog/ports"
-import { defineModule, providePort } from "@voyant-travel/core/project"
+import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
 
 import { operationsExpiredHoldsJobRuntimePort } from "./expired-holds-job-runtime-port.js"
 
@@ -38,6 +38,12 @@ export const operationsVoyantModule = defineModule({
       providePort(operationsExpiredHoldsJobRuntimePort),
     ],
   },
+  // The reaper resolves this port at run time, so the module has to declare it
+  // as a requirement as well as provide it. Providing alone composes fine and
+  // then fails only when the job actually fires:
+  // `composeVoyantGraphRuntime: module "@voyant-travel/operations" requested
+  // undeclared port "operations.expired-holds-job"`.
+  runtimePorts: [requirePort(operationsExpiredHoldsJobRuntimePort)],
   jobs: [
     {
       id: "operations.release-expired-availability-holds",

--- a/packages/operations/tests/unit/voyant-manifest.test.ts
+++ b/packages/operations/tests/unit/voyant-manifest.test.ts
@@ -10,6 +10,9 @@ describe("operations deployment manifest", () => {
       provides: {
         ports: [{ id: "catalog.extension.operations" }, { id: "operations.expired-holds-job" }],
       },
+      // Required as well as provided — the job resolves the port at run time and
+      // composition rejects an undeclared request.
+      runtimePorts: [{ id: "operations.expired-holds-job" }],
       jobs: [
         {
           id: "operations.release-expired-availability-holds",


### PR DESCRIPTION
Follow-up to #3798, caught on the sandbox at 00:40 UTC — the reaper's first scheduled tick after the release registered it.

## What happened

The job ran and failed, every time:

```
composeVoyantGraphRuntime: module "@voyant-travel/operations"
requested undeclared port "operations.expired-holds-job".
```

I declared the port as **provided** but never as **required**:

```ts
provides: { ports: [providePort(operationsExpiredHoldsJobRuntimePort)] }
// …and nothing else
```

Bookings declares its equivalent job port in *both* places — `runtimePorts: [requirePort(bookingsStaleHoldsJobRuntimePort)]` and `provides.ports: [providePort(…)]`. Operations now matches.

## Why nothing caught it

The manifest composes, the package builds, the tests pass and CI is green — because a provide-only declaration is valid right up until something calls `context.getPort(...)`. The failure exists only at job-execution time, on a schedule, inside a deployed runtime. The manifest test now asserts the requirement is declared so the shape can't regress.

## Test plan

- [x] `pnpm --filter @voyant-travel/operations test` — 236 passed
- [x] `tsc --noEmit -p packages/operations/tsconfig.typecheck.json` — clean
- [x] `biome check` — clean
- [ ] Release, bump the runtime pin, redeploy the sandbox, and confirm `last_success_at` on `operations.release-expired-availability-holds` stops being null
- [ ] Confirm the 27 Jul departure recovers from 1/10 to ~6/10 seats

Related: #3798 (the job), platform#1434 (the pin).