### PR TITLE
fix(auth): trust Max acting-user attribution

### DIFF
--- a/.changeset/calm-pandas-act.md
+++ b/.changeset/calm-pandas-act.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/core": patch
+"@voyant-travel/hono": patch
+---
+
+Attribute trusted managed Max writes to the approving staff user while retaining Max provenance in the request context.

--- a/.changeset/calm-pandas-act.md
+++ b/.changeset/calm-pandas-act.md
@@ -3,4 +3,6 @@
 "@voyant-travel/hono": patch
 ---
 
-Attribute trusted managed Max writes to the approving staff user while retaining Max provenance in the request context.
+Attribute trusted managed Max writes to the approving staff user while retaining
+Max provenance in the request context and keeping internal credential scopes as
+a hard authorization cap.

--- a/.changeset/calm-pandas-act.md
+++ b/.changeset/calm-pandas-act.md
@@ -5,4 +5,5 @@
 
 Attribute trusted managed Max writes to the approving staff user while retaining
 Max provenance in the request context and keeping internal credential scopes as
-a hard authorization cap.
+a hard authorization cap. Resolve the asserted cloud identity to its
+deployment-local mirror user before exposing it to handlers.

--- a/docs/architecture/auth-identity-architecture.md
+++ b/docs/architecture/auth-identity-architecture.md
@@ -221,10 +221,12 @@ Do not overload user-session auth to cover every non-user access pattern.
 
 An internal caller authenticated by an exact configured `INTERNAL_API_KEY`
 match may send `x-voyant-acting-user-id` when it performs work interactively on
-behalf of a Voyant staff user. The Hono runtime records that identity as the
-request `userId` with `principalSubtype: "max"`; this is attribution and a
-delegated identity input, not a replacement for the machine credential's
-authorization.
+behalf of a Voyant staff user. Managed Max sends the Voyant Cloud / WorkOS
+provider account id. The Hono runtime must resolve that assertion through an
+active `cloud_auth_user_links` row and records the linked deployment-local auth
+user id as request `userId` with `principalSubtype: "max"`. An unknown or
+revoked link fails authentication. This is attribution and a delegated identity
+input, not a replacement for the machine credential's authorization.
 
 `INTERNAL_API_KEY_SCOPES` remains a hard permission ceiling. A route guarded by
 `requirePermission(resource, action)` must reject the request when the internal

--- a/docs/architecture/auth-identity-architecture.md
+++ b/docs/architecture/auth-identity-architecture.md
@@ -217,6 +217,29 @@ Rule:
 
 Do not overload user-session auth to cover every non-user access pattern.
 
+### 10a. Trusted internal acting-user attribution is not authorization
+
+An internal caller authenticated by an exact configured `INTERNAL_API_KEY`
+match may send `x-voyant-acting-user-id` when it performs work interactively on
+behalf of a Voyant staff user. The Hono runtime records that identity as the
+request `userId` with `principalSubtype: "max"`; this is attribution and a
+delegated identity input, not a replacement for the machine credential's
+authorization.
+
+`INTERNAL_API_KEY_SCOPES` remains a hard permission ceiling. A route guarded by
+`requirePermission(resource, action)` must reject the request when the internal
+credential lacks that scope, even if the asserted user would independently
+have the permission in an interactive session. Audit consumers should record
+both the internal caller and the asserted actor where their schema permits it.
+
+Every holder of a configured internal key is technically able to assert this
+header. Managed deployments must therefore distribute that key only to trusted
+internal workloads allowed to act on behalf of staff, rotate it with the
+comma-separated overlap procedure, and give it the narrowest practical scopes.
+Self-hosted deployments that do not operate such a trusted workload should not
+forward the header and may leave `INTERNAL_API_KEY` unset. Untrusted clients and
+ordinary `voy_*` API keys must never be allowed to assert acting-user identity.
+
 For the current token-signing baseline and the threshold for eventual JWKS-style
 distribution, see
 [`token-signing-and-key-distribution-policy.md`](./token-signing-and-key-distribution-policy.md).

--- a/packages/core/src/env.ts
+++ b/packages/core/src/env.ts
@@ -47,6 +47,8 @@ export interface VoyantAuthContext {
   isInternalRequest?: boolean
   apiTokenId?: string
   apiKeyId?: string
+  /** Auditable subtype for a trusted delegated principal (for example `max`). */
+  principalSubtype?: string
   appId?: string
   appInstallationId?: string
   appReleaseId?: string

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -254,7 +254,15 @@ export function requireAuth<TBindings extends VoyantBindings>(
     // Strategy 1: Internal API Key
     const internalKeys = parseInternalApiKeys(c.env.INTERNAL_API_KEY)
     if (token && internalKeys.length > 0 && (await matchesInternalApiKey(token, internalKeys))) {
-      const assertedActingUserId = trustedActingUserId(c.req.header(ACTING_USER_HEADER))
+      const actingUserHeader = c.req.header(ACTING_USER_HEADER)
+      const assertedActingUserId = trustedActingUserId(actingUserHeader)
+      if (actingUserHeader !== undefined && !assertedActingUserId) {
+        return c.json({ error: "Invalid acting user" }, 401)
+      }
+      const cloudDeploymentId = c.env.VOYANT_CLOUD_DEPLOYMENT_ID?.trim()
+      if (assertedActingUserId && !cloudDeploymentId) {
+        return c.json({ error: "Invalid acting user" }, 401)
+      }
       const lease = assertedActingUserId ? acquireRequestDb(c, dbFactory) : undefined
       try {
         let actingUserId: string | undefined
@@ -265,6 +273,7 @@ export function requireAuth<TBindings extends VoyantBindings>(
             .where(
               and(
                 eq(cloudAuthUserLinks.providerId, "voyant-cloud"),
+                eq(cloudAuthUserLinks.deploymentId, cloudDeploymentId as string),
                 isNull(cloudAuthUserLinks.revokedAt),
                 or(
                   eq(cloudAuthUserLinks.providerAccountId, assertedActingUserId),

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -1,8 +1,8 @@
 import type { Actor, VoyantAuthContext } from "@voyant-travel/core"
-import { apikeyTable, type SelectApikey } from "@voyant-travel/db/schema/iam"
+import { apikeyTable, cloudAuthUserLinks, type SelectApikey } from "@voyant-travel/db/schema/iam"
 import { API_KEY_AUDIENCES, permissionsToStrings } from "@voyant-travel/types/api-keys"
 import type { KVStore } from "@voyant-travel/utils/cache"
-import { and, eq, sql } from "drizzle-orm"
+import { and, eq, isNull, or, sql } from "drizzle-orm"
 import type { MiddlewareHandler } from "hono"
 
 import { constantTimeEqual, sha256Base64Url, sha256Hex } from "../auth/crypto.js"
@@ -254,15 +254,42 @@ export function requireAuth<TBindings extends VoyantBindings>(
     // Strategy 1: Internal API Key
     const internalKeys = parseInternalApiKeys(c.env.INTERNAL_API_KEY)
     if (token && internalKeys.length > 0 && (await matchesInternalApiKey(token, internalKeys))) {
-      const actingUserId = trustedActingUserId(c.req.header(ACTING_USER_HEADER))
-      applyAuthContext(c, {
-        ...(actingUserId ? { userId: actingUserId, principalSubtype: "max" } : {}),
-        callerType: "internal",
-        isInternalRequest: true,
-        actor: "staff",
-        scopes: parseInternalApiKeyScopes(c.env.INTERNAL_API_KEY_SCOPES),
-      })
-      return next()
+      const assertedActingUserId = trustedActingUserId(c.req.header(ACTING_USER_HEADER))
+      const lease = assertedActingUserId ? acquireRequestDb(c, dbFactory) : undefined
+      try {
+        let actingUserId: string | undefined
+        if (assertedActingUserId && lease) {
+          const [link] = await lease.db
+            .select({ userId: cloudAuthUserLinks.userId })
+            .from(cloudAuthUserLinks)
+            .where(
+              and(
+                eq(cloudAuthUserLinks.providerId, "voyant-cloud"),
+                isNull(cloudAuthUserLinks.revokedAt),
+                or(
+                  eq(cloudAuthUserLinks.providerAccountId, assertedActingUserId),
+                  eq(cloudAuthUserLinks.userId, assertedActingUserId),
+                ),
+              ),
+            )
+            .limit(1)
+          actingUserId = link?.userId
+          if (!actingUserId) {
+            return c.json({ error: "Invalid acting user" }, 401)
+          }
+        }
+
+        applyAuthContext(c, {
+          ...(actingUserId ? { userId: actingUserId, principalSubtype: "max" } : {}),
+          callerType: "internal",
+          isInternalRequest: true,
+          actor: "staff",
+          scopes: parseInternalApiKeyScopes(c.env.INTERNAL_API_KEY_SCOPES),
+        })
+        return await next()
+      } finally {
+        await lease?.release()
+      }
     }
 
     // Strategy 2: Core-owned API key support (voy_ prefixed)

--- a/packages/hono/src/middleware/auth.ts
+++ b/packages/hono/src/middleware/auth.ts
@@ -22,6 +22,14 @@ import {
 import { acquireRequestDb } from "./request-db.js"
 
 const API_KEY_PREFIX = "voy_"
+const ACTING_USER_HEADER = "x-voyant-acting-user-id"
+const ACTING_USER_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9:_-]{0,199}$/
+
+/** Read acting identity only after the request has matched a trusted internal key. */
+function trustedActingUserId(header: string | undefined): string | undefined {
+  const value = header?.trim()
+  return value && ACTING_USER_ID_PATTERN.test(value) ? value : undefined
+}
 
 /**
  * Parse `INTERNAL_API_KEY` as one-or-more comma-separated values, so the
@@ -172,6 +180,7 @@ function applyAuthContext(
   if (auth.isInternalRequest !== undefined) c.set("isInternalRequest", auth.isInternalRequest)
   if (auth.apiTokenId) c.set("apiTokenId", auth.apiTokenId)
   if (auth.apiKeyId) c.set("apiKeyId", auth.apiKeyId)
+  if (auth.principalSubtype) c.set("principalSubtype", auth.principalSubtype)
   if (auth.appId) c.set("appId", auth.appId)
   if (auth.appInstallationId) c.set("appInstallationId", auth.appInstallationId)
   if (auth.appReleaseId) c.set("appReleaseId", auth.appReleaseId)
@@ -245,7 +254,9 @@ export function requireAuth<TBindings extends VoyantBindings>(
     // Strategy 1: Internal API Key
     const internalKeys = parseInternalApiKeys(c.env.INTERNAL_API_KEY)
     if (token && internalKeys.length > 0 && (await matchesInternalApiKey(token, internalKeys))) {
+      const actingUserId = trustedActingUserId(c.req.header(ACTING_USER_HEADER))
       applyAuthContext(c, {
+        ...(actingUserId ? { userId: actingUserId, principalSubtype: "max" } : {}),
         callerType: "internal",
         isInternalRequest: true,
         actor: "staff",

--- a/packages/hono/src/middleware/require-permission.ts
+++ b/packages/hono/src/middleware/require-permission.ts
@@ -40,6 +40,14 @@ export function requirePermission<TBindings extends VoyantBindings>(
       return next()
     }
 
+    // An internal credential's configured scopes are a hard authorization
+    // ceiling. An asserted acting user supplies attribution and delegated
+    // identity; it must never turn a denied machine scope into a user-session
+    // permission fallback.
+    if (c.get("isInternalRequest")) {
+      throw new ForbiddenApiError()
+    }
+
     const userId = requireUserId(c)
     const actor = c.get("actor") as Actor | undefined
     if (!actor) {

--- a/packages/hono/src/types.ts
+++ b/packages/hono/src/types.ts
@@ -30,6 +30,7 @@ export interface VoyantExecutionContext {
 export interface VoyantBindings {
   INTERNAL_API_KEY?: string
   INTERNAL_API_KEY_SCOPES?: string
+  VOYANT_CLOUD_DEPLOYMENT_ID?: string
   SESSION_CLAIMS_ADMIN_SECRET?: string
   SESSION_CLAIMS_CUSTOMER_SECRET?: string
   BETTER_AUTH_ADMIN_SECRET?: string

--- a/packages/hono/tests/unit/auth-middleware.test.ts
+++ b/packages/hono/tests/unit/auth-middleware.test.ts
@@ -310,6 +310,77 @@ describe("requireAuth API keys", () => {
     })
   })
 
+  it("accepts Max acting-user attribution only with the trusted internal key", async () => {
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => ({}) as never),
+    )
+    app.get("/secure", (c) =>
+      c.json({
+        callerType: c.get("callerType"),
+        userId: c.get("userId"),
+        principalSubtype: c.get("principalSubtype"),
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure", {
+        headers: {
+          Authorization: "Bearer managed-max-key",
+          "x-voyant-acting-user-id": "user_01KQ9J3M7KE6FNHQPYJJ7VYBF1",
+        },
+      }),
+      { ...TEST_ENV, INTERNAL_API_KEY: "managed-max-key" },
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      callerType: "internal",
+      userId: "user_01KQ9J3M7KE6FNHQPYJJ7VYBF1",
+      principalSubtype: "max",
+    })
+  })
+
+  it("ignores acting-user attribution on an ordinary API key", async () => {
+    const token = "voy_test_api_key"
+    const row = makeApiKeyRow({
+      key: await sha256Base64Url(token),
+      referenceId: "organization_123",
+    })
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => makeApiKeyDb(row)),
+    )
+    app.get("/secure", (c) =>
+      c.json({
+        callerType: c.get("callerType"),
+        userId: c.get("userId") ?? null,
+        principalSubtype: c.get("principalSubtype") ?? null,
+      }),
+    )
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure", {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "x-voyant-acting-user-id": "user_spoofed",
+        },
+      }),
+      TEST_ENV,
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      callerType: "api_key",
+      userId: null,
+      principalSubtype: null,
+    })
+  })
+
   it("defaults a custom resolver audience to its authenticated actor", async () => {
     const app = new Hono()
     app.use(

--- a/packages/hono/tests/unit/auth-middleware.test.ts
+++ b/packages/hono/tests/unit/auth-middleware.test.ts
@@ -314,7 +314,7 @@ describe("requireAuth API keys", () => {
     const app = new Hono()
     app.use(
       "*",
-      requireAuth(() => ({}) as never),
+      requireAuth(() => makeCloudActorDb("local_auth_user_123")),
     )
     app.get("/secure", (c) =>
       c.json({
@@ -338,9 +338,32 @@ describe("requireAuth API keys", () => {
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
       callerType: "internal",
-      userId: "user_01KQ9J3M7KE6FNHQPYJJ7VYBF1",
+      userId: "local_auth_user_123",
       principalSubtype: "max",
     })
+  })
+
+  it("rejects a trusted acting-user assertion with no active local mirror link", async () => {
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => makeCloudActorDb(null)),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure", {
+        headers: {
+          Authorization: "Bearer managed-max-key",
+          "x-voyant-acting-user-id": "user_unknown",
+        },
+      }),
+      { ...TEST_ENV, INTERNAL_API_KEY: "managed-max-key" },
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "Invalid acting user" })
   })
 
   it("ignores acting-user attribution on an ordinary API key", async () => {
@@ -608,6 +631,18 @@ function makeApiKeyDb(row: Record<string, unknown>) {
     update: () => ({
       set: () => ({
         where: async () => {},
+      }),
+    }),
+  } as never
+}
+
+function makeCloudActorDb(userId: string | null) {
+  return {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => (userId ? [{ userId }] : []),
+        }),
       }),
     }),
   } as never

--- a/packages/hono/tests/unit/auth-middleware.test.ts
+++ b/packages/hono/tests/unit/auth-middleware.test.ts
@@ -331,7 +331,11 @@ describe("requireAuth API keys", () => {
           "x-voyant-acting-user-id": "user_01KQ9J3M7KE6FNHQPYJJ7VYBF1",
         },
       }),
-      { ...TEST_ENV, INTERNAL_API_KEY: "managed-max-key" },
+      {
+        ...TEST_ENV,
+        INTERNAL_API_KEY: "managed-max-key",
+        VOYANT_CLOUD_DEPLOYMENT_ID: "deployment_current",
+      },
       mockExecutionCtx(),
     )
 
@@ -356,6 +360,64 @@ describe("requireAuth API keys", () => {
         headers: {
           Authorization: "Bearer managed-max-key",
           "x-voyant-acting-user-id": "user_unknown",
+        },
+      }),
+      {
+        ...TEST_ENV,
+        INTERNAL_API_KEY: "managed-max-key",
+        VOYANT_CLOUD_DEPLOYMENT_ID: "deployment_current",
+      },
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "Invalid acting user" })
+  })
+
+  it.each([
+    "",
+    "user!invalid",
+    `user_${"x".repeat(200)}`,
+  ])("rejects a malformed trusted acting-user assertion (%j)", async (assertion) => {
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => makeCloudActorDb("local_auth_user_123")),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure", {
+        headers: {
+          Authorization: "Bearer managed-max-key",
+          "x-voyant-acting-user-id": assertion,
+        },
+      }),
+      {
+        ...TEST_ENV,
+        INTERNAL_API_KEY: "managed-max-key",
+        VOYANT_CLOUD_DEPLOYMENT_ID: "deployment_current",
+      },
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(401)
+    expect(await response.json()).toEqual({ error: "Invalid acting user" })
+  })
+
+  it("rejects acting-user attribution when the active deployment is unavailable", async () => {
+    const app = new Hono()
+    app.use(
+      "*",
+      requireAuth(() => makeCloudActorDb("local_auth_user_123")),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure", {
+        headers: {
+          Authorization: "Bearer managed-max-key",
+          "x-voyant-acting-user-id": "user_01KQ9J3M7KE6FNHQPYJJ7VYBF1",
         },
       }),
       { ...TEST_ENV, INTERNAL_API_KEY: "managed-max-key" },

--- a/packages/hono/tests/unit/require-permission.test.ts
+++ b/packages/hono/tests/unit/require-permission.test.ts
@@ -143,6 +143,44 @@ describe("requirePermission", () => {
     expect(hasPermission).not.toHaveBeenCalled()
   })
 
+  it("does not let an asserted internal actor exceed the machine scope cap", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {})
+    const hasPermission = vi.fn().mockResolvedValue(true)
+
+    const app = new Hono()
+    app.onError(handleApiError)
+    app.use("*", requestId)
+    app.use("*", async (c, next) => {
+      c.set("callerType", "internal")
+      c.set("isInternalRequest", true)
+      c.set("userId", "user_privileged")
+      c.set("principalSubtype", "max")
+      c.set("actor", "staff")
+      c.set("scopes", ["crm:read"])
+      await next()
+    })
+    app.use(
+      "*",
+      requirePermission(() => ({}) as never, "crm", "write", {
+        auth: { hasPermission },
+      }),
+    )
+    app.get("/secure", (c) => c.json({ ok: true }))
+
+    const response = await app.fetch(
+      new Request("http://example.com/secure"),
+      {},
+      mockExecutionCtx(),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({
+      error: "Forbidden",
+      code: "forbidden",
+    })
+    expect(hasPermission).not.toHaveBeenCalled()
+  })
+
   it("returns 401 when userId is set but actor is not (upstream wiring bug)", async () => {
     // `requirePermission` runs after `requireActor`. If actor is missing here,
     // it means the auth pipeline silently let an unresolved request through —


### PR DESCRIPTION
## Summary

- honor `x-voyant-acting-user-id` only after the request matches the configured internal managed credential
- expose the approving staff user as `userId` so MCP-created records receive `createdBy` / `updatedBy`
- retain `principalSubtype: max` for action-ledger provenance
- ignore the header for ordinary `voy_*` API keys and other auth strategies
- publish patch changesets for `@voyant-travel/core` and `@voyant-travel/hono`

OSS/framework half of voyant-travel/platform#1450. The platform transport half is voyant-travel/platform#1484.

## Verification

- focused remote Hono auth suite: 21 tests passed
- Biome check passed for all touched TypeScript files
- independent high-effort security/trust-boundary review: no actionable findings