### PR TITLE
Cache storefront departures in managed Redis

### DIFF
--- a/.changeset/calm-departure-caches.md
+++ b/.changeset/calm-departure-caches.md
@@ -1,0 +1,5 @@
+---
+"@voyant-travel/storefront": patch
+---
+
+Keep anonymous departure browsing in the configured cache store for 15 minutes and invalidate every cached query variant when `availability.slot.changed` is delivered. Managed runtimes use Redis through the provider-neutral cache interface. Checkout continues to verify availability against the transactional database, and deployments without a cache provider continue to use the live query path.

--- a/.changeset/calm-departure-caches.md
+++ b/.changeset/calm-departure-caches.md
@@ -1,5 +1,6 @@
 ---
 "@voyant-travel/storefront": patch
+"@voyant-travel/utils": patch
 ---
 
-Keep anonymous departure browsing in the configured cache store for 15 minutes and invalidate every cached query variant when `availability.slot.changed` is delivered. Managed runtimes use Redis through the provider-neutral cache interface. Checkout continues to verify availability against the transactional database, and deployments without a cache provider continue to use the live query path.
+Keep anonymous departure browsing in the configured cache store for 15 minutes and invalidate every cached query variant when `availability.slot.changed` is delivered. Managed runtimes use Redis through the provider-neutral cache interface, with process-local tiered-cache entries capped at 60 seconds to bound cross-replica invalidation lag. Checkout continues to verify availability against the transactional database, and deployments without a cache provider continue to use the live query path.

--- a/packages/storefront/src/departures-read-model.ts
+++ b/packages/storefront/src/departures-read-model.ts
@@ -1,0 +1,113 @@
+import type { BootstrapContext, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
+import type { KVStore } from "@voyant-travel/utils/cache"
+import type { Context } from "hono"
+
+/**
+ * Cache-store-backed public departure documents. Managed Node deployments bind
+ * CACHE to Redis; the KVStore-shaped port keeps the OSS module provider-neutral.
+ * Checkout and price confirmation remain transactional Postgres paths; this
+ * read model only serves anonymous browse responses and is invalidated by the
+ * canonical availability event.
+ */
+const DEPARTURES_RM_PREFIX = "rm:v1:departures"
+
+/** Long fallback bound; normal freshness comes from exact event invalidation. */
+export const DEPARTURES_DOC_TTL_SECONDS = 15 * 60
+
+export function departuresDocPrefix(productId: string): string {
+  return `${DEPARTURES_RM_PREFIX}:${productId}:`
+}
+
+export function departuresDocKey(
+  productId: string,
+  query: Record<string, unknown>,
+): string {
+  const entries = Object.entries(query)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join("&")
+  return `${departuresDocPrefix(productId)}${entries || "default"}`
+}
+
+/** Best-effort read-through cache; failures degrade to the live query. */
+export async function readThroughDepartures<T>(
+  c: Context<{ Bindings: { CACHE?: KVStore } }>,
+  key: string,
+  compute: () => Promise<T>,
+): Promise<T> {
+  const kv = c.env?.CACHE
+  if (kv) {
+    try {
+      const hit = await kv.get<T>(key, { type: "json" })
+      if (hit !== null && hit !== undefined) return hit
+    } catch {
+      // fall through to live
+    }
+  }
+  const data = await compute()
+  if (kv && data !== null && data !== undefined) {
+    try {
+      await kv.put(key, JSON.stringify(data), {
+        expirationTtl: DEPARTURES_DOC_TTL_SECONDS,
+      })
+    } catch {
+      // best-effort
+    }
+  }
+  return data
+}
+
+/** Delete every query variant for one product. */
+export async function invalidateDeparturesReadModel(
+  kv: KVStore,
+  productId: string,
+): Promise<void> {
+  if (!kv.list) return
+  const { keys } = await kv.list({ prefix: departuresDocPrefix(productId) })
+  await Promise.all(keys.map(({ name }) => kv.delete(name)))
+}
+
+function productIdFromAvailabilityEvent(data: unknown): string | null {
+  if (!data || typeof data !== "object") return null
+  const productId = (data as { productId?: unknown }).productId
+  return typeof productId === "string" && productId.trim()
+    ? productId.trim()
+    : null
+}
+
+export const STOREFRONT_AVAILABILITY_READ_MODEL_SUBSCRIBER_ID =
+  "@voyant-travel/storefront#subscriber.invalidate-departures-on-availability-change"
+
+export function createStorefrontAvailabilityReadModelInvalidationSubscriber(
+  logger: Pick<Console, "warn"> = console,
+): SubscriberRuntimeDescriptor {
+  return {
+    id: STOREFRONT_AVAILABILITY_READ_MODEL_SUBSCRIBER_ID,
+    eventType: "availability.slot.changed",
+    register({ bindings, eventBus }: BootstrapContext) {
+      eventBus.subscribe(
+        "availability.slot.changed",
+        async ({ data }) => {
+          const productId = productIdFromAvailabilityEvent(data)
+          const kv = (bindings as { CACHE?: KVStore } | undefined)?.CACHE
+          if (!productId || !kv) return
+          try {
+            await invalidateDeparturesReadModel(kv, productId)
+          } catch (error) {
+            // Cache invalidation is a best-effort projection update. Never
+            // dead-letter the domain event when the cache is unavailable.
+            logger.warn("[storefront] departure read-model invalidation failed", {
+              productId,
+              error: error instanceof Error ? error.message : String(error),
+            })
+          }
+        },
+        { inline: false },
+      )
+    },
+  }
+}
+
+export const storefrontAvailabilityReadModelInvalidationSubscriber =
+  createStorefrontAvailabilityReadModelInvalidationSubscriber()

--- a/packages/storefront/src/departures-read-model.ts
+++ b/packages/storefront/src/departures-read-model.ts
@@ -1,6 +1,5 @@
 import type { BootstrapContext, SubscriberRuntimeDescriptor } from "@voyant-travel/core"
 import type { KVStore } from "@voyant-travel/utils/cache"
-import type { Context } from "hono"
 
 /**
  * Cache-store-backed public departure documents. Managed Node deployments bind
@@ -18,10 +17,7 @@ export function departuresDocPrefix(productId: string): string {
   return `${DEPARTURES_RM_PREFIX}:${productId}:`
 }
 
-export function departuresDocKey(
-  productId: string,
-  query: Record<string, unknown>,
-): string {
+export function departuresDocKey(productId: string, query: Record<string, unknown>): string {
   const entries = Object.entries(query)
     .filter(([, value]) => value !== undefined && value !== null)
     .sort(([a], [b]) => (a < b ? -1 : 1))
@@ -32,7 +28,7 @@ export function departuresDocKey(
 
 /** Best-effort read-through cache; failures degrade to the live query. */
 export async function readThroughDepartures<T>(
-  c: Context<{ Bindings: { CACHE?: KVStore } }>,
+  c: { env?: { CACHE?: KVStore } },
   key: string,
   compute: () => Promise<T>,
 ): Promise<T> {
@@ -59,10 +55,7 @@ export async function readThroughDepartures<T>(
 }
 
 /** Delete every query variant for one product. */
-export async function invalidateDeparturesReadModel(
-  kv: KVStore,
-  productId: string,
-): Promise<void> {
+export async function invalidateDeparturesReadModel(kv: KVStore, productId: string): Promise<void> {
   if (!kv.list) return
   const { keys } = await kv.list({ prefix: departuresDocPrefix(productId) })
   await Promise.all(keys.map(({ name }) => kv.delete(name)))
@@ -71,9 +64,7 @@ export async function invalidateDeparturesReadModel(
 function productIdFromAvailabilityEvent(data: unknown): string | null {
   if (!data || typeof data !== "object") return null
   const productId = (data as { productId?: unknown }).productId
-  return typeof productId === "string" && productId.trim()
-    ? productId.trim()
-    : null
+  return typeof productId === "string" && productId.trim() ? productId.trim() : null
 }
 
 export const STOREFRONT_AVAILABILITY_READ_MODEL_SUBSCRIBER_ID =

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -7,6 +7,17 @@ import { createStorefrontAdminRoutes } from "./routes-admin.js"
 import { createStorefrontPublicRoutes } from "./routes-public.js"
 import { storefrontIntakeRuntimePort, storefrontOffersRuntimePort } from "./runtime-port.js"
 
+export {
+  createStorefrontAvailabilityReadModelInvalidationSubscriber,
+  DEPARTURES_DOC_TTL_SECONDS,
+  departuresDocKey,
+  departuresDocPrefix,
+  invalidateDeparturesReadModel,
+  readThroughDepartures,
+  storefrontAvailabilityReadModelInvalidationSubscriber,
+  STOREFRONT_AVAILABILITY_READ_MODEL_SUBSCRIBER_ID,
+} from "./departures-read-model.js"
+
 export type {
   GuestBookingGuardOptions,
   GuestBookingGuardRequest,

--- a/packages/storefront/src/index.ts
+++ b/packages/storefront/src/index.ts
@@ -14,8 +14,8 @@ export {
   departuresDocPrefix,
   invalidateDeparturesReadModel,
   readThroughDepartures,
-  storefrontAvailabilityReadModelInvalidationSubscriber,
   STOREFRONT_AVAILABILITY_READ_MODEL_SUBSCRIBER_ID,
+  storefrontAvailabilityReadModelInvalidationSubscriber,
 } from "./departures-read-model.js"
 
 export type {

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -9,10 +9,7 @@ import {
 } from "@voyant-travel/hono"
 import type { Context } from "hono"
 
-import {
-  departuresDocKey,
-  readThroughDepartures,
-} from "./departures-read-model.js"
+import { departuresDocKey, readThroughDepartures } from "./departures-read-model.js"
 import {
   createStorefrontService,
   type StorefrontRequestContext,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -10,6 +10,9 @@ import {
 import type { Context } from "hono"
 
 import { departuresDocKey, readThroughDepartures } from "./departures-read-model.js"
+
+export { departuresDocKey, readThroughDepartures }
+
 import {
   createStorefrontService,
   type StorefrontRequestContext,

--- a/packages/storefront/src/routes-public.ts
+++ b/packages/storefront/src/routes-public.ts
@@ -10,6 +10,10 @@ import {
 import type { Context } from "hono"
 
 import {
+  departuresDocKey,
+  readThroughDepartures,
+} from "./departures-read-model.js"
+import {
   createStorefrontService,
   type StorefrontRequestContext,
   type StorefrontServiceOptions,
@@ -53,53 +57,6 @@ const PUBLIC_CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300"
 
 function setPublicCacheHeaders(c: Context) {
   c.header("Cache-Control", PUBLIC_CACHE_CONTROL)
-}
-
-/**
- * KV read-model TTL for the departure list (RFC voyant#1687 Phase 2.2).
- * Departure availability shifts with every booking, so unlike the
- * product-detail documents (24h + exact invalidation in products) this
- * is purely TTL-bounded: browse-grade freshness within 2 minutes, and
- * checkout always re-verifies capacity on the live transactional path.
- */
-const DEPARTURES_DOC_TTL_SECONDS = 120
-
-export function departuresDocKey(productId: string, query: Record<string, unknown>): string {
-  const entries = Object.entries(query)
-    .filter(([, value]) => value !== undefined && value !== null)
-    .sort(([a], [b]) => (a < b ? -1 : 1))
-    .map(([key, value]) => `${key}=${String(value)}`)
-    .join("&")
-  return `rm:v1:departures:${productId}:${entries || "default"}`
-}
-
-/**
- * Read-through KV cache for a departures payload. Best-effort: any KV
- * failure (or a missing CACHE binding) degrades to the live query.
- */
-export async function readThroughDepartures<T>(
-  c: Context<Env>,
-  key: string,
-  compute: () => Promise<T>,
-): Promise<T> {
-  const kv = c.env?.CACHE
-  if (kv) {
-    try {
-      const hit = await kv.get<T>(key, { type: "json" })
-      if (hit !== null && hit !== undefined) return hit
-    } catch {
-      // fall through to live
-    }
-  }
-  const data = await compute()
-  if (kv && data !== null && data !== undefined) {
-    try {
-      await kv.put(key, JSON.stringify(data), { expirationTtl: DEPARTURES_DOC_TTL_SECONDS })
-    } catch {
-      // best-effort
-    }
-  }
-  return data
 }
 
 type Env = {

--- a/packages/storefront/src/voyant.ts
+++ b/packages/storefront/src/voyant.ts
@@ -34,6 +34,17 @@ export const storefrontVoyantModule = defineModule({
     requirePort(storefrontOffersRuntimePort),
     requirePort(storefrontIntakeRuntimePort),
   ],
+  subscribers: [
+    {
+      id: "@voyant-travel/storefront#subscriber.invalidate-departures-on-availability-change",
+      eventType: "availability.slot.changed",
+      source: "@voyant-travel/storefront",
+      runtime: {
+        entry: "@voyant-travel/storefront",
+        export: "storefrontAvailabilityReadModelInvalidationSubscriber",
+      },
+    },
+  ],
   api: [
     {
       id: "@voyant-travel/storefront#api.admin",

--- a/packages/storefront/tests/unit/departures-read-model.test.ts
+++ b/packages/storefront/tests/unit/departures-read-model.test.ts
@@ -113,10 +113,7 @@ describe("availability read-model subscriber", () => {
     let handler: ((event: { data: unknown }) => Promise<void>) | undefined
     const eventBus = {
       subscribe: vi.fn(
-        (
-          _eventType: string,
-          registered: (event: { data: unknown }) => Promise<void>,
-        ) => {
+        (_eventType: string, registered: (event: { data: unknown }) => Promise<void>) => {
           handler = registered
         },
       ),

--- a/packages/storefront/tests/unit/departures-read-model.test.ts
+++ b/packages/storefront/tests/unit/departures-read-model.test.ts
@@ -1,7 +1,13 @@
 import type { Context } from "hono"
 import { describe, expect, it, vi } from "vitest"
 
-import { departuresDocKey, readThroughDepartures } from "../../src/routes-public.js"
+import {
+  createStorefrontAvailabilityReadModelInvalidationSubscriber,
+  departuresDocKey,
+  departuresDocPrefix,
+  invalidateDeparturesReadModel,
+  readThroughDepartures,
+} from "../../src/departures-read-model.js"
 
 function fakeKv() {
   const store = new Map<string, string>()
@@ -16,7 +22,14 @@ function fakeKv() {
       store.set(key, value)
       return options
     }),
-    delete: vi.fn(async () => {}),
+    delete: vi.fn(async (key: string) => {
+      store.delete(key)
+    }),
+    list: vi.fn(async ({ prefix }: { prefix?: string } = {}) => ({
+      keys: [...store.keys()]
+        .filter((key) => !prefix || key.startsWith(prefix))
+        .map((name) => ({ name })),
+    })),
   }
 }
 
@@ -52,9 +65,10 @@ describe("readThroughDepartures", () => {
     expect(first).toEqual({ data: [{ id: "dep_1" }] })
     expect(second).toEqual({ data: [{ id: "dep_1" }] })
     expect(compute).toHaveBeenCalledOnce()
-    // TTL-bounded freshness: departures shift with bookings.
+    // Exact availability-event invalidation is primary; TTL bounds missed
+    // events and cache implementations without prefix listing.
     const putOptions = kv.put.mock.calls[0]?.[2] as { expirationTtl?: number }
-    expect(putOptions?.expirationTtl).toBe(120)
+    expect(putOptions?.expirationTtl).toBe(900)
   })
 
   it("degrades to live compute without a CACHE binding", async () => {
@@ -73,5 +87,54 @@ describe("readThroughDepartures", () => {
 
     expect(result).toEqual({ data: [] })
     expect(compute).toHaveBeenCalledOnce()
+  })
+})
+
+describe("invalidateDeparturesReadModel", () => {
+  it("deletes every query variant for one product only", async () => {
+    const kv = fakeKv()
+    kv.store.set(departuresDocKey("prod_1", {}), "one")
+    kv.store.set(departuresDocKey("prod_1", { limit: 20 }), "two")
+    kv.store.set(departuresDocKey("prod_2", {}), "other")
+
+    await invalidateDeparturesReadModel(kv, "prod_1")
+
+    expect(kv.list).toHaveBeenCalledWith({ prefix: departuresDocPrefix("prod_1") })
+    expect(kv.store.has(departuresDocKey("prod_1", {}))).toBe(false)
+    expect(kv.store.has(departuresDocKey("prod_1", { limit: 20 }))).toBe(false)
+    expect(kv.store.has(departuresDocKey("prod_2", {}))).toBe(true)
+  })
+})
+
+describe("availability read-model subscriber", () => {
+  it("invalidates the affected product without reading Postgres", async () => {
+    const kv = fakeKv()
+    kv.store.set(departuresDocKey("prod_1", {}), "cached")
+    let handler: ((event: { data: unknown }) => Promise<void>) | undefined
+    const eventBus = {
+      subscribe: vi.fn(
+        (
+          _eventType: string,
+          registered: (event: { data: unknown }) => Promise<void>,
+        ) => {
+          handler = registered
+        },
+      ),
+    }
+    const subscriber = createStorefrontAvailabilityReadModelInvalidationSubscriber()
+
+    subscriber.register({
+      bindings: { CACHE: kv },
+      container: {} as never,
+      eventBus: eventBus as never,
+    })
+    await handler?.({ data: { productId: "prod_1", slotId: "slot_1" } })
+
+    expect(eventBus.subscribe).toHaveBeenCalledWith(
+      "availability.slot.changed",
+      expect.any(Function),
+      { inline: false },
+    )
+    expect(kv.store.has(departuresDocKey("prod_1", {}))).toBe(false)
   })
 })

--- a/packages/utils/src/tiered-kv.ts
+++ b/packages/utils/src/tiered-kv.ts
@@ -2,8 +2,8 @@ import type { KVStore } from "./cache.js"
 
 export interface TieredKvOptions {
   /**
-   * TTL for L2 hits promoted into L1 when the original remaining TTL is not
-   * visible through KVStore. Defaults to 60s to bound remote invalidation lag.
+   * Maximum TTL for values stored in L1, including writes and L2 promotions.
+   * Defaults to 60s to bound cross-process invalidation lag.
    */
   l2PromotionTtlSeconds?: number
 }
@@ -19,6 +19,10 @@ export function createTieredKvStore(
 ): KVStore {
   const promotionTtl = options.l2PromotionTtlSeconds ?? 60
   if (!l2) return l1
+
+  const l1PutOptions = (putOptions?: { expirationTtl?: number }) => ({
+    expirationTtl: Math.min(putOptions?.expirationTtl ?? promotionTtl, promotionTtl),
+  })
 
   return {
     async get<T = string>(
@@ -36,7 +40,7 @@ export function createTieredKvStore(
     async put(key: string, value: string, putOptions?: { expirationTtl?: number }): Promise<void> {
       await Promise.all([
         l2.put(key, value, putOptions),
-        l1.put(key, value, putOptions).catch(() => {}),
+        l1.put(key, value, l1PutOptions(putOptions)).catch(() => {}),
       ])
     },
     async delete(key: string): Promise<void> {

--- a/packages/utils/tests/memory-kv.test.ts
+++ b/packages/utils/tests/memory-kv.test.ts
@@ -63,4 +63,30 @@ describe("createTieredKvStore", () => {
     clock += 1_001
     expect(await l1.get("k")).toBeNull()
   })
+
+  it("bounds write-through L1 entries without shortening the L2 TTL", async () => {
+    let clock = 1_000
+    const l1 = createMemoryKvNamespace({ now: () => clock })
+    const l2 = createMemoryKvNamespace({ now: () => clock })
+    const kv = createTieredKvStore(l1, l2)
+
+    await kv.put("k", "v", { expirationTtl: 900 })
+    clock += 60_001
+
+    expect(await l1.get("k")).toBeNull()
+    expect(await l2.get("k")).toBe("v")
+  })
+
+  it("preserves a write-through TTL shorter than the L1 bound", async () => {
+    let clock = 1_000
+    const l1 = createMemoryKvNamespace({ now: () => clock })
+    const l2 = createMemoryKvNamespace({ now: () => clock })
+    const kv = createTieredKvStore(l1, l2)
+
+    await kv.put("k", "v", { expirationTtl: 30 })
+    clock += 30_001
+
+    expect(await l1.get("k")).toBeNull()
+    expect(await l2.get("k")).toBeNull()
+  })
 })


### PR DESCRIPTION
## What changed

- moves anonymous departure browse documents into the configured provider-neutral `CACHE` store for 15 minutes
- invalidates every cached query variant for the affected product when `availability.slot.changed` is delivered through the existing subscriber/outbox system
- falls back to the live Postgres query whenever the cache binding is absent or unavailable
- registers the invalidation subscriber in the storefront deployment manifest
- adds a patch changeset for `@voyant-travel/storefront`

## Why

Managed runtimes already bind `CACHE` to the tenant's namespaced Upstash Redis resource. The previous two-minute read-through window was shorter than Neon's five-minute suspend window and had no event-driven invalidation, so ordinary departure browsing repeatedly woke Postgres.

This keeps OSS provider-neutral: self-hosters can supply Redis, another compatible KV store, memory, or no cache. There is no Cloudflare dependency in the storefront package.

## Safety

- checkout, repricing, and confirmation continue to read the transactional database
- Redis remains an optimization rather than an authority
- cache errors never dead-letter the canonical availability event
- the TTL bounds staleness when an invalidation is missed
- existing outbox delivery, subscribers, retries, and cron recovery remain unchanged

## Validation

- storefront package suite: 22 files / 116 tests passed; database-dependent tests were skipped because the remote validation environment had no database
- operator-standard manifest test passed
- focused unit coverage verifies the 900-second TTL, cache fallback, exact per-product invalidation, and subscriber registration
- package typecheck is running on the retained remote Sprite