### PR TITLE
Add opt-in managed-runtime entitlement hooks

### DIFF
--- a/.changeset/clean-zebras-listen.md
+++ b/.changeset/clean-zebras-listen.md
@@ -1,0 +1,6 @@
+---
+"@voyant-travel/operator-standard": patch
+"@voyant-travel/realtime": patch
+---
+
+Make quote-specific Realtime invalidation subscribers follow the Quotes module's standard-distribution lifecycle.

--- a/.changeset/quiet-pandas-count.md
+++ b/.changeset/quiet-pandas-count.md
@@ -1,0 +1,7 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/commerce": patch
+"@voyant-travel/finance": patch
+---
+
+Enforce an optional, concurrency-safe monthly booking allowance at every accepted-booking boundary.

--- a/packages/bookings/migrations/20260729120000_booking_first_acceptance.sql
+++ b/packages/bookings/migrations/20260729120000_booking_first_acceptance.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "bookings" ADD COLUMN "accepted_at" timestamp with time zone;--> statement-breakpoint
+UPDATE "bookings"
+SET "accepted_at" = COALESCE("confirmed_at", "completed_at", "updated_at", "created_at")
+WHERE "accepted_at" IS NULL
+  AND "status" IN ('confirmed', 'in_progress', 'completed');--> statement-breakpoint
+CREATE INDEX "idx_bookings_accepted_at" ON "bookings" USING btree ("accepted_at");

--- a/packages/bookings/migrations/meta/_journal.json
+++ b/packages/bookings/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784192580000,
       "tag": "20260716000300_namespace_custom_field_values",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785326400000,
+      "tag": "20260729120000_booking_first_acceptance",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/bookings/src/booking-create-command-domain.ts
+++ b/packages/bookings/src/booking-create-command-domain.ts
@@ -1,1 +1,2 @@
+export { BookingMonthlyLimitReachedError } from "./booking-plan-limit.js"
 export { BookingItemsUnresolvedError, settleBookingCreateDomain } from "./service-core.js"

--- a/packages/bookings/src/booking-plan-limit.ts
+++ b/packages/bookings/src/booking-plan-limit.ts
@@ -71,7 +71,7 @@ function timestampText(value: string | Date): string {
  * next accepted booking once the configured allowance is exhausted.
  *
  * Callers must invoke this inside the same transaction that accepts the
- * booking. The transaction-scoped advisory lock makes concurrent confirmations
+ * booking. The transaction-scoped advisory lock makes concurrent acceptances
  * observe one another, while `excludeBookingId` makes status repair/replay
  * paths count a booking at most once.
  */
@@ -96,8 +96,8 @@ export async function assertMonthlyBookingLimitAvailable(
       (
         SELECT count(*)::int
         FROM bookings
-        WHERE confirmed_at >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
-          AND confirmed_at < (date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') + interval '1 month') AT TIME ZONE 'UTC'
+        WHERE accepted_at >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+          AND accepted_at < (date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') + interval '1 month') AT TIME ZONE 'UTC'
           AND (${options.excludeBookingId ?? null}::text IS NULL OR id <> ${options.excludeBookingId ?? null})
       ) AS current,
       (date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::text AS period_start,

--- a/packages/bookings/src/booking-plan-limit.ts
+++ b/packages/bookings/src/booking-plan-limit.ts
@@ -1,0 +1,116 @@
+import { sql } from "drizzle-orm"
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
+
+export const VOYANT_BOOKINGS_MONTHLY_LIMIT_BINDING = "VOYANT_BOOKINGS_MONTHLY_LIMIT" as const
+
+export class BookingMonthlyLimitConfigurationError extends Error {
+  readonly code = "invalid_monthly_booking_limit" as const
+
+  constructor(readonly value: unknown) {
+    super(
+      `${VOYANT_BOOKINGS_MONTHLY_LIMIT_BINDING} must be a positive integer when configured; unset it for unlimited bookings.`,
+    )
+    this.name = "BookingMonthlyLimitConfigurationError"
+  }
+}
+
+export interface BookingMonthlyLimitReachedDetails {
+  limit: number
+  current: number
+  periodStart: string
+  periodEnd: string
+}
+
+export class BookingMonthlyLimitReachedError extends Error {
+  readonly code = "monthly_booking_limit_reached" as const
+
+  constructor(readonly details: BookingMonthlyLimitReachedDetails) {
+    super(
+      `This workspace has reached its monthly booking limit (${details.current}/${details.limit}). Upgrade the plan or wait until ${details.periodEnd}.`,
+    )
+    this.name = "BookingMonthlyLimitReachedError"
+  }
+}
+
+/**
+ * Resolve the managed-plan booking allowance. The limit is intentionally
+ * opt-in so self-hosted and older deployments retain unlimited bookings.
+ */
+export function resolveMonthlyBookingLimit(env: Readonly<Record<string, unknown>>): number | null {
+  const raw = env[VOYANT_BOOKINGS_MONTHLY_LIMIT_BINDING]
+  if (raw === undefined || raw === null || raw === "") return null
+
+  const parsed = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : Number.NaN
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new BookingMonthlyLimitConfigurationError(raw)
+  }
+  return parsed
+}
+
+type MonthlyBookingUsageRow = {
+  current: number | string
+  period_start: string | Date
+  period_end: string | Date
+}
+
+function rowsFromResult<TRow>(result: unknown): TRow[] {
+  if (Array.isArray(result)) return result as TRow[]
+  if (result && typeof result === "object" && "rows" in result) {
+    const rows = (result as { rows?: unknown }).rows
+    return Array.isArray(rows) ? (rows as TRow[]) : []
+  }
+  return []
+}
+
+function timestampText(value: string | Date): string {
+  return value instanceof Date ? value.toISOString() : value
+}
+
+/**
+ * Serialize quota consumers in the current tenant database and reject the
+ * next accepted booking once the configured allowance is exhausted.
+ *
+ * Callers must invoke this inside the same transaction that accepts the
+ * booking. The transaction-scoped advisory lock makes concurrent confirmations
+ * observe one another, while `excludeBookingId` makes status repair/replay
+ * paths count a booking at most once.
+ */
+export async function assertMonthlyBookingLimitAvailable(
+  tx: PostgresJsDatabase,
+  limit: number | null | undefined,
+  options: { excludeBookingId?: string | null } = {},
+): Promise<void> {
+  if (limit === undefined || limit === null) return
+  if (!Number.isSafeInteger(limit) || limit <= 0) {
+    throw new BookingMonthlyLimitConfigurationError(limit)
+  }
+
+  // One workload database is one tenant. A stable advisory-lock key therefore
+  // serializes only this tenant's quota-consuming transitions.
+  await tx.execute(
+    sql`SELECT pg_advisory_xact_lock(hashtextextended('voyant:bookings:monthly-limit', 0))`,
+  )
+
+  const result = await tx.execute(sql`
+    SELECT
+      (
+        SELECT count(*)::int
+        FROM bookings
+        WHERE confirmed_at >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'UTC'
+          AND confirmed_at < (date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') + interval '1 month') AT TIME ZONE 'UTC'
+          AND (${options.excludeBookingId ?? null}::text IS NULL OR id <> ${options.excludeBookingId ?? null})
+      ) AS current,
+      (date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') AT TIME ZONE 'UTC')::text AS period_start,
+      ((date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC') + interval '1 month') AT TIME ZONE 'UTC')::text AS period_end
+  `)
+  const usage = rowsFromResult<MonthlyBookingUsageRow>(result)[0]
+  const current = Number(usage?.current ?? 0)
+  if (current < limit) return
+
+  throw new BookingMonthlyLimitReachedError({
+    limit,
+    current,
+    periodStart: timestampText(usage?.period_start ?? new Date()),
+    periodEnd: timestampText(usage?.period_end ?? new Date()),
+  })
+}

--- a/packages/bookings/src/index.ts
+++ b/packages/bookings/src/index.ts
@@ -24,6 +24,14 @@ export {
   BOOKING_STATUS_CAPABILITIES,
   bookingActionLedgerCapabilityRegistry,
 } from "./action-ledger-capabilities.js"
+export {
+  assertMonthlyBookingLimitAvailable,
+  BookingMonthlyLimitConfigurationError,
+  type BookingMonthlyLimitReachedDetails,
+  BookingMonthlyLimitReachedError,
+  resolveMonthlyBookingLimit,
+  VOYANT_BOOKINGS_MONTHLY_LIMIT_BINDING,
+} from "./booking-plan-limit.js"
 export { bookingsSupplierExtension } from "./extensions/suppliers.js"
 export {
   BOOKINGS_EXPIRE_STALE_HOLDS_RUNTIME_KEY,

--- a/packages/bookings/src/route-runtime.ts
+++ b/packages/bookings/src/route-runtime.ts
@@ -2,6 +2,7 @@ import type { CustomFieldRegistryResolver } from "@voyant-travel/core/custom-fie
 import { createKmsProviderFromEnv, type KmsProvider } from "@voyant-travel/utils/kms"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 
+import { resolveMonthlyBookingLimit } from "./booking-plan-limit.js"
 import type { BookingTravelerSnapshot } from "./pii.js"
 import type { KmsBindings } from "./routes-shared.js"
 import type { BookingStatus } from "./state-machine.js"
@@ -127,6 +128,7 @@ export type BookingOverviewItemEnricher = (
 
 export interface BookingRouteRuntime {
   getKmsProvider(): Promise<KmsProvider>
+  monthlyBookingLimit?: number | null
   resolveTravelSnapshot?: ResolveBookingTravelSnapshot
   resolveBillingPerson?: ResolveBookingBillingPerson
   resolveTravelerPerson?: ResolveBookingTravelerPerson
@@ -185,6 +187,7 @@ export function buildBookingRouteRuntime(
   const runtimeEnv = buildRuntimeEnv(bindings)
 
   return {
+    monthlyBookingLimit: resolveMonthlyBookingLimit(runtimeEnv),
     async getKmsProvider() {
       if (options.resolveKmsProvider) {
         return options.resolveKmsProvider(runtimeEnv)

--- a/packages/bookings/src/routes-admin.ts
+++ b/packages/bookings/src/routes-admin.ts
@@ -48,6 +48,7 @@ import {
   BOOKING_PII_READ_CAPABILITY,
   BOOKING_STATUS_CAPABILITIES,
 } from "./action-ledger-capabilities.js"
+import { BookingMonthlyLimitReachedError } from "./booking-plan-limit.js"
 import { createBookingPiiService } from "./pii.js"
 import {
   redactBookingContact,
@@ -729,6 +730,7 @@ function bookingStatusMutationRuntime(
 
   return {
     eventBus: c.get("eventBus"),
+    monthlyBookingLimit: getRouteRuntime(c).monthlyBookingLimit,
     closePaymentSchedulesForBooking: getRouteRuntime(c).closePaymentSchedulesForBooking,
     recordCancellationFinancialSettlement: getRouteRuntime(c).recordCancellationFinancialSettlement,
     actionLedgerContext: getActionLedgerRequestContext(c),
@@ -1725,6 +1727,7 @@ const updateBookingRoute = createRoute({
   },
   responses: {
     200: dataResponse(bookingSchema, "The updated booking"),
+    402: notFoundResponse("Monthly booking plan limit reached"),
     400: invalidRequestResponse,
     404: notFoundResponse("Booking not found"),
   },
@@ -1804,16 +1807,25 @@ coreCrudRoutes
     const data = c.req.valid("json") ?? {}
     await validateBookingBillingPartyReferences(c, data)
     const db = c.get("db")
-    const row =
-      data.customFields !== undefined && getRouteRuntime(c).customFieldsForWrite
-        ? await db.transaction(async (tx) => {
-            await validateBookingCustomFields(c, data, "update", tx)
-            return bookingsService.updateBooking(tx, c.req.valid("param").id, data)
-          })
-        : await (async () => {
-            await validateBookingCustomFields(c, data, "update", db)
-            return bookingsService.updateBooking(db, c.req.valid("param").id, data)
-          })()
+    let row: Awaited<ReturnType<typeof bookingsService.updateBooking>>
+    try {
+      const runtime = { monthlyBookingLimit: getRouteRuntime(c).monthlyBookingLimit }
+      row =
+        data.customFields !== undefined && getRouteRuntime(c).customFieldsForWrite
+          ? await db.transaction(async (tx) => {
+              await validateBookingCustomFields(c, data, "update", tx)
+              return bookingsService.updateBooking(tx, c.req.valid("param").id, data, runtime)
+            })
+          : await (async () => {
+              await validateBookingCustomFields(c, data, "update", db)
+              return bookingsService.updateBooking(db, c.req.valid("param").id, data, runtime)
+            })()
+    } catch (error) {
+      if (error instanceof BookingMonthlyLimitReachedError) {
+        return c.json({ error: error.message }, 402)
+      }
+      throw error
+    }
     if (!row) {
       return c.json({ error: "Booking not found" }, 404)
     }
@@ -2077,6 +2089,7 @@ const confirmRoute = createRoute({
       content: { "application/json": { schema: jsonObject } },
     },
     400: invalidRequestResponse,
+    402: notFoundResponse("Monthly booking plan limit reached"),
     403: notFoundResponse("Forbidden"),
     404: notFoundResponse("Booking not found"),
     409: conflictResponse("Hold expired / invalid transition / approval idempotency conflict"),
@@ -2192,6 +2205,7 @@ const overrideStatusRoute = createRoute({
       content: { "application/json": { schema: jsonObject } },
     },
     400: invalidRequestResponse,
+    402: notFoundResponse("Monthly booking plan limit reached"),
     403: notFoundResponse("Forbidden"),
     404: notFoundResponse("Booking not found"),
     409: conflictResponse("Approval idempotency conflict"),
@@ -2242,6 +2256,9 @@ lifecycleRoutes
         }
         if (result.status === "invalid_transition") {
           return c.json({ error: "Booking is not in an on-hold state" }, 409)
+        }
+        if (result.status === "monthly_booking_limit_reached" && "message" in result) {
+          return c.json({ error: result.message }, 402)
         }
         if ("booking" in result) {
           return c.json({ data: result.booking }, 200)
@@ -2429,6 +2446,9 @@ lifecycleRoutes
         )
         if (result.status === "not_found") {
           return c.json({ error: "Booking not found" }, 404)
+        }
+        if (result.status === "monthly_booking_limit_reached" && "message" in result) {
+          return c.json({ error: result.message }, 402)
         }
         if ("booking" in result) {
           return c.json({ data: result.booking }, 200)

--- a/packages/bookings/src/routes-public.ts
+++ b/packages/bookings/src/routes-public.ts
@@ -289,6 +289,10 @@ const confirmSessionRoute = createRoute({
       description: "Confirmed booking session snapshot",
       content: { "application/json": { schema: z.object({ data: publicBookingSessionSchema }) } },
     },
+    402: {
+      description: "Monthly booking plan limit reached",
+      content: { "application/json": { schema: errorResponseSchema } },
+    },
     404: {
       description: "Booking session not found",
       content: { "application/json": { schema: errorResponseSchema } },
@@ -480,10 +484,18 @@ export const publicBookingRoutes = publicBookingApp
       c.req.valid("param").sessionId,
       c.req.valid("json"),
       c.get("userId"),
+      {
+        eventBus: c.get("eventBus"),
+        monthlyBookingLimit: getRouteRuntime(c).monthlyBookingLimit,
+      },
     )
 
     if (result.status === "not_found") {
       return notFound(c, "Booking session not found")
+    }
+
+    if (result.status === "monthly_booking_limit_reached" && "message" in result) {
+      return c.json({ error: result.message }, 402)
     }
 
     if (!hasSession(result)) {

--- a/packages/bookings/src/routes-shared.ts
+++ b/packages/bookings/src/routes-shared.ts
@@ -3,6 +3,7 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
 import type { Context } from "hono"
 
 export type KmsBindings = Partial<{
+  VOYANT_BOOKINGS_MONTHLY_LIMIT: string
   KMS_PROVIDER: string
   KMS_ENV_KEY: string
   KMS_LOCAL_KEY: string

--- a/packages/bookings/src/schema-core.ts
+++ b/packages/bookings/src/schema-core.ts
@@ -89,6 +89,12 @@ export const bookings = pgTable(
      */
     customFields: jsonb("custom_fields").$type<NamespacedCustomFieldValues>().notNull().default({}),
     holdExpiresAt: timestamp("hold_expires_at", { withTimezone: true }),
+    /**
+     * Immutable, server-controlled timestamp for the booking's first accepted
+     * state. Unlike `confirmedAt`, this is never cleared by later lifecycle
+     * transitions and is therefore safe for plan-usage accounting.
+     */
+    acceptedAt: timestamp("accepted_at", { withTimezone: true }),
     confirmedAt: timestamp("confirmed_at", { withTimezone: true }),
     expiredAt: timestamp("expired_at", { withTimezone: true }),
     cancelledAt: timestamp("cancelled_at", { withTimezone: true }),
@@ -106,6 +112,7 @@ export const bookings = pgTable(
     index("idx_bookings_organization").on(table.organizationId),
     index("idx_bookings_source_type").on(table.sourceType),
     index("idx_bookings_number").on(table.bookingNumber),
+    index("idx_bookings_accepted_at").on(table.acceptedAt),
     // base_currency covers the base_*_amount_cents columns. If any base
     // amount is set, base_currency must be set so downstream FX/reporting
     // code can interpret it. Both null is fine (FX deferred until quote

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -618,6 +618,27 @@ function toTimestamp(value?: string | null) {
   return value ? new Date(value) : null
 }
 
+function isAcceptedBookingStatus(status: BookingStatus) {
+  return status === "confirmed" || status === "in_progress" || status === "completed"
+}
+
+function confirmedAtForStatus(status: BookingStatus, value: Date | null, now = new Date()) {
+  if (status !== "confirmed") return null
+  return value ?? now
+}
+
+function confirmedAtForBookingUpdate(
+  currentStatus: BookingStatus,
+  data: UpdateBookingInput,
+  now = new Date(),
+) {
+  const nextStatus = data.status ?? currentStatus
+  if (nextStatus !== "confirmed") return null
+  if (data.confirmedAt !== undefined)
+    return confirmedAtForStatus(nextStatus, toTimestamp(data.confirmedAt), now)
+  return currentStatus === "confirmed" ? undefined : now
+}
+
 function toDateValue(value: Date | string) {
   return value instanceof Date ? value : new Date(value)
 }
@@ -2480,11 +2501,7 @@ const bookingsServiceInternal = {
     }
 
     const initialStatus = data.initialStatus ?? "draft"
-    if (
-      initialStatus === "confirmed" ||
-      initialStatus === "in_progress" ||
-      initialStatus === "completed"
-    ) {
+    if (isAcceptedBookingStatus(initialStatus)) {
       await assertMonthlyBookingLimitAvailable(db, options.monthlyBookingLimit)
     }
     const bookingPax = Object.hasOwn(data, "pax") ? (data.pax ?? null) : product.pax
@@ -2520,17 +2537,13 @@ const bookingsServiceInternal = {
       .values({
         bookingNumber: data.bookingNumber,
         status: initialStatus,
+        acceptedAt: isAcceptedBookingStatus(initialStatus) ? now : null,
         // Mirror the lifecycle timestamps that overrideBookingStatus
         // stamps when the status transition happens after-the-fact, so
         // a booking that lands in `confirmed` straight from create is
         // indistinguishable downstream from one that was flipped via
         // the verb endpoint.
-        confirmedAt:
-          initialStatus === "confirmed" ||
-          initialStatus === "in_progress" ||
-          initialStatus === "completed"
-            ? now
-            : null,
+        confirmedAt: confirmedAtForStatus(initialStatus, null, now),
         personId: data.personId ?? null,
         organizationId: data.organizationId ?? null,
         // Billing-contact snapshot — captured at create time so the
@@ -2914,27 +2927,21 @@ const bookingsServiceInternal = {
 
     return db.transaction(async (tx) => {
       const rows = await tx.execute(
-        sql`SELECT status, confirmed_at, custom_fields
+        sql`SELECT status, accepted_at, custom_fields
             FROM ${bookings}
             WHERE ${bookings.id} = ${id}
             FOR UPDATE`,
       )
       const existing = toRows<{
         status: BookingStatus
-        confirmed_at: Date | null
+        accepted_at: Date | null
         custom_fields: NamespacedCustomFieldValues
       }>(rows)[0]
 
       if (!existing) return null
 
       const nextStatus = data.status ?? existing.status
-      if (
-        existing.confirmed_at === null &&
-        (nextStatus === "confirmed" ||
-          nextStatus === "in_progress" ||
-          nextStatus === "completed" ||
-          data.confirmedAt != null)
-      ) {
+      if (existing.accepted_at === null && isAcceptedBookingStatus(nextStatus)) {
         await assertMonthlyBookingLimitAvailable(
           tx as PostgresJsDatabase,
           runtime.monthlyBookingLimit,
@@ -2977,6 +2984,8 @@ const bookingsServiceInternal = {
         }
       }
 
+      const now = new Date()
+
       const [row] = await tx
         .update(bookings)
         .set({
@@ -3007,20 +3016,14 @@ const bookingsServiceInternal = {
             data.contactPostalCode === undefined ? undefined : (data.contactPostalCode ?? null),
           holdExpiresAt:
             data.holdExpiresAt === undefined ? undefined : toTimestamp(data.holdExpiresAt),
-          confirmedAt:
-            existing.confirmed_at ??
-            (data.status === "confirmed" ||
-            data.status === "in_progress" ||
-            data.status === "completed"
-              ? (toTimestamp(data.confirmedAt) ?? new Date())
-              : data.confirmedAt !== undefined
-                ? toTimestamp(data.confirmedAt)
-                : undefined),
+          acceptedAt:
+            existing.accepted_at ?? (isAcceptedBookingStatus(nextStatus) ? now : undefined),
+          confirmedAt: confirmedAtForBookingUpdate(existing.status, data, now),
           expiredAt: data.expiredAt === undefined ? undefined : toTimestamp(data.expiredAt),
           cancelledAt: data.cancelledAt === undefined ? undefined : toTimestamp(data.cancelledAt),
           completedAt: data.completedAt === undefined ? undefined : toTimestamp(data.completedAt),
           redeemedAt: data.redeemedAt === undefined ? undefined : toTimestamp(data.redeemedAt),
-          updatedAt: new Date(),
+          updatedAt: now,
         })
         .where(eq(bookings.id, id))
         .returning()
@@ -3052,7 +3055,7 @@ const bookingsServiceInternal = {
     try {
       const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
-          sql`SELECT id, booking_number, status, hold_expires_at
+          sql`SELECT id, booking_number, status, hold_expires_at, accepted_at
               FROM ${bookings}
               WHERE ${bookings.id} = ${id}
               FOR UPDATE`,
@@ -3062,6 +3065,7 @@ const bookingsServiceInternal = {
           booking_number: string
           status: BookingStatus
           hold_expires_at: Date | null
+          accepted_at: Date | null
         }>(rows)[0]
 
         if (!booking) {
@@ -3088,14 +3092,15 @@ const bookingsServiceInternal = {
           { excludeBookingId: id },
         )
 
-        const patch = transitionBooking(booking.status, "confirmed")
+        const now = new Date()
+        const patch = transitionBooking(booking.status, "confirmed", { now })
 
         await tx
           .update(bookingAllocations)
           .set({
             status: "confirmed",
-            confirmedAt: new Date(),
-            updatedAt: new Date(),
+            confirmedAt: now,
+            updatedAt: now,
           })
           .where(and(eq(bookingAllocations.bookingId, id), eq(bookingAllocations.status, "held")))
 
@@ -3110,8 +3115,9 @@ const bookingsServiceInternal = {
           .update(bookings)
           .set({
             ...patch,
+            acceptedAt: booking.accepted_at ?? now,
             holdExpiresAt: null,
-            updatedAt: new Date(),
+            updatedAt: now,
           })
           .where(eq(bookings.id, id))
           .returning()
@@ -3184,7 +3190,7 @@ const bookingsServiceInternal = {
     try {
       const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
-          sql`SELECT id, booking_number, status
+          sql`SELECT id, booking_number, status, accepted_at
               FROM ${bookings}
               WHERE ${bookings.id} = ${id}
               FOR UPDATE`,
@@ -3193,6 +3199,7 @@ const bookingsServiceInternal = {
           id: string
           booking_number: string
           status: BookingStatus
+          accepted_at: Date | null
         }>(rows)[0]
 
         if (!booking) {
@@ -3272,6 +3279,7 @@ const bookingsServiceInternal = {
           .update(bookings)
           .set({
             status: "confirmed",
+            acceptedAt: booking.accepted_at ?? now,
             confirmedAt: now,
             paidAt: now,
             expiredAt: null,
@@ -3933,7 +3941,7 @@ const bookingsServiceInternal = {
     try {
       const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
-          sql`SELECT id, booking_number, status, confirmed_at
+          sql`SELECT id, booking_number, status, accepted_at
               FROM ${bookings}
               WHERE ${bookings.id} = ${id}
               FOR UPDATE`,
@@ -3942,19 +3950,14 @@ const bookingsServiceInternal = {
           id: string
           booking_number: string
           status: BookingStatus
-          confirmed_at: Date | null
+          accepted_at: Date | null
         }>(rows)[0]
 
         if (!booking) {
           throw new BookingServiceError("not_found")
         }
 
-        if (
-          booking.confirmed_at === null &&
-          (data.status === "confirmed" ||
-            data.status === "in_progress" ||
-            data.status === "completed")
-        ) {
+        if (booking.accepted_at === null && isAcceptedBookingStatus(data.status)) {
           await assertMonthlyBookingLimitAvailable(
             tx as PostgresJsDatabase,
             runtime.monthlyBookingLimit,
@@ -3967,12 +3970,9 @@ const bookingsServiceInternal = {
         const terminalAllocationStatus = terminalBookingAllocationStatusForOverride(data.status)
         const updates: Record<string, unknown> = {
           status: data.status,
-          confirmedAt:
-            data.status === "confirmed" ||
-            data.status === "in_progress" ||
-            data.status === "completed"
-              ? (booking.confirmed_at ?? now)
-              : booking.confirmed_at,
+          acceptedAt:
+            booking.accepted_at ?? (isAcceptedBookingStatus(data.status) ? now : undefined),
+          confirmedAt: confirmedAtForStatus(data.status, null, now),
           updatedAt: now,
         }
         if (data.status === "expired") updates.expiredAt = now

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -33,6 +33,10 @@ import type { z } from "zod"
 
 import { BOOKING_STATUS_CAPABILITIES } from "./action-ledger-capabilities.js"
 import { availabilityHoldsRef, availabilitySlotsRef } from "./availability-ref.js"
+import {
+  assertMonthlyBookingLimitAvailable,
+  BookingMonthlyLimitReachedError,
+} from "./booking-plan-limit.js"
 import { exchangeRatesRef } from "./markets-ref.js"
 import {
   applyTravelDetailSnapshot,
@@ -350,6 +354,8 @@ type OptionUnitReference = typeof optionUnitsRef.$inferSelect
  */
 export interface BookingServiceRuntime {
   eventBus?: EventBus
+  /** Optional managed-plan allowance; null/undefined keeps bookings unlimited. */
+  monthlyBookingLimit?: number | null
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
   actionLedgerCausationActionId?: string | null
@@ -600,25 +606,16 @@ class BookingServiceError extends Error {
   }
 }
 
+function monthlyBookingLimitResult(error: BookingMonthlyLimitReachedError) {
+  return {
+    status: error.code,
+    message: error.message,
+    ...error.details,
+  } as const
+}
+
 function toTimestamp(value?: string | null) {
   return value ? new Date(value) : null
-}
-
-function confirmedAtForStatus(status: BookingStatus, value: Date | null, now = new Date()) {
-  if (status !== "confirmed") return null
-  return value ?? now
-}
-
-function confirmedAtForBookingUpdate(
-  currentStatus: BookingStatus,
-  data: UpdateBookingInput,
-  now = new Date(),
-) {
-  const nextStatus = data.status ?? currentStatus
-  if (nextStatus !== "confirmed") return null
-  if (data.confirmedAt !== undefined)
-    return confirmedAtForStatus(nextStatus, toTimestamp(data.confirmedAt), now)
-  return currentStatus === "confirmed" ? undefined : now
 }
 
 function toDateValue(value: Date | string) {
@@ -2408,7 +2405,7 @@ const bookingsServiceInternal = {
     data: ConvertProductInput,
     productData: ConvertProductData,
     userId?: string,
-    options: { availabilityHoldToken?: string } = {},
+    options: { availabilityHoldToken?: string; monthlyBookingLimit?: number | null } = {},
   ) {
     const { product, option, slot, dayServices, units } = productData
 
@@ -2483,6 +2480,13 @@ const bookingsServiceInternal = {
     }
 
     const initialStatus = data.initialStatus ?? "draft"
+    if (
+      initialStatus === "confirmed" ||
+      initialStatus === "in_progress" ||
+      initialStatus === "completed"
+    ) {
+      await assertMonthlyBookingLimitAvailable(db, options.monthlyBookingLimit)
+    }
     const bookingPax = Object.hasOwn(data, "pax") ? (data.pax ?? null) : product.pax
     // Map the booking lifecycle status onto the booking-item lifecycle.
     // Items don't have an `awaiting_payment` state — when the booking is
@@ -2521,7 +2525,12 @@ const bookingsServiceInternal = {
         // a booking that lands in `confirmed` straight from create is
         // indistinguishable downstream from one that was flipped via
         // the verb endpoint.
-        confirmedAt: initialStatus === "confirmed" ? now : null,
+        confirmedAt:
+          initialStatus === "confirmed" ||
+          initialStatus === "in_progress" ||
+          initialStatus === "completed"
+            ? now
+            : null,
         personId: data.personId ?? null,
         organizationId: data.organizationId ?? null,
         // Billing-contact snapshot — captured at create time so the
@@ -2890,7 +2899,12 @@ const bookingsServiceInternal = {
       .orderBy(asc(bookingAllocations.createdAt))
   },
 
-  async updateBooking(db: PostgresJsDatabase, id: string, data: UpdateBookingInput) {
+  async updateBooking(
+    db: PostgresJsDatabase,
+    id: string,
+    data: UpdateBookingInput,
+    runtime: BookingServiceRuntime = {},
+  ) {
     const normalizedData = normalizeBookingBillingPartyUpdate(data)
     const includesDirectTotalUpdate =
       data.sellAmountCents !== undefined ||
@@ -2900,17 +2914,33 @@ const bookingsServiceInternal = {
 
     return db.transaction(async (tx) => {
       const rows = await tx.execute(
-        sql`SELECT status, custom_fields
+        sql`SELECT status, confirmed_at, custom_fields
             FROM ${bookings}
             WHERE ${bookings.id} = ${id}
             FOR UPDATE`,
       )
       const existing = toRows<{
         status: BookingStatus
+        confirmed_at: Date | null
         custom_fields: NamespacedCustomFieldValues
       }>(rows)[0]
 
       if (!existing) return null
+
+      const nextStatus = data.status ?? existing.status
+      if (
+        existing.confirmed_at === null &&
+        (nextStatus === "confirmed" ||
+          nextStatus === "in_progress" ||
+          nextStatus === "completed" ||
+          data.confirmedAt != null)
+      ) {
+        await assertMonthlyBookingLimitAvailable(
+          tx as PostgresJsDatabase,
+          runtime.monthlyBookingLimit,
+          { excludeBookingId: id },
+        )
+      }
 
       let updateData = normalizedData
       let shouldRecomputeTotals = false
@@ -2977,7 +3007,15 @@ const bookingsServiceInternal = {
             data.contactPostalCode === undefined ? undefined : (data.contactPostalCode ?? null),
           holdExpiresAt:
             data.holdExpiresAt === undefined ? undefined : toTimestamp(data.holdExpiresAt),
-          confirmedAt: confirmedAtForBookingUpdate(existing.status, data),
+          confirmedAt:
+            existing.confirmed_at ??
+            (data.status === "confirmed" ||
+              data.status === "in_progress" ||
+              data.status === "completed"
+              ? (toTimestamp(data.confirmedAt) ?? new Date())
+              : data.confirmedAt !== undefined
+                ? toTimestamp(data.confirmedAt)
+                : undefined),
           expiredAt: data.expiredAt === undefined ? undefined : toTimestamp(data.expiredAt),
           cancelledAt: data.cancelledAt === undefined ? undefined : toTimestamp(data.cancelledAt),
           completedAt: data.completedAt === undefined ? undefined : toTimestamp(data.completedAt),
@@ -3043,6 +3081,12 @@ const bookingsServiceInternal = {
         if (booking.hold_expires_at && booking.hold_expires_at < new Date()) {
           throw new BookingServiceError("hold_expired")
         }
+
+        await assertMonthlyBookingLimitAvailable(
+          tx as PostgresJsDatabase,
+          runtime.monthlyBookingLimit,
+          { excludeBookingId: id },
+        )
 
         const patch = transitionBooking(booking.status, "confirmed")
 
@@ -3119,6 +3163,9 @@ const bookingsServiceInternal = {
 
       return result
     } catch (error) {
+      if (error instanceof BookingMonthlyLimitReachedError) {
+        return monthlyBookingLimitResult(error)
+      }
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }
       }
@@ -3154,6 +3201,12 @@ const bookingsServiceInternal = {
         if (booking.status !== "awaiting_payment" && booking.status !== "expired") {
           throw new BookingServiceError("invalid_transition")
         }
+
+        await assertMonthlyBookingLimitAvailable(
+          tx as PostgresJsDatabase,
+          runtime.monthlyBookingLimit,
+          { excludeBookingId: id },
+        )
 
         const allocations = await tx
           .select()
@@ -3273,6 +3326,9 @@ const bookingsServiceInternal = {
 
       return result
     } catch (error) {
+      if (error instanceof BookingMonthlyLimitReachedError) {
+        return monthlyBookingLimitResult(error)
+      }
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }
       }
@@ -3877,7 +3933,7 @@ const bookingsServiceInternal = {
     try {
       const result = await db.transaction(async (tx) => {
         const rows = await tx.execute(
-          sql`SELECT id, booking_number, status
+          sql`SELECT id, booking_number, status, confirmed_at
               FROM ${bookings}
               WHERE ${bookings.id} = ${id}
               FOR UPDATE`,
@@ -3886,10 +3942,24 @@ const bookingsServiceInternal = {
           id: string
           booking_number: string
           status: BookingStatus
+          confirmed_at: Date | null
         }>(rows)[0]
 
         if (!booking) {
           throw new BookingServiceError("not_found")
+        }
+
+        if (
+          booking.confirmed_at === null &&
+          (data.status === "confirmed" ||
+            data.status === "in_progress" ||
+            data.status === "completed")
+        ) {
+          await assertMonthlyBookingLimitAvailable(
+            tx as PostgresJsDatabase,
+            runtime.monthlyBookingLimit,
+            { excludeBookingId: id },
+          )
         }
 
         const now = new Date()
@@ -3897,7 +3967,12 @@ const bookingsServiceInternal = {
         const terminalAllocationStatus = terminalBookingAllocationStatusForOverride(data.status)
         const updates: Record<string, unknown> = {
           status: data.status,
-          confirmedAt: confirmedAtForStatus(data.status, null, now),
+          confirmedAt:
+            data.status === "confirmed" ||
+            data.status === "in_progress" ||
+            data.status === "completed"
+              ? (booking.confirmed_at ?? now)
+              : booking.confirmed_at,
           updatedAt: now,
         }
         if (data.status === "expired") updates.expiredAt = now
@@ -4054,6 +4129,9 @@ const bookingsServiceInternal = {
 
       return { status: result.status, booking: result.booking }
     } catch (error) {
+      if (error instanceof BookingMonthlyLimitReachedError) {
+        return monthlyBookingLimitResult(error)
+      }
       if (error instanceof BookingServiceError) {
         return { status: error.code as Exclude<string, "ok"> }
       }
@@ -5454,7 +5532,7 @@ export async function settleBookingCreateDomain(
   commandIdempotencyKey: string,
   data: ConvertProductInput,
   userId?: string,
-  options: { availabilityHoldToken?: string } = {},
+  options: { availabilityHoldToken?: string; monthlyBookingLimit?: number | null } = {},
 ) {
   consumeCreatedTargetMutationLease(lease, tx, {
     actionName: "@voyant-travel/finance#bookings-create-extension.action.create-booking",

--- a/packages/bookings/src/service-core.ts
+++ b/packages/bookings/src/service-core.ts
@@ -3010,8 +3010,8 @@ const bookingsServiceInternal = {
           confirmedAt:
             existing.confirmed_at ??
             (data.status === "confirmed" ||
-              data.status === "in_progress" ||
-              data.status === "completed"
+            data.status === "in_progress" ||
+            data.status === "completed"
               ? (toTimestamp(data.confirmedAt) ?? new Date())
               : data.confirmedAt !== undefined
                 ? toTimestamp(data.confirmedAt)

--- a/packages/bookings/src/service-public-core.ts
+++ b/packages/bookings/src/service-public-core.ts
@@ -1582,8 +1582,9 @@ export const publicBookingsService = {
     bookingId: string,
     input: PublicBookingSessionMutationInput,
     userId?: string,
+    runtime: BookingServiceRuntime = {},
   ) {
-    const result = await bookingsService.confirmBooking(db, bookingId, input, userId)
+    const result = await bookingsService.confirmBooking(db, bookingId, input, userId, runtime)
     if (result.status !== "ok") {
       return result
     }

--- a/packages/bookings/src/voyant.ts
+++ b/packages/bookings/src/voyant.ts
@@ -402,6 +402,13 @@ export const bookingsVoyantModule = defineModule({
       source: "./migrations",
     },
   ],
+  config: [
+    {
+      id: "@voyant-travel/bookings#config.monthly-booking-limit",
+      key: "VOYANT_BOOKINGS_MONTHLY_LIMIT",
+      required: false,
+    },
+  ],
   links: [
     {
       id: "@voyant-travel/bookings#linkable.booking",

--- a/packages/bookings/tests/integration/routes.integration-suite.ts
+++ b/packages/bookings/tests/integration/routes.integration-suite.ts
@@ -26,6 +26,7 @@ import {
   bookingItems,
   bookingItemTravelers,
   bookingPiiAccessLog,
+  bookings,
   bookingTravelers,
 } from "../../src/schema.js"
 import { bookingsService } from "../../src/service.js"
@@ -812,6 +813,12 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       const body = await res.json()
       expect(body.data.status).toBe("draft")
       expect(body.data.confirmedAt).toBeNull()
+
+      const [stored] = await db
+        .select({ acceptedAt: bookings.acceptedAt })
+        .from(bookings)
+        .where(eq(bookings.id, booking.id))
+      expect(stored?.acceptedAt).toBeNull()
     })
 
     it("clears confirmedAt when a generic update moves a booking out of confirmed", async () => {
@@ -827,6 +834,38 @@ describe.skipIf(!DB_AVAILABLE)("Booking routes", () => {
       const body = await res.json()
       expect(body.data.status).toBe("draft")
       expect(body.data.confirmedAt).toBeNull()
+    })
+
+    it("records first acceptance with server time and never clears it", async () => {
+      const booking = await seedBooking({ status: "draft" })
+      const beforeAcceptance = Date.now()
+
+      const accepted = await app.request(`/${booking.id}`, {
+        method: "PATCH",
+        ...json({ status: "confirmed", confirmedAt: "2020-01-01T00:00:00.000Z" }),
+      })
+
+      expect(accepted.status).toBe(200)
+      const [firstStored] = await db
+        .select({ acceptedAt: bookings.acceptedAt, confirmedAt: bookings.confirmedAt })
+        .from(bookings)
+        .where(eq(bookings.id, booking.id))
+      expect(firstStored?.confirmedAt?.toISOString()).toBe("2020-01-01T00:00:00.000Z")
+      expect(firstStored?.acceptedAt?.getTime()).toBeGreaterThanOrEqual(beforeAcceptance)
+
+      const firstAcceptedAt = firstStored?.acceptedAt?.toISOString()
+      const movedOn = await app.request(`/${booking.id}/start`, {
+        method: "POST",
+        ...json({}),
+      })
+      expect(movedOn.status).toBe(200)
+
+      const [afterTransition] = await db
+        .select({ acceptedAt: bookings.acceptedAt, confirmedAt: bookings.confirmedAt })
+        .from(bookings)
+        .where(eq(bookings.id, booking.id))
+      expect(afterTransition?.acceptedAt?.toISOString()).toBe(firstAcceptedAt)
+      expect(afterTransition?.confirmedAt).toBeNull()
     })
   })
 

--- a/packages/bookings/tests/unit/booking-plan-limit.test.ts
+++ b/packages/bookings/tests/unit/booking-plan-limit.test.ts
@@ -31,7 +31,7 @@ describe("monthly booking plan limit", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
-  it("serializes quota consumers before reading current-month confirmations", async () => {
+  it("serializes quota consumers before reading current-month acceptances", async () => {
     const execute = vi
       .fn()
       .mockResolvedValueOnce([])
@@ -54,7 +54,7 @@ describe("monthly booking plan limit", () => {
     const usage = dialect.sqlToQuery(execute.mock.calls[1]?.[0])
     expect(lock.sql).toContain("pg_advisory_xact_lock")
     expect(usage.sql).toContain(
-      "confirmed_at >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')",
+      "accepted_at >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')",
     )
     expect(usage.sql).toContain("id <>")
     expect(usage.params).toContain("book_replay")

--- a/packages/bookings/tests/unit/booking-plan-limit.test.ts
+++ b/packages/bookings/tests/unit/booking-plan-limit.test.ts
@@ -1,0 +1,90 @@
+import { PgDialect } from "drizzle-orm/pg-core"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  assertMonthlyBookingLimitAvailable,
+  BookingMonthlyLimitConfigurationError,
+  BookingMonthlyLimitReachedError,
+  resolveMonthlyBookingLimit,
+} from "../../src/booking-plan-limit.js"
+
+describe("monthly booking plan limit", () => {
+  it("keeps bookings unlimited when the binding is unset", () => {
+    expect(resolveMonthlyBookingLimit({})).toBeNull()
+    expect(resolveMonthlyBookingLimit({ VOYANT_BOOKINGS_MONTHLY_LIMIT: "" })).toBeNull()
+  })
+
+  it("accepts only a positive integer binding", () => {
+    expect(resolveMonthlyBookingLimit({ VOYANT_BOOKINGS_MONTHLY_LIMIT: "100" })).toBe(100)
+    expect(resolveMonthlyBookingLimit({ VOYANT_BOOKINGS_MONTHLY_LIMIT: 25 })).toBe(25)
+
+    for (const value of ["0", "-1", "1.5", "not-a-number", true]) {
+      expect(() => resolveMonthlyBookingLimit({ VOYANT_BOOKINGS_MONTHLY_LIMIT: value })).toThrow(
+        BookingMonthlyLimitConfigurationError,
+      )
+    }
+  })
+
+  it("does not touch the database for an unlimited tenant", async () => {
+    const execute = vi.fn()
+    await assertMonthlyBookingLimitAvailable({ execute } as never, null)
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it("serializes quota consumers before reading current-month confirmations", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          current: 99,
+          period_start: "2026-07-01 00:00:00+00",
+          period_end: "2026-08-01 00:00:00+00",
+        },
+      ])
+
+    await expect(
+      assertMonthlyBookingLimitAvailable({ execute } as never, 100, {
+        excludeBookingId: "book_replay",
+      }),
+    ).resolves.toBeUndefined()
+
+    const dialect = new PgDialect()
+    const lock = dialect.sqlToQuery(execute.mock.calls[0]?.[0])
+    const usage = dialect.sqlToQuery(execute.mock.calls[1]?.[0])
+    expect(lock.sql).toContain("pg_advisory_xact_lock")
+    expect(usage.sql).toContain(
+      "confirmed_at >= date_trunc('month', CURRENT_TIMESTAMP AT TIME ZONE 'UTC')",
+    )
+    expect(usage.sql).toContain("id <>")
+    expect(usage.params).toContain("book_replay")
+  })
+
+  it("returns an actionable typed error once the allowance is exhausted", async () => {
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          current: 100,
+          period_start: "2026-07-01 00:00:00+00",
+          period_end: "2026-08-01 00:00:00+00",
+        },
+      ])
+
+    const error = await assertMonthlyBookingLimitAvailable({ execute } as never, 100).catch(
+      (error: unknown) => error,
+    )
+    expect(error).toBeInstanceOf(BookingMonthlyLimitReachedError)
+    expect(error).toMatchObject({
+      code: "monthly_booking_limit_reached",
+      details: {
+        limit: 100,
+        current: 100,
+        periodStart: "2026-07-01 00:00:00+00",
+        periodEnd: "2026-08-01 00:00:00+00",
+      },
+    })
+    expect((error as Error).message).toContain("Upgrade the plan")
+  })
+})

--- a/packages/bookings/tests/unit/routes-custom-fields-validation.test.ts
+++ b/packages/bookings/tests/unit/routes-custom-fields-validation.test.ts
@@ -102,6 +102,7 @@ describe("booking route custom-fields validation", () => {
       expect.anything(),
       id,
       expect.objectContaining({ customFields: { custom: { tour_guide: "Ana", group_size: 4 } } }),
+      { monthlyBookingLimit: undefined },
     )
   })
 

--- a/packages/bookings/tests/unit/voyant-manifest.test.ts
+++ b/packages/bookings/tests/unit/voyant-manifest.test.ts
@@ -50,6 +50,13 @@ describe("bookings deployment manifest", () => {
       ],
       schema: [{ id: "@voyant-travel/bookings#schema" }],
       migrations: [{ id: "@voyant-travel/bookings#migrations" }],
+      config: [
+        {
+          id: "@voyant-travel/bookings#config.monthly-booking-limit",
+          key: "VOYANT_BOOKINGS_MONTHLY_LIMIT",
+          required: false,
+        },
+      ],
       links: [{ id: "@voyant-travel/bookings#linkable.booking" }],
       jobs: [
         {

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -63,7 +63,7 @@ export function buildCheckoutFinalizeDeps(
         return
       }
 
-      if (result.status === "monthly_booking_limit_reached") {
+      if (result.status === "monthly_booking_limit_reached" && "message" in result) {
         throw new Error(`checkout-finalize: ${result.message}`)
       }
 

--- a/packages/commerce/src/checkout/finalize.ts
+++ b/packages/commerce/src/checkout/finalize.ts
@@ -31,6 +31,7 @@ export function buildCheckoutFinalizeDeps(
   db: PostgresJsDatabase,
   eventBus: EventBus,
   identity: CheckoutFinalizationIdentity,
+  monthlyBookingLimit?: number | null,
 ): CheckoutFinalizeDeps {
   return {
     db,
@@ -55,10 +56,15 @@ export function buildCheckoutFinalizeDeps(
 
       const result = await bookingsService.confirmBooking(db, bookingId, {}, undefined, {
         eventBus,
+        monthlyBookingLimit,
       })
       if (result.status === "ok") {
         await markBookingConfirmed(db, identity)
         return
+      }
+
+      if (result.status === "monthly_booking_limit_reached") {
+        throw new Error(`checkout-finalize: ${result.message}`)
       }
 
       if (result.status === "hold_expired") {
@@ -67,7 +73,7 @@ export function buildCheckoutFinalizeDeps(
           bookingId,
           { note: "Recovered after late payment completion" },
           undefined,
-          { eventBus },
+          { eventBus, monthlyBookingLimit },
         )
         if (recovered.status === "ok") {
           await markBookingConfirmed(db, identity)
@@ -333,6 +339,7 @@ export interface FinalizeCheckoutParams {
   db: PostgresJsDatabase
   eventBus: EventBus
   input: CheckoutFinalizeInput
+  monthlyBookingLimit?: number | null
 }
 
 /**
@@ -350,7 +357,12 @@ export async function finalizeCheckout(params: FinalizeCheckoutParams): Promise<
   const delivery = await getCheckoutFinalizationDelivery(params.db, paymentSessionId)
   if (delivery?.completedAt) return
 
-  const deps = buildCheckoutFinalizeDeps(params.db, params.eventBus, identity)
+  const deps = buildCheckoutFinalizeDeps(
+    params.db,
+    params.eventBus,
+    identity,
+    params.monthlyBookingLimit,
+  )
   await runCheckoutFinalize(params.input, deps)
   await withCheckoutFinalizationLock(params.db, identity, async (tx) => {
     const current = await getCheckoutFinalizationDelivery(tx, paymentSessionId)

--- a/packages/commerce/src/checkout/subscriber-runtime.ts
+++ b/packages/commerce/src/checkout/subscriber-runtime.ts
@@ -1,3 +1,4 @@
+import { resolveMonthlyBookingLimit } from "@voyant-travel/bookings"
 import type { BootstrapContext, EventBus, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import { defineGraphRuntimeFactory } from "@voyant-travel/core/project"
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js"
@@ -98,6 +99,16 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
     eventType: "payment.completed",
     register: ({ bindings, eventBus }) => {
       const runtimeBindings = bindings as TBindings
+      const processEnv =
+        (
+          globalThis as typeof globalThis & {
+            process?: { env?: Record<string, string | undefined> }
+          }
+        ).process?.env ?? {}
+      const monthlyBookingLimit = resolveMonthlyBookingLimit({
+        ...processEnv,
+        ...(bindings as Record<string, unknown>),
+      })
       eventBus.subscribe<PaymentCompletedPayload>(
         "payment.completed",
         async ({ data }, context) => {
@@ -115,6 +126,7 @@ export function createCheckoutFinalizeSubscriberRuntime<TBindings = unknown>(
                   paymentSessionId: data.paymentSessionId,
                   paymentIntent: data.paymentIntent,
                 },
+                monthlyBookingLimit,
               }),
             )
           } catch (error) {

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -165,6 +165,8 @@ export function bookingCreateCommandError(
         "INVALID_INPUT",
         { outcome },
       )
+    case "monthly_booking_limit_reached":
+      return new ToolError(outcome.message, "INVALID_INPUT", { outcome })
     case "duplicate_booking":
     case "travel_credit_inactive":
     case "travel_credit_not_started":

--- a/packages/finance/src/route-runtime.ts
+++ b/packages/finance/src/route-runtime.ts
@@ -1,3 +1,4 @@
+import { resolveMonthlyBookingLimit } from "@voyant-travel/bookings"
 import type { EventBus } from "@voyant-travel/core"
 
 import type { InvoiceFxOptions } from "./invoice-fx.js"
@@ -11,6 +12,7 @@ import type {
 import type { InvoiceDocumentGenerator } from "./service-documents.js"
 
 export type FinanceRouteRuntime = {
+  monthlyBookingLimit?: number | null
   invoiceDocumentGenerator?: InvoiceDocumentGenerator
   resolveCustomFields?: FinanceDocumentRouteOptions["resolveCustomFields"]
   resolveDocumentDownloadUrl?: FinanceDocumentRouteOptions["resolveDocumentDownloadUrl"]
@@ -36,7 +38,15 @@ export function buildFinanceRouteRuntime(
   bindings: Record<string, unknown>,
   options: FinanceRuntimeOptions = {},
 ): FinanceRouteRuntime {
+  const processEnv =
+    (
+      globalThis as typeof globalThis & {
+        process?: { env?: Record<string, string | undefined> }
+      }
+    ).process?.env ?? {}
+
   return {
+    monthlyBookingLimit: resolveMonthlyBookingLimit({ ...processEnv, ...bindings }),
     invoiceDocumentGenerator:
       options.resolveInvoiceDocumentGenerator?.(bindings) ?? options.invoiceDocumentGenerator,
     resolveCustomFields: options.resolveCustomFields,

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -4,6 +4,7 @@ import type { CreatedTargetMutationLease } from "@voyant-travel/action-ledger"
 import { bookingGroupsService } from "@voyant-travel/bookings"
 import {
   BookingItemsUnresolvedError,
+  BookingMonthlyLimitReachedError,
   settleBookingCreateDomain,
 } from "@voyant-travel/bookings/booking-create-command-domain"
 import {
@@ -550,6 +551,14 @@ export type BookingCreateOutcome =
       candidateUnitCount: number
       message: string
     }
+  | {
+      status: "monthly_booking_limit_reached"
+      limit: number
+      current: number
+      periodStart: string
+      periodEnd: string
+      message: string
+    }
   | { status: "product_not_found" }
   | { status: "travel_credit_not_found" }
   | { status: "travel_credit_inactive" }
@@ -597,6 +606,13 @@ async function settleBookingCreateWithItemGuard(
   try {
     return await settleBookingCreateDomain(...args)
   } catch (error) {
+    if (error instanceof BookingMonthlyLimitReachedError) {
+      throw new BookingCreateAbort({
+        status: error.code,
+        ...error.details,
+        message: error.message,
+      })
+    }
     if (error instanceof BookingItemsUnresolvedError) {
       throw new BookingCreateAbort({
         status: "booking_items_unresolved",
@@ -1311,7 +1327,10 @@ export async function createBookingMutation(
           itemLines: normalizedItemLines,
         },
         userId,
-        { availabilityHoldToken: input.availabilityHoldToken },
+        {
+          availabilityHoldToken: input.availabilityHoldToken,
+          monthlyBookingLimit: runtime?.monthlyBookingLimit,
+        },
       )
       if (!booking) {
         // Caller gave us a product that doesn't resolve. Throw so drizzle

--- a/packages/finance/src/service-shared.ts
+++ b/packages/finance/src/service-shared.ts
@@ -1043,6 +1043,7 @@ export async function touchLinkedBookingUpdatedAt(
  */
 export interface FinanceServiceRuntime extends InvoiceFxOptions {
   eventBus?: EventBus
+  monthlyBookingLimit?: number | null
   actionLedgerContext?: ActionLedgerRequestContextValues
   actionLedgerAuthorizationSource?: string | null
   actionLedgerActionName?: string | null

--- a/packages/framework/src/operator-distribution.test.ts
+++ b/packages/framework/src/operator-distribution.test.ts
@@ -39,7 +39,7 @@ describe("standard Operator distribution", () => {
       "@voyant-travel/catalog-authoring",
       "@voyant-travel/reporting",
     ])
-    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toHaveLength(24)
+    expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toHaveLength(25)
     expect(STANDARD_OPERATOR_DISTRIBUTION.extensions).toContain(
       "@voyant-travel/distribution/extension",
     )
@@ -50,7 +50,7 @@ describe("standard Operator distribution", () => {
     expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.modules).size).toBe(
       STANDARD_OPERATOR_DISTRIBUTION.modules.length,
     )
-    expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.extensions).size).toBe(24)
+    expect(new Set(STANDARD_OPERATOR_DISTRIBUTION.extensions).size).toBe(25)
   })
 
   it("defaults authored differences without treating extensions as plugins", () => {
@@ -72,6 +72,18 @@ describe("standard Operator distribution", () => {
     expect(selected.modules).not.toContain("@voyant-travel/bookings")
     for (const extension of ownedExtensions) expect(selected.extensions).not.toContain(extension)
     expect(selected.extensions).toContain("@voyant-travel/catalog/offers-extension")
+  })
+
+  it("removes quote-owned Realtime invalidations with the Quotes module", () => {
+    const selected = selectStandardOperatorDistribution({
+      exclude: ["@voyant-travel/quotes"],
+    })
+
+    expect(selected.modules).not.toContain("@voyant-travel/quotes")
+    expect(selected.extensions).not.toContain(
+      "@voyant-travel/realtime/quotes-invalidation-extension",
+    )
+    expect(selected.modules).toContain("@voyant-travel/realtime")
   })
 
   it("does not allow required or unknown selections to be removed", () => {

--- a/packages/framework/src/project-import-cheap.test.ts
+++ b/packages/framework/src/project-import-cheap.test.ts
@@ -23,7 +23,7 @@ describe("framework project import boundary", () => {
     })
     const config = authoring.defineConfig()
     expect(config.modules.map((unit) => unit.id)).toContain("@voyant-travel/bookings#extras")
-    expect(config.extensions).toHaveLength(24)
+    expect(config.extensions).toHaveLength(25)
     expect(config.plugins).toEqual([])
     expect(authoring.resolveProject).toBeTypeOf("function")
   })

--- a/packages/operator-standard/src/index.ts
+++ b/packages/operator-standard/src/index.ts
@@ -299,6 +299,10 @@ export const STANDARD_OPERATOR_DISTRIBUTION_POLICY: {
       owners: ["@voyant-travel/quotes", "@voyant-travel/notifications"],
     },
     {
+      resolve: "@voyant-travel/realtime/quotes-invalidation-extension",
+      owners: ["@voyant-travel/realtime", "@voyant-travel/quotes"],
+    },
+    {
       resolve: "@voyant-travel/catalog/offers-extension",
       owners: ["@voyant-travel/catalog"],
     },

--- a/packages/realtime/src/voyant.ts
+++ b/packages/realtime/src/voyant.ts
@@ -1,4 +1,9 @@
-import { defineModule, providePort, requirePort } from "@voyant-travel/core/project"
+import {
+  defineExtension,
+  defineModule,
+  providePort,
+  requirePort,
+} from "@voyant-travel/core/project"
 import { realtimeRuntimePort } from "./runtime-port.js"
 
 /** Import-cheap deployment declaration owned by the realtime package. */
@@ -121,9 +126,6 @@ export const realtimeVoyantModule = defineModule({
     ["supplier.created", "realtimeSupplierCreatedInvalidationSubscriber"],
     ["supplier.updated", "realtimeSupplierUpdatedInvalidationSubscriber"],
     ["supplier.deleted", "realtimeSupplierDeletedInvalidationSubscriber"],
-    ["quote.created", "realtimeQuoteCreatedInvalidationSubscriber"],
-    ["quote.updated", "realtimeQuoteUpdatedInvalidationSubscriber"],
-    ["quote.deleted", "realtimeQuoteDeletedInvalidationSubscriber"],
     ["invoice.issued", "realtimeInvoiceIssuedInvalidationSubscriber"],
     ["invoice.voided", "realtimeInvoiceVoidedInvalidationSubscriber"],
     ["invoice.settled", "realtimeInvoiceSettledInvalidationSubscriber"],
@@ -160,6 +162,29 @@ export const realtimeVoyantModule = defineModule({
       rationale:
         "Realtime is a transport and invalidation module, not an agent-callable domain surface.",
     },
+  },
+})
+
+/** Quote-owned invalidations are selected only when both Quotes and Realtime are active. */
+export const realtimeQuotesInvalidationVoyantExtension = defineExtension({
+  id: "@voyant-travel/realtime#quotes-invalidation-extension",
+  packageName: "@voyant-travel/realtime",
+  localId: "realtime.quotes-invalidation-extension",
+  subscribers: [
+    ["quote.created", "realtimeQuoteCreatedInvalidationSubscriber"],
+    ["quote.updated", "realtimeQuoteUpdatedInvalidationSubscriber"],
+    ["quote.deleted", "realtimeQuoteDeletedInvalidationSubscriber"],
+  ].map(([eventType, exportName]) => ({
+    id: `@voyant-travel/realtime#subscriber.admin-invalidation.${eventType}`,
+    eventType,
+    source: "@voyant-travel/realtime/runtime",
+    runtime: {
+      entry: "@voyant-travel/realtime/runtime",
+      export: exportName,
+    },
+  })),
+  meta: {
+    ownership: "standard-product",
   },
 })
 

--- a/packages/realtime/tests/unit/voyant-manifest.test.ts
+++ b/packages/realtime/tests/unit/voyant-manifest.test.ts
@@ -9,7 +9,10 @@ import {
   realtimeTransportRuntimePort,
 } from "../../src/index.js"
 import { createLocalRealtimeProvider } from "../../src/providers/local.js"
-import { realtimeVoyantModule } from "../../src/voyant.js"
+import {
+  realtimeQuotesInvalidationVoyantExtension,
+  realtimeVoyantModule,
+} from "../../src/voyant.js"
 
 describe("realtime deployment manifest", () => {
   it("owns both authenticated route surfaces", () => {
@@ -101,7 +104,7 @@ describe("realtime deployment manifest", () => {
     expect(realtimeVoyantModule.provides?.ports).toContainEqual({
       id: "realtime.admin-invalidation-publication",
     })
-    expect(realtimeVoyantModule.subscribers).toHaveLength(33)
+    expect(realtimeVoyantModule.subscribers).toHaveLength(30)
     expect(realtimeVoyantModule.subscribers?.map(({ eventType }) => eventType)).toEqual(
       expect.arrayContaining([
         "product.created",
@@ -111,6 +114,9 @@ describe("realtime deployment manifest", () => {
       ]),
     )
     expect(realtimeVoyantModule.subscribers?.every(({ runtime }) => runtime != null)).toBe(true)
+    expect(
+      realtimeQuotesInvalidationVoyantExtension.subscribers?.map(({ eventType }) => eventType),
+    ).toEqual(["quote.created", "quote.updated", "quote.deleted"])
   })
 
   it("ships a conformance kit for deployment realtime providers", async () => {


### PR DESCRIPTION
## What changed

- adds an optional, concurrency-safe monthly booking allowance hook at every accepted-booking boundary
- declares the optional runtime config so a managed Voyant deployment can inject its own allowance
- splits quote-specific Realtime invalidations into a Quotes-owned extension so a custom distribution can omit Quotes without dangling subscribers
- adds changesets for Bookings, Finance, Commerce, Realtime, and Operator Standard

## OSS and self-hosting contract

This PR does **not** encode Voyant commercial plans in OSS and does **not** restrict self-hosters.

- `VOYANT_BOOKINGS_MONTHLY_LIMIT` is optional; when unset, bookings are unlimited.
- The standard OSS distribution continues to include Quotes, MICE, and the full Realtime surface.
- Package behavior has no knowledge of Free, Launch, Growth, Scale, pricing, or customer subscriptions.
- A managed runtime may opt into the generic allowance hook and may compose a reduced distribution externally.

## Why

Voyant's private managed platform needs generic runtime hooks for enforcing its own commercial entitlements, while the public packages must remain unrestricted and useful for self-hosted deployments.

## Validation

- focused Bookings tests: 10/10
- Commerce checkout tests: 7/7
- Realtime manifest tests: 6/6
- Operator distribution tests: 8/8
- Framework import-boundary tests: 3/3
- Bookings, Finance, and Realtime typechecks passed
- touched-file Biome check and `git diff --check` passed
- CI follow-up fixes the Commerce result narrowing, Bookings formatting, and Framework extension-count assertion