### PR TITLE
fix(bookings): support supplier product discovery

### DIFF
--- a/.changeset/smooth-manual-booking-discovery.md
+++ b/.changeset/smooth-manual-booking-discovery.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Make manual booking product discovery search the unified catalog so operators can
+select both owned and supplier products. Supplier selections now retain exact
+catalog provenance, use catalog departures and live quote configuration, and
+automatically update options, units, traveler types, add-ons, promotions,
+currency, and pricing, including open-dated products.

--- a/packages/bookings-react/src/components/booking-create-preview-card.tsx
+++ b/packages/bookings-react/src/components/booking-create-preview-card.tsx
@@ -19,6 +19,9 @@ import type { TravelerEntry } from "./travelers-section.js"
  */
 export function BookingPreviewCard({
   productId,
+  productName,
+  isSourcedProduct = false,
+  quotePricing,
   optionId,
   slotId,
   slotLabel,
@@ -32,6 +35,19 @@ export function BookingPreviewCard({
   onPricingChange,
 }: {
   productId: string
+  productName?: string | null
+  isSourcedProduct?: boolean
+  quotePricing?: {
+    totalAmountCents: number
+    currency: string
+    lines?: ReadonlyArray<{
+      kind: string
+      label: string
+      quantity?: number
+      unitAmount: number
+      totalAmount: number
+    }>
+  }
   optionId: string | null
   slotId: string | null
   slotLabel: string | null
@@ -45,8 +61,13 @@ export function BookingPreviewCard({
   onPricingChange: (value: PriceBreakdownValue) => void
 }) {
   const { formatCurrency, formatNumber } = useBookingsUiI18nOrDefault()
-  const productQuery = useProduct(productId || undefined, { enabled: Boolean(productId) })
-  const mediaQuery = useProductMedia(productId, { limit: 1, enabled: Boolean(productId) })
+  const productQuery = useProduct(productId || undefined, {
+    enabled: Boolean(productId) && !isSourcedProduct,
+  })
+  const mediaQuery = useProductMedia(productId, {
+    limit: 1,
+    enabled: Boolean(productId) && !isSourcedProduct,
+  })
   const product = productQuery.data ?? null
   const cover = (mediaQuery.data?.data ?? []).find((m) => m.isCover) ?? mediaQuery.data?.data?.[0]
   const labels = messages.bookingCreateDialog.labels
@@ -55,11 +76,12 @@ export function BookingPreviewCard({
   // onPricingChange. Manual overrides flow through the same field, so
   // the tax line follows whatever the operator decides to charge.
   const [breakdown, setBreakdown] = React.useState<PriceBreakdownValue | null>(null)
+  const lastBreakdownKeyRef = React.useRef("")
   const handlePricingChange = React.useCallback(
     (value: PriceBreakdownValue) => {
       const extraTotal = extraLines.reduce((sum, line) => sum + (line.totalSellAmountCents ?? 0), 0)
       const next =
-        extraTotal > 0
+        extraTotal > 0 && !isSourcedProduct
           ? {
               ...value,
               catalogAmountCents:
@@ -80,10 +102,23 @@ export function BookingPreviewCard({
               ],
             }
           : value
+      const nextKey = JSON.stringify(next)
+      if (nextKey === lastBreakdownKeyRef.current) return
+      lastBreakdownKeyRef.current = nextKey
       setBreakdown(next)
       onPricingChange(next)
     },
-    [extraLines, onPricingChange],
+    [extraLines, isSourcedProduct, onPricingChange],
+  )
+  const providedPricing = React.useMemo(
+    () =>
+      quotePricing
+        ? {
+            ...quotePricing,
+            label: productName ?? undefined,
+          }
+        : undefined,
+    [productName, quotePricing],
   )
   const taxSubtotalCents = breakdown?.confirmedAmountCents ?? breakdown?.catalogAmountCents ?? 0
   const taxCurrency = breakdown?.currency ?? "EUR"
@@ -91,7 +126,7 @@ export function BookingPreviewCard({
     productId,
     subtotalCents: taxSubtotalCents,
     currency: taxCurrency,
-    enabled: Boolean(productId) && taxSubtotalCents > 0,
+    enabled: Boolean(productId) && taxSubtotalCents > 0 && !isSourcedProduct,
   })
   const previewMessages = {
     heading: labels.previewHeading,
@@ -103,7 +138,7 @@ export function BookingPreviewCard({
     travelerUnnamed: labels.previewTravelerUnnamed,
   }
 
-  const showPriceBreakdown = Boolean(productId && slotId)
+  const showPriceBreakdown = Boolean(productId && (isSourcedProduct ? quotePricing : slotId))
   const hasContent =
     Boolean(productId) || slotLabel != null || travelers.length > 0 || showPriceBreakdown
 
@@ -123,7 +158,7 @@ export function BookingPreviewCard({
             {cover?.url ? (
               <img
                 src={cover.url}
-                alt={product?.name ?? ""}
+                alt={product?.name ?? productName ?? ""}
                 className="h-14 w-14 shrink-0 rounded-md object-cover ring-1 ring-border"
                 loading="lazy"
               />
@@ -137,7 +172,7 @@ export function BookingPreviewCard({
                 {previewMessages.product}
               </span>
               <span className="truncate text-sm font-medium">
-                {product?.name ?? previewMessages.loading}
+                {product?.name ?? productName ?? previewMessages.loading}
               </span>
             </div>
           </div>
@@ -197,6 +232,7 @@ export function BookingPreviewCard({
               unitLabels={unitLabels}
               pricingCategoryQuantities={pricingCategoryQuantities}
               pricingCategoryLabels={pricingCategoryLabels}
+              providedPricing={providedPricing}
               labels={{
                 heading: labels.breakdownHeading,
                 total: labels.breakdownTotal,

--- a/packages/bookings-react/src/components/booking-create-product-extras-picker.tsx
+++ b/packages/bookings-react/src/components/booking-create-product-extras-picker.tsx
@@ -10,6 +10,20 @@ import { type ProductExtraRecord, useProductExtras } from "../extras.js"
 import { useBookingsUiI18nOrDefault } from "../i18n/provider.js"
 import type { BookingCreateExtraLineInput } from "../index.js"
 
+export interface CatalogBookingExtraOption {
+  id: string
+  name: string
+  description?: string | null
+  pricingMode?: string | null
+  pricedPerPerson?: boolean | null
+  unitAmountCents?: number | null
+  currency?: string | null
+  selectionType?: "optional" | "required" | "default_selected" | "unavailable" | null
+  minQuantity?: number | null
+  maxQuantity?: number | null
+  defaultQuantity?: number | null
+}
+
 export function ProductExtrasPickerSection({
   productId,
   optionId,
@@ -19,6 +33,7 @@ export function ProductExtrasPickerSection({
   onChange,
   enabled,
   labels,
+  providedExtras,
 }: {
   productId: string
   optionId: string | null
@@ -27,6 +42,8 @@ export function ProductExtrasPickerSection({
   value: BookingCreateExtraLineInput[]
   onChange: (value: BookingCreateExtraLineInput[]) => void
   enabled: boolean
+  /** Live quote add-ons for a supplier-sourced product. */
+  providedExtras?: ReadonlyArray<CatalogBookingExtraOption>
   labels: {
     heading: string
     empty: string
@@ -37,33 +54,47 @@ export function ProductExtrasPickerSection({
 }) {
   const { formatCurrency } = useBookingsUiI18nOrDefault()
   const pricingClient = useVoyantPricingContext()
+  const usesProvidedExtras = providedExtras !== undefined
   const extrasQuery = useProductExtras({
     productId,
     active: true,
     limit: 100,
-    enabled: enabled && Boolean(productId),
+    enabled: enabled && Boolean(productId) && !usesProvidedExtras,
   })
-  const extras = extrasQuery.data?.data ?? []
+  const extras = providedExtras ?? extrasQuery.data?.data ?? []
   const priceQueries = useQueries({
-    queries: extras.map((extra) => ({
-      ...getExtraPriceRulesQueryOptions(pricingClient, {
-        productExtraId: extra.id,
-        ...(optionId ? { optionId } : {}),
-        active: true,
-        limit: 10,
-      }),
-      enabled,
-    })),
+    queries: usesProvidedExtras
+      ? []
+      : extras.map((extra) => ({
+          ...getExtraPriceRulesQueryOptions(pricingClient, {
+            productExtraId: extra.id,
+            ...(optionId ? { optionId } : {}),
+            active: true,
+            limit: 10,
+          }),
+          enabled,
+        })),
   })
   const priceByExtraId = new Map(
     extras.flatMap((extra, index) => {
+      if (usesProvidedExtras && "unitAmountCents" in extra) {
+        return [
+          [
+            extra.id,
+            {
+              pricingMode: extra.pricingMode ?? (extra.pricedPerPerson ? "per_person" : "fixed"),
+              sellAmountCents: extra.unitAmountCents ?? null,
+            },
+          ] as const,
+        ]
+      }
       const row = priceQueries[index]?.data?.data?.[0]
       return row ? ([[extra.id, row]] as const) : []
     }),
   )
   const selectedByExtraId = new Map(value.map((line) => [line.productExtraId, line]))
 
-  const setQuantity = (extra: ProductExtraRecord, quantity: number) => {
+  const setQuantity = (extra: ProductExtraRecord | CatalogBookingExtraOption, quantity: number) => {
     const next = value.filter((line) => line.productExtraId !== extra.id)
     if (quantity > 0) {
       const price = priceByExtraId.get(extra.id)
@@ -81,7 +112,7 @@ export function ProductExtrasPickerSection({
         name: extra.name,
         description: extra.description,
         pricingMode,
-        pricedPerPerson: extra.pricedPerPerson,
+        pricedPerPerson: Boolean(extra.pricedPerPerson),
         quantity,
         sellCurrency: currency,
         unitSellAmountCents,
@@ -91,7 +122,7 @@ export function ProductExtrasPickerSection({
     onChange(next)
   }
 
-  if (extras.length === 0 && extrasQuery.isSuccess) {
+  if (extras.length === 0 && (usesProvidedExtras || extrasQuery.isSuccess)) {
     return (
       <div className="flex flex-col gap-2 rounded-md border p-3">
         <Label>{labels.heading}</Label>
@@ -124,6 +155,10 @@ export function ProductExtrasPickerSection({
                       : ""
                   }`
           const maxQuantity = extra.maxQuantity ?? undefined
+          const minQuantity =
+            "selectionType" in extra && extra.selectionType === "required"
+              ? Math.max(1, extra.minQuantity ?? 1)
+              : (extra.minQuantity ?? 0)
           return (
             <div key={extra.id} className="flex items-center gap-3 rounded-md border px-3 py-2">
               <div className="min-w-0 flex-1">
@@ -132,7 +167,9 @@ export function ProductExtrasPickerSection({
               </div>
               <QuantityButtons
                 value={quantity}
+                min={minQuantity}
                 max={maxQuantity}
+                disabled={"selectionType" in extra && extra.selectionType === "unavailable"}
                 onChange={(next) => setQuantity(extra, next)}
               />
             </div>
@@ -145,11 +182,15 @@ export function ProductExtrasPickerSection({
 
 function QuantityButtons({
   value,
+  min = 0,
   max,
+  disabled = false,
   onChange,
 }: {
   value: number
+  min?: number
   max?: number
+  disabled?: boolean
   onChange(value: number): void
 }) {
   return (
@@ -159,8 +200,8 @@ function QuantityButtons({
         variant="ghost"
         size="sm"
         className="h-7 w-7 p-0"
-        disabled={value <= 0}
-        onClick={() => onChange(Math.max(0, value - 1))}
+        disabled={disabled || value <= min}
+        onClick={() => onChange(Math.max(min, value - 1))}
       >
         -
       </Button>
@@ -170,7 +211,7 @@ function QuantityButtons({
         variant="ghost"
         size="sm"
         className="h-7 w-7 p-0"
-        disabled={max != null && value >= max}
+        disabled={disabled || (max != null && value >= max)}
         onClick={() => onChange(value + 1)}
       >
         +

--- a/packages/bookings-react/src/components/booking-create-utils.ts
+++ b/packages/bookings-react/src/components/booking-create-utils.ts
@@ -1,7 +1,61 @@
-import type { ProductRecord } from "@voyant-travel/inventory-react"
 import type { BookingCreateItemLineInput } from "../index.js"
 
-export type ProductPickerSearchRecord = Pick<ProductRecord, "description" | "name" | "sellCurrency">
+export interface ProductPickerSearchRecord {
+  id?: string
+  name: string
+  description?: string | null
+  sellCurrency?: string | null
+  sellAmountCents?: number | null
+  supplierName?: string | null
+  sourceKind?: string | null
+  sourceConnectionId?: string | null
+  sourceRef?: string | null
+}
+
+export interface CatalogProductSearchHitLike {
+  id: string
+  document: { fields: Record<string, unknown> }
+}
+
+/** Normalize an indexed catalog hit into the small record the booking picker needs. */
+export function catalogProductPickerRecordFromHit(
+  hit: CatalogProductSearchHitLike,
+): ProductPickerSearchRecord & { id: string } {
+  const fields = hit.document.fields
+  return {
+    id: hit.id,
+    name: firstString(fields, ["name", "title"]) ?? hit.id,
+    description: firstString(fields, ["description", "shortDescription", "short_description"]),
+    sellCurrency: firstString(fields, [
+      "sellCurrency",
+      "sell_currency",
+      "priceFromCurrency",
+      "price_from_currency",
+    ]),
+    sellAmountCents: firstNumber(fields, [
+      "sellAmountCents",
+      "sell_amount_cents",
+      "priceFromAmountCents",
+      "priceFromAmountMinor",
+      "price_from_amount_cents",
+    ]),
+    supplierName: firstString(fields, [
+      "supplierName",
+      "supplier_name",
+      "supplierId",
+      "supplier",
+      "source.provider",
+    ]),
+    sourceKind: firstString(fields, ["source.kind", "sourceKind", "source_kind"]) ?? "owned",
+    sourceConnectionId: firstString(fields, [
+      "source.connectionId",
+      "source.connection_id",
+      "sourceConnectionId",
+      "source_connection_id",
+    ]),
+    sourceRef: firstString(fields, ["source.ref", "sourceRef", "source_ref"]),
+  }
+}
 
 export interface DepartureSlotSearchRecord {
   id: string
@@ -82,9 +136,33 @@ export function productMatchesPickerSearch(
   query: string,
 ): boolean {
   if (!product) return false
-  return [product.name, product.description, product.sellCurrency].some((value) =>
-    matchesBookingSearchText(value, query),
-  )
+  return [
+    product.id,
+    product.name,
+    product.description,
+    product.sellCurrency,
+    product.supplierName,
+    product.sourceKind,
+  ].some((value) => matchesBookingSearchText(value, query))
+}
+
+function firstString(fields: Record<string, unknown>, keys: readonly string[]): string | null {
+  for (const key of keys) {
+    const value = fields[key]
+    if (typeof value === "string" && value.trim()) return value
+  }
+  return null
+}
+
+function firstNumber(fields: Record<string, unknown>, keys: readonly string[]): number | null {
+  for (const key of keys) {
+    const value = fields[key]
+    if (typeof value === "number" && Number.isFinite(value)) return value
+    if (typeof value === "string" && value.trim() && Number.isFinite(Number(value))) {
+      return Number(value)
+    }
+  }
+  return null
 }
 
 export type BillingPersonContactValidationResult = "valid" | "missing-contact" | "invalid-email"

--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -9,10 +9,17 @@ import {
   travelersToRows,
 } from "@voyant-travel/bookings/pricing-assignment"
 import {
+  type BookingDraftShapeV1,
   type BookingDraftV1,
   bookingDraftV1,
   type PaxBandCode,
 } from "@voyant-travel/catalog-contracts/booking-engine/contracts"
+import {
+  type CatalogDetailEnrichment,
+  type CatalogSlot,
+  createCatalogEnrichmentFetchers,
+  useCatalogSlots,
+} from "@voyant-travel/catalog-react"
 import { useBookingQuote } from "@voyant-travel/catalog-react/booking-engine"
 import {
   useOptionUnitPriceRules,
@@ -39,6 +46,12 @@ import {
   FieldSet,
   Input,
   Label,
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
   Textarea,
 } from "@voyant-travel/ui/components"
 import { AsyncCombobox } from "@voyant-travel/ui/components/async-combobox"
@@ -78,7 +91,10 @@ import {
   stripUnitSuffix,
 } from "./booking-create-form-utils.js"
 import { BookingPreviewCard } from "./booking-create-preview-card.js"
-import { ProductExtrasPickerSection } from "./booking-create-product-extras-picker.js"
+import {
+  type CatalogBookingExtraOption,
+  ProductExtrasPickerSection,
+} from "./booking-create-product-extras-picker.js"
 import {
   getBookableDepartureSlots,
   getOverCapacityInventoryAssignments,
@@ -225,6 +241,9 @@ export function manualBookingTravelersToRows(
 
 export function buildManualBookingQuoteDraft(input: {
   productId: string
+  sourceKind?: string
+  sourceConnectionId?: string
+  sourceRef?: string
   optionId: string | null
   slotId: string | null
   quantities: Record<string, number>
@@ -239,7 +258,13 @@ export function buildManualBookingQuoteDraft(input: {
   if (!input.productId) return null
   const unitsById = new Map(input.units.map((unit) => [unit.optionUnitId, unit]))
   return bookingDraftV1.parse({
-    entity: { module: "products", id: input.productId, sourceKind: "owned" },
+    entity: {
+      module: "products",
+      id: input.productId,
+      sourceKind: input.sourceKind ?? "owned",
+      ...(input.sourceConnectionId ? { sourceConnectionId: input.sourceConnectionId } : {}),
+      ...(input.sourceRef ? { sourceRef: input.sourceRef } : {}),
+    },
     configure: {
       ...(input.slotId ? { departureSlotId: input.slotId } : {}),
       pax: countManualBookingPaxBands(input.travelers.travelers, input.pricingCategories),
@@ -364,6 +389,7 @@ export function buildManualBookingContactInput(input: {
 export function validateManualBookingDraft(input: {
   productId: string
   slotId?: string | null
+  requireDeparture?: boolean
   hasSelectedUnits?: boolean
   billing: PersonPickerValue
   contactFirstName: string
@@ -377,7 +403,7 @@ export function validateManualBookingDraft(input: {
   messages: ReturnType<typeof useBookingsUiMessagesOrDefault>["manualBookingCreate"]
 }): string | null {
   if (!input.productId) return input.messages.validation.product
-  if (input.slotId === null) return input.messages.validation.departure
+  if (input.requireDeparture !== false && !input.slotId) return input.messages.validation.departure
   if (input.hasSelectedUnits === false) return input.messages.validation.units
   const billTo = input.billing.billTo ?? "person"
   if (billTo === "person" && !input.billing.personId) return input.messages.validation.person
@@ -446,6 +472,9 @@ export function ManualBookingCreateForm({
     emptyTravelCreditPickerValue,
   )
   const [pricing, setPricing] = React.useState<PriceBreakdownValue | null>(null)
+  const handlePricingChange = React.useCallback((next: PriceBreakdownValue) => {
+    setPricing((current) => (JSON.stringify(current) === JSON.stringify(next) ? current : next))
+  }, [])
   const [promotionCode, setPromotionCode] = React.useState("")
   const [paymentSchedule, setPaymentScheduleState] =
     React.useState<PaymentScheduleValue>(emptyPaymentScheduleValue)
@@ -492,9 +521,55 @@ export function ManualBookingCreateForm({
   const defaultSlot = defaultSlotQuery.data?.data ?? null
 
   const productQuery = useProduct(product.productId || undefined, {
-    enabled: Boolean(product.productId),
+    enabled: Boolean(product.productId) && (!product.sourceKind || product.sourceKind === "owned"),
   })
   const productRecord = productQuery.data
+  const enrichmentFetchers = React.useMemo(
+    () =>
+      createCatalogEnrichmentFetchers({
+        baseUrl,
+        fetch: fetcher as typeof globalThis.fetch,
+        contentBasePathByVertical: { products: "/v1/admin/products" },
+      }),
+    [baseUrl, fetcher],
+  )
+  const productContentQuery = useQuery({
+    queryKey: ["manual-booking-product-content", product.productId],
+    queryFn: () =>
+      enrichmentFetchers.loadProductDetail(
+        { id: product.productId, score: 0, document: { id: product.productId, fields: {} } },
+        "products",
+      ),
+    enabled: Boolean(product.productId),
+    staleTime: 30_000,
+  })
+  const productContent = productContentQuery.data ?? null
+  const resolvedSourceKind =
+    productContent?.sourceKind ?? product.sourceKind ?? (productRecord ? "owned" : "")
+  const resolvedSourceConnectionId =
+    productContent?.sourceConnectionId ?? product.sourceConnectionId
+  const resolvedSourceRef = productContent?.sourceRef ?? product.sourceRef
+  const isSourcedProduct = Boolean(resolvedSourceKind && resolvedSourceKind !== "owned")
+  const productDisplayName =
+    productContent?.name ?? productRecord?.name ?? product.productName ?? product.productId
+
+  React.useEffect(() => {
+    if (!product.productId || !productContent) return
+    setProduct((current) => {
+      if (current.productId !== product.productId) return current
+      const next = {
+        ...current,
+        ...(productContent.name ? { productName: productContent.name } : {}),
+        ...(productContent.supplier ? { supplierName: productContent.supplier } : {}),
+        ...(productContent.sourceKind ? { sourceKind: productContent.sourceKind } : {}),
+        ...(productContent.sourceConnectionId
+          ? { sourceConnectionId: productContent.sourceConnectionId }
+          : {}),
+        ...(productContent.sourceRef ? { sourceRef: productContent.sourceRef } : {}),
+      }
+      return JSON.stringify(next) === JSON.stringify(current) ? current : next
+    })
+  }, [product.productId, productContent])
   const billingPerson = usePerson(
     (billing.billTo ?? "person") === "person" ? billing.personId || undefined : undefined,
     { enabled: (billing.billTo ?? "person") === "person" && Boolean(billing.personId) },
@@ -508,33 +583,54 @@ export function ManualBookingCreateForm({
     if (product.productId) setSlotsFromIso(new Date().toISOString())
   }, [product.productId])
 
-  const slotsQuery = useSlots({
+  const ownedSlotsQuery = useSlots({
     productId: product.productId || undefined,
     status: "open",
     startsAtFrom: slotsFromIso,
     limit: 100,
-    enabled: Boolean(product.productId),
+    enabled: Boolean(product.productId) && !isSourcedProduct,
   })
+  const sourcedSlotsQuery = useCatalogSlots({
+    entityModule: "products",
+    entityId: product.productId,
+    surface: "admin",
+    enabled: Boolean(product.productId) && isSourcedProduct,
+  })
+  const catalogSlots = React.useMemo(
+    () =>
+      (sourcedSlotsQuery.data?.rows ?? []).flatMap((slot) => {
+        const normalized = normalizeCatalogBookingSlot(slot, product.productId)
+        return normalized ? [normalized] : []
+      }),
+    [sourcedSlotsQuery.data?.rows, product.productId],
+  )
+  const availableSlots = React.useMemo(
+    () => (isSourcedProduct ? catalogSlots : (ownedSlotsQuery.data?.data ?? [])),
+    [isSourcedProduct, catalogSlots, ownedSlotsQuery.data?.data],
+  )
   const allOpenSlots = React.useMemo(
     () =>
-      getBookableDepartureSlots(slotsQuery.data?.data ?? [], {
+      getBookableDepartureSlots(availableSlots, {
         nowIso: slotsFromIso,
         optionId: null,
       }),
-    [slotsQuery.data?.data, slotsFromIso],
+    [availableSlots, slotsFromIso],
   )
   const slots = React.useMemo(() => {
-    const optionSlots = getBookableDepartureSlots(slotsQuery.data?.data ?? [], {
+    const optionSlots = getBookableDepartureSlots(availableSlots, {
       nowIso: slotsFromIso,
       optionId: product.optionId,
     })
     return optionSlots.length > 0 ? optionSlots : allOpenSlots
-  }, [slotsQuery.data?.data, slotsFromIso, product.optionId, allOpenSlots])
+  }, [availableSlots, slotsFromIso, product.optionId, allOpenSlots])
   const selectedSlot = React.useMemo(
     () =>
       slots.find((slot) => slot.id === slotId) ?? (defaultSlot?.id === slotId ? defaultSlot : null),
     [slots, slotId, defaultSlot],
   )
+  const canBookWithoutDeparture =
+    isSourcedProduct && sourcedSlotsQuery.isSuccess && catalogSlots.length === 0
+  const hasBookingTiming = Boolean(slotId) || canBookWithoutDeparture
   const departureDateIso = selectedSlot?.startsAt?.slice(0, 10) ?? null
 
   const formatSlotLabel = React.useCallback(
@@ -585,7 +681,7 @@ export function ManualBookingCreateForm({
       const nextOptionId = defaultSlotId ? (defaultSlot?.optionId ?? prev.optionId) : prev.optionId
       return prev.productId === nextProductId && prev.optionId === nextOptionId
         ? prev
-        : { productId: nextProductId, optionId: nextOptionId }
+        : { ...prev, productId: nextProductId, optionId: nextOptionId }
     })
     setSlotId(defaultSlotId ?? null)
   }, [defaultProductId, defaultSlotId, defaultSlot?.productId, defaultSlot?.optionId])
@@ -675,25 +771,188 @@ export function ManualBookingCreateForm({
     [billing.billTo, billing.organizationId, billing.personId],
   )
 
+  const sourcedQuoteDraft = React.useMemo(
+    () =>
+      buildManualBookingQuoteDraft({
+        productId: product.productId,
+        sourceKind: resolvedSourceKind || undefined,
+        sourceConnectionId: resolvedSourceConnectionId,
+        sourceRef: resolvedSourceRef,
+        optionId: product.optionId,
+        slotId,
+        quantities: rooms.quantities,
+        units: roomUnits,
+        travelers,
+        contact: null,
+        extraLines,
+        promotionCode,
+        paymentSchedule,
+      }),
+    [
+      product.productId,
+      product.optionId,
+      resolvedSourceKind,
+      resolvedSourceConnectionId,
+      resolvedSourceRef,
+      slotId,
+      rooms.quantities,
+      roomUnits,
+      travelers,
+      extraLines,
+      promotionCode,
+      paymentSchedule,
+    ],
+  )
+  const sourcedQuote = useBookingQuote({
+    surface: "admin",
+    baseUrl,
+    fetcher,
+    draft: sourcedQuoteDraft,
+    scope: { audience: "staff", currency: product.sellCurrency },
+    enabled:
+      isSourcedProduct && Boolean(product.productId && hasBookingTiming && resolvedSourceKind),
+  })
+  const [sourcedQuoteProductId, setSourcedQuoteProductId] = React.useState("")
+  React.useEffect(() => {
+    if (isSourcedProduct && product.productId && !sourcedQuote.isSettling && sourcedQuote.data) {
+      setSourcedQuoteProductId(product.productId)
+    }
+  }, [isSourcedProduct, product.productId, sourcedQuote.data, sourcedQuote.isSettling])
+  const currentSourcedQuoteData =
+    sourcedQuoteProductId === product.productId ? sourcedQuote.data : null
+  const sourcedProductOptions = React.useMemo(
+    () => resolveSourcedProductOptions(currentSourcedQuoteData?.shape, productContent),
+    [currentSourcedQuoteData?.shape, productContent],
+  )
+  const sourcedProductSelectItems = React.useMemo(
+    () => sourcedProductOptions.map((option) => ({ label: option.name, value: option.id })),
+    [sourcedProductOptions],
+  )
+  const sourcedOptionUnits = React.useMemo(
+    () =>
+      resolveSourcedOptionUnits(
+        sourcedProductOptions,
+        product.optionId,
+        selectedSlot?.remainingPax ?? null,
+      ),
+    [sourcedProductOptions, product.optionId, selectedSlot?.remainingPax],
+  )
+  const sourcedExtras = React.useMemo(
+    () => (currentSourcedQuoteData?.shape?.addons?.catalog ?? []) as CatalogBookingExtraOption[],
+    [currentSourcedQuoteData?.shape?.addons?.catalog],
+  )
+
+  React.useEffect(() => {
+    if (!isSourcedProduct || sourcedExtras.length === 0) return
+    setExtraLines((current) => {
+      const extrasById = new Map(sourcedExtras.map((extra) => [extra.id, extra]))
+      const synchronized = current.flatMap((line) => {
+        const extra = extrasById.get(line.productExtraId)
+        if (!extra || extra.selectionType === "unavailable") return []
+        const pricingMode = extra.pricingMode ?? (extra.pricedPerPerson ? "per_person" : "fixed")
+        const chargedQuantity =
+          pricingMode === "per_person" || extra.pricedPerPerson
+            ? Math.max(1, travelers.travelers.length) * line.quantity
+            : line.quantity
+        const unitSellAmountCents = extra.unitAmountCents ?? null
+        return [
+          {
+            ...line,
+            name: extra.name,
+            description: extra.description ?? null,
+            pricingMode,
+            pricedPerPerson: Boolean(extra.pricedPerPerson),
+            sellCurrency:
+              extra.currency ??
+              currentSourcedQuoteData?.pricing?.currency ??
+              product.sellCurrency ??
+              line.sellCurrency,
+            unitSellAmountCents,
+            totalSellAmountCents:
+              unitSellAmountCents == null ? null : unitSellAmountCents * chargedQuantity,
+          },
+        ] satisfies BookingCreateExtraLineInput[]
+      })
+      const selectedIds = new Set(synchronized.map((line) => line.productExtraId))
+      const defaults = sourcedExtras.flatMap((extra) => {
+        if (
+          selectedIds.has(extra.id) ||
+          (extra.selectionType !== "required" && extra.selectionType !== "default_selected")
+        ) {
+          return []
+        }
+        const quantity = Math.max(
+          extra.selectionType === "required" ? 1 : 0,
+          extra.minQuantity ?? 0,
+          extra.defaultQuantity ?? 0,
+        )
+        if (quantity <= 0) return []
+        const sellCurrency =
+          extra.currency ?? currentSourcedQuoteData?.pricing?.currency ?? product.sellCurrency
+        if (!sellCurrency) return []
+        const pricingMode = extra.pricingMode ?? (extra.pricedPerPerson ? "per_person" : "fixed")
+        const chargedQuantity =
+          pricingMode === "per_person" || extra.pricedPerPerson
+            ? Math.max(1, travelers.travelers.length) * quantity
+            : quantity
+        return [
+          {
+            productExtraId: extra.id,
+            name: extra.name,
+            description: extra.description ?? null,
+            pricingMode,
+            pricedPerPerson: Boolean(extra.pricedPerPerson),
+            quantity,
+            sellCurrency,
+            unitSellAmountCents: extra.unitAmountCents ?? null,
+            totalSellAmountCents:
+              extra.unitAmountCents == null ? null : extra.unitAmountCents * chargedQuantity,
+          },
+        ] satisfies BookingCreateExtraLineInput[]
+      })
+      const next = defaults.length > 0 ? [...synchronized, ...defaults] : synchronized
+      return JSON.stringify(next) === JSON.stringify(current) ? current : next
+    })
+  }, [
+    isSourcedProduct,
+    product.sellCurrency,
+    sourcedExtras,
+    currentSourcedQuoteData?.pricing?.currency,
+    travelers.travelers.length,
+  ])
+
+  React.useEffect(() => {
+    if (
+      !isSourcedProduct ||
+      sourcedProductOptions.length === 0 ||
+      (product.optionId && sourcedProductOptions.some((option) => option.id === product.optionId))
+    ) {
+      return
+    }
+    const preferred =
+      sourcedProductOptions.find((option) => option.isDefault) ?? sourcedProductOptions[0]
+    if (preferred) setProduct((current) => ({ ...current, optionId: preferred.id }))
+  }, [isSourcedProduct, product.optionId, sourcedProductOptions])
+
   const slotUnitAvailability = useSlotUnitAvailability({
     slotId: slotId ?? undefined,
-    enabled: Boolean(slotId),
+    enabled: Boolean(slotId) && !isSourcedProduct,
   })
   const pricingPreview = usePricingPreview({
     productId: product.productId,
     optionId: product.optionId,
-    enabled: Boolean(product.productId),
+    enabled: Boolean(product.productId) && !isSourcedProduct,
   })
   const pricingCategoriesQuery = usePricingCategories({
     active: true,
     limit: 200,
-    enabled: Boolean(product.productId),
+    enabled: Boolean(product.productId) && !isSourcedProduct,
   })
   const optionUnitPriceRulesQuery = useOptionUnitPriceRules({
     optionId: product.optionId ?? selectedSlot?.optionId ?? undefined,
     active: true,
     limit: 200,
-    enabled: Boolean(product.productId),
+    enabled: Boolean(product.productId) && !isSourcedProduct,
   })
   const handleRoomUnitsChange = React.useCallback((units: OptionUnitsStepperUnit[]) => {
     setRoomUnits((prev) => (sameRoomUnits(prev, units) ? prev : units))
@@ -776,6 +1035,18 @@ export function ManualBookingCreateForm({
   }, [bookingUnits])
 
   const travelerPricingCategories: TravelerPricingCategoryOption[] = React.useMemo(() => {
+    if (isSourcedProduct) {
+      const unitIds = sourcedOptionUnits.map((unit) => unit.optionUnitId)
+      return (currentSourcedQuoteData?.shape?.paxBands ?? []).map((band) => ({
+        categoryId: band.code,
+        name: band.label,
+        code: band.code,
+        categoryType: paxBandCategoryType(band.code),
+        minAge: band.minAge ?? null,
+        maxAge: band.maxAge ?? null,
+        unitIds,
+      }))
+    }
     const snapshot = pricingPreview.data?.data
     const categoriesById = new Map<string, PricingCategoryLike>()
     const bookingUnitIds = new Set(bookingUnits.map((unit) => unit.optionUnitId))
@@ -825,6 +1096,9 @@ export function ManualBookingCreateForm({
     pricingCategoriesQuery.data?.data,
     optionUnitPriceRulesQuery.data?.data,
     bookingUnits,
+    isSourcedProduct,
+    sourcedOptionUnits,
+    currentSourcedQuoteData?.shape?.paxBands,
   ])
 
   const travelerPricingCategoryLabels = React.useMemo(
@@ -885,6 +1159,9 @@ export function ManualBookingCreateForm({
     () =>
       buildManualBookingQuoteDraft({
         productId: product.productId,
+        sourceKind: resolvedSourceKind || undefined,
+        sourceConnectionId: resolvedSourceConnectionId,
+        sourceRef: resolvedSourceRef,
         optionId: product.optionId,
         slotId,
         quantities: displayDraft.quantities,
@@ -899,6 +1176,9 @@ export function ManualBookingCreateForm({
     [
       product.productId,
       product.optionId,
+      resolvedSourceKind,
+      resolvedSourceConnectionId,
+      resolvedSourceRef,
       slotId,
       displayDraft.quantities,
       bookingUnits,
@@ -910,16 +1190,21 @@ export function ManualBookingCreateForm({
       paymentSchedule,
     ],
   )
-  const quote = useBookingQuote({
+  const ownedQuote = useBookingQuote({
     surface: "admin",
     baseUrl,
     fetcher,
     draft: quoteDraft,
     scope: { audience: "staff", currency: productRecord?.sellCurrency ?? undefined },
-    enabled: Boolean(
-      product.productId && slotId && Object.values(displayDraft.quantities).some((qty) => qty > 0),
-    ),
+    enabled:
+      !isSourcedProduct &&
+      Boolean(
+        product.productId &&
+          slotId &&
+          Object.values(displayDraft.quantities).some((qty) => qty > 0),
+      ),
   })
+  const quote = isSourcedProduct ? { ...sourcedQuote, data: currentSourcedQuoteData } : ownedQuote
   const quoteTotalAmountCents =
     quote.isSettling || quote.data?.available === false
       ? null
@@ -927,12 +1212,22 @@ export function ManualBookingCreateForm({
   const pricingCurrency =
     quote.data?.pricing?.currency ??
     productRecord?.sellCurrency ??
+    product.sellCurrency ??
     pricing?.currency ??
     messages.bookingCreateDialog.labels.currency
+  const sourcedPreviewPricing = React.useMemo(() => {
+    const quotePricing = currentSourcedQuoteData?.pricing
+    if (!quotePricing) return undefined
+    return {
+      totalAmountCents: quotePricing.total,
+      currency: quotePricing.currency,
+      lines: quotePricing.lines,
+    }
+  }, [currentSourcedQuoteData?.pricing])
   const resolvedPricing = resolveManualBookingPricing({
     pricing,
     quoteTotalAmountCents,
-    productAmountCents: productRecord?.sellAmountCents ?? null,
+    productAmountCents: productRecord?.sellAmountCents ?? product.sellAmountCents ?? null,
     currency: pricingCurrency,
   })
   const paymentRows = paymentScheduleToRows(
@@ -940,10 +1235,9 @@ export function ManualBookingCreateForm({
     pricingCurrency,
     resolvedPricing?.confirmedAmountCents ?? null,
   )
-  const hasSelectedUnits = React.useMemo(
-    () => Object.values(rooms.quantities).some((qty) => qty > 0),
-    [rooms.quantities],
-  )
+  const requiresUnitSelection = !isSourcedProduct || sourcedOptionUnits.length > 0
+  const hasSelectedUnits =
+    !requiresUnitSelection || Object.values(rooms.quantities).some((qty) => qty > 0)
   const manualOverrideRequiresReason = Boolean(
     pricing?.isManualOverride &&
       resolvedPricing &&
@@ -953,6 +1247,12 @@ export function ManualBookingCreateForm({
   const hasPromotionCode = Boolean(promotionCode.trim())
   const promotionReady =
     !hasPromotionCode ||
+    (!quote.isSettling &&
+      !quote.error &&
+      quote.data?.available !== false &&
+      Boolean(quote.data?.pricing))
+  const sourcedQuoteReady =
+    !isSourcedProduct ||
     (!quote.isSettling &&
       !quote.error &&
       quote.data?.available !== false &&
@@ -982,6 +1282,10 @@ export function ManualBookingCreateForm({
       setError(copy.validation.pricingPending)
       return
     }
+    if (!sourcedQuoteReady) {
+      setError(copy.validation.pricingUnavailable)
+      return
+    }
     if (hasPromotionCode && !promotionReady) {
       setError(
         quote.data?.available === false ? copy.promotion.invalid : copy.promotion.unavailable,
@@ -991,6 +1295,7 @@ export function ManualBookingCreateForm({
     const validationError = validateManualBookingDraft({
       productId: product.productId,
       slotId,
+      requireDeparture: !canBookWithoutDeparture,
       hasSelectedUnits,
       billing,
       contactFirstName: contact.firstName,
@@ -1031,7 +1336,7 @@ export function ManualBookingCreateForm({
     const confirmed = await confirmDialog({
       title: copy.confirm.title,
       description: copy.confirm.description
-        .replace("{product}", productRecord?.name ?? product.productId)
+        .replace("{product}", productDisplayName)
         .replace(
           "{amount}",
           formatManualBookingAmount(
@@ -1242,7 +1547,7 @@ export function ManualBookingCreateForm({
             labels={{ optionNone: messages.bookingCreateDialog.labels.noSpecificOption }}
             showOptionPicker={false}
           />
-          {product.productId ? (
+          {product.productId && !canBookWithoutDeparture ? (
             <div className="flex flex-col gap-1">
               <Label>{messages.bookingCreateDialog.fields.departure}</Label>
               <AsyncCombobox<AvailabilitySlotRecord>
@@ -1261,7 +1566,41 @@ export function ManualBookingCreateForm({
             </div>
           ) : null}
 
-          {product.productId && slotId ? (
+          {isSourcedProduct &&
+          product.productId &&
+          hasBookingTiming &&
+          sourcedProductOptions.length > 0 ? (
+            <Field className="gap-2">
+              <FieldLabel>{messages.productPickerSection.labels.option}</FieldLabel>
+              <Select
+                items={sourcedProductSelectItems}
+                value={product.optionId ?? undefined}
+                onValueChange={(optionId) => {
+                  setRooms(emptyOptionUnitsStepperValue)
+                  setRoomUnits([])
+                  setExtraLines([])
+                  setProduct((current) => ({ ...current, optionId: optionId ?? null }))
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={messages.productPickerSection.labels.optionNone} />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    {sourcedProductOptions.map((option) => (
+                      <SelectItem key={option.id} value={option.id}>
+                        {option.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            </Field>
+          ) : null}
+
+          {product.productId &&
+          hasBookingTiming &&
+          (!isSourcedProduct || sourcedOptionUnits.length > 0) ? (
             <OptionUnitsStepperSection
               value={rooms}
               onChange={(next) => {
@@ -1269,7 +1608,7 @@ export function ManualBookingCreateForm({
                 setRooms(next)
               }}
               productId={product.productId}
-              slotId={slotId}
+              slotId={slotId ?? undefined}
               optionId={product.optionId}
               onUnitsChange={handleRoomUnitsChange}
               slotHasFiniteCapacity={
@@ -1278,6 +1617,8 @@ export function ManualBookingCreateForm({
                 typeof selectedSlot?.remainingPax === "number"
               }
               invalidOptionUnitIds={payloadMismatchUnitIds}
+              providedOptions={isSourcedProduct ? sourcedProductOptions : undefined}
+              providedUnits={isSourcedProduct ? sourcedOptionUnits : undefined}
               labels={{
                 heading: messages.bookingCreateDialog.labels.roomsHeading,
                 noOption: messages.bookingCreateDialog.labels.roomsNoOption,
@@ -1289,7 +1630,7 @@ export function ManualBookingCreateForm({
             />
           ) : null}
 
-          {product.productId && slotId ? (
+          {product.productId && hasBookingTiming ? (
             <ProductExtrasPickerSection
               productId={product.productId}
               optionId={product.optionId}
@@ -1298,6 +1639,7 @@ export function ManualBookingCreateForm({
               value={extraLines}
               onChange={setExtraLines}
               enabled
+              providedExtras={isSourcedProduct ? sourcedExtras : undefined}
               labels={{
                 heading: messages.bookingCreateDialog.labels.extrasHeading,
                 empty: messages.bookingCreateDialog.labels.extrasEmpty,
@@ -1308,7 +1650,7 @@ export function ManualBookingCreateForm({
             />
           ) : null}
 
-          {product.productId && slotId ? (
+          {product.productId && hasBookingTiming ? (
             <FieldSet className="gap-4 rounded-md border p-3">
               <FieldLegend className="px-1">
                 {messages.bookingCreateDialog.labels.billingHeading}
@@ -1357,7 +1699,9 @@ export function ManualBookingCreateForm({
             </FieldSet>
           ) : null}
 
-          {product.productId && slotId ? (
+          {product.productId &&
+          hasBookingTiming &&
+          (!isSourcedProduct || sourcedOptionUnits.some(isBookingInventoryUnit)) ? (
             <SharedRoomSection
               value={sharedRoom}
               onChange={setSharedRoom}
@@ -1374,7 +1718,7 @@ export function ManualBookingCreateForm({
             />
           ) : null}
 
-          {product.productId && slotId ? (
+          {product.productId && hasBookingTiming ? (
             <TravelersSection
               value={travelers}
               onChange={(next) => {
@@ -1410,7 +1754,7 @@ export function ManualBookingCreateForm({
             />
           ) : null}
 
-          {product.productId && slotId ? (
+          {product.productId && hasBookingTiming ? (
             <Field className="gap-2">
               <FieldLabel htmlFor="manual-booking-notes">
                 {messages.bookingCreateDialog.fields.internalNotes}
@@ -1424,7 +1768,7 @@ export function ManualBookingCreateForm({
             </Field>
           ) : null}
 
-          {product.productId && slotId ? (
+          {product.productId && hasBookingTiming ? (
             <div className="flex flex-col gap-3 rounded-md border p-3">
               <Label>{messages.bookingCreateDialog.labels.documentGenerationHeading}</Label>
               <div className="flex flex-col gap-2">
@@ -1512,9 +1856,10 @@ export function ManualBookingCreateForm({
               submitting ||
               permissionState !== "allowed" ||
               !product.productId ||
-              !slotId ||
+              !hasBookingTiming ||
               !hasSelectedUnits ||
               quote.isSettling ||
+              !sourcedQuoteReady ||
               !promotionReady
             }
           >
@@ -1533,6 +1878,9 @@ export function ManualBookingCreateForm({
       <div className="flex flex-col gap-4 lg:col-span-4">
         <BookingPreviewCard
           productId={product.productId}
+          productName={productDisplayName}
+          isSourcedProduct={isSourcedProduct}
+          quotePricing={isSourcedProduct ? sourcedPreviewPricing : undefined}
           optionId={product.optionId}
           slotId={slotId}
           slotLabel={selectedSlot ? formatSlotLabel(selectedSlot) : null}
@@ -1543,9 +1891,18 @@ export function ManualBookingCreateForm({
           extraLines={displayExtraLines}
           travelers={travelers.travelers}
           messages={messages}
-          onPricingChange={setPricing}
+          onPricingChange={handlePricingChange}
         />
-        {product.productId && slotId ? (
+        {product.productId &&
+        hasBookingTiming &&
+        isSourcedProduct &&
+        !quote.isSettling &&
+        !sourcedQuoteReady ? (
+          <p className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+            {copy.validation.pricingUnavailable}
+          </p>
+        ) : null}
+        {product.productId && hasBookingTiming ? (
           <FieldSet className="gap-3 rounded-md border p-3">
             <FieldLegend className="px-1">{copy.promotion.heading}</FieldLegend>
             <Field className="gap-2">
@@ -1568,7 +1925,7 @@ export function ManualBookingCreateForm({
             </Field>
           </FieldSet>
         ) : null}
-        {product.productId && slotId ? (
+        {product.productId && hasBookingTiming ? (
           <FieldSet className="gap-3 rounded-md border p-3">
             <FieldLegend className="px-1">{copy.fields.currency}</FieldLegend>
             <CurrencyCombobox
@@ -1579,7 +1936,7 @@ export function ManualBookingCreateForm({
             />
           </FieldSet>
         ) : null}
-        {product.productId && slotId ? (
+        {product.productId && hasBookingTiming ? (
           <TravelCreditPickerSection
             value={travelCredit}
             onChange={setTravelCredit}
@@ -1594,7 +1951,7 @@ export function ManualBookingCreateForm({
             }}
           />
         ) : null}
-        {product.productId && slotId ? (
+        {product.productId && hasBookingTiming ? (
           <PaymentScheduleSection
             value={paymentSchedule}
             onChange={setPaymentSchedule}
@@ -1626,6 +1983,131 @@ export function ManualBookingCreateForm({
       </div>
     </form>
   )
+}
+
+export interface SourcedProductOption {
+  id: string
+  name: string
+  isDefault?: boolean
+  units?: ReadonlyArray<{
+    id: string
+    name: string
+    unitType?: string | null
+    minQuantity?: number | null
+    maxQuantity?: number | null
+  }>
+}
+
+export function resolveSourcedProductOptions(
+  shape: BookingDraftShapeV1 | undefined,
+  content: CatalogDetailEnrichment | null,
+): SourcedProductOption[] {
+  const optionStep = shape?.configureSubSteps?.find((step) => step.kind === "product-option")
+  if (optionStep?.kind === "product-option" && optionStep.options.length > 0) {
+    return optionStep.options
+  }
+  return (content?.options ?? []).map((option) => ({
+    id: option.id,
+    name: option.name,
+  }))
+}
+
+export function resolveSourcedOptionUnits(
+  options: ReadonlyArray<SourcedProductOption>,
+  selectedOptionId: string | null,
+  remainingPax: number | null,
+): OptionUnitsStepperUnit[] {
+  const selected =
+    options.find((option) => option.id === selectedOptionId) ??
+    (options.length === 1 ? options[0] : undefined)
+  if (!selected?.units) return []
+  return selected.units.map((unit) => {
+    const remaining = unit.maxQuantity ?? remainingPax
+    return {
+      optionId: selected.id,
+      optionUnitId: unit.id,
+      unitName: `${selected.name} · ${unit.name}`,
+      unitType: normalizeSourcedUnitType(unit.unitType),
+      occupancyMax: null,
+      initial: remaining,
+      reserved: 0,
+      remaining,
+    }
+  })
+}
+
+function normalizeSourcedUnitType(
+  unitType: string | null | undefined,
+): OptionUnitsStepperUnit["unitType"] {
+  switch (unitType) {
+    case "person":
+    case "group":
+    case "room":
+    case "vehicle":
+    case "service":
+    case "other":
+      return unitType
+    default:
+      return "other"
+  }
+}
+
+export function normalizeCatalogBookingSlot(
+  slot: CatalogSlot,
+  productId: string,
+): AvailabilitySlotRecord | null {
+  if (!slot.startsAt) return null
+  const status = normalizeCatalogSlotStatus(slot.status)
+  return {
+    id: slot.id,
+    productId,
+    itineraryId: null,
+    optionId: null,
+    facilityId: null,
+    availabilityRuleId: null,
+    startTimeId: null,
+    dateLocal: slot.startsAt.slice(0, 10),
+    endDateLocal: null,
+    startsAt: slot.startsAt,
+    endsAt: null,
+    timezone: "UTC",
+    status,
+    unlimited: slot.unlimited ?? slot.remainingPax == null,
+    initialPax: slot.initialPax ?? null,
+    remainingPax: slot.remainingPax ?? null,
+    nights: null,
+    days: null,
+    notes: null,
+  }
+}
+
+function normalizeCatalogSlotStatus(
+  status: string | null | undefined,
+): AvailabilitySlotRecord["status"] {
+  switch (status) {
+    case "closed":
+    case "sold_out":
+    case "cancelled":
+      return status
+    default:
+      return "open"
+  }
+}
+
+function paxBandCategoryType(code: string): TravelerPricingCategoryOption["categoryType"] {
+  switch (code.trim().toLowerCase()) {
+    case "child":
+    case "children":
+      return "child"
+    case "infant":
+    case "infants":
+      return "infant"
+    case "senior":
+    case "seniors":
+      return "senior"
+    default:
+      return "adult"
+  }
 }
 
 function EditableContactField({

--- a/packages/bookings-react/src/components/option-units-stepper-section.tsx
+++ b/packages/bookings-react/src/components/option-units-stepper-section.tsx
@@ -76,6 +76,18 @@ export interface OptionUnitsStepperSectionProps {
   }
   slotHasFiniteCapacity?: boolean
   invalidOptionUnitIds?: readonly string[]
+  /** Catalog-sourced products provide option/unit shape through the live quote. */
+  providedOptions?: ReadonlyArray<{ id: string; name: string }>
+  /** When present (including an empty array), skip owned product/availability lookups. */
+  providedUnits?: ReadonlyArray<OptionUnitsStepperUnit>
+}
+
+export interface OptionUnitsStepperRow {
+  optionKey: string
+  optionName: string
+  primary: OptionUnitsStepperUnit
+  allUnits: OptionUnitsStepperUnit[]
+  totalRemaining: number | null
 }
 
 /**
@@ -110,11 +122,17 @@ export function OptionUnitsStepperSection({
   labels,
   slotHasFiniteCapacity = false,
   invalidOptionUnitIds = [],
+  providedOptions,
+  providedUnits,
 }: OptionUnitsStepperSectionProps) {
   const productsClient = useVoyantProductsContext()
   const messages = useBookingsUiMessagesOrDefault()
   const merged = { ...messages.roomsStepperSection.labels, ...labels }
-  const availability = useSlotUnitAvailability({ slotId, enabled: enabled && Boolean(slotId) })
+  const usesProvidedUnits = providedUnits !== undefined
+  const availability = useSlotUnitAvailability({
+    slotId,
+    enabled: enabled && Boolean(slotId) && !usesProvidedUnits,
+  })
 
   // Always fetch option-level units for the product. They're needed
   // both before a slot is picked AND as a fallback after picking a slot
@@ -124,32 +142,35 @@ export function OptionUnitsStepperSection({
     productId,
     status: "active",
     limit: 100,
-    enabled: enabled && Boolean(productId),
+    enabled: enabled && Boolean(productId) && !usesProvidedUnits,
   })
   const productOptions = React.useMemo(() => {
-    const options = optionsQuery.data?.data ?? []
+    const options = providedOptions ?? optionsQuery.data?.data ?? []
     if (!optionId) return options
     const selected = options.find((option) => option.id === optionId)
     const rest = options.filter((option) => option.id !== optionId)
     return selected ? [selected, ...rest] : options
-  }, [optionsQuery.data?.data, optionId])
+  }, [optionsQuery.data?.data, optionId, providedOptions])
   const optionUnitQueries = useQueries({
-    queries: productOptions.map((option) => ({
-      ...getOptionUnitsQueryOptions(productsClient, {
-        optionId: option.id,
-        limit: 100,
-      }),
-      enabled: enabled && Boolean(productId),
-    })),
+    queries: usesProvidedUnits
+      ? []
+      : productOptions.map((option) => ({
+          ...getOptionUnitsQueryOptions(productsClient, {
+            optionId: option.id,
+            limit: 100,
+          }),
+          enabled: enabled && Boolean(productId),
+        })),
   })
   const optionUnitRows = React.useMemo(() => {
+    if (providedUnits) return [...providedUnits]
     const rows: OptionUnitsStepperUnit[] = []
     productOptions.forEach((option, index) => {
       const units = optionUnitQueries[index]?.data?.data ?? []
       rows.push(...units.map((unit) => optionUnitToStepperUnit(option, unit, units.length)))
     })
     return rows
-  }, [productOptions, optionUnitQueries])
+  }, [productOptions, optionUnitQueries, providedUnits])
   // optionUnitId → optionId lookup, derived from the product's own option
   // catalog. The slot-availability endpoint only returns option_unit rows
   // for the slot's bound option and doesn't stamp the option_id on each
@@ -194,6 +215,7 @@ export function OptionUnitsStepperSection({
   // the no-slot-rows branch and use the product fallback for everything.
   // See issue #960.
   const units = React.useMemo(() => {
+    if (providedUnits) return [...providedUnits]
     const merged = mergeStepperUnits(
       availabilityUnitRows,
       optionUnitRows,
@@ -205,7 +227,15 @@ export function OptionUnitsStepperSection({
     // with no rooms of its own correctly shows none).
     if (restrictToOption && optionId) return merged.filter((unit) => unit.optionId === optionId)
     return merged
-  }, [availabilityUnitRows, optionUnitRows, slotOptionId, slotId, restrictToOption, optionId])
+  }, [
+    availabilityUnitRows,
+    optionUnitRows,
+    slotOptionId,
+    slotId,
+    restrictToOption,
+    optionId,
+    providedUnits,
+  ])
   const invalidOptionUnitIdSet = React.useMemo(
     () => new Set(invalidOptionUnitIds),
     [invalidOptionUnitIds],
@@ -219,54 +249,10 @@ export function OptionUnitsStepperSection({
   // count, then traveler rows split Adult / Child / Infant. Inventory
   // options are different: rooms and vehicles are physical containers,
   // so each room/vehicle unit must be selectable independently.
-  const optionRows = React.useMemo(() => {
-    const groups = new Map<
-      string,
-      { primary: OptionUnitsStepperUnit; allUnits: OptionUnitsStepperUnit[] }
-    >()
-    for (const unit of units) {
-      const key = unit.optionId ?? unit.optionUnitId
-      const entry = groups.get(key)
-      if (entry) {
-        entry.allUnits.push(unit)
-        // Prefer an explicit ADULT unit as primary; fall back to whatever
-        // arrived first.
-        if (isAdultUnit(unit) && !isAdultUnit(entry.primary)) entry.primary = unit
-      } else {
-        groups.set(key, { primary: unit, allUnits: [unit] })
-      }
-    }
-    return Array.from(groups.entries()).flatMap(([optionKey, group]) => {
-      const optionName =
-        productOptions.find((option) => option.id === optionKey)?.name ?? group.primary.unitName
-      const inventoryUnits = group.allUnits.filter(isInventoryUnit)
-
-      if (inventoryUnits.length > 0) {
-        return inventoryUnits.map((unit) => ({
-          optionKey: unit.optionUnitId,
-          optionName: unit.unitName,
-          primary: unit,
-          allUnits: [unit],
-          totalRemaining: unit.remaining,
-        }))
-      }
-
-      const totalRemaining = group.allUnits.reduce<number | null>((acc, unit) => {
-        if (unit.remaining === null) return null
-        if (acc === null) return null
-        return acc + unit.remaining
-      }, 0)
-      return [
-        {
-          optionKey,
-          optionName,
-          primary: group.primary,
-          allUnits: group.allUnits,
-          totalRemaining,
-        },
-      ]
-    })
-  }, [units, productOptions])
+  const optionRows = React.useMemo(
+    () => buildOptionUnitsStepperRows(units, productOptions),
+    [units, productOptions],
+  )
 
   if (!slotId && !productId && !optionId) {
     return (
@@ -281,9 +267,14 @@ export function OptionUnitsStepperSection({
   // — slot units may legitimately be empty (product-level slot), and
   // we don't want to flash the empty state before option-level units
   // finish loading.
-  const optionsLoaded =
-    optionsQuery.isSuccess && optionUnitQueries.every((query) => query.isSuccess)
-  const loaded = slotId ? availability.isSuccess && optionsLoaded : optionsLoaded
+  const optionsLoaded = usesProvidedUnits
+    ? true
+    : optionsQuery.isSuccess && optionUnitQueries.every((query) => query.isSuccess)
+  const loaded = usesProvidedUnits
+    ? true
+    : slotId
+      ? availability.isSuccess && optionsLoaded
+      : optionsLoaded
   if (loaded && units.length === 0) {
     return (
       <div className="flex flex-col gap-2 rounded-md border p-3">
@@ -457,8 +448,61 @@ function isInventoryUnit(unit: Pick<OptionUnitsStepperUnit, "unitType">): boolea
   return unit.unitType === "room" || unit.unitType === "vehicle"
 }
 
+export function buildOptionUnitsStepperRows(
+  units: ReadonlyArray<OptionUnitsStepperUnit>,
+  productOptions: ReadonlyArray<Pick<ProductOptionRecord, "id" | "name">>,
+): OptionUnitsStepperRow[] {
+  const groups = new Map<
+    string,
+    { primary: OptionUnitsStepperUnit; allUnits: OptionUnitsStepperUnit[] }
+  >()
+  for (const unit of units) {
+    const key = unit.optionId ?? unit.optionUnitId
+    const entry = groups.get(key)
+    if (entry) {
+      entry.allUnits.push(unit)
+      if (isAdultUnit(unit) && !isAdultUnit(entry.primary)) entry.primary = unit
+    } else {
+      groups.set(key, { primary: unit, allUnits: [unit] })
+    }
+  }
+
+  return Array.from(groups.entries()).flatMap(([optionKey, group]) => {
+    const optionName =
+      productOptions.find((option) => option.id === optionKey)?.name ?? group.primary.unitName
+    const inventoryUnits = group.allUnits.filter(isInventoryUnit)
+    const inventoryRows: OptionUnitsStepperRow[] = inventoryUnits.map((unit) => ({
+      optionKey: unit.optionUnitId,
+      optionName: unit.unitName,
+      primary: unit,
+      allUnits: [unit],
+      totalRemaining: unit.remaining,
+    }))
+    const countUnits = group.allUnits.filter((unit) => !isInventoryUnit(unit))
+    if (countUnits.length === 0) return inventoryRows
+
+    const countPrimary = countUnits.find(isAdultUnit) ?? countUnits[0]
+    if (!countPrimary) return inventoryRows
+    const totalRemaining = countUnits.reduce<number | null>((acc, unit) => {
+      if (unit.remaining === null || acc === null) return null
+      return acc + unit.remaining
+    }, 0)
+    return [
+      ...inventoryRows,
+      {
+        optionKey:
+          inventoryRows.length > 0 ? `${optionKey}:${countPrimary.optionUnitId}` : optionKey,
+        optionName: inventoryRows.length > 0 ? countPrimary.unitName : optionName,
+        primary: countPrimary,
+        allUnits: countUnits,
+        totalRemaining,
+      },
+    ]
+  })
+}
+
 function optionUnitToStepperUnit(
-  option: ProductOptionRecord,
+  option: Pick<ProductOptionRecord, "id" | "name">,
   unit: OptionUnitRecord,
   unitCount: number,
 ): OptionUnitsStepperUnit {

--- a/packages/bookings-react/src/components/price-breakdown-section.tsx
+++ b/packages/bookings-react/src/components/price-breakdown-section.tsx
@@ -50,6 +50,19 @@ export interface PriceBreakdownSectionProps {
    * uses — matches what a customer would see.
    */
   catalogId?: string | null
+  /** Authoritative live quote for a supplier-sourced product. */
+  providedPricing?: {
+    totalAmountCents: number
+    currency: string
+    label?: string
+    lines?: ReadonlyArray<{
+      kind: string
+      label: string
+      quantity?: number
+      unitAmount: number
+      totalAmount: number
+    }>
+  }
   labels?: {
     heading?: string
     total?: string
@@ -150,6 +163,7 @@ export function PriceBreakdownSection({
   pricingCategoryQuantities,
   pricingCategoryLabels,
   catalogId,
+  providedPricing,
   labels,
   onChange,
   flat = false,
@@ -161,9 +175,11 @@ export function PriceBreakdownSection({
     productId: productId ?? "",
     optionId: optionId ?? null,
     catalogId: catalogId ?? null,
-    enabled: Boolean(productId),
+    enabled: Boolean(productId) && !providedPricing,
   })
-  const productQuery = useProduct(productId, { enabled: Boolean(productId) })
+  const productQuery = useProduct(productId, {
+    enabled: Boolean(productId) && !providedPricing,
+  })
   const quantitiesKey = React.useMemo(() => JSON.stringify(unitQuantities), [unitQuantities])
   const [manualAmountCents, setManualAmountCents] = React.useState<number | null>(null)
   const [overrideReason, setOverrideReason] = React.useState("")
@@ -172,12 +188,23 @@ export function PriceBreakdownSection({
   React.useEffect(() => {
     setManualAmountCents(null)
     setOverrideReason("")
-  }, [productId, optionId, catalogId, quantitiesKey])
+  }, [
+    productId,
+    optionId,
+    catalogId,
+    quantitiesKey,
+    providedPricing?.totalAmountCents,
+    providedPricing?.currency,
+  ])
 
   const snapshot = preview.data?.data
   const fallbackProduct = productQuery.data
   const fallbackUnitAmountCents = fallbackProduct?.sellAmountCents ?? null
-  const currency = snapshot?.catalog.currencyCode ?? fallbackProduct?.sellCurrency ?? null
+  const currency =
+    providedPricing?.currency ??
+    snapshot?.catalog.currencyCode ??
+    fallbackProduct?.sellCurrency ??
+    null
   const formatAmount = React.useCallback(
     (cents: number) =>
       currency
@@ -190,6 +217,35 @@ export function PriceBreakdownSection({
   )
 
   const { lines, total } = React.useMemo(() => {
+    if (providedPricing) {
+      const providedLines = providedPricing.lines ?? []
+      const lines: PriceBreakdownLine[] =
+        providedLines.length > 0
+          ? providedLines.map((line, index) => ({
+              unitId: `quote:${line.kind}:${index}`,
+              label: line.label,
+              quantity: line.quantity ?? 1,
+              unitAmountCents: line.unitAmount,
+              totalAmountCents: line.totalAmount,
+              tierLabel: null,
+              isGroupRate: false,
+            }))
+          : [
+              {
+                unitId: "quote:total",
+                label: providedPricing.label ?? merged.total,
+                quantity: 1,
+                unitAmountCents: providedPricing.totalAmountCents,
+                totalAmountCents: providedPricing.totalAmountCents,
+                tierLabel: null,
+                isGroupRate: false,
+              },
+            ]
+      return {
+        lines,
+        total: providedPricing.totalAmountCents,
+      }
+    }
     const out: PriceBreakdownLine[] = []
     let runningTotal = 0
     let anyOnRequest = false
@@ -346,6 +402,8 @@ export function PriceBreakdownSection({
     pricingCategoryLabels,
     merged.onRequest,
     merged.groupRate,
+    merged.total,
+    providedPricing,
   ])
 
   const confirmedAmountCents = manualAmountCents ?? total
@@ -429,7 +487,11 @@ export function PriceBreakdownSection({
   const wrapperClassName = flat
     ? "flex flex-col gap-2" // i18n-literal-ok: tailwind utilities
     : "flex flex-col gap-2 rounded-md border p-3" // i18n-literal-ok: tailwind utilities
-  if ((preview.isError || (preview.isSuccess && !snapshot)) && fallbackUnitAmountCents === null) {
+  if (
+    !providedPricing &&
+    (preview.isError || (preview.isSuccess && !snapshot)) &&
+    fallbackUnitAmountCents === null
+  ) {
     return (
       <div className={wrapperClassName}>
         {flat ? null : <Label>{merged.heading}</Label>}

--- a/packages/bookings-react/src/components/product-picker-section.tsx
+++ b/packages/bookings-react/src/components/product-picker-section.tsx
@@ -1,15 +1,13 @@
 "use client"
 
+import { useCatalogSearch } from "@voyant-travel/catalog-react"
+import { type ProductRecord, useProduct, useProductOptions } from "@voyant-travel/inventory-react"
 import {
-  type ProductRecord,
-  useProduct,
-  useProductOptions,
-  useProducts,
-} from "@voyant-travel/inventory-react"
-import {
+  Badge,
   Label,
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
   SelectTrigger,
   SelectValue,
@@ -24,8 +22,12 @@ import {
   ComboboxList,
 } from "@voyant-travel/ui/components/combobox"
 import * as React from "react"
-import { useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
-import { productMatchesPickerSearch } from "./booking-create-utils.js"
+import { useBookingsUiI18nOrDefault, useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
+import {
+  catalogProductPickerRecordFromHit,
+  type ProductPickerSearchRecord,
+  productMatchesPickerSearch,
+} from "./booking-create-utils.js"
 
 const OPTION_NONE = "__none__"
 
@@ -33,6 +35,13 @@ export interface ProductPickerValue {
   productId: string
   /** `null` means "no specific option" — the product has options but none was picked. */
   optionId: string | null
+  sourceKind?: string
+  sourceConnectionId?: string
+  sourceRef?: string
+  productName?: string
+  supplierName?: string
+  sellCurrency?: string
+  sellAmountCents?: number | null
 }
 
 export interface ProductPickerSectionProps {
@@ -67,26 +76,57 @@ export function ProductPickerSection({
   labels,
 }: ProductPickerSectionProps) {
   const [productSearch, setProductSearch] = React.useState("")
-  const cachedProductsRef = React.useRef(new Map<string, ProductRecord>())
+  const [debouncedProductSearch, setDebouncedProductSearch] = React.useState("")
+  const cachedProductsRef = React.useRef(
+    new Map<string, ProductPickerSearchRecord & { id: string }>(),
+  )
+  const { formatCurrency } = useBookingsUiI18nOrDefault()
   const messages = useBookingsUiMessagesOrDefault()
   const merged = { ...messages.productPickerSection.labels, ...labels }
 
-  const { data: productsData } = useProducts({
-    search: productSearch || undefined,
-    limit: 20,
+  React.useEffect(() => {
+    const timeout = window.setTimeout(() => setDebouncedProductSearch(productSearch.trim()), 250)
+    return () => window.clearTimeout(timeout)
+  }, [productSearch])
+
+  const productsQuery = useCatalogSearch({
+    vertical: "products",
+    query: debouncedProductSearch,
+    mode: "keyword",
+    projection: "raw",
+    pagination: { limit: 30 },
+    surface: "admin",
     enabled: enabled && !lockProduct,
   })
   const selectedProductQuery = useProduct(value.productId || undefined, {
-    enabled: enabled && Boolean(value.productId),
+    enabled:
+      enabled && Boolean(value.productId) && (!value.sourceKind || value.sourceKind === "owned"),
   })
 
   const products = React.useMemo(() => {
     const map = new Map(cachedProductsRef.current)
-    for (const product of productsData?.data ?? []) map.set(product.id, product)
-    if (selectedProductQuery.data) map.set(selectedProductQuery.data.id, selectedProductQuery.data)
+    for (const hit of productsQuery.data?.hits ?? []) {
+      const product = catalogProductPickerRecordFromHit(hit)
+      map.set(product.id, product)
+    }
+    if (selectedProductQuery.data) {
+      map.set(selectedProductQuery.data.id, ownedProductToPickerRecord(selectedProductQuery.data))
+    }
+    if (value.productId && value.productName) {
+      map.set(value.productId, {
+        id: value.productId,
+        name: value.productName,
+        sellCurrency: value.sellCurrency,
+        sellAmountCents: value.sellAmountCents,
+        supplierName: value.supplierName,
+        sourceKind: value.sourceKind ?? "owned",
+        sourceConnectionId: value.sourceConnectionId,
+        sourceRef: value.sourceRef,
+      })
+    }
     cachedProductsRef.current = map
     return Array.from(map.values())
-  }, [productsData?.data, selectedProductQuery.data])
+  }, [productsQuery.data?.hits, selectedProductQuery.data, value])
 
   const productMap = React.useMemo(
     () => new Map(products.map((product) => [product.id, product])),
@@ -134,7 +174,24 @@ export function ProductPickerSection({
             }}
             onValueChange={(next) => {
               const productId = (next as string | null) ?? ""
-              onChange({ productId, optionId: null })
+              const selected = productId ? productMap.get(productId) : null
+              onChange({
+                productId,
+                optionId: null,
+                ...(selected
+                  ? {
+                      sourceKind: selected.sourceKind ?? "owned",
+                      ...(selected.sourceConnectionId
+                        ? { sourceConnectionId: selected.sourceConnectionId }
+                        : {}),
+                      ...(selected.sourceRef ? { sourceRef: selected.sourceRef } : {}),
+                      productName: selected.name,
+                      ...(selected.supplierName ? { supplierName: selected.supplierName } : {}),
+                      ...(selected.sellCurrency ? { sellCurrency: selected.sellCurrency } : {}),
+                      sellAmountCents: selected.sellAmountCents ?? null,
+                    }
+                  : {}),
+              })
               setProductInputValue(productId ? resolveProductLabel(productId) : "")
             }}
           >
@@ -151,14 +208,30 @@ export function ProductPickerSection({
                     if (!product) return null
                     return (
                       <ComboboxItem key={product.id} value={product.id}>
-                        <div className="flex min-w-0 flex-col">
-                          <span className="truncate font-medium">{product.name}</span>
-                          <span className="truncate text-xs text-muted-foreground">
-                            {product.sellCurrency}
-                            {product.sellAmountCents != null
-                              ? ` · ${product.sellAmountCents / 100}`
-                              : ""}
-                          </span>
+                        <div className="flex min-w-0 flex-1 flex-col gap-1">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <span className="truncate font-medium">{product.name}</span>
+                            <Badge variant="secondary">
+                              {product.sourceKind && product.sourceKind !== "owned"
+                                ? merged.supplier
+                                : merged.owned}
+                            </Badge>
+                          </div>
+                          <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                            {product.supplierName ? (
+                              <span className="truncate">{product.supplierName}</span>
+                            ) : null}
+                            {product.sellCurrency ? (
+                              <span>
+                                {product.sellAmountCents != null
+                                  ? formatCurrency(
+                                      product.sellAmountCents / 100,
+                                      product.sellCurrency,
+                                    )
+                                  : product.sellCurrency}
+                              </span>
+                            ) : null}
+                          </div>
                         </div>
                       </ComboboxItem>
                     )
@@ -190,16 +263,31 @@ export function ProductPickerSection({
               <SelectValue />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value={OPTION_NONE}>{merged.optionNone}</SelectItem>
-              {options.map((o) => (
-                <SelectItem key={o.id} value={o.id}>
-                  {o.name}
-                </SelectItem>
-              ))}
+              <SelectGroup>
+                <SelectItem value={OPTION_NONE}>{merged.optionNone}</SelectItem>
+                {options.map((o) => (
+                  <SelectItem key={o.id} value={o.id}>
+                    {o.name}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
             </SelectContent>
           </Select>
         </div>
       )}
     </>
   )
+}
+
+function ownedProductToPickerRecord(
+  product: ProductRecord,
+): ProductPickerSearchRecord & { id: string } {
+  return {
+    id: product.id,
+    name: product.name,
+    description: product.description,
+    sellCurrency: product.sellCurrency,
+    sellAmountCents: product.sellAmountCents,
+    sourceKind: "owned",
+  }
 }

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -41,6 +41,8 @@ export const bookingsUiEnCreateList = {
       leadTraveler: "Choose exactly one lead traveler.",
       amount: "Enter a valid sell amount.",
       pricingPending: "Wait a moment while we calculate the total.",
+      pricingUnavailable:
+        "We couldn't calculate a live supplier price. Review the selection and try again.",
       overrideReason: "Add a reason for the manual total.",
       payment: "Complete the payment schedule and make its total match the sell amount.",
       paidPaymentDate: "Payment date is required when Already paid is checked.",

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -39,6 +39,7 @@ export type BookingsUiCreateListMessages = {
       leadTraveler: string
       amount: string
       pricingPending: string
+      pricingUnavailable: string
       overrideReason: string
       payment: string
       paidPaymentDate: string

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -41,6 +41,8 @@ export const bookingsUiRoCreateList = {
       leadTraveler: "Alege exact un calator principal.",
       amount: "Introdu o valoare de vanzare valida.",
       pricingPending: "Asteapta putin cat timp calculam totalul.",
+      pricingUnavailable:
+        "Nu am putut calcula pretul furnizorului. Verifica selectia si incearca din nou.",
       overrideReason: "Adauga un motiv pentru totalul manual.",
       payment: "Completeaza calendarul de plata, cu un total egal valorii rezervarii.",
       paidPaymentDate: "Data platii este obligatorie cand plata este marcata ca deja achitata.",

--- a/packages/bookings-react/tests/unit/booking-create-utils.test.ts
+++ b/packages/bookings-react/tests/unit/booking-create-utils.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { findAlreadyPaidInstallmentMissingPaymentDate } from "../../src/components/booking-create-form-utils.js"
 import {
+  catalogProductPickerRecordFromHit,
   getBookableDepartureSlots,
   getOverCapacityInventoryAssignments,
   getSelectedSharedRoomUnitId,
@@ -73,6 +74,46 @@ describe("booking create helpers", () => {
         "rasnov",
       ),
     ).toBe(true)
+  })
+
+  it("normalizes supplier catalog hits for the unified product picker", () => {
+    expect(
+      catalogProductPickerRecordFromHit({
+        id: "prod_supplier_1",
+        document: {
+          fields: {
+            name: "Northern Lights Tour",
+            supplierId: "Demo Tours",
+            sellAmountCents: "12900",
+            sellCurrency: "EUR",
+            "source.kind": "voyant-connect",
+            "source.ref": "upstream-42",
+          },
+        },
+      }),
+    ).toEqual({
+      id: "prod_supplier_1",
+      name: "Northern Lights Tour",
+      description: null,
+      supplierName: "Demo Tours",
+      sellAmountCents: 12900,
+      sellCurrency: "EUR",
+      sourceKind: "voyant-connect",
+      sourceConnectionId: null,
+      sourceRef: "upstream-42",
+    })
+  })
+
+  it("matches product picker search by supplier and source", () => {
+    const product = {
+      id: "prod_supplier_1",
+      name: "Northern Lights Tour",
+      supplierName: "Demo Tours",
+      sourceKind: "voyant-connect",
+      sellCurrency: "EUR",
+    }
+    expect(productMatchesPickerSearch(product, "demo tours")).toBe(true)
+    expect(productMatchesPickerSearch(product, "voyant-connect")).toBe(true)
   })
 
   it("keeps future open departures for the selected product option", () => {

--- a/packages/bookings-react/tests/unit/manual-booking-validation.test.ts
+++ b/packages/bookings-react/tests/unit/manual-booking-validation.test.ts
@@ -4,7 +4,10 @@ import {
   buildManualBookingQuoteDraft,
   formatManualBookingAmount,
   manualBookingTravelersToRows,
+  normalizeCatalogBookingSlot,
   resolveManualBookingPricing,
+  resolveSourcedOptionUnits,
+  resolveSourcedProductOptions,
   validateManualBookingDraft,
 } from "../../src/components/manual-booking-create-form.js"
 import { bookingsUiEn } from "../../src/i18n/en.js"
@@ -70,6 +73,83 @@ describe("manual booking validation", () => {
     expect(validateManualBookingDraft({ ...valid, hasSelectedUnits: false })).toBe(
       bookingsUiEn.manualBookingCreate.validation.units,
     )
+  })
+
+  it("allows an open-dated sourced product without a departure or owned units", () => {
+    expect(
+      validateManualBookingDraft({
+        ...valid,
+        slotId: null,
+        requireDeparture: false,
+        hasSelectedUnits: true,
+      }),
+    ).toBeNull()
+  })
+
+  it("uses live supplier options and applies unit availability bounds", () => {
+    const options = resolveSourcedProductOptions(
+      {
+        showsConfigure: true,
+        showsBilling: true,
+        showsTravelers: true,
+        showsAccommodation: true,
+        showsAddons: false,
+        showsPayment: true,
+        showsReview: true,
+        configureSubSteps: [
+          {
+            kind: "product-option",
+            options: [
+              {
+                id: "family",
+                name: "Family package",
+                isDefault: true,
+                units: [
+                  { id: "double", name: "Double room", unitType: "room", maxQuantity: 3 },
+                  { id: "adult", name: "Adult seat", unitType: "person" },
+                ],
+              },
+            ],
+          },
+        ],
+        paxBands: [],
+        paxBandsAllowedTotal: { min: 1, max: 7 },
+        travelerFields: [],
+        bookingFields: [],
+        paymentIntents: ["hold"],
+      },
+      { options: [{ id: "stale", name: "Stale cached option" }] },
+    )
+
+    expect(options.map((option) => option.id)).toEqual(["family"])
+    expect(resolveSourcedOptionUnits(options, "family", 7)).toMatchObject([
+      { optionUnitId: "double", unitType: "room", remaining: 3 },
+      { optionUnitId: "adult", unitType: "person", remaining: 7 },
+    ])
+  })
+
+  it("normalizes supplier departures and ignores open-dated rows without a start", () => {
+    expect(normalizeCatalogBookingSlot({ id: "open-date" }, "prod_source")).toBeNull()
+    expect(
+      normalizeCatalogBookingSlot(
+        {
+          id: "departure_1",
+          startsAt: "2026-09-15T08:00:00.000Z",
+          status: "available",
+          unlimited: false,
+          initialPax: 12,
+          remainingPax: 7,
+        },
+        "prod_source",
+      ),
+    ).toMatchObject({
+      id: "departure_1",
+      productId: "prod_source",
+      dateLocal: "2026-09-15",
+      status: "open",
+      unlimited: false,
+      remainingPax: 7,
+    })
   })
 
   it("requires the selected organization in organization billing mode", () => {
@@ -185,6 +265,9 @@ describe("manual booking validation", () => {
   it("includes unit selections, extras, and promotion code in the quote draft", () => {
     const draft = buildManualBookingQuoteDraft({
       productId: "prod_1",
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "connection_1",
+      sourceRef: "supplier-product-42",
       optionId: "opt_1",
       slotId: "slot_1",
       quantities: { unit_1: 2 },
@@ -239,6 +322,13 @@ describe("manual booking validation", () => {
     ])
     expect(draft?.addons).toEqual([{ extraId: "extra_1", quantity: 2 }])
     expect(draft?.promotionCode).toBe("SUMMER")
+    expect(draft?.entity).toEqual({
+      module: "products",
+      id: "prod_1",
+      sourceKind: "voyant-connect",
+      sourceConnectionId: "connection_1",
+      sourceRef: "supplier-product-42",
+    })
   })
 
   it("quotes a selected dynamic traveler category using its pricing band", () => {

--- a/packages/bookings-react/tests/unit/option-units-stepper-merge.test.ts
+++ b/packages/bookings-react/tests/unit/option-units-stepper-merge.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  buildOptionUnitsStepperRows,
   mergeStepperUnits,
   type OptionUnitsStepperUnit,
   optionRowHasInvalidUnit,
@@ -96,6 +97,21 @@ describe("mergeStepperUnits", () => {
     const productRows = [sgl, dbl]
 
     expect(mergeStepperUnits([], productRows, "popt_SGL", true)).toEqual(productRows)
+  })
+})
+
+describe("buildOptionUnitsStepperRows", () => {
+  it("keeps both inventory and person controls for a mixed supplier option", () => {
+    const rows = buildOptionUnitsStepperRows(
+      [
+        { ...makeRow("family", "double-room", 3), unitName: "Double room", unitType: "room" },
+        { ...makeRow("family", "adult-seat", 7), unitName: "Adult seat", unitType: "person" },
+      ],
+      [{ id: "family", name: "Family package" }],
+    )
+
+    expect(rows.map((row) => row.optionName)).toEqual(["Double room", "Adult seat"])
+    expect(rows.map((row) => row.primary.optionUnitId)).toEqual(["double-room", "adult-seat"])
   })
 })
 


### PR DESCRIPTION
## What changed

Follow-up to #3850.

- Search the unified product catalog from manual booking, including both owned and supplier products.
- Show clear Owned/Supplier provenance, supplier names, and formatted indexed prices in product results.
- Preserve supplier source kind, connection, and reference through quoting and booking creation.
- Use catalog departures and live supplier quote configuration for scheduled and open-dated products.
- Auto-select supplier defaults and keep rooms, person-count units, traveler types, required/default add-ons, promotions, currency, and sell totals synchronized with the live quote.
- Keep owned product availability and pricing flows unchanged.
- Prevent supplier pricing failures from silently falling back to stale indexed prices.
- Add non-technical EN/RO feedback when a live supplier price cannot be calculated.

## Why

The restored manual booking form only discovered owned inventory and then called owned-product APIs for every selection. Supplier catalog products therefore could not be booked reliably, and live quote objects could retrigger pricing state indefinitely in source flows.

## Browser validation

Validated an exact worktree snapshot in Chromium through the manual-booking harness:

- Unified search by product and supplier, with owned/supplier badges and RON/EUR/USD formatting.
- Owned Bucharest City Walk with an owned departure and RON currency.
- Scheduled Alpine supplier flow with a live departure, default option, room and person categories, required/optional add-ons, international phone input, locked EUR currency, and FAMILY10 repricing from EUR 274.00 to EUR 246.60.
- Open-dated Safari with no departure/room controls, required/optional add-ons, international phone input, locked USD currency, and no render loop after an explicit stability wait.
- 430px viewport with no horizontal overflow.

The browser pass caught two regressions during implementation: an unstable live-price preview causing a maximum-update-depth loop, and mixed supplier room/person units suppressing the person-count control. Both are fixed; the latter also has a focused regression test.

## Checks

- Biome on all changed files
- `@voyant-travel/bookings-react` typecheck
- Full package tests: 30 files, 144 tests passed
- Focused mixed-unit tests: 13 passed
