### PR TITLE
Fix release verification for caret peer unions

### DIFF
--- a/scripts/tests/release-plan.test.mjs
+++ b/scripts/tests/release-plan.test.mjs
@@ -52,6 +52,21 @@ test("accepts a compatible published caret peer without creating a workspace edg
   )
 })
 
+test("accepts a compatible published union of caret peers", () => {
+  assert.deepEqual(
+    collectWorkspaceRangeProblems(
+      createPackages({
+        "@fixture/consumer": {
+          version: "1.1.0",
+          peerDependencies: { "@fixture/provider": "^0.64.24 || ^1.0.0" },
+        },
+        "@fixture/provider": { version: "0.64.24" },
+      }),
+    ),
+    [],
+  )
+})
+
 test("rejects a future internal peer range when either package is absent from the release plan", () => {
   const packages = createPackages({
     "@fixture/consumer": {

--- a/scripts/verify-release-config.cjs
+++ b/scripts/verify-release-config.cjs
@@ -77,6 +77,8 @@ const DEPENDENCY_FIELDS = [
   "optionalDependencies",
 ]
 const REQUIRED_WORKSPACE_RANGE = "workspace:^"
+const COMPATIBLE_PUBLISHED_CARET_RANGE =
+  /^\^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\s*\|\|\s*\^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)*$/
 
 // The standard product distribution pins its runtime modules to the EXACT current version
 // (`workspace:*` → `X.Y.Z` on publish) so the published set is deterministic and
@@ -117,7 +119,7 @@ function collectWorkspaceRangeProblems(packages, projectedVersions = new Map()) 
         const currentProviderVersion = workspacePackageVersions.get(name)
         const isCompatiblePublishedPeerRange =
           field === "peerDependencies" &&
-          /^\^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(version) &&
+          COMPATIBLE_PUBLISHED_CARET_RANGE.test(version) &&
           semver.satisfies(currentProviderVersion, version)
         const isExactStagedPeerRange =
           field === "peerDependencies" &&


### PR DESCRIPTION
## Summary

- accept compatible published peer ranges composed exclusively of caret clauses
- retain the workspace-edge requirement for non-caret and incompatible staged ranges
- add a regression for the MCP `^0.64.24 || ^1.0.0` Framework compatibility contract

## Why

Main's Release run [30474535649](https://github.com/voyant-travel/voyant/actions/runs/30474535649) failed before Changesets PR creation because release verification accepted one compatible caret clause but rejected the newly released MCP caret union.

## Validation

Disposable Sprite, exact worktree snapshot:

- `pnpm verify:release-config` (8/8 tests; full config accepted)
- Biome on both changed files
- `git diff --check`

No package changeset is needed: this only corrects repository release tooling.