### PR TITLE
feat: add scale-to-zero job recovery profile

### DIFF
--- a/.changeset/calm-jobs-sleep.md
+++ b/.changeset/calm-jobs-sleep.md
@@ -1,0 +1,15 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/catalog": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/db": patch
+"@voyant-travel/legal": patch
+"@voyant-travel/notifications": patch
+"@voyant-travel/operations": patch
+"@voyant-travel/storefront": patch
+"@voyant-travel/trips": patch
+---
+
+Add a provider-neutral `scale-to-zero` recovery profile for package-owned jobs
+and expose safe durable-send, payment-reconciliation, and promotion-reindex
+jobs to payload-free wakeups.

--- a/.changeset/calm-jobs-sleep.md
+++ b/.changeset/calm-jobs-sleep.md
@@ -3,6 +3,7 @@
 "@voyant-travel/catalog": patch
 "@voyant-travel/commerce": patch
 "@voyant-travel/db": patch
+"@voyant-travel/distribution": patch
 "@voyant-travel/legal": patch
 "@voyant-travel/notifications": patch
 "@voyant-travel/operations": patch
@@ -10,6 +11,7 @@
 "@voyant-travel/trips": patch
 ---
 
-Add a provider-neutral `scale-to-zero` recovery profile for package-owned jobs
-and expose safe durable-send, payment-reconciliation, and promotion-reindex
-jobs to payload-free wakeups.
+Add a provider-neutral `scale-to-zero` recovery profile for package-owned jobs,
+including channel-push subscribers, and expose safe durable-send,
+payment-reconciliation, promotion-reindex, and channel-push jobs to payload-free
+wakeups.

--- a/docs/architecture/deployment-targets.md
+++ b/docs/architecture/deployment-targets.md
@@ -145,6 +145,21 @@ The host requires an explicit `scheduleAuthority`. Self-hosted Wrangler
 deployments select `cloudflare-cron`; managed workloads select `managed-http`.
 This prevents both systems from firing the same cadence during rollout.
 
+Wakeups are target-neutral signals, not a Cloudflare contract. A package marks
+a fixed, payload-free job with `wakeup: true`; the deployment host may then
+invoke the same `POST /__voyant/jobs/:id` contract from an in-process timer,
+AWS EventBridge/SQS, Google Cloud Scheduler/Tasks, Vercel Cron, Cloudflare, or
+another scheduler. Package code never imports a vendor SDK or assumes which
+control plane requested the wake. The declared cadence remains the recovery
+authority when a wake is lost or coalesced.
+
+The optional `scale-to-zero` scheduling profile aligns frequent recovery work
+on a 15-minute floor, leaving enough idle time for a five-minute database
+autosuspend window while bounding recovery when a wake is lost. Longer-running
+reminder and maintenance cadences retain their existing six-hour schedule.
+Selecting this profile is a deployment decision; self-hosted projects retain
+package defaults unless they opt in explicitly.
+
 The Worker entry owns no product IDs. Its integration shape is:
 
 ```ts

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -418,6 +418,7 @@ export const bookingsVoyantModule = defineModule({
         profiles: {
           eager: { cron: "* * * * *", overlap: "skip" },
           economical: { cron: "*/15 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       runtime: {

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -60,6 +60,7 @@ describe("bookings deployment manifest", () => {
             profiles: {
               eager: { cron: "* * * * *", overlap: "skip" },
               economical: { cron: "*/15 * * * *", overlap: "skip" },
+              "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
             },
           },
           runtime: {

--- a/packages/catalog/src/voyant.ts
+++ b/packages/catalog/src/voyant.ts
@@ -265,6 +265,7 @@ export const catalogVoyantModule = defineModule({
         profiles: {
           eager: { cron: "*/15 * * * *", overlap: "skip" },
           economical: { cron: "5 */6 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "5 */6 * * *", overlap: "skip" },
         },
       },
       runtime: {
@@ -283,6 +284,7 @@ export const catalogVoyantModule = defineModule({
         profiles: {
           eager: { cron: "*/20 * * * *", overlap: "skip" },
           economical: { cron: "20 */6 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "20 */6 * * *", overlap: "skip" },
         },
       },
       runtime: {

--- a/packages/catalog/tests/unit/voyant-manifest.test.ts
+++ b/packages/catalog/tests/unit/voyant-manifest.test.ts
@@ -134,6 +134,7 @@ describe("catalog deployment manifest", () => {
           profiles: {
             eager: { cron: "*/15 * * * *", overlap: "skip" },
             economical: { cron: "5 */6 * * *", overlap: "skip" },
+            "scale-to-zero": { cron: "5 */6 * * *", overlap: "skip" },
           },
         },
         runtime: {
@@ -149,6 +150,7 @@ describe("catalog deployment manifest", () => {
           profiles: {
             eager: { cron: "*/20 * * * *", overlap: "skip" },
             economical: { cron: "20 */6 * * *", overlap: "skip" },
+            "scale-to-zero": { cron: "20 */6 * * *", overlap: "skip" },
           },
         },
         runtime: {

--- a/packages/commerce/src/voyant.test.ts
+++ b/packages/commerce/src/voyant.test.ts
@@ -13,7 +13,7 @@ describe("commerce deployment manifest", () => {
           profiles: {
             eager: { every: "1m", overlap: "skip" },
             economical: { every: "15m", overlap: "skip" },
-            "scale-to-zero": { every: "15m", overlap: "skip" },
+            "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
           },
         },
         wakeup: true,

--- a/packages/commerce/src/voyant.test.ts
+++ b/packages/commerce/src/voyant.test.ts
@@ -13,8 +13,10 @@ describe("commerce deployment manifest", () => {
           profiles: {
             eager: { every: "1m", overlap: "skip" },
             economical: { every: "15m", overlap: "skip" },
+            "scale-to-zero": { every: "15m", overlap: "skip" },
           },
         },
+        wakeup: true,
         runtime: {
           entry: "@voyant-travel/commerce/promotion-reindex-job",
           export: "runPromotionReindexJob",
@@ -28,6 +30,7 @@ describe("commerce deployment manifest", () => {
           profiles: {
             eager: { cron: "* * * * *", overlap: "skip" },
             economical: { cron: "*/15 * * * *", overlap: "skip" },
+            "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
           },
         },
         wakeup: true,

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -437,7 +437,7 @@ export const commerceVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "15m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/commerce/src/voyant.ts
+++ b/packages/commerce/src/voyant.ts
@@ -437,8 +437,10 @@ export const commerceVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "15m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
         },
       },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/commerce/promotion-reindex-job",
         export: "runPromotionReindexJob",
@@ -452,6 +454,7 @@ export const commerceVoyantModule = defineModule({
         profiles: {
           eager: { cron: "* * * * *", overlap: "skip" },
           economical: { cron: "*/15 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -153,7 +153,7 @@ describe("commerce deployment manifest", () => {
             profiles: {
               eager: { every: "1m", overlap: "skip" },
               economical: { every: "15m", overlap: "skip" },
-              "scale-to-zero": { every: "15m", overlap: "skip" },
+              "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
             },
           },
           wakeup: true,

--- a/packages/commerce/tests/unit/voyant-manifest.test.ts
+++ b/packages/commerce/tests/unit/voyant-manifest.test.ts
@@ -153,8 +153,10 @@ describe("commerce deployment manifest", () => {
             profiles: {
               eager: { every: "1m", overlap: "skip" },
               economical: { every: "15m", overlap: "skip" },
+              "scale-to-zero": { every: "15m", overlap: "skip" },
             },
           },
+          wakeup: true,
           runtime: {
             entry: "@voyant-travel/commerce/promotion-reindex-job",
             export: "runPromotionReindexJob",
@@ -168,6 +170,7 @@ describe("commerce deployment manifest", () => {
             profiles: {
               eager: { cron: "* * * * *", overlap: "skip" },
               economical: { cron: "*/15 * * * *", overlap: "skip" },
+              "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
             },
           },
           wakeup: true,

--- a/packages/db/src/voyant.ts
+++ b/packages/db/src/voyant.ts
@@ -67,6 +67,7 @@ export const dbVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "10m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/db/src/voyant.ts
+++ b/packages/db/src/voyant.ts
@@ -67,7 +67,7 @@ export const dbVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "10m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/db/tests/unit/voyant-manifest.test.ts
+++ b/packages/db/tests/unit/voyant-manifest.test.ts
@@ -42,7 +42,7 @@ describe("database deployment manifest", () => {
             profiles: {
               eager: { every: "1m", overlap: "skip" },
               economical: { every: "10m", overlap: "skip" },
-              "scale-to-zero": { every: "15m", overlap: "skip" },
+              "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
             },
           },
           wakeup: true,

--- a/packages/db/tests/unit/voyant-manifest.test.ts
+++ b/packages/db/tests/unit/voyant-manifest.test.ts
@@ -42,6 +42,7 @@ describe("database deployment manifest", () => {
             profiles: {
               eager: { every: "1m", overlap: "skip" },
               economical: { every: "10m", overlap: "skip" },
+              "scale-to-zero": { every: "15m", overlap: "skip" },
             },
           },
           wakeup: true,

--- a/packages/distribution/src/voyant-extensions.ts
+++ b/packages/distribution/src/voyant-extensions.ts
@@ -97,7 +97,7 @@ export const distributionChannelPushVoyantExtensionDefinition = {
         required: true,
         profiles: {
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,
@@ -113,7 +113,7 @@ export const distributionChannelPushVoyantExtensionDefinition = {
         required: true,
         profiles: {
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,
@@ -129,7 +129,7 @@ export const distributionChannelPushVoyantExtensionDefinition = {
         required: true,
         profiles: {
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/distribution/src/voyant-extensions.ts
+++ b/packages/distribution/src/voyant-extensions.ts
@@ -93,6 +93,14 @@ export const distributionChannelPushVoyantExtensionDefinition = {
     {
       id: "channel.booking.push",
       schedule: { every: "2m", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/distribution/channel-push-jobs",
         export: "runChannelBookingPushJob",
@@ -101,6 +109,14 @@ export const distributionChannelPushVoyantExtensionDefinition = {
     {
       id: "channel.availability.push",
       schedule: { every: "1m", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/distribution/channel-push-jobs",
         export: "runChannelAvailabilityPushJob",
@@ -109,6 +125,14 @@ export const distributionChannelPushVoyantExtensionDefinition = {
     {
       id: "channel.content.push",
       schedule: { every: "5m", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
+        },
+      },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/distribution/channel-push-jobs",
         export: "runChannelContentPushJob",
@@ -117,6 +141,13 @@ export const distributionChannelPushVoyantExtensionDefinition = {
     {
       id: "distribution.channel-push-reconcile-booking-links",
       schedule: { cron: "*/15 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          economical: { cron: "0 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "0 */6 * * *", overlap: "skip" },
+        },
+      },
       runtime: {
         entry: "@voyant-travel/distribution/channel-push-jobs",
         export: "runChannelBookingLinkReconcilerJob",
@@ -125,6 +156,13 @@ export const distributionChannelPushVoyantExtensionDefinition = {
     {
       id: "distribution.channel-push-reconcile-availability",
       schedule: { cron: "0 * * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          economical: { cron: "0 */6 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "0 */6 * * *", overlap: "skip" },
+        },
+      },
       runtime: {
         entry: "@voyant-travel/distribution/channel-push-jobs",
         export: "runChannelAvailabilityReconcilerJob",
@@ -133,6 +171,13 @@ export const distributionChannelPushVoyantExtensionDefinition = {
     {
       id: "distribution.channel-push-reconcile-content",
       schedule: { cron: "0 3 * * *", overlap: "skip" },
+      scheduling: {
+        required: true,
+        profiles: {
+          economical: { cron: "0 3 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "0 3 * * *", overlap: "skip" },
+        },
+      },
       runtime: {
         entry: "@voyant-travel/distribution/channel-push-jobs",
         export: "runChannelContentReconcilerJob",

--- a/packages/distribution/tests/unit/voyant-manifest.test.ts
+++ b/packages/distribution/tests/unit/voyant-manifest.test.ts
@@ -297,7 +297,7 @@ describe("distribution deployment manifests", () => {
           required: true,
           profiles: {
             economical: { every: "5m", overlap: "skip" },
-            "scale-to-zero": { every: "15m", overlap: "skip" },
+            "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
           },
         },
         wakeup: true,

--- a/packages/distribution/tests/unit/voyant-manifest.test.ts
+++ b/packages/distribution/tests/unit/voyant-manifest.test.ts
@@ -293,6 +293,14 @@ describe("distribution deployment manifests", () => {
     expect(distributionChannelPushVoyantPlugin.jobs).toEqual([
       expect.objectContaining({
         id: "channel.booking.push",
+        scheduling: {
+          required: true,
+          profiles: {
+            economical: { every: "5m", overlap: "skip" },
+            "scale-to-zero": { every: "15m", overlap: "skip" },
+          },
+        },
+        wakeup: true,
         runtime: {
           entry: "@voyant-travel/distribution/channel-push-jobs",
           export: "runChannelBookingPushJob",
@@ -300,18 +308,35 @@ describe("distribution deployment manifests", () => {
       }),
       expect.objectContaining({
         id: "channel.availability.push",
+        wakeup: true,
       }),
       expect.objectContaining({
         id: "channel.content.push",
+        wakeup: true,
       }),
       expect.objectContaining({
         id: "distribution.channel-push-reconcile-booking-links",
+        scheduling: expect.objectContaining({
+          profiles: expect.objectContaining({
+            "scale-to-zero": { cron: "0 */6 * * *", overlap: "skip" },
+          }),
+        }),
       }),
       expect.objectContaining({
         id: "distribution.channel-push-reconcile-availability",
+        scheduling: expect.objectContaining({
+          profiles: expect.objectContaining({
+            "scale-to-zero": { cron: "0 */6 * * *", overlap: "skip" },
+          }),
+        }),
       }),
       expect.objectContaining({
         id: "distribution.channel-push-reconcile-content",
+        scheduling: expect.objectContaining({
+          profiles: expect.objectContaining({
+            "scale-to-zero": { cron: "0 3 * * *", overlap: "skip" },
+          }),
+        }),
       }),
     ])
   })

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -156,6 +156,7 @@ const contractDocumentJobs = [
       profiles: {
         eager: { every: "1m", overlap: "skip" as const },
         economical: { every: "5m", overlap: "skip" as const },
+        "scale-to-zero": { every: "15m", overlap: "skip" as const },
       },
     },
     wakeup: true,

--- a/packages/legal/src/voyant.ts
+++ b/packages/legal/src/voyant.ts
@@ -156,7 +156,7 @@ const contractDocumentJobs = [
       profiles: {
         eager: { every: "1m", overlap: "skip" as const },
         economical: { every: "5m", overlap: "skip" as const },
-        "scale-to-zero": { every: "15m", overlap: "skip" as const },
+        "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" as const },
       },
     },
     wakeup: true,

--- a/packages/notifications/src/voyant.ts
+++ b/packages/notifications/src/voyant.ts
@@ -112,8 +112,10 @@ export const notificationsVoyantModule = defineModule({
         profiles: {
           eager: { cron: "* * * * *", overlap: "skip" },
           economical: { cron: "*/5 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/notifications/reminder-job",
         export: "runDueNotificationSendsJob",
@@ -127,6 +129,7 @@ export const notificationsVoyantModule = defineModule({
         profiles: {
           eager: { cron: "*/15 * * * *", overlap: "skip" },
           economical: { cron: "0 */6 * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "0 */6 * * *", overlap: "skip" },
         },
       },
       runtime: {

--- a/packages/notifications/tests/unit/voyant-manifest.test.ts
+++ b/packages/notifications/tests/unit/voyant-manifest.test.ts
@@ -57,8 +57,10 @@ describe("notifications deployment manifest", () => {
             profiles: {
               eager: { cron: "* * * * *", overlap: "skip" },
               economical: { cron: "*/5 * * * *", overlap: "skip" },
+              "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
             },
           },
+          wakeup: true,
           runtime: {
             entry: "@voyant-travel/notifications/reminder-job",
             export: "runDueNotificationSendsJob",
@@ -72,6 +74,7 @@ describe("notifications deployment manifest", () => {
             profiles: {
               eager: { cron: "*/15 * * * *", overlap: "skip" },
               economical: { cron: "0 */6 * * *", overlap: "skip" },
+              "scale-to-zero": { cron: "0 */6 * * *", overlap: "skip" },
             },
           },
           runtime: {

--- a/packages/operations/src/voyant.ts
+++ b/packages/operations/src/voyant.ts
@@ -53,6 +53,7 @@ export const operationsVoyantModule = defineModule({
         profiles: {
           eager: { cron: "* * * * *", overlap: "skip" },
           economical: { cron: "*/15 * * * *", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       runtime: {

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -1,8 +1,16 @@
 import { bookingsVoyantModule } from "@voyant-travel/bookings/voyant"
+import { catalogVoyantModule } from "@voyant-travel/catalog/voyant"
+import { commerceVoyantModule } from "@voyant-travel/commerce/voyant"
+import cruisesVoyantModule from "@voyant-travel/cruises/voyant"
+import { dbVoyantModule } from "@voyant-travel/db/voyant"
 import { financeVoyantModule } from "@voyant-travel/finance/voyant"
+import { legalVoyantModule } from "@voyant-travel/legal/voyant"
 import navigationPreferencesVoyantModule from "@voyant-travel/navigation-preferences/voyant"
+import { notificationsVoyantModule } from "@voyant-travel/notifications/voyant"
+import { operationsVoyantModule } from "@voyant-travel/operations/voyant"
 import reportingVoyantModule from "@voyant-travel/reporting/voyant"
 import { storefrontVoyantModule } from "@voyant-travel/storefront/voyant"
+import { tripsVoyantModule } from "@voyant-travel/trips/voyant"
 import operatorWebhooksVoyantModule from "@voyant-travel/webhook-delivery/voyant"
 import { describe, expect, it } from "vitest"
 import {
@@ -82,6 +90,50 @@ describe("standard package manifests", () => {
   it("runs selected product jobs in the standard Operator by default", () => {
     expect(STANDARD_OPERATOR_DEPLOYMENT.providers?.scheduledJobs).toBe("node-cron")
     expect(STANDARD_OPERATOR_DEPLOYMENT.providers?.legalDocumentArtifact).toBe("standard")
+  })
+
+  it("resolves the provider-neutral scale-to-zero recovery profile across standard jobs", async () => {
+    const graph = await resolveDeploymentGraph({
+      project: defineProject({
+        modules: [
+          bookingsVoyantModule,
+          catalogVoyantModule,
+          commerceVoyantModule,
+          cruisesVoyantModule,
+          dbVoyantModule,
+          legalVoyantModule,
+          notificationsVoyantModule,
+          operationsVoyantModule,
+          storefrontVoyantModule,
+          tripsVoyantModule,
+        ],
+        jobScheduling: { profile: "scale-to-zero" },
+      }),
+      target: "node",
+      mode: "self-hosted",
+    })
+
+    expect(
+      graph.diagnostics.filter((diagnostic) => diagnostic.code.includes("JOB_SCHEDULE")),
+    ).toEqual([])
+    const schedules = new Map(graph.provisioning.jobs.map((job) => [job.id, job.schedule]))
+    expect(schedules.get("infrastructure.event-outbox-drain")).toEqual({
+      every: "15m",
+      overlap: "skip",
+    })
+    expect(schedules.get("notifications.deliver-durable-sends")).toEqual({
+      cron: "*/15 * * * *",
+      overlap: "skip",
+    })
+    expect(schedules.get("cruises.external-catalog-refresh")).toEqual({
+      cron: "30 3 * * *",
+      overlap: "skip",
+    })
+    expect(
+      graph.provisioning.jobs
+        .filter((job) => job.scheduling?.profiles["scale-to-zero"])
+        .every((job) => job.scheduling?.selected === "scale-to-zero"),
+    ).toBe(true)
   })
 
   it("selects the composed dashboard with a staff preset that satisfies every source scope", () => {

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -3,6 +3,7 @@ import { catalogVoyantModule } from "@voyant-travel/catalog/voyant"
 import { commerceVoyantModule } from "@voyant-travel/commerce/voyant"
 import cruisesVoyantModule from "@voyant-travel/cruises/voyant"
 import { dbVoyantModule } from "@voyant-travel/db/voyant"
+import { distributionChannelPushVoyantPlugin } from "@voyant-travel/distribution/voyant"
 import { financeVoyantModule } from "@voyant-travel/finance/voyant"
 import { legalVoyantModule } from "@voyant-travel/legal/voyant"
 import navigationPreferencesVoyantModule from "@voyant-travel/navigation-preferences/voyant"
@@ -107,6 +108,7 @@ describe("standard package manifests", () => {
           storefrontVoyantModule,
           tripsVoyantModule,
         ],
+        extensions: [distributionChannelPushVoyantPlugin],
         jobScheduling: { profile: "scale-to-zero" },
       }),
       target: "node",
@@ -123,6 +125,14 @@ describe("standard package manifests", () => {
     })
     expect(schedules.get("notifications.deliver-durable-sends")).toEqual({
       cron: "*/15 * * * *",
+      overlap: "skip",
+    })
+    expect(schedules.get("channel.availability.push")).toEqual({
+      every: "15m",
+      overlap: "skip",
+    })
+    expect(schedules.get("distribution.channel-push-reconcile-booking-links")).toEqual({
+      cron: "0 */6 * * *",
       overlap: "skip",
     })
     expect(schedules.get("cruises.external-catalog-refresh")).toEqual({

--- a/packages/operator-standard/tests/standard-package-manifests.test.ts
+++ b/packages/operator-standard/tests/standard-package-manifests.test.ts
@@ -120,7 +120,7 @@ describe("standard package manifests", () => {
     ).toEqual([])
     const schedules = new Map(graph.provisioning.jobs.map((job) => [job.id, job.schedule]))
     expect(schedules.get("infrastructure.event-outbox-drain")).toEqual({
-      every: "15m",
+      cron: "*/15 * * * *",
       overlap: "skip",
     })
     expect(schedules.get("notifications.deliver-durable-sends")).toEqual({
@@ -128,7 +128,7 @@ describe("standard package manifests", () => {
       overlap: "skip",
     })
     expect(schedules.get("channel.availability.push")).toEqual({
-      every: "15m",
+      cron: "*/15 * * * *",
       overlap: "skip",
     })
     expect(schedules.get("distribution.channel-push-reconcile-booking-links")).toEqual({
@@ -144,6 +144,11 @@ describe("standard package manifests", () => {
         .filter((job) => job.scheduling?.profiles["scale-to-zero"])
         .every((job) => job.scheduling?.selected === "scale-to-zero"),
     ).toBe(true)
+    expect(
+      graph.provisioning.jobs.filter(
+        (job) => job.scheduling?.selected === "scale-to-zero" && job.schedule.every === "15m",
+      ),
+    ).toEqual([])
   })
 
   it("selects the composed dashboard with a staff preset that satisfies every source scope", () => {

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -505,7 +505,7 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -505,8 +505,10 @@ export const storefrontPaymentLinkVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
         },
       },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/storefront/payment-reconciliation-job",
         export: "runPaymentAdapterReconciliationJob",

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -231,7 +231,7 @@ describe("storefront deployment manifest", () => {
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/storefront/tests/unit/voyant-manifest.test.ts
+++ b/packages/storefront/tests/unit/voyant-manifest.test.ts
@@ -231,8 +231,10 @@ describe("storefront deployment manifest", () => {
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
         },
       },
+      wakeup: true,
       runtime: {
         entry: "@voyant-travel/storefront/payment-reconciliation-job",
         export: "runPaymentAdapterReconciliationJob",

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -168,6 +168,7 @@ export const tripsVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
         },
       },
       wakeup: true,
@@ -184,6 +185,7 @@ export const tripsVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
+          "scale-to-zero": { every: "15m", overlap: "skip" },
         },
       },
       wakeup: true,

--- a/packages/trips/src/voyant.ts
+++ b/packages/trips/src/voyant.ts
@@ -168,7 +168,7 @@ export const tripsVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,
@@ -185,7 +185,7 @@ export const tripsVoyantModule = defineModule({
         profiles: {
           eager: { every: "1m", overlap: "skip" },
           economical: { every: "5m", overlap: "skip" },
-          "scale-to-zero": { every: "15m", overlap: "skip" },
+          "scale-to-zero": { cron: "*/15 * * * *", overlap: "skip" },
         },
       },
       wakeup: true,


### PR DESCRIPTION
## What changed

- add a provider-neutral `scale-to-zero` recovery profile to standard package-owned jobs
- mark durable notification delivery, payment reconciliation, and promotion reindex as payload-free wakeable jobs
- document the target-neutral activation contract for AWS, GCP, Vercel, Cloudflare, and in-process hosts
- add full standard-graph coverage and package manifest assertions

## Why

The managed standard profile currently dispatches roughly 386 tenant-runtime jobs per hour, which prevents a five-minute Neon autosuspend window even when no customer traffic or durable work exists. The new profile aligns ten frequent recovery jobs at a 15-minute floor while retaining six-hour and daily maintenance cadences.

Voyant OSS remains provider-neutral: packages own fixed job IDs, handlers, wakeability, and bounded recovery schedules; deployment adapters choose the control plane.

## Validation

- affected manifest suites: 41 tests passed
- standard package graph suite: 8 tests passed
- `scale-to-zero` resolves across the standard scheduled-job graph
- `git diff --check` passed
