### PR TITLE
Expose customer portal links in notifications

### DIFF
--- a/.changeset/expose-customer-portal-links.md
+++ b/.changeset/expose-customer-portal-links.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/notifications": patch
+---
+
+Expose deployment-provided customer portal URLs in notification template data.

--- a/packages/notifications/src/routes.ts
+++ b/packages/notifications/src/routes.ts
@@ -76,6 +76,10 @@ export type NotificationsRoutesOptions = {
   resolveProviders?: (bindings: Record<string, unknown>) => ReadonlyArray<NotificationProvider>
   publicCheckoutBaseUrl?: string | null
   resolvePublicCheckoutBaseUrl?: (bindings: Record<string, unknown>) => string | null | undefined
+  publicCustomerPortalBaseUrl?: string | null
+  resolvePublicCustomerPortalBaseUrl?: (
+    bindings: Record<string, unknown>,
+  ) => string | null | undefined
   documentAttachmentResolver?: BookingDocumentAttachmentResolver
   resolveDocumentAttachmentResolver?: (
     bindings: Record<string, unknown>,
@@ -87,6 +91,7 @@ export type NotificationsRoutesOptions = {
 export type NotificationsRouteRuntime = {
   providers: ReadonlyArray<NotificationProvider>
   publicCheckoutBaseUrl?: string | null
+  publicCustomerPortalBaseUrl?: string | null
   documentAttachmentResolver?: BookingDocumentAttachmentResolver
   eventBus?: EventBus
 }
@@ -101,6 +106,10 @@ export function buildNotificationsRouteRuntime(
     providers: options?.resolveProviders?.(bindings) ?? options?.providers ?? [],
     publicCheckoutBaseUrl:
       options?.resolvePublicCheckoutBaseUrl?.(bindings) ?? options?.publicCheckoutBaseUrl ?? null,
+    publicCustomerPortalBaseUrl:
+      options?.resolvePublicCustomerPortalBaseUrl?.(bindings) ??
+      options?.publicCustomerPortalBaseUrl ??
+      null,
     documentAttachmentResolver:
       options?.resolveDocumentAttachmentResolver?.(bindings) ?? options?.documentAttachmentResolver,
     eventBus: options?.resolveEventBus?.(bindings) ?? options?.eventBus,
@@ -1136,7 +1145,10 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
           dispatcher,
           c.req.valid("param").id,
           c.req.valid("json"),
-          { paymentLinkBaseUrl: runtime.publicCheckoutBaseUrl },
+          {
+            paymentLinkBaseUrl: runtime.publicCheckoutBaseUrl,
+            publicCustomerPortalBaseUrl: runtime.publicCustomerPortalBaseUrl,
+          },
         )
         if (!row) return c.json({ error: "Payment session not found" }, 404)
         return c.json({ data: row }, 201)
@@ -1155,7 +1167,10 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
           dispatcher,
           c.req.valid("param").id,
           c.req.valid("json"),
-          { paymentLinkBaseUrl: runtime.publicCheckoutBaseUrl },
+          {
+            paymentLinkBaseUrl: runtime.publicCheckoutBaseUrl,
+            publicCustomerPortalBaseUrl: runtime.publicCustomerPortalBaseUrl,
+          },
         )
         if (!row) return c.json({ error: "Invoice not found" }, 404)
         return c.json({ data: row }, 201)
@@ -1183,6 +1198,7 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
           c.req.valid("json"),
           {
             attachmentResolver: runtime.documentAttachmentResolver,
+            publicCustomerPortalBaseUrl: runtime.publicCustomerPortalBaseUrl,
           },
         )
         if (result.status === "not_found") return c.json({ error: "Booking not found" }, 404)
@@ -1244,6 +1260,7 @@ export function createNotificationsRoutes(options?: NotificationsRoutesOptions) 
           c.req.valid("json"),
           {
             attachmentResolver: runtime.documentAttachmentResolver,
+            publicCustomerPortalBaseUrl: runtime.publicCustomerPortalBaseUrl,
           },
         )
         if (result.status === "not_found") return c.json({ error: "Booking not found" }, 404)

--- a/packages/notifications/src/runtime.ts
+++ b/packages/notifications/src/runtime.ts
@@ -18,6 +18,8 @@ export function createNotificationsRuntime(
   return {
     resolveProviders,
     resolvePublicCheckoutBaseUrl: (bindings) => resolvePublicBaseUrl(primitives.env(bindings)),
+    resolvePublicCustomerPortalBaseUrl: (bindings) =>
+      resolvePublicCustomerPortalBaseUrl(primitives.env(bindings)),
     resolveDocumentAttachmentResolver: (bindings) => async (document) => {
       if (document.storageKey) {
         const contentBase64 = await primitives.storage.read(bindings, document.storageKey)
@@ -48,6 +50,7 @@ export function createNotificationsRuntime(
         resolveRuntimeOptions: (runtimeEnv) =>
           buildNotificationTaskRuntime(runtimeEnv, {
             resolveProviders: (taskEnv) => notificationProviders(primitives, taskEnv),
+            publicCustomerPortalBaseUrl: resolvePublicCustomerPortalBaseUrl(runtimeEnv),
             reminderSweepLockManager: resolveReminderSweepLockManager(env),
           }),
       })
@@ -77,6 +80,15 @@ function resolvePublicBaseUrl(env: Readonly<Record<string, unknown>>): string | 
     return key === "APP_URL" ? value.replace(/\/api\/?$/, "") : value
   }
   return null
+}
+
+function resolvePublicCustomerPortalBaseUrl(env: Readonly<Record<string, unknown>>): string | null {
+  const value =
+    nonEmpty(env.VOYANT_CUSTOMER_PORTAL_URL) ??
+    nonEmpty(env.CUSTOMER_PORTAL_URL) ??
+    nonEmpty(env.PUBLIC_CUSTOMER_PORTAL_URL) ??
+    null
+  return value ? value.replace(/\/+$/, "") : null
 }
 
 function nonEmpty(value: unknown): string | undefined {

--- a/packages/notifications/src/service-booking-documents.ts
+++ b/packages/notifications/src/service-booking-documents.ts
@@ -5,6 +5,7 @@ import { and, desc, eq, ne, or } from "drizzle-orm"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { enqueueNotification } from "./service-durable-send.js"
+import { buildNotificationPortalContext } from "./service-portal-context.js"
 import type {
   BookingDocumentBundleItem,
   NotificationService,
@@ -24,6 +25,7 @@ export type BookingDocumentAttachmentResolver = (
 
 export interface SendBookingDocumentsRuntimeOptions {
   attachmentResolver?: BookingDocumentAttachmentResolver
+  publicCustomerPortalBaseUrl?: string | null
 }
 
 export interface BookingDocumentsSentEvent {
@@ -337,6 +339,7 @@ export const bookingDocumentNotificationsService = {
           travelers: participants,
           documents,
           items,
+          portal: buildNotificationPortalContext(runtime.publicCustomerPortalBaseUrl, booking.id),
         },
         targetType: "booking",
         targetId: booking.id,

--- a/packages/notifications/src/service-deliveries.ts
+++ b/packages/notifications/src/service-deliveries.ts
@@ -10,6 +10,7 @@ import {
   resolveNotificationPaymentUrl,
 } from "./service-delivery-metadata.js"
 import { enqueueNotification } from "./service-durable-send.js"
+import { buildNotificationPortalContext } from "./service-portal-context.js"
 import type {
   NotificationDeliveryListQuery,
   NotificationService,
@@ -45,6 +46,7 @@ interface InternalDomainNotificationInput {
   reminderRunId?: string | null
   scheduledFor?: string | null
   paymentLinkBaseUrl?: string | null
+  publicCustomerPortalBaseUrl?: string | null
 }
 
 export interface SendInvoiceReminderNotificationInput {
@@ -58,6 +60,7 @@ export interface SendInvoiceReminderNotificationInput {
   metadata?: Record<string, unknown> | null
   reminderRunId: string
   scheduledFor: string
+  publicCustomerPortalBaseUrl?: string | null
 }
 
 export async function listDeliveries(db: PostgresJsDatabase, query: NotificationDeliveryListQuery) {
@@ -151,7 +154,7 @@ export async function sendPaymentSessionNotification(
   dispatcher: NotificationService,
   sessionId: string,
   input: SendPaymentSessionNotificationInput,
-  options: { paymentLinkBaseUrl?: string | null } = {},
+  options: { paymentLinkBaseUrl?: string | null; publicCustomerPortalBaseUrl?: string | null } = {},
 ) {
   const request: InternalDomainNotificationInput = { ...input, ...options }
   const [session] = await db
@@ -251,6 +254,7 @@ export async function sendPaymentSessionNotification(
           : null,
         travelers: participants,
         items,
+        portal: buildNotificationPortalContext(request.publicCustomerPortalBaseUrl, booking?.id),
         ...(request.data ?? {}),
       },
       targetType: "payment_session",
@@ -272,7 +276,7 @@ export async function sendInvoiceNotification(
   dispatcher: NotificationService,
   invoiceId: string,
   input: SendInvoiceNotificationInput,
-  options: { paymentLinkBaseUrl?: string | null } = {},
+  options: { paymentLinkBaseUrl?: string | null; publicCustomerPortalBaseUrl?: string | null } = {},
 ) {
   return sendInvoiceNotificationInternal(db, dispatcher, invoiceId, { ...input, ...options })
 }
@@ -387,6 +391,7 @@ async function sendInvoiceNotificationInternal(
           : null,
         travelers: participants,
         items,
+        portal: buildNotificationPortalContext(input.publicCustomerPortalBaseUrl, booking?.id),
         ...(input.data ?? {}),
       },
       targetType: "invoice",

--- a/packages/notifications/src/service-portal-context.ts
+++ b/packages/notifications/src/service-portal-context.ts
@@ -1,0 +1,26 @@
+export interface NotificationPortalContext {
+  url: string
+  bookingUrl: string
+}
+
+export interface NotificationPortalContextOptions {
+  publicCustomerPortalBaseUrl?: string | null
+}
+
+export function buildNotificationPortalContext(
+  publicCustomerPortalBaseUrl: string | null | undefined,
+  bookingId: string | null | undefined,
+): NotificationPortalContext {
+  const url = normalizeCustomerPortalBaseUrl(publicCustomerPortalBaseUrl)
+  if (!url) return { url: "", bookingUrl: "" }
+
+  return {
+    url,
+    bookingUrl: bookingId ? `${url}/bookings/${encodeURIComponent(bookingId)}` : "",
+  }
+}
+
+function normalizeCustomerPortalBaseUrl(value: string | null | undefined) {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed.replace(/\/+$/, "") : ""
+}

--- a/packages/notifications/src/service-reminder-booking-context.ts
+++ b/packages/notifications/src/service-reminder-booking-context.ts
@@ -8,6 +8,7 @@ import {
   bookingDocumentNotificationsService,
   createDefaultBookingDocumentAttachment,
 } from "./service-booking-documents.js"
+import { buildNotificationPortalContext } from "./service-portal-context.js"
 import type { BookingDocumentBundleItem, BookingPaymentScheduleRow } from "./service-shared.js"
 import { listBookingNotificationItems, resolveReminderRecipient } from "./service-shared.js"
 import type { NotificationAttachment } from "./types.js"
@@ -339,6 +340,7 @@ export async function buildBookingPaymentReminderTemplateData(
   schedule: BookingPaymentScheduleRow,
   recipientEmail?: string | null,
   extraData: Record<string, unknown> = {},
+  options: { publicCustomerPortalBaseUrl?: string | null } = {},
 ) {
   const [booking] = await db
     .select({
@@ -408,6 +410,7 @@ export async function buildBookingPaymentReminderTemplateData(
       booking: serializeReminderBooking(booking),
       ...serializeBookingPaymentContext(paymentContext, schedule, booking.bookingNumber),
       items,
+      portal: buildNotificationPortalContext(options.publicCustomerPortalBaseUrl, booking.id),
     },
   }
 }

--- a/packages/notifications/src/service-reminder-stage-runs.ts
+++ b/packages/notifications/src/service-reminder-stage-runs.ts
@@ -274,7 +274,6 @@ async function emitStageChannelRun(
           metadata: { reminderRuleId: rule.id, reminderRunId: processingRun.id, stageId: stage.id },
           reminderRunId: processingRun.id,
           scheduledFor: scheduledAt.toISOString(),
-          publicCustomerPortalBaseUrl: options.publicCustomerPortalBaseUrl,
         },
       })
     } else {

--- a/packages/notifications/src/service-reminder-stage-runs.ts
+++ b/packages/notifications/src/service-reminder-stage-runs.ts
@@ -11,6 +11,7 @@ import {
 } from "./schema.js"
 import { sendInvoiceReminderNotification } from "./service-deliveries.js"
 import { enqueueNotification } from "./service-durable-send.js"
+import type { NotificationPortalContextOptions } from "./service-portal-context.js"
 import {
   bookingStatusSkipReason,
   buildBookingPaymentReminderTemplateData,
@@ -88,6 +89,7 @@ async function emitStageChannelRun(
   sendCountAtFire: number,
   enqueueDelivery: ReminderDeliveryEnqueuer | null,
   now: Date,
+  options: NotificationPortalContextOptions,
 ): Promise<{
   status: "queued" | "sent" | "skipped" | "failed"
   runId: string | null
@@ -198,6 +200,7 @@ async function emitStageChannelRun(
         metadata: { reminderRuleId: rule.id, reminderRunId: processingRun.id, stageId: stage.id },
         reminderRunId: processingRun.id,
         scheduledFor: scheduledAt.toISOString(),
+        publicCustomerPortalBaseUrl: options.publicCustomerPortalBaseUrl,
       })
     } else if (rule.targetType === "booking_payment_schedule") {
       const schedule = await fetchScheduleRow(db, target.id)
@@ -228,6 +231,7 @@ async function emitStageChannelRun(
         schedule,
         recipient.email,
         data,
+        options,
       )
       if (!context) {
         return {
@@ -270,6 +274,7 @@ async function emitStageChannelRun(
           metadata: { reminderRuleId: rule.id, reminderRunId: processingRun.id, stageId: stage.id },
           reminderRunId: processingRun.id,
           scheduledFor: scheduledAt.toISOString(),
+          publicCustomerPortalBaseUrl: options.publicCustomerPortalBaseUrl,
         },
       })
     } else {
@@ -306,6 +311,7 @@ async function processStageRuleTargets(
     now: Date
     dispatcher: NotificationService | null
     enqueueDelivery: ReminderDeliveryEnqueuer | null
+    portal: NotificationPortalContextOptions
   },
 ): Promise<{ processed: number; sent: number; queued: number; skipped: number; failed: number }> {
   const tally = { processed: 0, sent: 0, queued: 0, skipped: 0, failed: 0 }
@@ -393,6 +399,7 @@ async function processStageRuleTargets(
         decision.sendCountAtFire,
         options.enqueueDelivery,
         options.now,
+        options.portal,
       )
       tally.processed += 1
       if (result.status === "sent") tally.sent += 1
@@ -408,6 +415,7 @@ export async function runStageBasedDueReminders(
   db: PostgresJsDatabase,
   dispatcher: NotificationService,
   input: RunDueRemindersInput = {},
+  options: NotificationPortalContextOptions = {},
 ): Promise<ReminderSweepResult> {
   const now = toTimestamp(input.now) ?? new Date()
   const today = startOfUtcDay(now)
@@ -429,6 +437,7 @@ export async function runStageBasedDueReminders(
       now,
       dispatcher,
       enqueueDelivery: null,
+      portal: options,
     })
     summary.processed += tally.processed
     summary.sent += tally.sent
@@ -464,6 +473,7 @@ export async function queueStageBasedDueReminders(
       now,
       dispatcher: null,
       enqueueDelivery,
+      portal: {},
     })
     summary.processed += tally.processed
     summary.queued += tally.queued

--- a/packages/notifications/src/service-reminders.ts
+++ b/packages/notifications/src/service-reminders.ts
@@ -4,6 +4,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
 import { sendInvoiceReminderNotification } from "./service-deliveries.js"
 import { enqueueNotification } from "./service-durable-send.js"
+import type { NotificationPortalContextOptions } from "./service-portal-context.js"
 import {
   bookingStatusSkipReason,
   buildBookingPaymentReminderTemplateData,
@@ -31,6 +32,8 @@ import type {
   RunDueRemindersInput,
 } from "./service-shared.js"
 
+export type NotificationReminderDeliveryOptions = NotificationPortalContextOptions
+
 export {
   bookingIsPaidInFullForNotification,
   dispatchReminderEventRules,
@@ -43,6 +46,7 @@ async function sendQueuedBookingPaymentScheduleReminder(
   rule: NotificationReminderRuleRow,
   now: Date,
   channelOverride: ChannelOverride,
+  options: NotificationReminderDeliveryOptions = {},
 ) {
   const [schedule] = await db
     .select()
@@ -62,7 +66,13 @@ async function sendQueuedBookingPaymentScheduleReminder(
     return markReminderRunSkipped(db, run.id, now, paymentScheduleStatusSkipReason(schedule.status))
   }
 
-  const context = await buildBookingPaymentReminderTemplateData(db, schedule, run.recipient)
+  const context = await buildBookingPaymentReminderTemplateData(
+    db,
+    schedule,
+    run.recipient,
+    {},
+    options,
+  )
 
   if (!context) {
     return markReminderRunSkipped(db, run.id, now, "Booking not found for payment schedule")
@@ -122,6 +132,7 @@ async function sendQueuedInvoiceReminder(
   rule: NotificationReminderRuleRow,
   now: Date,
   channelOverride: ChannelOverride,
+  options: NotificationReminderDeliveryOptions = {},
 ) {
   if (!run.recipient) {
     return markReminderRunSkipped(db, run.id, now, "No recipient available for invoice reminder")
@@ -142,6 +153,7 @@ async function sendQueuedInvoiceReminder(
     },
     reminderRunId: run.id,
     scheduledFor: run.scheduledFor.toISOString(),
+    publicCustomerPortalBaseUrl: options.publicCustomerPortalBaseUrl,
   })
 
   if (!delivery) {
@@ -163,6 +175,7 @@ export async function deliverReminderRun(
   db: PostgresJsDatabase,
   dispatcher: NotificationService,
   input: { reminderRunId: string },
+  options: NotificationReminderDeliveryOptions = {},
 ) {
   const now = new Date()
   const run = await getReminderRunById(db, input.reminderRunId)
@@ -190,11 +203,20 @@ export async function deliverReminderRun(
         rule,
         now,
         channelOverride,
+        options,
       )
     }
 
     if (run.targetType === "invoice") {
-      return await sendQueuedInvoiceReminder(db, dispatcher, run, rule, now, channelOverride)
+      return await sendQueuedInvoiceReminder(
+        db,
+        dispatcher,
+        run,
+        rule,
+        now,
+        channelOverride,
+        options,
+      )
     }
 
     return markReminderRunSkipped(db, run.id, now, "Unsupported reminder target type")
@@ -208,6 +230,7 @@ export async function runDueReminders(
   db: PostgresJsDatabase,
   dispatcher: NotificationService,
   input: RunDueRemindersInput = {},
+  options: NotificationReminderDeliveryOptions = {},
 ) {
-  return runStageBasedDueReminders(db, dispatcher, input)
+  return runStageBasedDueReminders(db, dispatcher, input, options)
 }

--- a/packages/notifications/src/task-runtime.ts
+++ b/packages/notifications/src/task-runtime.ts
@@ -10,12 +10,14 @@ export type ReminderDeliveryJob = {
 
 export type NotificationTaskRuntime = {
   providers: ReadonlyArray<NotificationProvider>
+  publicCustomerPortalBaseUrl?: string | null
   reminderSweepLockManager?: ExecutionLockManager
   enqueueReminderDelivery?: (job: ReminderDeliveryJob) => Promise<void>
 }
 
 export type NotificationTaskRuntimeOptions = {
   providers?: ReadonlyArray<NotificationProvider>
+  publicCustomerPortalBaseUrl?: string | null
   reminderSweepLockManager?: ExecutionLockManager
   enqueueReminderDelivery?: (job: ReminderDeliveryJob) => Promise<void>
   resolveProviders?: (env: NotificationTaskEnv) => ReadonlyArray<NotificationProvider>
@@ -34,6 +36,7 @@ export function buildNotificationTaskRuntime(
 
   return {
     providers,
+    publicCustomerPortalBaseUrl: options.publicCustomerPortalBaseUrl ?? null,
     reminderSweepLockManager: options.reminderSweepLockManager,
     enqueueReminderDelivery: options.enqueueReminderDelivery,
   }

--- a/packages/notifications/src/tasks/deliver-reminder.ts
+++ b/packages/notifications/src/tasks/deliver-reminder.ts
@@ -16,7 +16,9 @@ export async function deliverQueuedNotificationReminder(
 ) {
   const runtime = buildNotificationTaskRuntime(env, options)
   const dispatcher = createNotificationService(runtime.providers)
-  const result = await deliverReminderRun(db, dispatcher, input)
+  const result = await deliverReminderRun(db, dispatcher, input, {
+    publicCustomerPortalBaseUrl: runtime.publicCustomerPortalBaseUrl,
+  })
 
   return {
     reminderRunId: input.reminderRunId,

--- a/packages/notifications/src/tasks/send-due-reminders.ts
+++ b/packages/notifications/src/tasks/send-due-reminders.ts
@@ -20,7 +20,9 @@ export async function sendDueNotificationReminders(
   const runSweep: () => Promise<ReminderQueueResult | ReminderSweepResult> = () =>
     runtime.enqueueReminderDelivery
       ? queueDueReminders(db, input, runtime.enqueueReminderDelivery)
-      : runDueReminders(db, dispatcher, input)
+      : runDueReminders(db, dispatcher, input, {
+          publicCustomerPortalBaseUrl: runtime.publicCustomerPortalBaseUrl,
+        })
 
   if (!runtime.reminderSweepLockManager) {
     return runSweep()

--- a/packages/notifications/src/template-authoring.ts
+++ b/packages/notifications/src/template-authoring.ts
@@ -158,6 +158,26 @@ export const notificationTemplateVariableCatalog: NotificationTemplateVariableCa
     ],
   },
   {
+    id: "portal",
+    label: "Customer portal",
+    description:
+      "Deployment-provided customer portal links. Values are empty when no portal is configured.",
+    variables: [
+      {
+        key: "portal.url",
+        label: "Portal URL",
+        example: "https://portal.example.com",
+        type: "url",
+      },
+      {
+        key: "portal.bookingUrl",
+        label: "Booking portal URL",
+        example: "https://portal.example.com/bookings/book_01abcxyz",
+        type: "url",
+      },
+    ],
+  },
+  {
     id: "invoice",
     label: "Invoice",
     description: "Available in invoice notifications and invoice reminder flows.",
@@ -420,5 +440,11 @@ export const notificationLiquidSnippets: NotificationLiquidSnippet[] = [
     label: "Payment link CTA",
     description: "Link to the latest active payment session when one exists.",
     code: "{% if payment.link %}\nPay now: {{ payment.link }}\n{% endif %}",
+  },
+  {
+    id: "portal-booking-link",
+    label: "Portal booking CTA",
+    description: "Link to the booking in the customer portal when one is configured.",
+    code: "{% if portal.bookingUrl %}\nView booking: {{ portal.bookingUrl }}\n{% endif %}",
   },
 ]

--- a/packages/notifications/tests/unit/deliver-reminder.test.ts
+++ b/packages/notifications/tests/unit/deliver-reminder.test.ts
@@ -41,8 +41,15 @@ describe("deliverQueuedNotificationReminder", () => {
     ).resolves.toEqual({ reminderRunId: "ntrn_123", status: "sent" })
 
     expect(createNotificationServiceMock).toHaveBeenCalledWith([])
-    expect(deliverReminderRunMock).toHaveBeenCalledWith({} as never, dispatcher, {
-      reminderRunId: "ntrn_123",
-    })
+    expect(deliverReminderRunMock).toHaveBeenCalledWith(
+      {} as never,
+      dispatcher,
+      {
+        reminderRunId: "ntrn_123",
+      },
+      {
+        publicCustomerPortalBaseUrl: undefined,
+      },
+    )
   })
 })

--- a/packages/notifications/tests/unit/runtime.test.ts
+++ b/packages/notifications/tests/unit/runtime.test.ts
@@ -1,0 +1,39 @@
+import type { VoyantRuntimeHostPrimitives } from "@voyant-travel/core"
+import { describe, expect, it, vi } from "vitest"
+
+import { createNotificationsRuntime } from "../../src/runtime.js"
+
+function primitives(env: Record<string, unknown>): VoyantRuntimeHostPrimitives {
+  return {
+    env: () => env,
+    database: {
+      resolve: vi.fn(),
+      fromContext: vi.fn(),
+      transaction: vi.fn(),
+    },
+    storage: {
+      resolve: vi.fn(),
+      read: vi.fn(),
+      downloadUrl: vi.fn(),
+    },
+    events: { deliver: vi.fn() },
+    config: { read: vi.fn() },
+  } as never
+}
+
+describe("createNotificationsRuntime", () => {
+  it("resolves the host-injected customer portal URL from bindings", () => {
+    const runtime = createNotificationsRuntime(
+      primitives({ VOYANT_CUSTOMER_PORTAL_URL: " https://portal.example.test/ " }),
+    )
+
+    expect(runtime.resolvePublicCustomerPortalBaseUrl?.({})).toBe("https://portal.example.test")
+  })
+
+  it("resolves no customer portal URL when deployment configuration is unset", () => {
+    const runtime = createNotificationsRuntime(primitives({ APP_URL: "https://operator.test/api" }))
+
+    expect(runtime.resolvePublicCustomerPortalBaseUrl?.({})).toBeNull()
+    expect(runtime.resolvePublicCheckoutBaseUrl?.({})).toBe("https://operator.test")
+  })
+})

--- a/packages/notifications/tests/unit/service.test.ts
+++ b/packages/notifications/tests/unit/service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { createNotificationService, renderNotificationTemplate } from "../../src/service.js"
 import { resolveNotificationPaymentUrl } from "../../src/service-deliveries.js"
+import { buildNotificationPortalContext } from "../../src/service-portal-context.js"
 import { resolveReminderRecipient } from "../../src/service-shared.js"
 import type { NotificationProvider } from "../../src/types.js"
 
@@ -191,6 +192,34 @@ describe("renderNotificationTemplate", () => {
         payment: { isPaidInFull: true },
       }),
     ).toBe("Paid")
+  })
+
+  it("renders configured customer portal URLs in Liquid templates", () => {
+    const portal = buildNotificationPortalContext(" https://portal.example.test/ ", "book 123")
+
+    expect(portal).toEqual({
+      url: "https://portal.example.test",
+      bookingUrl: "https://portal.example.test/bookings/book%20123",
+    })
+    expect(
+      renderNotificationTemplate("Portal {{ portal.url }} booking {{ portal.bookingUrl }}", {
+        portal,
+      }),
+    ).toBe(
+      "Portal https://portal.example.test booking https://portal.example.test/bookings/book%20123",
+    )
+  })
+
+  it("renders empty portal values when no customer portal URL is configured", () => {
+    const portal = buildNotificationPortalContext(undefined, "book_123")
+
+    expect(portal).toEqual({ url: "", bookingUrl: "" })
+    expect(
+      renderNotificationTemplate(
+        "{% if portal.bookingUrl %}{{ portal.bookingUrl }}{% else %}empty{% endif %}",
+        { portal },
+      ),
+    ).toBe("empty")
   })
 })
 


### PR DESCRIPTION
Fixes #3828.

Adds deployment-provided customer portal data to notification Liquid contexts:

- `portal.url` resolves to the configured portal root.
- `portal.bookingUrl` resolves to the booking-specific portal route.
- Unconfigured deployments render both values as empty strings.

The value is resolved from the host environment (with `VOYANT_CUSTOMER_PORTAL_URL` as the primary name), is available for direct sends and reminder delivery paths, and is surfaced in the template-variable catalog with a conditional CTA snippet.

Includes a patch changeset for `@voyant-travel/notifications`.

Validation:

- Focused notification unit tests: passed — 4 files, 26 tests.
- Package notification tests: passed — 17 files, 120 tests (9 files / 31 tests skipped).
- Package lint and `git diff --check`: passed.
- GitHub Actions CI is green, including build graph, typecheck, database integration, package artifacts, and packaged acceptance.