### PR TITLE
fix distribution reconciliation timestamp parameters

### DIFF
--- a/.changeset/fix-channel-push-date-params.md
+++ b/.changeset/fix-channel-push-date-params.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/distribution": patch
+---
+
+Encode channel-push reconciliation timestamps before they reach database drivers.

--- a/packages/distribution/src/channel-push/boundary-sql.ts
+++ b/packages/distribution/src/channel-push/boundary-sql.ts
@@ -95,7 +95,7 @@ export async function loadRecentlyUpdatedAvailabilityPushSlots(
     sql`
       SELECT id, product_id, option_id, starts_at, unlimited, remaining_pax, updated_at
       FROM availability_slots
-      WHERE updated_at > ${input.updatedAfter}
+      WHERE updated_at > ${input.updatedAfter.toISOString()}
       ORDER BY updated_at ASC
       LIMIT ${input.limit}
     `,

--- a/packages/distribution/src/channel-push/reconciler.ts
+++ b/packages/distribution/src/channel-push/reconciler.ts
@@ -20,7 +20,7 @@
  * Per docs/architecture/channel-push-architecture.md §13.
  */
 
-import { and, asc, eq, inArray, sql } from "drizzle-orm"
+import { and, asc, eq, inArray, isNull, lt, ne, or } from "drizzle-orm"
 
 import {
   channelBookingLinks,
@@ -77,11 +77,9 @@ export async function reconcileBookingLinks(
     .from(channelBookingLinks)
     .where(
       and(
-        // agent-quality: raw-sql reviewed -- owner: distribution; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-        sql`${channelBookingLinks.pushStatus} <> 'ok'`,
-        // agent-quality: raw-sql reviewed -- owner: distribution; dynamic SQL interpolation uses Drizzle parameter binding or vetted SQL identifiers.
-        sql`(${channelBookingLinks.lastPushAt} IS NULL OR ${channelBookingLinks.lastPushAt} < ${staleAfter})`,
-        options.channelId ? eq(channelBookingLinks.channelId, options.channelId) : sql`true`,
+        ne(channelBookingLinks.pushStatus, "ok"),
+        or(isNull(channelBookingLinks.lastPushAt), lt(channelBookingLinks.lastPushAt, staleAfter)),
+        options.channelId ? eq(channelBookingLinks.channelId, options.channelId) : undefined,
       ),
     )
     .orderBy(asc(channelBookingLinks.lastPushAt))
@@ -161,7 +159,7 @@ export async function reconcileAvailability(
         eq(channelProductMappings.active, true),
         eq(channelProductMappings.pushAvailability, true),
         eq(channels.status, "active"),
-        options.channelId ? eq(channelInventoryAllotments.channelId, options.channelId) : sql`true`,
+        options.channelId ? eq(channelInventoryAllotments.channelId, options.channelId) : undefined,
       ),
     )) as Array<{
     allotment: typeof channelInventoryAllotments.$inferSelect
@@ -219,7 +217,7 @@ export async function reconcileContent(
         eq(channelProductMappings.active, true),
         eq(channelProductMappings.pushContent, true),
         eq(channels.status, "active"),
-        options.channelId ? eq(channelProductMappings.channelId, options.channelId) : sql`true`,
+        options.channelId ? eq(channelProductMappings.channelId, options.channelId) : undefined,
       ),
     )
     .limit(limit)) as Array<{

--- a/packages/distribution/tests/unit/channel-push-query-parameters.test.ts
+++ b/packages/distribution/tests/unit/channel-push-query-parameters.test.ts
@@ -1,0 +1,56 @@
+import { PgDialect } from "drizzle-orm/pg-core"
+import { describe, expect, it, vi } from "vitest"
+
+import { loadRecentlyUpdatedAvailabilityPushSlots } from "../../src/channel-push/boundary-sql.js"
+import { reconcileBookingLinks } from "../../src/channel-push/reconciler.js"
+
+const dialect = new PgDialect()
+
+describe("channel-push query parameters", () => {
+  it("encodes the booking reconciliation timestamp before it reaches the driver", async () => {
+    let whereSql: unknown
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn((value: unknown) => {
+            whereSql = value
+            return {
+              orderBy: vi.fn(() => ({
+                limit: vi.fn(async () => []),
+              })),
+            }
+          }),
+        })),
+      })),
+    }
+
+    await reconcileBookingLinks({ staleAfterMs: 0 }, {
+      db,
+      registry: { resolveByConnection: () => undefined },
+    } as never)
+
+    const query = dialect.sqlToQuery(whereSql as never)
+    expect(query.params).toHaveLength(2)
+    expect(query.params[0]).toBe("ok")
+    expect(typeof query.params[1]).toBe("string")
+    expect(() => new Date(query.params[1] as string).toISOString()).not.toThrow()
+  })
+
+  it("encodes the availability cursor before it reaches the driver", async () => {
+    const updatedAfter = new Date("2026-07-29T03:45:47.000Z")
+    let params: unknown[] = []
+    const db = {
+      execute: vi.fn(async (query) => {
+        params = dialect.sqlToQuery(query).params
+        return []
+      }),
+    }
+
+    await loadRecentlyUpdatedAvailabilityPushSlots(db as never, {
+      updatedAfter,
+      limit: 500,
+    })
+
+    expect(params).toEqual([updatedAfter.toISOString(), 500])
+  })
+})


### PR DESCRIPTION
## What changed

- replace the booking-link reconciler's untyped raw timestamp comparison with typed Drizzle predicates
- encode the availability reconciler's raw SQL cursor as ISO-8601
- add regression tests asserting database-driver parameters are strings rather than JavaScript `Date` objects
- publish a patch changeset for `@voyant-travel/distribution`

## Root cause

The managed Node/Postgres driver cannot serialize a raw `Date` interpolated into an untyped Drizzle SQL fragment. Both affected jobs failed before processing any rows with `ERR_INVALID_ARG_TYPE`.

## Impact

Restores `channel.booking.push`, `distribution.channel-push-reconcile-booking-links`, and `distribution.channel-push-reconcile-availability` on Node deployments without changing the provider-neutral job or outbox contracts.

## Validation

- focused regression suite: 2 tests passed
- read-only execution of both patched query paths against Pro Travel's live Neon database: passed
- package typecheck attempted remotely; TypeScript exceeded 6 GB heap before producing diagnostics, so CI remains the full typecheck gate
