### PR TITLE
perf(inventory): extend public catalog shared cache

### DIFF
--- a/.changeset/calm-catalogs-cache.md
+++ b/.changeset/calm-catalogs-cache.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/inventory": patch
+"@voyant-travel/framework": patch
+---
+
+Cache non-personalized public product catalog responses in shared caches for fifteen minutes, keeping repeated storefront browsing off application and database computes while leaving availability, booking, customer, and payment routes untouched. Publish a new Framework runtime coordinate so managed images can roll this cache policy together with the serverless database idle-connection fix.

--- a/packages/inventory/src/routes-public.ts
+++ b/packages/inventory/src/routes-public.ts
@@ -59,12 +59,15 @@ function readModelQuery(query: { languageTag?: string | null; include?: string |
 
 /**
  * Shared edge/CDN policy for the public catalog reads. These endpoints are
- * not personalized (they never read the authenticated identity), so short
- * shared caching keeps storefront list traffic off Worker isolates (#1686).
+ * not personalized (they never read the authenticated identity), so a
+ * fifteen-minute shared TTL keeps catalog browsing off application computes
+ * long enough for serverless databases to suspend between real changes.
+ * Availability, bookings, customer sessions, and payments use separate routes
+ * and are deliberately outside this policy.
  * Applied per-handler on successful responses only — a framework-level
  * cache middleware lives in `@voyant-travel/hono` and supersedes this later.
  */
-const PUBLIC_CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300"
+const PUBLIC_CACHE_CONTROL = "public, s-maxage=900, stale-while-revalidate=3600"
 
 function setPublicCacheHeaders(c: Context) {
   c.header("Cache-Control", PUBLIC_CACHE_CONTROL)

--- a/packages/inventory/tests/unit/routes-public.test.ts
+++ b/packages/inventory/tests/unit/routes-public.test.ts
@@ -21,7 +21,7 @@ import { publicProductsService } from "../../src/service-public.js"
 
 const mockedService = vi.mocked(publicProductsService)
 
-const PUBLIC_CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300"
+const PUBLIC_CACHE_CONTROL = "public, s-maxage=900, stale-while-revalidate=3600"
 
 function emptyList(limit: number, offset = 0) {
   return { data: [], total: 0, limit, offset }


### PR DESCRIPTION
## Summary

- extend the shared-cache TTL for non-personalized public product catalog reads from 60 seconds to 15 minutes
- allow one hour of stale-while-revalidate service during refreshes
- keep availability, bookings, customer sessions, payments, and authenticated routes outside this policy

This is a standard HTTP cache contract rather than a hosting-provider dependency: the managed Cloudflare edge consumes it, while self-hosters on other CDNs receive the same behavior.

## Verification

- focused public inventory contract tests: 3 passed
- Biome check: passed
- package typecheck was attempted remotely; the first 4 GB run exhausted its heap and the 8 GB retry exhausted the retained validation host before completion. The changed route compiled successfully in the focused Vitest transform and repository CI remains the authoritative full graph check.