### PR TITLE
feat(catalog): make the embedding provider selectable (OpenAI/Gemini)

### DIFF
--- a/.changeset/catalog-embedding-openai-adapter.md
+++ b/.changeset/catalog-embedding-openai-adapter.md
@@ -1,0 +1,10 @@
+---
+"@voyant-travel/catalog": minor
+---
+
+Make the catalog embedding provider selectable between OpenAI and Gemini.
+
+`buildCatalogEmbeddingProvider` now reads `CATALOG_EMBEDDING_PROVIDER`
+(`"openai" | "gemini"`) and builds the matching adapter over the Voyant Cloud
+`/ai/v1/{provider}` gateway. Defaults to `gemini` for compatibility; deployments
+that use the OpenAI embeddings proxy (e.g. managed runtimes) set `openai`.

--- a/.changeset/catalog-embedding-openai-adapter.md
+++ b/.changeset/catalog-embedding-openai-adapter.md
@@ -8,3 +8,8 @@ Make the catalog embedding provider selectable between OpenAI and Gemini.
 (`"openai" | "gemini"`) and builds the matching adapter over the Voyant Cloud
 `/ai/v1/{provider}` gateway. Defaults to `gemini` for compatibility; deployments
 that use the OpenAI embeddings proxy (e.g. managed runtimes) set `openai`.
+
+Switching provider switches the embedding model/dimensionality, so it is a
+deliberate `bulkReindex` operation. The Postgres indexer flips in place (unsized
+`vector` column keyed by `embedding_model_id`); Typesense-backed deployments must
+migrate the vector field's `num_dim` first, as `ensureCollection` does not.

--- a/packages/catalog/src/runtime-support.ts
+++ b/packages/catalog/src/runtime-support.ts
@@ -169,6 +169,16 @@ export interface CatalogRuntimeEnv {
    * Embedding backend the catalog authenticates through the Voyant Cloud AI
    * gateway. Both are adapters over the same `/ai/v1/{provider}` proxy shape;
    * defaults to `gemini` for compatibility. Managed runtimes set `openai`.
+   *
+   * Switching provider switches the embedding MODEL (and its vector
+   * dimensionality), so — like any model change — it is a deliberate
+   * `bulkReindex` operation, not a hot swap. The Postgres indexer is safe to
+   * flip in place: its `search_embedding` column is an unsized `vector` and
+   * rows are keyed by `embedding_model_id`, so old/new dimensions coexist and
+   * search reads only the active model. The Typesense indexer pins `num_dim`
+   * at collection creation and `ensureCollection` does not migrate it, so a
+   * Typesense-backed deployment must recreate/migrate the vector field before
+   * enabling a provider whose model dimension differs.
    */
   CATALOG_EMBEDDING_PROVIDER?: "openai" | "gemini"
 }

--- a/packages/catalog/src/runtime-support.ts
+++ b/packages/catalog/src/runtime-support.ts
@@ -16,6 +16,7 @@ import type {
 import type { FieldPolicyRegistry, Visibility } from "./contract.js"
 import type { EmbeddingProvider } from "./embeddings/contract.js"
 import { createGeminiEmbeddingProvider } from "./embeddings/gemini.js"
+import { createOpenAIEmbeddingProvider } from "./embeddings/openai.js"
 import type {
   CatalogOffersIndexFields,
   CatalogOffersSearchDestination,
@@ -164,6 +165,12 @@ export interface CatalogRuntimeEnv {
   VOYANT_API_KEY?: string
   VOYANT_CLOUD_API_KEY?: string
   VOYANT_CLOUD_API_URL?: string
+  /**
+   * Embedding backend the catalog authenticates through the Voyant Cloud AI
+   * gateway. Both are adapters over the same `/ai/v1/{provider}` proxy shape;
+   * defaults to `gemini` for compatibility. Managed runtimes set `openai`.
+   */
+  CATALOG_EMBEDDING_PROVIDER?: "openai" | "gemini"
 }
 
 export function buildCatalogEmbeddingProvider(
@@ -172,6 +179,14 @@ export function buildCatalogEmbeddingProvider(
   const apiKey = env.VOYANT_API_KEY ?? env.VOYANT_CLOUD_API_KEY
   if (!apiKey) return undefined
   const cloudBase = (env.VOYANT_CLOUD_API_URL ?? "https://api.voyant.travel").replace(/\/$/, "")
+  if (env.CATALOG_EMBEDDING_PROVIDER === "openai") {
+    // `createOpenAIEmbeddingProvider` POSTs `${baseUrl}/embeddings` with a
+    // Bearer key — matching the Voyant Cloud `/ai/v1/openai/embeddings` proxy.
+    return createOpenAIEmbeddingProvider({
+      apiKey,
+      baseUrl: `${cloudBase}/ai/v1/openai`,
+    })
+  }
   return createGeminiEmbeddingProvider({
     apiKey,
     auth: "bearer",


### PR DESCRIPTION
## Why

`buildCatalogEmbeddingProvider` (`packages/catalog/src/runtime-support.ts`) hardcodes the **Gemini** adapter against the Voyant Cloud `/ai/v1/gemini` gateway. That path returns **404** on Voyant Cloud (there is no `/ai/v1/gemini` route), so managed runtimes generate zero embeddings — every catalog projection logs `Gemini embeddings request failed (404)` and indexes documents with a null vector. It also contradicts the package docs, which state OpenAI is the v1 default.

Closes the intent of #3816.

## What

Both adapters already exist (`createGeminiEmbeddingProvider`, `createOpenAIEmbeddingProvider`) — this just makes the selection configurable:

```ts
if (env.CATALOG_EMBEDDING_PROVIDER === "openai") {
  return createOpenAIEmbeddingProvider({ apiKey, baseUrl: `${cloudBase}/ai/v1/openai` })
}
return createGeminiEmbeddingProvider({ apiKey, auth: "bearer", baseUrl: `${cloudBase}/ai/v1/gemini` })
```

- New `CATALOG_EMBEDDING_PROVIDER` (`"openai" | "gemini"`) on `CatalogRuntimeEnv`.
- **Defaults to `gemini`** so existing behavior is unchanged; deployments backed by the OpenAI embeddings proxy set `openai`.
- `createOpenAIEmbeddingProvider` POSTs `${baseUrl}/embeddings` with a Bearer key, matching the Voyant Cloud `/ai/v1/openai/embeddings` proxy.

## Cloud side

The Voyant Cloud gateway route this targets — `POST /ai/v1/openai/embeddings` (managed-data-token auth, forwards to OpenAI with the platform key, model-allow-listed) — is already live (voyant-cloud #1454). The managed runtime will set `CATALOG_EMBEDDING_PROVIDER=openai`, so once this releases and the operator-runtime bumps, managed catalog embeddings run on OpenAI (batched → fast) instead of the dead Gemini path.

Changeset included (minor).