### PR TITLE
fix(media): derive delivery URLs instead of persisting a CDN origin

### DIFF
--- a/.changeset/media-derive-delivery-url.md
+++ b/.changeset/media-derive-delivery-url.md
@@ -1,0 +1,24 @@
+---
+"@voyant-travel/storage": minor
+"@voyant-travel/media": minor
+"@voyant-travel/runtime": patch
+---
+
+Derive media delivery URLs at read time instead of persisting a CDN origin
+
+`media_asset.url` stored a fully-qualified delivery URL captured at upload time,
+so any change to the media CDN hostname invalidated every row at once — the
+bucket, the object keys and `storage_key` stayed correct, but the library
+rendered nothing until the rows were rewritten by hand.
+
+`storage_key` is now the only durable locator. `StorageProvider` gains an
+optional `publicUrl(key)` that composes the delivery URL from the provider's
+currently configured origin, and `@voyant-travel/media` calls it on every read.
+The wire shape is unchanged: responses still carry `url`, it is just derived
+rather than stored. `url` is `null` when the store exposes no public origin, and
+consumers already fall back to the deployment's own byte-serving route
+(`GET /v1/admin/media/{storageKey}`).
+
+The gateway provider accepts an optional `publicBaseUrl` (wired from
+`MEDIA_PUBLIC_BASE_URL`) so managed deployments keep CDN delivery with the origin
+held in one configurable place. A migration drops the `media_asset.url` column.

--- a/.changeset/media-derive-delivery-url.md
+++ b/.changeset/media-derive-delivery-url.md
@@ -19,6 +19,13 @@ rather than stored. `url` is `null` when the store exposes no public origin, and
 consumers already fall back to the deployment's own byte-serving route
 (`GET /v1/admin/media/{storageKey}`).
 
-The gateway provider accepts an optional `publicBaseUrl` (wired from
-`MEDIA_PUBLIC_BASE_URL`) so managed deployments keep CDN delivery with the origin
-held in one configurable place. A migration drops the `media_asset.url` column.
+The gateway provider now derives from a `publicBaseUrl` wired from
+`MEDIA_PUBLIC_BASE_URL`, so the origin lives in one configurable place. **A
+deployment selecting the `gateway` storage provider must set
+`MEDIA_PUBLIC_BASE_URL`** — the gateway mints delivery URLs server-side, so
+there is nothing else to derive from, and falling back to the deployment's own
+`/v1/admin/media/*` route is not viable because that route is staff-guarded and
+storefront guests would render nothing. It fails closed at provider construction
+with an actionable message rather than degrading silently.
+
+A migration drops the `media_asset.url` column.

--- a/docs/architecture/storage-architecture.md
+++ b/docs/architecture/storage-architecture.md
@@ -52,9 +52,18 @@ That fits things like:
 - CMS/editor uploads
 - storefront-facing assets
 
+"Stable" describes the *delivery strategy*, not a value to write into a row. The
+public origin is deployment configuration: it changes when a CDN hostname or a
+custom domain changes, and a catalogue that has baked the old origin into every
+row is invalidated wholesale, with no code path that repairs it. That failure is
+silent — the rows still look right, the objects are still there, and the only
+symptom is broken images.
+
 Rule:
 
-Public media may use durable public URLs when the asset is intentionally public.
+Public media may be delivered through a durable public URL, but that URL is
+composed at read time from the configured origin plus the stored key. Persist
+the key; never persist the origin.
 
 ### 3. Private documents should use signed or authenticated access
 
@@ -78,7 +87,7 @@ Sensitive documents should be private by default and resolved per-request.
 
 ## Storage Metadata
 
-### 4. Persist storage keys, not expiring download URLs
+### 4. Persist storage keys, not resolved access URLs
 
 Voyant should store durable storage metadata such as:
 
@@ -87,15 +96,23 @@ Voyant should store durable storage metadata such as:
 - filename
 - content type
 
-It should not persist temporary signed URLs as the primary durable reference to
-the document.
+It should not persist a resolved access URL as the primary durable reference to
+the object. That covers both shapes:
 
-Signed URLs expire. The durable record should be the storage key, and access
-URLs should be derived at read time.
+- **Signed URLs**, which expire.
+- **Public delivery URLs**, whose origin is deployment configuration and is
+  invalidated by any hostname or custom-domain change.
+
+The durable record should be the storage key, and access URLs should be derived
+at read time. `StorageProvider.publicUrl(key)` is the seam for the public case:
+it composes the URL from the provider's *currently configured* origin, and
+returns `null` when the store has no public origin so the caller falls back to
+the deployment's own byte-serving route rather than to a stale absolute URL.
 
 Rule:
 
-Store `storageKey`-style durable metadata, not expiring access URLs.
+Store `storageKey`-style durable metadata, not resolved access URLs — expiring
+or otherwise.
 
 ### 5. Resolve document access at read time
 

--- a/packages/media/migrations/20260728085836_media_asset_drop_persisted_url.sql
+++ b/packages/media/migrations/20260728085836_media_asset_drop_persisted_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "media_asset" DROP COLUMN "url";

--- a/packages/media/migrations/meta/20260728085836_snapshot.json
+++ b/packages/media/migrations/meta/20260728085836_snapshot.json
@@ -1,0 +1,398 @@
+{
+  "id": "920d5079-416e-46fc-a6c1-625b2a1af18b",
+  "prevId": "fcb7bdcd-0881-4b21-93dc-f957f2248223",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.asset_usage": {
+      "name": "asset_usage",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_asset_usage_asset_entity": {
+          "name": "uidx_asset_usage_asset_entity",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_asset": {
+      "name": "media_asset",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_language_tag": {
+          "name": "default_language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'en'"
+        },
+        "storage_key": {
+          "name": "storage_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "provider_meta": {
+          "name": "provider_meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_media_asset_checksum": {
+          "name": "uidx_media_asset_checksum",
+          "columns": [
+            {
+              "expression": "checksum",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_asset_translation": {
+      "name": "media_asset_translation",
+      "schema": "",
+      "columns": {
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language_tag": {
+          "name": "language_tag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_asset_translation_asset_id_media_asset_id_fk": {
+          "name": "media_asset_translation_asset_id_media_asset_id_fk",
+          "tableFrom": "media_asset_translation",
+          "tableTo": "media_asset",
+          "columnsFrom": [
+            "asset_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pk_media_asset_translation": {
+          "name": "pk_media_asset_translation",
+          "columns": [
+            "asset_id",
+            "language_tag"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_folder": {
+      "name": "media_folder",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media_folder_member": {
+      "name": "media_folder_member",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "asset_id": {
+          "name": "asset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "folder_id": {
+          "name": "folder_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uidx_media_folder_member_asset_folder": {
+          "name": "uidx_media_folder_member_asset_folder",
+          "columns": [
+            {
+              "expression": "asset_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "folder_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/media/migrations/meta/_journal.json
+++ b/packages/media/migrations/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1784960435888,
       "tag": "20260725062035_media_alt_text_localization",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1785229116774,
+      "tag": "20260728085836_media_asset_drop_persisted_url",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/media/src/routes.ts
+++ b/packages/media/src/routes.ts
@@ -103,6 +103,12 @@ const mediaAssetRowSchema = z.object({
   defaultLanguageTag: z.string(),
   altTranslations: z.array(mediaAssetTranslationRowSchema),
   storageKey: z.string(),
+  /**
+   * Derived per response from the resolved provider's configured origin — never
+   * stored. `null` means this deployment exposes no public media origin, and the
+   * caller should serve bytes through `GET /v1/admin/media/{storageKey}`
+   * (voyant#3845).
+   */
   url: z.string().nullable(),
   mimeType: z.string().nullable(),
   fileSize: z.number().nullable(),
@@ -412,14 +418,18 @@ export function createMediaLibraryRoutes(options: MediaLibraryRoutesOptions) {
       asRouteResponse(
         (async () => {
           const query = parseQuery(c, listMediaAssetsQuerySchema)
-          return c.json(await listMediaAssets(c.get("db"), query), 200)
+          return c.json(await listMediaAssets(c.get("db"), query, options.resolveStorage(c)), 200)
         })(),
       ),
     )
     .openapi(getAssetRoute, (c) =>
       asRouteResponse(
         (async () => {
-          const asset = await getMediaAsset(c.get("db"), c.req.valid("param").assetId)
+          const asset = await getMediaAsset(
+            c.get("db"),
+            c.req.valid("param").assetId,
+            options.resolveStorage(c),
+          )
           if (!asset) return c.json({ error: "Media asset not found" }, 404)
           return c.json({ data: asset }, 200)
         })(),
@@ -430,7 +440,12 @@ export function createMediaLibraryRoutes(options: MediaLibraryRoutesOptions) {
         (async () => {
           const input = await parseJsonBody(c, updateMediaAssetSchema)
           try {
-            const asset = await updateMediaAsset(c.get("db"), c.req.valid("param").assetId, input)
+            const asset = await updateMediaAsset(
+              c.get("db"),
+              c.req.valid("param").assetId,
+              input,
+              options.resolveStorage(c),
+            )
             if (!asset) return c.json({ error: "Media asset not found" }, 404)
             return c.json({ data: asset }, 200)
           } catch (error) {

--- a/packages/media/src/schema.ts
+++ b/packages/media/src/schema.ts
@@ -12,6 +12,8 @@
  *   deliberately does not touch `product_media`.
  * - Folders are modelled as *membership* (`media_folder_member`) so an asset can
  *   live in many folders; there is no `folderId` column on the asset itself.
+ * - NO persisted delivery URL. `storage_key` is the durable locator; absolute
+ *   URLs are derived on read from the configured storage origin (voyant#3845).
  */
 
 import { typeId } from "@voyant-travel/db/lib/typeid-column"
@@ -44,10 +46,15 @@ export const mediaAsset = pgTable(
     altText: text("alt"),
     /** Language of the base `altText`; localized alternatives live below. */
     defaultLanguageTag: text("default_language_tag").notNull().default("en"),
-    /** Object key inside the resolved `"media"` StorageProvider. */
+    /**
+     * Object key inside the resolved `"media"` StorageProvider — the only
+     * durable locator for the bytes. The absolute delivery URL is deliberately
+     * NOT stored: it is derived per read from the provider's configured origin
+     * (`StorageProvider.publicUrl`). A persisted origin is invalidated wholesale
+     * by a CDN hostname change and fails silently as broken images
+     * (voyant#3845).
+     */
     storageKey: text("storage_key").notNull(),
-    /** Stable public delivery URL returned by the selected storage provider. */
-    url: text("url"),
     mimeType: text("mime_type"),
     /** Size in bytes. */
     fileSize: integer("file_size"),

--- a/packages/media/src/service.test.ts
+++ b/packages/media/src/service.test.ts
@@ -180,7 +180,7 @@ describe("@voyant-travel/media service (pglite)", () => {
     expect(products.data.every((row) => row.entityType === "product")).toBe(true)
   })
 
-  it("persists a canonical delivery URL and localized alt text", async () => {
+  it("derives the delivery URL from the provider and stores localized alt text", async () => {
     const { asset } = await createMediaAsset(
       db,
       storage,
@@ -204,12 +204,17 @@ describe("@voyant-travel/media service (pglite)", () => {
       }),
     ])
 
-    const updated = await updateMediaAsset(db, asset.id, {
-      altTranslations: [
-        { languageTag: "en", altText: "Sunset beach" },
-        { languageTag: "de", altText: "Strand bei Sonnenuntergang" },
-      ],
-    })
+    const updated = await updateMediaAsset(
+      db,
+      asset.id,
+      {
+        altTranslations: [
+          { languageTag: "en", altText: "Sunset beach" },
+          { languageTag: "de", altText: "Strand bei Sonnenuntergang" },
+        ],
+      },
+      storage,
+    )
     expect(
       updated?.altTranslations.map(({ languageTag, altText }) => ({ languageTag, altText })),
     ).toEqual([
@@ -217,8 +222,8 @@ describe("@voyant-travel/media service (pglite)", () => {
       { languageTag: "en", altText: "Sunset beach" },
     ])
 
-    expect((await getMediaAsset(db, asset.id))?.altTranslations).toHaveLength(2)
-    const listed = await listMediaAssets(db, { limit: 50, offset: 0 })
+    expect((await getMediaAsset(db, asset.id, storage))?.altTranslations).toHaveLength(2)
+    const listed = await listMediaAssets(db, { limit: 50, offset: 0 }, storage)
     expect(listed.data[0]?.altTranslations).toHaveLength(2)
 
     await expect(
@@ -226,5 +231,39 @@ describe("@voyant-travel/media service (pglite)", () => {
         defaultLanguageTag: "en",
       }),
     ).rejects.toMatchObject({ code: "invalid_alt_translation" })
+  })
+
+  it("re-derives delivery URLs after the media origin changes (voyant#3845)", async () => {
+    const { asset } = await createMediaAsset(db, storage, imageInput, bytesOf("origin-move"))
+    expect(asset.url).toBe(`https://cdn.example.test/${asset.storageKey}`)
+
+    // The deployment's media CDN moves to a new hostname. Nothing about the
+    // bucket, the object keys or `storage_key` changes — only the origin.
+    const movedStorage = createLocalStorageProvider({
+      name: "memory:media",
+      baseUrl: "https://cdn.moved.test/",
+    })
+
+    expect((await getMediaAsset(db, asset.id, movedStorage))?.url).toBe(
+      `https://cdn.moved.test/${asset.storageKey}`,
+    )
+    const listed = await listMediaAssets(db, { limit: 50, offset: 0 }, movedStorage)
+    expect(listed.data[0]?.url).toBe(`https://cdn.moved.test/${asset.storageKey}`)
+    expect(listed.data[0]?.storageKey).toBe(asset.storageKey)
+  })
+
+  it("reports a null URL when the store exposes no public origin", async () => {
+    const { asset } = await createMediaAsset(db, storage, imageInput, bytesOf("private-store"))
+
+    // A provider without `publicUrl` (or one whose bucket is private) must not
+    // fall back to a stale persisted origin — consumers serve the bytes through
+    // the deployment's own media route instead.
+    const privateStorage: StorageProvider = {
+      ...storage,
+      publicUrl: () => null,
+    }
+
+    expect((await getMediaAsset(db, asset.id, privateStorage))?.url).toBeNull()
+    expect((await getMediaAsset(db, asset.id))?.url).toBeNull()
   })
 })

--- a/packages/media/src/service.ts
+++ b/packages/media/src/service.ts
@@ -25,6 +25,7 @@ import {
   mediaFolder,
   mediaFolderMember,
 } from "./schema.js"
+import { computeChecksum, mediaStorageKey, toBytes } from "./storage-key.js"
 import type {
   CreateMediaAssetInput,
   CreateMediaFolderInput,
@@ -35,6 +36,10 @@ import type {
   UpdateMediaAssetInput,
   UpdateMediaFolderInput,
 } from "./validation.js"
+
+// Storage-key derivation lives in `./storage-key`; re-exported so the service
+// remains the single import site for consumers.
+export { computeChecksum, MEDIA_STORAGE_KEY_PREFIX, mediaStorageKey } from "./storage-key.js"
 
 /** Stable, machine-readable failure codes surfaced by the service. */
 export type MediaErrorCode = "asset_in_use" | "invalid_alt_translation" | "not_found"
@@ -57,64 +62,40 @@ export interface CreateMediaAssetResult {
 
 export type MediaAssetWithTranslations = MediaAsset & {
   altTranslations: MediaAssetTranslation[]
+  /**
+   * Absolute delivery URL derived from the provider's *currently configured*
+   * origin, or `null` when this store exposes no public origin — consumers then
+   * fall back to the deployment's own byte-serving media route. Never read back
+   * from the database: a persisted origin goes stale on the next CDN hostname
+   * change and fails silently as broken images (voyant#3845).
+   */
+  url: string | null
 }
-
-/** All object keys minted by the library live under this servable prefix. */
-const MEDIA_STORAGE_KEY_PREFIX = "uploads/media/"
 
 /**
- * Storage keys are content-addressed by checksum. Append the file extension so
- * the byte-serving route (`@voyant-travel/storage`, which sends
- * `X-Content-Type-Options: nosniff`) can infer the correct `Content-Type` from
- * the key and browsers render the asset instead of downloading octet-stream.
+ * The slice of `StorageProvider` the read paths need. Accepting the narrow shape
+ * (rather than a full provider) keeps `getMediaAsset`/`listMediaAssets` callable
+ * from surfaces that only resolve a URL origin.
  */
-const MEDIA_EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
-  "image/png": "png",
-  "image/jpeg": "jpg",
-  "image/webp": "webp",
-  "image/gif": "gif",
-  "image/avif": "avif",
-  "image/svg+xml": "svg",
-  "video/mp4": "mp4",
-  "video/webm": "webm",
-  "video/quicktime": "mov",
-  "application/pdf": "pdf",
-}
+export type MediaUrlSource = Pick<StorageProvider, "publicUrl"> | null | undefined
 
-function storageKeyExtension(mimeType: string | null | undefined): string {
-  const normalized = (mimeType ?? "").toLowerCase().split(";")[0]?.trim() ?? ""
-  const ext = MEDIA_EXTENSION_BY_MIME[normalized]
-  return ext ? `.${ext}` : ""
-}
-
-async function toBytes(body: StorageUploadBody): Promise<Uint8Array> {
-  if (body instanceof Uint8Array) return body
-  if (body instanceof ArrayBuffer) return new Uint8Array(body)
-  return new Uint8Array(await body.arrayBuffer())
-}
-
-/** SHA-256 hex digest of the given bytes (org-global dedup key). */
-export async function computeChecksum(body: StorageUploadBody): Promise<string> {
-  const bytes = await toBytes(body)
-  // Copy into a fresh ArrayBuffer-backed view so the digest arg is a concrete
-  // BufferSource (Uint8Array<ArrayBufferLike>` isn't assignable under TS 6).
-  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes))
-  return Array.from(new Uint8Array(digest))
-    .map((b) => b.toString(16).padStart(2, "0"))
-    .join("")
+function resolveAssetUrl(storageKey: string, storage: MediaUrlSource): string | null {
+  return storage?.publicUrl?.(storageKey) ?? null
 }
 
 async function findAssetByChecksum(
   db: PostgresJsDatabase,
   checksum: string,
+  storage: MediaUrlSource,
 ): Promise<MediaAssetWithTranslations | null> {
   const [row] = await db.select().from(mediaAsset).where(eq(mediaAsset.checksum, checksum)).limit(1)
-  return row ? attachTranslations(db, [row]).then((assets) => assets[0] ?? null) : null
+  return row ? attachTranslations(db, [row], storage).then((assets) => assets[0] ?? null) : null
 }
 
 async function attachTranslations(
   db: PostgresJsDatabase,
   assets: MediaAsset[],
+  storage: MediaUrlSource,
 ): Promise<MediaAssetWithTranslations[]> {
   if (assets.length === 0) return []
 
@@ -139,6 +120,7 @@ async function attachTranslations(
   return assets.map((asset) => ({
     ...asset,
     altTranslations: byAssetId.get(asset.id) ?? [],
+    url: resolveAssetUrl(asset.storageKey, storage),
   }))
 }
 
@@ -192,13 +174,15 @@ export async function createMediaAsset(
   const bytes = await toBytes(body)
   const checksum = await computeChecksum(bytes)
 
-  const existing = await findAssetByChecksum(db, checksum)
+  const existing = await findAssetByChecksum(db, checksum, storage)
   if (existing) {
     return { asset: existing, deduped: true }
   }
 
-  const storageKey = `${MEDIA_STORAGE_KEY_PREFIX}${checksum}${storageKeyExtension(input.mimeType)}`
-  const stored = await storage.upload(bytes, {
+  const storageKey = mediaStorageKey(checksum, input.mimeType)
+  // The upload result's `url` is deliberately discarded: `storageKey` is the
+  // durable locator and delivery URLs are derived per read (voyant#3845).
+  await storage.upload(bytes, {
     key: storageKey,
     ...(input.mimeType ? { contentType: input.mimeType } : {}),
   })
@@ -212,7 +196,6 @@ export async function createMediaAsset(
         altText: input.altText ?? null,
         defaultLanguageTag,
         storageKey,
-        url: stored.url || null,
         mimeType: input.mimeType ?? null,
         fileSize: bytes.byteLength,
         checksum,
@@ -232,13 +215,13 @@ export async function createMediaAsset(
     }
     await replaceAltTranslations(db, created.id, input.altTranslations)
 
-    const [asset] = await attachTranslations(db, [created])
+    const [asset] = await attachTranslations(db, [created], storage)
     if (!asset) throw new MediaError("not_found", "Failed to load created media asset")
     return { asset, deduped: false }
   } catch (error) {
     // Lost a race with a concurrent identical upload: the unique checksum index
     // rejected our insert. Fall back to the row the winner created.
-    const raced = await findAssetByChecksum(db, checksum)
+    const raced = await findAssetByChecksum(db, checksum, storage)
     if (raced) return { asset: raced, deduped: true }
     throw error
   }
@@ -247,15 +230,20 @@ export async function createMediaAsset(
 export async function getMediaAsset(
   db: PostgresJsDatabase,
   id: string,
+  storage?: MediaUrlSource,
 ): Promise<MediaAssetWithTranslations | null> {
   const [row] = await db.select().from(mediaAsset).where(eq(mediaAsset.id, id)).limit(1)
   if (!row) return null
-  const [asset] = await attachTranslations(db, [row])
+  const [asset] = await attachTranslations(db, [row], storage)
   return asset ?? null
 }
 
 /** Paginated list/search over assets. Filters combine with AND. */
-export async function listMediaAssets(db: PostgresJsDatabase, query: ListMediaAssetsQuery) {
+export async function listMediaAssets(
+  db: PostgresJsDatabase,
+  query: ListMediaAssetsQuery,
+  storage?: MediaUrlSource,
+) {
   const conditions = []
   if (query.type) conditions.push(eq(mediaAsset.type, query.type))
   if (query.mimeType) conditions.push(eq(mediaAsset.mimeType, query.mimeType))
@@ -285,7 +273,7 @@ export async function listMediaAssets(db: PostgresJsDatabase, query: ListMediaAs
     db.select({ count: sql<number>`count(*)::int` }).from(mediaAsset).where(where),
   ])
 
-  return listResponse(await attachTranslations(db, rows), {
+  return listResponse(await attachTranslations(db, rows, storage), {
     total: counted?.count ?? 0,
     limit: query.limit,
     offset: query.offset,
@@ -300,8 +288,9 @@ export async function updateMediaAsset(
   db: PostgresJsDatabase,
   id: string,
   patch: UpdateMediaAssetInput,
+  storage?: MediaUrlSource,
 ): Promise<MediaAssetWithTranslations | null> {
-  const existing = await getMediaAsset(db, id)
+  const existing = await getMediaAsset(db, id, storage)
   if (!existing) return null
   const defaultLanguageTag = patch.defaultLanguageTag ?? existing.defaultLanguageTag
   const altTranslations = patch.altTranslations ?? existing.altTranslations
@@ -332,7 +321,7 @@ export async function updateMediaAsset(
     await replaceAltTranslations(db, id, patch.altTranslations)
   }
 
-  const [asset] = await attachTranslations(db, [updated])
+  const [asset] = await attachTranslations(db, [updated], storage)
   return asset ?? null
 }
 
@@ -346,7 +335,7 @@ export async function deleteMediaAsset(
   storage: StorageProvider,
   id: string,
 ): Promise<MediaAssetWithTranslations | null> {
-  const existing = await getMediaAsset(db, id)
+  const existing = await getMediaAsset(db, id, storage)
   if (!existing) return null
 
   const usageCount = await countAssetUsage(db, id)

--- a/packages/media/src/site-bridge.ts
+++ b/packages/media/src/site-bridge.ts
@@ -67,12 +67,15 @@ export function createMediaSiteBridgeRoutes(options: MediaSiteBridgeOptions) {
         const body = await readJson(c)
         const query = listMediaAssetsQuerySchema.safeParse(body ?? {})
         if (!query.success) return invalid(c, query.error.issues)
-        return c.json(await listMediaAssets(c.get("db"), query.data), 200)
+        return c.json(
+          await listMediaAssets(c.get("db"), query.data, options.resolveStorage(c)),
+          200,
+        )
       }
       case "get": {
         const body = assetIdBodySchema.safeParse(await readJson(c))
         if (!body.success) return invalid(c, body.error.issues)
-        const asset = await getMediaAsset(c.get("db"), body.data.assetId)
+        const asset = await getMediaAsset(c.get("db"), body.data.assetId, options.resolveStorage(c))
         return asset
           ? c.json({ data: asset }, 200)
           : c.json({ error: "Media asset not found" }, 404)
@@ -81,7 +84,12 @@ export function createMediaSiteBridgeRoutes(options: MediaSiteBridgeOptions) {
         const body = updateBodySchema.safeParse(await readJson(c))
         if (!body.success) return invalid(c, body.error.issues)
         try {
-          const asset = await updateMediaAsset(c.get("db"), body.data.assetId, body.data.input)
+          const asset = await updateMediaAsset(
+            c.get("db"),
+            body.data.assetId,
+            body.data.input,
+            options.resolveStorage(c),
+          )
           return asset
             ? c.json({ data: asset }, 200)
             : c.json({ error: "Media asset not found" }, 404)

--- a/packages/media/src/storage-key.ts
+++ b/packages/media/src/storage-key.ts
@@ -1,0 +1,58 @@
+/**
+ * `@voyant-travel/media` storage-key derivation. The object key is the library's
+ * only durable locator for an asset's bytes — delivery URLs are composed from it
+ * per read against the configured origin, never persisted (voyant#3845) — so the
+ * rules that shape a key live together here.
+ */
+
+import type { StorageUploadBody } from "@voyant-travel/storage"
+
+/** All object keys minted by the library live under this servable prefix. */
+export const MEDIA_STORAGE_KEY_PREFIX = "uploads/media/"
+
+/**
+ * Storage keys are content-addressed by checksum. Append the file extension so
+ * the byte-serving route (`@voyant-travel/storage`, which sends
+ * `X-Content-Type-Options: nosniff`) can infer the correct `Content-Type` from
+ * the key and browsers render the asset instead of downloading octet-stream.
+ */
+const MEDIA_EXTENSION_BY_MIME: Readonly<Record<string, string>> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/webp": "webp",
+  "image/gif": "gif",
+  "image/avif": "avif",
+  "image/svg+xml": "svg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+  "application/pdf": "pdf",
+}
+
+function storageKeyExtension(mimeType: string | null | undefined): string {
+  const normalized = (mimeType ?? "").toLowerCase().split(";")[0]?.trim() ?? ""
+  const ext = MEDIA_EXTENSION_BY_MIME[normalized]
+  return ext ? `.${ext}` : ""
+}
+
+/** The content-addressed object key for bytes with the given checksum/MIME. */
+export function mediaStorageKey(checksum: string, mimeType: string | null | undefined): string {
+  return `${MEDIA_STORAGE_KEY_PREFIX}${checksum}${storageKeyExtension(mimeType)}`
+}
+
+export async function toBytes(body: StorageUploadBody): Promise<Uint8Array> {
+  if (body instanceof Uint8Array) return body
+  if (body instanceof ArrayBuffer) return new Uint8Array(body)
+  return new Uint8Array(await body.arrayBuffer())
+}
+
+/** SHA-256 hex digest of the given bytes (org-global dedup key). */
+export async function computeChecksum(body: StorageUploadBody): Promise<string> {
+  const bytes = await toBytes(body)
+  // Copy into a fresh ArrayBuffer-backed view so the digest arg is a concrete
+  // BufferSource (Uint8Array<ArrayBufferLike>` isn't assignable under TS 6).
+  const digest = await crypto.subtle.digest("SHA-256", new Uint8Array(bytes))
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("")
+}

--- a/packages/runtime/src/filesystem-storage.ts
+++ b/packages/runtime/src/filesystem-storage.ts
@@ -99,6 +99,11 @@ function withDiskProvider(inner: StorageProvider, dir: string): StorageProvider 
   if (inner.signedUrl) {
     provider.signedUrl = (key, expiresIn) => inner.signedUrl!(key, expiresIn)
   }
+  // Delivery URLs are derived per read from the wrapped store's configured
+  // origin; the wrapper must forward that seam or callers silently lose it.
+  if (inner.publicUrl) {
+    provider.publicUrl = (key) => inner.publicUrl!(key)
+  }
   return provider
 }
 
@@ -192,6 +197,11 @@ function withRequiredDiskProvider(inner: StorageProvider, dir: string): StorageP
   }
   if (inner.signedUrl) {
     provider.signedUrl = (key, expiresIn) => inner.signedUrl!(key, expiresIn)
+  }
+  // Delivery URLs are derived per read from the wrapped store's configured
+  // origin; the wrapper must forward that seam or callers silently lose it.
+  if (inner.publicUrl) {
+    provider.publicUrl = (key) => inner.publicUrl!(key)
   }
   return provider
 }

--- a/packages/storage/src/conformance.ts
+++ b/packages/storage/src/conformance.ts
@@ -13,13 +13,21 @@ export async function assertStorageProviderConformance(
   const key = options.key ?? `voyant-conformance/${globalThis.crypto.randomUUID()}`
   const expected = new Uint8Array([0, 1, 2, 127, 255])
 
+  // Derivation must be pure: same key in, same URL out (voyant#3845). Sampled
+  // before the upload so the post-upload comparison below can prove it does not
+  // depend on the object existing — a provider that only derives for objects it
+  // has already seen would otherwise pass by returning `null` twice.
+  const publicUrlBeforeUpload = provider.publicUrl?.(key) ?? null
   if (provider.publicUrl) {
-    // Derivation must be pure: same key in, same URL out, with no dependency on
-    // whether the object has been uploaded yet (voyant#3845).
-    const before = provider.publicUrl(key)
-    assert(before === provider.publicUrl(key), "publicUrl is not stable for the same key")
-    if (before !== null) {
-      assert(before.trim().length > 0, "publicUrl returned an empty URL instead of null")
+    assert(
+      publicUrlBeforeUpload === provider.publicUrl(key),
+      "publicUrl is not stable for the same key",
+    )
+    if (publicUrlBeforeUpload !== null) {
+      assert(
+        publicUrlBeforeUpload.trim().length > 0,
+        "publicUrl returned an empty URL instead of null",
+      )
     }
   }
 
@@ -29,6 +37,14 @@ export async function assertStorageProviderConformance(
     metadata: { conformance: "true" },
   })
   assert(uploaded.key === key, `upload returned key ${uploaded.key}; expected ${key}`)
+
+  if (provider.publicUrl) {
+    const publicUrlAfterUpload = provider.publicUrl(key)
+    assert(
+      publicUrlAfterUpload === publicUrlBeforeUpload,
+      `publicUrl changed once the object existed (${publicUrlBeforeUpload} -> ${publicUrlAfterUpload}); it must derive from configuration, not from object state`,
+    )
+  }
 
   const stored = await provider.get(key)
   assert(stored !== null, "get returned null after upload")

--- a/packages/storage/src/conformance.ts
+++ b/packages/storage/src/conformance.ts
@@ -13,6 +13,16 @@ export async function assertStorageProviderConformance(
   const key = options.key ?? `voyant-conformance/${globalThis.crypto.randomUUID()}`
   const expected = new Uint8Array([0, 1, 2, 127, 255])
 
+  if (provider.publicUrl) {
+    // Derivation must be pure: same key in, same URL out, with no dependency on
+    // whether the object has been uploaded yet (voyant#3845).
+    const before = provider.publicUrl(key)
+    assert(before === provider.publicUrl(key), "publicUrl is not stable for the same key")
+    if (before !== null) {
+      assert(before.trim().length > 0, "publicUrl returned an empty URL instead of null")
+    }
+  }
+
   const uploaded = await provider.upload(expected, {
     key,
     contentType: "application/octet-stream",

--- a/packages/storage/src/providers/gateway.test.ts
+++ b/packages/storage/src/providers/gateway.test.ts
@@ -85,18 +85,18 @@ describe("createGatewayStorageProvider", () => {
     const first = createGatewayStorageProvider({
       endpoint: "https://gateway.example",
       tier: "documents",
-      token: "workspace-a-secret",
+      token: "test-workspace-a-credential",
     })
     const second = createGatewayStorageProvider({
       endpoint: "https://gateway.example",
       tier: "documents",
-      token: "workspace-b-secret",
+      token: "test-workspace-b-credential",
     })
 
     const firstIdentity = await first.resolveBackendIdentity?.()
     expect(firstIdentity).toMatch(/^[a-f0-9]{64}$/)
     expect(await second.resolveBackendIdentity?.()).not.toBe(firstIdentity)
-    expect(firstIdentity).not.toContain("workspace-a-secret")
+    expect(firstIdentity).not.toContain("test-workspace-a-credential")
   })
 
   it("uploads bytes and returns the gateway-issued key and url", async () => {
@@ -121,6 +121,27 @@ describe("createGatewayStorageProvider", () => {
     expect(stored?.bytes).toEqual(new Uint8Array([1, 2, 3]))
     expect(stored?.contentType).toBe("application/pdf")
     expect(stored?.metadata).toEqual({ owner: "workspace" })
+  })
+
+  it("derives public urls from the configured base and returns null without one", () => {
+    const withBase = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      tier: "media",
+      publicBaseUrl: "https://cdn.example.test/eu/org_1/media/",
+    })
+    const withoutBase = createGatewayStorageProvider({
+      endpoint: "https://gw.test",
+      token: "t",
+      tier: "media",
+    })
+
+    // Derived, not persisted: the same key resolves against whatever origin the
+    // deployment is configured with right now (voyant#3845).
+    expect(withBase.publicUrl?.("uploads/media/abc.jpg")).toBe(
+      "https://cdn.example.test/eu/org_1/media/uploads/media/abc.jpg",
+    )
+    expect(withoutBase.publicUrl?.("uploads/media/abc.jpg")).toBeNull()
   })
 
   it("round-trips bytes through get and returns null for a missing key", async () => {

--- a/packages/storage/src/providers/gateway.ts
+++ b/packages/storage/src/providers/gateway.ts
@@ -31,10 +31,11 @@ export interface GatewayStorageProviderOptions {
    * `${publicBaseUrl}/${key}` resolves for a caller-facing key.
    *
    * Supplying it lets {@link StorageProvider.publicUrl} derive delivery URLs on
-   * every read from a single configured value; when it is absent `publicUrl`
-   * returns `null` and callers fall back to serving bytes through the
-   * deployment's own media route. Either way no absolute origin is persisted
-   * (voyant#3845).
+   * every read from a single configured value, so no absolute origin is ever
+   * persisted (voyant#3845). When absent `publicUrl` returns `null`, meaning
+   * "this store has no public origin" — correct for a private tier such as
+   * documents, but a media store feeding a storefront must set it, which is why
+   * the graph provider requires it there.
    */
   publicBaseUrl?: string
 }

--- a/packages/storage/src/providers/gateway.ts
+++ b/packages/storage/src/providers/gateway.ts
@@ -24,6 +24,19 @@ export interface GatewayStorageProviderOptions {
    * provider are always the un-prefixed, caller-facing keys.
    */
   tier?: string
+  /**
+   * Public CDN base that fronts this store's object namespace, if the
+   * deployment has one. The base must be the origin **plus** whatever path
+   * prefix the gateway serves this store under, so that
+   * `${publicBaseUrl}/${key}` resolves for a caller-facing key.
+   *
+   * Supplying it lets {@link StorageProvider.publicUrl} derive delivery URLs on
+   * every read from a single configured value; when it is absent `publicUrl`
+   * returns `null` and callers fall back to serving bytes through the
+   * deployment's own media route. Either way no absolute origin is persisted
+   * (voyant#3845).
+   */
+  publicBaseUrl?: string
 }
 
 async function opaqueBackendIdentity(value: string): Promise<string> {
@@ -47,6 +60,7 @@ export function createGatewayStorageProvider(
   const doFetch = options.fetch ?? globalThis.fetch
   const name = options.name ?? "gateway"
   const tier = options.tier?.replace(/^\/+|\/+$/g, "") || ""
+  const publicBaseUrl = options.publicBaseUrl?.trim().replace(/\/+$/, "") || ""
 
   /** Prepend the pinned tier so the gateway routes to the right bucket. */
   function wireKey(key: string): string {
@@ -65,6 +79,9 @@ export function createGatewayStorageProvider(
     name,
     resolveBackendIdentity: () =>
       opaqueBackendIdentity(`gateway:${endpoint}:${tier || "default"}:${options.token}`),
+    publicUrl(key) {
+      return publicBaseUrl ? `${publicBaseUrl}/${encodeKey(key)}` : null
+    },
     async upload(
       body: StorageUploadBody,
       uploadOptions: UploadOptions = {},

--- a/packages/storage/src/providers/graph.ts
+++ b/packages/storage/src/providers/graph.ts
@@ -107,11 +107,12 @@ export function createGatewayGraphStorageProvider(
     "STORAGE_GATEWAY_ENDPOINT",
   )
   const token = requiredString(context.getSecret(SECRET.gatewayToken), "STORAGE_GATEWAY_TOKEN")
-  // Optional: the CDN base the gateway serves media under. Configuring it keeps
-  // delivery on the CDN while the origin stays derived on every read; leaving it
-  // unset falls back to the deployment's own byte-serving media route. Neither
-  // path persists an absolute origin (voyant#3845).
-  const mediaPublicBaseUrl = optionalString(
+  // Required: the CDN base the gateway serves media under. The gateway mints
+  // delivery URLs server-side, so this is the only way the provider can derive
+  // one per read (voyant#3845). It fails closed rather than degrading to the
+  // deployment's own `/v1/admin/media/*` route: that route is staff-guarded, so
+  // handing it to a storefront guest would render nothing at all.
+  const mediaPublicBaseUrl = requiredString(
     context.getConfig(CONFIG.mediaPublicBaseUrl),
     "MEDIA_PUBLIC_BASE_URL",
   )
@@ -127,7 +128,7 @@ export function createGatewayGraphStorageProvider(
       token,
       name: "gateway:media",
       tier: "media",
-      ...(mediaPublicBaseUrl ? { publicBaseUrl: mediaPublicBaseUrl } : {}),
+      publicBaseUrl: mediaPublicBaseUrl,
     }),
   })
 }

--- a/packages/storage/src/providers/graph.ts
+++ b/packages/storage/src/providers/graph.ts
@@ -107,6 +107,14 @@ export function createGatewayGraphStorageProvider(
     "STORAGE_GATEWAY_ENDPOINT",
   )
   const token = requiredString(context.getSecret(SECRET.gatewayToken), "STORAGE_GATEWAY_TOKEN")
+  // Optional: the CDN base the gateway serves media under. Configuring it keeps
+  // delivery on the CDN while the origin stays derived on every read; leaving it
+  // unset falls back to the deployment's own byte-serving media route. Neither
+  // path persists an absolute origin (voyant#3845).
+  const mediaPublicBaseUrl = optionalString(
+    context.getConfig(CONFIG.mediaPublicBaseUrl),
+    "MEDIA_PUBLIC_BASE_URL",
+  )
   return fixedStores({
     documents: createGatewayStorageProvider({
       endpoint,
@@ -114,7 +122,13 @@ export function createGatewayGraphStorageProvider(
       name: "gateway:documents",
       tier: "documents",
     }),
-    media: createGatewayStorageProvider({ endpoint, token, name: "gateway:media", tier: "media" }),
+    media: createGatewayStorageProvider({
+      endpoint,
+      token,
+      name: "gateway:media",
+      tier: "media",
+      ...(mediaPublicBaseUrl ? { publicBaseUrl: mediaPublicBaseUrl } : {}),
+    }),
   })
 }
 

--- a/packages/storage/src/providers/local.ts
+++ b/packages/storage/src/providers/local.ts
@@ -47,6 +47,10 @@ export function createLocalStorageProvider(options: LocalStorageOptions = {}): S
 
   const store = new Map<string, StoredRecord>()
 
+  function publicUrl(key: string): string {
+    return `${baseUrl}${encodeKey(key)}`
+  }
+
   async function upload(body: StorageUploadBody, opts: UploadOptions = {}): Promise<StorageObject> {
     const key = opts.key ?? generateKey()
     const bytes = await toBytes(body)
@@ -54,18 +58,19 @@ export function createLocalStorageProvider(options: LocalStorageOptions = {}): S
     if (opts.contentType !== undefined) record.contentType = opts.contentType
     if (opts.metadata !== undefined) record.metadata = opts.metadata
     store.set(key, record)
-    return { key, url: `${baseUrl}${encodeKey(key)}` }
+    return { key, url: publicUrl(key) }
   }
 
   return {
     name,
     resolveBackendIdentity: () => opaqueBackendIdentity(`local:${baseUrl}`),
+    publicUrl,
     upload,
     async delete(key) {
       store.delete(key)
     },
     async signedUrl(key) {
-      return `${baseUrl}${encodeKey(key)}`
+      return publicUrl(key)
     },
     async get(key) {
       const record = store.get(key)

--- a/packages/storage/src/providers/s3-compatible.ts
+++ b/packages/storage/src/providers/s3-compatible.ts
@@ -43,8 +43,13 @@ export function createS3CompatibleStorageProvider(
   const publicBaseUrl = normalizeBaseUrl(options.publicBaseUrl)
   const generateKey = options.generateKey ?? defaultKey
 
+  function publicUrl(key: string): string | null {
+    return publicBaseUrl ? `${publicBaseUrl}/${encodeKey(key)}` : null
+  }
+
   return {
     name: options.name ?? "s3-compatible",
+    publicUrl,
     resolveBackendIdentity: () =>
       opaqueBackendIdentity(
         JSON.stringify({
@@ -69,7 +74,7 @@ export function createS3CompatibleStorageProvider(
           ...(uploadOptions.metadata ? { Metadata: uploadOptions.metadata } : {}),
         }),
       )
-      return { key, url: publicBaseUrl ? `${publicBaseUrl}/${encodeKey(key)}` : "" }
+      return { key, url: publicUrl(key) ?? "" }
     },
     async delete(key) {
       await client.send(new DeleteObjectCommand({ Bucket: options.bucket, Key: key }))

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -28,6 +28,10 @@ export interface StorageObject {
   /**
    * Public URL for the object when the provider exposes one. Empty string
    * when the object is private and can only be accessed via `signedUrl`.
+   *
+   * Point-in-time only — do NOT persist it. The origin baked into this string
+   * goes stale the moment the store's public hostname changes. Persist `key`
+   * and re-derive through {@link StorageProvider.publicUrl} on every read.
    */
   url: string
 }
@@ -46,6 +50,17 @@ export interface StorageProvider {
   resolveBackendIdentity?(): Promise<string>
   /** Upload an object. */
   upload(body: StorageUploadBody, options?: UploadOptions): Promise<StorageObject>
+  /**
+   * Derive the stable public delivery URL for `key` from the provider's
+   * *currently configured* origin. Returns `null` when this store has no public
+   * origin (private bucket, or a gateway without a configured CDN base).
+   *
+   * Deliberately synchronous and pure so callers can derive on every read.
+   * Catalogues must call this instead of persisting the absolute URL returned by
+   * {@link upload}: a stored origin is invalidated wholesale by a CDN hostname
+   * change and fails silently as broken media (voyant#3845).
+   */
+  publicUrl?(key: string): string | null
   /** Delete an object by key. No-op if the key does not exist. */
   delete(key: string): Promise<void>
   /**

--- a/packages/storage/src/voyant.ts
+++ b/packages/storage/src/voyant.ts
@@ -162,7 +162,10 @@ export const storageVoyantModule = defineModule({
       port: storageObjectRuntimePort.id,
       selection: { role: "storage", value: "gateway" },
       uses: {
-        config: ["@voyant-travel/storage#config.gateway-endpoint"],
+        config: [
+          "@voyant-travel/storage#config.gateway-endpoint",
+          "@voyant-travel/storage#config.media-public-base-url",
+        ],
         secrets: ["@voyant-travel/storage#secret.gateway-token"],
       },
       runtime: {

--- a/packages/storage/tests/unit/graph-providers.test.ts
+++ b/packages/storage/tests/unit/graph-providers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  createGatewayGraphStorageProvider,
   createMemoryGraphStorageProvider,
   createS3CompatibleGraphStorageProvider,
 } from "../../src/providers/graph.js"
@@ -61,5 +62,35 @@ describe("graph-selected storage providers", () => {
         }),
       ),
     ).not.toThrow()
+  })
+
+  it("derives gateway media URLs from the required public base", () => {
+    const resolver = createGatewayGraphStorageProvider(
+      context({
+        "@voyant-travel/storage#config.gateway-endpoint": "https://gw.example.test",
+        "@voyant-travel/storage#secret.gateway-token": "workspace-test-credential",
+        "@voyant-travel/storage#config.media-public-base-url":
+          "https://cdn.example.test/org_1/media",
+      }),
+    )
+
+    expect(resolver.resolve("media")?.publicUrl?.("uploads/media/abc.jpg")).toBe(
+      "https://cdn.example.test/org_1/media/uploads/media/abc.jpg",
+    )
+    // Documents are private by design: no public origin, so no derived URL.
+    expect(resolver.resolve("documents")?.publicUrl?.("invoices/inv_1.pdf")).toBeNull()
+  })
+
+  it("fails closed when the gateway media public base is absent", () => {
+    // Degrading to `/v1/admin/media/*` is not an option: that route is
+    // staff-guarded, so a storefront guest would get nothing (voyant#3845).
+    expect(() =>
+      createGatewayGraphStorageProvider(
+        context({
+          "@voyant-travel/storage#config.gateway-endpoint": "https://gw.example.test",
+          "@voyant-travel/storage#secret.gateway-token": "workspace-test-credential",
+        }),
+      ),
+    ).toThrow(/MEDIA_PUBLIC_BASE_URL/)
   })
 })


### PR DESCRIPTION
Closes #3845.

`media_asset` stored a fully-qualified delivery URL captured at upload time, so a change to the media CDN hostname invalidated every row at once. The bucket, the object keys and `storage_key` all stayed correct — only the persisted origin was stale — and the failure surfaced as broken images rather than as an error anyone could trace. Recovery was a manual `UPDATE` over every row, and the next hostname change reproduces it.

## What changed

`storage_key` is now the only durable locator; the absolute URL is composed per read.

**`@voyant-travel/storage`**

- `StorageProvider` gains an optional `publicUrl(key): string | null` — a pure, synchronous derivation from the provider's *currently configured* origin. `null` means the store has no public origin.
- `local` and `s3-compatible` implement it from the base URL they already hold; `upload()` now returns that same derived value rather than composing its own.
- `gateway` derives from a `publicBaseUrl` wired from `MEDIA_PUBLIC_BASE_URL`, holding the origin in one configurable place. **This is now required when the gateway provider is selected** — see Compatibility below.
- `StorageObject.url` is documented as point-in-time only — not a value to persist.
- Conformance samples `publicUrl` before *and after* the upload and compares them, so a provider that only derives for objects it has already seen cannot pass.

**`@voyant-travel/media`**

- The `url` column is gone from the schema, and a migration drops it — returning `media_asset` to the baseline shape it had before `20260725062035` added the column.
- `createMediaAsset` discards the upload result's `url`; every read path (`getMediaAsset`, `listMediaAssets`, `updateMediaAsset`, `deleteMediaAsset`, dedup hits) derives `url` through the resolved provider. Routes and the site bridge thread `resolveStorage(c)` into those reads.
- Storage-key derivation moved to `src/storage-key.ts` (the piece this change makes load-bearing), re-exported from `./service` so the public API is unchanged.

**`@voyant-travel/runtime`** — the two `filesystem-storage` provider wrappers forward `publicUrl` alongside `signedUrl`; without it a local/dev deployment would silently lose derivation.

## Compatibility

The wire shape does not change: responses still carry `url`, it is just derived rather than stored, so `packages/media/openapi/admin/media-library.json` is byte-identical.

**A deployment selecting the `gateway` storage provider must now set `MEDIA_PUBLIC_BASE_URL`**, and fails closed at provider construction naming the variable if it does not. The value is the CDN base fronting the store's object namespace, including whatever path prefix the gateway serves the store under, so that `base + '/' + storageKey` resolves — for the deployment in the issue that is the origin already present in its `media_asset.url` rows.

This started out optional, falling back to `url: null`. Codex correctly caught that the fallback is not viable: consumers resolve `null` to `GET /v1/admin/media/{storageKey}`, `@voyant-travel/hono` guards `/v1/admin/*` with `requireActor(..., "staff")`, and `product-day-media-tray.tsx` persists that URL into `product_media.url` — so a storefront guest would render nothing. Requiring the base trades a silent storefront breakage for a loud startup error. `memory` and `s3-compatible` keep their existing optional handling, and the gateway's documents tier keeps no public origin, as it should.

## Docs

`docs/architecture/storage-architecture.md` §2 previously read as a blanket licence to store public media URLs, which is the loophole this bug came through. It now says "stable" describes the delivery strategy, not a value to write into a row, and §4 covers both failure shapes (expiring signed URLs *and* frozen public origins) with `publicUrl` named as the seam.

## Verification

- `@voyant-travel/media`, `@voyant-travel/storage`, `@voyant-travel/media-react`, `@voyant-travel/runtime`, `@voyant-travel/commerce`, `@voyant-travel/catalog` tests
- typecheck for media, storage and runtime with their dependency closures
- `verify:migration-replay-parity` against a local Postgres — legacy upgrade == package-owned replay, so the `DROP COLUMN` replays cleanly
- `verify:migration-boundaries`, `verify:migration-cutline`, `verify:deployment-graph`, `verify:storage-media-runtime-authority`, `verify:release-config`, `verify:dep-paths`, `verify:dist-configs`, `verify:agent-quality:changed`, biome

New regression tests: reads re-derive against a moved origin while `storage_key` is untouched; a store with no public origin reports `url: null` rather than a stale value; the gateway graph provider derives media URLs from its configured base, keeps documents originless, and throws naming `MEDIA_PUBLIC_BASE_URL` when the base is absent.

## Follow-up (not in this PR)

`product_media.url` in `@voyant-travel/inventory` persists an absolute URL next to its own `storage_key` — the same pattern the issue asks to audit for. Left alone here to keep this scoped to `media_asset`.