### PR TITLE
Recognise ApiHttpError from pre-brand copies

### DIFF
--- a/.changeset/api-http-error-legacy-copy-fallback.md
+++ b/.changeset/api-http-error-legacy-copy-fallback.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/hono": patch
+---
+
+Recognise unbranded `ApiHttpError` instances thrown by a pre-brand copy of this
+package, so validation failures return `400 invalid_request` in a partly
+upgraded dependency graph instead of waiting for every module package to be
+re-released. Matched by class name plus a numeric status — never by status
+alone, which would reflect internal messages.

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -58,12 +58,34 @@ export class ApiHttpError extends Error {
  * boundary. Subclasses inherit the brand through `super()`.
  */
 export function isApiHttpError(error: unknown): error is ApiHttpError {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    (error as Record<PropertyKey, unknown>)[API_HTTP_ERROR_BRAND] === true
-  )
+  if (typeof error === "object" && error !== null) {
+    const candidate = error as Record<PropertyKey, unknown>
+    if (candidate[API_HTTP_ERROR_BRAND] === true) return true
+    // A copy published before the brand existed throws an unbranded instance,
+    // and a partly-upgraded graph is the normal case: the boundary resolves the
+    // newest `@voyant-travel/hono` while ~30 module packages still pin exact
+    // older versions until each is re-released. Recognise those by class name —
+    // there are exactly four, all declared in this file.
+    //
+    // Deliberately NOT `typeof status === "number"` alone: any thrown object can
+    // carry a `status`, and reflecting those would leak internal messages to the
+    // client (see the error-boundary test that keeps a generic `{ status: 400 }`
+    // error a 500).
+    return (
+      typeof candidate.name === "string" &&
+      LEGACY_API_HTTP_ERROR_NAMES.has(candidate.name) &&
+      typeof candidate.status === "number"
+    )
+  }
+  return false
 }
+
+const LEGACY_API_HTTP_ERROR_NAMES = new Set([
+  "ApiHttpError",
+  "RequestValidationError",
+  "UnauthorizedApiError",
+  "ForbiddenApiError",
+])
 
 /**
  * `ZodError` and `HTTPException` reach the boundary from whichever copy the

--- a/packages/hono/src/validation.ts
+++ b/packages/hono/src/validation.ts
@@ -61,21 +61,7 @@ export function isApiHttpError(error: unknown): error is ApiHttpError {
   if (typeof error === "object" && error !== null) {
     const candidate = error as Record<PropertyKey, unknown>
     if (candidate[API_HTTP_ERROR_BRAND] === true) return true
-    // A copy published before the brand existed throws an unbranded instance,
-    // and a partly-upgraded graph is the normal case: the boundary resolves the
-    // newest `@voyant-travel/hono` while ~30 module packages still pin exact
-    // older versions until each is re-released. Recognise those by class name —
-    // there are exactly four, all declared in this file.
-    //
-    // Deliberately NOT `typeof status === "number"` alone: any thrown object can
-    // carry a `status`, and reflecting those would leak internal messages to the
-    // client (see the error-boundary test that keeps a generic `{ status: 400 }`
-    // error a 500).
-    return (
-      typeof candidate.name === "string" &&
-      LEGACY_API_HTTP_ERROR_NAMES.has(candidate.name) &&
-      typeof candidate.status === "number"
-    )
+    return isPreBrandApiHttpError(candidate)
   }
   return false
 }
@@ -86,6 +72,41 @@ const LEGACY_API_HTTP_ERROR_NAMES = new Set([
   "UnauthorizedApiError",
   "ForbiddenApiError",
 ])
+
+/**
+ * Recognise an `ApiHttpError` thrown by a copy published before the brand.
+ *
+ * A partly-upgraded graph is the normal case, not an edge case: the error
+ * boundary resolves the newest `@voyant-travel/hono` while ~30 module packages
+ * still pin exact older versions until each is re-released. Without this the
+ * brand fixes nothing in production.
+ *
+ * The check reconstructs the *full* invariant of the pre-brand class rather
+ * than a couple of convenient fields, because `handleApiError` reflects an
+ * accepted error's `message` and `details` to the client — a loose predicate is
+ * a confidentiality hole, not just a wrong status.
+ *
+ * A genuine instance satisfies all four, verified against published 0.128.x:
+ * it is a real `Error` (`Error` is a realm intrinsic, so `instanceof` holds
+ * across module copies); its `name` is one of exactly four classes, all
+ * declared in this file; its `status` is numeric; and the constructor assigns
+ * `status`, `code` and `details` unconditionally, so all three are own
+ * properties even when the value is `undefined`.
+ *
+ * Notably this rejects `Object.assign(new Error(...), { status: 400 })` and any
+ * bare object literal wearing a familiar `name`.
+ */
+function isPreBrandApiHttpError(candidate: Record<PropertyKey, unknown>): boolean {
+  return (
+    candidate instanceof Error &&
+    typeof candidate.name === "string" &&
+    LEGACY_API_HTTP_ERROR_NAMES.has(candidate.name) &&
+    typeof candidate.status === "number" &&
+    Object.hasOwn(candidate, "status") &&
+    Object.hasOwn(candidate, "code") &&
+    Object.hasOwn(candidate, "details")
+  )
+}
 
 /**
  * `ZodError` and `HTTPException` reach the boundary from whichever copy the

--- a/packages/hono/tests/unit/error-boundary.test.ts
+++ b/packages/hono/tests/unit/error-boundary.test.ts
@@ -2,7 +2,37 @@ import { Hono } from "hono"
 import { describe, expect, it } from "vitest"
 
 import { handleApiError } from "../../src/middleware/error-boundary.js"
-import { RequestValidationError } from "../../src/validation.js"
+import { isApiHttpError, RequestValidationError } from "../../src/validation.js"
+
+/**
+ * The pre-brand `RequestValidationError`, transcribed from published
+ * `@voyant-travel/hono@0.128.1` `dist/validation.js`. Declaring the fields (not
+ * just assigning them) is what makes `status`/`code`/`details` own properties
+ * even when undefined — the invariant the fallback matches on.
+ */
+class PreBrandApiHttpError extends Error {
+  status: number
+  code?: string
+  details?: Record<string, unknown>
+
+  constructor(
+    message: string,
+    options: { status: number; code?: string; details?: Record<string, unknown> },
+  ) {
+    super(message)
+    this.name = "ApiHttpError"
+    this.status = options.status
+    this.code = options.code
+    this.details = options.details
+  }
+}
+
+class PreBrandRequestValidationError extends PreBrandApiHttpError {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super(message, { status: 400, code: "invalid_request", details })
+    this.name = "RequestValidationError"
+  }
+}
 
 describe("handleApiError", () => {
   it("does not reflect generic thrown status messages or details", async () => {
@@ -75,36 +105,64 @@ describe("handleApiError", () => {
     const app = new Hono()
     app.onError(handleApiError)
     app.get("/bad", () => {
-      // What `new RequestValidationError(...)` produced before the brand.
-      throw Object.assign(new Error("dateLocal is required"), {
-        name: "RequestValidationError",
-        status: 400,
-        code: "invalid_request",
-      })
+      throw new PreBrandRequestValidationError("dateLocal is required", { field: "dateLocal" })
     })
 
     const response = await app.request("/bad")
-    const body = (await response.json()) as { error: string; code?: string }
+    const body = (await response.json()) as { error: string; code?: string; details?: unknown }
 
     expect(response.status).toBe(400)
     expect(body.error).toBe("dateLocal is required")
     expect(body.code).toBe("invalid_request")
+    expect(body.details).toEqual({ field: "dateLocal" })
   })
 
-  // The name check must not widen into "anything with a status", which would
-  // reflect internal messages. This is the guard for that.
-  it("still hides a generic error that merely carries a status", async () => {
+  // `handleApiError` reflects an accepted error's message and details, so a
+  // loose predicate leaks internals rather than merely mis-statusing. Each of
+  // these satisfies part of the pre-brand shape and must still be rejected.
+  it.each([
+    [
+      "a generic error carrying a status",
+      () => Object.assign(new Error("database hostname leaked"), { status: 400, code: "nope" }),
+    ],
+    [
+      "a generic error wearing a familiar name",
+      () =>
+        Object.assign(new Error("database hostname leaked"), {
+          name: "RequestValidationError",
+          status: 400,
+        }),
+    ],
+  ])("hides %s", async (_label, make) => {
     const app = new Hono()
     app.onError(handleApiError)
     app.get("/bad", () => {
-      throw Object.assign(new Error("database hostname leaked"), { status: 400, code: "nope" })
+      throw make()
     })
 
     const response = await app.request("/bad")
-    const body = (await response.json()) as { error: string }
+    const body = (await response.json()) as { error: string; details?: unknown }
 
     expect(response.status).toBe(500)
     expect(body.error).toBe("Internal Server Error")
+    expect(body.details).toBeUndefined()
+  })
+
+  // Hono rethrows non-Error values rather than routing them to `onError`, so a
+  // bare object never reaches the boundary — assert the predicate directly.
+  it("does not accept a bare object wearing the full pre-brand field set", () => {
+    expect(
+      isApiHttpError({
+        name: "RequestValidationError",
+        status: 400,
+        code: "invalid_request",
+        details: undefined,
+        message: "database hostname leaked",
+      }),
+    ).toBe(false)
+
+    expect(isApiHttpError(new PreBrandRequestValidationError("real"))).toBe(true)
+    expect(isApiHttpError(new RequestValidationError("real"))).toBe(true)
   })
 
   it("reflects a ZodError thrown by a duplicate zod copy", async () => {

--- a/packages/hono/tests/unit/error-boundary.test.ts
+++ b/packages/hono/tests/unit/error-boundary.test.ts
@@ -68,6 +68,45 @@ describe("handleApiError", () => {
     expect(body.code).toBe("invalid_request")
   })
 
+  // The brand only helps once BOTH copies carry it. In a partly-upgraded graph
+  // the boundary is new while the throwing module still pins a pre-brand
+  // `@voyant-travel/hono`, which is the shape production actually runs.
+  it("reflects an unbranded error from a pre-brand copy", async () => {
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      // What `new RequestValidationError(...)` produced before the brand.
+      throw Object.assign(new Error("dateLocal is required"), {
+        name: "RequestValidationError",
+        status: 400,
+        code: "invalid_request",
+      })
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as { error: string; code?: string }
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe("dateLocal is required")
+    expect(body.code).toBe("invalid_request")
+  })
+
+  // The name check must not widen into "anything with a status", which would
+  // reflect internal messages. This is the guard for that.
+  it("still hides a generic error that merely carries a status", async () => {
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.get("/bad", () => {
+      throw Object.assign(new Error("database hostname leaked"), { status: 400, code: "nope" })
+    })
+
+    const response = await app.request("/bad")
+    const body = (await response.json()) as { error: string }
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe("Internal Server Error")
+  })
+
   it("reflects a ZodError thrown by a duplicate zod copy", async () => {
     // A cross-copy ZodError is a real ZodError instance — it just fails
     // `instanceof` here — so match it on the `issues` array it always carries.


### PR DESCRIPTION
Follow-up to #3817. That change is correct but, on its own, does not yet fix production.

## Why

The symbol brand only helps once **both** the throwing module and the error boundary carry it. After the release they don't. In the operator runtime's lockfile:

| `@voyant-travel/hono` | packages resolving it |
|---|---|
| 0.134.7 (branded) | 2 — `framework`, `inventory` |
| 0.134.6 | 28 — `auth`, `bookings`, `catalog`, `operations`, … |
| 0.134.5 | 6 |
| 0.133.0 | 1 |

Those are exact pins, so each moves only when that package is itself re-released. The boundary resolves the newest copy while `openApiValidationHook` throws from an old one — precisely the split the production stack trace showed:

```
at openApiValidationHook (.../@voyant-travel+hono@0.134.6_.../dist/openapi-validation.js:40:15)
...
at async file:///app/dist/server/assets/dist-i2FSbeNX.js:4557:4
```

The thrown error has no brand, `isApiHttpError` returns false, and `POST /v1/admin/operations/availability/slots` keeps returning 500. Re-releasing ~35 packages to fix an error-contract bug is the wrong lever.

## Change

Fall back to the class name when the brand is absent. There are exactly four, all declared in `validation.ts`: `ApiHttpError`, `RequestValidationError`, `UnauthorizedApiError`, `ForbiddenApiError` — so the match is complete rather than a heuristic.

Paired with a numeric `status`, and deliberately **not** `status` alone: any thrown object can carry one, and reflecting those would leak internal messages to the client. `handleApiError` already has a test asserting a generic `{ status: 400 }` error stays a 500; this adds a second that pins the same boundary against the new name check, next to a test for the pre-brand error shape.

307 tests pass.