### PR TITLE
fix(inventory): keep base itinerary day locale authoritative

### DIFF
--- a/.changeset/tidy-days-localize.md
+++ b/.changeset/tidy-days-localize.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/inventory": patch
+---
+
+Keep edited base itinerary-day content authoritative for a product's default
+language instead of allowing stale or unrelated translation rows to shadow it.

--- a/packages/inventory/src/service-content-owned.ts
+++ b/packages/inventory/src/service-content-owned.ts
@@ -476,12 +476,23 @@ function pickBestDayTranslation(
   base: Pick<typeof productDays.$inferSelect, "title" | "description" | "location">,
   defaultLanguageTag: string | null | undefined,
 ) {
-  const translations: DayTrnCandidate[] = rows.map((r) => ({
-    locale: r.languageTag,
-    title: r.title,
-    description: r.description,
-    location: r.location,
-  }))
+  const normalizedDefaultLanguageTag = defaultLanguageTag?.trim().toLowerCase()
+  const translations: DayTrnCandidate[] = rows
+    // BCP-47 tags are case-insensitive. Drop every spelling of the declared
+    // default locale so an exact-scored stale translation cannot outrank the
+    // authoritative base candidate solely because its casing matches the
+    // request more closely.
+    .filter(
+      (r) =>
+        !normalizedDefaultLanguageTag ||
+        r.languageTag.trim().toLowerCase() !== normalizedDefaultLanguageTag,
+    )
+    .map((r) => ({
+      locale: r.languageTag,
+      title: r.title,
+      description: r.description,
+      location: r.location,
+    }))
 
   if (defaultLanguageTag) {
     // Base day columns are the source of truth for the product's declared

--- a/packages/inventory/src/service-content-owned.ts
+++ b/packages/inventory/src/service-content-owned.ts
@@ -249,6 +249,8 @@ export async function buildOwnedProductContent(
       const bestDayTrn = pickBestDayTranslation(
         dayTranslationsByDay.get(d.id) ?? [],
         options.preferredLocales,
+        d,
+        productRow.defaultLanguageTag,
       )
       const services = (dayServicesByDay.get(d.id) ?? []).map(
         (service: typeof productDayServices.$inferSelect) => {
@@ -471,15 +473,40 @@ function pickBestOptionTranslation(
 function pickBestDayTranslation(
   rows: ReadonlyArray<typeof productDayTranslations.$inferSelect>,
   preferred: ReadonlyArray<string>,
+  base: Pick<typeof productDays.$inferSelect, "title" | "description" | "location">,
+  defaultLanguageTag: string | null | undefined,
 ) {
-  if (rows.length === 0) return null
-  const candidates: DayTrnCandidate[] = rows.map((r) => ({
+  const translations: DayTrnCandidate[] = rows.map((r) => ({
     locale: r.languageTag,
     title: r.title,
     description: r.description,
     location: r.location,
   }))
-  return pickBestCachedLocale(candidates, preferred)
+
+  if (defaultLanguageTag) {
+    // Base day columns are the source of truth for the product's declared
+    // default language. Put that candidate first so a stale legacy
+    // default-language translation row cannot shadow a successful base edit.
+    return pickBestCachedLocale(
+      [
+        {
+          locale: defaultLanguageTag,
+          title: base.title,
+          description: base.description,
+          location: base.location,
+        },
+        ...translations,
+      ],
+      preferred,
+    )
+  }
+
+  const resolved = pickBestCachedLocale(translations, preferred)
+  // Older products may not declare their base language. In that case an
+  // unrelated translation is not a safer fallback than the base columns.
+  return resolved?.match_kind === "exact" || resolved?.match_kind === "language_match"
+    ? resolved
+    : null
 }
 
 function pickBestDayServiceTranslation(

--- a/packages/inventory/tests/unit/service-content-owned.test.ts
+++ b/packages/inventory/tests/unit/service-content-owned.test.ts
@@ -147,7 +147,7 @@ describe("buildOwnedProductContent", () => {
               name: "Tur de baza",
               status: "active",
               description: "Descriere produs",
-              defaultLanguageTag: "ro-RO",
+              defaultLanguageTag: "ro-ro",
               inclusionsHtml: null,
               exclusionsHtml: null,
               termsHtml: null,
@@ -194,6 +194,8 @@ describe("buildOwnedProductContent", () => {
           [
             {
               dayId: "day_1",
+              // Same BCP-47 locale with request-matching case. This stale row
+              // must not outrank the authoritative base day.
               languageTag: "ro-RO",
               title: "Titlu romanesc vechi",
               description: "Descriere romaneasca veche",

--- a/packages/inventory/tests/unit/service-content-owned.test.ts
+++ b/packages/inventory/tests/unit/service-content-owned.test.ts
@@ -136,6 +136,102 @@ describe("buildOwnedProductContent", () => {
     ])
   })
 
+  it("keeps base day content authoritative for the product default language", async () => {
+    const db = fakeDb(
+      new Map<unknown, unknown[]>([
+        [
+          products,
+          [
+            {
+              id: "prod_1",
+              name: "Tur de baza",
+              status: "active",
+              description: "Descriere produs",
+              defaultLanguageTag: "ro-RO",
+              inclusionsHtml: null,
+              exclusionsHtml: null,
+              termsHtml: null,
+              contractTemplateId: null,
+              startDate: null,
+              endDate: null,
+              sellCurrency: "EUR",
+              supplierId: null,
+              tags: [],
+            },
+          ],
+        ],
+        [productOptions, []],
+        [productOptionTranslations, []],
+        [productMedia, []],
+        [productTranslations, []],
+        [
+          productItineraries,
+          [
+            {
+              id: "itin_1",
+              productId: "prod_1",
+              name: "Default",
+              isDefault: true,
+              sortOrder: 0,
+            },
+          ],
+        ],
+        [
+          productDays,
+          [
+            {
+              id: "day_1",
+              itineraryId: "itin_1",
+              dayNumber: 1,
+              title: "Titlu romanesc actualizat",
+              description: "Descriere romaneasca actualizata",
+              location: "Brasov",
+            },
+          ],
+        ],
+        [
+          productDayTranslations,
+          [
+            {
+              dayId: "day_1",
+              languageTag: "ro-RO",
+              title: "Titlu romanesc vechi",
+              description: "Descriere romaneasca veche",
+              location: "Locatie veche",
+            },
+            {
+              dayId: "day_1",
+              languageTag: "en-GB",
+              title: "English title",
+              description: "English description",
+              location: "English location",
+            },
+          ],
+        ],
+        [productDayServices, []],
+        [productDayServiceTranslations, []],
+      ]),
+    )
+
+    const romanian = await buildOwnedProductContent(db, "prod_1", {
+      preferredLocales: ["ro-RO"],
+    })
+    expect(romanian?.content.days[0]).toMatchObject({
+      title: "Titlu romanesc actualizat",
+      description: "Descriere romaneasca actualizata",
+      location: "Brasov",
+    })
+
+    const english = await buildOwnedProductContent(db, "prod_1", {
+      preferredLocales: ["en-GB", "ro-RO"],
+    })
+    expect(english?.content.days[0]).toMatchObject({
+      title: "English title",
+      description: "English description",
+      location: "English location",
+    })
+  })
+
   it("resolves localized SEO fallbacks and an explicit Open Graph image", async () => {
     const db = fakeDb(
       new Map<unknown, unknown[]>([


### PR DESCRIPTION
## Summary

- make base itinerary-day columns authoritative for a product's declared default language
- prevent stale default-language or unrelated translation rows from shadowing successful base edits
- preserve explicit non-default translations for matching locale requests
- add an OSS inventory changeset and focused locale regressions

Addresses voyant-travel/platform#971 and contributes to voyant-travel/platform#1508.

## Validation

- focused `service-content-owned` suite: 3/3 passed remotely
- scoped Biome: passed remotely
- `git diff --check`: passed
- inventory package typecheck: attempted remotely, runner exhausted its 2 GB heap; GitHub CI is the authoritative full type gate