### PR TITLE
Keep validation errors a 400 across duplicate module copies

### DIFF
--- a/.changeset/api-http-error-cross-realm-brand.md
+++ b/.changeset/api-http-error-cross-realm-brand.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/hono": patch
+"@voyant-travel/inventory": patch
+---
+
+Identify `ApiHttpError` by a registry symbol instead of `instanceof`, so
+validation failures keep returning `400 invalid_request` when the throwing
+module and the error boundary loaded different copies of `@voyant-travel/hono`.
+`ZodError` and `HTTPException` are matched structurally for the same reason.

--- a/packages/hono/src/index.ts
+++ b/packages/hono/src/index.ts
@@ -130,6 +130,7 @@ export type {
 export {
   ApiHttpError,
   ForbiddenApiError,
+  isApiHttpError,
   normalizeValidationError,
   parseJsonBody,
   parseOptionalJsonBody,

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -4,6 +4,25 @@ import { ZodError, type ZodType } from "zod"
 
 import { DEFAULT_REQUEST_BODY_LIMIT_BYTES } from "./middleware/body-size.js"
 
+/**
+ * Cross-realm brand for {@link ApiHttpError}.
+ *
+ * `instanceof` compares class identity, which only holds when thrower and
+ * catcher loaded the SAME module instance. The managed operator runtime breaks
+ * that assumption: `ssr.noExternal: [/^@voyant-travel\//]` inlines a copy of
+ * this file into the SSR bundle, while modules composed at runtime resolve
+ * their own copy from `node_modules`. Two `ApiHttpError` classes then exist,
+ * `instanceof` is false across them, and `normalizeValidationError` returns
+ * `undefined` — so every validation failure surfaced as a bare
+ * `500 Internal Server Error` instead of the `400 invalid_request` contract
+ * (an empty POST body to any `.openapi()` route reproduced it).
+ *
+ * `Symbol.for` resolves through the global symbol registry, which IS shared
+ * across module copies in the same realm, so the brand matches regardless of
+ * how many times this file was bundled.
+ */
+const API_HTTP_ERROR_BRAND = Symbol.for("voyant.hono.ApiHttpError")
+
 export class ApiHttpError extends Error {
   readonly status: number
   readonly code?: string
@@ -22,7 +41,56 @@ export class ApiHttpError extends Error {
     this.status = options.status
     this.code = options.code
     this.details = options.details
+    // Non-enumerable so the brand never leaks into a serialized error body.
+    Object.defineProperty(this, API_HTTP_ERROR_BRAND, {
+      value: true,
+      enumerable: false,
+      configurable: false,
+      writable: false,
+    })
   }
+}
+
+/**
+ * Identifies an {@link ApiHttpError} across module copies. Prefer this over
+ * `error instanceof ApiHttpError` anywhere the error may have been thrown by a
+ * different bundle of `@voyant-travel/hono` — notably any framework-wide error
+ * boundary. Subclasses inherit the brand through `super()`.
+ */
+export function isApiHttpError(error: unknown): error is ApiHttpError {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as Record<PropertyKey, unknown>)[API_HTTP_ERROR_BRAND] === true
+  )
+}
+
+/**
+ * `ZodError` and `HTTPException` reach the boundary from whichever copy the
+ * throwing module loaded, so they need the same treatment. Neither class is
+ * ours to brand, so match on the shape each one is uniquely identified by:
+ * a `ZodError` always carries an `issues` array, and an `HTTPException` always
+ * pairs a numeric `status` with a `getResponse()` method (it does not set
+ * `name`, so that is not a usable discriminator).
+ */
+function isZodError(error: unknown): error is ZodError {
+  if (error instanceof ZodError) return true
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as Error).name === "ZodError" &&
+    Array.isArray((error as ZodError).issues)
+  )
+}
+
+function isHttpException(error: unknown): error is HTTPException {
+  if (error instanceof HTTPException) return true
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    typeof (error as HTTPException).status === "number" &&
+    typeof (error as HTTPException).getResponse === "function"
+  )
 }
 
 export class RequestValidationError extends ApiHttpError {
@@ -62,7 +130,9 @@ function toValidationError(
 ): RequestValidationError {
   return new RequestValidationError(error.issues[0]?.message ?? fallbackMessage, {
     issues: error.issues,
-    fields: error.flatten(),
+    // `isZodError` admits a cross-copy instance, which still carries `flatten`;
+    // the guard only covers a shape-compatible object that does not.
+    fields: typeof error.flatten === "function" ? error.flatten() : undefined,
   })
 }
 
@@ -145,15 +215,15 @@ export function parseQuery<T>(
 }
 
 export function normalizeValidationError(error: unknown): ApiHttpError | undefined {
-  if (error instanceof ApiHttpError) {
+  if (isApiHttpError(error)) {
     return error
   }
 
-  if (error instanceof ZodError) {
+  if (isZodError(error)) {
     return toValidationError(error)
   }
 
-  if (error instanceof HTTPException) {
+  if (isHttpException(error)) {
     // Hono's request validators throw HTTPException before our validation hook
     // runs — most notably HTTPException(400, "Malformed JSON in request body")
     // from the JSON body parser on `.openapi()` routes. Map it onto the

--- a/packages/hono/tests/unit/error-boundary.test.ts
+++ b/packages/hono/tests/unit/error-boundary.test.ts
@@ -37,4 +37,54 @@ describe("handleApiError", () => {
     expect(body.error).toBe("Invalid input")
     expect(body.details).toEqual({ fields: { name: ["Required"] } })
   })
+
+  // The managed operator runtime inlines `@voyant-travel/hono` into its SSR
+  // bundle while runtime-composed modules load their own copy from
+  // `node_modules`. The query suffix reproduces that faithfully: Vite evaluates
+  // the same source a second time, yielding classes that are structurally
+  // identical but fail `instanceof` against the first copy. Before the brand,
+  // this made every `.openapi()` validation failure a 500.
+  it("reflects validation errors thrown by a duplicate module copy", async () => {
+    const duplicate = await import("../../src/validation.js?duplicate-bundle")
+    const error = new duplicate.RequestValidationError("Invalid input", {
+      fields: { name: ["Required"] },
+    })
+
+    // Guard the premise: if this ever becomes true the test no longer covers
+    // the cross-copy case and would pass for the wrong reason.
+    expect(error instanceof RequestValidationError).toBe(false)
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      throw error
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as { error: string; code?: string }
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe("Invalid input")
+    expect(body.code).toBe("invalid_request")
+  })
+
+  it("reflects a ZodError thrown by a duplicate zod copy", async () => {
+    // A cross-copy ZodError is a real ZodError instance — it just fails
+    // `instanceof` here — so match it on the `issues` array it always carries.
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      throw Object.assign(new Error("crossed"), {
+        name: "ZodError",
+        issues: [{ code: "invalid_type", path: ["dateLocal"], message: "Required" }],
+      })
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as { error: string; code?: string }
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe("Required")
+    expect(body.code).toBe("invalid_request")
+  })
 })

--- a/packages/inventory/src/routes-editorial-overlays.ts
+++ b/packages/inventory/src/routes-editorial-overlays.ts
@@ -4,7 +4,7 @@ import type { SourceAdapterRegistry } from "@voyant-travel/catalog/booking-engin
 import { OVERLAY_DEFAULT_SCOPE } from "@voyant-travel/catalog/overlay/schema"
 import type { EventBus } from "@voyant-travel/core"
 import type { AnyDrizzleDb } from "@voyant-travel/db"
-import { ApiHttpError, openApiValidationHook, requireUserId } from "@voyant-travel/hono"
+import { isApiHttpError, openApiValidationHook, requireUserId } from "@voyant-travel/hono"
 import type { Context } from "hono"
 
 import {
@@ -202,7 +202,7 @@ export function createProductEditorialOverlayRoutes(
             409,
           )
         }
-        if (err instanceof ApiHttpError) {
+        if (isApiHttpError(err)) {
           throw err
         }
         return c.json({ error: "invalid_editorial_overlay", detail: errorMessage(err) }, 400)


### PR DESCRIPTION
## What

Request-validation failures on `.openapi()` routes return `400 invalid_request` again in the managed operator runtime, instead of a bare `500 Internal Server Error`.

## Reproduction

An empty JSON body to any `.openapi()` route on a managed admin:

| endpoint | before | after |
|---|---|---|
| `POST /v1/admin/operations/availability/slots` | 500 | 400 |
| `POST /v1/admin/operations/availability/rules` | 500 | 400 |
| `POST /v1/admin/operations/availability/closeouts` | 500 | 400 |
| `POST /v1/admin/products` | 500 | 400 |

The server log showed the hook throwing the correct error while the boundary recorded `status: 500, code: undefined`:

```
err: 'Invalid input: expected string, received undefined',
stack: 'RequestValidationError: ...
    at toValidationError (.../@voyant-travel+hono@0.134.6_.../dist/validation.js:45:12)
    at normalizeValidationError (.../@voyant-travel+hono@0.134.6_.../dist/validation.js:104:16)
    at openApiValidationHook (.../@voyant-travel+hono@0.134.6_.../dist/openapi-validation.js:40:15)
    ...
    at async file:///app/dist/server/assets/dist-i2FSbeNX.js:4557:4
```

## Cause

`openApiValidationHook` throws `RequestValidationError` correctly. `normalizeValidationError` then identified it with `instanceof ApiHttpError`, which only holds when thrower and catcher loaded the same module instance.

The managed runtime breaks that assumption. `ssr.noExternal: [/^@voyant-travel\//]` inlines a copy of `validation.ts` into the SSR bundle — confirmed in a built image, where `dist/server/assets/managed-profile-runtime-*.js` contains its own `var ApiHttpError = class extends Error` — while modules composed at runtime resolve a separate copy from `node_modules` (visible in the stack above). Two class identities, `instanceof` false, `normalizeValidationError` returns `undefined`, and the boundary falls through to its 500 default.

So the operator — and Max, through the same routes — saw an opaque `Internal Server Error` rather than which field was missing.

## Change

- Brand `ApiHttpError` with `Symbol.for("voyant.hono.ApiHttpError")`. The global symbol registry is shared across module copies in a realm, so the brand matches however many times the file was bundled. Non-enumerable, so it never reaches a serialized body. Subclasses inherit it through `super()`.
- Export `isApiHttpError` and use it in `normalizeValidationError` and the one other `instanceof ApiHttpError` call site (`inventory/routes-editorial-overlays.ts`).
- Match `ZodError` and `HTTPException` structurally for the same reason — they also arrive from whichever copy threw them. `ZodError` by its `issues` array; `HTTPException` by numeric `status` plus a `getResponse()` method, since it sets no `name`.

## Tests

The new case imports `validation.js` under a query suffix so Vite evaluates the source twice, reproducing the real cross-copy condition rather than hand-rolling a lookalike. It asserts the premise (`error instanceof RequestValidationError` is `false`) so it cannot pass for the wrong reason.

Both new tests fail against the previous implementation with `expected 500 to be 400`. Full package suite: 305 passed.

## Note

The underlying condition — the same framework package existing both inlined in the SSR bundle and again in `node_modules` — is worth a separate look, since class identity is not the only thing that can straddle that split. This change makes the error contract hold regardless.