### PR TITLE
Allow configuring both Voyant Pay modes

### DIFF
--- a/packages/operator-settings-react/src/payments-settings-page.test.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.test.tsx
@@ -4,6 +4,7 @@ import {
   canActivatePaymentConnection,
   canConfigurePaymentProvider,
   canDisconnectPaymentProvider,
+  firstUnconfiguredPaymentProviderMode,
   PaymentEmbeddedOnboardingBoundary,
   type PaymentEmbeddedOnboardingClientProps,
   paymentActivationControlState,
@@ -199,6 +200,37 @@ describe("payments settings contract", () => {
         connectionMethod: "credentials",
       }),
     ).toBe(true)
+  })
+
+  it("selects the first advertised payment mode without an existing connection", () => {
+    const provider = { id: "voyant-pay", modes: ["sandbox", "live"] as const }
+
+    expect(firstUnconfiguredPaymentProviderMode(provider, undefined)).toBe("sandbox")
+    expect(
+      firstUnconfiguredPaymentProviderMode(provider, [
+        { providerId: "voyant-pay", mode: "sandbox" },
+      ]),
+    ).toBe("live")
+    expect(
+      firstUnconfiguredPaymentProviderMode(provider, [{ providerId: "voyant-pay", mode: "live" }]),
+    ).toBe("sandbox")
+  })
+
+  it("reports no unconfigured mode only when every advertised mode is represented", () => {
+    const provider = { id: "voyant-pay", modes: ["sandbox", "live"] as const }
+
+    expect(
+      firstUnconfiguredPaymentProviderMode(provider, [
+        { providerId: "netopia", mode: "sandbox" },
+        { providerId: "voyant-pay", mode: null },
+      ]),
+    ).toBe("sandbox")
+    expect(
+      firstUnconfiguredPaymentProviderMode(provider, [
+        { providerId: "voyant-pay", mode: "sandbox" },
+        { providerId: "voyant-pay", mode: "live" },
+      ]),
+    ).toBeNull()
   })
 
   it("only enables activation for ready, inactive, writable connections", () => {

--- a/packages/operator-settings-react/src/payments-settings-page.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.tsx
@@ -280,7 +280,7 @@ export function canConfigurePaymentProvider(
  * active default but another (for example Sandbox vs Live) still needs setup.
  */
 export function firstUnconfiguredPaymentProviderMode(
-  provider: Pick<ProviderDescriptor, "id" | "modes">,
+  provider: { id: ProviderDescriptor["id"]; modes: readonly ProviderMode[] },
   connections: readonly Pick<ConnectionSummary, "providerId" | "mode">[] | undefined,
 ): ProviderMode | null {
   return (

--- a/packages/operator-settings-react/src/payments-settings-page.tsx
+++ b/packages/operator-settings-react/src/payments-settings-page.tsx
@@ -275,6 +275,26 @@ export function canConfigurePaymentProvider(
 }
 
 /**
+ * Pick the first advertised mode that does not already have a connection.
+ * Hosted providers can keep their setup action available when one mode is the
+ * active default but another (for example Sandbox vs Live) still needs setup.
+ */
+export function firstUnconfiguredPaymentProviderMode(
+  provider: Pick<ProviderDescriptor, "id" | "modes">,
+  connections: readonly Pick<ConnectionSummary, "providerId" | "mode">[] | undefined,
+): ProviderMode | null {
+  return (
+    provider.modes.find(
+      (availableMode) =>
+        !connections?.some(
+          (connection) =>
+            connection.providerId === provider.id && connection.mode === availableMode,
+        ),
+    ) ?? null
+  )
+}
+
+/**
  * A connection can be made the active default only when it is ready (its
  * lifecycle reached `connected`) and it is not already the active one. This
  * gates the "Make active" control so a not-ready or already-active connection
@@ -571,7 +591,10 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
     setDialogProvider(provider)
     setCredentials({})
     setOnboardingSession(null)
-    setMode(provider.modes.includes("sandbox") ? "sandbox" : (provider.modes[0] ?? "live"))
+    setMode(
+      firstUnconfiguredPaymentProviderMode(provider, connection?.connections) ??
+        (provider.modes.includes("sandbox") ? "sandbox" : (provider.modes[0] ?? "live")),
+    )
   }
 
   const modeLabels = {
@@ -777,6 +800,9 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                 {providers.map((provider) => {
                   const isActive = provider.id === activeId
                   const unavailable = !canConfigurePaymentProvider(provider)
+                  const hasAdditionalHostedMode =
+                    provider.connectionMethod === "embedded_onboarding" &&
+                    firstUnconfiguredPaymentProviderMode(provider, connection?.connections) !== null
                   return (
                     <Card key={provider.id}>
                       <CardHeader>
@@ -794,7 +820,7 @@ export function PaymentsSettingsPage({ embeddedOnboardingClient }: PaymentsSetti
                         <Button
                           size="sm"
                           variant={isActive ? "outline" : "default"}
-                          disabled={unavailable || isActive}
+                          disabled={unavailable || (isActive && !hasAdditionalHostedMode)}
                           onClick={() => openConnect(provider)}
                         >
                           {provider.connectionMethod === "embedded_onboarding"


### PR DESCRIPTION
## Summary
- keep Voyant Pay setup available while Sandbox or Live is still unconfigured
- default setup to the first missing mode
- preserve the existing Sandbox/Live selector and credential-provider behavior

## Validation
- remote package tests: 13 passed
- Biome check passed
- git diff --check passed