### PR TITLE
Stop spending room unit counts against passenger capacity

### DIFF
--- a/.changeset/booking-room-unit-pax-capacity.md
+++ b/.changeset/booking-room-unit-pax-capacity.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/bookings": patch
+---
+
+Stop spending room and vehicle unit counts against passenger capacity. `availability_slots.remaining_pax` is passenger-denominated, but the auto-seeded slot allocation passed the line quantity straight through — a count of units for anything that is not a person-typed unit. A 2-traveller booking on a "Double" room with `minQuantity` 3 took 3 seats off the departure. The seeded allocation is now passenger-denominated, matching what the hold-conversion path already did.

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -2702,6 +2702,24 @@ const bookingsServiceInternal = {
             ]
 
     const insertedItems = await db.insert(bookingItems).values(itemRows).returning()
+    // `availability_slots.remaining_pax` is passenger-denominated, and a slot
+    // allocation's quantity is what gets subtracted from it. For a person-typed
+    // unit the line quantity already *is* the traveller count, but for a room or
+    // vehicle it is a count of units, so passing it through spent the wrong
+    // currency: a 2-traveller booking on a "Double" room whose `minQuantity` is 3
+    // took 3 seats off the departure. The hold-conversion branch below has always
+    // used `paxCount` for exactly this reason.
+    //
+    // Only the auto-seeded single line is corrected here. When the caller supplied
+    // explicit `itemLines` it chose the units and quantities deliberately, and
+    // second-guessing that would change committed booking behaviour.
+    const seededSingleUnit =
+      requestedItemLines.length === 0 && unitsToSeed.length === 1 ? unitsToSeed[0] : null
+    const slotAllocationQuantity = (item: (typeof insertedItems)[number]): number => {
+      if (!seededSingleUnit || seededSingleUnit.unitType === "person") return item.quantity
+      if (!bookingPax || bookingPax <= 0) return item.quantity
+      return bookingPax
+    }
     const allocationRows = insertedItems
       .filter((item) => item.availabilitySlotId)
       .map((item) => ({
@@ -2712,7 +2730,7 @@ const bookingsServiceInternal = {
         optionUnitId: item.optionUnitId ?? null,
         pricingCategoryId: item.pricingCategoryId ?? null,
         availabilitySlotId: item.availabilitySlotId,
-        quantity: item.quantity,
+        quantity: slotAllocationQuantity(item),
         allocationType: "unit" as const,
         status: allocationStatusForBookingItemStatus(item.status),
         holdExpiresAt: null,


### PR DESCRIPTION
## Problem

Found while stress-testing Max on a managed sandbox. Booking a room-type product for **2 travellers** decremented the slot's remaining capacity by **3**, matching the requested *unit* count rather than the passenger count.

When a booking seeds a single unit line (no explicit item lines from the caller), `service-core` allocated `item.quantity` against the slot. For a `person` unit that is correct — quantity *is* pax. For a `room`/`unit` type it is not: three rooms for two travellers spends three seats of passenger capacity, and the slot sells out early.

## Change

In `packages/bookings/src/service-core.ts`, when exactly one unit was seeded and that unit is **not** a `person` type, allocate the booking's passenger count instead of the unit quantity. Explicit caller-supplied item lines and multi-unit bookings keep their existing behaviour untouched, and the fallback stays `item.quantity` whenever pax is absent or non-positive.

## Verification

`packages/bookings` — 472 tests pass. `tsc --noEmit` clean.