### PR TITLE
Fix manual booking creation and room pricing

### DIFF
--- a/.changeset/calm-rooms-book-clearly.md
+++ b/.changeset/calm-rooms-book-clearly.md
@@ -1,0 +1,9 @@
+---
+"@voyant-travel/bookings": patch
+"@voyant-travel/bookings-react": patch
+"@voyant-travel/catalog-contracts": patch
+"@voyant-travel/finance": patch
+"@voyant-travel/inventory": patch
+---
+
+Make manual booking creation actionable and predictable: submit errors are visible, existing CRM contacts no longer require duplicate data entry, room assignments fill selected capacity, authoritative quotes preserve per-person/per-room pricing, and Finance tool failures explain how to correct invalid room or payment inputs.

--- a/packages/bookings-react/src/components/booking-create-preview-card.tsx
+++ b/packages/bookings-react/src/components/booking-create-preview-card.tsx
@@ -46,6 +46,7 @@ export function BookingPreviewCard({
       quantity?: number
       unitAmount: number
       totalAmount: number
+      pricingBasis?: "per_person" | "per_unit" | "per_booking"
     }>
   }
   optionId: string | null
@@ -81,7 +82,7 @@ export function BookingPreviewCard({
     (value: PriceBreakdownValue) => {
       const extraTotal = extraLines.reduce((sum, line) => sum + (line.totalSellAmountCents ?? 0), 0)
       const next =
-        extraTotal > 0 && !isSourcedProduct
+        extraTotal > 0 && !isSourcedProduct && !quotePricing
           ? {
               ...value,
               catalogAmountCents:
@@ -108,7 +109,7 @@ export function BookingPreviewCard({
       setBreakdown(next)
       onPricingChange(next)
     },
-    [extraLines, isSourcedProduct, onPricingChange],
+    [extraLines, isSourcedProduct, onPricingChange, quotePricing],
   )
   const providedPricing = React.useMemo(
     () =>
@@ -201,6 +202,9 @@ export function BookingPreviewCard({
                 const categoryLabel = traveler.pricingCategoryId
                   ? pricingCategoryLabels[traveler.pricingCategoryId]
                   : null
+                const roomLabel = traveler.inventoryUnitId
+                  ? unitLabels[traveler.inventoryUnitId]
+                  : null
                 return (
                   <li
                     key={traveler.clientTravelerKey ?? traveler.personId ?? `traveler-${idx}`}
@@ -211,6 +215,7 @@ export function BookingPreviewCard({
                     </span>
                     <span className="shrink-0 text-xs uppercase tracking-wider text-muted-foreground">
                       {categoryLabel ?? traveler.role}
+                      {roomLabel ? ` · ${roomLabel}` : ""}
                     </span>
                   </li>
                 )
@@ -246,6 +251,9 @@ export function BookingPreviewCard({
                 overrideReason: labels.breakdownOverrideReason,
                 overrideReasonPlaceholder: labels.breakdownOverrideReasonPlaceholder,
                 overrideReasonRequired: labels.breakdownOverrideReasonRequired,
+                perPerson: labels.breakdownPerTraveler,
+                perUnit: labels.breakdownPerRoom,
+                perBooking: labels.breakdownPerBooking,
               }}
               onChange={handlePricingChange}
             />

--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -395,6 +395,7 @@ export function validateManualBookingDraft(input: {
   contactFirstName: string
   contactLastName: string
   contactEmail: string
+  contactPhone: string
   travelers: TravelerListValue
   pricing: ManualBookingResolvedPricing | null
   manualOverrideRequiresReason?: boolean
@@ -411,8 +412,14 @@ export function validateManualBookingDraft(input: {
     return input.messages.validation.organization
   }
   if (!input.contactFirstName.trim()) return input.messages.validation.contact
+  if (billTo === "person" && !input.contactLastName.trim()) {
+    return input.messages.validation.contactName
+  }
   if (input.contactEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(input.contactEmail)) {
     return input.messages.validation.email
+  }
+  if (billTo === "person" && !input.contactEmail.trim() && !input.contactPhone.trim()) {
+    return input.messages.validation.contactMethod
   }
   if (input.travelers.travelers.length === 0) return input.messages.validation.travelers
   if (
@@ -505,6 +512,7 @@ export function ManualBookingCreateForm({
   const [contactTouched, setContactTouched] = React.useState(false)
   const [notes, setNotes] = React.useState("")
   const [error, setError] = React.useState<string | null>(null)
+  const errorRef = React.useRef<HTMLParagraphElement>(null)
   const [submitting, setSubmitting] = React.useState(false)
   const [payloadMismatchUnitIds, setPayloadMismatchUnitIds] = React.useState<string[]>([])
   const [permissionState, setPermissionState] = React.useState<
@@ -513,6 +521,12 @@ export function ManualBookingCreateForm({
   const attemptRef = React.useRef<ManualBookingAttempt | null>(null)
   const submissionRef = React.useRef(false)
   const [slotsFromIso, setSlotsFromIso] = React.useState(() => new Date().toISOString())
+
+  React.useEffect(() => {
+    if (!error) return
+    errorRef.current?.focus()
+    errorRef.current?.scrollIntoView({ block: "nearest" })
+  }, [error])
 
   const defaultSlotQuery = useQuery({
     ...getSlotQueryOptions(availabilityClient, defaultSlotId),
@@ -570,10 +584,11 @@ export function ManualBookingCreateForm({
       return JSON.stringify(next) === JSON.stringify(current) ? current : next
     })
   }, [product.productId, productContent])
-  const billingPerson = usePerson(
+  const billingPersonQuery = usePerson(
     (billing.billTo ?? "person") === "person" ? billing.personId || undefined : undefined,
     { enabled: (billing.billTo ?? "person") === "person" && Boolean(billing.personId) },
-  ).data
+  )
+  const billingPerson = billingPersonQuery.data
   const billingOrganization = useOrganization(
     billing.billTo === "organization" ? (billing.organizationId ?? undefined) : undefined,
     { enabled: billing.billTo === "organization" && Boolean(billing.organizationId) },
@@ -1166,7 +1181,7 @@ export function ManualBookingCreateForm({
         slotId,
         quantities: displayDraft.quantities,
         units: bookingUnits,
-        travelers,
+        travelers: { travelers: displayDraft.travelers },
         pricingCategories: travelerPricingCategories,
         contact: quoteContact,
         extraLines: displayExtraLines,
@@ -1182,7 +1197,7 @@ export function ManualBookingCreateForm({
       slotId,
       displayDraft.quantities,
       bookingUnits,
-      travelers,
+      displayDraft.travelers,
       travelerPricingCategories,
       quoteContact,
       displayExtraLines,
@@ -1215,15 +1230,15 @@ export function ManualBookingCreateForm({
     product.sellCurrency ??
     pricing?.currency ??
     messages.bookingCreateDialog.labels.currency
-  const sourcedPreviewPricing = React.useMemo(() => {
-    const quotePricing = currentSourcedQuoteData?.pricing
+  const quotePreviewPricing = React.useMemo(() => {
+    const quotePricing = quote.data?.pricing
     if (!quotePricing) return undefined
     return {
       totalAmountCents: quotePricing.total,
       currency: quotePricing.currency,
       lines: quotePricing.lines,
     }
-  }, [currentSourcedQuoteData?.pricing])
+  }, [quote.data?.pricing])
   const resolvedPricing = resolveManualBookingPricing({
     pricing,
     quoteTotalAmountCents,
@@ -1301,7 +1316,8 @@ export function ManualBookingCreateForm({
       contactFirstName: contact.firstName,
       contactLastName: contact.lastName,
       contactEmail: contact.email,
-      travelers,
+      contactPhone: contact.phone,
+      travelers: { travelers: displayDraft.travelers },
       pricing: resolvedPricing,
       manualOverrideRequiresReason,
       paymentRows,
@@ -1318,8 +1334,8 @@ export function ManualBookingCreateForm({
     }
     const overCapacity = getOverCapacityInventoryAssignments(
       bookingUnits,
-      rooms.quantities,
-      travelers.travelers,
+      displayDraft.quantities,
+      displayDraft.travelers,
     )[0]
     if (overCapacity) {
       setError(
@@ -1345,7 +1361,7 @@ export function ManualBookingCreateForm({
             formatCurrency,
           ),
         )
-        .replace("{travelers}", String(travelers.travelers.length)),
+        .replace("{travelers}", String(displayDraft.travelers.length)),
       confirmLabel: copy.actions.confirmCreate,
       cancelLabel: messages.common.cancel,
     })
@@ -1523,9 +1539,17 @@ export function ManualBookingCreateForm({
     setContact((current) => ({ ...current, [field]: value }))
   }
 
+  const billingPersonContactIncomplete = Boolean(
+    billingPerson &&
+      (!billingPerson.firstName.trim() ||
+        !billingPerson.lastName.trim() ||
+        (!billingPerson.email?.trim() && !billingPerson.phone?.trim())),
+  )
+
   return (
     <form
       className="grid min-h-0 flex-1 gap-6 lg:grid-cols-12"
+      noValidate
       onSubmit={(event) => {
         event.preventDefault()
         void handleSubmit()
@@ -1664,38 +1688,51 @@ export function ManualBookingCreateForm({
                   organizationNone: messages.bookingCreateDialog.labels.organizationNone,
                 }}
               />
-              <div className="grid gap-4 sm:grid-cols-2">
-                <EditableContactField
-                  id="manual-booking-contact-first-name"
-                  label={copy.fields.contactFirstName}
-                  value={contact.firstName}
-                  required
-                  onChange={(value) => updateContact("firstName", value)}
-                />
-                <EditableContactField
-                  id="manual-booking-contact-last-name"
-                  label={copy.fields.contactLastName}
-                  value={contact.lastName}
-                  onChange={(value) => updateContact("lastName", value)}
-                />
-                <EditableContactField
-                  id="manual-booking-contact-email"
-                  label={copy.fields.contactEmail}
-                  value={contact.email}
-                  type="email"
-                  onChange={(value) => updateContact("email", value)}
-                />
-                <Field className="gap-2">
-                  <FieldLabel htmlFor="manual-booking-contact-phone">
-                    {copy.fields.contactPhone}
-                  </FieldLabel>
-                  <PhoneInput
-                    id="manual-booking-contact-phone"
-                    value={contact.phone}
-                    onChange={(value) => updateContact("phone", value)}
+              {(billing.billTo ?? "person") === "person" ? (
+                billing.personId && billingPersonQuery.isLoading ? (
+                  <p className="text-sm text-muted-foreground">{copy.hints.contactLoading}</p>
+                ) : billingPersonContactIncomplete ? (
+                  <p
+                    className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+                    role="alert"
+                  >
+                    {copy.hints.contactIncomplete}
+                  </p>
+                ) : null
+              ) : (
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <EditableContactField
+                    id="manual-booking-contact-first-name"
+                    label={copy.fields.contactFirstName}
+                    value={contact.firstName}
+                    required
+                    onChange={(value) => updateContact("firstName", value)}
                   />
-                </Field>
-              </div>
+                  <EditableContactField
+                    id="manual-booking-contact-last-name"
+                    label={copy.fields.contactLastName}
+                    value={contact.lastName}
+                    onChange={(value) => updateContact("lastName", value)}
+                  />
+                  <EditableContactField
+                    id="manual-booking-contact-email"
+                    label={copy.fields.contactEmail}
+                    value={contact.email}
+                    type="email"
+                    onChange={(value) => updateContact("email", value)}
+                  />
+                  <Field className="gap-2">
+                    <FieldLabel htmlFor="manual-booking-contact-phone">
+                      {copy.fields.contactPhone}
+                    </FieldLabel>
+                    <PhoneInput
+                      id="manual-booking-contact-phone"
+                      value={contact.phone}
+                      onChange={(value) => updateContact("phone", value)}
+                    />
+                  </Field>
+                </div>
+              )}
             </FieldSet>
           ) : null}
 
@@ -1839,7 +1876,9 @@ export function ManualBookingCreateForm({
         ) : null}
         {error ? (
           <p
+            ref={errorRef}
             role="alert"
+            tabIndex={-1}
             className="mt-3 rounded-md border border-destructive/50 bg-destructive/10 px-3 py-2 text-xs text-destructive"
           >
             {error}
@@ -1880,7 +1919,7 @@ export function ManualBookingCreateForm({
           productId={product.productId}
           productName={productDisplayName}
           isSourcedProduct={isSourcedProduct}
-          quotePricing={isSourcedProduct ? sourcedPreviewPricing : undefined}
+          quotePricing={quotePreviewPricing}
           optionId={product.optionId}
           slotId={slotId}
           slotLabel={selectedSlot ? formatSlotLabel(selectedSlot) : null}
@@ -1889,7 +1928,7 @@ export function ManualBookingCreateForm({
           pricingCategoryQuantities={travelerPricingCategoryQuantities}
           pricingCategoryLabels={travelerPricingCategoryLabels}
           extraLines={displayExtraLines}
-          travelers={travelers.travelers}
+          travelers={displayDraft.travelers}
           messages={messages}
           onPricingChange={handlePricingChange}
         />

--- a/packages/bookings-react/src/components/manual-booking-create-form.tsx
+++ b/packages/bookings-react/src/components/manual-booking-create-form.tsx
@@ -1545,6 +1545,9 @@ export function ManualBookingCreateForm({
         !billingPerson.lastName.trim() ||
         (!billingPerson.email?.trim() && !billingPerson.phone?.trim())),
   )
+  const billingPersonContactUnavailable = Boolean(
+    billing.personId && !billingPersonQuery.isLoading && !billingPerson,
+  )
 
   return (
     <form
@@ -1691,6 +1694,22 @@ export function ManualBookingCreateForm({
               {(billing.billTo ?? "person") === "person" ? (
                 billing.personId && billingPersonQuery.isLoading ? (
                   <p className="text-sm text-muted-foreground">{copy.hints.contactLoading}</p>
+                ) : billingPersonContactUnavailable ? (
+                  <div
+                    className="flex items-center justify-between gap-3 rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"
+                    role="alert"
+                  >
+                    <p>{copy.hints.contactUnavailable}</p>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="shrink-0"
+                      onClick={() => void billingPersonQuery.refetch()}
+                    >
+                      {copy.actions.retryContact}
+                    </Button>
+                  </div>
                 ) : billingPersonContactIncomplete ? (
                   <p
                     className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive"

--- a/packages/bookings-react/src/components/price-breakdown-section.tsx
+++ b/packages/bookings-react/src/components/price-breakdown-section.tsx
@@ -22,6 +22,7 @@ export interface PriceBreakdownLine {
    */
   tierLabel: string | null
   isGroupRate: boolean
+  pricingBasis?: "per_person" | "per_unit" | "per_booking"
 }
 
 export interface PriceBreakdownValue {
@@ -61,6 +62,7 @@ export interface PriceBreakdownSectionProps {
       quantity?: number
       unitAmount: number
       totalAmount: number
+      pricingBasis?: "per_person" | "per_unit" | "per_booking"
     }>
   }
   labels?: {
@@ -76,6 +78,9 @@ export interface PriceBreakdownSectionProps {
     overrideReason?: string
     overrideReasonPlaceholder?: string
     overrideReasonRequired?: string
+    perPerson?: string
+    perUnit?: string
+    perBooking?: string
   }
   onChange?: (value: PriceBreakdownValue) => void
   /**
@@ -229,6 +234,7 @@ export function PriceBreakdownSection({
               totalAmountCents: line.totalAmount,
               tierLabel: null,
               isGroupRate: false,
+              pricingBasis: line.pricingBasis,
             }))
           : [
               {
@@ -239,6 +245,7 @@ export function PriceBreakdownSection({
                 totalAmountCents: providedPricing.totalAmountCents,
                 tierLabel: null,
                 isGroupRate: false,
+                pricingBasis: "per_booking",
               },
             ]
       return {
@@ -524,6 +531,16 @@ export function PriceBreakdownSection({
               <span>{line.label}</span>
               {line.tierLabel ? (
                 <span className="text-xs text-muted-foreground">· {line.tierLabel}</span>
+              ) : null}
+              {line.pricingBasis ? (
+                <span className="text-xs text-muted-foreground">
+                  ·{" "}
+                  {line.pricingBasis === "per_person"
+                    ? merged.perPerson
+                    : line.pricingBasis === "per_booking"
+                      ? merged.perBooking
+                      : merged.perUnit}
+                </span>
               ) : null}
             </div>
             <div className="tabular-nums">

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -28,6 +28,8 @@ export const bookingsUiEnCreateList = {
       departureOptional: "Leave empty for an open-dated booking.",
       payment: "The scheduled total must match the booking sell amount.",
       contactLoading: "Loading contact details...",
+      contactUnavailable:
+        "We couldn't load this contact. Try again, or select or create another contact.",
       contactIncomplete:
         "This contact needs a first and last name plus an email address or phone number. Edit the contact above, or select or create another contact.",
     },
@@ -71,6 +73,7 @@ export const bookingsUiEnCreateList = {
     actions: {
       create: "Create booking",
       confirmCreate: "Confirm and create",
+      retryContact: "Try again",
     },
     confirm: {
       title: "Create this booking?",

--- a/packages/bookings-react/src/i18n/en-create-list.ts
+++ b/packages/bookings-react/src/i18n/en-create-list.ts
@@ -27,6 +27,9 @@ export const bookingsUiEnCreateList = {
     hints: {
       departureOptional: "Leave empty for an open-dated booking.",
       payment: "The scheduled total must match the booking sell amount.",
+      contactLoading: "Loading contact details...",
+      contactIncomplete:
+        "This contact needs a first and last name plus an email address or phone number. Edit the contact above, or select or create another contact.",
     },
     validation: {
       product: "Select a product.",
@@ -35,6 +38,8 @@ export const bookingsUiEnCreateList = {
       person: "Select the individual being billed.",
       organization: "Select the organization being billed.",
       contact: "Add a contact name for the booking.",
+      contactName: "Add the billing person's first and last name.",
+      contactMethod: "Add an email address or phone number for the billing person.",
       email: "Enter a valid contact email.",
       travelers: "Add at least one traveler.",
       travelerNames: "Each traveler needs a first and last name.",
@@ -249,6 +254,9 @@ export const bookingsUiEnCreateList = {
       breakdownOverrideReason: "Override reason",
       breakdownOverrideReasonPlaceholder: "Why is this total different?",
       breakdownOverrideReasonRequired: "Add a reason for the manual total.",
+      breakdownPerTraveler: "per traveler",
+      breakdownPerRoom: "per room",
+      breakdownPerBooking: "per booking",
       breakdownSubtotal: "Subtotal",
       breakdownTax: "Tax",
       breakdownTaxIncluded: "incl.",

--- a/packages/bookings-react/src/i18n/en-sections.ts
+++ b/packages/bookings-react/src/i18n/en-sections.ts
@@ -307,6 +307,9 @@ export const bookingsUiEnSections = {
       overrideReason: "Override reason",
       overrideReasonPlaceholder: "Why is this total different?",
       overrideReasonRequired: "Add a reason for the manual total.",
+      perPerson: "per traveler",
+      perUnit: "per room",
+      perBooking: "per booking",
     },
   },
   bookingDocumentDialog: {

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -26,6 +26,7 @@ export type BookingsUiCreateListMessages = {
       departureOptional: string
       payment: string
       contactLoading: string
+      contactUnavailable: string
       contactIncomplete: string
     }
     validation: {
@@ -67,6 +68,7 @@ export type BookingsUiCreateListMessages = {
     actions: {
       create: string
       confirmCreate: string
+      retryContact: string
     }
     confirm: {
       title: string

--- a/packages/bookings-react/src/i18n/messages-create-list.ts
+++ b/packages/bookings-react/src/i18n/messages-create-list.ts
@@ -25,6 +25,8 @@ export type BookingsUiCreateListMessages = {
     hints: {
       departureOptional: string
       payment: string
+      contactLoading: string
+      contactIncomplete: string
     }
     validation: {
       product: string
@@ -33,6 +35,8 @@ export type BookingsUiCreateListMessages = {
       person: string
       organization: string
       contact: string
+      contactName: string
+      contactMethod: string
       email: string
       travelers: string
       travelerNames: string
@@ -241,6 +245,9 @@ export type BookingsUiCreateListMessages = {
       breakdownOverrideReason: string
       breakdownOverrideReasonPlaceholder: string
       breakdownOverrideReasonRequired: string
+      breakdownPerTraveler: string
+      breakdownPerRoom: string
+      breakdownPerBooking: string
       breakdownSubtotal: string
       breakdownTax: string
       breakdownTaxIncluded: string

--- a/packages/bookings-react/src/i18n/messages-sections.ts
+++ b/packages/bookings-react/src/i18n/messages-sections.ts
@@ -293,6 +293,9 @@ export type BookingsUiSectionsMessages = {
       overrideReason: string
       overrideReasonPlaceholder: string
       overrideReasonRequired: string
+      perPerson: string
+      perUnit: string
+      perBooking: string
     }
   }
   bookingDocumentDialog: {

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -28,6 +28,8 @@ export const bookingsUiRoCreateList = {
       departureOptional: "Lasa necompletat pentru o rezervare cu data deschisa.",
       payment: "Totalul programat trebuie sa fie egal cu valoarea rezervarii.",
       contactLoading: "Se incarca datele de contact...",
+      contactUnavailable:
+        "Nu am putut incarca acest contact. Incearca din nou sau selecteaza ori creeaza alt contact.",
       contactIncomplete:
         "Acest contact are nevoie de prenume si nume, plus un e-mail sau un numar de telefon. Editeaza contactul de mai sus sau selecteaza ori creeaza alt contact.",
     },
@@ -72,6 +74,7 @@ export const bookingsUiRoCreateList = {
     actions: {
       create: "Creeaza rezervarea",
       confirmCreate: "Confirma si creeaza",
+      retryContact: "Incearca din nou",
     },
     confirm: {
       title: "Creezi aceasta rezervare?",

--- a/packages/bookings-react/src/i18n/ro-create-list.ts
+++ b/packages/bookings-react/src/i18n/ro-create-list.ts
@@ -27,6 +27,9 @@ export const bookingsUiRoCreateList = {
     hints: {
       departureOptional: "Lasa necompletat pentru o rezervare cu data deschisa.",
       payment: "Totalul programat trebuie sa fie egal cu valoarea rezervarii.",
+      contactLoading: "Se incarca datele de contact...",
+      contactIncomplete:
+        "Acest contact are nevoie de prenume si nume, plus un e-mail sau un numar de telefon. Editeaza contactul de mai sus sau selecteaza ori creeaza alt contact.",
     },
     validation: {
       product: "Alege un produs.",
@@ -35,6 +38,8 @@ export const bookingsUiRoCreateList = {
       person: "Alege persoana facturata.",
       organization: "Alege organizatia facturata.",
       contact: "Adauga un nume de contact pentru rezervare.",
+      contactName: "Adauga prenumele si numele persoanei facturate.",
+      contactMethod: "Adauga un e-mail sau un numar de telefon pentru persoana facturata.",
       email: "Introdu un e-mail de contact valid.",
       travelers: "Adauga cel putin un calator.",
       travelerNames: "Fiecare calator are nevoie de prenume si nume.",
@@ -251,6 +256,9 @@ export const bookingsUiRoCreateList = {
       breakdownOverrideReason: "Motiv suprascriere",
       breakdownOverrideReasonPlaceholder: "De ce este acest total diferit?",
       breakdownOverrideReasonRequired: "Adauga un motiv pentru totalul manual.",
+      breakdownPerTraveler: "per calator",
+      breakdownPerRoom: "per camera",
+      breakdownPerBooking: "per rezervare",
       breakdownSubtotal: "Subtotal",
       breakdownTax: "Taxa",
       breakdownTaxIncluded: "inclus",

--- a/packages/bookings-react/src/i18n/ro-sections.ts
+++ b/packages/bookings-react/src/i18n/ro-sections.ts
@@ -307,6 +307,9 @@ export const bookingsUiRoSections = {
       overrideReason: "Motiv suprascriere",
       overrideReasonPlaceholder: "De ce este acest total diferit?",
       overrideReasonRequired: "Adauga un motiv pentru totalul manual.",
+      perPerson: "per calator",
+      perUnit: "per camera",
+      perBooking: "per rezervare",
     },
   },
   bookingDocumentDialog: {

--- a/packages/bookings-react/tests/unit/manual-booking-validation.test.ts
+++ b/packages/bookings-react/tests/unit/manual-booking-validation.test.ts
@@ -26,6 +26,7 @@ const valid = {
   contactFirstName: "Ana",
   contactLastName: "Pop",
   contactEmail: "ana@example.com",
+  contactPhone: "",
   travelers: {
     travelers: [
       {
@@ -162,6 +163,12 @@ describe("manual booking validation", () => {
   })
 
   it("rejects invalid contact, traveler, lead, amount, and payment state", () => {
+    expect(validateManualBookingDraft({ ...valid, contactLastName: "" })).toBe(
+      bookingsUiEn.manualBookingCreate.validation.contactName,
+    )
+    expect(validateManualBookingDraft({ ...valid, contactEmail: "", contactPhone: "" })).toBe(
+      bookingsUiEn.manualBookingCreate.validation.contactMethod,
+    )
     expect(validateManualBookingDraft({ ...valid, contactEmail: "invalid" })).toBe(
       bookingsUiEn.manualBookingCreate.validation.email,
     )

--- a/packages/bookings/src/pricing-assignment/draft.ts
+++ b/packages/bookings/src/pricing-assignment/draft.ts
@@ -83,11 +83,25 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
   const selectedInventoryByOption = new Map<string, PricingAssignmentUnit[]>()
   const inventoryCapacityByUnitId = new Map<string, number>()
   for (const [key, inventoryUnits] of inventoryUnitsByOption) {
-    const selected = inventoryUnits.filter((unit) => (quantities[unit.optionUnitId] ?? 0) > 0)
+    const directlySelected = inventoryUnits.filter(
+      (unit) => (quantities[unit.optionUnitId] ?? 0) > 0,
+    )
+    // Legacy accommodation drafts can carry their quantity on the option's
+    // person-pricing unit. Keep normalizing those drafts onto the primary room
+    // while direct room selections retain their exact unit mix.
+    const selected =
+      directlySelected.length > 0
+        ? directlySelected
+        : (totalByOption.get(key) ?? 0) > 0 && inventoryUnits[0]
+          ? [inventoryUnits[0]]
+          : []
     if (selected.length === 0) continue
     selectedInventoryByOption.set(key, selected)
     for (const unit of selected) {
-      const quantity = quantities[unit.optionUnitId] ?? 0
+      const quantity =
+        directlySelected.length > 0
+          ? (quantities[unit.optionUnitId] ?? 0)
+          : (totalByOption.get(key) ?? 0)
       inventoryCapacityByUnitId.set(
         unit.optionUnitId,
         quantity * Math.max(1, unit.occupancyMax ?? 1),

--- a/packages/bookings/src/pricing-assignment/draft.ts
+++ b/packages/bookings/src/pricing-assignment/draft.ts
@@ -53,10 +53,10 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     else unitsByOption.set(key, [unit])
   }
 
-  const primaryInventoryByOption = new Map<string, PricingAssignmentUnit>()
+  const inventoryUnitsByOption = new Map<string, PricingAssignmentUnit[]>()
   for (const [key, optionUnits] of unitsByOption) {
-    const inventoryUnit = optionUnits.find(isInventoryUnit)
-    if (inventoryUnit) primaryInventoryByOption.set(key, inventoryUnit)
+    const inventoryUnits = optionUnits.filter(isInventoryUnit)
+    if (inventoryUnits.length > 0) inventoryUnitsByOption.set(key, inventoryUnits)
   }
 
   // An option is "person-priced" when it has at least one person unit
@@ -80,6 +80,32 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     totalByOption.set(key, (totalByOption.get(key) ?? 0) + quantity)
   }
 
+  const selectedInventoryByOption = new Map<string, PricingAssignmentUnit[]>()
+  const inventoryCapacityByUnitId = new Map<string, number>()
+  for (const [key, inventoryUnits] of inventoryUnitsByOption) {
+    const selected = inventoryUnits.filter((unit) => (quantities[unit.optionUnitId] ?? 0) > 0)
+    if (selected.length === 0) continue
+    selectedInventoryByOption.set(key, selected)
+    for (const unit of selected) {
+      const quantity = quantities[unit.optionUnitId] ?? 0
+      inventoryCapacityByUnitId.set(
+        unit.optionUnitId,
+        quantity * Math.max(1, unit.occupancyMax ?? 1),
+      )
+    }
+  }
+
+  const assignmentDemandByOption = new Map(totalByOption)
+  for (const [key, selected] of selectedInventoryByOption) {
+    assignmentDemandByOption.set(
+      key,
+      selected.reduce(
+        (sum, unit) => sum + (inventoryCapacityByUnitId.get(unit.optionUnitId) ?? 0),
+        0,
+      ),
+    )
+  }
+
   const assignedForDefaulting = new Map<string, number>()
   for (const traveler of travelers) {
     const inventorySource = traveler.inventoryUnitSource ?? "auto"
@@ -96,7 +122,7 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     assignedForDefaulting.set(key, (assignedForDefaulting.get(key) ?? 0) + 1)
   }
 
-  const optionDemand = Array.from(totalByOption.entries())
+  const optionDemand = Array.from(assignmentDemandByOption.entries())
   const pickOptionWithDemand = () =>
     optionDemand.find(
       ([candidate, total]) => (assignedForDefaulting.get(candidate) ?? 0) < total,
@@ -111,6 +137,35 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
       computeAgeYears(traveler.dateOfBirth, now),
       roleHintForTraveler(traveler),
     )
+
+  const inventoryUsedByUnitId = new Map<string, number>()
+  for (const traveler of travelers) {
+    if ((traveler.inventoryUnitSource ?? "auto") !== "manual" || !traveler.inventoryUnitId) {
+      continue
+    }
+    if (!inventoryCapacityByUnitId.has(traveler.inventoryUnitId)) continue
+    inventoryUsedByUnitId.set(
+      traveler.inventoryUnitId,
+      (inventoryUsedByUnitId.get(traveler.inventoryUnitId) ?? 0) + 1,
+    )
+  }
+
+  const pickInventoryUnit = (key: string): PricingAssignmentUnit | null => {
+    const selected = selectedInventoryByOption.get(key) ?? []
+    const available = selected.find(
+      (unit) =>
+        (inventoryUsedByUnitId.get(unit.optionUnitId) ?? 0) <
+        (inventoryCapacityByUnitId.get(unit.optionUnitId) ?? 0),
+    )
+    const picked = available ?? selected[0] ?? null
+    if (picked) {
+      inventoryUsedByUnitId.set(
+        picked.optionUnitId,
+        (inventoryUsedByUnitId.get(picked.optionUnitId) ?? 0) + 1,
+      )
+    }
+    return picked
+  }
 
   const resolveTargetOption = (
     traveler: TTraveler,
@@ -177,14 +232,14 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
       inventorySource === "manual" &&
       currentInventoryUnit &&
       isInventoryUnit(currentInventoryUnit) &&
-      currentInventoryKey === targetKey
-    const targetInventoryUnit = primaryInventoryByOption.get(targetKey) ?? null
+      currentInventoryKey === targetKey &&
+      inventoryCapacityByUnitId.has(currentInventoryUnit.optionUnitId)
     const nextInventoryUnit =
       inventorySource === "none"
         ? null
         : keepManualInventory
           ? currentInventoryUnit
-          : targetInventoryUnit
+          : pickInventoryUnit(targetKey)
 
     if (target.fromDemand && (nextPricingUnit || nextInventoryUnit)) {
       assignedForDefaulting.set(targetKey, (assignedForDefaulting.get(targetKey) ?? 0) + 1)
@@ -214,7 +269,7 @@ export function resolveBookingDraft<TTraveler extends BookingDraftTraveler>(opti
     const targetUnitId =
       submittedUnit && isInventoryUnit(submittedUnit)
         ? unitId
-        : (primaryInventoryByOption.get(key)?.optionUnitId ?? unitId)
+        : (selectedInventoryByOption.get(key)?.[0]?.optionUnitId ?? unitId)
     next[targetUnitId] = (next[targetUnitId] ?? 0) + quantity
   }
 

--- a/packages/bookings/src/pricing-assignment/types.ts
+++ b/packages/bookings/src/pricing-assignment/types.ts
@@ -83,6 +83,8 @@ export interface PricingAssignmentUnit {
   maxAge?: number | null
   /** Unit category — drives the pricing-tier vs inventory split. */
   unitType?: "person" | "group" | "room" | "vehicle" | "service" | "other" | null
+  /** Maximum travelers held by one selected inventory unit. */
+  occupancyMax?: number | null
 }
 
 export type BookingDraftQuantities = Record<string, number>

--- a/packages/bookings/tests/unit/pricing-assignment/draft-accommodation.suite.ts
+++ b/packages/bookings/tests/unit/pricing-assignment/draft-accommodation.suite.ts
@@ -72,6 +72,80 @@ describe("resolveBookingDraft — accommodation (Moldova DBL shape)", () => {
     expect(result.travelerIndexesByUnitId).toEqual({ u_dbl_room: [0, 1] })
   })
 
+  it("fills selected room capacity across room types", () => {
+    const roomUnits: PricingAssignmentUnit[] = [
+      unit({
+        optionId: "opto_rooms",
+        optionUnitId: "u_double",
+        unitName: "Double",
+        unitType: "room",
+        occupancyMax: 2,
+      }),
+      unit({
+        optionId: "opto_rooms",
+        optionUnitId: "u_single",
+        unitName: "Single",
+        unitType: "room",
+        occupancyMax: 1,
+      }),
+    ]
+    const result = resolveBookingDraft({
+      now: NOW,
+      quantities: { u_double: 1, u_single: 1 },
+      travelers: [
+        traveler({ role: "lead" }),
+        traveler({ role: "adult" }),
+        traveler({ role: "adult" }),
+      ],
+      units: roomUnits,
+    })
+
+    expect(result.quantities).toEqual({ u_double: 1, u_single: 1 })
+    expect(result.travelers.map((entry) => entry.inventoryUnitId)).toEqual([
+      "u_double",
+      "u_double",
+      "u_single",
+    ])
+    expect(result.travelerIndexesByUnitId).toEqual({ u_double: [0, 1], u_single: [2] })
+  })
+
+  it("respects manual room choices before assigning remaining travelers", () => {
+    const roomUnits: PricingAssignmentUnit[] = [
+      unit({
+        optionId: "opto_rooms",
+        optionUnitId: "u_double",
+        unitType: "room",
+        occupancyMax: 2,
+      }),
+      unit({
+        optionId: "opto_rooms",
+        optionUnitId: "u_single",
+        unitType: "room",
+        occupancyMax: 1,
+      }),
+    ]
+    const result = resolveBookingDraft({
+      now: NOW,
+      quantities: { u_double: 1, u_single: 1 },
+      travelers: [
+        traveler({
+          role: "lead",
+          inventoryUnitId: "u_single",
+          inventoryUnitSource: "manual",
+        }),
+        traveler({ role: "adult" }),
+        traveler({ role: "adult" }),
+      ],
+      units: roomUnits,
+    })
+
+    expect(result.travelers.map((entry) => entry.inventoryUnitId)).toEqual([
+      "u_single",
+      "u_double",
+      "u_double",
+    ])
+  })
+
   it("reassigns stale manual assignments when the option changes", () => {
     // Operator switched the room from DBL to TWN. The stale inventory
     // id is no longer in unitById, so the resolver re-derives both

--- a/packages/bookings/tests/unit/pricing-assignment/fixtures.ts
+++ b/packages/bookings/tests/unit/pricing-assignment/fixtures.ts
@@ -16,6 +16,7 @@ export function unit(
     minAge: partial.minAge ?? null,
     maxAge: partial.maxAge ?? null,
     unitType: partial.unitType ?? "person",
+    occupancyMax: partial.occupancyMax ?? null,
   }
 }
 

--- a/packages/catalog-contracts/src/booking-engine/draft-contracts.ts
+++ b/packages/catalog-contracts/src/booking-engine/draft-contracts.ts
@@ -246,6 +246,9 @@ export const pricingLineV1 = z.object({
   unitAmount: z.number().int(),
   totalAmount: z.number().int(),
   taxIncluded: z.boolean().optional(),
+  /** How quantity is interpreted for this line. Booking UIs use this to
+   * distinguish inventory held from travelers charged. */
+  pricingBasis: z.enum(["per_person", "per_unit", "per_booking"]).optional(),
 })
 
 export const pricingTaxV1 = z.object({

--- a/packages/finance/src/booking-create-command.ts
+++ b/packages/finance/src/booking-create-command.ts
@@ -129,7 +129,7 @@ async function insertBookingCreatedOutbox(
   await insertOutboxEvents(tx, events)
 }
 
-function bookingCreateCommandError(
+export function bookingCreateCommandError(
   outcome: Exclude<Awaited<ReturnType<typeof createBookingMutation>>, { status: "ok" }>,
 ) {
   switch (outcome.status) {
@@ -141,6 +141,30 @@ function bookingCreateCommandError(
       // Surfaced verbatim to the operator, so it has to read as a next step
       // rather than an internal failure.
       return new ToolError(outcome.message, "INVALID_INPUT", { outcome })
+    case "room_occupancy_insufficient":
+      return new ToolError(
+        `The selected rooms fit ${outcome.occupancyMax} traveler(s), but the booking has ${outcome.pax}. Add room capacity for ${outcome.shortfall} more traveler(s), then assign every traveler to a room.`,
+        "INVALID_INPUT",
+        { outcome },
+      )
+    case "payload_resolver_mismatch":
+      return new ToolError(
+        "The traveler-to-room assignments do not match the selected booking items. Rebuild the room item lines, assign each traveler key to exactly one selected room, and try again.",
+        "INVALID_INPUT",
+        { outcome },
+      )
+    case "invalid_payment_schedules":
+      return new ToolError(
+        `The payment schedule is invalid: ${formatBookingCreateIssues(outcome.issues)}`,
+        "INVALID_INPUT",
+        { outcome },
+      )
+    case "invalid_tax_lines":
+      return new ToolError(
+        `The tax lines are invalid: ${formatBookingCreateIssues(outcome.issues)}`,
+        "INVALID_INPUT",
+        { outcome },
+      )
     case "duplicate_booking":
     case "travel_credit_inactive":
     case "travel_credit_not_started":
@@ -153,6 +177,14 @@ function bookingCreateCommandError(
     default:
       return new ToolError("The booking command failed validation.", "INVALID_INPUT", { outcome })
   }
+}
+
+function formatBookingCreateIssues(
+  issues: Array<{ path: Array<string | number>; message: string }>,
+) {
+  return issues
+    .map((issue) => `${issue.path.length > 0 ? `${issue.path.join(".")}: ` : ""}${issue.message}`)
+    .join("; ")
 }
 
 export function financeBookingCreatedEventId(bookingId: string) {

--- a/packages/finance/src/service-booking-create.ts
+++ b/packages/finance/src/service-booking-create.ts
@@ -41,7 +41,15 @@ import {
 // ---------- validation ----------
 
 const travelerInputSchema = z.object({
-  clientTravelerKey: z.string().min(1).max(255).optional().nullable(),
+  clientTravelerKey: z
+    .string()
+    .min(1)
+    .max(255)
+    .optional()
+    .nullable()
+    .describe(
+      "Stable key for this traveler within the request. Use the same key in exactly one room itemLine.travelerKeys entry to assign the traveler to that room.",
+    ),
   firstName: z.string().min(1).max(255),
   lastName: z.string().min(1).max(255),
   email: z.string().email().optional().nullable(),
@@ -86,8 +94,19 @@ const itemLineInputSchema = z.object({
    * via `booking_item_travelers`. See voyant-travel/voyant#1267.
    */
   clientLineKey: z.string().min(1).max(255).optional().nullable(),
-  optionUnitId: z.string().min(1),
-  quantity: z.number().int().min(1),
+  optionUnitId: z
+    .string()
+    .min(1)
+    .describe(
+      "Selected product option-unit id. Resolve valid room or person units with `list_option_units` for the chosen option.",
+    ),
+  quantity: z
+    .number()
+    .int()
+    .min(1)
+    .describe(
+      "Number of this unit selected. For a room unit this is the number of rooms, not the number of travelers.",
+    ),
   title: z.string().min(1).max(255).optional().nullable(),
   description: z.string().max(5000).optional().nullable(),
   unitSellAmountCents: z.number().int().min(0).optional().nullable(),
@@ -96,7 +115,13 @@ const itemLineInputSchema = z.object({
    * Stable traveler keys this item applies to. Server inserts one
    * `booking_item_travelers` row per traveler.
    */
-  travelerKeys: z.array(z.string().min(1).max(255)).optional().nullable(),
+  travelerKeys: z
+    .array(z.string().min(1).max(255))
+    .optional()
+    .nullable()
+    .describe(
+      "clientTravelerKey values assigned to this room or priced unit. For accommodation, assign every traveler to exactly one selected room and respect room occupancy.",
+    ),
 })
 
 const extraLineInputSchema = z.object({
@@ -340,7 +365,13 @@ function isRealEmail(value: string | null | undefined): value is string {
 const bookingCreateBaseSchema = z.object({
   // Convert-product fields (mirrors convertProductSchema in bookings)
   productId: z.string().min(1),
-  optionId: z.string().optional().nullable(),
+  optionId: z
+    .string()
+    .optional()
+    .nullable()
+    .describe(
+      "Chosen product option id. Resolve it with `list_product_options`; supply it explicitly when the product has rooms or multiple options.",
+    ),
   slotId: z.string().optional().nullable(),
   /** Pre-booking availability hold converted inside the create transaction. */
   availabilityHoldToken: z.string().min(1).optional(),
@@ -381,7 +412,15 @@ const bookingCreateBaseSchema = z.object({
     .describe(
       "Id of the organization billed for this booking, for a company or agency booking. Required unless `personId` is set — a booking needs a billing party. Resolve it with `list_organizations`, or create it first with `create_organization`.",
     ),
-  pax: z.number().int().positive().optional().nullable(),
+  pax: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .nullable()
+    .describe(
+      "Total traveler count. This must match the travelers array and selected room capacity.",
+    ),
   internalNotes: z.string().optional().nullable(),
   /**
    * Override the seed `sellAmountCents` on the new booking + line item.
@@ -437,8 +476,16 @@ const bookingCreateBaseSchema = z.object({
   contactPostalCode: z.string().max(20).optional().nullable(),
 
   // Orchestration fields
-  travelers: z.array(travelerInputSchema).optional(),
-  itemLines: z.array(itemLineInputSchema).optional(),
+  travelers: z
+    .array(travelerInputSchema)
+    .optional()
+    .describe("Travelers on the booking. Give each one a unique clientTravelerKey."),
+  itemLines: z
+    .array(itemLineInputSchema)
+    .optional()
+    .describe(
+      "Explicit selected rooms or priced units. Required for room products: quantity is room count, and travelerKeys assigns travelers to each room type.",
+    ),
   extraLines: z.array(extraLineInputSchema).optional(),
   taxLines: z.array(taxLineInputSchema).optional(),
   paymentSchedules: z.array(paymentScheduleInputSchema).optional(),

--- a/packages/finance/src/tools.ts
+++ b/packages/finance/src/tools.ts
@@ -238,7 +238,7 @@ export const createBookingTool = defineTool({
   capabilityVersion: "v1",
   name: "create_booking",
   description:
-    "Durably create one booking from a product or slot. Requires a billing party: set `personId` for a private client (find it with `list_people`), or `organizationId` for a company booking (find it with `list_organizations`) — at least one is mandatory. Exact retries resolve the original immutable booking reference.",
+    "Durably create one booking from a product or slot. Requires a billing party: set `personId` for a private client (find it with `list_people`), or `organizationId` for a company booking (find it with `list_organizations`) — at least one is mandatory. For a product with rooms or options, first use `list_product_options` and `list_option_units`, then pass explicit `optionId` and `itemLines`: room quantity means number of rooms, while each line's `travelerKeys` assigns travelers to that room type. Exact retries resolve the original immutable booking reference.",
   inputSchema: createBookingToolInputSchema,
   outputSchema: durableBookingCreateResultSchema,
   requiredScopes: ["bookings:write", "finance:write"],

--- a/packages/finance/tests/tools.test.ts
+++ b/packages/finance/tests/tools.test.ts
@@ -436,6 +436,8 @@ describe("finance tools", () => {
 
     expect(tool.description).toMatch(/personId/)
     expect(tool.description).toMatch(/organizationId/)
+    expect(tool.description).toMatch(/list_option_units/)
+    expect(tool.description).toMatch(/room quantity means number of rooms/i)
 
     // Assert on the same carrier `bookingNumber` already relies on to reach a
     // caller, so this pins the description actually shipping, not a doc comment.
@@ -456,6 +458,8 @@ describe("finance tools", () => {
     expect(shape.personId?.description).not.toMatch(/list_organizations/)
     expect(shape.organizationId?.description).toMatch(/list_organizations/)
     expect(shape.organizationId?.description).not.toMatch(/list_people/)
+    expect(shape.optionId?.description).toMatch(/list_product_options/)
+    expect(shape.itemLines?.description).toMatch(/room products/i)
 
     // "at least one", never "exactly one": createBookingMutation stores both,
     // for a traveller billed through their company, and no rule forbids it.

--- a/packages/finance/tests/unit/booking-create-command-errors.test.ts
+++ b/packages/finance/tests/unit/booking-create-command-errors.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { bookingCreateCommandError } from "../../src/booking-create-command.js"
+
+describe("booking create command errors", () => {
+  it("explains room capacity failures as a corrective action", () => {
+    const error = bookingCreateCommandError({
+      status: "room_occupancy_insufficient",
+      pax: 3,
+      occupancyMax: 2,
+      shortfall: 1,
+    })
+
+    expect(error.message).toMatch(/fit 2 traveler/)
+    expect(error.message).toMatch(/Add room capacity for 1 more traveler/)
+    expect(error.message).toMatch(/assign every traveler to a room/)
+  })
+
+  it("explains traveler and room payload mismatches", () => {
+    const error = bookingCreateCommandError({
+      status: "payload_resolver_mismatch",
+      mismatches: [],
+    })
+
+    expect(error.message).toMatch(/traveler-to-room assignments/)
+    expect(error.message).toMatch(/assign each traveler key/)
+  })
+
+  it("includes the invalid payment field and reason", () => {
+    const error = bookingCreateCommandError({
+      status: "invalid_payment_schedules",
+      issues: [{ path: ["paymentSchedules", 0, "amountCents"], message: "Total is too high" }],
+    })
+
+    expect(error.message).toContain("paymentSchedules.0.amountCents: Total is too high")
+  })
+})

--- a/packages/inventory/src/booking-engine/handler-support.ts
+++ b/packages/inventory/src/booking-engine/handler-support.ts
@@ -236,7 +236,13 @@ export async function priceOptionSelections(input: {
       // Prefer the specific room/unit name ("Standard - Single"); fall back to
       // the option name, then the product name.
       label:
-        selection.optionUnitName ?? optionsById.get(selection.optionId)?.name ?? input.product.name,
+        (selection.optionUnitId
+          ? findProductOptionUnit(input.productOptions, selection.optionId, selection.optionUnitId)
+              ?.name
+          : null) ??
+        selection.optionUnitName ??
+        optionsById.get(selection.optionId)?.name ??
+        input.product.name,
       quantity: pricingQuantity,
       unitAmount,
       totalAmount,

--- a/packages/inventory/src/booking-engine/handler-support.ts
+++ b/packages/inventory/src/booking-engine/handler-support.ts
@@ -44,6 +44,7 @@ export interface PricedLine {
   quantity: number
   unitAmount: number
   totalAmount: number
+  pricingBasis?: "per_person" | "per_unit" | "per_booking"
   /** Internal quote provenance used to persist the accepted price per booking item. */
   optionId?: string
   optionUnitId?: string
@@ -110,6 +111,8 @@ export async function priceOptionSelections(input: {
   effectivePax: number
   /** Booking-level pax counts by band code, for per-traveler-type room prices. */
   pax?: Partial<Record<string, number>>
+  /** Explicit traveler-to-room assignments from the booking draft. */
+  travelerAssignments?: Record<string, string>
 }): Promise<PricedQuote> {
   const lines: PricedLine[] = []
   let totalCents = 0
@@ -153,12 +156,13 @@ export async function priceOptionSelections(input: {
       selection.optionUnitId && resolvedPrice?.unitPrices
         ? resolvedPrice.unitPrices.filter((unit) => unit.unitId === selection.optionUnitId)
         : []
-    // A category-less unit price charges flat per room (× quantity). Per-
+    // A category-less unit price follows its configured pricing mode. Per-
     // category rows (the Rooms & prices matrix — "Double / Adult") price per
     // traveler band instead, so collect them for the booking-level charge below
-    // and skip the flat per-room line for this selection.
+    // and skip the category-less line for this selection.
     const categoryUnitRows = unitRows.filter((unit) => unit.travelerCategory)
-    const unitPrice = unitRows.find((unit) => !unit.travelerCategory)?.sellAmountCents ?? null
+    const defaultUnitPrice = unitRows.find((unit) => !unit.travelerCategory) ?? null
+    const unitPrice = defaultUnitPrice?.sellAmountCents ?? null
     if (unitPrice == null && categoryUnitRows.length > 0) {
       const unitLabel =
         findProductOptionUnit(input.productOptions, selection.optionId, selection.optionUnitId)
@@ -178,6 +182,21 @@ export async function priceOptionSelections(input: {
       }
       continue
     }
+    const assignedTravelerCount = selection.optionUnitId
+      ? Object.values(input.travelerAssignments ?? {}).filter(
+          (assignedUnitId) => assignedUnitId === selection.optionUnitId,
+        ).length
+      : 0
+    const pricingQuantity =
+      defaultUnitPrice?.pricingMode === "per_person"
+        ? assignedTravelerCount > 0
+          ? assignedTravelerCount
+          : input.selections.length === 1
+            ? input.effectivePax
+            : selection.quantity
+        : defaultUnitPrice?.pricingMode === "per_booking"
+          ? 1
+          : selection.quantity
     const paxTier =
       unitPrice == null && selection.optionUnitId
         ? await resolveSelectionPaxTier({
@@ -210,7 +229,7 @@ export async function priceOptionSelections(input: {
       input.product.sellAmountCents ??
       0
     if (unitAmount <= 0) continue
-    const totalAmount = unitAmount * selection.quantity
+    const totalAmount = unitAmount * pricingQuantity
     totalCents += totalAmount
     lines.push({
       kind: "base",
@@ -218,9 +237,15 @@ export async function priceOptionSelections(input: {
       // the option name, then the product name.
       label:
         selection.optionUnitName ?? optionsById.get(selection.optionId)?.name ?? input.product.name,
-      quantity: selection.quantity,
+      quantity: pricingQuantity,
       unitAmount,
       totalAmount,
+      pricingBasis:
+        defaultUnitPrice?.pricingMode === "per_person"
+          ? "per_person"
+          : defaultUnitPrice?.pricingMode === "per_booking"
+            ? "per_booking"
+            : "per_unit",
       optionId: selection.optionId,
       ...(selection.optionUnitId ? { optionUnitId: selection.optionUnitId } : {}),
     })
@@ -240,6 +265,7 @@ export async function priceOptionSelections(input: {
       quantity: count,
       unitAmount: price.cents,
       totalAmount,
+      pricingBasis: "per_person",
       optionId: price.optionId,
       ...(price.optionUnitId ? { optionUnitId: price.optionUnitId } : {}),
     })
@@ -400,6 +426,8 @@ export function applyAddonSelections(input: {
       quantity,
       unitAmount,
       totalAmount,
+      pricingBasis:
+        extra.pricingMode === "per_person" || extra.pricedPerPerson ? "per_person" : "per_unit",
     })
   }
   return { totalCents, lines }
@@ -495,6 +523,7 @@ export function priceQuote(input: {
         quantity: count,
         unitAmount: sell,
         totalAmount: lineTotal,
+        pricingBasis: "per_person",
       })
     }
     if (bandLines.length > 0) {
@@ -514,6 +543,7 @@ export function priceQuote(input: {
           quantity: effectivePax,
           unitAmount: unitCents,
           totalAmount: totalCents,
+          pricingBasis: "per_person",
         },
       ],
     }
@@ -530,6 +560,7 @@ export function priceQuote(input: {
         quantity: effectivePax,
         unitAmount: unitCents,
         totalAmount: totalCents,
+        pricingBasis: "per_person",
       },
     ],
   }

--- a/packages/inventory/src/booking-engine/handler.ts
+++ b/packages/inventory/src/booking-engine/handler.ts
@@ -72,12 +72,16 @@ export interface DraftLike {
     address?: { country?: string }
   }
   travelers?: Array<{
+    rowId?: string
     firstName: string
     lastName: string
     email?: string
     phone?: string
     band?: string
   }>
+  accommodation?: {
+    travelerAssignments?: Record<string, string>
+  }
   addons?: Array<{
     extraId: string
     quantity: number
@@ -179,6 +183,7 @@ export interface ResolvedUnitPrice {
   unitId: string
   unitType: "person" | "room" | "vehicle" | "service" | "group" | "other" | string
   travelerCategory: "adult" | "child" | "infant" | "senior" | null
+  pricingMode?: "per_unit" | "per_person" | "per_booking" | "included" | "free" | "on_request"
   sellAmountCents: number | null
 }
 
@@ -493,6 +498,7 @@ export function createProductsBookingHandler(
                 slotDate,
                 effectivePax,
                 pax: draft.configure?.pax,
+                travelerAssignments: draft.accommodation?.travelerAssignments,
               })
             : priceQuote({
                 product,

--- a/packages/inventory/src/booking-engine/product-runtime.ts
+++ b/packages/inventory/src/booking-engine/product-runtime.ts
@@ -489,6 +489,7 @@ export function registerProductBookingHandler(
               unitId: optionUnitPriceRules.unitId,
               sellAmountCents: optionUnitPriceRules.sellAmountCents,
               pricingCategoryId: optionUnitPriceRules.pricingCategoryId,
+              pricingMode: optionUnitPriceRules.pricingMode,
             })
             .from(optionUnitPriceRules)
             .where(
@@ -541,6 +542,7 @@ export function registerProductBookingHandler(
                 unitId: up.unitId,
                 unitType: unit.unitType,
                 travelerCategory: band as "adult" | "child" | "infant" | "senior",
+                pricingMode: up.pricingMode,
                 sellAmountCents: up.sellAmountCents,
               },
             ]
@@ -550,6 +552,7 @@ export function registerProductBookingHandler(
               unitId: up.unitId,
               unitType: unit.unitType,
               travelerCategory: deriveTravelerCategory(unit),
+              pricingMode: up.pricingMode,
               sellAmountCents: up.sellAmountCents,
             },
           ]

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -196,7 +196,7 @@ describe("createProductsBookingHandler.computeQuote", () => {
     const lines = breakdown?.lines as Array<{ label: string; quantity: number; unitAmount: number }>
     expect(lines[0]).toEqual(
       expect.objectContaining({
-        label: "Junior suite upgrade",
+        label: "Suite",
         quantity: 2,
         unitAmount: 32000,
       }),

--- a/packages/inventory/tests/unit/booking-engine-quote.test.ts
+++ b/packages/inventory/tests/unit/booking-engine-quote.test.ts
@@ -254,6 +254,82 @@ describe("createProductsBookingHandler.computeQuote", () => {
     )
   })
 
+  it("prices category-less per-person room rates from traveler room assignments", async () => {
+    const handler = createProductsBookingHandler({
+      loadSlotDate: async () => "2026-11-09",
+      loadProductOptions: async () => [
+        {
+          id: "opt_standard",
+          name: "Standard",
+          units: [
+            { id: "unit_double", name: "Double", unitType: "room" },
+            { id: "unit_single", name: "Single", unitType: "room" },
+          ],
+        },
+      ],
+      loadResolvedOptionPrice: async () => ({
+        baseSellAmountCents: 0,
+        unitPrices: [
+          {
+            unitId: "unit_double",
+            unitType: "room",
+            travelerCategory: null,
+            pricingMode: "per_person",
+            sellAmountCents: 142_000,
+          },
+          {
+            unitId: "unit_single",
+            unitType: "room",
+            travelerCategory: null,
+            pricingMode: "per_person",
+            sellAmountCents: 198_000,
+          },
+        ],
+      }),
+    })
+
+    const result = await handler.computeQuote(
+      makeCtx([product]),
+      baseRequest({
+        configure: {
+          departureSlotId: "slot_1",
+          pax: { adult: 3 },
+          optionSelections: [
+            { optionId: "opt_standard", optionUnitId: "unit_double", quantity: 1 },
+            { optionId: "opt_standard", optionUnitId: "unit_single", quantity: 1 },
+          ],
+        },
+        accommodation: {
+          travelerAssignments: {
+            traveler_x: "unit_double",
+            traveler_y: "unit_double",
+            traveler_z: "unit_single",
+          },
+        },
+      }),
+    )
+
+    expect(result.available).toBe(true)
+    const breakdown = result.pricing?.breakdown as Record<string, unknown>
+    expect(breakdown?.total).toBe(482_000)
+    expect(breakdown?.lines).toEqual([
+      expect.objectContaining({
+        label: "Double",
+        quantity: 2,
+        unitAmount: 142_000,
+        totalAmount: 284_000,
+        pricingBasis: "per_person",
+      }),
+      expect.objectContaining({
+        label: "Single",
+        quantity: 1,
+        unitAmount: 198_000,
+        totalAmount: 198_000,
+        pricingBasis: "per_person",
+      }),
+    ])
+  })
+
   it("uses selected option-unit pax tiers before falling back to the product base price", async () => {
     const loadPaxPricingTier = vi.fn(
       async (


### PR DESCRIPTION
## What changed

- make the manual Create booking action surface application validation instead of being swallowed by native form validation
- use selected CRM person details directly and remove duplicate name/email/phone inputs for individual billing; incomplete CRM records get an actionable warning
- auto-assign travelers across selected room capacity while preserving explicit room choices
- preserve and display authoritative per-traveler, per-room, and per-booking price bases
- calculate category-less per-person room prices from traveler-to-room assignments
- improve MAX/Finance booking contracts and return corrective room, assignment, payment, and tax errors
- keep owned and supplier quotes on the same authoritative preview path

## Root cause

Native browser validation could prevent the React submit handler from running, leaving Create booking with no visible effect. Room pricing also dropped the configured pricing mode before quoting, so category-less per-person prices were multiplied as room quantities. Automatic accommodation assignment always chose the first inventory unit, and the Finance tool contract did not explain how room quantities and traveler keys relate.

## Impact

Operators can create bookings without retyping an existing contact, see why an incomplete booking cannot be submitted, build mixed room allocations such as one Double plus one Single, and see whether each price is per traveler, per room, or per booking. Agent-assisted creates receive actionable correction steps instead of a generic validation failure.

## Validation

Not run at the request of the maintainer (`push with no verify`). CI is expected to perform repository validation.
