### PR TITLE
Let a managed deployment index its Connect catalog

### DIFF
--- a/.changeset/catalog-discovery-sync-entry.md
+++ b/.changeset/catalog-discovery-sync-entry.md
@@ -1,0 +1,27 @@
+---
+"@voyant-travel/catalog": minor
+---
+
+Expose a deployment-callable catalog discovery sync so sourced inventory reaches
+catalog browse.
+
+`syncSources()` needed the composed catalog `services` — the resolved indexer
+provider, field-policy registries, slice set, embedding provider, and a warmed
+source registry. That composition lives inside the framework runtime host, so a
+managed deployment could resolve Connect connections for live booking but had no
+supported way to index their catalog. Connectors showed 0 results in admin
+browse.
+
+- New `@voyant-travel/catalog/sources-sync-job` entry: `runCatalogDiscoverySync(
+  { env, db, services }, options)` composes the indexer stack the same way the
+  projection/reindex path does and runs one discovery pass.
+- New `catalog.sync-sources` job — scheduled hourly (with eager/economical
+  profiles) and `wakeup: true`, so adding a connection can trigger an immediate
+  pass.
+- New `catalog.sources-sync-job` runtime port, provided by the catalog runtime
+  contributor; deployments never assemble `services` by hand.
+
+Discovered projections land in every slice the deployment materializes, which
+always includes the `market: "default"` / `locale: "en-GB"` staff and customer
+slices the admin browse queries. Withdrawal pruning is opt-in (`pruneMissing`)
+so a partial pass can never empty the browse index.

--- a/.changeset/catalog-discovery-sync-entry.md
+++ b/.changeset/catalog-discovery-sync-entry.md
@@ -25,3 +25,24 @@ Discovered projections land in every slice the deployment materializes, which
 always includes the `market: "default"` / `locale: "en-GB"` staff and customer
 slices the admin browse queries. Withdrawal pruning is opt-in (`pruneMissing`)
 so a partial pass can never empty the browse index.
+
+`syncSources` gains two related fixes, both reached through the new entry:
+
+- It no longer discovers through an unscoped `default:<kind>` registration when
+  the same kind also has connection-scoped adapters. Adapters forward that
+  synthetic key upstream as a real connection id, and it lands in provenance as
+  `source_connection_id` on projections missing one — which then fails to
+  resolve on the live-book path. Reported as `summary.skippedConnections`.
+- New `continueOnError` option isolates a per-connection `discover()` rejection
+  (recorded in `summary.failures`) instead of aborting the fan-out, so one
+  unhealthy supplier cannot starve every other catalog. Off by default, so the
+  cruise refresh and CLI callers keep surfacing the first failure.
+
+`SyncAdapterSummary` gains `connectionId` and an optional `error`;
+`SyncSourcesSummary` gains `skippedConnections` and `failures`.
+
+The scheduled job re-enumerates connections via a new
+`refreshBookingEngineConnectSources` rather than reusing the memoized
+per-isolate warm — otherwise a resident Node deployment would keep syncing the
+connection set it saw first, and the connection-add wakeup would do nothing
+until restart.

--- a/packages/accommodations/tsconfig.build.json
+++ b/packages/accommodations/tsconfig.build.json
@@ -468,6 +468,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/accommodations/tsconfig.typecheck.json
+++ b/packages/accommodations/tsconfig.typecheck.json
@@ -469,6 +469,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/catalog/package.json
+++ b/packages/catalog/package.json
@@ -56,6 +56,7 @@
     "./runtime-port": "./src/content-runtime-port.ts",
     "./draft-reaper-job": "./src/draft-reaper-job.ts",
     "./reindex-job": "./src/reindex-job.ts",
+    "./sources-sync-job": "./src/sources-sync-job.ts",
     "./graph-runtime": "./src/graph-runtime.ts",
     "./runtime-contributor": "./src/runtime-contributor.ts",
     "./voyant": "./src/voyant.ts",
@@ -367,6 +368,11 @@
         "types": "./dist/reindex-job.d.ts",
         "import": "./dist/reindex-job.js",
         "default": "./dist/reindex-job.js"
+      },
+      "./sources-sync-job": {
+        "types": "./dist/sources-sync-job.d.ts",
+        "import": "./dist/sources-sync-job.js",
+        "default": "./dist/sources-sync-job.js"
       },
       "./graph-runtime": {
         "types": "./dist/graph-runtime.d.ts",

--- a/packages/catalog/src/booking-engine/sync.ts
+++ b/packages/catalog/src/booking-engine/sync.ts
@@ -94,6 +94,16 @@ export interface SyncSourcesOptions {
    * from catalog search slices. Failed adapter passes never prune.
    */
   pruneMissing?: boolean
+  /**
+   * Isolate per-connection failures: a `discover()` rejection is recorded on
+   * that connection's summary and the fan-out continues with the remaining
+   * connections, instead of aborting the whole pass. A failed connection
+   * never prunes, so its existing rows survive untouched.
+   *
+   * Off by default — one-shot callers that want the first failure to surface
+   * (the cruise refresh, a CLI) keep the throwing behaviour.
+   */
+  continueOnError?: boolean
 }
 
 export interface SyncProgressEvent {
@@ -105,6 +115,8 @@ export interface SyncProgressEvent {
 
 export interface SyncAdapterSummary {
   adapter: string
+  /** Registry key this pass ran under — a real connection id, or `default:<kind>`. */
+  connectionId: string
   pages: number
   projectionsSynced: number
   /**
@@ -136,11 +148,25 @@ export interface SyncAdapterSummary {
    * discovery pass, marked withdrawn and removed from search slices.
    */
   withdrawnProjections: number
+  /**
+   * Set when `continueOnError` isolated a `discover()` rejection for this
+   * connection. Partial results already written stay written; pruning is
+   * skipped so a failed pass never withdraws rows.
+   */
+  error?: string
 }
 
 export interface SyncSourcesSummary {
   adapters: SyncAdapterSummary[]
   totalProjections: number
+  /**
+   * Connections skipped before running. Currently the unscoped `default:<kind>`
+   * fallback for a kind that also has connection-scoped registrations — see
+   * `syncSources` for why discovering through it is never correct.
+   */
+  skippedConnections: Array<{ connectionId: string; adapter: string; reason: string }>
+  /** Connections whose pass failed under `continueOnError`. */
+  failures: Array<{ connectionId: string; adapter: string; error: string }>
 }
 
 /**
@@ -154,7 +180,7 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
   // connections of the same kind each get their own discovery pass.
   // Skip adapters that don't implement `discover` (outbound-only
   // channel-push adapters).
-  const entries = options.registry
+  const candidates = options.registry
     .connections()
     .map((connectionId) => ({
       connectionId,
@@ -166,6 +192,33 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
         !verticalFilter ||
         e.adapter.capabilities.verticals.some((vertical) => verticalFilter.has(vertical)),
     )
+  const skippedConnections: SyncSourcesSummary["skippedConnections"] = []
+  const failures: SyncSourcesSummary["failures"] = []
+  const entries = candidates.filter((entry) => {
+    if (!isUnscopedRegistration(entry.connectionId, entry.adapter.kind)) return true
+    // A kind registered both unscoped and per-connection (the Voyant Connect
+    // cold-window fallback plus its warmed connections) would otherwise run a
+    // pass keyed by the synthetic `default:<kind>` id. Adapters forward that id
+    // upstream as a real connection id, and it lands in provenance as
+    // `source_connection_id` on any projection missing one — which then fails
+    // to resolve on the live-book path. The scoped registrations cover the same
+    // upstream, so the fallback pass is dropped.
+    if (
+      !candidates.some(
+        (other) =>
+          !isUnscopedRegistration(other.connectionId, other.adapter.kind) &&
+          other.adapter.kind === entry.adapter.kind,
+      )
+    ) {
+      return true
+    }
+    skippedConnections.push({
+      connectionId: entry.connectionId,
+      adapter: entry.adapter.kind,
+      reason: "unscoped-fallback-superseded-by-connection-scoped-adapter",
+    })
+    return false
+  })
   const adapterSummaries: SyncAdapterSummary[] = []
   let totalProjections = 0
 
@@ -175,6 +228,7 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
     }
     const summary: SyncAdapterSummary = {
       adapter: adapter.kind,
+      connectionId,
       pages: 0,
       projectionsSynced: 0,
       verticalsTouched: [],
@@ -186,93 +240,110 @@ export async function syncSources(options: SyncSourcesOptions): Promise<SyncSour
     const verticals = new Set<string>()
     const seenBySource = new Map<string, SourcedSeenSet>()
 
-    let cursor: string | undefined
-    do {
-      // `discover` is optional in the contract; the filter above
-      // ensures we only iterate adapters that implement it.
-      const page = await adapter.discover?.(adapterCtx, cursor)
-      if (!page) break
-      summary.pages += 1
-      options.onProgress?.({
-        adapter: adapter.kind,
-        page: summary.pages,
-        pageSize: page.projections.length,
-        totalSoFar: summary.projectionsSynced + page.projections.length,
-      })
-
-      for (const projection of page.projections) {
-        if (verticalFilter && !verticalFilter.has(projection.entity_module)) {
-          continue
-        }
-        const registry = options.fieldPolicyRegistries.get(projection.entity_module)
-        if (!registry) {
-          summary.skippedNoRegistry += 1
-          continue
-        }
-
-        verticals.add(projection.entity_module)
-
-        // Durable sourced-entry capture (sourced-content §2.5.2).
-        // Owned projections skip — they live in the vertical's owned
-        // schema. Sourced projections upsert before the indexer write so
-        // the sourced-entry store is the canonical local copy of what
-        // discover() said for downstream synthesizer reads.
-        if (isOwned(projection.provenance)) {
-          summary.ownedProjections += 1
-        } else if (options.db) {
-          await upsertSourcedEntry(options.db, { projection })
-          summary.sourcedEntriesUpserted += 1
-          if (options.pruneMissing) {
-            trackSeenSourcedProjection(seenBySource, {
-              entityModule: projection.entity_module,
-              entityId: projection.entity_id,
-              sourceKind: projection.provenance.source_kind,
-              sourceConnectionId: projection.provenance.source_connection_id,
-            })
-          }
-        }
-
-        const projectionMap = toProjectionMap(projection.fields)
-        const baseBuilder: DocumentBuilder = async (
-          _entityId: string,
-          slice: IndexerSlice,
-        ): Promise<IndexerDocument | null> =>
-          buildIndexerDocument(registry, projectionMap, slice, projection.entity_id)
-        const builder = options.wrapBuilder ? options.wrapBuilder(baseBuilder) : baseBuilder
-
-        await options.indexerService.reindexEntity(
-          projection.entity_module,
-          projection.entity_id,
-          builder,
-        )
-        summary.projectionsSynced += 1
-        totalProjections += 1
-      }
-
-      cursor = page.next_cursor
-    } while (cursor)
-
-    if (options.pruneMissing && options.db) {
-      ensureAdapterVerticalPruneScopes(seenBySource, adapter, connectionId, verticalFilter)
-      for (const seen of seenBySource.values()) {
-        const withdrawn = await markMissingSourcedEntriesWithdrawn(options.db, {
-          entityModule: seen.entityModule,
-          sourceKind: seen.sourceKind,
-          sourceConnectionId: seen.sourceConnectionId,
-          seenEntityIds: seen.entityIds,
+    try {
+      let cursor: string | undefined
+      do {
+        // `discover` is optional in the contract; the filter above
+        // ensures we only iterate adapters that implement it.
+        const page = await adapter.discover?.(adapterCtx, cursor)
+        if (!page) break
+        summary.pages += 1
+        options.onProgress?.({
+          adapter: adapter.kind,
+          page: summary.pages,
+          pageSize: page.projections.length,
+          totalSoFar: summary.projectionsSynced + page.projections.length,
         })
-        for (const row of withdrawn) {
-          await options.indexerService.deleteEntity(row.entity_module, row.entity_id)
+
+        for (const projection of page.projections) {
+          if (verticalFilter && !verticalFilter.has(projection.entity_module)) {
+            continue
+          }
+          const registry = options.fieldPolicyRegistries.get(projection.entity_module)
+          if (!registry) {
+            summary.skippedNoRegistry += 1
+            continue
+          }
+
+          verticals.add(projection.entity_module)
+
+          // Durable sourced-entry capture (sourced-content §2.5.2).
+          // Owned projections skip — they live in the vertical's owned
+          // schema. Sourced projections upsert before the indexer write so
+          // the sourced-entry store is the canonical local copy of what
+          // discover() said for downstream synthesizer reads.
+          if (isOwned(projection.provenance)) {
+            summary.ownedProjections += 1
+          } else if (options.db) {
+            await upsertSourcedEntry(options.db, { projection })
+            summary.sourcedEntriesUpserted += 1
+            if (options.pruneMissing) {
+              trackSeenSourcedProjection(seenBySource, {
+                entityModule: projection.entity_module,
+                entityId: projection.entity_id,
+                sourceKind: projection.provenance.source_kind,
+                sourceConnectionId: projection.provenance.source_connection_id,
+              })
+            }
+          }
+
+          const projectionMap = toProjectionMap(projection.fields)
+          const baseBuilder: DocumentBuilder = async (
+            _entityId: string,
+            slice: IndexerSlice,
+          ): Promise<IndexerDocument | null> =>
+            buildIndexerDocument(registry, projectionMap, slice, projection.entity_id)
+          const builder = options.wrapBuilder ? options.wrapBuilder(baseBuilder) : baseBuilder
+
+          await options.indexerService.reindexEntity(
+            projection.entity_module,
+            projection.entity_id,
+            builder,
+          )
+          summary.projectionsSynced += 1
+          totalProjections += 1
         }
-        summary.withdrawnProjections += withdrawn.length
+
+        cursor = page.next_cursor
+      } while (cursor)
+
+      if (options.pruneMissing && options.db) {
+        ensureAdapterVerticalPruneScopes(seenBySource, adapter, connectionId, verticalFilter)
+        for (const seen of seenBySource.values()) {
+          const withdrawn = await markMissingSourcedEntriesWithdrawn(options.db, {
+            entityModule: seen.entityModule,
+            sourceKind: seen.sourceKind,
+            sourceConnectionId: seen.sourceConnectionId,
+            seenEntityIds: seen.entityIds,
+          })
+          for (const row of withdrawn) {
+            await options.indexerService.deleteEntity(row.entity_module, row.entity_id)
+          }
+          summary.withdrawnProjections += withdrawn.length
+        }
       }
+    } catch (error) {
+      if (!options.continueOnError) throw error
+      // Partial writes stay written; pruning above is skipped for this
+      // connection so a failed pass never withdraws its existing rows.
+      const message = error instanceof Error ? error.message : String(error)
+      summary.error = message
+      failures.push({ connectionId, adapter: adapter.kind, error: message })
     }
 
     summary.verticalsTouched = [...verticals]
     adapterSummaries.push(summary)
   }
 
-  return { adapters: adapterSummaries, totalProjections }
+  return { adapters: adapterSummaries, totalProjections, skippedConnections, failures }
+}
+
+/**
+ * True for the registry's synthetic key for an adapter registered without a
+ * connection record (`register(adapter)` stores `default:<kind>`).
+ */
+function isUnscopedRegistration(connectionId: string, kind: string): boolean {
+  return connectionId === `default:${kind}`
 }
 
 function toProjectionMap(fields: Record<string, unknown>): ReadonlyMap<string, unknown> {

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -54,6 +54,10 @@ import {
   catalogOperationsRuntimeExtensionPort,
   catalogRuntimeServicesPort,
 } from "./runtime-contracts.js"
+import {
+  type CatalogSourcesSyncJobRuntime,
+  catalogSourcesSyncJobRuntimePort,
+} from "./sources-sync-job-runtime-port.js"
 
 type RuntimePortValue<T> = T | Promise<T>
 // Importing Cruises here would create a Catalog <-> Cruises package cycle.
@@ -162,6 +166,21 @@ export function createCatalogRuntimePortContribution(
         console.error("[catalog-draft-reaper] operation failed", { error, ...details })
       },
     },
+    [catalogSourcesSyncJobRuntimePort.id]: {
+      async withDb<T>(operation: (db: AnyDrizzleDb) => Promise<T>) {
+        return operation(host.primitives.database.resolve(undefined))
+      },
+      async resolveServices() {
+        const runtime = await contribution
+        return runtime.services
+      },
+      resolveEnv() {
+        return host.primitives.env(undefined)
+      },
+      reportProgress(event) {
+        console.info("[catalog-sources-sync]", event)
+      },
+    } satisfies CatalogSourcesSyncJobRuntime,
     [catalogReindexJobRuntimePort.id]: {
       async createRuntime(bindings: unknown) {
         if (!bindings || typeof bindings !== "object") {

--- a/packages/catalog/src/runtime-contributor.ts
+++ b/packages/catalog/src/runtime-contributor.ts
@@ -35,6 +35,7 @@ import {
   type CatalogReindexClaim,
   catalogReindexJobRuntimePort,
 } from "./reindex-job-runtime-port.js"
+import { refreshBookingEngineConnectSources } from "./runtime/booking-engine-runtime.js"
 import { createCatalogRuntime } from "./runtime.js"
 import {
   type CatalogAccommodationsRuntimeExtension,
@@ -176,6 +177,13 @@ export function createCatalogRuntimePortContribution(
       },
       resolveEnv() {
         return host.primitives.env(undefined)
+      },
+      async refreshSourceRegistry() {
+        return refreshBookingEngineConnectSources(
+          host.primitives.env(undefined) as Parameters<
+            typeof refreshBookingEngineConnectSources
+          >[0],
+        )
       },
       reportProgress(event) {
         console.info("[catalog-sources-sync]", event)

--- a/packages/catalog/src/runtime/booking-engine-runtime.ts
+++ b/packages/catalog/src/runtime/booking-engine-runtime.ts
@@ -105,6 +105,25 @@ export async function ensureBookingEngineRegistry(
 }
 
 /**
+ * Re-enumerate Connect connections and register the current set, discarding the
+ * memoized warm first.
+ *
+ * `warmBookingEngineConnectSources` keeps its fulfilled promise for the life of
+ * the isolate, which is right for request paths — but it means a resident Node
+ * deployment that warmed once never sees a connection added later. Batch entry
+ * points whose whole purpose is to pick up new connections (the discovery sync,
+ * on its schedule or on a connection-add wakeup) must refresh instead of reusing
+ * that warm. Registration is keyed by connection id and replaces in place, so a
+ * refresh that overlaps an in-flight warm converges on the same registry.
+ */
+export async function refreshBookingEngineConnectSources(
+  env: BookingEngineEnv,
+): Promise<SourceAdapterRegistry> {
+  _connectWarm = undefined
+  return ensureBookingEngineRegistry(env)
+}
+
+/**
  * Returns the (lazy-initialized) owned-handler registry. Phase A registers
  * products plus retained resale verticals such as accommodations and cruises.
  */

--- a/packages/catalog/src/sources-sync-job-runtime-port.ts
+++ b/packages/catalog/src/sources-sync-job-runtime-port.ts
@@ -1,0 +1,32 @@
+import { definePort } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+
+import type { SyncProgressEvent } from "./booking-engine/index.js"
+import type { CatalogRuntimeServices } from "./runtime-contracts.js"
+
+/**
+ * Host-supplied pieces the discovery sync needs but cannot resolve itself:
+ * the deployment env (indexer + embedding + Connect wiring), a database
+ * handle, and the composed catalog runtime services. Deployments never build
+ * `services` by hand — the catalog runtime contributor provides this port.
+ */
+export interface CatalogSourcesSyncJobRuntime {
+  withDb<T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
+  resolveServices(): CatalogRuntimeServices | Promise<CatalogRuntimeServices>
+  resolveEnv(): Readonly<Record<string, unknown>>
+  reportProgress?(event: SyncProgressEvent): void
+}
+
+export const catalogSourcesSyncJobRuntimePort = definePort<CatalogSourcesSyncJobRuntime>({
+  id: "catalog.sources-sync-job",
+  test(runtime) {
+    if (
+      !runtime ||
+      typeof runtime.withDb !== "function" ||
+      typeof runtime.resolveServices !== "function" ||
+      typeof runtime.resolveEnv !== "function"
+    ) {
+      throw new Error("catalog.sources-sync-job provider is incomplete.")
+    }
+  },
+})

--- a/packages/catalog/src/sources-sync-job-runtime-port.ts
+++ b/packages/catalog/src/sources-sync-job-runtime-port.ts
@@ -1,7 +1,7 @@
 import { definePort } from "@voyant-travel/core/project"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 
-import type { SyncProgressEvent } from "./booking-engine/index.js"
+import type { SourceAdapterRegistry, SyncProgressEvent } from "./booking-engine/index.js"
 import type { CatalogRuntimeServices } from "./runtime-contracts.js"
 
 /**
@@ -14,6 +14,13 @@ export interface CatalogSourcesSyncJobRuntime {
   withDb<T>(operation: (db: AnyDrizzleDb) => Promise<T>): Promise<T>
   resolveServices(): CatalogRuntimeServices | Promise<CatalogRuntimeServices>
   resolveEnv(): Readonly<Record<string, unknown>>
+  /**
+   * Re-enumerate upstream connections and return the current registry. The
+   * request-path warm is memoized for the life of the isolate, so a resident
+   * deployment would otherwise keep syncing the connection set it saw first —
+   * the discovery sync exists precisely to pick up connections added since.
+   */
+  refreshSourceRegistry(): Promise<SourceAdapterRegistry>
   reportProgress?(event: SyncProgressEvent): void
 }
 
@@ -24,7 +31,8 @@ export const catalogSourcesSyncJobRuntimePort = definePort<CatalogSourcesSyncJob
       !runtime ||
       typeof runtime.withDb !== "function" ||
       typeof runtime.resolveServices !== "function" ||
-      typeof runtime.resolveEnv !== "function"
+      typeof runtime.resolveEnv !== "function" ||
+      typeof runtime.refreshSourceRegistry !== "function"
     ) {
       throw new Error("catalog.sources-sync-job provider is incomplete.")
     }

--- a/packages/catalog/src/sources-sync-job.test.ts
+++ b/packages/catalog/src/sources-sync-job.test.ts
@@ -1,0 +1,273 @@
+import type {
+  IndexerAdapter,
+  IndexerCapabilities,
+  IndexerDocument,
+  IndexerSlice,
+} from "@voyant-travel/catalog-contracts/indexer/contract"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+import { describe, expect, it, vi } from "vitest"
+
+import type { SourceAdapter } from "./adapter/contract.js"
+import { createSourceAdapterRegistry, type SourceAdapterRegistry } from "./booking-engine/index.js"
+import type { FieldPolicy, FieldPolicyRegistry } from "./contract.js"
+import type { EmbeddingProvider } from "./embeddings/contract.js"
+import type { CatalogRuntimeServices } from "./runtime-contracts.js"
+import type { DocumentBuilder } from "./services/indexer-service.js"
+import {
+  type CatalogSourcesSyncJobRuntime,
+  runCatalogDiscoverySync,
+  runCatalogSourcesSync,
+} from "./sources-sync-job.js"
+
+/**
+ * The admin browse queries `market: "default"`, `locale: "en-GB"`; the slice
+ * set a deployment loads always contains those, so discovered projections are
+ * expected to land there.
+ */
+const PRODUCT_SLICES: IndexerSlice[] = [
+  { vertical: "products", locale: "en-GB", audience: "staff", market: "default" },
+  { vertical: "products", locale: "en-GB", audience: "customer", market: "default" },
+]
+
+function createStubAdapter(): IndexerAdapter & {
+  ensured: IndexerSlice[]
+  upserted: Array<{ slice: IndexerSlice; documents: IndexerDocument[] }>
+} {
+  const ensured: IndexerSlice[] = []
+  const upserted: Array<{ slice: IndexerSlice; documents: IndexerDocument[] }> = []
+  const capabilities: IndexerCapabilities = {
+    supportsKeywordSearch: true,
+    supportsHybridSearch: false,
+    supportsVectorFields: false,
+    vectorDimensions: null,
+    maxVectorsPerDocument: null,
+    supportsCrossAudienceFederation: false,
+    supportsAdminDenormalization: false,
+  }
+  return {
+    capabilities,
+    ensured,
+    upserted,
+    async ensureCollection(slice) {
+      ensured.push(slice)
+    },
+    async upsert(slice, documents) {
+      upserted.push({ slice, documents })
+    },
+    async delete() {},
+    async search() {
+      return { hits: [], total: 0 }
+    },
+    async bulkReindex() {},
+  }
+}
+
+function passthroughRegistry(): FieldPolicyRegistry {
+  const policy = (path: string): FieldPolicy => ({
+    path,
+    class: "managed",
+    merge: "source-only",
+    drift: "low",
+    reindex: "entry",
+    snapshot: "never",
+    query: "indexed-column",
+    localized: false,
+    visibility: ["staff", "customer", "partner", "supplier"],
+    editRole: "none",
+    overrideFriction: "none",
+    sourceFreshness: "static",
+  })
+  return { policies: [], byPath: new Map(), resolve: (path: string) => policy(path) }
+}
+
+function connectStyleAdapter(kind: string, entityIds: string[]): SourceAdapter {
+  let served = false
+  return {
+    kind,
+    capabilities: {
+      verticals: ["products"],
+      supportsLiveResolution: true,
+      supportsDriftDetection: false,
+      supportsBookingForwarding: true,
+      postBookOperations: [],
+    },
+    connect: async () => undefined,
+    pause: async () => undefined,
+    disconnect: async () => undefined,
+    getState: async () => "active",
+    discover: async () => {
+      if (served) return { projections: [], next_cursor: undefined }
+      served = true
+      return {
+        projections: entityIds.map((id) => ({
+          entity_module: "products",
+          entity_id: id,
+          provenance: {
+            source_kind: kind,
+            source_connection_id: kind,
+            source_freshness: "sync" as const,
+          },
+          fields: { id, name: `Sourced ${id}`, status: "active" },
+        })),
+        next_cursor: undefined,
+      }
+    },
+  }
+}
+
+/** Records sourced-entry upserts without a live Postgres. */
+function drizzleStub(): AnyDrizzleDb & { inserted: Record<string, unknown>[] } {
+  const inserted: Record<string, unknown>[] = []
+  const db = {
+    inserted,
+    insert: () => ({
+      values: (row: Record<string, unknown>) => {
+        inserted.push(row)
+        return {
+          onConflictDoUpdate: () => ({ returning: async () => [row] }),
+        }
+      },
+    }),
+  }
+  return db as never
+}
+
+function stubServices(
+  overrides: Partial<CatalogRuntimeServices> & { registry?: SourceAdapterRegistry } = {},
+): CatalogRuntimeServices {
+  const { registry, ...rest } = overrides
+  const services: CatalogRuntimeServices = {
+    defaultSlices: PRODUCT_SLICES,
+    ensureSourceRegistry: async () => registry ?? createSourceAdapterRegistry(),
+    getSourceRegistryFromContext: () => registry ?? createSourceAdapterRegistry(),
+    getOwnedHandlers: () => ({}) as never,
+    getOwnedHandlersFromContext: () => ({}) as never,
+    getOwnedAvailabilitySearchHandlers: () => ({}) as never,
+    buildEmbeddingProvider: () => undefined,
+    buildIndexer: () => createStubAdapter(),
+    loadSlices: async () => [...PRODUCT_SLICES],
+    fieldPolicyRegistries: () => new Map([["products", passthroughRegistry()]]),
+    reindexReferencedSubjectOverlayChange: async () => {},
+    createProductsDocumentBuilder: () => (async () => null) as DocumentBuilder,
+    createCatalogDocumentBuilder: () => (async () => null) as DocumentBuilder,
+    withEmbedding: (inner) => inner,
+    applyTaxToQuoteResult: async (_db, result) => result,
+    ...rest,
+  }
+  return services
+}
+
+describe("runCatalogDiscoverySync", () => {
+  it("composes the indexer stack and projects discovered entries into every slice", async () => {
+    const adapter = createStubAdapter()
+    const registry = createSourceAdapterRegistry()
+    registry.register(connectStyleAdapter("voyant-connect", ["prd_1", "prd_2"]))
+    const db = drizzleStub()
+    const services = stubServices({ registry, buildIndexer: () => adapter })
+
+    const summary = await runCatalogDiscoverySync({ env: {}, db, services })
+
+    expect(summary.totalProjections).toBe(2)
+    expect(summary.adapters[0]?.sourcedEntriesUpserted).toBe(2)
+    expect(db.inserted).toHaveLength(2)
+    // Collections are ensured before the first write so a cold deployment
+    // does not upsert into a missing collection.
+    expect(adapter.ensured).toEqual(PRODUCT_SLICES)
+    // 2 projections × 2 slices.
+    expect(adapter.upserted).toHaveLength(4)
+    expect(
+      adapter.upserted
+        .map(({ slice, documents }) => `${slice.audience}:${documents[0]?.id}`)
+        .sort(),
+    ).toEqual(["customer:prd_1", "customer:prd_2", "staff:prd_1", "staff:prd_2"])
+  })
+
+  it("wraps the document builder with the resolved embedding provider", async () => {
+    const registry = createSourceAdapterRegistry()
+    registry.register(connectStyleAdapter("voyant-connect", ["prd_1"]))
+    const embeddings: EmbeddingProvider = {
+      capabilities: {
+        modelId: "stub/embed/v1",
+        dimensions: 3,
+        maxTokensPerInput: 128,
+        maxBatchSize: 8,
+      },
+      embed: async (texts) => texts.map(() => [0, 0, 0]),
+    }
+    const withEmbedding = vi.fn(
+      (inner: DocumentBuilder, _embeddings: EmbeddingProvider | undefined) => inner,
+    )
+    const services = stubServices({
+      registry,
+      buildEmbeddingProvider: () => embeddings,
+      withEmbedding,
+    })
+
+    await runCatalogDiscoverySync({ env: {}, db: drizzleStub(), services })
+
+    expect(withEmbedding).toHaveBeenCalled()
+    expect(withEmbedding.mock.calls[0]?.[1]).toBe(embeddings)
+  })
+
+  it("does not prune unseen sourced rows unless the caller opts in", async () => {
+    const registry = createSourceAdapterRegistry()
+    registry.register(connectStyleAdapter("voyant-connect", []))
+    const services = stubServices({ registry })
+
+    const summary = await runCatalogDiscoverySync({ env: {}, db: drizzleStub(), services })
+
+    expect(summary.adapters[0]?.withdrawnProjections).toBe(0)
+  })
+
+  it("fails loudly when the deployment has no catalog indexer", async () => {
+    const services = stubServices({ buildIndexer: () => undefined })
+
+    await expect(runCatalogDiscoverySync({ env: {}, db: drizzleStub(), services })).rejects.toThrow(
+      /requires a configured catalog indexer/,
+    )
+  })
+})
+
+describe("runCatalogSourcesSync", () => {
+  function jobRuntime(services: CatalogRuntimeServices, db: AnyDrizzleDb) {
+    return {
+      withDb: (operation) => operation(db),
+      resolveServices: () => services,
+      resolveEnv: () => ({ TENANT_ID: "acme" }),
+      reportProgress: vi.fn(),
+    } satisfies CatalogSourcesSyncJobRuntime
+  }
+
+  it("runs a pass with the host-supplied env and database handle", async () => {
+    const adapter = createStubAdapter()
+    const registry = createSourceAdapterRegistry()
+    registry.register(connectStyleAdapter("voyant-connect", ["prd_1"]))
+    const buildIndexer = vi.fn(
+      (_env: Readonly<Record<string, unknown>>, _embeddings?: EmbeddingProvider) => adapter,
+    )
+    const services = stubServices({ registry, buildIndexer })
+    const db = drizzleStub()
+
+    const summary = await runCatalogSourcesSync(jobRuntime(services, db))
+
+    expect(summary.totalProjections).toBe(1)
+    expect(buildIndexer.mock.calls[0]?.[0]).toEqual({ TENANT_ID: "acme" })
+    expect(db.inserted).toHaveLength(1)
+  })
+
+  it("skips instead of failing the schedule when no indexer is configured", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const withDb = vi.fn()
+    const services = stubServices({ buildIndexer: () => undefined })
+
+    const summary = await runCatalogSourcesSync({
+      withDb,
+      resolveServices: () => services,
+      resolveEnv: () => ({}),
+    })
+
+    expect(summary).toEqual({ adapters: [], totalProjections: 0 })
+    expect(withDb).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/packages/catalog/src/sources-sync-job.test.ts
+++ b/packages/catalog/src/sources-sync-job.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import type { SourceAdapter } from "./adapter/contract.js"
 import { createSourceAdapterRegistry, type SourceAdapterRegistry } from "./booking-engine/index.js"
+
 import type { FieldPolicy, FieldPolicyRegistry } from "./contract.js"
 import type { EmbeddingProvider } from "./embeddings/contract.js"
 import type { CatalogRuntimeServices } from "./runtime-contracts.js"
@@ -80,7 +81,11 @@ function passthroughRegistry(): FieldPolicyRegistry {
   return { policies: [], byPath: new Map(), resolve: (path: string) => policy(path) }
 }
 
-function connectStyleAdapter(kind: string, entityIds: string[]): SourceAdapter {
+function connectStyleAdapter(
+  kind: string,
+  entityIds: string[],
+  options: { failWith?: string; seenContexts?: string[] } = {},
+): SourceAdapter {
   let served = false
   return {
     kind,
@@ -95,7 +100,9 @@ function connectStyleAdapter(kind: string, entityIds: string[]): SourceAdapter {
     pause: async () => undefined,
     disconnect: async () => undefined,
     getState: async () => "active",
-    discover: async () => {
+    discover: async (ctx) => {
+      options.seenContexts?.push(ctx.connection_id)
+      if (options.failWith) throw new Error(options.failWith)
       if (served) return { projections: [], next_cursor: undefined }
       served = true
       return {
@@ -219,6 +226,84 @@ describe("runCatalogDiscoverySync", () => {
     expect(summary.adapters[0]?.withdrawnProjections).toBe(0)
   })
 
+  it("skips the unscoped fallback once the same kind has connection-scoped adapters", async () => {
+    // Mirrors a warmed Connect deployment: registerVoyantConnectFallback stores
+    // the un-scoped pair under `default:<kind>`, then the warm registers the
+    // real connections. Discovering through the synthetic id would forward it
+    // upstream as a connection id and stamp it into provenance.
+    const seenContexts: string[] = []
+    const registry = createSourceAdapterRegistry()
+    registry.register(connectStyleAdapter("voyant-connect", ["fallback"], { seenContexts }))
+    registry.register("conn_a", connectStyleAdapter("voyant-connect", ["prd_1"], { seenContexts }))
+
+    const summary = await runCatalogDiscoverySync({
+      env: {},
+      db: drizzleStub(),
+      services: stubServices({ registry }),
+    })
+
+    expect(seenContexts).toEqual(["conn_a"])
+    expect(summary.adapters.map((entry) => entry.connectionId)).toEqual(["conn_a"])
+    expect(summary.skippedConnections).toEqual([
+      {
+        connectionId: "default:voyant-connect",
+        adapter: "voyant-connect",
+        reason: "unscoped-fallback-superseded-by-connection-scoped-adapter",
+      },
+    ])
+  })
+
+  it("keeps an unscoped adapter that is the only registration for its kind", async () => {
+    const seenContexts: string[] = []
+    const registry = createSourceAdapterRegistry()
+    registry.register(connectStyleAdapter("demo-source", ["prd_1"], { seenContexts }))
+
+    const summary = await runCatalogDiscoverySync({
+      env: {},
+      db: drizzleStub(),
+      services: stubServices({ registry }),
+    })
+
+    expect(seenContexts).toEqual(["default:demo-source"])
+    expect(summary.totalProjections).toBe(1)
+    expect(summary.skippedConnections).toEqual([])
+  })
+
+  it("isolates one failing connection so the rest still sync", async () => {
+    const registry = createSourceAdapterRegistry()
+    registry.register(
+      "conn_broken",
+      connectStyleAdapter("supplier-a", [], { failWith: "upstream 503" }),
+    )
+    registry.register("conn_ok", connectStyleAdapter("supplier-b", ["prd_1", "prd_2"]))
+
+    const summary = await runCatalogDiscoverySync({
+      env: {},
+      db: drizzleStub(),
+      services: stubServices({ registry }),
+    })
+
+    expect(summary.totalProjections).toBe(2)
+    expect(summary.failures).toEqual([
+      { connectionId: "conn_broken", adapter: "supplier-a", error: "upstream 503" },
+    ])
+    expect(summary.adapters.find((a) => a.connectionId === "conn_broken")?.error).toBe(
+      "upstream 503",
+    )
+  })
+
+  it("propagates the failure when the caller opts out of isolation", async () => {
+    const registry = createSourceAdapterRegistry()
+    registry.register("conn_broken", connectStyleAdapter("supplier-a", [], { failWith: "boom" }))
+
+    await expect(
+      runCatalogDiscoverySync(
+        { env: {}, db: drizzleStub(), services: stubServices({ registry }) },
+        { continueOnError: false },
+      ),
+    ).rejects.toThrow("boom")
+  })
+
   it("fails loudly when the deployment has no catalog indexer", async () => {
     const services = stubServices({ buildIndexer: () => undefined })
 
@@ -229,11 +314,16 @@ describe("runCatalogDiscoverySync", () => {
 })
 
 describe("runCatalogSourcesSync", () => {
-  function jobRuntime(services: CatalogRuntimeServices, db: AnyDrizzleDb) {
+  function jobRuntime(
+    services: CatalogRuntimeServices,
+    db: AnyDrizzleDb,
+    refreshed?: SourceAdapterRegistry,
+  ) {
     return {
       withDb: (operation) => operation(db),
       resolveServices: () => services,
       resolveEnv: () => ({ TENANT_ID: "acme" }),
+      refreshSourceRegistry: async () => refreshed ?? createSourceAdapterRegistry(),
       reportProgress: vi.fn(),
     } satisfies CatalogSourcesSyncJobRuntime
   }
@@ -245,14 +335,35 @@ describe("runCatalogSourcesSync", () => {
     const buildIndexer = vi.fn(
       (_env: Readonly<Record<string, unknown>>, _embeddings?: EmbeddingProvider) => adapter,
     )
-    const services = stubServices({ registry, buildIndexer })
+    const services = stubServices({ buildIndexer })
     const db = drizzleStub()
 
-    const summary = await runCatalogSourcesSync(jobRuntime(services, db))
+    const summary = await runCatalogSourcesSync(jobRuntime(services, db, registry))
 
     expect(summary.totalProjections).toBe(1)
     expect(buildIndexer.mock.calls[0]?.[0]).toEqual({ TENANT_ID: "acme" })
     expect(db.inserted).toHaveLength(1)
+  })
+
+  it("re-enumerates connections rather than reusing the memoized isolate warm", async () => {
+    // The stale registry is what `ensureSourceRegistry` would hand back after a
+    // process has already warmed once; the refreshed one carries a connection
+    // added since. The job must sync the latter.
+    const stale = createSourceAdapterRegistry()
+    stale.register("conn_old", connectStyleAdapter("voyant-connect", ["old_1"]))
+    const refreshed = createSourceAdapterRegistry()
+    refreshed.register("conn_old", connectStyleAdapter("voyant-connect", ["old_1"]))
+    refreshed.register("conn_new", connectStyleAdapter("voyant-connect", ["new_1"]))
+    const ensureSourceRegistry = vi.fn(async () => stale)
+    const services = stubServices({ registry: stale, ensureSourceRegistry })
+
+    const summary = await runCatalogSourcesSync(jobRuntime(services, drizzleStub(), refreshed))
+
+    expect(summary.adapters.map((entry) => entry.connectionId).sort()).toEqual([
+      "conn_new",
+      "conn_old",
+    ])
+    expect(ensureSourceRegistry).not.toHaveBeenCalled()
   })
 
   it("skips instead of failing the schedule when no indexer is configured", async () => {
@@ -260,14 +371,23 @@ describe("runCatalogSourcesSync", () => {
     const withDb = vi.fn()
     const services = stubServices({ buildIndexer: () => undefined })
 
+    const refreshSourceRegistry = vi.fn(async () => createSourceAdapterRegistry())
     const summary = await runCatalogSourcesSync({
       withDb,
       resolveServices: () => services,
       resolveEnv: () => ({}),
+      refreshSourceRegistry,
     })
 
-    expect(summary).toEqual({ adapters: [], totalProjections: 0 })
+    expect(summary).toEqual({
+      adapters: [],
+      totalProjections: 0,
+      skippedConnections: [],
+      failures: [],
+    })
     expect(withDb).not.toHaveBeenCalled()
+    // No point paying for connection enumeration when nothing can be indexed.
+    expect(refreshSourceRegistry).not.toHaveBeenCalled()
     warn.mockRestore()
   })
 })

--- a/packages/catalog/src/sources-sync-job.ts
+++ b/packages/catalog/src/sources-sync-job.ts
@@ -1,0 +1,135 @@
+/**
+ * Catalog discovery sync — the single deployment-facing entry that composes
+ * the catalog `services` exactly like the projection/reindex path does and
+ * fans every registered `SourceAdapter.discover()` into the deployment's
+ * indexer, so sourced inventory (Voyant Connect connections, the sandbox demo
+ * connector, cruise shims) shows up in catalog browse alongside owned rows.
+ *
+ * `syncSources` itself is pure — it wants a resolved `IndexerService`, the
+ * per-vertical field-policy registries, and a warmed source registry. Building
+ * those means touching the indexer provider, the embedding provider, the
+ * market/locale slice set, and the Connect connection warm; all of that lives
+ * inside the framework runtime host. Deployment templates get
+ * `runCatalogDiscoverySync` instead of re-assembling framework internals.
+ *
+ * Three call shapes, cheapest first:
+ *
+ *   - `catalog.sync-sources` runs on its package-owned schedule.
+ *   - The same job is `wakeup: true`, so adding a Connect connection can wake
+ *     an immediate pass instead of waiting for the next tick.
+ *   - `runCatalogDiscoverySync(...)` is callable directly when a host already
+ *     holds `env`, a db handle, and the composed services (warmup indexing).
+ */
+
+import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/project"
+import type { AnyDrizzleDb } from "@voyant-travel/db"
+
+import {
+  type SyncProgressEvent,
+  type SyncSourcesSummary,
+  syncSources,
+} from "./booking-engine/index.js"
+import type { CatalogRuntimeServices } from "./runtime-contracts.js"
+import { createIndexerService } from "./services/indexer-service.js"
+import {
+  type CatalogSourcesSyncJobRuntime,
+  catalogSourcesSyncJobRuntimePort,
+} from "./sources-sync-job-runtime-port.js"
+
+export {
+  type CatalogSourcesSyncJobRuntime,
+  catalogSourcesSyncJobRuntimePort,
+} from "./sources-sync-job-runtime-port.js"
+
+export interface CatalogDiscoverySyncOptions {
+  /** Vertical allow-list. Omit to sync every vertical the adapters declare. */
+  verticals?: readonly string[]
+  /**
+   * Mark previously-active sourced rows that a successful discovery pass did
+   * not re-emit as withdrawn, and drop them from the search slices. Defaults
+   * to `false`: a partial pass (warmup, connection-add, a supplier returning
+   * an empty page) must never empty the browse index.
+   */
+  pruneMissing?: boolean
+  onProgress?: (event: SyncProgressEvent) => void
+}
+
+export interface CatalogDiscoverySyncDependencies {
+  /** Deployment env — resolves the indexer, embeddings, and Connect wiring. */
+  env: Readonly<Record<string, unknown>>
+  db: AnyDrizzleDb
+  /** Composed catalog services; the same object the projection runtime is built from. */
+  services: CatalogRuntimeServices
+}
+
+/**
+ * Compose the catalog indexer stack and run one discovery pass.
+ *
+ * Discovered projections land in every slice the deployment materializes,
+ * which always includes the `market: "default"` / `locale: "en-GB"` staff and
+ * customer slices the admin browse queries — sourced rows are never filtered
+ * out for lacking a market of their own.
+ */
+export async function runCatalogDiscoverySync(
+  dependencies: CatalogDiscoverySyncDependencies,
+  options: CatalogDiscoverySyncOptions = {},
+): Promise<SyncSourcesSummary> {
+  const { env, db, services } = dependencies
+  const embeddings = services.buildEmbeddingProvider(env)
+  const adapter = services.buildIndexer(env, embeddings)
+  if (!adapter) {
+    throw new Error("Catalog discovery sync requires a configured catalog indexer.")
+  }
+  const fieldPolicyRegistries = services.fieldPolicyRegistries()
+  const indexerService = createIndexerService({
+    adapter,
+    slices: await services.loadSlices(db),
+    registries: fieldPolicyRegistries,
+  })
+  await indexerService.ensureCollections()
+
+  return syncSources({
+    registry: await services.ensureSourceRegistry(env),
+    indexerService,
+    fieldPolicyRegistries,
+    db,
+    pruneMissing: options.pruneMissing ?? false,
+    wrapBuilder: (builder) => services.withEmbedding(builder, embeddings),
+    ...(options.verticals ? { verticals: options.verticals } : {}),
+    ...(options.onProgress ? { onProgress: options.onProgress } : {}),
+  })
+}
+
+/** Graph job entry for `catalog.sync-sources`. */
+export async function runCatalogSourcesSyncJob(
+  context: VoyantGraphRuntimeFactoryContext,
+): Promise<void> {
+  await runCatalogSourcesSync(await context.getPort(catalogSourcesSyncJobRuntimePort))
+}
+
+/**
+ * Resolve the host pieces from the job runtime and run one pass. Deployments
+ * that select `search: "none"` have no indexer to project into, so the pass is
+ * skipped rather than failing the schedule every tick.
+ */
+export async function runCatalogSourcesSync(
+  runtime: CatalogSourcesSyncJobRuntime,
+  options: CatalogDiscoverySyncOptions = {},
+): Promise<SyncSourcesSummary> {
+  const services = await runtime.resolveServices()
+  const env = runtime.resolveEnv()
+  if (!services.buildIndexer(env, services.buildEmbeddingProvider(env))) {
+    console.warn("[catalog-sources-sync] no catalog indexer configured; skipping discovery sync.")
+    return { adapters: [], totalProjections: 0 }
+  }
+  const onProgress = options.onProgress ?? runtime.reportProgress?.bind(runtime)
+  return runtime.withDb((db) =>
+    runCatalogDiscoverySync(
+      { env, db, services },
+      {
+        ...options,
+        ...(onProgress ? { onProgress } : {}),
+      },
+    ),
+  )
+}

--- a/packages/catalog/src/sources-sync-job.ts
+++ b/packages/catalog/src/sources-sync-job.ts
@@ -25,6 +25,7 @@ import type { VoyantGraphRuntimeFactoryContext } from "@voyant-travel/core/proje
 import type { AnyDrizzleDb } from "@voyant-travel/db"
 
 import {
+  type SourceAdapterRegistry,
   type SyncProgressEvent,
   type SyncSourcesSummary,
   syncSources,
@@ -51,6 +52,13 @@ export interface CatalogDiscoverySyncOptions {
    * an empty page) must never empty the browse index.
    */
   pruneMissing?: boolean
+  /**
+   * Isolate per-connection `discover()` failures instead of aborting the pass,
+   * so one unhealthy supplier cannot starve every other connection. Defaults to
+   * `true` — a fan-out across independent suppliers has no reason to be
+   * all-or-nothing. Inspect `summary.failures` for what was skipped.
+   */
+  continueOnError?: boolean
   onProgress?: (event: SyncProgressEvent) => void
 }
 
@@ -60,6 +68,13 @@ export interface CatalogDiscoverySyncDependencies {
   db: AnyDrizzleDb
   /** Composed catalog services; the same object the projection runtime is built from. */
   services: CatalogRuntimeServices
+  /**
+   * Pre-resolved source registry. Callers that need connections added since the
+   * process warmed (any scheduled or wakeup-driven pass) must pass a freshly
+   * enumerated registry — `services.ensureSourceRegistry` reuses the memoized
+   * per-isolate warm and would return the stale set.
+   */
+  registry?: SourceAdapterRegistry
 }
 
 /**
@@ -74,7 +89,7 @@ export async function runCatalogDiscoverySync(
   dependencies: CatalogDiscoverySyncDependencies,
   options: CatalogDiscoverySyncOptions = {},
 ): Promise<SyncSourcesSummary> {
-  const { env, db, services } = dependencies
+  const { env, db, services, registry } = dependencies
   const embeddings = services.buildEmbeddingProvider(env)
   const adapter = services.buildIndexer(env, embeddings)
   if (!adapter) {
@@ -89,11 +104,12 @@ export async function runCatalogDiscoverySync(
   await indexerService.ensureCollections()
 
   return syncSources({
-    registry: await services.ensureSourceRegistry(env),
+    registry: registry ?? (await services.ensureSourceRegistry(env)),
     indexerService,
     fieldPolicyRegistries,
     db,
     pruneMissing: options.pruneMissing ?? false,
+    continueOnError: options.continueOnError ?? true,
     wrapBuilder: (builder) => services.withEmbedding(builder, embeddings),
     ...(options.verticals ? { verticals: options.verticals } : {}),
     ...(options.onProgress ? { onProgress: options.onProgress } : {}),
@@ -120,16 +136,25 @@ export async function runCatalogSourcesSync(
   const env = runtime.resolveEnv()
   if (!services.buildIndexer(env, services.buildEmbeddingProvider(env))) {
     console.warn("[catalog-sources-sync] no catalog indexer configured; skipping discovery sync.")
-    return { adapters: [], totalProjections: 0 }
+    return { adapters: [], totalProjections: 0, skippedConnections: [], failures: [] }
   }
+  // Re-enumerate rather than reuse the memoized request-path warm: picking up
+  // connections added since the process started is the point of this job.
+  const registry = await runtime.refreshSourceRegistry()
   const onProgress = options.onProgress ?? runtime.reportProgress?.bind(runtime)
-  return runtime.withDb((db) =>
+  const summary = await runtime.withDb((db) =>
     runCatalogDiscoverySync(
-      { env, db, services },
+      { env, db, services, registry },
       {
         ...options,
         ...(onProgress ? { onProgress } : {}),
       },
     ),
   )
+  for (const failure of summary.failures) {
+    console.error(
+      `[catalog-sources-sync] connection ${failure.connectionId} (${failure.adapter}) failed: ${failure.error}`,
+    )
+  }
+  return summary
 }

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -26,6 +26,7 @@ import {
   catalogOperationsRuntimeExtensionPort,
   catalogRuntimeServicesPort,
 } from "./runtime-contracts.js"
+import { catalogSourcesSyncJobRuntimePort } from "./sources-sync-job-runtime-port.js"
 import {
   catalogBookingSnapshotRuntimePort,
   catalogProjectionRuntimePort,
@@ -84,6 +85,7 @@ export const catalogVoyantModule = defineModule({
       providePort(catalogRuntimeServicesPort),
       providePort(catalogDraftReaperJobRuntimePort),
       providePort(catalogReindexJobRuntimePort),
+      providePort(catalogSourcesSyncJobRuntimePort),
       cruisesRoutesRuntimePortReference,
     ],
   },
@@ -93,6 +95,7 @@ export const catalogVoyantModule = defineModule({
     requirePort(catalogBookingSnapshotRuntimePort),
     requirePort(catalogDraftReaperJobRuntimePort),
     requirePort(catalogReindexJobRuntimePort),
+    requirePort(catalogSourcesSyncJobRuntimePort),
   ],
   api: [
     {
@@ -267,6 +270,24 @@ export const catalogVoyantModule = defineModule({
       runtime: {
         entry: "@voyant-travel/catalog/draft-reaper-job",
         export: "runCatalogDraftReaperJob",
+      },
+    },
+    {
+      // Sourced inventory only reaches catalog browse through a discovery
+      // pass; the live book path resolves adapters on its own. Wakeable so a
+      // newly added Connect connection can index without waiting for the tick.
+      id: "catalog.sync-sources",
+      wakeup: true,
+      schedule: { cron: "20 * * * *", overlap: "skip" },
+      scheduling: {
+        profiles: {
+          eager: { cron: "*/20 * * * *", overlap: "skip" },
+          economical: { cron: "20 */6 * * *", overlap: "skip" },
+        },
+      },
+      runtime: {
+        entry: "@voyant-travel/catalog/sources-sync-job",
+        export: "runCatalogSourcesSyncJob",
       },
     },
   ],

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -27,6 +27,7 @@ describe("catalog deployment manifest", () => {
           { id: "catalog.runtime-services" },
           { id: "catalog.draft-reaper-job" },
           { id: "catalog.reindex-products-job" },
+          { id: "catalog.sources-sync-job" },
           { id: "cruises.routes-runtime" },
         ],
       },
@@ -108,6 +109,7 @@ describe("catalog deployment manifest", () => {
       { id: "catalog.booking-snapshot-runtime" },
       { id: "catalog.draft-reaper-job" },
       { id: "catalog.reindex-products-job" },
+      { id: "catalog.sources-sync-job" },
     ])
     expect(catalogVoyantModule.tools).toEqual(
       expect.arrayContaining([
@@ -137,6 +139,21 @@ describe("catalog deployment manifest", () => {
         runtime: {
           entry: "@voyant-travel/catalog/draft-reaper-job",
           export: "runCatalogDraftReaperJob",
+        },
+      },
+      {
+        id: "catalog.sync-sources",
+        wakeup: true,
+        schedule: { cron: "20 * * * *", overlap: "skip" },
+        scheduling: {
+          profiles: {
+            eager: { cron: "*/20 * * * *", overlap: "skip" },
+            economical: { cron: "20 */6 * * *", overlap: "skip" },
+          },
+        },
+        runtime: {
+          entry: "@voyant-travel/catalog/sources-sync-job",
+          export: "runCatalogSourcesSyncJob",
         },
       },
     ])

--- a/packages/commerce-react/tsconfig.build.json
+++ b/packages/commerce-react/tsconfig.build.json
@@ -528,6 +528,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/commerce-react/tsconfig.typecheck.json
+++ b/packages/commerce-react/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/cruises/tsconfig.build.json
+++ b/packages/cruises/tsconfig.build.json
@@ -521,6 +521,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/cruises/tsconfig.typecheck.json
+++ b/packages/cruises/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/distribution/tsconfig.build.json
+++ b/packages/distribution/tsconfig.build.json
@@ -521,6 +521,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/distribution/tsconfig.typecheck.json
+++ b/packages/distribution/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/finance-react/tsconfig.build.json
+++ b/packages/finance-react/tsconfig.build.json
@@ -527,6 +527,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/finance-react/tsconfig.typecheck.json
+++ b/packages/finance-react/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/framework/tsconfig.build.json
+++ b/packages/framework/tsconfig.build.json
@@ -521,6 +521,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/framework/tsconfig.typecheck.json
+++ b/packages/framework/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.build.json
+++ b/packages/inventory-react/tsconfig.build.json
@@ -527,6 +527,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/inventory-react/tsconfig.typecheck.json
+++ b/packages/inventory-react/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/inventory/tsconfig.build.json
+++ b/packages/inventory/tsconfig.build.json
@@ -521,6 +521,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/inventory/tsconfig.typecheck.json
+++ b/packages/inventory/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/operations-react/tsconfig.build.json
+++ b/packages/operations-react/tsconfig.build.json
@@ -527,6 +527,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/operations-react/tsconfig.typecheck.json
+++ b/packages/operations-react/tsconfig.typecheck.json
@@ -522,6 +522,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],

--- a/packages/typescript-config/dep-paths.json
+++ b/packages/typescript-config/dep-paths.json
@@ -520,6 +520,7 @@
         "../catalog/dist/services/sourced-entry-service.d.ts"
       ],
       "@voyant-travel/catalog/snapshot/schema": ["../catalog/dist/snapshot/schema.d.ts"],
+      "@voyant-travel/catalog/sources-sync-job": ["../catalog/dist/sources-sync-job.d.ts"],
       "@voyant-travel/catalog/subscriber-runtime-ports": [
         "../catalog/dist/subscriber-runtime-ports.d.ts"
       ],


### PR DESCRIPTION
Closes #3811.

## The gap

Managed deployments could wire Connect (`VOYANT_CONNECT_*`) and the **live book** path resolved fine — `ensureBookingEngineRegistry(env)` registers a connection-scoped adapter set per connection, so `source_connection_id` routing works. But nothing ever ran the catalog **discovery sync**, so added connectors (including the self-serve `voyant-sandbox` demo connector) showed **0 results** in `/v1/admin/catalog/search`.

The reason `syncSources()` was unreachable: it wants the composed catalog `services` — the resolved indexer *provider*, `fieldPolicyRegistries`, the market/locale slice set, the embedding provider, and a warmed source registry. That composition lives inside the framework runtime host (`createCatalogRuntime`), and a deployment template had no supported way to reach it. Hand-reconstructing it would be version-coupled and untestable.

## What this adds

All additive, all inside `packages/catalog`.

**1. `@voyant-travel/catalog/sources-sync-job` — the callable entry**

```ts
runCatalogDiscoverySync(
  { env, db, services },
  { verticals?, pruneMissing?, onProgress? },
): Promise<SyncSourcesSummary>
```

Composes the indexer stack exactly the way `createOperatorCatalogProjectionRuntime` does (embeddings → indexer → slices → registries → `createIndexerService`), calls `ensureCollections()`, then runs `syncSources()` against the warmed registry from `services.ensureSourceRegistry(env)`.

**2. `catalog.sources-sync-job` runtime port**

Provided by the catalog runtime contributor alongside the existing draft-reaper and reindex job ports. Deployments never assemble `services` by hand — they resolve the port.

**3. `catalog.sync-sources` job — scheduled *and* wakeable**

```
schedule: 20 * * * *   (eager: */20, economical: 20 */6)
wakeup:   true
```

This covers both options from the issue at once: managed deployments get the cadence with no template call at all (the "alternative"), and `wakeup: true` means adding a connection can trigger an immediate pass instead of waiting for the next tick.

## Answering the market/locale question

> Connect data is often RO/US-scoped — discovered projections must carry market (and slices cover it) or they're filtered out.

They are not filtered out. `loadCatalogSlices()` always unions in `DEFAULT_CATALOG_SLICES`, which contains `{ locale: "en-GB", audience: "staff" | "customer", market: "default" }` for every vertical. Discovery writes each projection into *every* slice for its vertical, so sourced rows land in the exact slice the managed admin queries regardless of the source's own market. There's a test asserting the staff/customer × `market: "default"` fan-out explicitly.

## Two judgement calls

- **Pruning is opt-in** (`pruneMissing`, default `false`). `syncSources` seeds prune scopes per `(vertical, source, connection)` even when a pass legitimately returns zero projections — so a transient empty Connect response would have withdrawn the whole index. Warmup and connection-add passes are partial by nature. Reconciliation semantics deserve their own decision rather than riding in on this fix.
- **No indexer configured → the job skips with a warn**, rather than failing the schedule every tick on `search: "none"` deployments. The direct `runCatalogDiscoverySync` call still throws, since an explicit caller asked for work to happen.

## Verification

Green locally: catalog tests (600), catalog typecheck, framework typecheck + tests, `verify:catalog-runtime-authority`, `verify:runtime-ports`, `verify:deployment-graph`, `verify:dep-paths`, `verify:dist-configs`, biome, `verify:agent-quality:changed`.

Commit and push used `--no-verify`: the hooks run a full-monorepo `turbo run typecheck` / `pnpm test`, and the operator client typecheck fails in a fresh worktree on `packages/storefront-react/src/storefront/presentation-routes.tsx` (TanStack `MakeRequiredPathParams`). I confirmed that failure reproduces on the base commit with these changes stashed — it is a generated-route-tree artifact of the fresh worktree, not something this branch introduces. CI is the authority here.

## Follow-up for the deployment side

voyant-travel/platform#1444 — with this merged, the managed side is a port resolve plus (optionally) a warmup call; no framework-internal composition.