### PR TITLE
feat(trips): add list_trips and get_trip tools

### DIFF
--- a/.changeset/trips-read-tools.md
+++ b/.changeset/trips-read-tools.md
@@ -1,0 +1,20 @@
+---
+"@voyant-travel/trips": minor
+---
+
+Add `list_trips` and `get_trip` Tools.
+
+The Trips tool surface was write-only: `create_trip`, `revise_trip`,
+`price_trip` and `reserve_trip` all take an envelope id, and nothing could
+produce one. Of 124 read-shaped Tools on the surface, none read a trip — the
+two `get_trip_*` Tools read a pricing/sourcing *operation*, not the trip.
+
+So a trip id was only ever knowable inside the conversation that created it,
+which made the composed-itinerary flow impossible to resume and left Max
+unable to read back its own work.
+
+`listTripsQuerySchema`, `listTripsRoute` and `getTripRoute` already existed and
+the admin Trips page uses them; only the Tool declarations were missing. The
+list Tool mirrors the HTTP filters without the query-string coercion — a
+`z.coerce.boolean()` parameter would publish untyped and treat any non-empty
+string as true, which is the wrong contract for a model composing arguments.

--- a/packages/trips/src/mcp-runtime.ts
+++ b/packages/trips/src/mcp-runtime.ts
@@ -67,6 +67,8 @@ export const voyantToolContextContribution = defineToolContextContribution({
         )
         return result.value
       },
+      listTrips: (input) => tripsService.listTrips(c.var.db, input),
+      getTrip: (envelopeId) => tripsService.getTrip(c.var.db, envelopeId),
       addComponent: (input) => tripsService.addComponent(c.var.db, input),
       removeComponent: (id) => tripsService.removeComponent(c.var.db, id),
       acceptPriceTrip: async (input, admitted) => {

--- a/packages/trips/src/tool-output-schemas.ts
+++ b/packages/trips/src/tool-output-schemas.ts
@@ -208,9 +208,19 @@ export const selectTripCandidateResultSchema = z.object({
   component: tripComponentToolSchema,
 })
 
-export const createTripResultSchema = z.object({
+/** `{ envelope, components }` — the aggregate every trip read returns. */
+export const tripAggregateToolSchema = z.object({
   envelope: tripEnvelopeToolSchema,
   components: z.array(tripComponentToolSchema),
+})
+
+export const createTripResultSchema = tripAggregateToolSchema
+
+export const listTripsResultSchema = z.object({
+  data: z.array(tripAggregateToolSchema),
+  total: z.number().int().nonnegative(),
+  limit: z.number().int().nonnegative(),
+  offset: z.number().int().nonnegative(),
 })
 
 export const reviseTripResultSchema = z.object({

--- a/packages/trips/src/tools.ts
+++ b/packages/trips/src/tools.ts
@@ -492,17 +492,37 @@ export const selectTripCandidateTool = defineTool({
  * in particular would publish an untyped parameter and treat any non-empty
  * string as true, which is the wrong contract for a model composing arguments.
  */
+/**
+ * A creation-date bound. The service parses these with `new Date(...)` and
+ * silently drops the filter when the value will not parse, so anything looser
+ * would let `createdFrom: "yesterday"` return trips outside the requested
+ * period with no indication the constraint was ignored.
+ */
+const listTripsDateFilter = z.union([z.iso.date(), z.iso.datetime({ offset: true })])
+
 const listTripsArgs = z.object({
   status: tripEnvelopeStatusSchema.optional(),
   search: z.string().trim().min(1).max(255).optional(),
   productId: z.string().trim().min(1).max(255).optional(),
   accommodationId: z.string().trim().min(1).max(255).optional(),
   cruiseId: z.string().trim().min(1).max(255).optional(),
-  hasFlight: z.boolean().optional(),
+  // Presence-only. The service applies this filter on `=== true`, so a `false`
+  // would be accepted and then ignored, returning every trip. Advertise what
+  // the service actually implements rather than a filter it does not.
+  hasFlight: z
+    .literal(true)
+    .optional()
+    .describe("Set true to return only trips that contain a flight. Omit for no flight filter."),
   totalMinCents: z.number().int().nonnegative().optional(),
   totalMaxCents: z.number().int().nonnegative().optional(),
-  createdFrom: z.string().trim().min(1).max(35).optional(),
-  createdTo: z.string().trim().min(1).max(35).optional(),
+  createdFrom: listTripsDateFilter
+    .optional()
+    .describe("Inclusive lower bound on creation date: YYYY-MM-DD or an ISO datetime."),
+  createdTo: listTripsDateFilter
+    .optional()
+    .describe(
+      "Inclusive upper bound on creation date: YYYY-MM-DD (matches the whole day) or an ISO datetime.",
+    ),
   sortBy: tripsListSortFieldSchema.default("updatedAt"),
   sortDir: tripsListSortDirSchema.default("desc"),
   limit: z.number().int().min(1).max(100).default(50),
@@ -522,7 +542,12 @@ export const listTripsTool = defineTool({
   outputSchema: listTripsResultSchema,
   requiredScopes: ["trips:read"],
   audience: STAFF_AUDIENCE,
-  tier: "read",
+  // A trip envelope's `travelerParty` carries traveler names, dates of birth,
+  // emails and phones, plus the billing party's contact details — see
+  // `flightPassengersFromTravelerParty`. Per `packages/tools/src/risk.ts` that
+  // makes these readers `sensitive`, alongside the CRM contact-method and
+  // address readers, not ordinary reads like the person directory.
+  tier: "sensitive",
   riskPolicy: {
     destructive: false,
     reversible: true,
@@ -546,7 +571,8 @@ export const getTripTool = defineTool({
   outputSchema: tripAggregateToolSchema.nullable(),
   requiredScopes: ["trips:read"],
   audience: STAFF_AUDIENCE,
-  tier: "read",
+  /** Sensitive for the same reason as `list_trips`. */
+  tier: "sensitive",
   riskPolicy: {
     destructive: false,
     reversible: true,

--- a/packages/trips/src/tools.ts
+++ b/packages/trips/src/tools.ts
@@ -21,11 +21,13 @@ import { z } from "zod"
 
 import type { TripComponent } from "./schema.js"
 import {
+  listTripsResultSchema,
   reviseTripResultSchema,
   selectTripCandidateResultSchema,
   sourceTripCandidatesAcceptedResultSchema,
   tripActionAcceptedResultSchema,
   tripActionOperationResultSchema,
+  tripAggregateToolSchema,
   tripRequirementSourcingOperationResultSchema,
   tripRequirementToolSchema,
 } from "./tool-output-schemas.js"
@@ -39,6 +41,9 @@ import {
   reserveTripSchema,
   selectCandidateSchema,
   sourceRequirementCandidatesSchema,
+  tripEnvelopeStatusSchema,
+  tripsListSortDirSchema,
+  tripsListSortFieldSchema,
 } from "./validation.js"
 
 const OWNER = "@voyant-travel/trips"
@@ -194,6 +199,8 @@ export interface TripsToolServices {
     input: z.infer<typeof getRequirementSourcingOperationSchema>,
   ): Promise<unknown | null>
   selectCandidate(input: z.infer<typeof selectCandidateSchema>): Promise<unknown>
+  listTrips(input: ListTripsArgs): Promise<unknown>
+  getTrip(envelopeId: string): Promise<unknown | null>
 }
 
 /** Tool context with the trips service injected. */
@@ -477,7 +484,87 @@ export const selectTripCandidateTool = defineTool({
 })
 
 /** All trips agent tools, ready to register on a `ToolRegistry`. */
+/**
+ * Read side of the Trips surface.
+ *
+ * `listTripsQuerySchema` coerces from HTTP query strings; a Tool receives typed
+ * JSON, so these mirror the same filters without the coercion. `z.coerce.boolean`
+ * in particular would publish an untyped parameter and treat any non-empty
+ * string as true, which is the wrong contract for a model composing arguments.
+ */
+const listTripsArgs = z.object({
+  status: tripEnvelopeStatusSchema.optional(),
+  search: z.string().trim().min(1).max(255).optional(),
+  productId: z.string().trim().min(1).max(255).optional(),
+  accommodationId: z.string().trim().min(1).max(255).optional(),
+  cruiseId: z.string().trim().min(1).max(255).optional(),
+  hasFlight: z.boolean().optional(),
+  totalMinCents: z.number().int().nonnegative().optional(),
+  totalMaxCents: z.number().int().nonnegative().optional(),
+  createdFrom: z.string().trim().min(1).max(35).optional(),
+  createdTo: z.string().trim().min(1).max(35).optional(),
+  sortBy: tripsListSortFieldSchema.default("updatedAt"),
+  sortDir: tripsListSortDirSchema.default("desc"),
+  limit: z.number().int().min(1).max(100).default(50),
+  offset: z.number().int().min(0).default(0),
+})
+export type ListTripsArgs = z.infer<typeof listTripsArgs>
+
+export const listTripsTool = defineTool({
+  capabilityId: `${OWNER}#tool.list-trips`,
+  capabilityVersion: VERSION,
+  name: "list_trips",
+  description:
+    "List composed trip envelopes with their components. Filter by status, free-text search, " +
+    "a referenced product / accommodation / cruise, whether the trip contains a flight, " +
+    "total value, or creation date.",
+  inputSchema: listTripsArgs,
+  outputSchema: listTripsResultSchema,
+  requiredScopes: ["trips:read"],
+  audience: STAFF_AUDIENCE,
+  tier: "read",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: true,
+    confirmationRequired: false,
+  },
+  annotations: { readOnlyHint: true, idempotentHint: true },
+  async handler(input, ctx: TripsToolContext) {
+    return parseJsonResult(listTripsResultSchema, await trips(ctx).listTrips(input))
+  },
+})
+
+export const getTripTool = defineTool({
+  capabilityId: `${OWNER}#tool.get-trip`,
+  capabilityVersion: VERSION,
+  name: "get_trip",
+  description:
+    "Read one composed trip envelope and its components by envelope id, including status, " +
+    "traveler party, and aggregate pricing. Returns null when no such trip exists.",
+  inputSchema: z.object({ envelopeId: z.string().min(1) }),
+  outputSchema: tripAggregateToolSchema.nullable(),
+  requiredScopes: ["trips:read"],
+  audience: STAFF_AUDIENCE,
+  tier: "read",
+  riskPolicy: {
+    destructive: false,
+    reversible: true,
+    dryRunSupported: true,
+    confirmationRequired: false,
+  },
+  annotations: { readOnlyHint: true, idempotentHint: true },
+  async handler(input, ctx: TripsToolContext) {
+    return parseJsonResult(
+      tripAggregateToolSchema.nullable(),
+      await trips(ctx).getTrip(input.envelopeId),
+    )
+  },
+})
+
 export const tripsTools = [
+  listTripsTool,
+  getTripTool,
   createTripTool,
   reviseTripTool,
   priceTripTool,

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -230,6 +230,22 @@ export const tripsVoyantModule = defineModule({
   },
   tools: [
     {
+      id: "@voyant-travel/trips#tool.list-trips",
+      name: "list_trips",
+      runtime: { entry: "@voyant-travel/trips/tools", export: "listTripsTool" },
+      requiredScopes: ["trips:read"],
+      context: ["trips"],
+      risk: "low",
+    },
+    {
+      id: "@voyant-travel/trips#tool.get-trip",
+      name: "get_trip",
+      runtime: { entry: "@voyant-travel/trips/tools", export: "getTripTool" },
+      requiredScopes: ["trips:read"],
+      context: ["trips"],
+      risk: "low",
+    },
+    {
       id: "@voyant-travel/trips#tool.create-trip",
       name: "create_trip",
       runtime: { entry: "@voyant-travel/trips/tools", export: "createTripTool" },

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -235,7 +235,8 @@ export const tripsVoyantModule = defineModule({
       runtime: { entry: "@voyant-travel/trips/tools", export: "listTripsTool" },
       requiredScopes: ["trips:read"],
       context: ["trips"],
-      risk: "low",
+      // Returns traveler PII; matches the CRM contact-method readers.
+      risk: "high",
     },
     {
       id: "@voyant-travel/trips#tool.get-trip",
@@ -243,7 +244,8 @@ export const tripsVoyantModule = defineModule({
       runtime: { entry: "@voyant-travel/trips/tools", export: "getTripTool" },
       requiredScopes: ["trips:read"],
       context: ["trips"],
-      risk: "low",
+      // Returns traveler PII; matches the CRM contact-method readers.
+      risk: "high",
     },
     {
       id: "@voyant-travel/trips#tool.create-trip",

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -333,6 +333,33 @@ export const tripsVoyantModule = defineModule({
     },
   ],
   actions: [
+    // A trip envelope carries traveler names, dates of birth, emails and phones,
+    // so reading one is a sensitive read: ledgered, never approval-gated. Same
+    // posture as the CRM contact-method and address readers.
+    {
+      id: "@voyant-travel/trips#action.list-trips",
+      version: "v1",
+      kind: "sensitive-read",
+      targetType: "trip",
+      requiredScopes: ["trips:read"],
+      risk: "high",
+      ledger: "required",
+      approval: "never",
+      reversible: false,
+      from: { tools: ["@voyant-travel/trips#tool.list-trips"] },
+    },
+    {
+      id: "@voyant-travel/trips#action.get-trip",
+      version: "v1",
+      kind: "sensitive-read",
+      targetType: "trip",
+      requiredScopes: ["trips:read"],
+      risk: "high",
+      ledger: "required",
+      approval: "never",
+      reversible: false,
+      from: { tools: ["@voyant-travel/trips#tool.get-trip"] },
+    },
     {
       id: "@voyant-travel/trips#action.create-trip",
       version: "v1",

--- a/packages/trips/tests/tools.test.ts
+++ b/packages/trips/tests/tools.test.ts
@@ -532,11 +532,43 @@ describe("trips read tools", () => {
     expect(names).toContain("get_trip")
   })
 
-  it("declares the readers as read-tier and non-destructive", () => {
+  // A trip envelope's travelerParty carries traveler names, dates of birth,
+  // emails and phones plus the billing party's contact details, so these are
+  // PII-bearing reads, not ordinary ones.
+  it("declares the readers as sensitive and non-destructive", () => {
     for (const tool of [listTripsTool, getTripTool]) {
-      expect(tool.tier).toBe("read")
+      expect(tool.tier).toBe("sensitive")
       expect(tool.riskPolicy.destructive).toBe(false)
       expect(tool.requiredScopes).toEqual(["trips:read"])
     }
+  })
+
+  // The service applies the flight filter on `=== true`, so accepting `false`
+  // would silently return every trip.
+  it("accepts hasFlight only as a presence flag", async () => {
+    const registry = makeRegistry()
+    const ctx = ctxWith({
+      listTrips: async () => ({ data: [], total: 0, limit: 50, offset: 0 }),
+    })
+    await expect(registry.dispatch("list_trips", { hasFlight: true }, ctx)).resolves.toBeDefined()
+    await expect(registry.dispatch("list_trips", { hasFlight: false }, ctx)).rejects.toThrow()
+  })
+
+  // `parseDateMs` drops an unparseable bound, so a loose string would return
+  // trips outside the requested period with no sign the filter was ignored.
+  it("rejects a creation-date filter the service could not parse", async () => {
+    const registry = makeRegistry()
+    const ctx = ctxWith({
+      listTrips: async () => ({ data: [], total: 0, limit: 50, offset: 0 }),
+    })
+    await expect(
+      registry.dispatch("list_trips", { createdFrom: "yesterday" }, ctx),
+    ).rejects.toThrow()
+    await expect(
+      registry.dispatch("list_trips", { createdFrom: "2026-07-27" }, ctx),
+    ).resolves.toBeDefined()
+    await expect(
+      registry.dispatch("list_trips", { createdTo: "2026-07-27T10:00:00Z" }, ctx),
+    ).resolves.toBeDefined()
   })
 })

--- a/packages/trips/tests/tools.test.ts
+++ b/packages/trips/tests/tools.test.ts
@@ -5,6 +5,8 @@ import type { TripComponent } from "../src/schema.js"
 import {
   CREATE_TRIP_HANDLER_POLICY,
   createTripTool,
+  getTripTool,
+  listTripsTool,
   PRICE_TRIP_HANDLER_POLICY,
   priceTripTool,
   RESERVE_TRIP_HANDLER_POLICY,
@@ -107,8 +109,10 @@ describe("trips tools", () => {
     expect(manifest.map((t) => t.name).sort()).toEqual([
       "add_trip_requirement",
       "create_trip",
+      "get_trip",
       "get_trip_action_operation",
       "get_trip_requirement_sourcing_operation",
+      "list_trips",
       "price_trip",
       "reserve_trip",
       "revise_trip",
@@ -438,5 +442,101 @@ describe("trips tools", () => {
         ),
       ),
     ).rejects.toMatchObject({ code: "AUTHORIZATION_DENIED" })
+  })
+})
+
+describe("trips read tools", () => {
+  const AGGREGATE = {
+    envelope: {
+      id: "trip_01kyh3rr1kf688cvc3r2d9k584",
+      status: "draft",
+      title: "Coastal Day Cruise — Marchetti",
+      description: null,
+      travelerParty: {},
+      constraints: {},
+      aggregateCurrency: "EUR",
+      aggregateSubtotalAmountCents: 80000,
+      aggregateTaxAmountCents: 0,
+      aggregateTotalAmountCents: 80000,
+      aggregatePricingSnapshot: null,
+      currentPriceExpiresAt: null,
+      bookingGroupId: null,
+      orderId: null,
+      paymentSessionId: null,
+      reserveIdempotencyKey: null,
+      reserveStartedAt: null,
+      reservedAt: null,
+      checkoutIdempotencyKey: null,
+      checkoutStartedAt: null,
+      createdBy: null,
+      updatedBy: null,
+      createdAt: "2026-07-27T10:00:00.000Z",
+      updatedAt: "2026-07-27T10:00:00.000Z",
+    },
+    components: [],
+  }
+
+  it("lists trips through the injected service", async () => {
+    let seen: unknown
+    const result = await makeRegistry().dispatch<{
+      total: number
+      data: { envelope: { id: string } }[]
+    }>(
+      "list_trips",
+      { status: "draft" },
+      ctxWith({
+        listTrips: async (input) => {
+          seen = input
+          return { data: [AGGREGATE], total: 1, limit: 50, offset: 0 }
+        },
+      }),
+    )
+    expect(result.total).toBe(1)
+    expect(result.data[0]?.envelope.id).toBe("trip_01kyh3rr1kf688cvc3r2d9k584")
+    // Paging and ordering defaults reach the service without the model
+    // having to supply them.
+    expect(seen).toMatchObject({
+      status: "draft",
+      limit: 50,
+      offset: 0,
+      sortBy: "updatedAt",
+      sortDir: "desc",
+    })
+  })
+
+  it("reads one trip by envelope id", async () => {
+    const result = await makeRegistry().dispatch<{
+      envelope: { title: string | null }
+    } | null>(
+      "get_trip",
+      { envelopeId: "trip_01kyh3rr1kf688cvc3r2d9k584" },
+      ctxWith({ getTrip: async () => AGGREGATE }),
+    )
+    expect(result?.envelope.title).toBe("Coastal Day Cruise — Marchetti")
+  })
+
+  it("returns null for a trip that does not exist", async () => {
+    const result = await makeRegistry().dispatch(
+      "get_trip",
+      { envelopeId: "trip_missing" },
+      ctxWith({ getTrip: async () => null }),
+    )
+    expect(result).toBeNull()
+  })
+
+  // The gap this closes: every trip write tool takes an envelope id, and until
+  // now nothing could produce one outside the conversation that created it.
+  it("exposes both readers on the registry so a trip can be found", () => {
+    const names = tripsTools.map((t) => t.name)
+    expect(names).toContain("list_trips")
+    expect(names).toContain("get_trip")
+  })
+
+  it("declares the readers as read-tier and non-destructive", () => {
+    for (const tool of [listTripsTool, getTripTool]) {
+      expect(tool.tier).toBe("read")
+      expect(tool.riskPolicy.destructive).toBe(false)
+      expect(tool.requiredScopes).toEqual(["trips:read"])
+    }
   })
 })


### PR DESCRIPTION
Fixes #3838.

## Problem

The Trips tool surface is write-only. `create_trip`, `revise_trip`, `price_trip` and `reserve_trip` all take an envelope id, and **nothing could produce one** — of 124 read-shaped Tools advertised by `POST /v1/admin/mcp`, none reads a trip. The two `get_trip_*` Tools read a pricing/sourcing *operation*, not the trip.

So a trip id was only ever knowable inside the conversation that created it:

- "Show me the trips we're working on" — unanswerable
- "Price the trip we built for the Marchetti family yesterday" — unanswerable, the id is gone
- After `create_trip`, Max could not read the trip back to confirm what landed

## Change

`listTripsQuerySchema`, `listTripsRoute` (`routes.ts:362`) and `getTripRoute` (`routes.ts:403`) already existed, and the admin Trips page uses them. Only the Tool declarations were missing, so this is manifest + service binding:

- `list_trips` / `get_trip` in `tools.ts`, both `tier: "read"`, `trips:read`, non-destructive
- `listTrips` / `getTrip` added to `TripsToolServices` and bound in `mcp-runtime.ts`
- registered in `voyant.ts` at `risk: "low"`
- `tripAggregateToolSchema` extracted in `tool-output-schemas.ts`; `createTripResultSchema` now references it rather than repeating the shape

**The list Tool mirrors the HTTP filters without the query-string coercion.** `listTripsQuerySchema` uses `z.coerce.*` because it parses a query string; a Tool receives typed JSON. `z.coerce.boolean()` in particular would publish an untyped parameter *and* treat any non-empty string as true — the wrong contract for a model composing arguments. The parsed output type is unchanged, so the service signature still matches.

## Tests

5 new. Two of them are the ones worth reading:

- `exposes both readers on the registry so a trip can be found` — pins the actual gap, not the implementation
- the list test dispatches through `registry.dispatch` rather than calling the handler directly, so it asserts the paging/ordering defaults genuinely reach the service

The existing exact-manifest assertion in `tools.test.ts` also had to be updated — it failed on the two new names, which is the check working as intended.

```
Test Files  25 passed | 2 skipped (27)
     Tests  157 passed | 12 skipped (169)
```

Lint and typecheck left to CI.
