### PR TITLE
fix(db): let idle Postgres computes suspend

### DIFF
--- a/.changeset/calm-databases-sleep.md
+++ b/.changeset/calm-databases-sleep.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/db": patch
+---
+
+Close idle postgres-js connections after 30 seconds by default so resident application processes do not prevent serverless Postgres computes from suspending. Applications that deliberately need permanent idle sockets can disable or override the timeout through `nodeIdleTimeoutSeconds`.

--- a/packages/db/src/connection-config.ts
+++ b/packages/db/src/connection-config.ts
@@ -42,6 +42,13 @@ export const DEFAULT_DB_TIMEOUTS = {
 } as const
 
 /**
+ * Close idle postgres-js sockets well before a typical serverless Postgres
+ * suspend window. Resident application processes must not keep an otherwise
+ * idle database compute awake indefinitely.
+ */
+export const DEFAULT_NODE_IDLE_TIMEOUT_SECONDS = 30
+
+/**
  * Build the `PoolConfig` for the `serverless` adapter (Neon WebSocket Pool).
  *
  * Defaults are applied first and caller-supplied `pool` values spread after,
@@ -87,6 +94,8 @@ export function resolveServerlessPoolConfig(
  */
 export interface NodePostgresOptions {
   max?: number
+  /** Seconds before postgres-js closes an idle socket. */
+  idle_timeout?: number
   /** Connection-establishment timeout in SECONDS (postgres-js convention). */
   connect_timeout?: number
   /** Startup parameters sent to Postgres; `statement_timeout` is in ms. */
@@ -98,18 +107,25 @@ export interface NodePostgresOptions {
  *
  * - `statementMs` → `connection.statement_timeout` (ms, server-side).
  * - `connectMs` → `connect_timeout` (postgres-js takes seconds; rounded up).
+ * - `idleSeconds` → `idle_timeout` (defaults to 30 seconds; `false` disables it).
  * - `queryMs` is ignored — postgres-js has no client-side per-query timeout.
  */
 export function resolveNodePostgresOptions(options?: {
   max?: number
+  idleSeconds?: number | false
   timeouts?: DbTimeoutOptions
 }): NodePostgresOptions {
   const statementMs = options?.timeouts?.statementMs ?? DEFAULT_DB_TIMEOUTS.statementMs
   const connectMs = options?.timeouts?.connectMs ?? DEFAULT_DB_TIMEOUTS.connectMs
 
   const config: NodePostgresOptions = {}
+  const idleSeconds =
+    options?.idleSeconds === undefined ? DEFAULT_NODE_IDLE_TIMEOUT_SECONDS : options.idleSeconds
   if (options?.max !== undefined) {
     config.max = options.max
+  }
+  if (idleSeconds !== false) {
+    config.idle_timeout = idleSeconds
   }
   if (connectMs !== false) {
     config.connect_timeout = Math.ceil(connectMs / 1000)

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -28,6 +28,8 @@ export interface DbClientOptions<TSchema extends Record<string, unknown> = Recor
   adapter?: DbAdapter
   replicas?: string[]
   nodeMaxConnections?: number
+  /** Seconds before an idle Node/postgres-js socket closes. Default: 30. */
+  nodeIdleTimeoutSeconds?: number | false
   serverlessPool?: Omit<PoolConfig, "connectionString">
   /**
    * Query/connection timeouts (ms) applied per adapter. Defaults:
@@ -90,11 +92,16 @@ export function createDbClient<TSchema extends Record<string, unknown> = Record<
     schema,
     replicas = [],
     nodeMaxConnections,
+    nodeIdleTimeoutSeconds,
     timeouts,
   } = options || {}
 
   if (adapter === "node") {
-    const nodeOptions = resolveNodePostgresOptions({ max: nodeMaxConnections, timeouts })
+    const nodeOptions = resolveNodePostgresOptions({
+      max: nodeMaxConnections,
+      idleSeconds: nodeIdleTimeoutSeconds,
+      timeouts,
+    })
     const client = postgres(connectionString, nodeOptions)
     const primary = tagTransactionCapability(
       schema ? drizzlePostgres(client, { schema }) : drizzlePostgres(client),

--- a/packages/db/tests/unit/connection-config.test.ts
+++ b/packages/db/tests/unit/connection-config.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   DEFAULT_DB_TIMEOUTS,
+  DEFAULT_NODE_IDLE_TIMEOUT_SECONDS,
   isNeonConnectionString,
   isPooledNeonConnectionString,
   resolveNodePostgresOptions,
@@ -83,6 +84,7 @@ describe("resolveNodePostgresOptions", () => {
 
     expect(config).toEqual({
       connect_timeout: 10,
+      idle_timeout: DEFAULT_NODE_IDLE_TIMEOUT_SECONDS,
       connection: { statement_timeout: 10_000 },
     })
   })
@@ -96,6 +98,12 @@ describe("resolveNodePostgresOptions", () => {
   it("passes max connections through when provided", () => {
     expect(resolveNodePostgresOptions({ max: 7 }).max).toBe(7)
     expect("max" in resolveNodePostgresOptions()).toBe(false)
+  })
+
+  it("closes idle resident sockets by default and allows an explicit override", () => {
+    expect(resolveNodePostgresOptions().idle_timeout).toBe(30)
+    expect(resolveNodePostgresOptions({ idleSeconds: 90 }).idle_timeout).toBe(90)
+    expect("idle_timeout" in resolveNodePostgresOptions({ idleSeconds: false })).toBe(false)
   })
 
   it("lets the timeouts option override defaults", () => {
@@ -112,7 +120,7 @@ describe("resolveNodePostgresOptions", () => {
       timeouts: { statementMs: false, connectMs: false },
     })
 
-    expect(config).toEqual({})
+    expect(config).toEqual({ idle_timeout: DEFAULT_NODE_IDLE_TIMEOUT_SECONDS })
   })
 })
 


### PR DESCRIPTION
Closes idle postgres-js sockets after 30 seconds by default so resident application processes do not pin serverless Postgres compute awake. The timeout remains configurable or disableable for self-hosters.\n\nValidated remotely:\n- packages/db focused connection-config tests: 18 passed\n- packages/db typecheck: passed\n- Biome formatting checked