### PR TITLE
Publish real parameters for tools whose input carries a transform

### DIFF
--- a/.changeset/tool-json-schema-input-direction.md
+++ b/.changeset/tool-json-schema-input-direction.md
@@ -1,9 +1,8 @@
 ---
 "@voyant-travel/tools": patch
-"@voyant-travel/mcp": patch
 ---
 
-Serialize Tool input schemas with `io: "input"`. `z.toJSONSchema` defaults to
-the output direction, which cannot resolve a transform's output type and threw
-— so 26 of 284 Tools were published with a description-only stub carrying no
-parameter names, types or required list.
+Serialize Tool input schemas with `io: "input"` in the discovery manifest.
+`z.toJSONSchema` defaults to the output direction, which cannot resolve a
+transform's output type and threw — so 26 of 284 Tools were published with a
+description-only stub carrying no parameter names, types or required list.

--- a/.changeset/tool-json-schema-input-direction.md
+++ b/.changeset/tool-json-schema-input-direction.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/tools": patch
+"@voyant-travel/mcp": patch
+---
+
+Serialize Tool input schemas with `io: "input"`. `z.toJSONSchema` defaults to
+the output direction, which cannot resolve a transform's output type and threw
+— so 26 of 284 Tools were published with a description-only stub carrying no
+parameter names, types or required list.

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -470,7 +470,8 @@ type ZodCompositionDef = {
  * Wire clients send ISO strings; before registry dispatch those strings are
  * revived to `Date` wherever the domain schema expects a date node.
  */
-function toMcpInputSchema(schema: z.ZodType, entry: ToolManifestEntry): z.ZodObject {
+/** Exported for tests: the double-parse hazard it guards is not observable from outside. */
+export function toMcpInputSchema(schema: z.ZodType, entry: ToolManifestEntry): z.ZodObject {
   const shape =
     schema instanceof z.ZodObject
       ? schema.shape
@@ -501,14 +502,25 @@ function projectShapeForMcpDiscovery(shape: z.ZodRawShape): z.ZodRawShape {
   )
 }
 
+/**
+ * Pick the schema REGISTERED with the MCP SDK — which both advertises the tool
+ * and parses the caller's arguments before the callback runs.
+ *
+ * Do NOT "fix" this the way the registry manifest was fixed, by asking for
+ * `io: "input"` so a transform-bearing schema passes and is returned as-is.
+ * That schema would then execute domain transforms during the SDK's parse, and
+ * `dispatchToResult` re-parses the result through the registry's original
+ * schema: `booleanQueryParam` is `z.enum(["true","false","1","0"]).transform()`,
+ * so `active: "true"` becomes `true` and the second parse rejects a boolean
+ * against a string enum with INVALID_INPUT.
+ *
+ * The projection below replaces a transform with its INPUT side, which is both
+ * what the wire actually carries and safe to parse twice. The output-direction
+ * probe is what routes transforms here, so it is deliberate.
+ */
 function projectSchemaForMcpDiscovery(schema: z.ZodType): z.ZodType {
   try {
-    // This projects TOOL INPUTS, so ask zod for the input direction. The
-    // default (`io: "output"`) cannot resolve a transform's output type and
-    // throws, which sent every schema coercing a query param — `active`,
-    // `activated`, `isPrimary` — down the lossy projection path below even
-    // though its input shape is perfectly representable.
-    z.toJSONSchema(schema, { io: "input" })
+    z.toJSONSchema(schema)
     return schema
   } catch {
     return projectUnrepresentableSchema(schema)

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -503,7 +503,12 @@ function projectShapeForMcpDiscovery(shape: z.ZodRawShape): z.ZodRawShape {
 
 function projectSchemaForMcpDiscovery(schema: z.ZodType): z.ZodType {
   try {
-    z.toJSONSchema(schema)
+    // This projects TOOL INPUTS, so ask zod for the input direction. The
+    // default (`io: "output"`) cannot resolve a transform's output type and
+    // throws, which sent every schema coercing a query param — `active`,
+    // `activated`, `isPrimary` — down the lossy projection path below even
+    // though its input shape is perfectly representable.
+    z.toJSONSchema(schema, { io: "input" })
     return schema
   } catch {
     return projectUnrepresentableSchema(schema)

--- a/packages/mcp/tests/input-projection-double-parse.test.ts
+++ b/packages/mcp/tests/input-projection-double-parse.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { toMcpInputSchema } from "../src/server.js"
+
+/**
+ * The schema registered with the MCP SDK is parsed BEFORE the tool callback
+ * runs, and `dispatchToResult` then re-parses through the registry's original
+ * schema. So the registered schema must not execute domain transforms: a
+ * non-idempotent one corrupts the value between the two parses.
+ *
+ * `booleanQueryParam` is the live example — `z.enum(["true","false","1","0"])
+ * .transform(...)`. If the SDK ran the transform, the callback would receive
+ * `true` and the registry's enum would reject a boolean with INVALID_INPUT.
+ *
+ * Making `projectSchemaForMcpDiscovery` probe with `io: "input"` (symmetrical
+ * with the registry manifest fix, and superficially the obvious thing to do)
+ * reintroduces exactly that. This test exists to catch it.
+ */
+const booleanQueryParam = z
+  .enum(["true", "false", "1", "0"])
+  .transform((value) => value === "true" || value === "1")
+
+const entry = {
+  name: "probe",
+  description: "Probe tool.",
+  capabilityId: "test#tool.probe",
+  capabilityVersion: "v1",
+  aliases: [],
+} as unknown as Parameters<typeof toMcpInputSchema>[1]
+
+describe("MCP-registered input schema", () => {
+  it("does not execute a domain transform during the SDK's parse", () => {
+    const schema = toMcpInputSchema(z.object({ active: booleanQueryParam.optional() }), entry)
+    const parsed = schema.parse({ active: "true" }) as { active?: unknown }
+
+    // The wire value must survive intact for the registry's own parse.
+    expect(parsed.active).toBe("true")
+    expect(parsed.active).not.toBe(true)
+  })
+
+  it("still accepts every value the domain schema accepts", () => {
+    const schema = toMcpInputSchema(z.object({ active: booleanQueryParam.optional() }), entry)
+
+    for (const value of ["true", "false", "1", "0"]) {
+      expect(schema.safeParse({ active: value }).success).toBe(true)
+    }
+    expect(schema.safeParse({ active: "yes" }).success).toBe(false)
+  })
+})

--- a/packages/tools/src/registry.ts
+++ b/packages/tools/src/registry.ts
@@ -497,9 +497,23 @@ async function executeTool(
 }
 
 /**
- * Serialize a tool schema to JSON Schema via zod v4's native
- * `z.toJSONSchema`. A non-serializable schema (e.g. a top-level transform)
- * is labelled as runtime-only rather than breaking the whole manifest.
+ * Serialize a tool schema to JSON Schema via zod v4's native `z.toJSONSchema`.
+ *
+ * The `io` direction is load-bearing, not a detail. `z.toJSONSchema` defaults
+ * to `io: "output"`, and a schema containing a transform has no statically
+ * known output type — so zod threw `Transforms cannot be represented in JSON
+ * Schema`, this function fell into the catch below, and the tool was published
+ * with a description-only stub carrying NO parameter names, types or required
+ * list. An agent could then only guess field names, and every guess came back
+ * as a -32602 it could not learn from.
+ *
+ * That silently degraded 26 of 284 Tools, including every `list_*` whose query
+ * schema coerces a boolean query param (`active`, `activated`, `isPrimary`) and
+ * every write that trims a string (`website`, `taxId`, `currency`).
+ *
+ * An input schema must serialize as `io: "input"` — what the caller SENDS —
+ * which is both correct and representable through a transform. Output schemas
+ * describe what the tool RETURNS, so they stay `io: "output"`.
  */
 function toJsonSchema(
   schema: z.ZodType,
@@ -507,7 +521,9 @@ function toJsonSchema(
   name: string,
 ): Record<string, unknown> {
   try {
-    const serialized = z.toJSONSchema(schema) as Record<string, unknown>
+    const serialized = z.toJSONSchema(schema, {
+      io: direction === "Input" ? "input" : "output",
+    }) as Record<string, unknown>
     const meaningfulKeys = Object.keys(serialized).filter((key) => key !== "$schema")
     if (meaningfulKeys.length > 0) return serialized
     return {

--- a/packages/tools/tests/json-schema-direction.test.ts
+++ b/packages/tools/tests/json-schema-direction.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+import { z } from "zod"
+
+import { createToolRegistry, defineTool } from "../src/index.js"
+
+/**
+ * `z.toJSONSchema` defaults to `io: "output"`, and a transform has no
+ * statically known output type — so serializing a tool INPUT that way throws,
+ * and the registry published a description-only stub with no parameter names,
+ * types or required list. An agent could only guess field names, and every
+ * guess returned a -32602 it could not learn from.
+ *
+ * A boolean query param is the common carrier: `active`, `activated`,
+ * `isPrimary` all coerce a string, and that alone silently blanked the whole
+ * tool's parameter list.
+ */
+const booleanQueryParam = z
+  .union([z.boolean(), z.enum(["true", "false"])])
+  .transform((value) => value === true || value === "true")
+
+function registryWith(inputSchema: z.ZodType) {
+  const registry = createToolRegistry()
+  registry.register(
+    defineTool({
+      capabilityId: "test#tool.probe",
+      name: "probe",
+      description: "Probe tool.",
+      inputSchema,
+      outputSchema: z.object({ ok: z.boolean() }),
+      requiredScopes: [],
+      tier: "read",
+      riskPolicy: {
+        destructive: false,
+        reversible: true,
+        dryRunSupported: false,
+        confirmationRequired: false,
+        sideEffects: [],
+      },
+      async handler() {
+        return { ok: true }
+      },
+    }),
+  )
+  return registry.list()[0]
+}
+
+describe("tool input schemas serialize in the input direction", () => {
+  it("publishes real properties for a schema carrying a transform", () => {
+    const manifest = registryWith(
+      z.object({
+        productId: z.string().min(1).describe("Which product."),
+        active: booleanQueryParam.optional().describe("Filter by active state."),
+      }),
+    )
+
+    const inputSchema = manifest.inputSchema as {
+      properties?: Record<string, { description?: string }>
+      required?: string[]
+      "x-voyant-schema-quality"?: string
+    }
+
+    // The regression: this used to be the description-only stub.
+    expect(inputSchema["x-voyant-schema-quality"]).toBeUndefined()
+    expect(Object.keys(inputSchema.properties ?? {}).sort()).toEqual(["active", "productId"])
+    expect(inputSchema.required).toEqual(["productId"])
+    expect(inputSchema.properties?.active?.description).toBe("Filter by active state.")
+  })
+
+  it("still labels a genuinely unrepresentable input rather than throwing", () => {
+    const manifest = registryWith(z.object({ when: z.coerce.date() }))
+    const inputSchema = manifest.inputSchema as { "x-voyant-schema-quality"?: string }
+
+    expect(inputSchema["x-voyant-schema-quality"]).toBe("runtime-only")
+  })
+
+  it("keeps output schemas in the output direction", () => {
+    const manifest = registryWith(z.object({ id: z.string() }))
+    const outputSchema = manifest.outputSchema as {
+      properties?: Record<string, unknown>
+    }
+
+    expect(Object.keys(outputSchema.properties ?? {})).toEqual(["ok"])
+  })
+})


### PR DESCRIPTION
Fixes the bulk of #3824.

## What was wrong

26 of 284 Tools advertised **no parameters at all** — no field names, no types, no required list. An agent could only guess field names, and every guess returned a `-32602` it could not learn from. This is #3814's failure shape one level worse: there a single rule was hidden, here the entire input contract was.

The cause is a default. `z.toJSONSchema` serializes in the **output** direction unless told otherwise, and a schema containing a transform has no statically known output type — so zod throws `Transforms cannot be represented in JSON Schema`. `toJsonSchema` in the registry caught that and substituted:

```json
{ "description": "Input schema for \"list_products\" is not JSON-Schema-serializable; validated server-side.",
  "x-voyant-schema-quality": "runtime-only" }
```

A reasonable guard against breaking the whole manifest — which quietly turned a wrong argument into an invisible one.

But a tool's input schema describes what the caller **sends**, so it must serialize as `io: "input"`, the direction in which a transform is perfectly representable. Output schemas describe what the tool returns and stay `io: "output"`.

## Blast radius

One coerced boolean query param was enough to blank a tool's entire parameter list:

| field | tools affected |
|---|---|
| `active` | 14 |
| `website` | 6 |
| `isPrimary` | 3 |
| `taxId` | 2 |
| `currency` / `baseCurrency` | 2 |

Affected surfaces included most of inventory, identity, relationships, distribution, operations, and the whole bookings question family.

`projectSchemaForMcpDiscovery` in `@voyant-travel/mcp` carried the same default. It projects tool **inputs**, so it was rewriting representable schemas into lossy substitutes for exactly the same reason.

## Result

Measured against the published packages installed in the operator runtime, before and after:

| | before | after |
|---|---|---|
| usable parameter schema | 243 | **269** |
| no usable parameter schema | 28 | **2** |

The 2 remaining are `commerce/create_promotion` and `update_promotion`, which contain a genuine `z.coerce.date()` — unrepresentable in either direction. That is a real schema change rather than a serialization one, so it stays on #3824.

The 13 "no properties" tools from that issue turned out **not** to be defects: `list_team_roles`, `get_setup_state`, `dismiss_setup` and friends are genuinely zero-argument. I'd overcounted them.

## Tests

The regression test asserts the published manifest carries the actual properties, required list and per-field descriptions for a schema containing a transform, and separately that a genuinely unrepresentable input still degrades to the labelled stub rather than throwing. Reverting the one-line change fails it with `expected 'runtime-only' to be undefined`.

`@voyant-travel/tools` 27 tests pass, `@voyant-travel/mcp` 31 pass.