### PR TITLE
fix(bookings): show edited travel period

### DIFF
--- a/.changeset/fix-booking-period-display.md
+++ b/.changeset/fix-booking-period-display.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/bookings-react": patch
+---
+
+Show an edited booking travel period in booking lists instead of continuing to
+display the original booking-item departure timestamps.

--- a/packages/bookings-react/src/components/booking-combobox.tsx
+++ b/packages/bookings-react/src/components/booking-combobox.tsx
@@ -4,6 +4,7 @@ import { AsyncCombobox } from "@voyant-travel/ui/components/async-combobox"
 import * as React from "react"
 import { useBookingsUiMessagesOrDefault } from "../i18n/provider.js"
 import { type BookingRecord, useBooking, useBookings } from "../index.js"
+import { resolveBookingDisplayDateRange } from "./booking-display-date-range.js"
 
 export interface BookingComboboxProps {
   value: string | null | undefined
@@ -33,8 +34,7 @@ function formatPrimaryItem(booking: BookingRecord) {
 }
 
 function formatDateRange(booking: BookingRecord) {
-  const start = booking.startDate ?? booking.startsAt
-  const end = booking.endDate ?? booking.endsAt
+  const { start, end } = resolveBookingDisplayDateRange(booking)
   if (start && end) return `${start} - ${end}`
   return start ?? end ?? null
 }

--- a/packages/bookings-react/src/components/booking-display-date-range.ts
+++ b/packages/bookings-react/src/components/booking-display-date-range.ts
@@ -1,0 +1,18 @@
+export interface BookingDisplayDateRangeSource {
+  startDate?: string | null
+  endDate?: string | null
+  startsAt?: string | null
+  endsAt?: string | null
+}
+
+/**
+ * Booking-level dates are the operator-editable travel period. Item timestamps
+ * are immutable booking-time snapshots and only fill dates for legacy records
+ * that do not have the canonical booking fields populated.
+ */
+export function resolveBookingDisplayDateRange(booking: BookingDisplayDateRangeSource) {
+  return {
+    start: booking.startDate ?? booking.startsAt ?? null,
+    end: booking.endDate ?? booking.endsAt ?? null,
+  }
+}

--- a/packages/bookings-react/src/components/booking-list.tsx
+++ b/packages/bookings-react/src/components/booking-list.tsx
@@ -35,6 +35,7 @@ import {
   useBookings,
 } from "../index.js"
 import { BookingDialog } from "./booking-dialog.js"
+import { resolveBookingDisplayDateRange } from "./booking-display-date-range.js"
 import { BookingListFiltersPopover } from "./booking-list-filters.js"
 import { StatusBadge } from "./status-badge.js"
 
@@ -459,12 +460,7 @@ export function BookingList({
                   </TableCell>
                   <TableCell>{booking.pax ?? "—"}</TableCell>
                   <TableCell className="whitespace-nowrap">
-                    {formatBookingDateRange(
-                      booking.startsAt ?? booking.startDate,
-                      booking.endsAt ?? booking.endDate,
-                      formatDate,
-                      locale,
-                    )}
+                    {formatBookingRecordDateRange(booking, formatDate, locale)}
                   </TableCell>
                 </TableRow>
               ))
@@ -777,6 +773,15 @@ function formatBookingDateRange(
     return `${body}, ${e.getFullYear()}`
   }
   return `${formatDate(s, { month: "short", day: "numeric", year: "numeric" })} – ${formatDate(e, { month: "short", day: "numeric", year: "numeric" })}`
+}
+
+function formatBookingRecordDateRange(
+  booking: BookingRecord,
+  formatDate: (value: Date | string | number, options?: Intl.DateTimeFormatOptions) => string,
+  locale: string,
+) {
+  const { start, end } = resolveBookingDisplayDateRange(booking)
+  return formatBookingDateRange(start, end, formatDate, locale)
 }
 
 /** Detect whether the locale renders the day before the month in a

--- a/packages/bookings-react/tests/unit/booking-display-date-range.test.ts
+++ b/packages/bookings-react/tests/unit/booking-display-date-range.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveBookingDisplayDateRange } from "../../src/components/booking-display-date-range.js"
+
+describe("resolveBookingDisplayDateRange", () => {
+  it("shows the operator-edited booking period instead of stale item timestamps", () => {
+    expect(
+      resolveBookingDisplayDateRange({
+        startDate: "2026-10-28",
+        endDate: "2026-11-01",
+        startsAt: "2026-10-21T08:00:00.000Z",
+        endsAt: "2026-10-25T18:00:00.000Z",
+      }),
+    ).toEqual({ start: "2026-10-28", end: "2026-11-01" })
+  })
+
+  it("falls back to item timestamps for legacy bookings without booking dates", () => {
+    expect(
+      resolveBookingDisplayDateRange({
+        startDate: null,
+        endDate: null,
+        startsAt: "2026-10-21T08:00:00.000Z",
+        endsAt: "2026-10-25T18:00:00.000Z",
+      }),
+    ).toEqual({
+      start: "2026-10-21T08:00:00.000Z",
+      end: "2026-10-25T18:00:00.000Z",
+    })
+  })
+})

--- a/packages/bookings/tests/integration/routes.integration-suite.ts
+++ b/packages/bookings/tests/integration/routes.integration-suite.ts
@@ -705,14 +705,29 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       expect((await res.json()).data.id).toBe(booking.id)
     })
 
-    it("updates a booking", async () => {
+    it("persists an updated booking travel period", async () => {
       const booking = await seedBooking()
       const res = await app.request(`/${booking.id}`, {
         method: "PATCH",
-        ...json({ internalNotes: "Updated" }),
+        ...json({
+          internalNotes: "Updated",
+          startDate: "2026-10-28",
+          endDate: "2026-11-01",
+        }),
       })
       expect(res.status).toBe(200)
-      expect((await res.json()).data.internalNotes).toBe("Updated")
+      expect((await res.json()).data).toMatchObject({
+        internalNotes: "Updated",
+        startDate: "2026-10-28",
+        endDate: "2026-11-01",
+      })
+
+      const getRes = await app.request(`/${booking.id}`, { method: "GET" })
+      expect(getRes.status).toBe(200)
+      expect((await getRes.json()).data).toMatchObject({
+        startDate: "2026-10-28",
+        endDate: "2026-11-01",
+      })
     })
 
     it("deletes a booking", async () => {


### PR DESCRIPTION
## What changed

- prefer the editable booking-level travel period when rendering booking dates
- keep booking-item timestamps as a fallback for legacy records without canonical booking dates
- cover the Pro Travel 21–25 October → 28 October–1 November scenario with a focused UI-domain regression test
- verify the PATCH route returns and subsequently reads back the updated travel period

## Root cause

The edit request was already persisted correctly. The bookings list rendered immutable booking-item snapshot timestamps before the editable booking-level dates, so it continued showing the original period and made the save appear to fail.

The fix changes display precedence only; it does not silently reschedule booked items or allocations.

## Validation

- Biome check for all changed files
- `@voyant-travel/bookings-react` typecheck
- `@voyant-travel/bookings` typecheck
- focused `booking-display-date-range` unit tests: 2 passed
- bookings route integration suite discovered successfully but skipped in the isolated runner because no `DATABASE_URL` is available; GitHub CI will run the database-backed coverage

Fixes #3860