### PR TITLE
Add Voyant Pay dual-mode changeset

### DIFF
--- a/.changeset/tidy-pandas-toggle.md
+++ b/.changeset/tidy-pandas-toggle.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/operator-settings-react": patch
+---
+
+Allow operators to configure Voyant Pay Sandbox and Live connections independently.


### PR DESCRIPTION
## What changed

- Adds the missing patch changeset for `@voyant-travel/operator-settings-react`.
- Describes the independent Voyant Pay Sandbox and Live configuration support merged in #3852.

## Why

PR #3852 merged without release metadata, so the affected published package would not be versioned by Changesets.

## Validation

- `changeset status --since=origin/main`
- `git diff --check origin/main...HEAD`

Changesets reports patch bumps for `@voyant-travel/operator-settings-react` and its dependent `@voyant-travel/operator-standard`.