### PR TITLE
Rename Voyant Payments to Voyant Pay and add processor activation

### DIFF
--- a/.changeset/calm-cats-activate-payments.md
+++ b/.changeset/calm-cats-activate-payments.md
@@ -1,6 +1,6 @@
 ---
 "@voyant-travel/payments": minor
-"@voyant-travel/framework": minor
+"@voyant-travel/framework": patch
 "@voyant-travel/operator-settings": minor
 "@voyant-travel/operator-settings-react": minor
 "@voyant-travel/i18n": patch

--- a/.changeset/calm-cats-activate-payments.md
+++ b/.changeset/calm-cats-activate-payments.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/payments": minor
+"@voyant-travel/framework": minor
+"@voyant-travel/operator-settings": minor
+"@voyant-travel/operator-settings-react": minor
+"@voyant-travel/i18n": patch
+---
+
+Rename the first-party processor to Voyant Pay while accepting legacy provider identifiers, and add readiness-aware active processor selection to managed payment settings.

--- a/docs/adr/0015-payment-adapter-transports-and-managed-connect.md
+++ b/docs/adr/0015-payment-adapter-transports-and-managed-connect.md
@@ -21,7 +21,7 @@ already exists in `@voyant-travel/payments` (`PaymentAdapter`,
 payment, and checkout state.
 
 Today a deployment **hard-selects one adapter at build time** through
-`deployment.providers.payments` (`voyant-payments` | `netopia` | `custom` |
+`deployment.providers.payments` (`voyant-pay` | `netopia` | `custom` |
 `none`) and **configures it with environment variables**. There is no way for an
 operator to browse available processors and connect one from the admin UI; the
 provider is fixed by the deployment graph and its credentials are baked into the
@@ -34,7 +34,7 @@ Two forces make that insufficient:
    way they manage every other integration. Not by editing environment
    variables and redeploying.
 2. **Scale of the connector catalog.** We (Voyant) will build and maintain
-   *first-party* adapters for Voyant Payments, Netopia, Stripe, Adyen, Razorpay,
+   *first-party* adapters for Voyant Pay, Netopia, Stripe, Adyen, Razorpay,
    and a long tail of country-specific processors — potentially tens of them.
    Bundling every adapter's SDK and code into every Operator build is
    unacceptable bloat, most of it dead weight for any single deployment.
@@ -75,12 +75,16 @@ how many processors the catalog offers.
   it through the remote transport and the voyant-cloud provider registry. Used
   by Voyant Cloud deployments. Requires a control-plane endpoint + trust token,
   not per-processor secrets.
-- `voyant-payments` | `netopia` | `custom` — unchanged. A self-hosted deployment
+- `voyant-pay` | `netopia` | `custom` — unchanged. A self-hosted deployment
   pins one in-process adapter and configures it with environment variables, as
   today. `custom` remains for operator-owned adapters that pass the conformance
   kit.
 - `none` — unchanged; valid only for deployments without payment-capable graph
   units.
+
+The legacy `voyant-payments` deployment value remains accepted at input
+boundaries for existing configurations and is normalized to `voyant-pay` in
+canonical deployment output.
 
 Exactly one active adapter per deployment/org is enforced. In `managed` mode
 this is a single active configuration row; in the pinned modes it is the graph
@@ -100,7 +104,7 @@ Self-host and managed differ **only** in credential custody:
   connect form posts credentials **directly to the voyant-cloud control
   plane** — they are KMS-encrypted at rest there and decrypted by the
   **stateless** processor worker at call time.
-- **Managed hosted-account providers** such as Voyant Payments do not ask the
+- **Managed hosted-account providers** such as Voyant Pay do not ask the
   operator for a processor API key. Voyant Cloud owns the platform Stripe
   credentials and creates an organization-scoped connected account. Settings
   renders short-lived embedded onboarding and account-management sessions
@@ -143,7 +147,7 @@ The Operator exposes the catalog and connection state under
 
 ### 5. Connect flow
 
-1. Settings → Payments shows the catalog (Netopia `available`, Voyant Payments
+1. Settings → Payments shows the catalog (Netopia `available`, Voyant Pay
    `coming_soon` at launch).
 2. Operator selects a provider.
 3. For `credentials`, Settings renders `credentialFieldSchema`, submits
@@ -165,10 +169,66 @@ The Operator exposes the catalog and connection state under
    previous provider is retired as an immutable connection revision, preserving
    the identity required by existing sessions and callbacks.
 
-Voyant Payments must use `embedded_onboarding`; its catalog entry must not
+Voyant Pay must use `embedded_onboarding`; its catalog entry must not
 declare a fake API-key credential. It remains `coming_soon` until the cloud
 adapter, embedded components, callback transport, sandbox conformance run, and
 operational launch gates are complete.
+
+### 5a. Connected is not active — explicit activation
+
+*Connected/ready* and *active/default* are modeled as independent facts. A
+deployment may hold several known connections (across providers, or successive
+revisions of one provider) each carrying its own lifecycle/readiness, while at
+most one is the **active default** used at checkout. Connecting or completing
+onboarding does not silently make a connection active.
+
+The contract additions on `@voyant-travel/payments` (all backward compatible —
+existing fields and callers are unchanged):
+
+- `PaymentConnectionIdentity { providerId, connectionId }` — the stable identity
+  of one connection, structurally aligned with `PaymentProcessorIdentity` so a
+  selected connection threads onto initiation/callback events.
+- `PaymentConnectionSummary` — a deliberately **non-sensitive** per-connection
+  projection: identity, `state`, `readiness` (`ready | not_ready | unknown`),
+  `mode`, `active`, non-secret `requirements`, and `readOnly`. It never carries
+  credentials, KMS references, or platform tokens.
+- `PaymentConnectionStatus` gains optional `activeConnectionId` and
+  `connections: PaymentConnectionSummary[]`, so the active default and the list
+  of known connections + readiness are reported separately.
+- `paymentConnectionReadiness(state)` / `isPaymentConnectionReady(state)` — the
+  single readiness rule: only the `connected` lifecycle state is `ready`.
+- `PaymentProviderRegistry.activate?(input): PaymentActivationResult` — an
+  **optional** method that promotes an already-known, ready connection to the
+  active default. `activate` requires an exact `{ providerId, connectionId }`
+  identity (never "the provider's latest") and reports success/failure
+  explicitly via `ok`; the absence of an error is not success.
+
+The Operator exposes this as `POST /v1/admin/settings/payments/activate`
+(validated `{ providerId, connectionId }`), which delegates generically to the
+resolved registry.
+
+**Behavior by transport:**
+
+- **Self-host (default registry):** activation is **read-only** and fails closed
+  — the processor is pinned via environment variables and there is no second
+  connection to promote. The route/registry never reports `ok: true` for a
+  switch it did not perform.
+- **Managed default (this repo, no live control plane yet):** activation fails
+  closed with "not yet available"; the default registry has no authority over
+  managed connection records and must not invent an activation.
+- **Managed control plane (separate platform repo):** owns the real
+  implementation — it enforces the readiness gate server-side (rejecting a
+  not-ready connection regardless of any client gating), performs the atomic
+  one-active-per-org switch, retires the previous connection as an immutable
+  revision (preserving the identity existing sessions/callbacks depend on), and
+  returns the updated `PaymentConnectionStatus`. A registry that does not
+  implement `activate` is treated as "activation unsupported" and fails closed
+  at the route.
+
+Readiness gating is enforced in depth: the UI only offers "Make active" for
+ready, inactive, writable connections, and the authoritative registry re-checks
+readiness before switching. Client gating is a convenience, never the security
+boundary.
 
 ### 6. Runtime resolution seam
 
@@ -259,7 +319,7 @@ id conflicts with the stored session identity.
   port); Operator payments settings surface (config row: active provider,
   status, mode, connection reference — no secrets; service; `/v1/admin/settings/
   payments/*` routes); Settings → Payments page + i18n (en + ro), with Netopia
-  `available` and Voyant Payments `coming_soon`; `managed` provider value in the
+  `available` and Voyant Pay `coming_soon`; `managed` provider value in the
   framework deployment types + requirements. The registry/connect calls are
   wired against the `PaymentProviderRegistry` port with a first-party catalog so
   the UI is real; live voyant-cloud wiring is Phase 2.
@@ -267,7 +327,7 @@ id conflicts with the stored session identity.
   (Netopia), the provider registry endpoint, KMS-backed credential storage
   reusing `connect-utils`, dispatcher routing, and signed callback forwarding —
   making managed connect function end to end.
-- **Phase 3:** the Voyant Payments worker, then Stripe / Adyen / Razorpay and
+- **Phase 3:** the Voyant Pay worker, then Stripe / Adyen / Razorpay and
   country-specific processors as pure worker + registry-entry additions with no
   Operator bundle change.
 
@@ -299,7 +359,7 @@ id conflicts with the stored session identity.
 - Contract: `createRemotePaymentAdapter(...)` satisfies `paymentAdapterRuntimePort`
   conformance.
 - Self-host regression: pinned `netopia` continues to resolve from environment
-  variables with no DB credential storage; a fake Voyant Payments API key does
+  variables with no DB credential storage; a fake Voyant Pay API key does
   not invent a hosted-account connection.
 - Credential connect flow: selecting a credential provider and submitting valid
   credentials runs `health()` and transitions to `connected`; invalid

--- a/docs/architecture/payment-adapter-boundary.md
+++ b/docs/architecture/payment-adapter-boundary.md
@@ -8,12 +8,16 @@ The deployment selects one active adapter through
 `deployment.providers.payments`. The provider values are:
 
 - `managed`
-- `voyant-payments`
+- `voyant-pay`
 - `netopia`
 - `custom`
 - `none`
 
-For the pinned values (`voyant-payments`, `netopia`, `custom`), environment
+The legacy `voyant-payments` value remains accepted at deployment input
+boundaries and is normalized to the canonical `voyant-pay` value in generated
+deployment output.
+
+For the pinned values (`voyant-pay`, `netopia`, `custom`), environment
 variables configure the selected adapter; their presence never selects a
 processor. This is the self-host path: one in-process adapter package, pinned by
 the graph, configured through the environment.
@@ -46,7 +50,15 @@ matching provider facets for a concrete selected adapter.
 - idempotency and retry expectations;
 - health diagnostics and sandbox/test-mode declaration;
 - conformance helpers for money handling, state transitions, duplicate/replay
-  callbacks, signature failure, idempotency, and failure posture.
+  callbacks, signature failure, idempotency, and failure posture;
+- the provider selection/connection layer: `PaymentProviderDescriptor`,
+  `PaymentProviderRegistry`, connection identity/summary/readiness types, and
+  the `activate` contract for explicit processor activation (see
+  [ADR 0015 §5a](../adr/0015-payment-adapter-transports-and-managed-connect.md)).
+  Connected/ready and active/default are independent facts; only a ready
+  connection may be made the active default, and the authoritative registry
+  enforces that gate. The default/self-host registry is read-only for activation
+  and fails closed.
 
 The existing finance `CardPaymentStarter` seam remains as the checkout bridge.
 Deployments can adapt a selected `PaymentAdapter` through

--- a/docs/architecture/payments-architecture.md
+++ b/docs/architecture/payments-architecture.md
@@ -1,9 +1,9 @@
-# Voyant Payments Architecture
+# Voyant Pay Architecture
 
 > **Proposed provider direction:**
 > [`remote-app-platform-rfc.md`](./remote-app-platform-rfc.md) classifies payment
 > processors as deployment-selected payment adapters rather than installable
-> apps. Netopia, Voyant Payments, and future processors implement one selected
+> apps. Netopia, Voyant Pay, and future processors implement one selected
 > adapter port and conformance suite. Accounting integrations follow the remote
 > OAuth app model instead. This document describes the current payment stack;
 > its plugin terminology will migrate with that RFC.
@@ -327,7 +327,7 @@ prefer one payment event stream.
 
 ## Package Layout
 
-The Voyant payments stack is **already built** — these are the actual
+The Voyant Pay stack is **already built** — these are the actual
 packages, not new ones to create:
 
 ```

--- a/packages/framework/src/deployment-graph.test.ts
+++ b/packages/framework/src/deployment-graph.test.ts
@@ -2311,6 +2311,19 @@ describe("deployment graph v1", () => {
     expect(second).toEqual(first)
   })
 
+  it("normalizes the legacy Voyant Payments deployment selector in output", () => {
+    const deployment = defineDeployment({
+      project: defineProject({ modules: [] }),
+      target: "node",
+      providers: { payments: "voyant-payments" },
+    })
+
+    expect(deployment.providers.payments).toBe("voyant-pay")
+    expect(deployment.requirements.resources).toEqual([
+      expect.objectContaining({ provider: "voyant-pay", resourceKey: "payments:voyant-pay" }),
+    ])
+  })
+
   it("normalizes deployment resource requirements before hashing", async () => {
     const project = defineProject({
       modules: [],

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -64,7 +64,7 @@ import type {
   VoyantDeploymentProviderRole,
   VoyantDeploymentResourceRequirement,
 } from "./deployment-types.js"
-import { DEPLOYMENT_PROVIDER_ROLES } from "./deployment-types.js"
+import { canonicalDeploymentProvider, DEPLOYMENT_PROVIDER_ROLES } from "./deployment-types.js"
 import type { VoyantScheduledJob } from "./scheduled-jobs.js"
 
 export const VOYANT_GRAPH_DEPLOYMENT_SCHEMA_VERSION = "voyant.deployment.v1" as const
@@ -575,15 +575,16 @@ export function defineDeployment(input: DefineVoyantGraphDeploymentInput): Voyan
     throw new Error('defineDeployment: target must be "node".')
   }
 
+  const providers = canonicalDeploymentProviders(input.providers)
   const deployment = {
     schemaVersion: input.schemaVersion ?? VOYANT_GRAPH_DEPLOYMENT_SCHEMA_VERSION,
     project: input.project,
     target: input.target,
-    providers: { ...(input.providers ?? {}) },
+    providers,
     ...(input.migrations?.length ? { migrations: [...input.migrations] } : {}),
     ...(input.mode ? { mode: input.mode } : {}),
     requirements: normalizeDeploymentRequirements(
-      input.requirements ?? deriveDeploymentRequirements(input.providers),
+      input.requirements ?? deriveDeploymentRequirements(providers),
     ),
     ...(input.meta ? { meta: input.meta } : {}),
   } satisfies VoyantGraphDeployment
@@ -607,6 +608,19 @@ export function deriveDeploymentRequirements(
         : []
     }),
   })
+}
+
+function canonicalDeploymentProviders(
+  providers: Partial<Record<VoyantDeploymentProviderRole | string, string>> = {},
+): Partial<Record<VoyantDeploymentProviderRole | string, string>> {
+  return Object.fromEntries(
+    Object.entries(providers).map(([role, provider]) => [
+      role,
+      typeof provider === "string"
+        ? canonicalDeploymentProvider(role, provider)
+        : provider,
+    ]),
+  )
 }
 
 export function validateGraphUnitManifest(
@@ -720,7 +734,7 @@ export async function resolveDeploymentGraph(
     throw new Error('resolveDeploymentGraph: target must be "node".')
   }
   const mode = input.mode ?? input.deployment?.mode
-  const deploymentProviders = { ...(input.deployment?.providers ?? {}) }
+  const deploymentProviders = canonicalDeploymentProviders(input.deployment?.providers)
   const requirements = normalizeDeploymentRequirements(input.deployment?.requirements)
   const migrations = input.deployment?.migrations ?? input.project.deployment?.migrations
   const selectionConfigById = new Map(
@@ -4361,7 +4375,10 @@ function providerDeclarationIsSelected(
   selections: Partial<Record<VoyantDeploymentProviderRole | string, string>>,
 ): boolean {
   const selection = declaration.selection
-  return selection !== undefined && selections[selection.role] === selection.value
+  return (
+    selection !== undefined &&
+    selections[selection.role] === canonicalDeploymentProvider(selection.role, selection.value)
+  )
 }
 
 function validatePaymentProviderSelection(
@@ -4383,7 +4400,7 @@ function validatePaymentProviderSelection(
         facet: "deployment.providers.payments",
         message:
           "Payment-capable graphs must explicitly select one active deployment.providers.payments adapter.",
-        hint: 'Set deployment.providers.payments to "voyant-payments", "netopia", or "custom"; environment variables never select a payment processor.',
+        hint: 'Set deployment.providers.payments to "voyant-pay", "netopia", or "custom"; environment variables never select a payment processor.',
       }),
     ]
   }
@@ -4394,7 +4411,8 @@ function validatePaymentProviderSelection(
     (unit.providers ?? [])
       .filter(
         (provider) =>
-          provider.selection?.role === "payments" && provider.selection.value === selected,
+          provider.selection?.role === "payments" &&
+          canonicalDeploymentProvider("payments", provider.selection.value) === selected,
       )
       .map((provider) => ({ unitId: unit.id, providerId: provider.id })),
   )

--- a/packages/framework/src/deployment-graph.ts
+++ b/packages/framework/src/deployment-graph.ts
@@ -616,9 +616,7 @@ function canonicalDeploymentProviders(
   return Object.fromEntries(
     Object.entries(providers).map(([role, provider]) => [
       role,
-      typeof provider === "string"
-        ? canonicalDeploymentProvider(role, provider)
-        : provider,
+      typeof provider === "string" ? canonicalDeploymentProvider(role, provider) : provider,
     ]),
   )
 }

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -1,8 +1,9 @@
-import type {
-  VoyantDeploymentEnvRequirement,
-  VoyantDeploymentProviderRole,
-  VoyantDeploymentProviders,
-  VoyantDeploymentResourceRequirement,
+import {
+  canonicalDeploymentProvider,
+  type VoyantDeploymentEnvRequirement,
+  type VoyantDeploymentProviderRole,
+  type VoyantDeploymentProviders,
+  type VoyantDeploymentResourceRequirement,
 } from "./deployment-types.js"
 
 export function resourceRequirementsFor(
@@ -16,6 +17,7 @@ export function resourceRequirementsForProvider(
   role: VoyantDeploymentProviderRole,
   provider: string,
 ): VoyantDeploymentResourceRequirement[] {
+  provider = canonicalDeploymentProvider(role, provider)
   if (provider === "none") {
     return [
       {
@@ -296,12 +298,12 @@ function envForProvider(
         ),
       ]
     }
-    if (provider === "voyant-payments") {
+    if (provider === "voyant-pay") {
       return [
-        secret("VOYANT_PAYMENTS_API_KEY", "Voyant Payments API key."),
+        secret("VOYANT_PAYMENTS_API_KEY", "Voyant Pay API key."),
         variable(
           "VOYANT_PAYMENTS_API_URL",
-          "Optional Voyant Payments API base URL.",
+          "Optional Voyant Pay API base URL.",
           false,
           "http-url",
         ),

--- a/packages/framework/src/deployment-requirements.ts
+++ b/packages/framework/src/deployment-requirements.ts
@@ -301,12 +301,7 @@ function envForProvider(
     if (provider === "voyant-pay") {
       return [
         secret("VOYANT_PAYMENTS_API_KEY", "Voyant Pay API key."),
-        variable(
-          "VOYANT_PAYMENTS_API_URL",
-          "Optional Voyant Pay API base URL.",
-          false,
-          "http-url",
-        ),
+        variable("VOYANT_PAYMENTS_API_URL", "Optional Voyant Pay API base URL.", false, "http-url"),
       ]
     }
     if (provider === "netopia") {

--- a/packages/framework/src/deployment-types.test.ts
+++ b/packages/framework/src/deployment-types.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  canonicalDeploymentProvider,
   DEFAULT_MANAGED_CLOUD_PROVIDERS,
   DEPLOYMENT_PROVIDER_CONTRACTS,
 } from "./deployment-types.js"
@@ -46,5 +47,17 @@ describe("deployment provider contracts", () => {
       sharedState: "postgres",
       rateLimit: "redis",
     })
+  })
+
+  it("accepts the legacy Voyant Payments selector but identifies Voyant Pay canonically", () => {
+    expect(DEPLOYMENT_PROVIDER_CONTRACTS.payments).toEqual([
+      "managed",
+      "voyant-pay",
+      "voyant-payments",
+      "netopia",
+      "custom",
+      "none",
+    ])
+    expect(canonicalDeploymentProvider("payments", "voyant-payments")).toBe("voyant-pay")
   })
 })

--- a/packages/framework/src/deployment-types.ts
+++ b/packages/framework/src/deployment-types.ts
@@ -30,7 +30,14 @@ export interface VoyantDeploymentProviders {
   realtime: "voyant-cloud" | "local" | "custom" | "none"
   scheduledJobs: "cloud-scheduler" | "node-cron" | "none"
   outboundWebhooks: "postgres" | "host" | "none"
-  payments: "managed" | "voyant-payments" | "netopia" | "custom" | "none"
+  payments:
+    | "managed"
+    | "voyant-pay"
+    /** @deprecated Legacy deployment value; normalized to `voyant-pay`. */
+    | "voyant-payments"
+    | "netopia"
+    | "custom"
+    | "none"
 }
 
 export type VoyantDeploymentEnvValueFormat = "postgres-url" | "redis-url" | "http-url"
@@ -84,8 +91,16 @@ export const DEPLOYMENT_PROVIDER_CONTRACTS = {
   realtime: ["voyant-cloud", "local", "custom", "none"],
   scheduledJobs: ["cloud-scheduler", "node-cron", "none"],
   outboundWebhooks: ["postgres", "host", "none"],
-  payments: ["managed", "voyant-payments", "netopia", "custom", "none"],
+  payments: ["managed", "voyant-pay", "voyant-payments", "netopia", "custom", "none"],
 } as const satisfies Record<VoyantDeploymentProviderRole, readonly string[]>
+
+/** Normalize legacy provider values at deployment input boundaries. */
+export function canonicalDeploymentProvider(
+  role: VoyantDeploymentProviderRole | string,
+  provider: string,
+): string {
+  return role === "payments" && provider === "voyant-payments" ? "voyant-pay" : provider
+}
 
 export const DEPLOYMENT_PROVIDER_ROLES = Object.keys(
   DEPLOYMENT_PROVIDER_CONTRACTS,

--- a/packages/framework/src/index.ts
+++ b/packages/framework/src/index.ts
@@ -24,6 +24,7 @@ export {
   type FrameworkProviders,
 } from "./create-app.js"
 export {
+  canonicalDeploymentProvider,
   DEFAULT_MANAGED_CLOUD_PROVIDERS,
   DEPLOYMENT_PROVIDER_CONTRACTS,
   DEPLOYMENT_PROVIDER_ROLES,

--- a/packages/i18n/src/admin/settings-operator/en-part-1.ts
+++ b/packages/i18n/src/admin/settings-operator/en-part-1.ts
@@ -402,5 +402,17 @@ export const operatorAdminSettingsMessagesEnPart1 = {
     loadFailed: "Could not load payment providers.",
     loading: "Loading payment providers",
     tryAgainLater: "Try again in a moment.",
+    connectionsTitle: "Connections",
+    connectionsDescription:
+      "Each connected processor and whether it is ready to be made the active default.",
+    activeBadge: "Active",
+    defaultBadge: "Default",
+    readyBadge: "Ready",
+    notReadyBadge: "Not ready",
+    makeActive: "Make active",
+    activating: "Activating…",
+    makeActiveNotReady: "This connection isn't ready to be made active yet.",
+    activatedToast: "{provider} is now the active payment processor.",
+    activateFailed: "Could not make this connection active.",
   },
 }

--- a/packages/i18n/src/admin/settings-operator/ro-part-1.ts
+++ b/packages/i18n/src/admin/settings-operator/ro-part-1.ts
@@ -409,5 +409,17 @@ export const operatorAdminSettingsMessagesRoPart1 = {
     loadFailed: "Nu s-au putut incarca procesatoarele de plati.",
     loading: "Se incarca procesatoarele de plati",
     tryAgainLater: "Incearca din nou in cateva momente.",
+    connectionsTitle: "Conexiuni",
+    connectionsDescription:
+      "Fiecare procesator conectat si daca este pregatit sa devina cel activ implicit.",
+    activeBadge: "Activ",
+    defaultBadge: "Implicit",
+    readyBadge: "Pregatit",
+    notReadyBadge: "Nepregatit",
+    makeActive: "Fa activ",
+    activating: "Se activeaza…",
+    makeActiveNotReady: "Aceasta conexiune nu este inca pregatita pentru a fi activata.",
+    activatedToast: "{provider} este acum procesatorul de plati activ.",
+    activateFailed: "Nu s-a putut activa aceasta conexiune.",
   },
 }

--- a/packages/operator-settings-react/src/payments-settings-page.test.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.test.tsx
@@ -227,14 +227,12 @@ describe("payments settings contract", () => {
     const ready = { connectionId: "c1", readiness: "ready" as const, readOnly: false }
 
     // Already active → shows the default marker, no button.
-    expect(
-      paymentActivationControlState({ summary: { ...ready, active: true } }),
-    ).toBe("active")
+    expect(paymentActivationControlState({ summary: { ...ready, active: true } })).toBe("active")
 
     // Ready + inactive, nothing pending → an actionable button.
-    expect(
-      paymentActivationControlState({ summary: { ...ready, active: false } }),
-    ).toBe("activatable")
+    expect(paymentActivationControlState({ summary: { ...ready, active: false } })).toBe(
+      "activatable",
+    )
 
     // This connection's request is in flight → pending state (spinner).
     expect(

--- a/packages/operator-settings-react/src/payments-settings-page.test.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.test.tsx
@@ -1,10 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server"
 import { describe, expect, it, vi } from "vitest"
 import {
+  canActivatePaymentConnection,
   canConfigurePaymentProvider,
   canDisconnectPaymentProvider,
   PaymentEmbeddedOnboardingBoundary,
   type PaymentEmbeddedOnboardingClientProps,
+  paymentActivationControlState,
   paymentConnectionStatusLabel,
   requestPaymentOnboardingSession,
 } from "./payments-settings-page.js"
@@ -103,7 +105,7 @@ describe("payments settings contract", () => {
         data: {
           ok: true,
           status: {
-            activeProviderId: "voyant-payments",
+            activeProviderId: "voyant-pay",
             status: "pending_requirements",
             mode: "sandbox",
           },
@@ -120,7 +122,7 @@ describe("payments settings contract", () => {
     const result = await requestPaymentOnboardingSession(
       fetcher,
       "/api",
-      "voyant-payments",
+      "voyant-pay",
       "sandbox",
       "Failed",
     )
@@ -128,7 +130,7 @@ describe("payments settings contract", () => {
     expect(fetcher).toHaveBeenCalledWith("/api/v1/admin/settings/payments/onboarding", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ providerId: "voyant-payments", mode: "sandbox" }),
+      body: JSON.stringify({ providerId: "voyant-pay", mode: "sandbox" }),
     })
     expect(fetcher.mock.calls[0]?.[0]).not.toContain("ephemeral_secret")
     expect(result.session?.clientSecret).toBe("ephemeral_secret")
@@ -146,7 +148,7 @@ describe("payments settings contract", () => {
       requestPaymentOnboardingSession(
         fetcher,
         "/api",
-        "voyant-payments",
+        "voyant-pay",
         "sandbox",
         "Safe generic failure",
       ),
@@ -197,5 +199,65 @@ describe("payments settings contract", () => {
         connectionMethod: "credentials",
       }),
     ).toBe(true)
+  })
+
+  it("only enables activation for ready, inactive, writable connections", () => {
+    // Ready + inactive → the one activatable case.
+    expect(
+      canActivatePaymentConnection({ readiness: "ready", active: false, readOnly: false }),
+    ).toBe(true)
+    // Already the active default → no activation offered.
+    expect(
+      canActivatePaymentConnection({ readiness: "ready", active: true, readOnly: false }),
+    ).toBe(false)
+    // Not ready → gated off even when inactive.
+    expect(
+      canActivatePaymentConnection({ readiness: "not_ready", active: false, readOnly: false }),
+    ).toBe(false)
+    expect(
+      canActivatePaymentConnection({ readiness: "unknown", active: false, readOnly: false }),
+    ).toBe(false)
+    // Env-pinned (read-only) connections cannot be re-activated here.
+    expect(
+      canActivatePaymentConnection({ readiness: "ready", active: false, readOnly: true }),
+    ).toBe(false)
+  })
+
+  it("resolves the activation control to distinct active/activating/activatable/gated states", () => {
+    const ready = { connectionId: "c1", readiness: "ready" as const, readOnly: false }
+
+    // Already active → shows the default marker, no button.
+    expect(
+      paymentActivationControlState({ summary: { ...ready, active: true } }),
+    ).toBe("active")
+
+    // Ready + inactive, nothing pending → an actionable button.
+    expect(
+      paymentActivationControlState({ summary: { ...ready, active: false } }),
+    ).toBe("activatable")
+
+    // This connection's request is in flight → pending state (spinner).
+    expect(
+      paymentActivationControlState({
+        summary: { ...ready, active: false },
+        activatingConnectionId: "c1",
+      }),
+    ).toBe("activating")
+
+    // A different connection is activating → this one stays activatable (the
+    // component disables it to prevent duplicate concurrent submits).
+    expect(
+      paymentActivationControlState({
+        summary: { ...ready, active: false },
+        activatingConnectionId: "c2",
+      }),
+    ).toBe("activatable")
+
+    // Not ready → gated (disabled control + reason).
+    expect(
+      paymentActivationControlState({
+        summary: { connectionId: "c3", readiness: "not_ready", active: false, readOnly: false },
+      }),
+    ).toBe("gated")
   })
 })

--- a/packages/operator-settings-react/src/payments-settings-page.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.tsx
@@ -699,7 +699,9 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                             <CreditCard aria-hidden="true" />
                             <CardTitle>{summary.displayName ?? summary.providerId}</CardTitle>
                             {summary.active ? <Badge>{t.activeBadge}</Badge> : null}
-                            <Badge variant={summary.readiness === "ready" ? "secondary" : "outline"}>
+                            <Badge
+                              variant={summary.readiness === "ready" ? "secondary" : "outline"}
+                            >
                               {summary.readiness === "ready" ? t.readyBadge : t.notReadyBadge}
                             </Badge>
                             <Badge variant={summary.state === "error" ? "destructive" : "outline"}>

--- a/packages/operator-settings-react/src/payments-settings-page.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.tsx
@@ -85,10 +85,27 @@ interface ConnectionRequirement {
   deadlineAt?: string | null
 }
 
+type ConnectionReadiness = "ready" | "not_ready" | "unknown"
+
+interface ConnectionSummary {
+  providerId: string
+  connectionId: string
+  displayName?: string
+  state: ConnectionState
+  readiness: ConnectionReadiness
+  mode: ProviderMode | null
+  active: boolean
+  requirements?: ConnectionRequirement[]
+  lastError?: string | null
+  readOnly?: boolean
+}
+
 interface ConnectionStatus {
   activeProviderId: string | null
   status: ConnectionState
   mode: ProviderMode | null
+  activeConnectionId?: string | null
+  connections?: ConnectionSummary[]
   requirements?: ConnectionRequirement[]
   lastError?: string | null
   readOnly?: boolean
@@ -97,6 +114,13 @@ interface ConnectionStatus {
 interface ConnectResult {
   ok: boolean
   status: ConnectionStatus
+  error?: string
+}
+
+interface ActivationResult {
+  ok: boolean
+  status: ConnectionStatus
+  activated?: { providerId: string; connectionId: string }
   error?: string
 }
 
@@ -248,6 +272,44 @@ export function canConfigurePaymentProvider(
   provider: Pick<ProviderDescriptor, "availability" | "connectionMethod">,
 ): boolean {
   return provider.availability === "available" && provider.connectionMethod !== "read_only"
+}
+
+/**
+ * A connection can be made the active default only when it is ready (its
+ * lifecycle reached `connected`) and it is not already the active one. This
+ * gates the "Make active" control so a not-ready or already-active connection
+ * never offers activation.
+ */
+export function canActivatePaymentConnection(
+  connection: Pick<ConnectionSummary, "readiness" | "active" | "readOnly">,
+): boolean {
+  return connection.readiness === "ready" && !connection.active && !connection.readOnly
+}
+
+/**
+ * The four mutually-exclusive states the per-connection activation control can
+ * be in. Pure so the pending/duplicate-prevention behavior is testable without
+ * a DOM harness and stays in sync with what the component renders:
+ * - `active` — this connection is already the default; no action.
+ * - `activating` — this connection's activation request is in flight.
+ * - `activatable` — ready + inactive; the "Make active" button is offered
+ *   (disabled while any activation is pending, preventing duplicate submits).
+ * - `gated` — not ready / read-only; a disabled control + reason are shown.
+ */
+export type PaymentActivationControl = "active" | "activating" | "activatable" | "gated"
+
+export function paymentActivationControlState(input: {
+  summary: Pick<ConnectionSummary, "readiness" | "active" | "readOnly" | "connectionId">
+  activatingConnectionId?: string | null
+}): PaymentActivationControl {
+  if (input.summary.active) return "active"
+  if (
+    input.activatingConnectionId != null &&
+    input.activatingConnectionId === input.summary.connectionId
+  ) {
+    return "activating"
+  }
+  return canActivatePaymentConnection(input.summary) ? "activatable" : "gated"
 }
 
 /** Hosted disconnect is fail-closed until the managed control plane exposes it. */
@@ -444,6 +506,32 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
     onError: (error) => toast.error(error instanceof Error ? error.message : t.connectFailed),
   })
 
+  const activate = useMutation({
+    mutationFn: async (summary: ConnectionSummary): Promise<ActivationResult> => {
+      const response = await fetcher(`${baseUrl}/v1/admin/settings/payments/activate`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          providerId: summary.providerId,
+          connectionId: summary.connectionId,
+        }),
+      })
+      if (!response.ok) throw new Error(await responseError(response, t.activateFailed))
+      return ((await response.json()) as { data: ActivationResult }).data
+    },
+    onSuccess: (result, summary) => {
+      if (result.ok) {
+        toast.success(
+          t.activatedToast.replace("{provider}", summary.displayName ?? summary.providerId),
+        )
+        invalidateConnection()
+      } else {
+        toast.error(result.error ?? t.activateFailed)
+      }
+    },
+    onError: (error) => toast.error(error instanceof Error ? error.message : t.activateFailed),
+  })
+
   if (providersQuery.isPending || connectionQuery.isPending) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -584,6 +672,90 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                 )}
               </CardFooter>
             </Card>
+          ) : null}
+
+          {connection?.connections?.length ? (
+            <section className="flex flex-col gap-3">
+              <div>
+                <h2 className="text-sm font-semibold text-muted-foreground">
+                  {t.connectionsTitle}
+                </h2>
+                <p className="text-sm text-muted-foreground">{t.connectionsDescription}</p>
+              </div>
+              <ul className="flex list-none flex-col gap-3">
+                {connection.connections.map((summary) => {
+                  const summaryStatusLabel = statusLabels[summary.state]
+                  const control = paymentActivationControlState({
+                    summary,
+                    activatingConnectionId: activate.isPending
+                      ? (activate.variables?.connectionId ?? null)
+                      : null,
+                  })
+                  return (
+                    <li key={`${summary.providerId}:${summary.connectionId}`}>
+                      <Card>
+                        <CardHeader>
+                          <div className="flex flex-wrap items-center gap-2">
+                            <CreditCard aria-hidden="true" />
+                            <CardTitle>{summary.displayName ?? summary.providerId}</CardTitle>
+                            {summary.active ? <Badge>{t.activeBadge}</Badge> : null}
+                            <Badge variant={summary.readiness === "ready" ? "secondary" : "outline"}>
+                              {summary.readiness === "ready" ? t.readyBadge : t.notReadyBadge}
+                            </Badge>
+                            <Badge variant={summary.state === "error" ? "destructive" : "outline"}>
+                              {summaryStatusLabel}
+                            </Badge>
+                            {summary.mode ? (
+                              <Badge variant="outline">{modeLabel(summary.mode, modeLabels)}</Badge>
+                            ) : null}
+                          </div>
+                        </CardHeader>
+                        <CardFooter className="flex flex-wrap items-center gap-3">
+                          {control === "active" ? (
+                            <span className="text-sm font-medium text-muted-foreground">
+                              {t.defaultBadge}
+                            </span>
+                          ) : control === "activating" ? (
+                            <Button size="sm" disabled aria-busy="true">
+                              <Spinner data-icon="inline-start" />
+                              {t.activating}
+                            </Button>
+                          ) : control === "activatable" ? (
+                            <Button
+                              size="sm"
+                              // Disabling on any in-flight activation prevents
+                              // duplicate/concurrent "make active" submissions.
+                              disabled={activate.isPending}
+                              onClick={() => activate.mutate(summary)}
+                            >
+                              {t.makeActive}
+                            </Button>
+                          ) : (
+                            <>
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled
+                                aria-disabled="true"
+                                aria-describedby={`activate-hint-${summary.connectionId}`}
+                              >
+                                {t.makeActive}
+                              </Button>
+                              <span
+                                id={`activate-hint-${summary.connectionId}`}
+                                className="text-sm text-muted-foreground"
+                              >
+                                {t.makeActiveNotReady}
+                              </span>
+                            </>
+                          )}
+                        </CardFooter>
+                      </Card>
+                    </li>
+                  )
+                })}
+              </ul>
+            </section>
           ) : null}
 
           <section className="flex flex-col gap-3">

--- a/packages/operator-settings/src/payment-provider-registry.test.ts
+++ b/packages/operator-settings/src/payment-provider-registry.test.ts
@@ -14,6 +14,22 @@ const emptyDb = {
   }),
 } as unknown as PostgresJsDatabase
 
+const legacyVoyantPayDb = {
+  select: () => ({
+    from: () => ({
+      orderBy: () => ({
+        limit: async () => [
+          {
+            activeProviderId: "voyant-payments",
+            status: "connected",
+            mode: "sandbox",
+          },
+        ],
+      }),
+    }),
+  }),
+} as unknown as PostgresJsDatabase
+
 const managedEnv = { VOYANT_PAYMENTS_CONTROL_PLANE_URL: "https://payments.example" }
 
 describe("default payment provider registry", () => {
@@ -48,6 +64,39 @@ describe("default payment provider registry", () => {
       expect(result.ok).toBe(false)
     })
 
+    it("summarizes the env-pinned connection as active and ready", async () => {
+      const registry = createDefaultPaymentProviderRegistry({
+        db: emptyDb,
+        env: { NETOPIA_MERCHANT_ID: "M1", NETOPIA_SANDBOX: "true" },
+      })
+      const status = await registry.getConnection()
+      expect(status.activeConnectionId).toBe("environment")
+      expect(status.connections).toEqual([
+        expect.objectContaining({
+          providerId: "netopia",
+          connectionId: "environment",
+          state: "connected",
+          readiness: "ready",
+          active: true,
+          readOnly: true,
+        }),
+      ])
+    })
+
+    it("refuses to activate (read-only, configured via environment)", async () => {
+      const registry = createDefaultPaymentProviderRegistry({
+        db: emptyDb,
+        env: { NETOPIA_MERCHANT_ID: "M1", NETOPIA_SANDBOX: "true" },
+      })
+      const result = await registry.activate?.({
+        providerId: "netopia",
+        connectionId: "environment",
+      })
+      expect(result?.ok).toBe(false)
+      expect(result?.activated).toBeUndefined()
+      expect(result?.error).toContain("environment")
+    })
+
     it("does not infer a hosted-account connection from a fake API key", async () => {
       const registry = createDefaultPaymentProviderRegistry({
         db: emptyDb,
@@ -62,6 +111,13 @@ describe("default payment provider registry", () => {
   })
 
   describe("managed", () => {
+    it("returns the canonical id for a legacy persisted Voyant Payments connection", async () => {
+      const registry = createDefaultPaymentProviderRegistry({ db: legacyVoyantPayDb, env: managedEnv })
+      await expect(registry.getConnection()).resolves.toMatchObject({
+        activeProviderId: "voyant-pay",
+      })
+    })
+
     it("rejects an unknown provider", async () => {
       const registry = createDefaultPaymentProviderRegistry({ db: emptyDb, env: managedEnv })
       const result = await registry.connect({
@@ -76,7 +132,7 @@ describe("default payment provider registry", () => {
     it("rejects a coming-soon provider", async () => {
       const registry = createDefaultPaymentProviderRegistry({ db: emptyDb, env: managedEnv })
       const result = await registry.connect({
-        providerId: "voyant-payments",
+        providerId: "voyant-pay",
         mode: "sandbox",
         credentials: {},
       })
@@ -86,7 +142,7 @@ describe("default payment provider registry", () => {
     it("fails closed when hosted onboarding is not available", async () => {
       const registry = createDefaultPaymentProviderRegistry({ db: emptyDb, env: managedEnv })
       const result = await registry.beginOnboarding({
-        providerId: "voyant-payments",
+        providerId: "voyant-pay",
         mode: "sandbox",
       })
       expect(result).toMatchObject({
@@ -95,6 +151,36 @@ describe("default payment provider registry", () => {
       })
       expect(result.session).toBeUndefined()
       expect(result.error).toContain("not yet available")
+    })
+
+    it("accepts the legacy Voyant Payments request id", async () => {
+      const registry = createDefaultPaymentProviderRegistry({ db: emptyDb, env: managedEnv })
+      const result = await registry.beginOnboarding({
+        providerId: "voyant-payments",
+        mode: "sandbox",
+      })
+      expect(result.error).toContain("Voyant Pay")
+    })
+
+    it("fails closed on activation without inventing an active switch", async () => {
+      const registry = createDefaultPaymentProviderRegistry({ db: emptyDb, env: managedEnv })
+      const result = await registry.activate?.({
+        providerId: "netopia",
+        connectionId: "conn_1",
+      })
+      expect(result?.ok).toBe(false)
+      expect(result?.activated).toBeUndefined()
+      expect(result?.error).toContain("not yet available")
+    })
+
+    it("rejects activating an unknown provider", async () => {
+      const registry = createDefaultPaymentProviderRegistry({ db: emptyDb, env: managedEnv })
+      const result = await registry.activate?.({
+        providerId: "nope",
+        connectionId: "conn_1",
+      })
+      expect(result?.ok).toBe(false)
+      expect(result?.error).toContain("Unknown")
     })
 
     it("rejects missing required credentials", async () => {

--- a/packages/operator-settings/src/payment-provider-registry.test.ts
+++ b/packages/operator-settings/src/payment-provider-registry.test.ts
@@ -112,7 +112,10 @@ describe("default payment provider registry", () => {
 
   describe("managed", () => {
     it("returns the canonical id for a legacy persisted Voyant Payments connection", async () => {
-      const registry = createDefaultPaymentProviderRegistry({ db: legacyVoyantPayDb, env: managedEnv })
+      const registry = createDefaultPaymentProviderRegistry({
+        db: legacyVoyantPayDb,
+        env: managedEnv,
+      })
       await expect(registry.getConnection()).resolves.toMatchObject({
         activeProviderId: "voyant-pay",
       })

--- a/packages/operator-settings/src/payment-provider-registry.ts
+++ b/packages/operator-settings/src/payment-provider-registry.ts
@@ -17,12 +17,12 @@ import {
   type PaymentActivationInput,
   type PaymentActivationResult,
   type PaymentConnectInput,
-  paymentConnectionReadiness,
   type PaymentConnectionStatus,
   type PaymentConnectionSummary,
   type PaymentConnectResult,
   type PaymentProviderDescriptor,
   type PaymentProviderRegistry,
+  paymentConnectionReadiness,
   validatePaymentCredentials,
 } from "@voyant-travel/payments"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"

--- a/packages/operator-settings/src/payment-provider-registry.ts
+++ b/packages/operator-settings/src/payment-provider-registry.ts
@@ -11,10 +11,15 @@
  */
 
 import {
+  canonicalPaymentProviderId,
   defaultPaymentProviderCatalog,
   findPaymentProviderDescriptor,
+  type PaymentActivationInput,
+  type PaymentActivationResult,
   type PaymentConnectInput,
+  paymentConnectionReadiness,
   type PaymentConnectionStatus,
+  type PaymentConnectionSummary,
   type PaymentConnectResult,
   type PaymentProviderDescriptor,
   type PaymentProviderRegistry,
@@ -63,6 +68,42 @@ const disconnected: PaymentConnectionStatus = {
   activeProviderId: null,
   status: "disconnected",
   mode: null,
+  activeConnectionId: null,
+  connections: [],
+}
+
+/**
+ * Derive the independent connections/readiness projection from an active
+ * selection. The default registry tracks at most one connection (the active
+ * default), so it emits a single summary; managed registries may list several.
+ * Never includes credentials, connection secrets, or platform tokens.
+ */
+function withConnectionsProjection(
+  status: PaymentConnectionStatus,
+  input: {
+    connectionId: string
+    catalog: readonly PaymentProviderDescriptor[]
+    readOnly?: boolean
+  },
+): PaymentConnectionStatus {
+  if (!status.activeProviderId) {
+    return { ...status, activeConnectionId: null, connections: [] }
+  }
+  const descriptor = findPaymentProviderDescriptor(status.activeProviderId, input.catalog)
+  const summary: PaymentConnectionSummary = {
+    providerId: status.activeProviderId,
+    connectionId: input.connectionId,
+    displayName: descriptor?.displayName,
+    state: status.status,
+    readiness: paymentConnectionReadiness(status.status),
+    mode: status.mode,
+    active: true,
+    requirements: status.requirements,
+    lastHealthAt: status.lastHealthAt,
+    lastError: status.lastError,
+    readOnly: input.readOnly,
+  }
+  return { ...status, activeConnectionId: input.connectionId, connections: [summary] }
 }
 
 export function createDefaultPaymentProviderRegistry(
@@ -83,23 +124,30 @@ export function createDefaultPaymentProviderRegistry(
       if (!managed) {
         const pinned = detectPinnedProvider(env)
         if (!pinned) return { ...disconnected, readOnly: true }
-        return {
-          activeProviderId: pinned.providerId,
-          status: "connected",
-          mode: pinned.mode,
-          readOnly: true,
-        }
+        return withConnectionsProjection(
+          {
+            activeProviderId: pinned.providerId,
+            status: "connected",
+            mode: pinned.mode,
+            readOnly: true,
+          },
+          { connectionId: "environment", catalog, readOnly: true },
+        )
       }
 
       const row = await getPaymentProviderConfig(db)
       if (!row?.activeProviderId) return disconnected
-      return {
-        activeProviderId: row.activeProviderId,
-        status: (row.status as PaymentProviderConnectionState) ?? "disconnected",
-        mode: (row.mode as PaymentConnectionStatus["mode"]) ?? null,
-        lastHealthAt: row.lastHealthAt ? row.lastHealthAt.toISOString() : null,
-        lastError: row.lastError ?? null,
-      }
+      const activeProviderId = canonicalPaymentProviderId(row.activeProviderId)
+      return withConnectionsProjection(
+        {
+          activeProviderId,
+          status: (row.status as PaymentProviderConnectionState) ?? "disconnected",
+          mode: (row.mode as PaymentConnectionStatus["mode"]) ?? null,
+          lastHealthAt: row.lastHealthAt ? row.lastHealthAt.toISOString() : null,
+          lastError: row.lastError ?? null,
+        },
+        { connectionId: row.connectionRef ?? activeProviderId, catalog },
+      )
     },
 
     async connect(input: PaymentConnectInput): Promise<PaymentConnectResult> {
@@ -202,6 +250,41 @@ export function createDefaultPaymentProviderRegistry(
         ok: false,
         status: current,
         error: "Managed payment onboarding is not yet available.",
+      }
+    },
+
+    async activate(input: PaymentActivationInput): Promise<PaymentActivationResult> {
+      const current = await this.getConnection()
+
+      // Self-host pins its processor through the environment; there is no second
+      // connection to promote and nothing here may change it.
+      if (!managed) {
+        return {
+          ok: false,
+          status: current,
+          error:
+            "Payment provider is configured via environment variables and cannot be changed here.",
+        }
+      }
+
+      const descriptor = findPaymentProviderDescriptor(input.providerId, catalog)
+      if (!descriptor) {
+        return {
+          ok: false,
+          status: current,
+          error: `Unknown payment provider "${input.providerId}".`,
+        }
+      }
+
+      // Activation promotes a control-plane-brokered connection to the active
+      // default. The default registry has no authority over managed connection
+      // records, so it fails closed instead of pretending the switch happened.
+      // The managed control-plane registry (separate platform repo) owns the
+      // real readiness gate and the atomic one-active-per-org switch.
+      return {
+        ok: false,
+        status: current,
+        error: "Managed payments activation is not yet available.",
       }
     },
 

--- a/packages/operator-settings/src/payment-provider-routes.test.ts
+++ b/packages/operator-settings/src/payment-provider-routes.test.ts
@@ -1,0 +1,160 @@
+import { OpenAPIHono } from "@hono/zod-openapi"
+import type { ModuleContainer } from "@voyant-travel/core"
+import {
+  type PaymentActivationInput,
+  type PaymentActivationResult,
+  type PaymentProviderRegistry,
+  paymentProviderRegistryRuntimePort,
+} from "@voyant-travel/payments"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+import { describe, expect, it } from "vitest"
+
+import { mountPaymentProviderRoutes } from "./payment-provider-routes.js"
+
+/** Dummy db — the injected registries below never touch it. */
+const db = {} as unknown as PostgresJsDatabase
+
+const disconnectedStatus = {
+  activeProviderId: null,
+  status: "disconnected" as const,
+  mode: null,
+  activeConnectionId: null,
+  connections: [],
+}
+
+type TestEnv = { Variables: { db: PostgresJsDatabase; container?: ModuleContainer } }
+
+/**
+ * Build a request app that injects `db` + `container` and mounts the payment
+ * routes, mirroring how the operator-settings runtime wires them.
+ */
+function buildApp(container?: ModuleContainer) {
+  const app = new OpenAPIHono<TestEnv>()
+  app.use("*", async (c, next) => {
+    c.set("db", db)
+    if (container) c.set("container", container)
+    await next()
+  })
+  mountPaymentProviderRoutes(app)
+  return app
+}
+
+/** A container that resolves the runtime port to the supplied registry. */
+function containerWithRegistry(registry: PaymentProviderRegistry): ModuleContainer {
+  return {
+    has: (id: string) => id === paymentProviderRegistryRuntimePort.id,
+    resolve: () => () => registry,
+  } as unknown as ModuleContainer
+}
+
+function activate(app: ReturnType<typeof buildApp>, body: unknown, env: Record<string, unknown> = {}) {
+  return app.request(
+    "/v1/admin/settings/payments/activate",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    },
+    env,
+  )
+}
+
+describe("POST /v1/admin/settings/payments/activate", () => {
+  it("rejects a request missing connectionId", async () => {
+    const app = buildApp()
+    const res = await activate(app, { providerId: "netopia" })
+    expect(res.status).toBe(400)
+  })
+
+  it("rejects a request with an empty providerId", async () => {
+    const app = buildApp()
+    const res = await activate(app, { providerId: "", connectionId: "conn_1" })
+    expect(res.status).toBe(400)
+  })
+
+  it("delegates to the injected registry and reports success", async () => {
+    const seen: PaymentActivationInput[] = []
+    const registry: PaymentProviderRegistry = {
+      listProviders: async () => [],
+      getConnection: async () => disconnectedStatus,
+      connect: async () => ({ ok: false, status: disconnectedStatus }),
+      beginOnboarding: async () => ({
+        ok: false,
+        status: disconnectedStatus,
+        error: "n/a",
+      }),
+      disconnect: async () => undefined,
+      activate: async (input): Promise<PaymentActivationResult> => {
+        seen.push(input)
+        return {
+          ok: true,
+          status: {
+            activeProviderId: input.providerId,
+            status: "connected",
+            mode: "live",
+            activeConnectionId: input.connectionId,
+          },
+          activated: { providerId: input.providerId, connectionId: input.connectionId },
+        }
+      },
+    }
+
+    const app = buildApp(containerWithRegistry(registry))
+    const res = await activate(app, { providerId: "netopia", connectionId: "conn_1" })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PaymentActivationResult }
+    expect(body.data.ok).toBe(true)
+    expect(body.data.activated).toEqual({ providerId: "netopia", connectionId: "conn_1" })
+    expect(seen).toEqual([{ providerId: "netopia", connectionId: "conn_1" }])
+  })
+
+  it("surfaces an explicit registry rejection without faking success", async () => {
+    const registry: PaymentProviderRegistry = {
+      listProviders: async () => [],
+      getConnection: async () => disconnectedStatus,
+      connect: async () => ({ ok: false, status: disconnectedStatus }),
+      beginOnboarding: async () => ({ ok: false, status: disconnectedStatus, error: "n/a" }),
+      disconnect: async () => undefined,
+      activate: async () => ({
+        ok: false,
+        status: disconnectedStatus,
+        error: "This connection isn't ready yet.",
+      }),
+    }
+
+    const app = buildApp(containerWithRegistry(registry))
+    const res = await activate(app, { providerId: "netopia", connectionId: "conn_1" })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PaymentActivationResult }
+    expect(body.data.ok).toBe(false)
+    expect(body.data.activated).toBeUndefined()
+    expect(body.data.error).toContain("ready")
+  })
+
+  it("fails closed when the registry does not implement activation", async () => {
+    const registry: PaymentProviderRegistry = {
+      listProviders: async () => [],
+      getConnection: async () => disconnectedStatus,
+      connect: async () => ({ ok: false, status: disconnectedStatus }),
+      beginOnboarding: async () => ({ ok: false, status: disconnectedStatus, error: "n/a" }),
+      disconnect: async () => undefined,
+      // no activate()
+    }
+
+    const app = buildApp(containerWithRegistry(registry))
+    const res = await activate(app, { providerId: "netopia", connectionId: "conn_1" })
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PaymentActivationResult }
+    expect(body.data.ok).toBe(false)
+    expect(body.data.error).toContain("not supported")
+  })
+
+  it("falls back to the default self-host registry and fails closed", async () => {
+    const app = buildApp()
+    const res = await activate(app, { providerId: "netopia", connectionId: "environment" }, {})
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { data: PaymentActivationResult }
+    expect(body.data.ok).toBe(false)
+    expect(body.data.activated).toBeUndefined()
+  })
+})

--- a/packages/operator-settings/src/payment-provider-routes.test.ts
+++ b/packages/operator-settings/src/payment-provider-routes.test.ts
@@ -1,5 +1,6 @@
 import { OpenAPIHono } from "@hono/zod-openapi"
 import type { ModuleContainer } from "@voyant-travel/core"
+import { handleApiError } from "@voyant-travel/hono"
 import {
   type PaymentActivationInput,
   type PaymentActivationResult,
@@ -36,6 +37,7 @@ function buildApp(container?: ModuleContainer) {
     await next()
   })
   mountPaymentProviderRoutes(app)
+  app.onError((error, c) => handleApiError(error, c))
   return app
 }
 
@@ -47,7 +49,11 @@ function containerWithRegistry(registry: PaymentProviderRegistry): ModuleContain
   } as unknown as ModuleContainer
 }
 
-function activate(app: ReturnType<typeof buildApp>, body: unknown, env: Record<string, unknown> = {}) {
+function activate(
+  app: ReturnType<typeof buildApp>,
+  body: unknown,
+  env: Record<string, unknown> = {},
+) {
   return app.request(
     "/v1/admin/settings/payments/activate",
     {

--- a/packages/operator-settings/src/payment-provider-routes.ts
+++ b/packages/operator-settings/src/payment-provider-routes.ts
@@ -163,9 +163,7 @@ const activateRequestSchema = z.object({
 const activationResultSchema = z.object({
   ok: z.boolean(),
   status: connectionStatusSchema,
-  activated: z
-    .object({ providerId: z.string(), connectionId: z.string() })
-    .optional(),
+  activated: z.object({ providerId: z.string(), connectionId: z.string() }).optional(),
   error: z.string().optional(),
 })
 

--- a/packages/operator-settings/src/payment-provider-routes.ts
+++ b/packages/operator-settings/src/payment-provider-routes.ts
@@ -2,12 +2,15 @@
  * Settings → Payments admin routes.
  *
  * `/v1/admin/settings/payments/*` — list the provider catalog, read the current
- * connection, connect a provider (managed), and disconnect. Mounted onto the
+ * connection, connect a provider (managed), activate an already-connected ready
+ * connection as the active default, and disconnect. Mounted onto the
  * operator-settings OpenAPIHono chain (see `routes.ts`), so it inherits the
  * shared validation hook and `/v1/admin/settings/*` lazy matcher.
  *
- * No processor credentials are persisted here; connect delegates to the
+ * No processor credentials are persisted here; connect/activate delegate to the
  * `PaymentProviderRegistry` (managed → control plane; self-host → read-only).
+ * Activation delegates generically: a registry that does not implement
+ * `activate()` fails closed rather than reporting a switch that never happened.
  */
 
 import { createRoute, OpenAPIHono, z } from "@hono/zod-openapi"
@@ -98,28 +101,45 @@ const providerDescriptorSchema = z.object({
   modes: z.array(z.enum(["sandbox", "test", "live"])),
 })
 
-const connectionStatusSchema = z.object({
-  activeProviderId: z.string().nullable(),
-  status: z.enum([
-    "pending_requirements",
-    "pending_verification",
-    "connected",
-    "restricted",
-    "error",
-    "disconnected",
-  ]),
+const connectionStateSchema = z.enum([
+  "pending_requirements",
+  "pending_verification",
+  "connected",
+  "restricted",
+  "error",
+  "disconnected",
+])
+
+const requirementSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  deadlineAt: z.string().nullable().optional(),
+})
+
+/** Non-sensitive per-connection summary. No credentials or platform secrets. */
+const connectionSummarySchema = z.object({
+  providerId: z.string(),
+  connectionId: z.string(),
+  displayName: z.string().optional(),
+  state: connectionStateSchema,
+  readiness: z.enum(["ready", "not_ready", "unknown"]),
   mode: z.enum(["sandbox", "test", "live"]).nullable(),
+  active: z.boolean(),
+  requirements: z.array(requirementSchema).optional(),
   lastHealthAt: z.string().nullable().optional(),
   lastError: z.string().nullable().optional(),
-  requirements: z
-    .array(
-      z.object({
-        code: z.string(),
-        message: z.string(),
-        deadlineAt: z.string().nullable().optional(),
-      }),
-    )
-    .optional(),
+  readOnly: z.boolean().optional(),
+})
+
+const connectionStatusSchema = z.object({
+  activeProviderId: z.string().nullable(),
+  status: connectionStateSchema,
+  mode: z.enum(["sandbox", "test", "live"]).nullable(),
+  activeConnectionId: z.string().nullable().optional(),
+  connections: z.array(connectionSummarySchema).optional(),
+  lastHealthAt: z.string().nullable().optional(),
+  lastError: z.string().nullable().optional(),
+  requirements: z.array(requirementSchema).optional(),
   readOnly: z.boolean().optional(),
 })
 
@@ -132,6 +152,20 @@ const connectRequestSchema = z.object({
 const connectResultSchema = z.object({
   ok: z.boolean(),
   status: connectionStatusSchema,
+  error: z.string().optional(),
+})
+
+const activateRequestSchema = z.object({
+  providerId: z.string().min(1),
+  connectionId: z.string().min(1),
+})
+
+const activationResultSchema = z.object({
+  ok: z.boolean(),
+  status: connectionStatusSchema,
+  activated: z
+    .object({ providerId: z.string(), connectionId: z.string() })
+    .optional(),
   error: z.string().optional(),
 })
 
@@ -196,6 +230,15 @@ const connectRoute = createRoute({
   },
 })
 
+const activateRoute = createRoute({
+  method: "post",
+  path: "/v1/admin/settings/payments/activate",
+  request: { body: jsonBody(activateRequestSchema) },
+  responses: {
+    200: jsonContent(dataEnvelope(activationResultSchema), "The activation attempt result"),
+  },
+})
+
 const beginOnboardingRoute = createRoute({
   method: "post",
   path: "/v1/admin/settings/payments/onboarding",
@@ -240,6 +283,30 @@ export function mountPaymentProviderRoutes(hono: OpenApiMountTarget): void {
         (async () => {
           const registry = await resolveRegistry(c)
           return c.json({ data: await registry.connect(c.req.valid("json")) }, 200)
+        })(),
+      ),
+    )
+    .openapi(activateRoute, (c) =>
+      asRouteResponse(
+        (async () => {
+          const registry = await resolveRegistry(c)
+          const input = c.req.valid("json")
+          // Generic delegation: the deployment-injected registry owns the real
+          // readiness gate and switch. A registry that does not implement
+          // activation fails closed here instead of faking success.
+          if (typeof registry.activate !== "function") {
+            return c.json(
+              {
+                data: {
+                  ok: false,
+                  status: await registry.getConnection(),
+                  error: "Payment activation is not supported by this deployment.",
+                },
+              },
+              200,
+            )
+          }
+          return c.json({ data: await registry.activate(input) }, 200)
         })(),
       ),
     )

--- a/packages/payments/src/default-catalog.ts
+++ b/packages/payments/src/default-catalog.ts
@@ -3,7 +3,7 @@
  *
  * The static set of Voyant-built processors an operator can browse in
  * Settings → Payments before the managed control plane serves a live registry.
- * Phase 1 ships Netopia (`available`) and Voyant Payments (`coming_soon`).
+ * Phase 1 ships Netopia (`available`) and Voyant Pay (`coming_soon`).
  *
  * These descriptors are catalog *data* (served to the admin UI as JSON), not
  * in-code UI copy. Field labels are English defaults; the page chrome
@@ -26,7 +26,7 @@ const redirectProcessorCapabilities: PaymentAdapterCapabilities = {
   retrySafeInitiation: true,
 }
 
-const voyantPaymentsCapabilities: PaymentAdapterCapabilities = {
+const voyantPayCapabilities: PaymentAdapterCapabilities = {
   ...redirectProcessorCapabilities,
   // Hosted refunds are deliberately unavailable until the control plane can
   // prove a member/role approval, not just a deployment checkout credential.
@@ -79,13 +79,24 @@ const netopia: PaymentProviderDescriptor = {
   ],
 }
 
-/** Voyant Payments — the first-party processor, announced but not yet live. */
-const voyantPayments: PaymentProviderDescriptor = {
-  id: "voyant-payments",
-  displayName: "Voyant Payments",
+/** Canonical id for the first-party Voyant Pay processor. */
+export const VOYANT_PAY_PROVIDER_ID = "voyant-pay"
+
+/** @deprecated Legacy persisted/request identity accepted during the Voyant Pay cutover. */
+export const LEGACY_VOYANT_PAYMENTS_PROVIDER_ID = "voyant-payments"
+
+/** Normalize known legacy provider identities before lookup or output. */
+export function canonicalPaymentProviderId(id: string): string {
+  return id === LEGACY_VOYANT_PAYMENTS_PROVIDER_ID ? VOYANT_PAY_PROVIDER_ID : id
+}
+
+/** Voyant Pay — the first-party processor, announced but not yet live. */
+const voyantPay: PaymentProviderDescriptor = {
+  id: VOYANT_PAY_PROVIDER_ID,
+  displayName: "Voyant Pay",
   description: "The Voyant-native payment processor. Coming soon.",
-  logoRef: "voyant-payments",
-  capabilities: voyantPaymentsCapabilities,
+  logoRef: "voyant-pay",
+  capabilities: voyantPayCapabilities,
   connectionMethod: "embedded_onboarding",
   availability: "coming_soon",
   modes: ["sandbox", "live"],
@@ -94,7 +105,7 @@ const voyantPayments: PaymentProviderDescriptor = {
 
 export const defaultPaymentProviderCatalog: readonly PaymentProviderDescriptor[] = [
   netopia,
-  voyantPayments,
+  voyantPay,
 ]
 
 /** Look up a catalog entry by id. */
@@ -102,5 +113,12 @@ export function findPaymentProviderDescriptor(
   id: string,
   catalog: readonly PaymentProviderDescriptor[] = defaultPaymentProviderCatalog,
 ): PaymentProviderDescriptor | undefined {
-  return catalog.find((provider) => provider.id === id)
+  const canonicalId = canonicalPaymentProviderId(id)
+  const provider = catalog.find(
+    (candidate) => canonicalPaymentProviderId(candidate.id) === canonicalId,
+  )
+  if (provider?.id === LEGACY_VOYANT_PAYMENTS_PROVIDER_ID) {
+    return { ...provider, id: VOYANT_PAY_PROVIDER_ID }
+  }
+  return provider
 }

--- a/packages/payments/src/index.ts
+++ b/packages/payments/src/index.ts
@@ -272,14 +272,22 @@ export type {
 } from "./conformance.js"
 export { runPaymentAdapterConformance } from "./conformance.js"
 export {
+  canonicalPaymentProviderId,
   defaultPaymentProviderCatalog,
   findPaymentProviderDescriptor,
+  LEGACY_VOYANT_PAYMENTS_PROVIDER_ID,
+  VOYANT_PAY_PROVIDER_ID,
 } from "./default-catalog.js"
 export type {
+  PaymentActivationInput,
+  PaymentActivationResult,
   PaymentConnectInput,
+  PaymentConnectionIdentity,
+  PaymentConnectionReadiness,
   PaymentConnectionRequirement,
   PaymentConnectionState,
   PaymentConnectionStatus,
+  PaymentConnectionSummary,
   PaymentConnectResult,
   PaymentCredentialField,
   PaymentCredentialFieldError,
@@ -294,7 +302,11 @@ export type {
   PaymentProviderDescriptor,
   PaymentProviderRegistry,
 } from "./provider-catalog.js"
-export { validatePaymentCredentials } from "./provider-catalog.js"
+export {
+  isPaymentConnectionReady,
+  paymentConnectionReadiness,
+  validatePaymentCredentials,
+} from "./provider-catalog.js"
 export type {
   RemotePaymentAdapterOptions,
   RemotePaymentCall,

--- a/packages/payments/src/provider-catalog.test.ts
+++ b/packages/payments/src/provider-catalog.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it } from "vitest"
 
 import { defaultPaymentProviderCatalog, findPaymentProviderDescriptor } from "./default-catalog.js"
 import { paymentAdapterRuntimePort } from "./index.js"
-import { validatePaymentCredentials } from "./provider-catalog.js"
+import {
+  isPaymentConnectionReady,
+  type PaymentConnectionState,
+  paymentConnectionReadiness,
+  validatePaymentCredentials,
+} from "./provider-catalog.js"
 import { createRemotePaymentAdapter, PAYMENT_REMOTE_NOT_IMPLEMENTED } from "./remote-adapter.js"
 
 const netopia = findPaymentProviderDescriptor("netopia")
@@ -62,14 +67,17 @@ describe("default payment provider catalog", () => {
     })
   })
 
-  it("ships Netopia as available and Voyant Payments as coming soon", () => {
+  it("ships Netopia as available and Voyant Pay as coming soon", () => {
     expect(netopia?.availability).toBe("available")
-    expect(findPaymentProviderDescriptor("voyant-payments")?.availability).toBe("coming_soon")
+    expect(findPaymentProviderDescriptor("voyant-pay")?.availability).toBe("coming_soon")
   })
 
   it("declares explicit connection methods without fake hosted-account credentials", () => {
     expect(netopia?.connectionMethod).toBe("credentials")
-    expect(findPaymentProviderDescriptor("voyant-payments")).toMatchObject({
+    expect(findPaymentProviderDescriptor("voyant-pay")).toMatchObject({
+      id: "voyant-pay",
+      displayName: "Voyant Pay",
+      logoRef: "voyant-pay",
       availability: "coming_soon",
       connectionMethod: "embedded_onboarding",
       credentialFieldSchema: [],
@@ -77,7 +85,11 @@ describe("default payment provider catalog", () => {
   })
 
   it("does not advertise a hosted refund without acting-user approval claims", () => {
-    expect(findPaymentProviderDescriptor("voyant-payments")?.capabilities.refund).toBe(false)
+    expect(findPaymentProviderDescriptor("voyant-pay")?.capabilities.refund).toBe(false)
+  })
+
+  it("accepts the legacy Voyant Payments id but returns the canonical descriptor", () => {
+    expect(findPaymentProviderDescriptor("voyant-payments")?.id).toBe("voyant-pay")
   })
 
   it("declares only signature-verified callbacks", () => {
@@ -122,6 +134,27 @@ describe("createRemotePaymentAdapter", () => {
         capabilities: { ...netopia!.capabilities, callbackSignatureVerification: false },
       }),
     ).toThrow()
+  })
+})
+
+describe("payment connection readiness", () => {
+  it("treats only a connected connection as ready", () => {
+    expect(paymentConnectionReadiness("connected")).toBe("ready")
+    expect(isPaymentConnectionReady("connected")).toBe(true)
+  })
+
+  it("gates every non-connected state as not ready", () => {
+    const notReady: PaymentConnectionState[] = [
+      "pending_requirements",
+      "pending_verification",
+      "restricted",
+      "error",
+      "disconnected",
+    ]
+    for (const state of notReady) {
+      expect(paymentConnectionReadiness(state)).toBe("not_ready")
+      expect(isPaymentConnectionReady(state)).toBe(false)
+    }
   })
 })
 

--- a/packages/payments/src/provider-catalog.ts
+++ b/packages/payments/src/provider-catalog.ts
@@ -97,14 +97,69 @@ export interface PaymentConnectionRequirement {
 }
 
 /**
+ * Stable identity of one processor connection: the catalog provider plus the
+ * opaque, immutable connection reference the managed control plane assigns (or
+ * an environment-derived pseudo-reference in self-host). Structurally aligned
+ * with `PaymentProcessorIdentity` on the checkout contract (`./index.js`), so a
+ * connection selected here can be threaded onto initiation/callback events.
+ */
+export interface PaymentConnectionIdentity {
+  providerId: string
+  connectionId: string
+}
+
+/**
+ * Whether a known connection is complete enough to be made the active default.
+ * `ready` maps to the `connected` lifecycle state; every other state (pending,
+ * restricted, error, disconnected) is `not_ready`. `unknown` is reserved for
+ * connections a registry cannot currently classify.
+ */
+export type PaymentConnectionReadiness = "ready" | "not_ready" | "unknown"
+
+/**
+ * A deliberately non-sensitive summary of one known connection. It carries the
+ * connection identity, lifecycle/readiness, and whether it is the active
+ * default — never processor secrets, submitted credentials, KMS references, or
+ * platform tokens. Managed deployments may list several; self-host lists at
+ * most the single environment-pinned connection.
+ */
+export interface PaymentConnectionSummary {
+  providerId: string
+  connectionId: string
+  /** Human label for the connection (usually the provider display name). */
+  displayName?: string
+  state: PaymentConnectionState
+  readiness: PaymentConnectionReadiness
+  mode: PaymentAdapterMode | null
+  /** True when this connection is the active default used at checkout. */
+  active: boolean
+  requirements?: readonly PaymentConnectionRequirement[]
+  /** ISO-8601. Last successful `health()` check, if any. */
+  lastHealthAt?: string | null
+  lastError?: string | null
+  /** True when this connection cannot be changed here (env-pinned self-host). */
+  readOnly?: boolean
+}
+
+/**
  * The current connection, independent of which transport backs it. `mode` is
  * `null` until a provider is connected. In self-host/pinned deployments this is
  * derived read-only from the environment-configured adapter.
+ *
+ * `activeProviderId`/`status`/`mode` describe the *active default* connection
+ * (retained for existing callers). `activeConnectionId` + `connections` model
+ * the independent facts — which known connections exist and how ready each is —
+ * separately from which one is active. Both new fields are optional so existing
+ * producers and consumers keep working unchanged.
  */
 export interface PaymentConnectionStatus {
   activeProviderId: string | null
   status: PaymentConnectionState
   mode: PaymentAdapterMode | null
+  /** Opaque reference of the active connection, paired with `activeProviderId`. */
+  activeConnectionId?: string | null
+  /** Non-sensitive summaries of every known connection + its readiness. */
+  connections?: readonly PaymentConnectionSummary[]
   /** ISO-8601. Last successful `health()` check, if any. */
   lastHealthAt?: string | null
   lastError?: string | null
@@ -130,6 +185,41 @@ export interface PaymentConnectResult {
   ok: boolean
   status: PaymentConnectionStatus
   error?: string
+}
+
+/**
+ * Input to make an already-known connection the active default. Activation is a
+ * distinct step from connecting: a deployment may hold several ready
+ * connections and promote one. Both fields are required — activation targets an
+ * exact `{ providerId, connectionId }` identity, never "the provider's latest".
+ */
+export interface PaymentActivationInput {
+  providerId: string
+  connectionId: string
+}
+
+/**
+ * Result of an activation attempt. `ok` reports success/failure explicitly;
+ * callers must not treat the absence of an error as success. `activated` echoes
+ * the identity that became active only when `ok` is true.
+ */
+export interface PaymentActivationResult {
+  ok: boolean
+  status: PaymentConnectionStatus
+  activated?: PaymentConnectionIdentity
+  error?: string
+}
+
+/** Map a lifecycle state to activation readiness. Only `connected` is ready. */
+export function paymentConnectionReadiness(
+  state: PaymentConnectionState,
+): PaymentConnectionReadiness {
+  return state === "connected" ? "ready" : "not_ready"
+}
+
+/** True when a connection in this state may be made the active default. */
+export function isPaymentConnectionReady(state: PaymentConnectionState): boolean {
+  return paymentConnectionReadiness(state) === "ready"
 }
 
 /** Input that begins or resumes a hosted provider's embedded onboarding. */
@@ -176,6 +266,16 @@ export interface PaymentProviderRegistry {
   getConnection(): Promise<PaymentConnectionStatus>
   connect(input: PaymentConnectInput): Promise<PaymentConnectResult>
   beginOnboarding(input: PaymentOnboardingSetupInput): Promise<PaymentOnboardingSetupResult>
+  /**
+   * Promote an already-known, ready connection to the active default.
+   *
+   * Optional so existing registry implementations keep satisfying the contract
+   * without change; callers that support activation must treat an absent method
+   * as "activation unsupported" and fail closed rather than assume success.
+   * Implementations must reject a not-ready connection and never report `ok`
+   * for an activation they did not actually perform.
+   */
+  activate?(input: PaymentActivationInput): Promise<PaymentActivationResult>
   disconnect(): Promise<void>
 }
 

--- a/packages/payments/src/remote-transport.test.ts
+++ b/packages/payments/src/remote-transport.test.ts
@@ -178,7 +178,7 @@ describe("control-plane remote payment transport", () => {
             status: "degraded",
             checkedAt,
             message: "Hosted payment account has outstanding requirements.",
-            details: { providerId: "voyant-payments" },
+            details: { providerId: "voyant-pay" },
           },
         },
       }),
@@ -200,7 +200,7 @@ describe("control-plane remote payment transport", () => {
     ).resolves.toMatchObject({
       status: "degraded",
       checkedAt,
-      details: { providerId: "voyant-payments" },
+      details: { providerId: "voyant-pay" },
     })
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://control.example/admin-runtime/payments/health",

--- a/packages/payments/src/voyant-pay-conformance.test.ts
+++ b/packages/payments/src/voyant-pay-conformance.test.ts
@@ -10,22 +10,22 @@ import {
 import { createControlPlaneRemotePaymentTransport } from "./remote-transport.js"
 
 const identity = {
-  providerId: "voyant-payments",
+  providerId: "voyant-pay",
   connectionId: "pacc_conformance",
 }
 const money = { amountMinor: 10_000, currency: "RON" }
 
-describe("Voyant Payments public adapter acceptance", () => {
+describe("Voyant Pay public adapter acceptance", () => {
   it("passes the public kit with the real hosted capability advertisement", async () => {
     // This is the concrete OSS managed adapter plus its concrete HTTP
     // transport, exercised against an in-process platform contract harness.
     // It is intentionally not presented as a deployed Stripe integration run.
-    const platform = createVoyantPaymentsPlatformHarness()
-    const descriptor = findPaymentProviderDescriptor("voyant-payments")
+    const platform = createVoyantPayPlatformHarness()
+    const descriptor = findPaymentProviderDescriptor("voyant-pay")
     expect(descriptor).toBeDefined()
     const adapter = createRemotePaymentAdapter({
-      id: "voyant-payments",
-      label: "Voyant Payments",
+      id: "voyant-pay",
+      label: "Voyant Pay",
       mode: "sandbox",
       capabilities: descriptor!.capabilities,
       connectionRef: identity.connectionId,
@@ -76,7 +76,7 @@ describe("Voyant Payments public adapter acceptance", () => {
   })
 })
 
-function createVoyantPaymentsPlatformHarness() {
+function createVoyantPayPlatformHarness() {
   const idempotency = new Map<string, { fingerprint: string; result: unknown }>()
   const paths: string[] = []
 
@@ -112,7 +112,7 @@ function createVoyantPaymentsPlatformHarness() {
           result: {
             status: "ok",
             checkedAt: "2026-07-25T08:00:00.000Z",
-            details: { providerId: "voyant-payments" },
+            details: { providerId: "voyant-pay" },
           },
         },
       })


### PR DESCRIPTION
## What changed

- makes `voyant-pay` / Voyant Pay canonical across the catalog, deployment graph, docs, and conformance fixtures
- accepts the legacy `voyant-payments` identifier at compatibility boundaries
- adds non-sensitive connection summaries, readiness, active connection identity, and an explicit activation contract
- adds the managed Settings → Payments “Make active” UI with readiness and pending/error gates
- adds release changesets for the affected public packages

## Why

Connecting a processor and selecting it for new checkouts are separate operations. This keeps Netopia active while Voyant Pay onboarding is incomplete and makes rollback an explicit selection change.

## Validation

- all GitHub checks are green
- changed-graph tests, typechecks, builds, architecture, i18n, package artifacts, packaged production/development acceptance, and database lanes passed
- focused payment packages: 41 tests passed + typecheck
- framework: 370 tests passed
- `git diff --check` passed

## Dependency

The platform cutover PR consumes this activation contract.